### PR TITLE
Working/data integrity 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "affinidi-secrets-resolver",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "did-webvh"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.5.4", path = "crates/affinidi-d
 affinidi-did-resolver-cache-server = { version = "0.5.4", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-server" }
 did-example = { version = "0.5.3", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-example" }
 did-peer = { version = "0.6.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
-did-webvh = { version = "0.1.3", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh" }
+did-webvh = { version = "0.1.4", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh" }
 affinidi-meeting-place = { version = "0.1.10", path = "./crates/affinidi-meeting-place" }
 affinidi-messaging-didcomm = { version = "0.10.8", path = "./crates/affinidi-messaging/affinidi-messaging-didcomm" }
 affinidi-messaging-helpers = { version = "0.10.7", path = "./crates/affinidi-messaging/affinidi-messaging-helpers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ affinidi-messaging-mediator-processors = { version = "0.10.7", path = "./crates/
 affinidi-messaging-sdk = { version = "0.11.2", path = "./crates/affinidi-messaging/affinidi-messaging-sdk" }
 affinidi-messaging-text-client = { version = "0.10.8", path = "./crates/affinidi-messaging/affinidi-messaging-text-client" }
 affinidi-tdk = { version = "0.1.12", path = "./crates/affinidi-tdk/affinidi-tdk" }
-affinidi-data-integrity = { version = "0.1.1", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
+affinidi-data-integrity = { version = "0.1.2", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.1.10", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
 affinidi-secrets-resolver = { version = "0.1.11", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
 affinidi-tdk-common = { version = "0.1.12", path = "./crates/affinidi-tdk/common/affinidi-tdk-common" }

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Changelog history
 
+### June 2025
+
+## DID webvh method (0.1.4)
+
 ### 16th June 2025
 
 ## DID webvh method (0.1.3)

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-webvh"
-version = "0.1.3"
+version = "0.1.4"
 description = "Implementation of the did:webvh method in Rust, uses the ssi crate"
 repository.workspace = true
 edition.workspace = true

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/lib.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/lib.rs
@@ -22,29 +22,32 @@ pub const SCID_HOLDER: &str = "{SCID}";
 /// Error types for WebVH method
 #[derive(Error, Debug)]
 pub enum DIDWebVHError {
-    #[error("DID Query NotFound")]
-    NotFound,
-    #[error("UnsupportedMethod: Must be did:webvh")]
-    UnsupportedMethod,
-    #[error("Invalid method identifier: {0}")]
-    InvalidMethodIdentifier(String),
-    #[error("ServerError: {0}")]
-    ServerError(String),
-    #[error("NotImplemented: {0}")]
-    NotImplemented(String),
-    #[error("SCIDError: {0}")]
-    SCIDError(String),
-    #[error("LogEntryError: {0}")]
-    LogEntryError(String),
-    #[error("ParametersError: {0}")]
-    ParametersError(String),
-    /// There was an error in validating the DID
-    #[error("ValidationError: {0}")]
-    ValidationError(String),
     #[error("DeactivatedError: {0}")]
     DeactivatedError(String),
     #[error("DIDError: {0}")]
     DIDError(String),
+    #[error("Invalid method identifier: {0}")]
+    InvalidMethodIdentifier(String),
+    #[error("LogEntryError: {0}")]
+    LogEntryError(String),
+    #[error("DID Query NotFound")]
+    NotFound,
+    #[error("NotImplemented: {0}")]
+    NotImplemented(String),
+    #[error("ParametersError: {0}")]
+    ParametersError(String),
+    #[error("SCIDError: {0}")]
+    SCIDError(String),
+    #[error("ServerError: {0}")]
+    ServerError(String),
+    #[error("UnsupportedMethod: Must be did:webvh")]
+    UnsupportedMethod,
+    /// There was an error in validating the DID
+    #[error("ValidationError: {0}")]
+    ValidationError(String),
+    /// An error occurred while working with Witness Proofs
+    #[error("WitnessProofError: {0}")]
+    WitnessProofError(String),
 }
 
 pub struct DIDWebVH;

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/witness/mod.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/witness/mod.rs
@@ -2,11 +2,14 @@
 *   Handling of witnessing changes to the log entries
 */
 
+use crate::DIDWebVHError;
+use affinidi_data_integrity::DataIntegrityProof;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
+pub mod proofs;
 
-use crate::DIDWebVHError;
 /// Witness nodes
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Witnesses {

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/witness/proofs.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-webvh/src/witness/proofs.rs
@@ -1,0 +1,77 @@
+/*!
+*   A webvh that has witnessing enabled requires a proof file containing each witness proof
+*/
+use affinidi_data_integrity::DataIntegrityProof;
+use serde::{Deserialize, Serialize};
+
+use crate::DIDWebVHError;
+
+// *********************************************************
+// Witness Proof File
+// *********************************************************
+
+/// Array of WitnessProofs for each Witness Proof
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessProofCollection(Vec<WitnessProof>);
+
+/// Record of each LogEntry that requires witnessing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessProof {
+    /// versionId of the DID Log Entry to which witness proofs apply.
+    pub version_id: String,
+    /// Array of DataIntegrity Proofs from each Witness
+    pub proof: Vec<DataIntegrityProof>,
+}
+
+impl WitnessProofCollection {
+    /// Insert a witness proof for a given versionId
+    pub fn add_proof(
+        &mut self,
+        version_id: &str,
+        proof: &DataIntegrityProof,
+    ) -> Result<(), DIDWebVHError> {
+        if let Some(record) = self.0.iter_mut().find(|p| p.version_id == version_id) {
+            // versionId already exists
+            record.proof.push(proof.to_owned());
+        } else {
+            // Need to create a new WitnessProof record
+            self.0.push(WitnessProof {
+                version_id: version_id.to_string(),
+                proof: vec![proof.to_owned()],
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Completely remove all proofs relating to a versionId
+    pub fn remove_version_id(&mut self, version_id: &str) {
+        self.0.retain(|p| p.version_id != version_id);
+    }
+
+    /// How many Witness proofs exist for a given versionId
+    /// Returns 0 if no proofs exist for that versionId (or not found)
+    /// This is a safe fail for how witness proofs are handled
+    pub fn get_proof_count(&self, version_id: &str) -> usize {
+        self.0
+            .iter()
+            .find(|p| p.version_id == version_id)
+            .map_or(0, |p| p.proof.len())
+    }
+
+    pub fn save_to_file(&self, file_path: &str) -> Result<(), DIDWebVHError> {
+        let json_data = serde_json::to_string(self).map_err(|e| {
+            DIDWebVHError::WitnessProofError(format!(
+                "Couldn't serialize Witness Proofs Data: {}",
+                e
+            ))
+        })?;
+        std::fs::write(file_path, json_data).map_err(|e| {
+            DIDWebVHError::WitnessProofError(format!(
+                "Couldn't write to Witness Proofs file ({}): {}",
+                file_path, e
+            ))
+        })?;
+        Ok(())
+    }
+}

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Affinidi Data Integrity Changelog
 
+## 17 June 2025 Release 0.1.2
+
+* **BREAKING:** `sign_data_jcs()` renamed to `sign_jcs_data()`
+* **BREAKING:** `sign_jcs_data()` no longer requires the  `vm_id` parameter
+* **BREAKING:** `sign_jcs_data()` `data_doc` parameter is now mutable, allowing
+in place insertion of the `DataIntegrityProof`
+  * Optimisation that stops an in-memory clone of the entire document
+* **FEATURE:** `sign_jcd_proof_only()` Generate Proof only and get `DataIntegrityProof`
+return
+  * Optimisation method for witness nodes that only require proof, not the full
+  signed document
+
 ## 6th June 2025 Release 0.1.1
 
 * **FEATURE:** Can now verify a JSON Document

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme.workspace = true

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/examples/sign_and_verify.rs
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/examples/sign_and_verify.rs
@@ -62,7 +62,7 @@ fn main() {
   }
 }"#;
 
-    let unsigned_values: GenericDocument =
+    let mut unsigned_values: GenericDocument =
         serde_json::from_str(input_doc_str).expect("Couldn't serialize input string");
 
     let pub_key = "z6MktDNePDZTvVcF5t6u362SsonU7HkuVFSMVCjSspQLDaBm";
@@ -75,16 +75,13 @@ fn main() {
     )
     .expect("Couldn't create Secret");
 
-    let signed = DataIntegrityProof::sign_data_jcs(&unsigned_values, &secret.id, &secret)
+    DataIntegrityProof::sign_jcs_data(&mut unsigned_values, &secret)
         .expect("Couldn't sign Document");
 
-    let _ = verify_data(
-        &serde_json::from_value(signed.clone()).expect("Couldn't convert genericDocument"),
-    )
-    .expect("Couldn't validate doc");
+    let _ = verify_data(&unsigned_values).expect("Couldn't validate doc");
 
     println!(
         "Signed Document: {}",
-        serde_json::to_string_pretty(&signed).unwrap()
+        serde_json::to_string_pretty(&unsigned_values).unwrap()
     );
 }


### PR DESCRIPTION
* **BREAKING:** `sign_data_jcs()` renamed to `sign_jcs_data()`
* **BREAKING:** `sign_jcs_data()` no longer requires the  `vm_id` parameter
* **BREAKING:** `sign_jcs_data()` `data_doc` parameter is now mutable, allowing
in place insertion of the `DataIntegrityProof`
  * Optimisation that stops an in-memory clone of the entire document
* **FEATURE:** `sign_jcd_proof_only()` Generate Proof only and get `DataIntegrityProof`
return
  * Optimisation method for witness nodes that only require proof, not the full
  signed document
