### PR TITLE
affinidi-did-common 0.3.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ publish = true
 rust-version = "1.90.0"
 
 [workspace.dependencies]
-affinidi-did-common = { version = "0.3.1", path = "crates/affinidi-did-resolver/affinidi-did-common" }
+affinidi-did-common = { version = "0.3.2", path = "crates/affinidi-did-resolver/affinidi-did-common" }
 affinidi-did-resolver-cache-sdk = { version = "0.7.2", path = "crates/affinidi-did-resolver/affinidi-did-resolver-cache-sdk", features = [
   "network",
 ] }

--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Changelog history
 
+### 5th February 2026
+
+#### affinidi-did-common (0.3.2)
+
+- **FEATURE:** Builder pattern for programmatic DID Document construction
+  - `DocumentBuilder` — fluent API for building `Document` with context helpers,
+    verification methods, relationships, services, and arbitrary parameters
+  - `VerificationMethodBuilder` — fluent API for building `VerificationMethod`
+    with convenience methods for `publicKeyMultibase` and `publicKeyJwk`
+  - `ServiceBuilder` — fluent API for building `Service` per the
+    [CID spec](https://www.w3.org/TR/cid-1.0/#services), supporting URL, map,
+    and raw `Endpoint` constructors
+  - All three builders are re-exported from the crate root
+- **DOCS:** README updated with usage examples for building DID Documents with
+  services
+- **TESTS:** 102 new unit tests across the crate covering previously untested
+  modules
+  - `one_or_many` — 37 tests for all public methods, iterators, and serde
+  - `service` — 17 tests for `Endpoint::get_uri`, `get_uris`,
+    `Document::find_service`, and type deserialization
+  - `verification_method` — 8 tests for `get_id`, error cases, and serde
+  - `did_method` — 4 tests for `DIDMethod::name`, `identifier`, and `Display`
+  - `did_method::peer` — 32 tests for enum conversions, `PeerCreateKey`,
+    endpoint format conversions, and `PeerService` encode/decode/to_did_service
+  - `lib` — 4 tests for `Document::new`, `Default`, and serde roundtrip
+
 ### 1st February 2026
 
 #### did-scid (0.1.1)

--- a/crates/affinidi-did-resolver/affinidi-did-common/Cargo.toml
+++ b/crates/affinidi-did-resolver/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.1"
+version = "0.3.2"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true
@@ -34,4 +34,3 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 [lints]
 workspace = true
-

--- a/crates/affinidi-did-resolver/affinidi-did-common/README.md
+++ b/crates/affinidi-did-resolver/affinidi-did-common/README.md
@@ -6,3 +6,75 @@ Contains common structs, traits and methods relating to Decentralized Identifier
 ## Prerequisites
 
 Rust version 1.90
+
+## Building DID Documents
+
+The crate provides builder types (`DocumentBuilder`, `VerificationMethodBuilder`,
+`ServiceBuilder`) for ergonomic, programmatic construction of DID Documents.
+
+### Creating a DID Document with a Service
+
+```rust
+use affinidi_did_common::{DocumentBuilder, ServiceBuilder, VerificationMethodBuilder};
+use serde_json::json;
+
+// 1. Build a verification method
+let vm = VerificationMethodBuilder::new(
+    "did:example:123#key-1",
+    "Multikey",
+    "did:example:123",
+)
+.unwrap()
+.public_key_multibase("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+.build();
+
+// 2. Build a service with a simple URL endpoint
+let linked_domain = ServiceBuilder::new_with_url(
+    "LinkedDomains",
+    "https://example.com",
+)
+.unwrap()
+.id("did:example:123#linked-domain")
+.unwrap()
+.build();
+
+// 3. Build a DIDComm service with a map endpoint and extra properties
+let didcomm = ServiceBuilder::new_with_map(
+    "DIDCommMessaging",
+    json!({
+        "uri": "https://example.com/didcomm",
+        "accept": ["didcomm/v2"],
+        "routingKeys": ["did:example:123#key-1"]
+    }),
+)
+.id("did:example:123#didcomm")
+.unwrap()
+.build();
+
+// 4. Assemble the full document
+let doc = DocumentBuilder::new("did:example:123")
+    .unwrap()
+    .context_did_v1()
+    .context_multikey_v1()
+    .verification_method(vm)
+    .authentication_reference("did:example:123#key-1")
+    .unwrap()
+    .assertion_method_reference("did:example:123#key-1")
+    .unwrap()
+    .service(linked_domain)
+    .service(didcomm)
+    .build();
+
+assert_eq!(doc.service.len(), 2);
+```
+
+### Service endpoint variants
+
+The `ServiceBuilder` supports both endpoint forms defined by the
+[CID specification](https://www.w3.org/TR/cid-1.0/#services):
+
+| Endpoint form | Constructor |
+|---|---|
+| Single URL string | `ServiceBuilder::new_with_url("type", "https://...")` |
+| Map or ordered set | `ServiceBuilder::new_with_map("type", json!({...}))` |
+| Pre-built `Endpoint` | `ServiceBuilder::new("type", endpoint)` |

--- a/crates/affinidi-did-resolver/affinidi-did-common/src/builder.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-common/src/builder.rs
@@ -1,0 +1,788 @@
+//! Builder pattern for DID Documents and Verification Methods
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use url::Url;
+
+use crate::{
+    Document, DocumentError,
+    service::{Endpoint, Service},
+    verification_method::{VerificationMethod, VerificationRelationship},
+};
+
+/// Builder for constructing a [`Document`] using a fluent API.
+pub struct DocumentBuilder {
+    id: Url,
+    verification_method: Vec<VerificationMethod>,
+    authentication: Vec<VerificationRelationship>,
+    assertion_method: Vec<VerificationRelationship>,
+    key_agreement: Vec<VerificationRelationship>,
+    capability_invocation: Vec<VerificationRelationship>,
+    capability_delegation: Vec<VerificationRelationship>,
+    service: Vec<Service>,
+    parameters_set: HashMap<String, Value>,
+}
+
+impl DocumentBuilder {
+    /// Create a new builder with the given DID identifier.
+    ///
+    /// The `id` string is parsed as a URL; returns an error if parsing fails.
+    pub fn new(id: &str) -> Result<Self, DocumentError> {
+        Ok(Self::from_url(Url::parse(id)?))
+    }
+
+    /// Create a new builder from a pre-parsed [`Url`].
+    pub fn from_url(id: Url) -> Self {
+        Self {
+            id,
+            verification_method: Vec::new(),
+            authentication: Vec::new(),
+            assertion_method: Vec::new(),
+            key_agreement: Vec::new(),
+            capability_invocation: Vec::new(),
+            capability_delegation: Vec::new(),
+            service: Vec::new(),
+            parameters_set: HashMap::new(),
+        }
+    }
+
+    /// Set an arbitrary `@context` value, replacing any existing context.
+    pub fn context(mut self, value: Value) -> Self {
+        self.parameters_set
+            .insert("@context".to_string(), value);
+        self
+    }
+
+    /// Append a context URL string to the `@context` array, deduplicating.
+    fn append_context(mut self, ctx: &str) -> Self {
+        let entry = self
+            .parameters_set
+            .entry("@context".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+
+        if let Value::Array(arr) = entry {
+            let val = Value::String(ctx.to_string());
+            if !arr.contains(&val) {
+                arr.push(val);
+            }
+        }
+        self
+    }
+
+    /// Add `https://www.w3.org/ns/did/v1` to `@context`.
+    pub fn context_did_v1(self) -> Self {
+        self.append_context("https://www.w3.org/ns/did/v1")
+    }
+
+    /// Add `https://w3id.org/security/multikey/v1` to `@context`.
+    pub fn context_multikey_v1(self) -> Self {
+        self.append_context("https://w3id.org/security/multikey/v1")
+    }
+
+    /// Add `https://www.w3.org/ns/did/v1.1` to `@context`.
+    pub fn context_did_v1_1(self) -> Self {
+        self.append_context("https://www.w3.org/ns/did/v1.1")
+    }
+
+    /// Add a single verification method.
+    pub fn verification_method(mut self, vm: VerificationMethod) -> Self {
+        self.verification_method.push(vm);
+        self
+    }
+
+    /// Add multiple verification methods.
+    pub fn verification_methods(mut self, vms: Vec<VerificationMethod>) -> Self {
+        self.verification_method.extend(vms);
+        self
+    }
+
+    // --- Authentication ---
+
+    /// Add a URL reference to `authentication`.
+    pub fn authentication_reference(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.authentication
+            .push(VerificationRelationship::Reference(Url::parse(url)?));
+        Ok(self)
+    }
+
+    /// Add an embedded verification method to `authentication`.
+    pub fn authentication_embedded(mut self, vm: VerificationMethod) -> Self {
+        self.authentication
+            .push(VerificationRelationship::VerificationMethod(Box::new(vm)));
+        self
+    }
+
+    /// Add a pre-built [`VerificationRelationship`] to `authentication`.
+    pub fn authentication(mut self, rel: VerificationRelationship) -> Self {
+        self.authentication.push(rel);
+        self
+    }
+
+    // --- Assertion Method ---
+
+    /// Add a URL reference to `assertion_method`.
+    pub fn assertion_method_reference(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.assertion_method
+            .push(VerificationRelationship::Reference(Url::parse(url)?));
+        Ok(self)
+    }
+
+    /// Add an embedded verification method to `assertion_method`.
+    pub fn assertion_method_embedded(mut self, vm: VerificationMethod) -> Self {
+        self.assertion_method
+            .push(VerificationRelationship::VerificationMethod(Box::new(vm)));
+        self
+    }
+
+    /// Add a pre-built [`VerificationRelationship`] to `assertion_method`.
+    pub fn assertion_method(mut self, rel: VerificationRelationship) -> Self {
+        self.assertion_method.push(rel);
+        self
+    }
+
+    // --- Key Agreement ---
+
+    /// Add a URL reference to `key_agreement`.
+    pub fn key_agreement_reference(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.key_agreement
+            .push(VerificationRelationship::Reference(Url::parse(url)?));
+        Ok(self)
+    }
+
+    /// Add an embedded verification method to `key_agreement`.
+    pub fn key_agreement_embedded(mut self, vm: VerificationMethod) -> Self {
+        self.key_agreement
+            .push(VerificationRelationship::VerificationMethod(Box::new(vm)));
+        self
+    }
+
+    /// Add a pre-built [`VerificationRelationship`] to `key_agreement`.
+    pub fn key_agreement(mut self, rel: VerificationRelationship) -> Self {
+        self.key_agreement.push(rel);
+        self
+    }
+
+    // --- Capability Invocation ---
+
+    /// Add a URL reference to `capability_invocation`.
+    pub fn capability_invocation_reference(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.capability_invocation
+            .push(VerificationRelationship::Reference(Url::parse(url)?));
+        Ok(self)
+    }
+
+    /// Add an embedded verification method to `capability_invocation`.
+    pub fn capability_invocation_embedded(mut self, vm: VerificationMethod) -> Self {
+        self.capability_invocation
+            .push(VerificationRelationship::VerificationMethod(Box::new(vm)));
+        self
+    }
+
+    /// Add a pre-built [`VerificationRelationship`] to `capability_invocation`.
+    pub fn capability_invocation(mut self, rel: VerificationRelationship) -> Self {
+        self.capability_invocation.push(rel);
+        self
+    }
+
+    // --- Capability Delegation ---
+
+    /// Add a URL reference to `capability_delegation`.
+    pub fn capability_delegation_reference(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.capability_delegation
+            .push(VerificationRelationship::Reference(Url::parse(url)?));
+        Ok(self)
+    }
+
+    /// Add an embedded verification method to `capability_delegation`.
+    pub fn capability_delegation_embedded(mut self, vm: VerificationMethod) -> Self {
+        self.capability_delegation
+            .push(VerificationRelationship::VerificationMethod(Box::new(vm)));
+        self
+    }
+
+    /// Add a pre-built [`VerificationRelationship`] to `capability_delegation`.
+    pub fn capability_delegation(mut self, rel: VerificationRelationship) -> Self {
+        self.capability_delegation.push(rel);
+        self
+    }
+
+    // --- Services ---
+
+    /// Add a single service.
+    pub fn service(mut self, svc: Service) -> Self {
+        self.service.push(svc);
+        self
+    }
+
+    /// Add multiple services.
+    pub fn services(mut self, svcs: Vec<Service>) -> Self {
+        self.service.extend(svcs);
+        self
+    }
+
+    /// Set an arbitrary parameter in the document's flattened parameter set.
+    pub fn parameter(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.parameters_set.insert(key.into(), value);
+        self
+    }
+
+    /// Consume the builder and produce a [`Document`].
+    pub fn build(self) -> Document {
+        Document {
+            id: self.id,
+            verification_method: self.verification_method,
+            authentication: self.authentication,
+            assertion_method: self.assertion_method,
+            key_agreement: self.key_agreement,
+            capability_invocation: self.capability_invocation,
+            capability_delegation: self.capability_delegation,
+            service: self.service,
+            parameters_set: self.parameters_set,
+        }
+    }
+}
+
+/// Builder for constructing a [`VerificationMethod`] using a fluent API.
+pub struct VerificationMethodBuilder {
+    id: Url,
+    type_: String,
+    controller: Url,
+    expires: Option<String>,
+    revoked: Option<String>,
+    property_set: HashMap<String, Value>,
+}
+
+impl VerificationMethodBuilder {
+    /// Create a new builder with required fields.
+    ///
+    /// Parses `id` and `controller` as URLs; returns an error if parsing fails.
+    pub fn new(id: &str, type_: &str, controller: &str) -> Result<Self, DocumentError> {
+        Ok(Self::from_urls(
+            Url::parse(id)?,
+            type_.to_string(),
+            Url::parse(controller)?,
+        ))
+    }
+
+    /// Create a new builder from pre-parsed values.
+    pub fn from_urls(id: Url, type_: String, controller: Url) -> Self {
+        Self {
+            id,
+            type_,
+            controller,
+            expires: None,
+            revoked: None,
+            property_set: HashMap::new(),
+        }
+    }
+
+    /// Set the `expires` field.
+    pub fn expires(mut self, s: impl Into<String>) -> Self {
+        self.expires = Some(s.into());
+        self
+    }
+
+    /// Set the `revoked` field.
+    pub fn revoked(mut self, s: impl Into<String>) -> Self {
+        self.revoked = Some(s.into());
+        self
+    }
+
+    /// Set an arbitrary property.
+    pub fn property(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.property_set.insert(key.into(), value);
+        self
+    }
+
+    /// Set multiple properties at once.
+    pub fn properties(mut self, map: HashMap<String, Value>) -> Self {
+        self.property_set.extend(map);
+        self
+    }
+
+    /// Convenience: set `publicKeyMultibase`.
+    pub fn public_key_multibase(self, s: impl Into<String>) -> Self {
+        self.property("publicKeyMultibase", Value::String(s.into()))
+    }
+
+    /// Convenience: set `publicKeyJwk`.
+    pub fn public_key_jwk(self, value: Value) -> Self {
+        self.property("publicKeyJwk", value)
+    }
+
+    /// Consume the builder and produce a [`VerificationMethod`].
+    pub fn build(self) -> VerificationMethod {
+        VerificationMethod {
+            id: self.id,
+            type_: self.type_,
+            controller: self.controller,
+            expires: self.expires,
+            revoked: self.revoked,
+            property_set: self.property_set,
+        }
+    }
+}
+
+/// Builder for constructing a [`Service`] using a fluent API.
+///
+/// Per the [CID spec](https://www.w3.org/TR/cid-1.0/#services), a service requires
+/// `type` (one or more strings) and `serviceEndpoint`. The `id` is optional.
+pub struct ServiceBuilder {
+    id: Option<Url>,
+    type_: Vec<String>,
+    service_endpoint: Endpoint,
+    property_set: HashMap<String, Value>,
+}
+
+impl ServiceBuilder {
+    /// Create a new builder with the required `type` and `serviceEndpoint`.
+    ///
+    /// `type_` is the initial service type string (at least one is required).
+    /// `endpoint` is the service endpoint.
+    pub fn new(type_: impl Into<String>, endpoint: Endpoint) -> Self {
+        Self {
+            id: None,
+            type_: vec![type_.into()],
+            service_endpoint: endpoint,
+            property_set: HashMap::new(),
+        }
+    }
+
+    /// Convenience: create a builder with a URL string endpoint.
+    ///
+    /// Parses `endpoint_url` as a URL; returns an error if parsing fails.
+    pub fn new_with_url(
+        type_: impl Into<String>,
+        endpoint_url: &str,
+    ) -> Result<Self, DocumentError> {
+        Ok(Self::new(type_, Endpoint::Url(Url::parse(endpoint_url)?)))
+    }
+
+    /// Convenience: create a builder with a map/JSON endpoint.
+    pub fn new_with_map(type_: impl Into<String>, endpoint_map: Value) -> Self {
+        Self::new(type_, Endpoint::Map(endpoint_map))
+    }
+
+    /// Set the optional `id` field by parsing a URL string.
+    pub fn id(mut self, url: &str) -> Result<Self, DocumentError> {
+        self.id = Some(Url::parse(url)?);
+        Ok(self)
+    }
+
+    /// Set the optional `id` field from a pre-parsed [`Url`].
+    pub fn id_url(mut self, url: Url) -> Self {
+        self.id = Some(url);
+        self
+    }
+
+    /// Add an additional type string.
+    pub fn add_type(mut self, type_: impl Into<String>) -> Self {
+        self.type_.push(type_.into());
+        self
+    }
+
+    /// Replace the type list with the given types.
+    pub fn types(mut self, types: Vec<String>) -> Self {
+        self.type_ = types;
+        self
+    }
+
+    /// Set an arbitrary property.
+    pub fn property(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.property_set.insert(key.into(), value);
+        self
+    }
+
+    /// Set multiple properties at once.
+    pub fn properties(mut self, map: HashMap<String, Value>) -> Self {
+        self.property_set.extend(map);
+        self
+    }
+
+    /// Consume the builder and produce a [`Service`].
+    pub fn build(self) -> Service {
+        Service {
+            id: self.id,
+            type_: self.type_,
+            service_endpoint: self.service_endpoint,
+            property_set: self.property_set,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn minimal_document_build() {
+        let doc = DocumentBuilder::new("did:example:123").unwrap().build();
+        assert_eq!(doc.id.as_str(), "did:example:123");
+        assert!(doc.verification_method.is_empty());
+        assert!(doc.authentication.is_empty());
+        assert!(doc.assertion_method.is_empty());
+        assert!(doc.key_agreement.is_empty());
+        assert!(doc.capability_invocation.is_empty());
+        assert!(doc.capability_delegation.is_empty());
+        assert!(doc.service.is_empty());
+        assert!(doc.parameters_set.is_empty());
+    }
+
+    #[test]
+    fn invalid_id_returns_error() {
+        assert!(DocumentBuilder::new("not a url").is_err());
+    }
+
+    #[test]
+    fn context_convenience_methods() {
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .context_did_v1()
+            .context_multikey_v1()
+            .build();
+
+        let ctx = doc.parameters_set.get("@context").unwrap();
+        let arr = ctx.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0], "https://www.w3.org/ns/did/v1");
+        assert_eq!(arr[1], "https://w3id.org/security/multikey/v1");
+    }
+
+    #[test]
+    fn context_deduplication() {
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .context_did_v1()
+            .context_did_v1()
+            .build();
+
+        let ctx = doc.parameters_set.get("@context").unwrap();
+        let arr = ctx.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn adding_verification_methods() {
+        let vm1 = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let vm2 = VerificationMethodBuilder::new(
+            "did:example:123#key-2",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let vm3 = VerificationMethodBuilder::new(
+            "did:example:123#key-3",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .verification_method(vm1)
+            .verification_methods(vec![vm2, vm3])
+            .build();
+
+        assert_eq!(doc.verification_method.len(), 3);
+    }
+
+    #[test]
+    fn authentication_reference_and_embedded() {
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .authentication_reference("did:example:123#key-1")
+            .unwrap()
+            .authentication_embedded(vm)
+            .build();
+
+        assert_eq!(doc.authentication.len(), 2);
+        assert!(matches!(
+            doc.authentication[0],
+            VerificationRelationship::Reference(_)
+        ));
+        assert!(matches!(
+            doc.authentication[1],
+            VerificationRelationship::VerificationMethod(_)
+        ));
+    }
+
+    #[test]
+    fn assertion_method_reference_and_embedded() {
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .assertion_method_reference("did:example:123#key-1")
+            .unwrap()
+            .assertion_method_embedded(vm)
+            .build();
+
+        assert_eq!(doc.assertion_method.len(), 2);
+    }
+
+    #[test]
+    fn key_agreement_reference_and_embedded() {
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .key_agreement_reference("did:example:123#key-1")
+            .unwrap()
+            .key_agreement_embedded(vm)
+            .build();
+
+        assert_eq!(doc.key_agreement.len(), 2);
+    }
+
+    #[test]
+    fn full_chained_build() {
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .public_key_multibase("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .context_did_v1()
+            .context_multikey_v1()
+            .verification_method(vm)
+            .authentication_reference("did:example:123#key-1")
+            .unwrap()
+            .assertion_method_reference("did:example:123#key-1")
+            .unwrap()
+            .key_agreement_reference("did:example:123#key-1")
+            .unwrap()
+            .capability_invocation_reference("did:example:123#key-1")
+            .unwrap()
+            .capability_delegation_reference("did:example:123#key-1")
+            .unwrap()
+            .parameter("custom", json!("value"))
+            .build();
+
+        assert_eq!(doc.id.as_str(), "did:example:123");
+        assert_eq!(doc.verification_method.len(), 1);
+        assert_eq!(doc.authentication.len(), 1);
+        assert_eq!(doc.assertion_method.len(), 1);
+        assert_eq!(doc.key_agreement.len(), 1);
+        assert_eq!(doc.capability_invocation.len(), 1);
+        assert_eq!(doc.capability_delegation.len(), 1);
+        assert_eq!(
+            doc.parameters_set.get("custom").unwrap(),
+            &json!("value")
+        );
+    }
+
+    #[test]
+    fn verification_method_builder_minimal() {
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .build();
+
+        assert_eq!(vm.id.as_str(), "did:example:123#key-1");
+        assert_eq!(vm.type_, "Multikey");
+        assert_eq!(vm.controller.as_str(), "did:example:123");
+        assert!(vm.expires.is_none());
+        assert!(vm.revoked.is_none());
+        assert!(vm.property_set.is_empty());
+    }
+
+    #[test]
+    fn verification_method_builder_with_properties() {
+        let mut extra = HashMap::new();
+        extra.insert("extra".to_string(), json!("data"));
+
+        let vm = VerificationMethodBuilder::new(
+            "did:example:123#key-1",
+            "Multikey",
+            "did:example:123",
+        )
+        .unwrap()
+        .public_key_multibase("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+        .public_key_jwk(json!({"kty": "OKP"}))
+        .expires("2025-12-31T00:00:00Z")
+        .revoked("2025-06-01T00:00:00Z")
+        .properties(extra)
+        .build();
+
+        assert!(vm.property_set.contains_key("publicKeyMultibase"));
+        assert!(vm.property_set.contains_key("publicKeyJwk"));
+        assert!(vm.property_set.contains_key("extra"));
+        assert_eq!(vm.expires.as_deref(), Some("2025-12-31T00:00:00Z"));
+        assert_eq!(vm.revoked.as_deref(), Some("2025-06-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn verification_method_builder_invalid_id() {
+        assert!(VerificationMethodBuilder::new("not a url", "Multikey", "did:example:123").is_err());
+    }
+
+    // --- ServiceBuilder tests ---
+
+    #[test]
+    fn service_builder_minimal_with_url_endpoint() {
+        let svc = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .build();
+
+        assert!(svc.id.is_none());
+        assert_eq!(svc.type_, vec!["LinkedDomains"]);
+        assert_eq!(
+            svc.service_endpoint,
+            Endpoint::Url(Url::parse("https://example.com").unwrap())
+        );
+        assert!(svc.property_set.is_empty());
+    }
+
+    #[test]
+    fn service_builder_with_map_endpoint() {
+        let map = json!({"uri": "https://example.com", "accept": ["didcomm/v2"]});
+        let svc = ServiceBuilder::new_with_map("DIDCommMessaging", map.clone()).build();
+
+        assert_eq!(svc.service_endpoint, Endpoint::Map(map));
+    }
+
+    #[test]
+    fn service_builder_with_id() {
+        let svc = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .id("did:example:123#linked-domain")
+        .unwrap()
+        .build();
+
+        assert_eq!(
+            svc.id.as_ref().unwrap().as_str(),
+            "did:example:123#linked-domain"
+        );
+    }
+
+    #[test]
+    fn service_builder_invalid_id_returns_error() {
+        let result = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .id("not a url");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn service_builder_invalid_endpoint_url_returns_error() {
+        assert!(ServiceBuilder::new_with_url("LinkedDomains", "not a url").is_err());
+    }
+
+    #[test]
+    fn service_builder_multiple_types() {
+        let svc = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .add_type("CredentialRepository")
+        .build();
+
+        assert_eq!(svc.type_.len(), 2);
+        assert_eq!(svc.type_[0], "LinkedDomains");
+        assert_eq!(svc.type_[1], "CredentialRepository");
+    }
+
+    #[test]
+    fn service_builder_replace_types() {
+        let svc = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .types(vec!["TypeA".to_string(), "TypeB".to_string()])
+        .build();
+
+        assert_eq!(svc.type_, vec!["TypeA", "TypeB"]);
+    }
+
+    #[test]
+    fn service_builder_with_properties() {
+        let mut extra = HashMap::new();
+        extra.insert("routingKeys".to_string(), json!(["did:example:123#key-1"]));
+
+        let svc = ServiceBuilder::new_with_url(
+            "DIDCommMessaging",
+            "https://example.com/didcomm",
+        )
+        .unwrap()
+        .id("did:example:123#didcomm")
+        .unwrap()
+        .property("accept", json!(["didcomm/v2"]))
+        .properties(extra)
+        .build();
+
+        assert!(svc.property_set.contains_key("accept"));
+        assert!(svc.property_set.contains_key("routingKeys"));
+    }
+
+    #[test]
+    fn service_builder_integrates_with_document_builder() {
+        let svc = ServiceBuilder::new_with_url(
+            "LinkedDomains",
+            "https://example.com",
+        )
+        .unwrap()
+        .id("did:example:123#linked-domain")
+        .unwrap()
+        .build();
+
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .service(svc)
+            .build();
+
+        assert_eq!(doc.service.len(), 1);
+        assert_eq!(doc.service[0].type_, vec!["LinkedDomains"]);
+    }
+}

--- a/crates/affinidi-did-resolver/affinidi-did-common/src/did_method/mod.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-common/src/did_method/mod.rs
@@ -141,3 +141,49 @@ impl fmt::Display for DIDMethod {
         write!(f, "{}", self.name())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::DID;
+
+    #[test]
+    fn name_returns_correct_method() {
+        let cases = [
+            ("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK", "key"),
+            ("did:peer:0z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK", "peer"),
+            ("did:web:example.com", "web"),
+            ("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a", "ethr"),
+            ("did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a", "pkh"),
+            ("did:example:custom123", "example"),
+        ];
+        for (did_str, expected_name) in cases {
+            let did: DID = did_str.parse().unwrap();
+            assert_eq!(did.method().name(), expected_name, "failed for {did_str}");
+        }
+    }
+
+    #[test]
+    fn identifier_returns_raw_id() {
+        let did: DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            did.method().identifier(),
+            "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        );
+    }
+
+    #[test]
+    fn display_matches_name() {
+        let did: DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+            .parse()
+            .unwrap();
+        assert_eq!(format!("{}", did.method()), "key");
+    }
+
+    #[test]
+    fn display_other_method() {
+        let did: DID = "did:example:abc123".parse().unwrap();
+        assert_eq!(format!("{}", did.method()), "example");
+    }
+}

--- a/crates/affinidi-did-resolver/affinidi-did-common/src/lib.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-common/src/lib.rs
@@ -15,6 +15,7 @@ use crate::{
     verification_method::{VerificationMethod, VerificationRelationship},
 };
 
+pub mod builder;
 pub mod did;
 pub mod did_method;
 pub mod document;
@@ -30,6 +31,7 @@ pub use did_method::peer::{
     PeerPurpose, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
     PeerServiceEndpointShort,
 };
+pub use builder::{DocumentBuilder, ServiceBuilder, VerificationMethodBuilder};
 pub use document::DocumentExt;
 
 #[derive(Error, Debug)]
@@ -120,11 +122,39 @@ impl Document {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use url::Url;
 
     #[test]
     fn valid_id() {
         assert!(Url::parse("did:example:123456789abcdefghi").is_ok());
         assert!(Url::parse("did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs").is_ok());
+    }
+
+    #[test]
+    fn document_new_valid() {
+        let doc = Document::new("did:example:123").unwrap();
+        assert_eq!(doc.id.as_str(), "did:example:123");
+        assert!(doc.verification_method.is_empty());
+        assert!(doc.service.is_empty());
+    }
+
+    #[test]
+    fn document_new_invalid() {
+        assert!(Document::new("not a url").is_err());
+    }
+
+    #[test]
+    fn document_default_has_example_id() {
+        let doc = Document::default();
+        assert_eq!(doc.id.as_str(), "did:example:123456789abcdefghi");
+    }
+
+    #[test]
+    fn document_serde_roundtrip_minimal() {
+        let doc = Document::new("did:example:456").unwrap();
+        let json = serde_json::to_string(&doc).unwrap();
+        let back: Document = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc, back);
     }
 }

--- a/crates/affinidi-did-resolver/affinidi-did-common/src/one_or_many.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-common/src/one_or_many.rs
@@ -151,3 +151,279 @@ impl<'a, T> OneOrManyRef<'a, T> {
         matches!(self, Self::Many([]))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- OneOrMany: default ---
+
+    #[test]
+    fn default_is_empty_many() {
+        let v: OneOrMany<i32> = OneOrMany::default();
+        assert!(matches!(v, OneOrMany::Many(ref v) if v.is_empty()));
+    }
+
+    // --- OneOrMany: len ---
+
+    #[test]
+    fn len_one() {
+        assert_eq!(OneOrMany::One(42).len(), 1);
+    }
+
+    #[test]
+    fn len_many() {
+        assert_eq!(OneOrMany::Many(vec![1, 2, 3]).len(), 3);
+    }
+
+    #[test]
+    fn len_many_empty() {
+        assert_eq!(OneOrMany::<i32>::Many(vec![]).len(), 0);
+    }
+
+    // --- OneOrMany: is_empty ---
+
+    #[test]
+    fn is_empty_one_is_false() {
+        assert!(!OneOrMany::One(42).is_empty());
+    }
+
+    #[test]
+    fn is_empty_many_empty() {
+        assert!(OneOrMany::<i32>::Many(vec![]).is_empty());
+    }
+
+    #[test]
+    fn is_empty_many_nonempty() {
+        assert!(!OneOrMany::Many(vec![1]).is_empty());
+    }
+
+    // --- OneOrMany: any ---
+
+    #[test]
+    fn any_one_true() {
+        assert!(OneOrMany::One(42).any(|x| *x == 42));
+    }
+
+    #[test]
+    fn any_one_false() {
+        assert!(!OneOrMany::One(42).any(|x| *x == 99));
+    }
+
+    #[test]
+    fn any_many_true() {
+        assert!(OneOrMany::Many(vec![1, 2, 3]).any(|x| *x == 2));
+    }
+
+    #[test]
+    fn any_many_false() {
+        assert!(!OneOrMany::Many(vec![1, 2, 3]).any(|x| *x == 99));
+    }
+
+    // --- OneOrMany: contains ---
+
+    #[test]
+    fn contains_one_found() {
+        assert!(OneOrMany::One("hello").contains(&"hello"));
+    }
+
+    #[test]
+    fn contains_one_not_found() {
+        assert!(!OneOrMany::One("hello").contains(&"world"));
+    }
+
+    #[test]
+    fn contains_many_found() {
+        assert!(OneOrMany::Many(vec!["a", "b"]).contains(&"b"));
+    }
+
+    #[test]
+    fn contains_many_not_found() {
+        assert!(!OneOrMany::Many(vec!["a", "b"]).contains(&"c"));
+    }
+
+    // --- OneOrMany: as_slice ---
+
+    #[test]
+    fn as_slice_one() {
+        let v = OneOrMany::One(42);
+        assert_eq!(v.as_slice(), &[42]);
+    }
+
+    #[test]
+    fn as_slice_many() {
+        let v = OneOrMany::Many(vec![1, 2]);
+        assert_eq!(v.as_slice(), &[1, 2]);
+    }
+
+    // --- OneOrMany: first ---
+
+    #[test]
+    fn first_one() {
+        assert_eq!(OneOrMany::One(42).first(), Some(&42));
+    }
+
+    #[test]
+    fn first_many() {
+        assert_eq!(OneOrMany::Many(vec![10, 20]).first(), Some(&10));
+    }
+
+    #[test]
+    fn first_many_empty() {
+        assert_eq!(OneOrMany::<i32>::Many(vec![]).first(), None);
+    }
+
+    // --- OneOrMany: to_single ---
+
+    #[test]
+    fn to_single_one() {
+        assert_eq!(OneOrMany::One(42).to_single(), Some(&42));
+    }
+
+    #[test]
+    fn to_single_many_single_element() {
+        assert_eq!(OneOrMany::Many(vec![42]).to_single(), Some(&42));
+    }
+
+    #[test]
+    fn to_single_many_empty() {
+        assert_eq!(OneOrMany::<i32>::Many(vec![]).to_single(), None);
+    }
+
+    // --- OneOrMany: to_single_mut ---
+
+    #[test]
+    fn to_single_mut_one() {
+        let mut v = OneOrMany::One(42);
+        *v.to_single_mut().unwrap() = 99;
+        assert_eq!(v, OneOrMany::One(99));
+    }
+
+    #[test]
+    fn to_single_mut_many() {
+        let mut v = OneOrMany::Many(vec![1, 2]);
+        *v.to_single_mut().unwrap() = 99;
+        assert_eq!(v, OneOrMany::Many(vec![99, 2]));
+    }
+
+    #[test]
+    fn to_single_mut_many_empty() {
+        let mut v = OneOrMany::<i32>::Many(vec![]);
+        assert!(v.to_single_mut().is_none());
+    }
+
+    // --- OneOrMany: into_single ---
+
+    #[test]
+    fn into_single_one() {
+        assert_eq!(OneOrMany::One(42).into_single(), Some(42));
+    }
+
+    #[test]
+    fn into_single_many_single() {
+        assert_eq!(OneOrMany::Many(vec![42]).into_single(), Some(42));
+    }
+
+    #[test]
+    fn into_single_many_multiple() {
+        assert_eq!(OneOrMany::Many(vec![1, 2]).into_single(), None);
+    }
+
+    #[test]
+    fn into_single_many_empty() {
+        assert_eq!(OneOrMany::<i32>::Many(vec![]).into_single(), None);
+    }
+
+    // --- OneOrMany: into_vec ---
+
+    #[test]
+    fn into_vec_one() {
+        assert_eq!(OneOrMany::One(42).into_vec(), vec![42]);
+    }
+
+    #[test]
+    fn into_vec_many() {
+        assert_eq!(OneOrMany::Many(vec![1, 2, 3]).into_vec(), vec![1, 2, 3]);
+    }
+
+    // --- OneOrMany: consuming iterator ---
+
+    #[test]
+    fn into_iter_one() {
+        let v: Vec<i32> = OneOrMany::One(42).into_iter().collect();
+        assert_eq!(v, vec![42]);
+    }
+
+    #[test]
+    fn into_iter_many() {
+        let v: Vec<i32> = OneOrMany::Many(vec![1, 2]).into_iter().collect();
+        assert_eq!(v, vec![1, 2]);
+    }
+
+    // --- OneOrMany: non-consuming iterator ---
+
+    #[test]
+    fn ref_into_iter_one() {
+        let v = OneOrMany::One(42);
+        let refs: Vec<&i32> = (&v).into_iter().collect();
+        assert_eq!(refs, vec![&42]);
+    }
+
+    #[test]
+    fn ref_into_iter_many() {
+        let v = OneOrMany::Many(vec![1, 2]);
+        let refs: Vec<&i32> = (&v).into_iter().collect();
+        assert_eq!(refs, vec![&1, &2]);
+    }
+
+    // --- OneOrMany: serde ---
+
+    #[test]
+    fn serde_one_roundtrip() {
+        let v = OneOrMany::One("hello".to_string());
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, r#""hello""#);
+        let back: OneOrMany<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn serde_many_roundtrip() {
+        let v = OneOrMany::Many(vec!["a".to_string(), "b".to_string()]);
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, r#"["a","b"]"#);
+        let back: OneOrMany<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    // --- OneOrManyRef ---
+
+    #[test]
+    fn from_slice_single() {
+        let data = [42];
+        let r = OneOrManyRef::from_slice(&data);
+        assert!(matches!(r, OneOrManyRef::One(&42)));
+    }
+
+    #[test]
+    fn from_slice_multiple() {
+        let data = [1, 2, 3];
+        let r = OneOrManyRef::from_slice(&data);
+        assert!(matches!(r, OneOrManyRef::Many(&[1, 2, 3])));
+    }
+
+    #[test]
+    fn from_slice_empty() {
+        let data: [i32; 0] = [];
+        let r = OneOrManyRef::from_slice(&data);
+        assert!(matches!(r, OneOrManyRef::Many(&[])));
+    }
+
+    #[test]
+    fn one_or_many_ref_is_empty() {
+        let data: [i32; 0] = [];
+        assert!(OneOrManyRef::from_slice(&data).is_empty());
+        assert!(!OneOrManyRef::from_slice(&[1]).is_empty());
+        assert!(!OneOrManyRef::from_slice(&[1, 2]).is_empty());
+    }
+}

--- a/crates/affinidi-did-resolver/affinidi-did-common/src/service.rs
+++ b/crates/affinidi-did-resolver/affinidi-did-common/src/service.rs
@@ -137,3 +137,206 @@ impl Endpoint {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn make_doc_with_services(services: Vec<Service>) -> Document {
+        Document {
+            id: Url::parse("did:test:1234").unwrap(),
+            verification_method: vec![],
+            authentication: vec![],
+            assertion_method: vec![],
+            key_agreement: vec![],
+            capability_invocation: vec![],
+            capability_delegation: vec![],
+            service: services,
+            parameters_set: HashMap::new(),
+        }
+    }
+
+    // --- Endpoint::get_uri ---
+
+    #[test]
+    fn get_uri_from_url_endpoint() {
+        let ep = Endpoint::Url(Url::parse("https://example.com").unwrap());
+        assert_eq!(ep.get_uri().unwrap(), "https://example.com/");
+    }
+
+    #[test]
+    fn get_uri_from_map_object() {
+        let ep = Endpoint::Map(json!({"uri": "https://example.com"}));
+        assert_eq!(ep.get_uri().unwrap(), "\"https://example.com\"");
+    }
+
+    #[test]
+    fn get_uri_from_map_array() {
+        let ep = Endpoint::Map(json!([
+            {"uri": "https://first.example.com"},
+            {"uri": "https://second.example.com"}
+        ]));
+        assert_eq!(ep.get_uri().unwrap(), "\"https://first.example.com\"");
+    }
+
+    #[test]
+    fn get_uri_from_map_empty_array() {
+        let ep = Endpoint::Map(json!([]));
+        assert!(ep.get_uri().is_none());
+    }
+
+    #[test]
+    fn get_uri_from_map_object_missing_uri_key() {
+        let ep = Endpoint::Map(json!({"endpoint": "https://example.com"}));
+        assert!(ep.get_uri().is_none());
+    }
+
+    #[test]
+    fn get_uri_from_map_non_object_non_array() {
+        let ep = Endpoint::Map(json!("just a string"));
+        assert!(ep.get_uri().is_none());
+    }
+
+    // --- Endpoint::get_uris ---
+
+    #[test]
+    fn get_uris_from_url_endpoint() {
+        let ep = Endpoint::Url(Url::parse("https://example.com").unwrap());
+        assert_eq!(ep.get_uris(), vec!["https://example.com/"]);
+    }
+
+    #[test]
+    fn get_uris_from_map_object() {
+        let ep = Endpoint::Map(json!({"uri": "https://example.com"}));
+        assert_eq!(ep.get_uris(), vec!["\"https://example.com\""]);
+    }
+
+    #[test]
+    fn get_uris_from_map_array() {
+        let ep = Endpoint::Map(json!([
+            {"uri": "https://first.example.com"},
+            {"uri": "https://second.example.com"}
+        ]));
+        let uris = ep.get_uris();
+        assert_eq!(uris.len(), 2);
+        assert!(uris[0].contains("first.example.com"));
+        assert!(uris[1].contains("second.example.com"));
+    }
+
+    #[test]
+    fn get_uris_from_map_array_with_missing_uri() {
+        let ep = Endpoint::Map(json!([
+            {"uri": "https://example.com"},
+            {"other": "no-uri-here"}
+        ]));
+        let uris = ep.get_uris();
+        assert_eq!(uris.len(), 1);
+    }
+
+    #[test]
+    fn get_uris_from_map_empty_array() {
+        let ep = Endpoint::Map(json!([]));
+        assert!(ep.get_uris().is_empty());
+    }
+
+    #[test]
+    fn get_uris_from_map_non_object_non_array() {
+        let ep = Endpoint::Map(json!(42));
+        assert!(ep.get_uris().is_empty());
+    }
+
+    // --- Document::find_service ---
+
+    #[test]
+    fn find_service_found() {
+        let svc = Service {
+            id: Some(Url::parse("did:test:1234#my-service").unwrap()),
+            type_: vec!["LinkedDomains".to_string()],
+            service_endpoint: Endpoint::Url(Url::parse("https://example.com").unwrap()),
+            property_set: HashMap::new(),
+        };
+        let doc = make_doc_with_services(vec![svc]);
+        assert!(doc.find_service("my-service").is_some());
+    }
+
+    #[test]
+    fn find_service_not_found() {
+        let svc = Service {
+            id: Some(Url::parse("did:test:1234#my-service").unwrap()),
+            type_: vec!["LinkedDomains".to_string()],
+            service_endpoint: Endpoint::Url(Url::parse("https://example.com").unwrap()),
+            property_set: HashMap::new(),
+        };
+        let doc = make_doc_with_services(vec![svc]);
+        assert!(doc.find_service("other-service").is_none());
+    }
+
+    #[test]
+    fn find_service_no_id() {
+        let svc = Service {
+            id: None,
+            type_: vec!["LinkedDomains".to_string()],
+            service_endpoint: Endpoint::Url(Url::parse("https://example.com").unwrap()),
+            property_set: HashMap::new(),
+        };
+        let doc = make_doc_with_services(vec![svc]);
+        assert!(doc.find_service("anything").is_none());
+    }
+
+    #[test]
+    fn find_service_empty_services() {
+        let doc = make_doc_with_services(vec![]);
+        assert!(doc.find_service("anything").is_none());
+    }
+
+    // --- Service deserialization (type as string or array) ---
+
+    #[test]
+    fn deserialize_service_type_as_string() {
+        let json = r#"{
+            "type": "LinkedDomains",
+            "serviceEndpoint": "https://example.com"
+        }"#;
+        let svc: Service = serde_json::from_str(json).unwrap();
+        assert_eq!(svc.type_, vec!["LinkedDomains"]);
+    }
+
+    #[test]
+    fn deserialize_service_type_as_array() {
+        let json = r#"{
+            "type": ["LinkedDomains", "CredentialRepository"],
+            "serviceEndpoint": "https://example.com"
+        }"#;
+        let svc: Service = serde_json::from_str(json).unwrap();
+        assert_eq!(svc.type_.len(), 2);
+        assert_eq!(svc.type_[0], "LinkedDomains");
+        assert_eq!(svc.type_[1], "CredentialRepository");
+    }
+
+    #[test]
+    fn deserialize_service_with_map_endpoint() {
+        let json = r#"{
+            "id": "did:test:1234#svc",
+            "type": "DIDCommMessaging",
+            "serviceEndpoint": {"uri": "https://example.com/didcomm", "accept": ["didcomm/v2"]}
+        }"#;
+        let svc: Service = serde_json::from_str(json).unwrap();
+        assert!(svc.id.is_some());
+        assert!(matches!(svc.service_endpoint, Endpoint::Map(_)));
+    }
+
+    #[test]
+    fn serialize_service_roundtrip() {
+        let svc = Service {
+            id: Some(Url::parse("did:test:1234#svc").unwrap()),
+            type_: vec!["LinkedDomains".to_string()],
+            service_endpoint: Endpoint::Url(Url::parse("https://example.com").unwrap()),
+            property_set: HashMap::new(),
+        };
+        let json = serde_json::to_string(&svc).unwrap();
+        let back: Service = serde_json::from_str(&json).unwrap();
+        assert_eq!(svc, back);
+    }
+}


### PR DESCRIPTION
# affinidi-did-common (0.3.2)

- **FEATURE:** Builder pattern for programmatic DID Document construction
  - `DocumentBuilder` — fluent API for building `Document` with context helpers,
    verification methods, relationships, services, and arbitrary parameters
  - `VerificationMethodBuilder` — fluent API for building `VerificationMethod`
    with convenience methods for `publicKeyMultibase` and `publicKeyJwk`
  - `ServiceBuilder` — fluent API for building `Service` per the
    [CID spec](https://www.w3.org/TR/cid-1.0/#services), supporting URL, map,
    and raw `Endpoint` constructors
  - All three builders are re-exported from the crate root
- **DOCS:** README updated with usage examples for building DID Documents with
  services
- **TESTS:** 102 new unit tests across the crate covering previously untested
  modules
  - `one_or_many` — 37 tests for all public methods, iterators, and serde
  - `service` — 17 tests for `Endpoint::get_uri`, `get_uris`,
    `Document::find_service`, and type deserialization
  - `verification_method` — 8 tests for `get_id`, error cases, and serde
  - `did_method` — 4 tests for `DIDMethod::name`, `identifier`, and `Display`
  - `did_method::peer` — 32 tests for enum conversions, `PeerCreateKey`,
    endpoint format conversions, and `PeerService` encode/decode/to_did_service
  - `lib` — 4 tests for `Document::new`, `Default`, and serde roundtrip
