### PR TITLE
did-peer and affinidi-secrets-resolver fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.6.1", path = "crates/affinidi-d
 ] }
 affinidi-did-resolver-cache-server = { version = "0.6.0", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-server" }
 did-example = { version = "0.5.5", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-example" }
-did-peer = { version = "0.7.0", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
+did-peer = { version = "0.7.1", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
 affinidi-did-key = { version = "0.1.0", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key" }
 affinidi-meeting-place = { version = "0.2.0", path = "./crates/affinidi-meeting-place" }
 affinidi-messaging-didcomm = { version = "0.11", path = "./crates/affinidi-messaging/affinidi-messaging-didcomm" }
@@ -61,7 +61,7 @@ affinidi-messaging-text-client = { version = "0.11.0", path = "./crates/affinidi
 affinidi-tdk = { version = "0.2.0", path = "./crates/affinidi-tdk/affinidi-tdk" }
 affinidi-data-integrity = { version = "0.2.2", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.2.0", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
-affinidi-secrets-resolver = { version = "0.2.1", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
+affinidi-secrets-resolver = { version = "0.2.2", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
 affinidi-tdk-common = { version = "0.2.0", path = "./crates/affinidi-tdk/common/affinidi-tdk-common" }
 
 [profile.release]

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - **FIX:** Adding WebVH DID method back in
 
+## did-peer (0.7.1)
+
+- **FIX:** Key ID's were not correctly implied
+  - ID's used to identify keys are `full_did#key-n`
+
 ### 30th September 2025
 
 ## DID Common (0.1.0)

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-peer"
-version = "0.7.0"
+version = "0.7.1"
 description = "Implementation of the did:peer method in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/document.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/document.rs
@@ -53,8 +53,8 @@ impl DIDCommVerificationMethodExt for VerificationMethod {
 
                 match JWK::from_multikey(key) {
                     Ok(jwk) => Some(jwk),
-                    Err(_) => {
-                        warn!("Failed to parse JWK from multicodec ({})", key);
+                    Err(e) => {
+                        warn!("Failed to parse JWK from multicodec ({key}): {e}");
                         None
                     }
                 }

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/message/pack_encrypted/authcrypt.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/message/pack_encrypted/authcrypt.rs
@@ -99,30 +99,6 @@ where
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    /*
-     let from_keys = from_kids
-        .into_iter()
-        .map(|kid| {
-            from_ddoc
-                .verification_method
-                .iter()
-                .find(|vm| {
-                    println!("vm.id: {}", vm.id);
-                    vm.id == kid
-                })
-                .ok_or_else(|| {
-                    // TODO: support external keys
-                    err_msg(
-                        ErrorKind::Malformed,
-                        format!(
-                            "No verification material found for sender key agreement {}",
-                            kid
-                        ),
-                    )
-                })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    */
 
     // Initial list of recipient keys is all key_agreements of recipient did doc
     // or filtered to keep only provided key

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/message/pack_encrypted/mod.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/message/pack_encrypted/mod.rs
@@ -100,7 +100,7 @@ impl Message {
             let (msg, PackSignedMetadata { sign_by_kid }) = self
                 .pack_signed(sign_by, did_resolver, secrets_resolver)
                 .await
-                .context("Unable to produce sign envelope")?;
+                .context("Unable to produce signed envelope")?;
 
             (msg, Some(sign_by_kid))
         } else {

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Affinidi Secrets Manager
 
-## 1st October 2025 (0.2.1)
+## 1st October 2025 (0.2.1, 0.2.2)
 
 - **FIX:** Secret struct deserialization was not correct
   - Added a unit test to check deserialization of Secret
   - serde now correctly names the SecretMaterial fields
+- **FIX:** JWK conversions from bytes were not correct for Ecliptic Curves
 
 ## 30th September 2025 (0.2.0)
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -24,12 +24,21 @@ ahash = "0.8"
 base58 = "0.2"
 base64 = "0.22"
 ed25519-dalek = { version = "2.2", features = ["rand_core"], optional = true }
-k256 = { version = "0.13", features = ["ecdsa-core"], optional = true }
+k256 = { version = "0.13", features = [
+  "ecdsa-core",
+  "arithmetic",
+], optional = true }
 multibase = "0.9"
 multihash = "0.19"
-p256 = { version = "0.13", features = ["ecdsa-core"], optional = true }
-p384 = { version = "0.13", features = ["ecdsa-core"], optional = true }
-rand = "0.8"                                                                   # Version conflict because of ed25519-dalek (2.2.0)
+p256 = { version = "0.13", features = [
+  "ecdsa-core",
+  "arithmetic",
+], optional = true }
+p384 = { version = "0.13", features = [
+  "ecdsa-core",
+  "arithmetic",
+], optional = true }
+rand = "0.8" # Version conflict because of ed25519-dalek (2.2.0)
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/jwk.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/jwk.rs
@@ -136,7 +136,6 @@ impl JWK {
 
 #[cfg(test)]
 mod tests {
-
     use crate::jwk::{ECParams, JWK, OctectParams, Params};
 
     #[test]
@@ -181,5 +180,25 @@ mod tests {
                 d: Some("kQrTUKhBU-6bHbCdiY0dIfg3knd5U2-1FlLGGHSbF6U".to_string())
             })
         );
+    }
+
+    #[test]
+    fn check_from_multikey() {
+        // secp256k1
+        assert!(JWK::from_multikey("zQ3shT2ynSjzY5XoTxhWHvYVZ6GiLWhBVincVekcEpZDRCBHV").is_ok());
+
+        // p256
+        assert!(JWK::from_multikey("zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169").is_ok());
+
+        // p384
+        assert!(
+            JWK::from_multikey(
+                "z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
+            )
+            .is_ok()
+        );
+
+        // Ed25519
+        assert!(JWK::from_multikey("z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp").is_ok());
     }
 }


### PR DESCRIPTION
affinidi-secrets-resolver --> 0.2.2
- FIX JWK conversions from multicodec values

did-peer --> 0.7.1
- FIX VerificationMethod identifiers to be full DID