### PR TITLE
 chore: harden mediator startup paths and bump version to 0.13.1

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 15th April 2026
 
+### 0.13.1 — Startup Hardening
+
+- **BREAKING:** LUA scripts file (`database.functions_file`) is now required in
+  mediator configuration. Previously, omitting it silently skipped script loading
+  and returned successfully; the mediator now exits with an error if it is not
+  specified. Ensure your `mediator.toml` includes a valid `functions_file` path.
+- **CHORE:** Replaced all `unwrap()`/`expect()`/`process::exit()` calls in
+  startup and runtime code with typed `Result` propagation via `MediatorError`
+  - `start()` now returns `Result<(), MediatorError>`; `main()` prints the error
+    and exits non-zero on failure
+  - Database initialization, TLS config, streaming task, DID resolver, and
+    signal handler installation all use explicit error handling
+- **CHORE:** Rate limiter construction uses safe `NonZeroU32` checks instead of
+  `expect()` (applies to both per-IP and per-DID rate limiters)
+
 - **DOC:** Added README section on running without a secure credential store
   (`string://` usage for dev/CI without keyring or AWS Secrets Manager)
 

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.13.0"
+version = "0.13.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/did_rate_limiter.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/did_rate_limiter.rs
@@ -26,11 +26,15 @@ impl DidRateLimiter {
             return Self { limiter: None };
         }
 
-        let quota = Quota::per_second(
-            NonZeroU32::new(per_second).expect("per_second checked non-zero above"),
-        )
-        .allow_burst(NonZeroU32::new(burst.max(1)).expect("burst.max(1) is always non-zero"));
+        let Some(per_second_nz) = NonZeroU32::new(per_second) else {
+            return Self { limiter: None };
+        };
 
+        let burst_nz = match NonZeroU32::new(burst.max(1)) {
+            Some(value) => value,
+            None => return Self { limiter: None },
+        };
+        let quota = Quota::per_second(per_second_nz).allow_burst(burst_nz);
         Self {
             limiter: Some(Arc::new(RateLimiter::keyed(quota))),
         }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/rate_limiter.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/rate_limiter.rs
@@ -30,11 +30,15 @@ impl RateLimiterState {
             return Self { limiter: None };
         }
 
-        let quota = Quota::per_second(
-            NonZeroU32::new(per_second).expect("per_second checked non-zero above"),
-        )
-        .allow_burst(NonZeroU32::new(burst.max(1)).expect("burst.max(1) is always non-zero"));
+        let Some(per_second_nz) = NonZeroU32::new(per_second) else {
+            return Self { limiter: None };
+        };
 
+        let burst_nz = match NonZeroU32::new(burst.max(1)) {
+            Some(value) => value,
+            None => return Self { limiter: None },
+        };
+        let quota = Quota::per_second(per_second_nz).allow_burst(burst_nz);
         Self {
             limiter: Some(Arc::new(RateLimiter::keyed(quota))),
         }

--- a/crates/messaging/affinidi-messaging-mediator/src/database/initialization.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/database/initialization.rs
@@ -19,14 +19,21 @@ impl Database {
 
         // Setup the mediator account if it doesn't exist
         // Set the ACL for the mediator account to deny_all by default
+        let default_mediator_acl = MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,BLOCKED")
+            .map_err(|e| {
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Hardcoded mediator ACL ruleset is invalid. Reason: {e}"),
+                )
+            })?;
+
         self.setup_admin_account(
             &config.mediator_did_hash,
             AccountType::Mediator,
-            &MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,BLOCKED")
-                .expect("hardcoded ACL ruleset is valid"),
+            &default_mediator_acl,
         )
-        .await
-        .expect("Could not setup mediator account! exiting...");
+        .await?;
 
         // Set up the administration account if it doesn't exist
         self.setup_admin_account(
@@ -34,8 +41,7 @@ impl Database {
             AccountType::RootAdmin,
             &config.security.global_acl_default,
         )
-        .await
-        .expect("Could not setup admin account! exiting...");
+        .await?;
         Ok(())
     }
 
@@ -82,7 +88,15 @@ impl Database {
                     schema_version, mediator_version
                 );
                 if schema_version
-                    < Version::parse("0.10.0").expect("hardcoded version string is valid")
+                    < Version::parse("0.10.0").map_err(|e| {
+                        MediatorError::InternalError(
+                            17,
+                            "NA".into(),
+                            format!(
+                                "Couldn't parse hardcoded schema migration version (0.10.0). Reason: {e}"
+                            ),
+                        )
+                    })?
                 {
                     // Upgrade the database schema to 0.10.0
                     self.upgrade_0_10_0(&config.security.global_acl_default)

--- a/crates/messaging/affinidi-messaging-mediator/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/main.rs
@@ -2,5 +2,8 @@ use affinidi_messaging_mediator::server::start;
 
 #[tokio::main]
 async fn main() {
-    return start().await;
+    if let Err(err) = start().await {
+        eprintln!("Mediator failed to start: {err}");
+        std::process::exit(1);
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -61,9 +61,13 @@ pub async fn start() {
 
     println!("[Loading Affinidi Secure Messaging Mediator configuration]");
 
-    let config = init("conf/mediator.toml", ansi)
-        .await
-        .expect("Couldn't initialize mediator!");
+    let config = match init("conf/mediator.toml", ansi).await {
+        Ok(config) => config,
+        Err(err) => {
+            error!("Couldn't initialize mediator: {err}");
+            return;
+        }
+    };
 
     // Start setting up the database durability and handling
     let database = match tokio::time::timeout(
@@ -88,10 +92,10 @@ pub async fn start() {
     // Convert from the common generic DatabaseHandler to the Mediator specific Database
     let database = Database::new(database);
 
-    database
-        .initialize(&config)
-        .await
-        .expect("Error initializing database");
+    if let Err(err) = database.initialize(&config).await {
+        error!("Error initializing database: {err}");
+        return;
+    }
 
     if let Some(functions_file) = &config.database.functions_file {
         info!(
@@ -183,10 +187,13 @@ pub async fn start() {
     let (streaming_task, _) = if config.streaming_enabled {
         let _database = database.clone(); // Clone the database handler for the subscriber thread
         let uuid = config.streaming_uuid.clone();
-        let (_task, _handle) = StreamingTask::new(_database.clone(), &uuid)
-            .await
-            .expect("Error starting streaming task");
-        (Some(_task), Some(_handle))
+        match StreamingTask::new(_database.clone(), &uuid).await {
+            Ok((task, handle)) => (Some(task), Some(handle)),
+            Err(err) => {
+                error!("Error starting streaming task: {err}");
+                return;
+            }
+        }
     } else {
         (None, None)
     };
@@ -299,18 +306,28 @@ pub async fn start() {
         // configure certificate and private key used by https
         // TODO: Build a proper TLS Config
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-        let ssl_config = RustlsConfig::from_pem_file(
-            config
-                .security
-                .ssl_certificate_file
-                .expect("SSL Certificate file must be specified in the Config"),
-            config
-                .security
-                .ssl_key_file
-                .expect("SSL Certificate key file must be specified in the Config"),
-        )
-        .await
-        .expect("bad certificate/key");
+        let certificate_file = match config.security.ssl_certificate_file.clone() {
+            Some(path) => path,
+            None => {
+                error!("SSL Certificate file must be specified in the config");
+                return;
+            }
+        };
+        let key_file = match config.security.ssl_key_file.clone() {
+            Some(path) => path,
+            None => {
+                error!("SSL Certificate key file must be specified in the config");
+                return;
+            }
+        };
+
+        let ssl_config = match RustlsConfig::from_pem_file(certificate_file, key_file).await {
+            Ok(config) => config,
+            Err(err) => {
+                error!("Invalid TLS certificate/key: {err}");
+                return;
+            }
+        };
 
         let handle = axum_server::Handle::new();
         let shutdown_handle = handle.clone();
@@ -330,11 +347,13 @@ pub async fn start() {
 
         info!("Mediator listening on {}", config.listen_address);
 
-        axum_server::bind_rustls(addr, ssl_config)
+        if let Err(err) = axum_server::bind_rustls(addr, ssl_config)
             .handle(handle)
             .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await
-            .unwrap();
+        {
+            error!("HTTPS server error: {err}");
+        }
     } else {
         warn!("**** WARNING: Running without SSL/TLS ****");
 
@@ -356,11 +375,13 @@ pub async fn start() {
 
         info!("Mediator listening on {}", config.listen_address);
 
-        axum_server::bind(addr)
+        if let Err(err) = axum_server::bind(addr)
             .handle(handle)
             .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await
-            .unwrap();
+        {
+            error!("HTTP server error: {err}");
+        }
     }
 
     info!("Mediator shutdown complete.");
@@ -369,17 +390,30 @@ pub async fn start() {
 /// Wait for a shutdown signal (SIGINT or SIGTERM).
 async fn shutdown_signal() {
     let ctrl_c = async {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("Failed to install Ctrl+C handler");
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {}
+            Err(err) => {
+                error!("Failed to install Ctrl+C handler: {err}");
+                // Keep this branch pending so another successfully installed signal
+                // handler can still trigger shutdown.
+                std::future::pending::<()>().await;
+            }
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("Failed to install SIGTERM handler")
-            .recv()
-            .await;
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut signal) => {
+                signal.recv().await;
+            }
+            Err(err) => {
+                error!("Failed to install SIGTERM handler: {err}");
+                // Keep this branch pending so another successfully installed signal
+                // handler can still trigger shutdown.
+                std::future::pending::<()>().await;
+            }
+        }
     };
 
     #[cfg(not(unix))]

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_mediator_common::database::DatabaseHandler;
+use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_mediator_processors::message_expiry_cleanup::processor::MessageExpiryCleanupProcessor;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_sdk::protocols::discover_features::DiscoverFeatures;
@@ -27,7 +28,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::{self, TraceLayer};
 use tracing::{Level, error, info, warn};
 
-pub async fn start() {
+pub async fn start() -> Result<(), MediatorError> {
     let ansi = env::var("LOCAL").is_ok();
 
     if ansi {
@@ -65,7 +66,7 @@ pub async fn start() {
         Ok(config) => config,
         Err(err) => {
             error!("Couldn't initialize mediator: {err}");
-            return;
+            return Err(err);
         }
     };
 
@@ -79,13 +80,19 @@ pub async fn start() {
         Ok(Ok(db)) => db,
         Ok(Err(err)) => {
             error!("Error opening database: {}", err);
-            error!("Exiting...");
-            std::process::exit(1);
+            return Err(MediatorError::DatabaseError(
+                14,
+                "NA".into(),
+                format!("Error opening database: {err}"),
+            ));
         }
         Err(_) => {
             error!("Database connection timed out after 30 seconds");
-            error!("Exiting...");
-            std::process::exit(1);
+            return Err(MediatorError::DatabaseError(
+                14,
+                "NA".into(),
+                "Database connection timed out after 30 seconds".into(),
+            ));
         }
     };
 
@@ -94,7 +101,7 @@ pub async fn start() {
 
     if let Err(err) = database.initialize(&config).await {
         error!("Error initializing database: {err}");
-        return;
+        return Err(err);
     }
 
     if let Some(functions_file) = &config.database.functions_file {
@@ -104,11 +111,15 @@ pub async fn start() {
         );
         if let Err(e) = database.load_scripts(functions_file).await {
             error!("Failed to load LUA scripts: {}", e);
-            return;
+            return Err(e);
         }
     } else {
-        info!("No LUA scripts file specified in the configuration. Skipping loading LUA scripts.");
-        return;
+        error!("LUA scripts file is required but not specified in the configuration");
+        return Err(MediatorError::ConfigError(
+            12,
+            "NA".into(),
+            "LUA scripts file is required but not specified in the configuration".into(),
+        ));
     }
 
     // Create a cancellation token for coordinated graceful shutdown
@@ -191,7 +202,7 @@ pub async fn start() {
             Ok((task, handle)) => (Some(task), Some(handle)),
             Err(err) => {
                 error!("Error starting streaming task: {err}");
-                return;
+                return Err(err);
             }
         }
     } else {
@@ -203,7 +214,11 @@ pub async fn start() {
         Ok(r) => r,
         Err(e) => {
             error!("Failed to create DID resolver: {}", e);
-            return;
+            return Err(MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                format!("Failed to create DID resolver: {e}"),
+            ));
         }
     };
 
@@ -310,14 +325,22 @@ pub async fn start() {
             Some(path) => path,
             None => {
                 error!("SSL Certificate file must be specified in the config");
-                return;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    "SSL Certificate file must be specified in the config".into(),
+                ));
             }
         };
         let key_file = match config.security.ssl_key_file.clone() {
             Some(path) => path,
             None => {
                 error!("SSL Certificate key file must be specified in the config");
-                return;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    "SSL Certificate key file must be specified in the config".into(),
+                ));
             }
         };
 
@@ -325,7 +348,11 @@ pub async fn start() {
             Ok(config) => config,
             Err(err) => {
                 error!("Invalid TLS certificate/key: {err}");
-                return;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Invalid TLS certificate/key: {err}"),
+                ));
             }
         };
 
@@ -341,7 +368,11 @@ pub async fn start() {
             Ok(addr) => addr,
             Err(e) => {
                 error!("Invalid listen_address '{}': {}", config.listen_address, e);
-                return;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Invalid listen_address '{}': {e}", config.listen_address),
+                ));
             }
         };
 
@@ -353,6 +384,11 @@ pub async fn start() {
             .await
         {
             error!("HTTPS server error: {err}");
+            return Err(MediatorError::InternalError(
+                17,
+                "NA".into(),
+                format!("HTTPS server error: {err}"),
+            ));
         }
     } else {
         warn!("**** WARNING: Running without SSL/TLS ****");
@@ -369,7 +405,11 @@ pub async fn start() {
             Ok(addr) => addr,
             Err(e) => {
                 error!("Invalid listen_address '{}': {}", config.listen_address, e);
-                return;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Invalid listen_address '{}': {e}", config.listen_address),
+                ));
             }
         };
 
@@ -381,10 +421,16 @@ pub async fn start() {
             .await
         {
             error!("HTTP server error: {err}");
+            return Err(MediatorError::InternalError(
+                17,
+                "NA".into(),
+                format!("HTTP server error: {err}"),
+            ));
         }
     }
 
     info!("Mediator shutdown complete.");
+    Ok(())
 }
 
 /// Wait for a shutdown signal (SIGINT or SIGTERM).


### PR DESCRIPTION
## Summary

 This PR hardens mediator startup/runtime code by removing panic-style error paths (unwrap/expect) in
 production code and replacing them with explicit error handling and typed propagation where
 appropriate.

 It also includes a patch version bump for the crate.

 - Crate: affinidi-messaging-mediator
 - Version: 0.13.0 → 0.13.1
 
---

 #### 1) Startup/runtime hardening (server.rs)

 Replaced panic-style startup logic with graceful error handling and logs for:
 - mediator config initialization
 - database initialization
 - streaming task startup
 - TLS cert/key presence and TLS config loading
 - HTTP/HTTPS server bind/serve errors
 - shutdown signal handler installation (Ctrl+C, SIGTERM)

 #### 2) Database initialization hardening (database/initialization.rs)

 Removed expect in initialization paths and mapped failures to typed mediator errors:
 - hardcoded ACL parsing
 - admin account setup calls
 - hardcoded schema migration version parsing

 #### 3) Rate limiter construction hardening

 Updated both:
 - common/rate_limiter.rs
 - common/did_rate_limiter.rs

 to avoid expect on NonZeroU32 and use explicit safe construction logic.

 #### 4) Version bump

 - Cargo.toml patch bump to 0.13.1