### PR TITLE
Working/data integrity 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "affinidi-secrets-resolver",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ affinidi-messaging-mediator-processors = { version = "0.10.7", path = "./crates/
 affinidi-messaging-sdk = { version = "0.11.2", path = "./crates/affinidi-messaging/affinidi-messaging-sdk" }
 affinidi-messaging-text-client = { version = "0.10.8", path = "./crates/affinidi-messaging/affinidi-messaging-text-client" }
 affinidi-tdk = { version = "0.1.12", path = "./crates/affinidi-tdk/affinidi-tdk" }
-affinidi-data-integrity = { version = "0.1.2", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
+affinidi-data-integrity = { version = "0.1.3", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.1.10", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
 affinidi-secrets-resolver = { version = "0.1.11", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
 affinidi-tdk-common = { version = "0.1.12", path = "./crates/affinidi-tdk/common/affinidi-tdk-common" }

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Affinidi Data Integrity Changelog
 
-## 17 June 2025 Release 0.1.2
+## 17th June 2025 Release 0.1.3
+
+* **FEATURE:** **BREAKING** `GenericDocument` replaced with `SigningDocument` and `SignedDocument`
+  * `SigningDocument`: Used when signing  data
+  * `SignedDocument`: Used when verifying data
+
+## 17th June 2025 Release 0.1.2
 
 * **BREAKING:** `sign_data_jcs()` renamed to `sign_jcs_data()`
 * **BREAKING:** `sign_jcs_data()` no longer requires the  `vm_id` parameter

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
-readme.workspace = true
+readme = "README.md"
 homepage.workspace = true
 license.workspace = true
 keywords.workspace = true

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/README.md
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/README.md
@@ -10,7 +10,7 @@ issues arising from the use or modification of the project.
 ## Overview
 
 An implementation of the W3C Data Integrity specification that is integrated
-with the Affinidi Trust Development Kit (TDK) famework.
+with the Affinidi Trust Development Kit (TDK) framework.
 
 ### Library Usage
 

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/examples/sign_and_verify.rs
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/examples/sign_and_verify.rs
@@ -1,5 +1,5 @@
 use affinidi_data_integrity::{
-    DataIntegrityProof, GenericDocument, verification_proof::verify_data,
+    DataIntegrityProof, SignedDocument, SigningDocument, verification_proof::verify_data,
 };
 use affinidi_secrets_resolver::secrets::Secret;
 
@@ -62,7 +62,7 @@ fn main() {
   }
 }"#;
 
-    let mut unsigned_values: GenericDocument =
+    let mut unsigned_values: SigningDocument =
         serde_json::from_str(input_doc_str).expect("Couldn't serialize input string");
 
     let pub_key = "z6MktDNePDZTvVcF5t6u362SsonU7HkuVFSMVCjSspQLDaBm";
@@ -78,10 +78,14 @@ fn main() {
     DataIntegrityProof::sign_jcs_data(&mut unsigned_values, &secret)
         .expect("Couldn't sign Document");
 
-    let _ = verify_data(&unsigned_values).expect("Couldn't validate doc");
+    let signed = SignedDocument {
+        extra: unsigned_values.extra,
+        proof: unsigned_values.proof,
+    };
+    let _ = verify_data(&signed).expect("Couldn't validate doc");
 
     println!(
         "Signed Document: {}",
-        serde_json::to_string_pretty(&unsigned_values).unwrap()
+        serde_json::to_string_pretty(&signed).unwrap()
     );
 }

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/src/verification_proof.rs
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/src/verification_proof.rs
@@ -7,7 +7,7 @@ use ssi::security::MultibaseBuf;
 use tracing::debug;
 
 use crate::{
-    DataIntegrityError, DataIntegrityProof, GenericDocument, crypto_suites::CryptoSuite,
+    DataIntegrityError, DataIntegrityProof, SignedDocument, crypto_suites::CryptoSuite,
     hashing_eddsa_jcs,
 };
 
@@ -23,7 +23,7 @@ pub struct VerificationProof {
 
 /// Verify a signed JSON Schema document.
 /// Must contain the field `proof`
-pub fn verify_data(signed_doc: &GenericDocument) -> Result<VerificationProof, DataIntegrityError> {
+pub fn verify_data(signed_doc: &SignedDocument) -> Result<VerificationProof, DataIntegrityError> {
     let mut verification_proof_result = VerificationProof {
         verified: false,
         verified_document: None,
@@ -144,12 +144,12 @@ pub fn verify_data(signed_doc: &GenericDocument) -> Result<VerificationProof, Da
 #[cfg(test)]
 mod tests {
     use super::verify_data;
-    use crate::{DataIntegrityError, GenericDocument, crypto_suites::CryptoSuite};
+    use crate::{DataIntegrityError, SignedDocument, crypto_suites::CryptoSuite};
     use std::collections::HashMap;
 
     #[test]
     fn missing_proof() {
-        let missing_proof = GenericDocument {
+        let missing_proof = SignedDocument {
             extra: HashMap::new(),
             proof: None,
         };
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn missing_proof_proof_value() {
-        let missing_proof_value = GenericDocument {
+        let missing_proof_value = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn invalid_proof_proof_value() {
-        let invalid_proof_value = GenericDocument {
+        let invalid_proof_value = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn invalid_context() {
-        let mut invalid_context = GenericDocument {
+        let mut invalid_context = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -256,7 +256,7 @@ mod tests {
             "https://example.com/1".to_string(),
             "https://example.com/2".to_string(),
         ];
-        let invalid_context = GenericDocument {
+        let invalid_context = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -286,7 +286,7 @@ mod tests {
             "https://example.com/1".to_string(),
             "https://example.com/2".to_string(),
         ];
-        let mut invalid_context = GenericDocument {
+        let mut invalid_context = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -326,7 +326,7 @@ mod tests {
             "https://example.com/1".to_string(),
             "https://example.com/2".to_string(),
         ];
-        let mut invalid_context = GenericDocument {
+        let mut invalid_context = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "Test".to_string(),
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn invalid_data_integrity_proof() {
-        let invalid_data_integrity_proof = GenericDocument {
+        let invalid_data_integrity_proof = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "test".to_string(),
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn invalid_created() {
-        let invalid_create = GenericDocument {
+        let invalid_create = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn invalid_created_future() {
-        let invalid_create = GenericDocument {
+        let invalid_create = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn invalid_verification_method() {
-        let invalid_verification_method = GenericDocument {
+        let invalid_verification_method = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn invalid_verification_method_2() {
-        let invalid_verification_method = GenericDocument {
+        let invalid_verification_method = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
@@ -491,7 +491,7 @@ mod tests {
     }
     #[test]
     fn invalid_verification_method_3() {
-        let invalid_verification_method = GenericDocument {
+        let invalid_verification_method = SignedDocument {
             extra: HashMap::new(),
             proof: Some(crate::DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
@@ -582,7 +582,7 @@ mod tests {
   "version_time": "2025-05-31T02:11:02Z"
 }"#;
 
-        let invalid_signed: GenericDocument = serde_json::from_str(invalid_signed).unwrap();
+        let invalid_signed: SignedDocument = serde_json::from_str(invalid_signed).unwrap();
 
         let result = verify_data(&invalid_signed);
         assert!(result.is_err());
@@ -662,7 +662,7 @@ mod tests {
   "version_id": "1-zQmW7ssogG8fwWBZTdH47S4vntYJzVB4vbXR1pYsAhriNh4",
   "version_time": "2025-05-31T02:11:02Z"
 }"#;
-        let signed: GenericDocument = serde_json::from_str(signed).unwrap();
+        let signed: SignedDocument = serde_json::from_str(signed).unwrap();
 
         let result = verify_data(&signed);
         assert!(result.is_ok());
@@ -737,7 +737,7 @@ mod tests {
   "version_time": "2025-05-31T02:11:02Z",
   "version_id": "1-zQmW7ssogG8fwWBZTdH47S4vntYJzVB4vbXR1pYsAhriNh4"
 }"#;
-        let signed: GenericDocument = serde_json::from_str(signed).unwrap();
+        let signed: SignedDocument = serde_json::from_str(signed).unwrap();
 
         let result = verify_data(&signed);
         assert!(result.is_ok());


### PR DESCRIPTION
* **FEATURE:** **BREAKING** `GenericDocument` replaced with `SigningDocument` and `SignedDocument`
  * `SigningDocument`: Used when signing  data
  * `SignedDocument`: Used when verifying data
