### PR TITLE
feat: switched to generic_array 1

### DIFF
--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -36,6 +36,7 @@ varint = "0.9"
 tokio = { version = "1.48", features = ["rt", "macros"] }
 tracing = { version = "0.1", features = ["valuable"] }
 uuid = { version = "1.18", features = ["v4", "fast-rng"] }
+generic-array = { version = "1", features = ["compat-0_14"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["async_futures"] }

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/jwe/encrypt.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/jwe/encrypt.rs
@@ -6,6 +6,7 @@ use askar_crypto::{
     repr::{KeyGen, ToSecretBytes},
 };
 use base64::prelude::*;
+use generic_array::GenericArray;
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -115,7 +116,7 @@ where
                 key,
                 alg.as_str().as_bytes(),
                 skid.as_ref().map(|s| s.as_bytes()).unwrap_or(&[]),
-                apv.as_slice(),
+                GenericArray::from_0_14(apv).as_slice(),
                 tag_raw,
                 false,
             )

--- a/crates/affinidi-messaging/affinidi-messaging-didcomm/src/jwe/parse.rs
+++ b/crates/affinidi-messaging/affinidi-messaging-didcomm/src/jwe/parse.rs
@@ -9,6 +9,7 @@ use crate::{
 use affinidi_did_common::document::DocumentExt;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use base64::prelude::*;
+use generic_array::GenericArray;
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
@@ -83,7 +84,7 @@ impl ParsedJWE {
             Sha256::digest(kids.join(".").as_bytes())
         };
 
-        if self.apv != did_comm_apv.as_slice() {
+        if self.apv != GenericArray::from_0_14(did_comm_apv).as_slice() {
             Err(err_msg(ErrorKind::Malformed, "APV mismatch"))?;
         }
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/Cargo.toml
@@ -48,6 +48,7 @@ thiserror = "2.0"
 unsigned-varint = "0.8"
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 zeroize = "1.8"
+generic-array = { version = "1", features = ["compat-0_14"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # This can be updated to 0.3 when other dependencies are updated to getrandom 0.3 (mainly ed25519-dalek crate)

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p256.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p256.rs
@@ -4,6 +4,7 @@ use crate::{
     secrets::{KeyType, Secret, SecretMaterial, SecretType},
 };
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use generic_array::GenericArray;
 use p256::{
     AffinePoint, EncodedPoint,
     ecdsa::{SigningKey, VerifyingKey},
@@ -78,18 +79,24 @@ impl Secret {
             curve: "P-256".to_string(),
             d: None,
             x: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.x()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.x()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
             y: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.y()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.y()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
         };
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p384.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p384.rs
@@ -4,6 +4,7 @@ use crate::{
     secrets::{KeyType, Secret, SecretMaterial, SecretType},
 };
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use generic_array::GenericArray;
 use p384::{
     AffinePoint, EncodedPoint,
     ecdsa::{SigningKey, VerifyingKey},
@@ -77,18 +78,24 @@ impl Secret {
             curve: "P-384".to_string(),
             d: None,
             x: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.x()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.x()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
             y: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.y()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.y()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
         };
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/secp256k1.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/secp256k1.rs
@@ -4,6 +4,7 @@ use crate::{
     secrets::{KeyType, Secret, SecretMaterial, SecretType},
 };
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use generic_array::GenericArray;
 use k256::{
     AffinePoint, EncodedPoint,
     ecdsa::{SigningKey, VerifyingKey},
@@ -80,18 +81,24 @@ impl Secret {
             curve: "secp256k1".to_string(),
             d: None,
             x: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.x()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.x()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get X coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
             y: BASE64_URL_SAFE_NO_PAD.encode(
-                ep.y()
-                    .ok_or_else(|| {
-                        SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
-                    })?
-                    .as_slice(),
+                GenericArray::from_0_14(
+                    ep.y()
+                        .ok_or_else(|| {
+                            SecretsResolverError::KeyError("Couldn't get Y coordinate".to_string())
+                        })?
+                        .to_owned(),
+                )
+                .as_slice(),
             ),
         };
 

--- a/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/affinidi-tdk/common/affinidi-secrets-resolver/src/secrets.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use base58::ToBase58;
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use generic_array::GenericArray;
 use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -292,11 +293,12 @@ impl Secret {
     pub fn base58_hash_string(key: &str) -> Result<String> {
         let hash = Sha256::digest(key.as_bytes());
         // SHA_256 code = 0x12
-        let hash_encoded = Multihash::<32>::wrap(0x12, hash.as_slice()).map_err(|e| {
-            SecretsResolverError::KeyError(format!(
-                "Couldn't create multihash encoding for Public Key. Reason: {e}",
-            ))
-        })?;
+        let hash_encoded = Multihash::<32>::wrap(0x12, GenericArray::from_0_14(hash).as_slice())
+            .map_err(|e| {
+                SecretsResolverError::KeyError(format!(
+                    "Couldn't create multihash encoding for Public Key. Reason: {e}",
+                ))
+            })?;
         Ok(hash_encoded.to_bytes().to_base58())
     }
 


### PR DESCRIPTION
Fixes:

```
warning: use of deprecated method `sha2::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
Warning:   --> crates/affinidi-tdk/common/affinidi-secrets-resolver/src/crypto/p256.rs:85:22
   |
85 |                     .as_slice(),
   |                      ^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

```