### PR TITLE
Addressing P-256 and P-384 errors (#124)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,16 +44,16 @@ rust-version = "1.88.0"
 
 [workspace.dependencies]
 affinidi-did-common = { version = "0.1.0", path = "crates/affinidi-did-resolver/affinidi-did-common" }
-affinidi-did-resolver-cache-sdk = { version = "0.6.1", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk", features = [
+affinidi-did-resolver-cache-sdk = { version = "0.6.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk", features = [
   "network",
 ] }
 affinidi-did-resolver-cache-server = { version = "0.6.1", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-server" }
 did-example = { version = "0.5.5", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-example" }
 did-peer = { version = "0.7.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
 did-cheqd = { version = "0.1.0", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-cheqd" }
-affinidi-did-key = { version = "0.1.1", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key" }
+affinidi-did-key = { version = "0.1.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key" }
 affinidi-meeting-place = { version = "0.2.0", path = "./crates/affinidi-meeting-place" }
-affinidi-messaging-didcomm = { version = "0.11.1", path = "./crates/affinidi-messaging/affinidi-messaging-didcomm" }
+affinidi-messaging-didcomm = { version = "0.11.2", path = "./crates/affinidi-messaging/affinidi-messaging-didcomm" }
 affinidi-messaging-helpers = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-helpers" }
 affinidi-messaging-mediator = { version = "0.11.2", path = "./crates/affinidi-messaging/affinidi-messaging-mediator" }
 affinidi-messaging-mediator-common = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
@@ -63,7 +63,7 @@ affinidi-messaging-text-client = { version = "0.11.0", path = "./crates/affinidi
 affinidi-tdk = { version = "0.2.1", path = "./crates/affinidi-tdk/affinidi-tdk" }
 affinidi-data-integrity = { version = "0.2.3", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.2.1", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
-affinidi-secrets-resolver = { version = "0.3.0", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
+affinidi-secrets-resolver = { version = "0.3.1", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }
 affinidi-tdk-common = { version = "0.2.1", path = "./crates/affinidi-tdk/common/affinidi-tdk-common" }
 
 [profile.release]

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+### 8th October 2025
+
+## affinidi-did-key (0.1.2)
+
+- **FIX:** Generating a DID was placing the wrong key ID in the generated secret
+  - Correct did:key key id's are now properly used
+
+## did-cheqd (0.1.0)
+
+- Initial release of Cheqd DID method support
+
+## affinidi-did-resolver-cache-sdk (0.6.2)
+
+- **IMPROVEMENT:** `did-cheqd` and `did-webvh` moved behind feature flags, helps with managing complex dependencies as needed
+- **CHORE:** Improved README documentation and feature flags
+
 ### 3rd October 2025
 
 ## affinidi-did-resolver-cache-server (0.6.1)

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.6.1"
+version = "0.6.2"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ rust-version.workspace = true
 crate-type = ["rlib", "cdylib"]
 
 [features]
-default = ["local"]
+default = ["local", "did-methods"]
 local = []
 network = [
   "dep:web-socket",
@@ -27,21 +27,24 @@ network = [
   "dep:rustls",
   "dep:rustls-platform-verifier",
 ]
+did-methods = ["did-cheqd", "did-webvh"]
 did_example = ["dep:did-example"]
 did-jwk = ["dep:did-jwk"]
+did-cheqd = ["dep:did-cheqd"]
+did-webvh = ["dep:didwebvh-rs"]
 
 [dependencies]
 # Affinidi Crates
 affinidi-did-common.workspace = true
 did-peer.workspace = true
 did-example = { workspace = true, optional = true }
-did-cheqd = { workspace = true }
+did-cheqd = { workspace = true, optional = true }
 affinidi-did-key.workspace = true
 
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
-didwebvh-rs = "0.1"
+didwebvh-rs = { version = "0.1", optional = true }
 futures-util = "0.3"
 highway = "1.3.0"
 moka = { version = "0.12", features = ["future"] }

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk/README.md
@@ -11,14 +11,15 @@ You can use this SDK in either local (resolving occurs locally) or in network
 
 ## Supported DID Methods
 
-- did:key
-- did:ethr
+- did:key (default)
+- did:ethr (default)
 - did:jwk (disabled as SSI library is using local references)
-- did:pkh
-- did:peer
-- did:web
-- did:webvh
-- did:example
+- did:pkh (default)
+- did:peer (default)
+- did:web (default)
+- did:webvh (did-methods)
+- did:cheqd (did-methods)
+- did:example (did-example)
   - NOTE: This is enabled using Rust feature `did:example`
   - NOTE: did:example must be manually loaded into the resolver as the DID DOC is
     NOT deterministic!
@@ -29,6 +30,18 @@ Rust version 1.88
 
 NOTE: For network mode, you will need access to a running a DID Universal Resolver
 Cache!
+
+## Feature Flags
+
+- `default`: `local` and `did-methods` enabled
+  - Disable default using the `--no-default-features` flag
+- `local`: Does nothing reserved for future use
+- `network`: Enable network for the resolver to use a network-cache service
+- `did-methods`: Includes `did-webvh` and `did-cheqd` alongside the default methods
+- `did-webvh`: WebVH DID Method support
+- `did-cheqd`: Cheqd's Blockchain based DID Method support
+- `did-example`: Example DID Method which allows for easy testing of DID Documents
+- `did-jwk`: Currently Broken due to local references
 
 ## Local Mode
 

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-key"
-version = "0.1.1"
+version = "0.1.2"
 description = "Implementation of did:key"
 repository.workspace = true
 edition.workspace = true
@@ -20,5 +20,3 @@ base58 = "0.2"
 serde_json = "1.0"
 thiserror = "2.0"
 url = "2.5"
-
-[dev-dependencies]

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key/src/create.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key/src/create.rs
@@ -7,7 +7,7 @@ use crate::{DIDKey, errors::Error};
 
 impl DIDKey {
     pub fn generate<'a>(key_type: KeyType) -> Result<(String, Secret), Error<'a>> {
-        let secret = match key_type {
+        let mut secret = match key_type {
             KeyType::Ed25519 => Secret::generate_ed25519(None, None),
             KeyType::X25519 => Secret::generate_x25519(None, None)?,
             KeyType::P256 => Secret::generate_p256(None, None)?,
@@ -20,9 +20,43 @@ impl DIDKey {
             }
         };
 
+        secret.id = [
+            "did:key:",
+            &secret.get_public_keymultibase()?,
+            "#",
+            &secret.get_public_keymultibase()?,
+        ]
+        .concat();
         Ok((
             ["did:key:", &secret.get_public_keymultibase()?].concat(),
             secret,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use affinidi_secrets_resolver::{jwk::JWK, secrets::KeyType};
+
+    use crate::DIDKey;
+
+    #[test]
+    fn check_generate() {
+        let (did, secret) =
+            DIDKey::generate(KeyType::P256).expect("COuldn't generate P256 DID Key");
+
+        assert_eq!(
+            [
+                &did,
+                "#",
+                &secret
+                    .get_public_keymultibase()
+                    .expect("Couldn't get multibase key")
+            ]
+            .concat(),
+            secret.id
+        );
+
+        assert!(JWK::from_multikey(did.trim_start_matches("did:key:")).is_ok());
     }
 }

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-cheqd/src/lib.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-cheqd/src/lib.rs
@@ -1,12 +1,5 @@
-/*!
- * This module is a simple example of a DID resolver that uses a cache to store DID documents.
- *
- * Should only be used for local testing and development
- *
- * Enable using the did_example feature flag
- */
-
-use std::collections::HashMap;
+/*! Cheqd Blockchain DID Resolver
+*/
 
 use affinidi_did_common::service::{Endpoint, Service};
 use affinidi_did_common::verification_method::VerificationRelationship;
@@ -14,6 +7,7 @@ use affinidi_did_common::{Document, verification_method::VerificationMethod};
 use did_cheqd::resolution::resolver::{DidCheqdResolver, DidCheqdResolverConfiguration};
 use did_resolver::did_doc::schema::verification_method::{PublicKeyField, VerificationMethodKind};
 use did_resolver::did_parser_nom::{Did, DidUrl};
+use std::collections::HashMap;
 use thiserror::Error;
 use url::Url;
 
@@ -190,13 +184,7 @@ impl DIDCheqd {
     pub async fn resolve_resource(did_url: &str) -> Result<Option<Vec<u8>>, DIDCheqdError> {
         // Initialize resolver
         let resolver = DidCheqdResolver::new(DidCheqdResolverConfiguration::default());
-        let did_url = match DidUrl::try_from(Did::try_from(did_url).unwrap()) {
-            Ok(d) => d,
-            Err(e) => {
-                eprintln!("Failed to parse DID Url: {:?}", e);
-                return Ok(None);
-            }
-        };
+        let did_url = DidUrl::from(Did::try_from(did_url).unwrap());
 
         // If not found in cache, attempt to resolve using did_cheqd crate
         match resolver.resolve_resource(&did_url).await {

--- a/crates/affinidi-messaging/CHANGELOG.md
+++ b/crates/affinidi-messaging/CHANGELOG.md
@@ -8,6 +8,12 @@ we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our
 tooling.
 
+## 8th October 2025
+
+### DIDComm Library (0.11.2)
+
+- **CHORE:** Updated key error messages to be more descriptive and helpful
+
 ## 1st October 2025
 
 ### Mediator (0.11.1)

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'affinidi-messaging-didcomm'
-version = "0.11.1"
+version = "0.11.2"
 description = 'DIDComm for Rust, integrates into Affinidi Messaging. See Affinidi Messaging for a complete communications solution.'
 authors = [
   'Vyacheslav Gudkov <vyacheslav.gudkov@dsr-corporation.com>',

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/document.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/document.rs
@@ -125,7 +125,7 @@ impl AsKnownKeyPair for VerificationMethod {
                         .map(KnownKeyPair::K256),
                     _ => Err(err_msg(
                         ErrorKind::Unsupported,
-                        "Unsupported key type or curve",
+                        format!("Unsupported key type or curve ({})", ec.curve),
                     )),
                 }
             }
@@ -140,7 +140,7 @@ impl AsKnownKeyPair for VerificationMethod {
                         .map(KnownKeyPair::X25519),
                     _ => Err(err_msg(
                         ErrorKind::Unsupported,
-                        "Unsupported key type or curve",
+                        format!("Unsupported key type or curve ({})", okp.curve),
                     )),
                 }
             }
@@ -203,7 +203,10 @@ impl AsKnownKeyPairSecret for Secret {
                     .map(KnownKeyPair::X25519),
                 _ => Err(err_msg(
                     ErrorKind::Unsupported,
-                    "Unsupported key type or curve",
+                    format!(
+                        "Unsupported key type or curve key_type({})",
+                        jwk.get_key_type()
+                    ),
                 )),
             },
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi Secrets Manager
 
+## 8th October 2025 (0.3.1)
+
+- **FIX:** P-256 and P-384 Public point compression was off by a byte causing decrypt
+  failures.
+  - No loss of security as it hard failed to decrypt
+- **FIX:** Incorrect Curve String in JWK representation of public-keys for P-256
+  and P-384
+  - Changed `P256` to `P-256` and `P384` to `P-384`
+- **CHORE:** Additional Unit Tests added (50.77% Coverage)
+
 ## 3rd October 2025 (0.3.0)
 
 - **FEATURE:** `Secret::generate_ed25519()` now allows for creation from optional

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/ed25519.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/ed25519.rs
@@ -154,7 +154,7 @@ pub fn ed25519_public_to_x25519_public_key(
     }
 
     let vk = VerifyingKey::try_from(multicodec.data()).map_err(|e| {
-        SecretsResolverError::KeyError(format!("Couldn't created ED25519 Verifying Key: {}", e))
+        SecretsResolverError::KeyError(format!("Couldn't created ED25519 Verifying Key: {e}"))
     })?;
 
     let x25519 = vk.to_montgomery().to_bytes();

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p256.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p256.rs
@@ -42,7 +42,7 @@ impl Secret {
             secret_material: SecretMaterial::JWK(JWK {
                 key_id: None,
                 params: Params::EC(ECParams {
-                    curve: "P256".to_string(),
+                    curve: "P-256".to_string(),
                     x: BASE64_URL_SAFE_NO_PAD
                         .encode(verifying_key.to_encoded_point(false).x().unwrap()),
                     y: BASE64_URL_SAFE_NO_PAD
@@ -59,7 +59,7 @@ impl Secret {
     /// Generates a Public JWK from a multikey value
     pub fn p256_public_jwk(data: &[u8]) -> Result<JWK, SecretsResolverError> {
         let ep = EncodedPoint::from_bytes(data).map_err(|e| {
-            SecretsResolverError::KeyError(format!("P256 public key isn't valid: {e}"))
+            SecretsResolverError::KeyError(format!("P-256 public key isn't valid: {e}"))
         })?;
 
         // Convert to AffinePoint to validate the point is on the curve
@@ -103,7 +103,7 @@ impl Secret {
 #[cfg(test)]
 mod tests {
     use crate::{
-        jwk::Params,
+        jwk::{JWK, Params},
         secrets::{Secret, SecretMaterial},
     };
     use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
@@ -162,5 +162,11 @@ mod tests {
         } else {
             panic!("Expected EC Params");
         }
+    }
+
+    #[test]
+    fn check_p256_public_multi_encoded() {
+        assert!(JWK::from_multikey("zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169").is_ok());
+        assert!(JWK::from_multikey("zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv").is_ok());
     }
 }

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p384.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p384.rs
@@ -42,7 +42,7 @@ impl Secret {
             secret_material: SecretMaterial::JWK(JWK {
                 key_id: None,
                 params: Params::EC(ECParams {
-                    curve: "P384".to_string(),
+                    curve: "P-384".to_string(),
                     x: BASE64_URL_SAFE_NO_PAD
                         .encode(verifying_key.to_encoded_point(false).x().unwrap()),
                     y: BASE64_URL_SAFE_NO_PAD
@@ -102,7 +102,7 @@ impl Secret {
 #[cfg(test)]
 mod tests {
     use crate::{
-        jwk::Params,
+        jwk::{JWK, Params},
         secrets::{Secret, SecretMaterial},
     };
     use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
@@ -169,5 +169,21 @@ mod tests {
         } else {
             panic!("Expected EC Params");
         }
+    }
+
+    #[test]
+    fn check_p384_public_multi_encoded() {
+        assert!(
+            JWK::from_multikey(
+                "z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
+            )
+            .is_ok()
+        );
+        assert!(
+            JWK::from_multikey(
+                "z82LkvCwHNreneWpsgPEbV3gu1C6NFJEBg4srfJ5gdxEsMGRJUz2sG9FE42shbn2xkZJh54"
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
@@ -231,27 +231,27 @@ impl Secret {
             KeyType::Ed25519 => MultiEncodedBuf::encode_bytes(ED25519_PUB, &self.public_bytes),
             KeyType::X25519 => MultiEncodedBuf::encode_bytes(X25519_PUB, &self.public_bytes),
             KeyType::P256 => {
-                let parity: u8 = if self.public_bytes[63].is_multiple_of(2) {
+                let parity: u8 = if self.public_bytes[64].is_multiple_of(2) {
                     0x02
                 } else {
                     0x03
                 };
                 let mut compressed: [u8; 33] = [0; 33];
                 compressed[0] = parity;
-                for x in self.public_bytes[0..32].iter().enumerate() {
+                for x in self.public_bytes[1..33].iter().enumerate() {
                     compressed[x.0 + 1] = *x.1;
                 }
                 MultiEncodedBuf::encode_bytes(P256_PUB, &compressed)
             }
             KeyType::P384 => {
-                let parity: u8 = if self.public_bytes[95].is_multiple_of(2) {
+                let parity: u8 = if self.public_bytes[96].is_multiple_of(2) {
                     0x02
                 } else {
                     0x03
                 };
                 let mut compressed: [u8; 49] = [0; 49];
                 compressed[0] = parity;
-                for x in self.public_bytes[0..48].iter().enumerate() {
+                for x in self.public_bytes[1..49].iter().enumerate() {
                     compressed[x.0 + 1] = *x.1;
                 }
                 MultiEncodedBuf::encode_bytes(P384_PUB, &compressed)


### PR DESCRIPTION
* Fixing issues

Secrets-Resolver - Incorrect P256/P384 curve string DIDComm Library - Cleaned up error reporting
did-key - Wrong Secret ID being used



* Fixing compression error on P256 and P384



* Adding test on did-key create



* Minor changes, versions updated



* Removing dev-dependency



* Fixing code linting



---------