### PR TITLE
feat: improve DIDComm service usability (0.2.0)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.2.0] - 2026-04-13
+
+### Added
+
+- `DIDCommService` now implements `Clone` — eliminates the need for `Arc<DIDCommService>` wrappers since the struct is already cheaply cloneable (all fields are `Arc`-wrapped internally).
+- `DIDCommService::wait_connected(listener_id, timeout)` blocks until a listener has established its mediator connection, eliminating the race between `start()` and first `send_message()`.
+- `DIDCommService::send_message_with_retry(listener_id, message, recipient_did, max_retries, initial_backoff)` retries on `NotConnected` errors with exponential backoff, using `wait_connected` between attempts.
+- `DIDCommService::listener_did(listener_id)` returns the DID associated with a listener for self-contained outbound message building.
+- `DIDCommService::subscribe()` returns a `broadcast::Receiver<ListenerEvent>` for listener lifecycle notifications.
+- `ListenerEvent` enum with `Connected`, `Disconnected { error }`, and `Restarting { attempt, delay }` variants, emitted as listeners connect, fail, or restart.
+
+### Changed
+
+- **Breaking:** `DIDCommService::shutdown()` now takes `&self` instead of consuming `self`, making it compatible with shared ownership patterns (`Arc`, cloned instances).
+
 ## [0.1.5] - 2026-04-13
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -10,10 +10,19 @@
 - `DIDCommService::listener_did(listener_id)` returns the DID associated with a listener for self-contained outbound message building.
 - `DIDCommService::subscribe()` returns a `broadcast::Receiver<ListenerEvent>` for listener lifecycle notifications.
 - `ListenerEvent` enum with `Connected`, `Disconnected { error }`, and `Restarting { attempt, delay }` variants, emitted as listeners connect, fail, or restart.
+- `ListenerConfig::new(id, profile)` constructor — takes the two required fields and defaults the rest.
+- `HandlerContext::listener_id` field — handlers can now identify which listener received the message.
+- `Debug` derive on `DIDCommResponse`, `DIDCommServiceConfig`, `ListenerConfig`, `RestartPolicy`, `RetryConfig`.
+- `PartialEq` derive on `ListenerEvent`, `ListenerState`, `ListenerStatus`.
+- `MiddlewareResult` type alias is now publicly exported.
+- Specific error variants `MessageAlreadyExtracted`, `MetadataAlreadyExtracted`, `ExtensionNotFound`, `InvalidRoutePattern` — replacing generic `Internal(String)` for known error conditions.
+- Documentation on `DIDCommResponse` explaining auto-fill behavior for `from`, `to`, `thid`, `pthid`.
 
 ### Changed
 
 - **Breaking:** `DIDCommService::shutdown()` now takes `&self` instead of consuming `self`, making it compatible with shared ownership patterns (`Arc`, cloned instances).
+- **Breaking:** `ErrorHandler::on_error()` is now `async` and returns `Option<DIDCommResponse>`. The default error handler now sends a problem report back to the sender instead of silently dropping the error.
+- **Breaking:** `HandlerContext` has a new `listener_id: String` field.
 
 ## [0.1.5] - 2026-04-13
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.1.5"
+version = "0.2.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -19,16 +19,16 @@ affinidi-messaging-didcomm = "0.13"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha256 = "1.6"
-regex = "1.12"
-thiserror = "2.0"
-tokio = { version = "1.49", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha256 = "1"
+regex = "1"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { version = "0.1", features = ["valuable"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1.21", features = ["v4", "fast-rng"] }
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 affinidi-did-common = "0.3.2"

--- a/crates/messaging/affinidi-messaging-didcomm-service/README.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/README.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-affinidi-messaging-didcomm-service = "0.1"
+affinidi-messaging-didcomm-service = "0.2"
 ```
 
 ## Features
@@ -24,7 +24,10 @@ affinidi-messaging-didcomm-service = "0.1"
 - **Graceful shutdown** -- in-flight message handlers are tracked via `JoinSet` and drained on shutdown; panicked tasks are detected and logged
 - **Built-in handlers** -- `trust_ping_handler` for trust-ping protocol, `ignore_handler` for silently dropping messages (e.g. `MESSAGE_PICKUP_STATUS_TYPE`)
 - **Fallback and error handling** -- `.fallback()` for unmatched message types, `.on_error()` with `ErrorHandler` trait for centralized error logging
-- **Outbound messaging** -- send proactive (unsolicited) DIDComm messages through an existing listener's mediator connection via `DIDCommService::send_message()`, avoiding duplicate websocket sessions
+- **Outbound messaging** -- send proactive (unsolicited) DIDComm messages through an existing listener's mediator connection via `DIDCommService::send_message()`, avoiding duplicate websocket sessions. `send_message_with_retry()` adds built-in retry with exponential backoff
+- **Connection readiness** -- `wait_connected(listener_id, timeout)` blocks until a listener's mediator connection is live, eliminating races between startup and first send
+- **Lifecycle events** -- `subscribe()` returns a broadcast receiver of `ListenerEvent`s (`Connected`, `Disconnected`, `Restarting`) for application-level reactions to connection state changes
+- **Cloneable service** -- `DIDCommService` implements `Clone` (cheaply, via internal `Arc`s), so it can be passed directly into handlers, spawn blocks, and shared state without an extra `Arc` wrapper
 - **Transport utilities** -- `build_response`, `send_response`, `build_problem_report`, `send_problem_report`
 - **Problem report protocol** -- `ProblemReport` struct with standard DIDComm error codes; `DIDCommResponse::problem_report()` for returning problem reports directly from handlers
 - **Message utilities** -- `get_thread_id`, `get_parent_thread_id`, `new_message_id`

--- a/crates/messaging/affinidi-messaging-didcomm-service/examples/echo_server.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/examples/echo_server.rs
@@ -13,6 +13,7 @@ use affinidi_messaging_didcomm_service::{
 use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 use affinidi_secrets_resolver::secrets::Secret;
 use affinidi_tdk_common::profiles::TDKProfile;
+use async_trait::async_trait;
 use serde_json::json;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -103,14 +104,21 @@ async fn fallback_handler(
 
 struct EchoErrorHandler;
 
+#[async_trait]
 impl ErrorHandler for EchoErrorHandler {
-    fn on_error(&self, ctx: &HandlerContext, error: &DIDCommServiceError) {
+    async fn on_error(
+        &self,
+        ctx: &HandlerContext,
+        error: &DIDCommServiceError,
+    ) -> Option<DIDCommResponse> {
         warn!(
             profile = %ctx.profile.inner.alias,
             message_id = %ctx.message_id,
             error = %error,
             "Echo server handler error"
         );
+        // Return None to silently drop — no problem report sent
+        None
     }
 }
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/config.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/config.rs
@@ -1,6 +1,7 @@
 use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 use affinidi_tdk_common::{config::TDKConfig, profiles::TDKProfile};
 
+#[derive(Debug)]
 pub struct DIDCommServiceConfig {
     pub listeners: Vec<ListenerConfig>,
 }
@@ -13,6 +14,34 @@ pub struct ListenerConfig {
     pub message_wait_duration_secs: u64,
     pub auto_delete: bool,
     pub tdk_config: Option<TDKConfig>,
+}
+
+impl std::fmt::Debug for ListenerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListenerConfig")
+            .field("id", &self.id)
+            .field("profile", &self.profile.alias)
+            .field("restart_policy", &self.restart_policy)
+            .field(
+                "message_wait_duration_secs",
+                &self.message_wait_duration_secs,
+            )
+            .field("auto_delete", &self.auto_delete)
+            .field("tdk_config", &self.tdk_config.as_ref().map(|_| "..."))
+            .finish()
+    }
+}
+
+impl ListenerConfig {
+    /// Create a new listener config with the required fields.
+    /// Optional fields use sensible defaults (restart: Never, wait: 5s, auto_delete: true).
+    pub fn new(id: impl Into<String>, profile: TDKProfile) -> Self {
+        Self {
+            id: id.into(),
+            profile,
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for ListenerConfig {
@@ -29,7 +58,7 @@ impl Default for ListenerConfig {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum RestartPolicy {
     #[default]
     Never,
@@ -42,7 +71,7 @@ pub enum RestartPolicy {
     },
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RetryConfig {
     pub initial_delay_secs: u64,
     pub max_delay_secs: u64,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
@@ -80,6 +80,18 @@ pub enum DIDCommServiceError {
     #[error("Handler error: {0}")]
     Handler(String),
 
+    #[error("Message body has already been extracted by another argument")]
+    MessageAlreadyExtracted,
+
+    #[error("UnpackMetadata has already been extracted by another argument")]
+    MetadataAlreadyExtracted,
+
+    #[error("Extension not found: {0}")]
+    ExtensionNotFound(String),
+
+    #[error("Invalid route pattern '{pattern}': {reason}")]
+    InvalidRoutePattern { pattern: String, reason: String },
+
     #[error("Policy violation: {0}")]
     Policy(#[from] PolicyViolation),
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/context.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/context.rs
@@ -4,9 +4,11 @@ use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 
 /// Per-message context passed to handlers and middleware.
 ///
+/// Cloning is cheap — all fields are either small strings or `Arc`-wrapped.
 /// `sender_did` is `None` when the message was anoncrypt'd (no `from` field).
 #[derive(Clone)]
 pub struct HandlerContext {
+    pub listener_id: String,
     pub atm: ATM,
     pub profile: Arc<ATMProfile>,
     pub sender_did: Option<String>,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/extractor.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/extractor.rs
@@ -50,7 +50,7 @@ impl FromMessageParts for Message {
         parts
             .message
             .take()
-            .ok_or_else(|| DIDCommServiceError::Internal("Message already consumed".into()))
+            .ok_or(DIDCommServiceError::MessageAlreadyExtracted)
     }
 }
 
@@ -59,7 +59,7 @@ impl FromMessageParts for UnpackMetadata {
         parts
             .meta
             .take()
-            .ok_or_else(|| DIDCommServiceError::Internal("UnpackMetadata already consumed".into()))
+            .ok_or(DIDCommServiceError::MetadataAlreadyExtracted)
     }
 }
 
@@ -73,10 +73,7 @@ impl<T: Clone + Send + Sync + 'static> FromMessageParts for Extension<T> {
             .cloned()
             .map(Extension)
             .ok_or_else(|| {
-                DIDCommServiceError::Internal(format!(
-                    "Extension not found: {}",
-                    std::any::type_name::<T>()
-                ))
+                DIDCommServiceError::ExtensionNotFound(std::any::type_name::<T>().to_string())
             })
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
@@ -22,7 +22,7 @@ use crate::response::DIDCommResponse;
 ///
 /// The return type is `Result` (not plain `Option`) so that raw implementors
 /// keep `?` ergonomics and middleware can intercept errors.
-/// When used through [`Router`], handler errors are caught and forwarded to
+/// When used through [`crate::router::Router`], handler errors are caught and forwarded to
 /// the configured [`ErrorHandler`], so `Router::handle` always returns `Ok`.
 #[async_trait]
 pub trait DIDCommHandler: Send + Sync + 'static {

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
@@ -12,6 +12,7 @@ use affinidi_messaging_didcomm::{Message, UnpackMetadata};
 use async_trait::async_trait;
 
 use crate::error::DIDCommServiceError;
+use crate::problem_report::ServiceProblemReport;
 use crate::response::DIDCommResponse;
 
 /// Top-level handler for incoming DIDComm messages.
@@ -34,14 +35,30 @@ pub trait DIDCommHandler: Send + Sync + 'static {
     ) -> Result<Option<DIDCommResponse>, DIDCommServiceError>;
 }
 
+/// Handler invoked when a route handler returns an error.
+///
+/// Return `Some(response)` to send a reply (e.g., a problem report) back to the
+/// sender. Return `None` to silently drop the error.
+///
+/// The default implementation logs the error and returns a problem report.
+#[async_trait]
 pub trait ErrorHandler: Send + Sync + 'static {
-    fn on_error(&self, ctx: &HandlerContext, error: &DIDCommServiceError);
+    async fn on_error(
+        &self,
+        ctx: &HandlerContext,
+        error: &DIDCommServiceError,
+    ) -> Option<DIDCommResponse>;
 }
 
 pub struct DefaultErrorHandler;
 
+#[async_trait]
 impl ErrorHandler for DefaultErrorHandler {
-    fn on_error(&self, ctx: &HandlerContext, error: &DIDCommServiceError) {
+    async fn on_error(
+        &self,
+        ctx: &HandlerContext,
+        error: &DIDCommServiceError,
+    ) -> Option<DIDCommResponse> {
         tracing::warn!(
             profile = %ctx.profile.inner.alias,
             message_id = %ctx.message_id,
@@ -50,6 +67,10 @@ impl ErrorHandler for DefaultErrorHandler {
             error = %error,
             "Error handling message"
         );
+
+        Some(DIDCommResponse::problem_report(
+            crate::problem_report::ProblemReport::internal_error(error.to_string()),
+        ))
     }
 }
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
@@ -20,6 +20,6 @@ pub use middleware::{MessagePolicy, MiddlewareHandler, Next, RequestLogging, mid
 pub use problem_report::{ProblemReport, ServiceProblemReport};
 pub use response::DIDCommResponse;
 pub use router::{MessageHandler, Router, handler_fn};
-pub use service::{DIDCommService, ListenerState, ListenerStatus};
+pub use service::{DIDCommService, ListenerEvent, ListenerState, ListenerStatus};
 pub use transport::{build_problem_report, build_response, send_problem_report, send_response};
 pub use utils::{get_parent_thread_id, get_thread_id, new_message_id};

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
@@ -16,7 +16,9 @@ pub use handler::{
     HandlerContext, MESSAGE_PICKUP_STATUS_TYPE, TRUST_PING_TYPE, TRUST_PONG_TYPE, ignore_handler,
     trust_ping_handler,
 };
-pub use middleware::{MessagePolicy, MiddlewareHandler, Next, RequestLogging, middleware_fn};
+pub use middleware::{
+    MessagePolicy, MiddlewareHandler, MiddlewareResult, Next, RequestLogging, middleware_fn,
+};
 pub use problem_report::{ProblemReport, ServiceProblemReport};
 pub use response::DIDCommResponse;
 pub use router::{MessageHandler, Router, handler_fn};

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/middleware/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/middleware/mod.rs
@@ -18,7 +18,8 @@ pub use policy::MessagePolicy;
 pub use request_logging::RequestLogging;
 
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-type MiddlewareResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
+/// The return type shared by middleware handlers and route handlers.
+pub type MiddlewareResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
 
 pub struct Next {
     handler: Arc<dyn MessageHandler>,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/response/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/response/mod.rs
@@ -6,6 +6,21 @@ use crate::problem_report::{ProblemReport, ServiceProblemReport};
 use crate::transport::PROBLEM_REPORT_TYPE;
 use crate::utils::new_message_id;
 
+/// A response to be sent back to the message sender.
+///
+/// When sent via a handler return value, the following fields are
+/// auto-filled from the [`HandlerContext`] if not explicitly set:
+///
+/// - **`from`** — defaults to the listener's profile DID
+/// - **`to`** — defaults to the incoming message's sender DID
+/// - **`thid`** — defaults to the incoming message's thread ID
+/// - **`pthid`** — defaults to the incoming message's parent thread ID (if any)
+///
+/// This means a minimal response only needs a type and body:
+/// ```ignore
+/// Ok(Some(DIDCommResponse::new("https://example.com/ack", json!({}))))
+/// ```
+#[derive(Debug)]
 pub struct DIDCommResponse {
     pub(crate) type_: String,
     pub(crate) body: Value,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/router/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/router/mod.rs
@@ -112,8 +112,8 @@ impl DIDCommHandler for Router {
             match next.run(ctx.clone(), message, meta).await {
                 Ok(response) => Ok(response),
                 Err(e) => {
-                    self.error_handler.on_error(&ctx, &e);
-                    Ok(None)
+                    let response = self.error_handler.on_error(&ctx, &e).await;
+                    Ok(response)
                 }
             }
         } else {

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/router/route.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/router/route.rs
@@ -21,9 +21,11 @@ impl Route {
             format!("^{}$", regex::escape(pattern))
         };
 
-        let regex = Regex::new(&anchored).map_err(|e| {
-            DIDCommServiceError::Internal(format!("Invalid route pattern '{pattern}': {e}"))
-        })?;
+        let regex =
+            Regex::new(&anchored).map_err(|e| DIDCommServiceError::InvalidRoutePattern {
+                pattern: pattern.to_string(),
+                reason: e.to_string(),
+            })?;
 
         Ok(Self {
             pattern: regex,
@@ -45,9 +47,11 @@ impl Route {
             format!("^{pattern}$")
         };
 
-        let regex = Regex::new(&anchored).map_err(|e| {
-            DIDCommServiceError::Internal(format!("Invalid route regex '{pattern}': {e}"))
-        })?;
+        let regex =
+            Regex::new(&anchored).map_err(|e| DIDCommServiceError::InvalidRoutePattern {
+                pattern: pattern.to_string(),
+                reason: e.to_string(),
+            })?;
 
         Ok(Self {
             pattern: regex,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -5,7 +5,7 @@ use affinidi_messaging_sdk::config::ATMConfigBuilder;
 use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use affinidi_secrets_resolver::SecretsResolver;
 use affinidi_tdk_common::TDKSharedState;
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -14,6 +14,7 @@ use crate::config::ListenerConfig;
 use crate::error::{DIDCommServiceError, StartupError};
 use crate::handler::{DIDCommHandler, HandlerContext};
 use crate::response::DIDCommResponse;
+use crate::service::ListenerEvent;
 use crate::transport;
 use crate::utils::{get_parent_thread_id, get_thread_id};
 
@@ -53,6 +54,8 @@ pub(crate) struct Listener {
     profile: Option<Arc<ATMProfile>>,
     /// Watch channel sender — updated after each successful connect().
     pub(crate) connection_tx: watch::Sender<Option<ConnectionHandle>>,
+    /// Broadcast sender for lifecycle events.
+    pub(crate) events_tx: broadcast::Sender<ListenerEvent>,
 }
 
 impl Listener {
@@ -61,6 +64,7 @@ impl Listener {
         handler: Arc<dyn DIDCommHandler>,
         shutdown: CancellationToken,
         connection_tx: watch::Sender<Option<ConnectionHandle>>,
+        events_tx: broadcast::Sender<ListenerEvent>,
     ) -> Self {
         Self {
             config,
@@ -69,6 +73,7 @@ impl Listener {
             atm: None,
             profile: None,
             connection_tx,
+            events_tx,
         }
     }
 
@@ -140,6 +145,10 @@ impl Listener {
 
         // Publish the connection handle so outbound messaging can use it
         let _ = self.connection_tx.send(Some(conn_handle));
+
+        let _ = self.events_tx.send(ListenerEvent::Connected {
+            listener_id: self.config.id.clone(),
+        });
 
         Ok(())
     }

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -164,12 +164,14 @@ impl Listener {
         let mut tasks = JoinSet::new();
 
         // Spawn offline sync as a tracked task
+        let listener_id = self.config.id.clone();
         let shutdown_clone = self.shutdown.clone();
         let atm_clone = atm.clone();
         let profile_clone = profile.clone();
         let handler_clone = self.handler.clone();
         tasks.spawn(async move {
             Listener::run_periodic_offline_sync(
+                &listener_id,
                 &atm_clone,
                 &profile_clone,
                 &handler_clone,
@@ -231,11 +233,12 @@ impl Listener {
 
         if let Some((message, meta)) = next {
             let meta = convert_meta(*meta);
+            let listener_id = self.config.id.clone();
             let atm = atm.clone();
             let profile = profile.clone();
             let handler = self.handler.clone();
             tasks.spawn(async move {
-                Self::dispatch_message(&atm, &profile, &handler, message, meta).await;
+                Self::dispatch_message(&listener_id, &atm, &profile, &handler, message, meta).await;
             });
         }
 
@@ -243,6 +246,7 @@ impl Listener {
     }
 
     pub(crate) async fn dispatch_message(
+        listener_id: &str,
         atm: &ATM,
         profile: &Arc<ATMProfile>,
         handler: &Arc<dyn DIDCommHandler>,
@@ -254,6 +258,7 @@ impl Listener {
         let parent_thread_id = get_parent_thread_id(&message, false);
 
         let ctx = HandlerContext {
+            listener_id: listener_id.to_string(),
             atm: atm.clone(),
             profile: profile.clone(),
             sender_did,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -44,6 +44,7 @@ impl Listener {
     }
 
     pub(crate) async fn run_periodic_offline_sync(
+        listener_id: &str,
         atm: &ATM,
         profile: &Arc<ATMProfile>,
         handler: &Arc<dyn DIDCommHandler>,
@@ -57,7 +58,7 @@ impl Listener {
                     break;
                 }
                 _ = tokio::time::sleep(Duration::from_secs(OFFLINE_SYNC_INTERVAL_SECS)) => {
-                    if let Err(e) = Listener::sync_offline_messages(atm, profile, handler).await {
+                    if let Err(e) = Listener::sync_offline_messages(listener_id, atm, profile, handler).await {
                         warn!(profile = %profile_alias, error = %e, "Offline sync failed");
                     }
                 }
@@ -66,6 +67,7 @@ impl Listener {
     }
 
     async fn sync_offline_messages(
+        listener_id: &str,
         atm: &ATM,
         profile: &Arc<ATMProfile>,
         handler: &Arc<dyn DIDCommHandler>,
@@ -96,7 +98,7 @@ impl Listener {
 
         for (message, meta) in offline_messages {
             let meta = super::listener::convert_meta(meta);
-            Listener::dispatch_message(atm, profile, handler, message, meta).await;
+            Listener::dispatch_message(listener_id, atm, profile, handler, message, meta).await;
         }
 
         let delete_result = atm

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use tokio::sync::broadcast;
+
 use affinidi_messaging_didcomm::Message;
 use tokio::sync::{RwLock, watch};
 use tokio::task::JoinHandle;
@@ -17,14 +19,37 @@ use crate::handler::DIDCommHandler;
 
 use listener::ConnectionHandle;
 
+const EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Lifecycle events emitted by listeners.
+#[derive(Debug, Clone)]
+pub enum ListenerEvent {
+    /// The listener has connected to its mediator.
+    Connected { listener_id: String },
+    /// The listener has disconnected from its mediator.
+    Disconnected {
+        listener_id: String,
+        error: Option<String>,
+    },
+    /// The listener is restarting after a failure.
+    Restarting {
+        listener_id: String,
+        attempt: u32,
+        delay: Duration,
+    },
+}
+
+#[derive(Clone)]
 pub struct DIDCommService {
     listeners: Arc<RwLock<HashMap<String, ListenerHandle>>>,
     handler: Arc<dyn DIDCommHandler>,
     shutdown: CancellationToken,
+    events_tx: broadcast::Sender<ListenerEvent>,
 }
 
 struct ListenerHandle {
     id: String,
+    did: String,
     task: JoinHandle<()>,
     token: CancellationToken,
     started_at: Instant,
@@ -55,11 +80,13 @@ impl DIDCommService {
     ) -> Result<DIDCommService, DIDCommServiceError> {
         let handler = Arc::new(handler) as Arc<dyn DIDCommHandler>;
         let listeners = Arc::new(RwLock::new(HashMap::new()));
+        let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
 
         let service = DIDCommService {
             listeners: listeners.clone(),
             handler: handler.clone(),
             shutdown: shutdown.clone(),
+            events_tx,
         };
 
         for listener_config in config.listeners {
@@ -67,6 +94,14 @@ impl DIDCommService {
         }
 
         Ok(service)
+    }
+
+    /// Subscribe to listener lifecycle events.
+    ///
+    /// Returns a receiver that yields [`ListenerEvent`]s as listeners
+    /// connect, disconnect, or restart. Multiple subscribers are supported.
+    pub fn subscribe(&self) -> broadcast::Receiver<ListenerEvent> {
+        self.events_tx.subscribe()
     }
 
     pub async fn add_listener(&self, config: ListenerConfig) -> Result<(), DIDCommServiceError> {
@@ -93,7 +128,7 @@ impl DIDCommService {
         Ok(())
     }
 
-    pub async fn shutdown(self) {
+    pub async fn shutdown(&self) {
         self.shutdown.cancel();
         let listeners = self.listeners.write().await;
         for (_, handle) in listeners.iter() {
@@ -121,6 +156,34 @@ impl DIDCommService {
                 }
             })
             .collect()
+    }
+
+    /// Returns the DID associated with a listener.
+    pub async fn listener_did(&self, listener_id: &str) -> Option<String> {
+        let listeners = self.listeners.read().await;
+        listeners.get(listener_id).map(|h| h.did.clone())
+    }
+
+    /// Waits until the specified listener has established a connection to
+    /// its mediator, or until the timeout expires.
+    pub async fn wait_connected(
+        &self,
+        listener_id: &str,
+        timeout: Duration,
+    ) -> Result<(), DIDCommServiceError> {
+        let listeners = self.listeners.read().await;
+        let handle = listeners
+            .get(listener_id)
+            .ok_or_else(|| DIDCommServiceError::ListenerNotFound(listener_id.to_string()))?;
+        let mut rx = handle.connection_rx.clone();
+        drop(listeners);
+
+        tokio::time::timeout(timeout, rx.wait_for(|v| v.is_some()))
+            .await
+            .map_err(DIDCommServiceError::Timeout)?
+            .map_err(|_| DIDCommServiceError::NotConnected(listener_id.to_string()))?;
+
+        Ok(())
     }
 
     /// Send a proactive DIDComm message through an existing listener's
@@ -156,23 +219,60 @@ impl DIDCommService {
         crate::transport::send_message(&conn.atm, &conn.profile, message, recipient_did).await
     }
 
+    /// Like [`send_message`](Self::send_message), but retries on
+    /// [`NotConnected`](DIDCommServiceError::NotConnected) errors using
+    /// exponential backoff.
+    ///
+    /// Waits for the listener's connection to become available between
+    /// retries rather than busy-looping.
+    pub async fn send_message_with_retry(
+        &self,
+        listener_id: &str,
+        message: Message,
+        recipient_did: &str,
+        max_retries: u32,
+        initial_backoff: Duration,
+    ) -> Result<(), DIDCommServiceError> {
+        let mut attempt = 0u32;
+        loop {
+            match self
+                .send_message(listener_id, message.clone(), recipient_did)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(DIDCommServiceError::NotConnected(_)) if attempt < max_retries => {
+                    attempt += 1;
+                    let backoff = initial_backoff
+                        .saturating_mul(2u32.saturating_pow(attempt.saturating_sub(1)));
+                    // Wait for connection or backoff timeout, whichever comes first
+                    let _ = self.wait_connected(listener_id, backoff).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     async fn spawn_listener(&self, config: ListenerConfig) -> Result<(), DIDCommServiceError> {
         let listener_id = config.id.clone();
+        let listener_did = config.profile.did.clone();
         let listener_token = self.shutdown.child_token();
         let handler = self.handler.clone();
         let restart_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let restart_count_clone = restart_count.clone();
         let token_clone = listener_token.clone();
+        let events_tx = self.events_tx.clone();
 
         let (connection_tx, connection_rx) = watch::channel(None);
 
         let task = tokio::spawn(async move {
-            let mut listener = listener::Listener::new(config, handler, token_clone, connection_tx);
+            let mut listener =
+                listener::Listener::new(config, handler, token_clone, connection_tx, events_tx);
             listener.run_with_restart(restart_count_clone).await;
         });
 
         let handle = ListenerHandle {
             id: listener_id.clone(),
+            did: listener_did,
             task,
             token: listener_token,
             started_at: Instant::now(),
@@ -198,10 +298,12 @@ mod tests {
         let handler = Router::new()
             .route("test", handler_fn(ignore_handler))
             .expect("valid route");
+        let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         DIDCommService {
             listeners: Arc::new(RwLock::new(HashMap::new())),
             handler: Arc::new(handler),
             shutdown: CancellationToken::new(),
+            events_tx,
         }
     }
 
@@ -243,6 +345,7 @@ mod tests {
         let (_tx, rx) = watch::channel(None);
         let handle = ListenerHandle {
             id: "test-listener".to_string(),
+            did: "did:example:test".to_string(),
             task: tokio::spawn(async {}),
             token: CancellationToken::new(),
             started_at: Instant::now(),

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -22,7 +22,7 @@ use listener::ConnectionHandle;
 const EVENT_CHANNEL_CAPACITY: usize = 64;
 
 /// Lifecycle events emitted by listeners.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ListenerEvent {
     /// The listener has connected to its mediator.
     Connected { listener_id: String },
@@ -57,7 +57,7 @@ struct ListenerHandle {
     connection_rx: watch::Receiver<Option<ConnectionHandle>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ListenerStatus {
     pub id: String,
     pub state: ListenerState,
@@ -65,7 +65,7 @@ pub struct ListenerStatus {
     pub uptime: Duration,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ListenerState {
     Running,
     Stopped,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/restart.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/restart.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::config::{RestartPolicy, RetryConfig};
 
+use super::ListenerEvent;
 use super::listener::Listener;
 
 enum ShouldRestart {
@@ -41,20 +42,34 @@ impl Listener {
         let alias = self.config.profile.alias.clone();
         let restart_policy = self.config.restart_policy.clone();
 
+        let listener_id = self.config.id.clone();
+
         loop {
             let was_success = if let Err(e) = self.connect().await {
                 warn!(profile = %alias, error = %e, "Failed to connect");
+                let _ = self.events_tx.send(ListenerEvent::Disconnected {
+                    listener_id: listener_id.clone(),
+                    error: Some(e.to_string()),
+                });
                 false
             } else {
                 let result = self.listen().await;
 
                 if self.shutdown.is_cancelled() {
                     debug!(profile = %alias, "Listener shutting down");
+                    let _ = self.events_tx.send(ListenerEvent::Disconnected {
+                        listener_id: listener_id.clone(),
+                        error: None,
+                    });
                     break;
                 }
 
                 if let Err(ref e) = result {
                     warn!(profile = %alias, error = %e, "Listener failed");
+                    let _ = self.events_tx.send(ListenerEvent::Disconnected {
+                        listener_id: listener_id.clone(),
+                        error: Some(e.to_string()),
+                    });
                 }
 
                 result.is_ok()
@@ -65,6 +80,11 @@ impl Listener {
             match should_restart(&restart_policy, count, was_success) {
                 ShouldRestart::Yes(delay) => {
                     info!(profile = %alias, attempt = count, backoff = ?delay, "Restarting");
+                    let _ = self.events_tx.send(ListenerEvent::Restarting {
+                        listener_id: listener_id.clone(),
+                        attempt: count,
+                        delay,
+                    });
                     tokio::time::sleep(delay).await;
                 }
                 ShouldRestart::Stop => {


### PR DESCRIPTION
## Summary
Bump `affinidi-messaging-didcomm-service` to 0.2.0 with usability and API improvements.

### Service-level improvements
- Make `DIDCommService` implement `Clone` — eliminates `Arc<DIDCommService>` wrappers
- Change `shutdown()` to take `&self` instead of consuming `self`
- Add `wait_connected(listener_id, timeout)` — blocks until mediator connection is live
- Add `send_message_with_retry()` with exponential backoff
- Add `listener_did(listener_id)` accessor for self-contained message building
- Add `ListenerEvent` lifecycle hooks (`Connected`, `Disconnected`, `Restarting`) via broadcast channel

### API ergonomics
- Add `listener_id` to `HandlerContext` — handlers can identify which listener received the message
- Add `ListenerConfig::new(id, profile)` constructor with sensible defaults
- Make `ErrorHandler::on_error()` async and return `Option<DIDCommResponse>` — default now sends a problem report instead of silently dropping errors
- Export `MiddlewareResult` type alias
- Document `DIDCommResponse` auto-fill behavior (`from`, `to`, `thid`, `pthid`)

### Error handling
- Split `Internal(String)` into specific variants: `MessageAlreadyExtracted`, `MetadataAlreadyExtracted`, `ExtensionNotFound`, `InvalidRoutePattern`
- Keep `Internal(String)` as catch-all for truly unexpected errors

### Trait improvements
- Add `Debug` to `DIDCommResponse`, `DIDCommServiceConfig`, `ListenerConfig`, `RestartPolicy`, `RetryConfig`
- Add `PartialEq` to `ListenerEvent`, `ListenerState`, `ListenerStatus`
- Fix pre-existing broken rustdoc link in handler/mod.rs

## Checklist
- [x] All tests pass (71/71)
- [x] CHANGELOG.md updated
- [x] Version references in README.md updated
- [x] No clippy warnings
- [x] Documentation builds cleanly