### PR TITLE
Fixing secp256k1 name error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.6.2", path = "crates/affinidi-d
 ] }
 affinidi-did-resolver-cache-server = { version = "0.6.1", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-server" }
 did-example = { version = "0.5.5", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-example" }
-did-peer = { version = "0.7.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
+did-peer = { version = "0.7.3", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer" }
 did-cheqd = { version = "0.1.0", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-cheqd" }
 affinidi-did-key = { version = "0.1.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-methods/affinidi-did-key" }
 affinidi-meeting-place = { version = "0.2.0", path = "./crates/affinidi-meeting-place" }
@@ -60,7 +60,7 @@ affinidi-messaging-mediator-common = { version = "0.11.0", path = "./crates/affi
 affinidi-messaging-mediator-processors = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors" }
 affinidi-messaging-sdk = { version = "0.12.0", path = "./crates/affinidi-messaging/affinidi-messaging-sdk" }
 affinidi-messaging-text-client = { version = "0.11.0", path = "./crates/affinidi-messaging/affinidi-messaging-text-client" }
-affinidi-tdk = { version = "0.2.1", path = "./crates/affinidi-tdk/affinidi-tdk" }
+affinidi-tdk = { version = "0.2.2", path = "./crates/affinidi-tdk/affinidi-tdk" }
 affinidi-data-integrity = { version = "0.2.3", path = "./crates/affinidi-tdk/common/affinidi-data-integrity" }
 affinidi-did-authentication = { version = "0.2.1", path = "./crates/affinidi-tdk/common/affinidi-did-authentication" }
 affinidi-secrets-resolver = { version = "0.3.2", path = "./crates/affinidi-tdk/common/affinidi-secrets-resolver" }

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Changelog history
 
+### 9th October 2025
+
+## did-peer (0.7.3)
+
+- **FIX:** secp256k1 keys were incorrectly using `Secp256k1` in some situations
+  instead of `secp256k1`
+
 ### 8th October 2025
 
 ## affinidi-did-key (0.1.2)
@@ -15,7 +22,8 @@
 
 ## affinidi-did-resolver-cache-sdk (0.6.2)
 
-- **IMPROVEMENT:** `did-cheqd` and `did-webvh` moved behind feature flags, helps with managing complex dependencies as needed
+- **IMPROVEMENT:** `did-cheqd` and `did-webvh` moved behind feature flags, helps
+  with managing complex dependencies as needed
 - **CHORE:** Improved README documentation and feature flags
 
 ### 3rd October 2025

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-peer"
-version = "0.7.2"
+version = "0.7.3"
 description = "Implementation of the did:peer method in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/www/did-peer.js
+++ b/crates/affinidi-did-resolver/affinidi-did-resolver-methods/did-peer/www/did-peer.js
@@ -187,7 +187,7 @@ window.createDID = function createDID() {
             case "Ed25519":
                 keyType = wasm.DIDPeerKeyType.Ed25519;
                 break;
-            case "Secp256K1":
+            case "secp256K1":
                 keyType = wasm.DIDPeerKeyType.Secp256k1;
                 break;
             case "P256":

--- a/crates/affinidi-tdk/CHANGELOG.md
+++ b/crates/affinidi-tdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Affinidi TDK Changelog
 
+## 9th October 2025 (Release 0.2.2)
+
+- **FIX:** Crypto handling improved for Elliptic Curves
+  - Key algo names incorrectly capitalized
+
 ## 30th September 2025 (Release 0.2.0)
 
 - **IMPROVEMENT:** Removed SSI crate dependencies

--- a/crates/affinidi-tdk/affinidi-tdk/Cargo.toml
+++ b/crates/affinidi-tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.2.1"
+version = "0.2.2"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/affinidi-tdk/affinidi-tdk/src/dids/mod.rs
+++ b/crates/affinidi-tdk/affinidi-tdk/src/dids/mod.rs
@@ -48,7 +48,7 @@ impl Display for KeyType {
             KeyType::P256 => write!(f, "P-256"),
             KeyType::P384 => write!(f, "P-384"),
             KeyType::Ed25519 => write!(f, "ED25519"),
-            KeyType::Secp256k1 => write!(f, "Secp256k1"),
+            KeyType::Secp256k1 => write!(f, "secp256k1"),
         }
     }
 }


### PR DESCRIPTION
ensuring secp256k1 name is lowercase everywhere. Was `Secp256k1` in some cases

did-peer -> 0.7.3
affinidi-tdk -> 0.2.2