### PR TITLE
fix: requwest config builder

### DIFF
--- a/crates/affinidi-tdk/common/affinidi-tdk-common/src/lib.rs
+++ b/crates/affinidi-tdk/common/affinidi-tdk-common/src/lib.rs
@@ -43,7 +43,7 @@ pub fn create_http_client() -> Client {
     let tls_config = ClientConfig::with_platform_verifier();
     reqwest::ClientBuilder::new()
         .use_rustls_tls()
-        .use_preconfigured_tls(tls_config.clone())
+        .use_preconfigured_tls(tls_config.unwrap())
         .user_agent(format!(
             "Affinidi Trust Development Kit {}",
             env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
tls_config var from `let tls_config = ClientConfig::with_platform_verifier();` line is a Result,  
so we should unwrap or handle error, but not clone.   
As this function returns not a Result, I used .unwrap instead of error handling