### PR TITLE
fix: Adding serde support for Url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ publish = true
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-affinidi-did-common = { version = "0.1.4", path = "crates/affinidi-did-resolver/affinidi-did-common" }
+affinidi-did-common = { version = "0.1.5", path = "crates/affinidi-did-resolver/affinidi-did-common" }
 affinidi-did-resolver-cache-sdk = { version = "0.6.5", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk", features = [
   "network",
 ] }

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Changelog history
 
+### 6th January 2026
+
+#### affinidi-did-common (0.1.5)
+
+- **FIX:** serde support was not enabled for `Url` type, causing compile errors
+
 ### 4th December 2025
 
 #### affinidi-did-resolver-cache-sdk (0.6.5)

--- a/crates/affinidi-did-resolver/affinidi-did-common/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.1.4"
+version = "0.1.5"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true
@@ -19,4 +19,4 @@ affinidi-secrets-resolver.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-url = "2.5"
+url = { version = "2.5", features = ["serde"] }


### PR DESCRIPTION
Serde support was dropped from Url Crate somehow. Adding ti back in via a feature flag