### PR TITLE
chore: remove vta-sdk local patch and fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ affinidi-messaging-sdk = { path = "crates/messaging/affinidi-messaging-sdk" }
 affinidi-did-authentication = { path = "crates/identity/affinidi-did-authentication" }
 affinidi-tdk-common = { path = "crates/tdk/affinidi-tdk-common" }
 affinidi-tsp = { path = "crates/messaging/affinidi-tsp" }
-vta-sdk = { path = "../../fpp/verifiable-trust-infrastructure/vta-sdk" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/crates/core/affinidi-bbs/src/ciphersuite.rs
+++ b/crates/core/affinidi-bbs/src/ciphersuite.rs
@@ -10,9 +10,10 @@
  */
 
 /// A BBS ciphersuite configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Ciphersuite {
     /// BLS12-381 with SHA-256 (XMD).
+    #[default]
     Bls12381Sha256,
     /// BLS12-381 with SHAKE-256 (XOF).
     Bls12381Shake256,
@@ -57,12 +58,6 @@ impl Ciphersuite {
     /// The signature byte length.
     pub fn signature_length(&self) -> usize {
         self.octet_point_length() + self.octet_scalar_length()
-    }
-}
-
-impl Default for Ciphersuite {
-    fn default() -> Self {
-        Self::Bls12381Sha256
     }
 }
 

--- a/crates/core/affinidi-bbs/src/proof.rs
+++ b/crates/core/affinidi-bbs/src/proof.rs
@@ -230,16 +230,16 @@ pub fn core_proof_verify(
         .ok_or_else(|| BbsError::InvalidProof("invalid D point".into()))?;
     offset += 48;
 
-    let e_hat = read_scalar(&proof_bytes, &mut offset)?;
-    let r1_hat = read_scalar(&proof_bytes, &mut offset)?;
-    let r3_hat = read_scalar(&proof_bytes, &mut offset)?;
+    let e_hat = read_scalar(proof_bytes, &mut offset)?;
+    let r1_hat = read_scalar(proof_bytes, &mut offset)?;
+    let r3_hat = read_scalar(proof_bytes, &mut offset)?;
 
     let mut m_hats = Vec::with_capacity(u);
     for _ in 0..u {
-        m_hats.push(read_scalar(&proof_bytes, &mut offset)?);
+        m_hats.push(read_scalar(proof_bytes, &mut offset)?);
     }
 
-    let challenge = read_scalar(&proof_bytes, &mut offset)?;
+    let challenge = read_scalar(proof_bytes, &mut offset)?;
 
     // 2. Convert disclosed messages to scalars
     let disclosed_scalars = messages_to_scalars(disclosed_messages, cs)?;
@@ -315,6 +315,7 @@ pub fn core_proof_verify(
 }
 
 /// Compute the Fiat-Shamir challenge.
+#[allow(clippy::too_many_arguments)]
 fn compute_challenge(
     abar: &G1Projective,
     bbar: &G1Projective,

--- a/crates/core/affinidi-cesr/src/matter.rs
+++ b/crates/core/affinidi-cesr/src/matter.rs
@@ -224,7 +224,7 @@ impl Matter {
 
             let encoded = codec::b64_encode(&padded);
             let num_groups = encoded.len() / 4;
-            if encoded.len() % 4 != 0 {
+            if !encoded.len().is_multiple_of(4) {
                 return Err(CesrError::Conversion(
                     "padded raw bytes did not produce aligned base64".into(),
                 ));

--- a/crates/credentials/affinidi-mdoc/src/cose_key.rs
+++ b/crates/credentials/affinidi-mdoc/src/cose_key.rs
@@ -247,15 +247,15 @@ impl CoseKey {
         }
 
         // Validate private key size if present
-        if let Some(ref d) = self.d {
-            if d.len() != expected {
-                return Err(MdocError::Cose(format!(
-                    "private key must be {} bytes for {:?}, got {}",
-                    expected,
-                    self.crv,
-                    d.len()
-                )));
-            }
+        if let Some(ref d) = self.d
+            && d.len() != expected
+        {
+            return Err(MdocError::Cose(format!(
+                "private key must be {} bytes for {:?}, got {}",
+                expected,
+                self.crv,
+                d.len()
+            )));
         }
 
         // Validate kty matches crv
@@ -357,13 +357,14 @@ impl CoseKey {
 
         let get_int = |label: i64| -> Option<i128> {
             entries.iter().find_map(|(k, v)| {
-                if let ciborium::Value::Integer(ki) = k {
-                    let ki_val: i128 = (*ki).into();
-                    if ki_val == label as i128 {
-                        if let ciborium::Value::Integer(vi) = v {
-                            return Some((*vi).into());
-                        }
+                if let ciborium::Value::Integer(ki) = k
+                    && {
+                        let ki_val: i128 = (*ki).into();
+                        ki_val == label as i128
                     }
+                    && let ciborium::Value::Integer(vi) = v
+                {
+                    return Some((*vi).into());
                 }
                 None
             })
@@ -371,13 +372,14 @@ impl CoseKey {
 
         let get_bytes = |label: i64| -> Option<Vec<u8>> {
             entries.iter().find_map(|(k, v)| {
-                if let ciborium::Value::Integer(ki) = k {
-                    let ki_val: i128 = (*ki).into();
-                    if ki_val == label as i128 {
-                        if let ciborium::Value::Bytes(b) = v {
-                            return Some(b.clone());
-                        }
+                if let ciborium::Value::Integer(ki) = k
+                    && {
+                        let ki_val: i128 = (*ki).into();
+                        ki_val == label as i128
                     }
+                    && let ciborium::Value::Bytes(b) = v
+                {
+                    return Some(b.clone());
                 }
                 None
             })
@@ -421,25 +423,26 @@ impl CoseKey {
 
         // Parse key_ops (4) — optional
         let key_ops = entries.iter().find_map(|(k, v)| {
-            if let ciborium::Value::Integer(ki) = k {
-                let ki_val: i128 = (*ki).into();
-                if ki_val == 4 {
-                    if let ciborium::Value::Array(arr) = v {
-                        let ops: Vec<KeyOp> = arr
-                            .iter()
-                            .filter_map(|item| {
-                                if let ciborium::Value::Integer(vi) = item {
-                                    let val: i128 = (*vi).into();
-                                    KeyOp::from_i64(val as i64)
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect();
-                        if !ops.is_empty() {
-                            return Some(ops);
+            if let ciborium::Value::Integer(ki) = k
+                && {
+                    let ki_val: i128 = (*ki).into();
+                    ki_val == 4
+                }
+                && let ciborium::Value::Array(arr) = v
+            {
+                let ops: Vec<KeyOp> = arr
+                    .iter()
+                    .filter_map(|item| {
+                        if let ciborium::Value::Integer(vi) = item {
+                            let val: i128 = (*vi).into();
+                            KeyOp::from_i64(val as i64)
+                        } else {
+                            None
                         }
-                    }
+                    })
+                    .collect();
+                if !ops.is_empty() {
+                    return Some(ops);
                 }
             }
             None

--- a/crates/credentials/affinidi-mdoc/src/device_auth.rs
+++ b/crates/credentials/affinidi-mdoc/src/device_auth.rs
@@ -76,7 +76,7 @@ pub struct DeviceSigned {
 #[derive(Debug, Clone)]
 pub enum DeviceAuth {
     /// COSE_Sign1 with detached payload (DeviceAuthenticationBytes as external aad).
-    Signature(CoseSign1),
+    Signature(Box<CoseSign1>),
     /// COSE_Mac0 with detached payload (HMAC-SHA-256 over DeviceAuthenticationBytes).
     ///
     /// Per ISO 18013-5, the MAC key is derived from ECDH between the device key
@@ -178,7 +178,7 @@ impl DeviceSigned {
 
         Ok(DeviceSigned {
             namespaces_bytes,
-            device_auth: DeviceAuth::Signature(sign1),
+            device_auth: DeviceAuth::Signature(Box::new(sign1)),
         })
     }
 

--- a/crates/credentials/affinidi-mdoc/src/device_engagement.rs
+++ b/crates/credentials/affinidi-mdoc/src/device_engagement.rs
@@ -276,29 +276,29 @@ impl DeviceEngagement {
                 ciborium::Value::Array(methods) => {
                     let mut parsed = Vec::new();
                     for m in methods {
-                        if let ciborium::Value::Array(ma) = m {
-                            if ma.len() >= 2 {
-                                let transport_type = match &ma[0] {
-                                    ciborium::Value::Integer(i) => {
-                                        let n: i128 = (*i).into();
-                                        n as u32
-                                    }
-                                    _ => continue,
-                                };
-                                let ver = match &ma[1] {
-                                    ciborium::Value::Integer(i) => {
-                                        let n: i128 = (*i).into();
-                                        n as u32
-                                    }
-                                    _ => continue,
-                                };
-                                let retrieval_options = ma.get(2).cloned();
-                                parsed.push(DeviceRetrievalMethod {
-                                    transport_type,
-                                    version: ver,
-                                    retrieval_options,
-                                });
-                            }
+                        if let ciborium::Value::Array(ma) = m
+                            && ma.len() >= 2
+                        {
+                            let transport_type = match &ma[0] {
+                                ciborium::Value::Integer(i) => {
+                                    let n: i128 = (*i).into();
+                                    n as u32
+                                }
+                                _ => continue,
+                            };
+                            let ver = match &ma[1] {
+                                ciborium::Value::Integer(i) => {
+                                    let n: i128 = (*i).into();
+                                    n as u32
+                                }
+                                _ => continue,
+                            };
+                            let retrieval_options = ma.get(2).cloned();
+                            parsed.push(DeviceRetrievalMethod {
+                                transport_type,
+                                version: ver,
+                                retrieval_options,
+                            });
                         }
                     }
                     Some(parsed)

--- a/crates/credentials/affinidi-sd-jwt-vc/src/lib.rs
+++ b/crates/credentials/affinidi-sd-jwt-vc/src/lib.rs
@@ -76,6 +76,7 @@ impl std::fmt::Display for SdJwtVc {
 /// - `iss` — issuer
 /// - `iat` — issued at
 /// - `cnf` — confirmation key (if present)
+#[allow(clippy::too_many_arguments)]
 pub fn issue(
     vct: &str,
     issuer: &str,
@@ -138,12 +139,12 @@ fn validate_frame_no_protected_claims(frame: &Value) -> error::Result<()> {
 
     if let Some(sd_array) = frame.get("_sd").and_then(|v| v.as_array()) {
         for item in sd_array {
-            if let Some(name) = item.as_str() {
-                if PROTECTED_CLAIMS.contains(&name) {
-                    return Err(SdJwtVcError::InvalidVct(format!(
-                        "\"{name}\" is a protected claim and must not be selectively disclosed"
-                    )));
-                }
+            if let Some(name) = item.as_str()
+                && PROTECTED_CLAIMS.contains(&name)
+            {
+                return Err(SdJwtVcError::InvalidVct(format!(
+                    "\"{name}\" is a protected claim and must not be selectively disclosed"
+                )));
             }
         }
     }
@@ -169,17 +170,17 @@ pub fn verify_temporal(payload: &Value, now_unix: u64) -> error::Result<()> {
     }
 
     // exp: if present, must be in the future
-    if let Some(exp) = payload.get("exp").and_then(|v| v.as_u64()) {
-        if now_unix > exp {
-            return Err(SdJwtVcError::Expired);
-        }
+    if let Some(exp) = payload.get("exp").and_then(|v| v.as_u64())
+        && now_unix > exp
+    {
+        return Err(SdJwtVcError::Expired);
     }
 
     // nbf: if present, must be in the past
-    if let Some(nbf) = payload.get("nbf").and_then(|v| v.as_u64()) {
-        if now_unix < nbf {
-            return Err(SdJwtVcError::NotYetValid);
-        }
+    if let Some(nbf) = payload.get("nbf").and_then(|v| v.as_u64())
+        && now_unix < nbf
+    {
+        return Err(SdJwtVcError::NotYetValid);
     }
 
     Ok(())

--- a/crates/credentials/affinidi-sd-jwt/src/signer.rs
+++ b/crates/credentials/affinidi-sd-jwt/src/signer.rs
@@ -79,13 +79,13 @@ pub mod test_utils {
             }
 
             let mut inner_hasher = Sha256::new();
-            inner_hasher.update(&ipad);
+            inner_hasher.update(ipad);
             inner_hasher.update(data);
             let inner_hash = inner_hasher.finalize();
 
             let mut outer_hasher = Sha256::new();
-            outer_hasher.update(&opad);
-            outer_hasher.update(&inner_hash);
+            outer_hasher.update(opad);
+            outer_hasher.update(inner_hash);
             outer_hasher.finalize().to_vec()
         }
     }

--- a/crates/credentials/affinidi-sd-jwt/tests/rfc9901_vectors.rs
+++ b/crates/credentials/affinidi-sd-jwt/tests/rfc9901_vectors.rs
@@ -235,9 +235,9 @@ fn rfc9901_data_type_coverage() {
     assert_eq!(parsed.claim_value, json!(42));
 
     // float
-    let d = Disclosure::new_claim("test_float", json!(3.14), &hasher).unwrap();
+    let d = Disclosure::new_claim("test_float", json!(3.15), &hasher).unwrap();
     let parsed = Disclosure::parse(&d.serialized, &hasher).unwrap();
-    assert_eq!(parsed.claim_value, json!(3.14));
+    assert_eq!(parsed.claim_value, json!(3.15));
 
     // string
     let d = Disclosure::new_claim("test_str", json!("foo"), &hasher).unwrap();

--- a/crates/credentials/affinidi-status-list/src/bitstring.rs
+++ b/crates/credentials/affinidi-status-list/src/bitstring.rs
@@ -68,7 +68,7 @@ impl BitstringStatusList {
     ///
     /// The size should be at least `MIN_BITSTRING_SIZE` (131,072) for herd privacy.
     pub fn new(size: usize, purpose: StatusPurpose) -> Self {
-        let byte_len = (size + 7) / 8;
+        let byte_len = size.div_ceil(8);
         Self {
             bits: vec![0u8; byte_len],
             size,
@@ -192,7 +192,7 @@ impl BitstringStatusList {
             .read_to_end(&mut bits)
             .map_err(|e| StatusListError::Compression(e.to_string()))?;
 
-        let expected_bytes = (size + 7) / 8;
+        let expected_bytes = size.div_ceil(8);
         if bits.len() < expected_bytes {
             return Err(StatusListError::Invalid(format!(
                 "decoded bitstring too short: {} bytes, expected {}",

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -690,7 +690,7 @@ where
 
     // 3. Get sender's private key from secrets resolver
     let sender_secret = secrets_resolver
-        .get_secret(&sender_kid.to_string())
+        .get_secret(sender_kid.as_ref())
         .await
         .ok_or_else(|| DIDAuthError::Secrets(format!("no secret found for {sender_kid}")))?;
 

--- a/crates/identity/affinidi-did-common/src/did_method/peer.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/peer.rs
@@ -296,6 +296,85 @@ impl PeerServiceEndpointLong {
 // Service Encoding/Decoding
 // ============================================================================
 
+impl PeerService {
+    /// Encode this service for inclusion in a did:peer string
+    pub fn encode(&self) -> Result<String, PeerError> {
+        let json = serde_json::to_string(self).map_err(|e| {
+            PeerError::ServiceSyntaxError(format!("Failed to serialize service: {e}"))
+        })?;
+        Ok(format!(
+            "S{}",
+            BASE64_URL_SAFE_NO_PAD.encode(json.as_bytes())
+        ))
+    }
+
+    /// Decode a service from a did:peer encoded string (including S prefix)
+    pub fn decode(encoded: &str) -> Result<Self, PeerError> {
+        let encoded = encoded.strip_prefix('S').unwrap_or(encoded);
+        let bytes = BASE64_URL_SAFE_NO_PAD
+            .decode(encoded)
+            .map_err(|e| PeerError::ServiceSyntaxError(format!("Base64 decode failed: {e}")))?;
+
+        serde_json::from_slice(&bytes)
+            .map_err(|e| PeerError::ServiceSyntaxError(format!("JSON parse failed: {e}")))
+    }
+
+    /// Convert to standard DID Document Service format
+    pub fn to_did_service(
+        &self,
+        did: &str,
+        index: u32,
+    ) -> Result<crate::service::Service, PeerError> {
+        use std::str::FromStr;
+        use url::Url;
+
+        // Build service ID
+        let id_fragment = if let Some(id) = &self.id {
+            id.clone()
+        } else if index == 0 {
+            "#service".to_string()
+        } else {
+            format!("#service-{index}")
+        };
+
+        let id = Url::from_str(&format!("{did}{id_fragment}"))
+            .map_err(|e| PeerError::ServiceSyntaxError(format!("Invalid service ID: {e}")))?;
+
+        // Convert endpoint to standard format
+        let service_endpoint = match &self.endpoint {
+            PeerServiceEndpoint::Uri(uri) => {
+                let url = Url::from_str(uri)
+                    .map_err(|e| PeerError::ServiceSyntaxError(format!("Invalid URI: {e}")))?;
+                crate::service::Endpoint::Url(url)
+            }
+            PeerServiceEndpoint::Short(endpoints) => {
+                let value = match endpoints {
+                    OneOrMany::One(ep) => serde_json::to_value(ep.to_long())
+                        .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?,
+                    OneOrMany::Many(eps) => {
+                        let long: Vec<_> = eps.iter().map(|e| e.to_long()).collect();
+                        serde_json::to_value(long)
+                            .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?
+                    }
+                };
+                crate::service::Endpoint::Map(value)
+            }
+            PeerServiceEndpoint::Long(endpoints) => {
+                let value = serde_json::to_value(endpoints)
+                    .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?;
+                crate::service::Endpoint::Map(value)
+            }
+        };
+
+        Ok(crate::service::Service {
+            id: Some(id),
+            type_: vec!["DIDCommMessaging".to_string()],
+            service_endpoint,
+            property_set: HashMap::new(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -566,84 +645,5 @@ mod tests {
             did_svc.service_endpoint,
             crate::service::Endpoint::Map(_)
         ));
-    }
-}
-
-impl PeerService {
-    /// Encode this service for inclusion in a did:peer string
-    pub fn encode(&self) -> Result<String, PeerError> {
-        let json = serde_json::to_string(self).map_err(|e| {
-            PeerError::ServiceSyntaxError(format!("Failed to serialize service: {e}"))
-        })?;
-        Ok(format!(
-            "S{}",
-            BASE64_URL_SAFE_NO_PAD.encode(json.as_bytes())
-        ))
-    }
-
-    /// Decode a service from a did:peer encoded string (including S prefix)
-    pub fn decode(encoded: &str) -> Result<Self, PeerError> {
-        let encoded = encoded.strip_prefix('S').unwrap_or(encoded);
-        let bytes = BASE64_URL_SAFE_NO_PAD
-            .decode(encoded)
-            .map_err(|e| PeerError::ServiceSyntaxError(format!("Base64 decode failed: {e}")))?;
-
-        serde_json::from_slice(&bytes)
-            .map_err(|e| PeerError::ServiceSyntaxError(format!("JSON parse failed: {e}")))
-    }
-
-    /// Convert to standard DID Document Service format
-    pub fn to_did_service(
-        &self,
-        did: &str,
-        index: u32,
-    ) -> Result<crate::service::Service, PeerError> {
-        use std::str::FromStr;
-        use url::Url;
-
-        // Build service ID
-        let id_fragment = if let Some(id) = &self.id {
-            id.clone()
-        } else if index == 0 {
-            "#service".to_string()
-        } else {
-            format!("#service-{index}")
-        };
-
-        let id = Url::from_str(&format!("{did}{id_fragment}"))
-            .map_err(|e| PeerError::ServiceSyntaxError(format!("Invalid service ID: {e}")))?;
-
-        // Convert endpoint to standard format
-        let service_endpoint = match &self.endpoint {
-            PeerServiceEndpoint::Uri(uri) => {
-                let url = Url::from_str(uri)
-                    .map_err(|e| PeerError::ServiceSyntaxError(format!("Invalid URI: {e}")))?;
-                crate::service::Endpoint::Url(url)
-            }
-            PeerServiceEndpoint::Short(endpoints) => {
-                let value = match endpoints {
-                    OneOrMany::One(ep) => serde_json::to_value(ep.to_long())
-                        .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?,
-                    OneOrMany::Many(eps) => {
-                        let long: Vec<_> = eps.iter().map(|e| e.to_long()).collect();
-                        serde_json::to_value(long)
-                            .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?
-                    }
-                };
-                crate::service::Endpoint::Map(value)
-            }
-            PeerServiceEndpoint::Long(endpoints) => {
-                let value = serde_json::to_value(endpoints)
-                    .map_err(|e| PeerError::ServiceSyntaxError(e.to_string()))?;
-                crate::service::Endpoint::Map(value)
-            }
-        };
-
-        Ok(crate::service::Service {
-            id: Some(id),
-            type_: vec!["DIDCommMessaging".to_string()],
-            service_endpoint,
-            property_set: HashMap::new(),
-        })
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
@@ -275,8 +275,7 @@ mod tests {
                 }
                 // Return a minimal valid document
                 let doc_json = format!(
-                    r#"{{"id":"{}","verificationMethod":[],"authentication":[],"assertionMethod":[],"keyAgreement":[],"capabilityInvocation":[],"capabilityDelegation":[],"service":[]}}"#,
-                    did_str
+                    r#"{{"id":"{did_str}","verificationMethod":[],"authentication":[],"assertionMethod":[],"keyAgreement":[],"capabilityInvocation":[],"capabilityDelegation":[],"service":[]}}"#,
                 );
                 Some(
                     serde_json::from_str::<Document>(&doc_json)
@@ -307,8 +306,7 @@ mod tests {
                 // Return a stub document with 0 verification methods
                 // (built-in KeyResolver returns 2 for Ed25519)
                 let doc_json = format!(
-                    r#"{{"id":"{}","verificationMethod":[],"authentication":[],"assertionMethod":[],"keyAgreement":[],"capabilityInvocation":[],"capabilityDelegation":[],"service":[]}}"#,
-                    did_str
+                    r#"{{"id":"{did_str}","verificationMethod":[],"authentication":[],"assertionMethod":[],"keyAgreement":[],"capabilityInvocation":[],"capabilityDelegation":[],"service":[]}}"#,
                 );
                 Some(
                     serde_json::from_str::<Document>(&doc_json)

--- a/crates/messaging/affinidi-messaging-didcomm-service/examples/echo_server.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/examples/echo_server.rs
@@ -34,9 +34,7 @@ async fn custom_middleware(
     next: Next,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
     // custom action
-    let result = next.run(ctx, message, meta).await;
-    // custom action
-    result
+    next.run(ctx, message, meta).await
 }
 
 async fn echo_handler(

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/aes_kw.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/aes_kw.rs
@@ -14,7 +14,7 @@ const IV: u64 = 0xA6A6A6A6A6A6A6A6;
 /// Input key must be a multiple of 8 bytes. Output is input_len + 8 bytes.
 pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, DIDCommError> {
     let n = plaintext_key.len();
-    if n % 8 != 0 || n < 16 {
+    if !n.is_multiple_of(8) || n < 16 {
         return Err(DIDCommError::KeyWrap(
             "key to wrap must be >= 16 bytes and multiple of 8".into(),
         ));
@@ -32,11 +32,11 @@ pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, DIDCommErro
 
     // 6 * n rounds
     for j in 0..6u64 {
-        for i in 0..n_blocks {
+        for (i, ri) in r.iter_mut().enumerate().take(n_blocks) {
             // B = AES(K, A || R[i])
             let mut block = [0u8; 16];
             block[..8].copy_from_slice(&a.to_be_bytes());
-            block[8..].copy_from_slice(&r[i].to_be_bytes());
+            block[8..].copy_from_slice(&ri.to_be_bytes());
 
             let b = aes::Block::from_mut_slice(&mut block);
             cipher.encrypt_block(b);
@@ -44,7 +44,7 @@ pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, DIDCommErro
             // A = MSB(64, B) XOR t where t = (n*j)+i+1
             let t = (n_blocks as u64) * j + (i as u64) + 1;
             a = u64::from_be_bytes(block[..8].try_into().unwrap()) ^ t;
-            r[i] = u64::from_be_bytes(block[8..].try_into().unwrap());
+            *ri = u64::from_be_bytes(block[8..].try_into().unwrap());
         }
     }
 
@@ -63,7 +63,7 @@ pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, DIDCommErro
 /// Input must be wrapped_len bytes (plaintext_len + 8). Returns the unwrapped key.
 pub fn unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, DIDCommError> {
     let total = ciphertext.len();
-    if total % 8 != 0 || total < 24 {
+    if !total.is_multiple_of(8) || total < 24 {
         return Err(DIDCommError::KeyWrap(
             "wrapped key must be >= 24 bytes and multiple of 8".into(),
         ));

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/content_encryption.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/content_encryption.rs
@@ -111,9 +111,9 @@ pub fn decrypt(
     // AES-256-CBC decrypt
     let enc_key_arr: [u8; 32] = enc_key.try_into().unwrap();
     let decryptor = Aes256CbcDec::new(&enc_key_arr.into(), iv.into());
-    let mut buf = ciphertext.to_vec();
+    let buf = ciphertext.to_vec();
     let decrypted = decryptor
-        .decrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&mut buf)
+        .decrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&buf)
         .map_err(|e| DIDCommError::ContentEncryption(format!("AES-CBC decrypt failed: {e}")))?;
 
     // Remove PKCS7 padding

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/ecdh_1pu.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/ecdh_1pu.rs
@@ -26,6 +26,7 @@ use crate::error::DIDCommError;
 /// * `apv` - PartyVInfo (raw bytes, SHA-256 of sorted recipient kids)
 /// * `cc_tag` - Content encryption authentication tag (for tag-in-KDF)
 /// * `key_len` - Output key length in bits (256 for A256KW)
+#[allow(clippy::too_many_arguments)]
 pub fn derive_key_1pu(
     ephemeral: &PrivateKeyAgreement,
     sender_private: &PrivateKeyAgreement,
@@ -52,6 +53,7 @@ pub fn derive_key_1pu(
 }
 
 /// Derive key wrapping key on the recipient side.
+#[allow(clippy::too_many_arguments)]
 pub fn derive_key_1pu_recipient(
     recipient_private: &PrivateKeyAgreement,
     sender_public: &PublicKeyAgreement,

--- a/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
@@ -232,16 +232,16 @@ impl DIDCommAgent {
                 if let Some(kid) = recipient["header"]["kid"].as_str() {
                     // Try each local identity to see if the KID matches
                     for local_did in self.store.local_dids() {
-                        if let Ok(local) = self.store.get_local(local_did) {
-                            if local.key_agreement_kid == kid {
-                                return unpack::unpack(
-                                    input,
-                                    Some(kid),
-                                    Some(&local.key_agreement_private),
-                                    sender_public,
-                                    None,
-                                );
-                            }
+                        if let Ok(local) = self.store.get_local(local_did)
+                            && local.key_agreement_kid == kid
+                        {
+                            return unpack::unpack(
+                                input,
+                                Some(kid),
+                                Some(&local.key_agreement_private),
+                                sender_public,
+                                None,
+                            );
                         }
                     }
                 }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/errors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/errors.rs
@@ -147,6 +147,7 @@ impl MediatorError {
     /// The `comment` is also used as the log message. For cases where the log
     /// message should differ (e.g., when comment has `{1}` placeholders but the
     /// log should have interpolated values), use [`problem_with_log`](Self::problem_with_log).
+    #[allow(clippy::too_many_arguments)]
     pub fn problem(
         code: u16,
         session_id: impl Into<String>,
@@ -179,6 +180,7 @@ impl MediatorError {
     ///
     /// Use this when the Problem Report comment has `{1}`, `{2}` placeholders
     /// but the log message should contain the actual interpolated values.
+    #[allow(clippy::too_many_arguments)]
     pub fn problem_with_log(
         code: u16,
         session_id: impl Into<String>,
@@ -259,9 +261,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "ErrorHandlingError".to_string(),
                     message: "Internal server error".to_string(),
                 }
@@ -277,9 +279,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "InternalError".to_string(),
                     message: "Internal server error".to_string(),
                 }
@@ -296,9 +298,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "BadRequest: ParseError".to_string(),
                     message: format!("Couldn't parse ({what})"),
                 }
@@ -307,8 +309,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::FORBIDDEN.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "Forbidden: PermissionError".to_string(),
                     message: msg.to_string(),
                 };
@@ -319,8 +321,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "BadRequest: RequestDataError".to_string(),
                     message: format!("Bad Request: ({msg})"),
                 };
@@ -331,8 +333,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "BadRequest: ServiceLimitError".to_string(),
                     message: msg.to_string(),
                 };
@@ -343,8 +345,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::UNAUTHORIZED.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "Unauthorized".to_string(),
                     message: "Unauthorized access".to_string(),
                 };
@@ -370,9 +372,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "DIDError".to_string(),
                     message: format!("did({did}) Error: invalid or unresolvable DID"),
                 }
@@ -388,9 +390,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "ConfigError".to_string(),
                     message: "Service configuration error".to_string(),
                 }
@@ -406,9 +408,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "DatabaseError".to_string(),
                     message: "Service temporarily unavailable".to_string(),
                 }
@@ -424,9 +426,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "MessageUnpackError".to_string(),
                     message: "Failed to unpack message".to_string(),
                 }
@@ -435,8 +437,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "MessageExpired".to_string(),
                     message: format!("Message expired: expiry({expired}) now({now})"),
                 };
@@ -454,9 +456,9 @@ impl IntoResponse for AppError {
                 );
                 ErrorResponse {
                     http_code: StatusCode::BAD_REQUEST.as_u16(),
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "MessagePackError".to_string(),
                     message: "Failed to pack message".to_string(),
                 }
@@ -465,8 +467,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::NOT_IMPLEMENTED.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "NotImplemented".to_string(),
                     message,
                 };
@@ -477,8 +479,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::NOT_ACCEPTABLE.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "SessionError".to_string(),
                     message,
                 };
@@ -489,8 +491,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::NOT_ACCEPTABLE.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "AnonymousMessageError".to_string(),
                     message,
                 };
@@ -501,8 +503,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::NOT_ACCEPTABLE.as_u16(),
                     session_id: session_id.to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "ForwardMessageError".to_string(),
                     message,
                 };
@@ -520,8 +522,8 @@ impl IntoResponse for AppError {
                 ErrorResponse {
                     http_code: StatusCode::UNAUTHORIZED.as_u16(),
                     session_id: "NO-SESSION".to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "AuthenticationError".to_string(),
                     message: "Authentication failed".to_string(),
                 }
@@ -530,8 +532,8 @@ impl IntoResponse for AppError {
                 let response = ErrorResponse {
                     http_code: StatusCode::UNAUTHORIZED.as_u16(),
                     session_id: "NO-SESSION".to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "ACLDenied".to_string(),
                     message,
                 };
@@ -550,8 +552,8 @@ impl IntoResponse for AppError {
                 ErrorResponse {
                     http_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
                     session_id: "NO-SESSION".to_string(),
-                    request_id: request_id,
-                    error_code: error_code,
+                    request_id,
+                    error_code,
                     error_code_str: "ProcessorError".to_string(),
                     message: "Internal server error".to_string(),
                 }
@@ -566,10 +568,10 @@ impl IntoResponse for AppError {
             ) => {
                 event!(Level::WARN, "{}{}", log_text, ctx_log);
                 ErrorResponse {
-                    http_code: http_code,
-                    session_id: session_id,
-                    request_id: request_id,
-                    error_code: error_code,
+                    http_code,
+                    session_id,
+                    request_id,
+                    error_code,
                     error_code_str: "DIDCommProblemReport".to_string(),
                     message: serde_json::to_string(&problem_report)
                         .unwrap_or_else(|_| "Failed to serialize Problem Report".to_string()),

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/src/lib/forwarding/database.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/src/lib/forwarding/database.rs
@@ -90,6 +90,7 @@ impl ForwardingProcessor {
             ProcessorError::ForwardingError(format!("DB blocking connection error: {e}"))
         })?;
 
+        #[allow(clippy::type_complexity)]
         let result: Option<Vec<(String, Vec<(String, HashMap<String, String>)>)>> =
             redis::cmd("XREADGROUP")
                 .arg("GROUP")
@@ -183,6 +184,7 @@ impl ForwardingProcessor {
                 ProcessorError::ForwardingError(format!("DB connection error: {e}"))
             })?;
 
+        #[allow(clippy::type_complexity)]
         let result: (String, Vec<(String, HashMap<String, String>)>, Vec<String>) =
             redis::cmd("XAUTOCLAIM")
                 .arg("FORWARD_Q")

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/src/lib/forwarding/processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/src/lib/forwarding/processor.rs
@@ -353,7 +353,7 @@ impl ForwardingProcessor {
     }
 
     fn calculate_backoff(&self, consecutive_failures: u32) -> Duration {
-        let base = self.config.initial_backoff_ms as u64;
+        let base = self.config.initial_backoff_ms;
         let max = self.config.max_backoff_ms;
         let backoff = base.saturating_mul(2u64.saturating_pow(consecutive_failures.min(10)));
         Duration::from_millis(backoff.min(max))

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -208,10 +208,10 @@ impl TryFrom<ConfigRaw> for Config {
         let aws_config = aws_builder.load().await;
         let mut tags = HashMap::from([("app".to_string(), "mediator".to_string())]);
         for (key, value) in env::vars() {
-            if key.get(..13) == Some("MEDIATOR_TAG_") {
-                if let Some(tag_key) = key.get(13..) {
-                    tags.insert(tag_key.to_lowercase(), value);
-                }
+            if key.get(..13) == Some("MEDIATOR_TAG_")
+                && let Some(tag_key) = key.get(13..)
+            {
+                tags.insert(tag_key.to_lowercase(), value);
             }
         }
 
@@ -273,14 +273,14 @@ impl TryFrom<ConfigRaw> for Config {
                                  but both services are interdependent.",
                                 result.did
                             );
-                        } else if let Some(vta_med_url) = &health.mediator_url {
-                            if health.mediator_did.is_some() {
-                                info!(
-                                    "VTA reports mediator dependency — mediator_did: {:?}, mediator_url: {:?}",
-                                    health.mediator_did.as_deref().unwrap_or("none"),
-                                    vta_med_url,
-                                );
-                            }
+                        } else if let Some(vta_med_url) = &health.mediator_url
+                            && health.mediator_did.is_some()
+                        {
+                            info!(
+                                "VTA reports mediator dependency — mediator_did: {:?}, mediator_url: {:?}",
+                                health.mediator_did.as_deref().unwrap_or("none"),
+                                vta_med_url,
+                            );
                         }
                     }
                     Err(e) => {

--- a/crates/messaging/affinidi-messaging-mediator/src/database/forwarding.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/database/forwarding.rs
@@ -153,6 +153,7 @@ impl Database {
         let mut conn = self.get_blocking_connection().await?;
 
         // XREADGROUP GROUP <group> <consumer> BLOCK <ms> COUNT <n> STREAMS FORWARD_Q >
+        #[allow(clippy::type_complexity)]
         let result: Option<Vec<(String, Vec<(String, HashMap<String, String>)>)>> =
             redis::cmd("XREADGROUP")
                 .arg("GROUP")
@@ -254,6 +255,7 @@ impl Database {
 
         // XAUTOCLAIM FORWARD_Q <group> <consumer> <min-idle-ms> 0 COUNT <n>
         // Returns: [next-start-id, [[id, [field, value, ...]], ...], [deleted-ids]]
+        #[allow(clippy::type_complexity)]
         let result: (String, Vec<(String, HashMap<String, String>)>, Vec<String>) =
             redis::cmd("XAUTOCLAIM")
                 .arg("FORWARD_Q")

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -72,49 +72,38 @@ impl MetaEnvelope {
             }
 
             // Check protected header for sender info (authcrypt)
-            if let Some(protected_b64) = value.get("protected").and_then(|p| p.as_str()) {
-                if let Ok(protected_bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected_b64) {
-                    if let Ok(header) =
-                        serde_json::from_slice::<serde_json::Value>(&protected_bytes)
-                    {
-                        // Check algorithm for authcrypt
-                        if let Some(alg) = header.get("alg").and_then(|a| a.as_str()) {
-                            if alg.contains("1PU") {
-                                authenticated = true;
-                                // Extract sender DID from skid
-                                if let Some(skid) = header.get("skid").and_then(|s| s.as_str()) {
-                                    if let Some(hash_pos) = skid.find('#') {
-                                        from_did = Some(skid[..hash_pos].to_string());
-                                    } else {
-                                        from_did = Some(skid.to_string());
-                                    }
-                                }
-                            }
-                        }
+            if let Some(protected_b64) = value.get("protected").and_then(|p| p.as_str())
+                && let Ok(protected_bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected_b64)
+                && let Ok(header) =
+                    serde_json::from_slice::<serde_json::Value>(&protected_bytes)
+                // Check algorithm for authcrypt
+                && let Some(alg) = header.get("alg").and_then(|a| a.as_str())
+                && alg.contains("1PU")
+            {
+                authenticated = true;
+                // Extract sender DID from skid
+                if let Some(skid) = header.get("skid").and_then(|s| s.as_str()) {
+                    if let Some(hash_pos) = skid.find('#') {
+                        from_did = Some(skid[..hash_pos].to_string());
+                    } else {
+                        from_did = Some(skid.to_string());
                     }
                 }
             }
 
             // If we couldn't get from_did from skid, try resolving via apu header
-            if from_did.is_none() && authenticated {
-                // Try apu (agreement party u-info) which sometimes contains the sender kid
-                if let Some(protected_b64) = value.get("protected").and_then(|p| p.as_str()) {
-                    if let Ok(protected_bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected_b64) {
-                        if let Ok(header) =
-                            serde_json::from_slice::<serde_json::Value>(&protected_bytes)
-                        {
-                            if let Some(apu) = header.get("apu").and_then(|a| a.as_str()) {
-                                if let Ok(apu_bytes) = BASE64_URL_SAFE_NO_PAD.decode(apu) {
-                                    if let Ok(apu_str) = String::from_utf8(apu_bytes) {
-                                        if let Some(hash_pos) = apu_str.find('#') {
-                                            from_did = Some(apu_str[..hash_pos].to_string());
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            // Try apu (agreement party u-info) which sometimes contains the sender kid
+            if from_did.is_none()
+                && authenticated
+                && let Some(protected_b64) = value.get("protected").and_then(|p| p.as_str())
+                && let Ok(protected_bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected_b64)
+                && let Ok(header) = serde_json::from_slice::<serde_json::Value>(&protected_bytes)
+                && let Some(apu) = header.get("apu").and_then(|a| a.as_str())
+                && let Ok(apu_bytes) = BASE64_URL_SAFE_NO_PAD.decode(apu)
+                && let Ok(apu_str) = String::from_utf8(apu_bytes)
+                && let Some(hash_pos) = apu_str.find('#')
+            {
+                from_did = Some(apu_str[..hash_pos].to_string());
             }
 
             Ok(MetaEnvelope {
@@ -222,22 +211,22 @@ async fn unpack_jwe<S: SecretsResolver>(
     let mut recipient_private: Option<PrivateKeyAgreement> = None;
 
     for recipient in recipients {
-        if let Some(kid) = recipient["header"]["kid"].as_str() {
-            if let Some(secret) = secrets_resolver.get_secret(kid).await {
-                let curve = match secret.get_key_type() {
-                    affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
-                    affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
-                    affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
-                    _ => continue,
-                };
-                match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
-                    Ok(pk) => {
-                        recipient_kid_str = kid.to_string();
-                        recipient_private = Some(pk);
-                        break;
-                    }
-                    Err(_) => continue,
+        if let Some(kid) = recipient["header"]["kid"].as_str()
+            && let Some(secret) = secrets_resolver.get_secret(kid).await
+        {
+            let curve = match secret.get_key_type() {
+                affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
+                affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
+                affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
+                _ => continue,
+            };
+            match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
+                Ok(pk) => {
+                    recipient_kid_str = kid.to_string();
+                    recipient_private = Some(pk);
+                    break;
                 }
+                Err(_) => continue,
             }
         }
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
@@ -322,23 +322,23 @@ pub async fn authentication_refresh(
                 )
             })?;
 
-        if let Some(stored) = stored_hash {
-            if !bool::from(stored.as_bytes().ct_eq(incoming_hash.as_bytes())) {
-                metrics::counter!(crate::common::metrics::names::AUTH_FAILURES_TOTAL, "reason" => "refresh_token_reuse").increment(1);
-                return Err(MediatorError::problem_with_log(
-                    38,
-                    "",
-                    None,
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "authentication.session.refresh_token.reuse",
-                    "Refresh token has already been used (possible token replay)",
-                    vec![],
-                    StatusCode::UNAUTHORIZED,
-                    "Refresh token has already been used (possible token replay)",
-                )
-                .into());
-            }
+        if let Some(stored) = stored_hash
+            && !bool::from(stored.as_bytes().ct_eq(incoming_hash.as_bytes()))
+        {
+            metrics::counter!(crate::common::metrics::names::AUTH_FAILURES_TOTAL, "reason" => "refresh_token_reuse").increment(1);
+            return Err(MediatorError::problem_with_log(
+                38,
+                "",
+                None,
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "authentication.session.refresh_token.reuse",
+                "Refresh token has already been used (possible token replay)",
+                vec![],
+                StatusCode::UNAUTHORIZED,
+                "Refresh token has already been used (possible token replay)",
+            )
+            .into());
         }
 
         // Generate a new access token

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -237,10 +237,10 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
                             },
                             WebSocketCommands::Close => {
                                 #[cfg(feature = "didcomm")]
-                                if let Ok(msg) =  _package_problem_report(&state, &session, None, _generate_duplicate_connection_problem_report()).await {
-                                    if let Err(e) = socket.send(Message::Text(msg.into())).await {
-                                        warn!("Failed to send message to WebSocket client: {e}");
-                                    }
+                                if let Ok(msg) =  _package_problem_report(&state, &session, None, _generate_duplicate_connection_problem_report()).await
+                                    && let Err(e) = socket.send(Message::Text(msg.into())).await
+                                {
+                                    warn!("Failed to send message to WebSocket client: {e}");
                                 }
                                 debug!("Streaming task requested close (duplicate connection)");
                                 already_deregistered_flag = true;

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/forwarding_processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/forwarding_processor.rs
@@ -683,7 +683,7 @@ impl ForwardingProcessor {
 
     /// Calculate exponential backoff duration
     fn calculate_backoff(&self, consecutive_failures: u32) -> Duration {
-        let base = self.config.initial_backoff_ms as u64;
+        let base = self.config.initial_backoff_ms;
         let max = self.config.max_backoff_ms;
         let backoff = base.saturating_mul(2u64.saturating_pow(consecutive_failures.min(10)));
         Duration::from_millis(backoff.min(max))

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
@@ -87,7 +87,7 @@ impl SharedState {
                 let sender_secret = self
                     .tdk_common
                     .secrets_resolver
-                    .get_secret(&sender_kid.to_string())
+                    .get_secret(sender_kid.as_ref())
                     .await
                     .ok_or_else(|| {
                         ATMError::SecretsError(format!("no secret found for {sender_kid}"))

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
@@ -117,22 +117,22 @@ impl SharedState {
         let mut recipient_private: Option<PrivateKeyAgreement> = None;
 
         for recipient in recipients {
-            if let Some(kid) = recipient["header"]["kid"].as_str() {
-                if let Some(secret) = self.tdk_common.secrets_resolver.get_secret(kid).await {
-                    let curve = match secret.get_key_type() {
-                        affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
-                        affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
-                        affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
-                        _ => continue,
-                    };
-                    match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
-                        Ok(pk) => {
-                            recipient_kid_str = kid.to_string();
-                            recipient_private = Some(pk);
-                            break;
-                        }
-                        Err(_) => continue,
+            if let Some(kid) = recipient["header"]["kid"].as_str()
+                && let Some(secret) = self.tdk_common.secrets_resolver.get_secret(kid).await
+            {
+                let curve = match secret.get_key_type() {
+                    affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
+                    affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
+                    affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
+                    _ => continue,
+                };
+                match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
+                    Ok(pk) => {
+                        recipient_kid_str = kid.to_string();
+                        recipient_private = Some(pk);
+                        break;
                     }
+                    Err(_) => continue,
                 }
             }
         }

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
@@ -109,7 +109,7 @@ impl StateStore {
                 message_received = inbound_message_channel.recv() => {
                     match message_received {
                         Ok(WebSocketResponses::MessageReceived(message, meta)) => {
-                            handle_message(&atm, &mut state, &*message, &*meta).await;
+                            handle_message(&atm, &mut state, &message, &meta).await;
                         },
                         Ok(WebSocketResponses::PackedMessageReceived(_)) => {
                             // Ignore packed messages

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -184,11 +184,11 @@ fn extract_and_expand(dh: &[u8], kem_context: &[u8]) -> Result<[u8; N_SECRET], T
     let kem_suite_id = KEM_SUITE_ID;
 
     // prk = LabeledExtract("", "shared_secret", dh)
-    let prk = labeled_extract(&kem_suite_id, &[], b"shared_secret", dh)?;
+    let prk = labeled_extract(kem_suite_id, &[], b"shared_secret", dh)?;
 
     // shared_secret = LabeledExpand(prk, "ss", kem_context, Nsecret)
     let mut shared_secret = [0u8; N_SECRET];
-    labeled_expand(&kem_suite_id, &prk, b"ss", kem_context, &mut shared_secret)?;
+    labeled_expand(kem_suite_id, &prk, b"ss", kem_context, &mut shared_secret)?;
 
     Ok(shared_secret)
 }
@@ -205,10 +205,10 @@ fn key_schedule(
     let psk_id = b"";
 
     // psk_id_hash = LabeledExtract("", "psk_id_hash", psk_id)
-    let psk_id_hash = labeled_extract(&suite_id, &[], b"psk_id_hash", psk_id)?;
+    let psk_id_hash = labeled_extract(suite_id, &[], b"psk_id_hash", psk_id)?;
 
     // info_hash = LabeledExtract("", "info_hash", info)
-    let info_hash = labeled_extract(&suite_id, &[], b"info_hash", info)?;
+    let info_hash = labeled_extract(suite_id, &[], b"info_hash", info)?;
 
     // ks_context = mode || psk_id_hash || info_hash (1 + 32 + 32 = 65 bytes, fixed size)
     let mut ks_context = [0u8; 1 + N_H + N_H];
@@ -217,16 +217,16 @@ fn key_schedule(
     ks_context[1 + N_H..].copy_from_slice(&info_hash);
 
     // secret = LabeledExtract(shared_secret, "secret", psk)
-    let secret = labeled_extract(&suite_id, shared_secret, b"secret", psk)?;
+    let secret = labeled_extract(suite_id, shared_secret, b"secret", psk)?;
 
     // key = LabeledExpand(secret, "key", ks_context, Nk)
     let mut key = [0u8; N_K];
-    labeled_expand(&suite_id, &secret, b"key", &ks_context, &mut key)?;
+    labeled_expand(suite_id, &secret, b"key", &ks_context, &mut key)?;
 
     // base_nonce = LabeledExpand(secret, "base_nonce", ks_context, Nn)
     let mut base_nonce = [0u8; N_N];
     labeled_expand(
-        &suite_id,
+        suite_id,
         &secret,
         b"base_nonce",
         &ks_context,

--- a/crates/messaging/affinidi-tsp/src/relationship.rs
+++ b/crates/messaging/affinidi-tsp/src/relationship.rs
@@ -18,9 +18,10 @@
 use serde::{Deserialize, Serialize};
 
 /// The state of a TSP relationship between two VIDs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RelationshipState {
     /// No relationship exists.
+    #[default]
     None,
     /// We sent a Relationship Forming Invite, awaiting acceptance.
     Pending,
@@ -77,12 +78,6 @@ impl RelationshipState {
             // Invalid transition
             (state, event) => Err(InvalidTransition { state, event }),
         }
-    }
-}
-
-impl Default for RelationshipState {
-    fn default() -> Self {
-        RelationshipState::None
     }
 }
 

--- a/crates/messaging/affinidi-tsp/src/vid/resolver.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/resolver.rs
@@ -107,10 +107,10 @@ impl VidResolver for DelegatingVidResolver {
         }
 
         // For DIDs, delegate to the DID resolver if available
-        if is_did(vid) {
-            if let Some(did_resolver) = &self.did_resolver {
-                return did_resolver.resolve(vid);
-            }
+        if is_did(vid)
+            && let Some(did_resolver) = &self.did_resolver
+        {
+            return did_resolver.resolve(vid);
         }
 
         Err(TspError::VidNotFound(vid.to_string()))

--- a/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
@@ -175,12 +175,12 @@ pub mod test_utils {
             }
 
             let inner = Sha256::new()
-                .chain_update(&ipad)
+                .chain_update(ipad)
                 .chain_update(data)
                 .finalize();
             Sha256::new()
-                .chain_update(&opad)
-                .chain_update(&inner)
+                .chain_update(opad)
+                .chain_update(inner)
                 .finalize()
                 .to_vec()
         }

--- a/crates/protocols/affinidi-oid4vc-core/src/lib.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/lib.rs
@@ -92,7 +92,7 @@ impl SubjectSyntaxType {
     pub const JWK_THUMBPRINT_URN: &'static str = "urn:ietf:params:oauth:jwk-thumbprint";
 
     /// Parse from a string.
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         if s == Self::JWK_THUMBPRINT_URN {
             Self::JwkThumbprint
         } else {
@@ -319,11 +319,11 @@ mod tests {
 
     #[test]
     fn subject_syntax_type_parsing() {
-        let jwk = SubjectSyntaxType::from_str("urn:ietf:params:oauth:jwk-thumbprint");
+        let jwk = SubjectSyntaxType::parse("urn:ietf:params:oauth:jwk-thumbprint");
         assert_eq!(jwk, SubjectSyntaxType::JwkThumbprint);
         assert!(!jwk.is_did());
 
-        let did = SubjectSyntaxType::from_str("did:key");
+        let did = SubjectSyntaxType::parse("did:key");
         assert!(did.is_did());
         assert_eq!(did.as_str(), "did:key");
     }

--- a/crates/trust/affinidi-trust-lists/src/xml/mod.rs
+++ b/crates/trust/affinidi-trust-lists/src/xml/mod.rs
@@ -155,10 +155,10 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                             }
                         } else if path_str.contains("TSPTradeName") {
                             current_tsp_trade_name = Some(text_buf.clone());
-                        } else if path_str.contains("ServiceName") {
-                            if current_service_name.is_empty() {
-                                current_service_name = text_buf.clone();
-                            }
+                        } else if path_str.contains("ServiceName")
+                            && current_service_name.is_empty()
+                        {
+                            current_service_name = text_buf.clone();
                         }
                     }
                     "ServiceTypeIdentifier" => {


### PR DESCRIPTION
## Summary
- Remove `vta-sdk` from `[patch.crates-io]` — it is now published on crates.io (v0.3.1)
- Fix all clippy warnings across the workspace (Rust 1.94 lint updates)
  - Collapsible `if` statements using `let` chains
  - Redundant field names in struct initialization
  - Needless borrows and unnecessary casts
  - Derivable `Default` impls
  - `is_multiple_of()` and `div_ceil()` replacements
  - Box large enum variant (`DeviceAuth::Signature`)
  - Moved `impl PeerService` above `#[cfg(test)]` module

## Checklist
- [x] All tests pass (94 test suites, 0 failures)
- [x] No clippy warnings (`-D warnings`)
- [x] Documentation builds cleanly
- [x] Code formatted with `cargo fmt`