### PR TITLE
Don't force log levels

### DIFF
--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -34,11 +34,7 @@ ssi = { version = "0.12" }
 thiserror = "2.0"
 varint = "0.9"
 tokio = { version = "1.47", features = ["rt", "macros"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 uuid = { version = "1.18", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]

--- a/crates/affinidi-messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-helpers/Cargo.toml
@@ -49,11 +49,7 @@ ssi = { version = "0.12" }
 time = "0.3"
 tokio = { version = "1.47", features = ["full"] }
 toml = "0.9"
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/Cargo.toml
@@ -65,11 +65,7 @@ tokio = { version = "1.47", features = ["full"] }
 tokio-stream = "0.1"
 toml = "0.9"
 tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -31,8 +31,4 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2.0"
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/Cargo.toml
@@ -26,11 +26,7 @@ deadpool-redis = { version = "0.22", features = ["rt_tokio_1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 tokio = { version = "1.47", features = ["full"] }
 toml = "0.9"
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/crates/affinidi-messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-sdk/Cargo.toml
@@ -35,11 +35,7 @@ ssi = { version = "0.12" }
 thiserror = "2.0"
 tokio = { version = "1.47", features = ["full"] }
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-native-roots"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 uuid = { version = "1.18", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]

--- a/crates/affinidi-messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-text-client/Cargo.toml
@@ -42,11 +42,7 @@ ssi = { version = "0.12" }
 textwrap = "0.16"
 tokio = { version = "1.47", features = ["full"] }
 tokio-stream = "0.1"
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-  "valuable",
-] }
+tracing = { version = "0.1", features = ["valuable"] }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/crates/affinidi-tdk/affinidi-tdk/Cargo.toml
+++ b/crates/affinidi-tdk/affinidi-tdk/Cargo.toml
@@ -37,10 +37,7 @@ rustls = { version = "0.23", default-features = false, features = [
 serde_json = "1.0"
 ssi = { version = "0.12" }
 tokio = { version = "1.47", features = ["full"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-data-integrity/Cargo.toml
@@ -23,10 +23,7 @@ serde_json = "1.0"
 serde_json_canonicalizer = "0.3"
 sha2 = "0.10"
 thiserror = "2.0"
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/affinidi-tdk/common/affinidi-did-authentication/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-did-authentication/Cargo.toml
@@ -25,8 +25,5 @@ serde_json = "1.0"
 ssi = { version = "0.12" }
 thiserror = "2.0"
 tokio = { version = "1.47", features = ["full"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }
 uuid = { version = "1.18", features = ["v4", "fast-rng"] }

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
@@ -25,10 +25,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.10"
 tokio = { version = "1.47", features = ["macros", "rt", "sync", "time"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }
 ssi-multicodec = { version = "0.2", features = [
   "ed25519",
   "k256",

--- a/crates/affinidi-tdk/common/affinidi-tdk-common/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-tdk-common/Cargo.toml
@@ -40,7 +40,4 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["full"] }
-tracing = { version = "0.1", features = [
-  "max_level_debug",
-  "release_max_level_info",
-] }
+tracing = { version = "0.1" }


### PR DESCRIPTION
Forcing tracing log levels in this way is bad because it forces these log levels upon any crate that may include one of these libraries as a (sub-)dependency, causing e.g. the following warning:
```
warning: some trace filter directives would enable traces that are disabled statically
 | `tsp=trace` would enable the TRACE level for the `tsp` target
 = note: the static max level is `info`
 = help: to enable DEBUG logging, remove the `max_level_info` feature from the `tracing` crate
```