### PR TITLE
Resolving bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ affinidi-messaging-text-client = { version = "0.11.0", path = "./crates/affinidi
 affinidi-tdk = { version = "0.2.0", path = "./crates/affinidi-tdk/affinidi-tdk" }
 affinidi-data-integrity = { version = "0.2.2", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.2.0", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
-affinidi-secrets-resolver = { version = "0.2.0", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
+affinidi-secrets-resolver = { version = "0.2.1", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
 affinidi-tdk-common = { version = "0.2.0", path = "./crates/affinidi-tdk/common/affinidi-tdk-common" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ affinidi-did-key = { version = "0.1.0", path = "crates/affinidi-did-resolver/aff
 affinidi-meeting-place = { version = "0.2.0", path = "./crates/affinidi-meeting-place" }
 affinidi-messaging-didcomm = { version = "0.11", path = "./crates/affinidi-messaging/affinidi-messaging-didcomm" }
 affinidi-messaging-helpers = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-helpers" }
-affinidi-messaging-mediator = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-mediator" }
+affinidi-messaging-mediator = { version = "0.11.1", path = "./crates/affinidi-messaging/affinidi-messaging-mediator" }
 affinidi-messaging-mediator-common = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
 affinidi-messaging-mediator-processors = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors" }
 affinidi-messaging-sdk = { version = "0.12.0", path = "./crates/affinidi-messaging/affinidi-messaging-sdk" }

--- a/crates/affinidi-messaging/CHANGELOG.md
+++ b/crates/affinidi-messaging/CHANGELOG.md
@@ -8,6 +8,14 @@ we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our
 tooling.
 
+## 1st October 2025
+
+### Mediator (0.11.1)
+
+- **FIX:** When SSL certificate and key file config is absent, would cause a crash
+  even though SSL was disabled.
+  - SSL config is now optional
+
 ## 30th September 2025
 
 ### DIDComm Library (0.11.0)

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.11.0"
+version = "0.11.1"
 description = "DIDComm Mediator service for Affinidi Messaging"
 edition.workspace = true
 authors.workspace = true

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/src/common/config.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/src/common/config.rs
@@ -56,8 +56,8 @@ pub struct SecurityConfigRaw {
     pub local_direct_delivery_allow_anon: String,
     pub mediator_secrets: String,
     pub use_ssl: String,
-    pub ssl_certificate_file: String,
-    pub ssl_key_file: String,
+    pub ssl_certificate_file: Option<String>,
+    pub ssl_key_file: Option<String>,
     pub jwt_authorization_secret: String,
     pub jwt_access_expiry: String,
     pub jwt_refresh_expiry: String,
@@ -77,9 +77,9 @@ pub struct SecurityConfig {
     #[serde(skip_serializing)]
     pub mediator_secrets: Arc<ThreadedSecretsResolver>,
     pub use_ssl: bool,
-    pub ssl_certificate_file: String,
+    pub ssl_certificate_file: Option<String>,
     #[serde(skip_serializing)]
-    pub ssl_key_file: String,
+    pub ssl_key_file: Option<String>,
     #[serde(skip_serializing)]
     pub jwt_encoding_key: EncodingKey,
     #[serde(skip_serializing)]
@@ -135,8 +135,8 @@ impl SecurityConfig {
             local_direct_delivery_allow_anon: false,
             mediator_secrets: secrets_resolver,
             use_ssl: true,
-            ssl_certificate_file: "".into(),
-            ssl_key_file: "".into(),
+            ssl_certificate_file: None,
+            ssl_key_file: None,
             jwt_encoding_key: EncodingKey::from_ed_der(&[0; 32]),
             jwt_decoding_key: DecodingKey::from_ed_der(&[0; 32]),
             jwt_access_expiry: 900,

--- a/crates/affinidi-messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-mediator/src/server.rs
@@ -163,8 +163,14 @@ pub async fn start() {
         // TODO: Build a proper TLS Config
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let ssl_config = RustlsConfig::from_pem_file(
-            config.security.ssl_certificate_file,
-            config.security.ssl_key_file,
+            config
+                .security
+                .ssl_certificate_file
+                .expect("SSL Certificate file must be specified in the Config"),
+            config
+                .security
+                .ssl_key_file
+                .expect("SSL Certificate key file must be specified in the Config"),
         )
         .await
         .expect("bad certificate/key");

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Affinidi Secrets Manager
 
+## 1st October 2025 (0.2.1)
+
+- **FIX:** Secret struct deserialization was not correct
+  - Added a unit test to check deserialization of Secret
+  - serde now correctly names the SecretMaterial fields
+
 ## 30th September 2025 (0.2.0)
 
 - **IMPROVEMENT:** SSI Crate dependency removed from this library
-- **IMPROVEMENT:** Crypto methods added directly to this library for easier 3rd party usage
+- **IMPROVEMENT:** Crypto methods added directly to this library for easier 3rd
+  party usage
 
 ## 13th September 2025 (0.1.18)
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
@@ -435,9 +435,9 @@ impl fmt::Display for KeyType {
 
 /// Represents secret crypto material.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
+//#[serde(untagged)]
 pub enum SecretMaterial {
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename = "privateKeyJwk", rename_all = "camelCase")]
     JWK(JWK),
 
     #[serde(rename_all = "camelCase")]
@@ -495,5 +495,24 @@ mod tests {
             .expect("Couldn't convert ed25519 to x25519");
 
         assert_eq!(x25519.private_bytes.as_slice(), x25519_sk_bytes);
+    }
+
+    #[test]
+    fn check_secret_deserialize() {
+        let txt = r#"{
+        "id": "did:web:localhost%3A7037:mediator:v1:.well-known#key-2",
+        "type": "JsonWebKey2020",
+        "privateKeyJwk": {
+            "crv": "secp256k1",
+            "d": "Cs5xn7WCkUWEua5vGxjP9_wBzIzMtEwjQ4KWKHHQR14",
+            "kty": "EC",
+            "x": "Lk1FY8MmyLjBswU4KbLoBQ_1THZJBMx2n6aIBXt1uXo",
+            "y": "tEv7EQHj4g4njOfrsjjDJBPKOI9RGWWMS8NYClo2cqo"
+        }
+    }"#;
+
+        let secret = serde_json::from_str::<Secret>(txt);
+
+        assert!(secret.is_ok());
     }
 }


### PR DESCRIPTION
affinidi-secrets-resolver -> 0.2.1
- Addresses a serialization/deserialization issue of Secrets

affinidi-messaging-mediator -> 0.11.1
- When not using SSL, would panic due to missing SSL config attributes