### PR TITLE
ci: consume pipeline workspace_publish workflow while waiting for pipeline-rust PR #71

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
     with:
       toolchain: "1.94.0"
       rustflags: "-D warnings --cfg tracing_unstable"
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0098,RUSTSEC-2026-0099"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   rust-pipeline:
-    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@main
+    # Waiting for https://github.com/affinidi/pipeline-rust/pull/71 to merge before using @main
+    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@feat/workspace-publish
     secrets: inherit
     with:
       toolchain: "1.94.0"
@@ -15,4 +16,5 @@ jobs:
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       release_debug: true
+      workspace_publish: true
       release_dry_run: false

--- a/crates/identity/affinidi-did-resolver-traits/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-traits/src/lib.rs
@@ -77,19 +77,18 @@ impl std::fmt::Display for MethodName {
 /// Convert `DIDMethod` (with data) to `MethodName` (pure discriminant).
 impl From<&DIDMethod> for MethodName {
     fn from(method: &DIDMethod) -> Self {
-        match method {
-            DIDMethod::Key { .. } => MethodName::Key,
-            DIDMethod::Peer { .. } => MethodName::Peer,
-            DIDMethod::Web { .. } => MethodName::Web,
-            DIDMethod::Jwk { .. } => MethodName::Jwk,
-            DIDMethod::Ethr { .. } => MethodName::Ethr,
-            DIDMethod::Pkh { .. } => MethodName::Pkh,
-            DIDMethod::Webvh { .. } => MethodName::Webvh,
-            DIDMethod::Cheqd { .. } => MethodName::Cheqd,
-            DIDMethod::Scid { .. } => MethodName::Scid,
-            DIDMethod::Ebsi { .. } => MethodName::Ebsi,
-            DIDMethod::Other { method, .. } => MethodName::Other(method.clone()),
-            _ => MethodName::Other(format!("{method}")),
+        match method.name() {
+            "key" => MethodName::Key,
+            "peer" => MethodName::Peer,
+            "web" => MethodName::Web,
+            "jwk" => MethodName::Jwk,
+            "ethr" => MethodName::Ethr,
+            "pkh" => MethodName::Pkh,
+            "webvh" => MethodName::Webvh,
+            "cheqd" => MethodName::Cheqd,
+            "scid" => MethodName::Scid,
+            "ebsi" => MethodName::Ebsi,
+            method => MethodName::Other(method.to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary
   Update the `affinidi-tdk-rs` release workflow to consume the `pipeline-rust` workspace publish
 changes while they are still in-flight.

   ## Changes
   - Pointed the reusable workflow call in `.github/workflows/release.yaml` to:
     - `affinidi/pipeline-rust/.github/workflows/release.yaml@feat/workspace-publish`
   - Kept `workspace_publish: true` enabled for release flow.
   - Added an inline comment documenting dependency on:
     - https://github.com/affinidi/pipeline-rust/pull/71

   ## Follow-up
   Once PR 71 is merged into `pipeline-rust`, we should switch the workflow ref back to `@main` and
 remove the waiting comment.