### PR TITLE
chore: remove yanked core2 transitive dependency (0.5.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ affinidi-messaging-sdk = { path = "crates/messaging/affinidi-messaging-sdk" }
 affinidi-did-authentication = { path = "crates/identity/affinidi-did-authentication" }
 affinidi-tdk-common = { path = "crates/tdk/affinidi-tdk-common" }
 affinidi-tsp = { path = "crates/messaging/affinidi-tsp" }
+did-scid = { path = "crates/identity/did-methods/did-scid" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi Secrets Manager
 
+## 15th April 2026 (0.5.3)
+
+- **CHANGE:** Removed `multihash` crate dependency (yanked `core2` transitive dep)
+  - Multihash encoding now uses inline varint encoding via existing `unsigned-varint`
+    dependency — output is byte-identical
+
 ## 3rd November October 2025 (0.5.2)
 
 - **BREAKING:** Now uses the affinidi-crypto library for all cryptographic operations

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -26,7 +26,6 @@ ahash = "0.8"
 base58 = "0.2"
 base64 = "0.22"
 multibase = "0.9"
-multihash = "0.19"
 rand = "0.10"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/crates/core/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/core/affinidi-secrets-resolver/src/secrets.rs
@@ -14,11 +14,11 @@ pub use affinidi_crypto::KeyType;
 use affinidi_crypto::{JWK, Params};
 use base58::ToBase58;
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tracing::warn;
+use unsigned_varint::encode as varint_encode;
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -292,14 +292,17 @@ impl Secret {
     /// base58<multihash<multikey>>
     pub fn base58_hash_string(key: &str) -> Result<String> {
         let hash = Sha256::digest(key.as_bytes());
-        // SHA_256 code = 0x12
-        #[allow(deprecated)]
-        let hash_encoded = Multihash::<32>::wrap(0x12, hash.as_slice()).map_err(|e| {
-            SecretsResolverError::KeyError(format!(
-                "Couldn't create multihash encoding for Public Key. Reason: {e}",
-            ))
-        })?;
-        Ok(hash_encoded.to_bytes().to_base58())
+        // Multihash binary format: varint(code) || varint(length) || digest
+        // SHA-256 code = 0x12
+        let mut code_buf = varint_encode::u64_buffer();
+        let code_varint = varint_encode::u64(0x12, &mut code_buf);
+        let mut len_buf = varint_encode::u64_buffer();
+        let len_varint = varint_encode::u64(hash.len() as u64, &mut len_buf);
+        let mut bytes = Vec::with_capacity(code_varint.len() + len_varint.len() + hash.len());
+        bytes.extend_from_slice(code_varint);
+        bytes.extend_from_slice(len_varint);
+        bytes.extend_from_slice(&hash);
+        Ok(bytes.to_base58())
     }
 
     /// Get the multibase (Base58btc) encoded private key

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.3"
 
-didwebvh-rs = { version = "0.4.0", optional = true }
+didwebvh-rs = { version = "0.4", optional = true }
 did-resolver-cheqd = { version = "1.0.1", optional = true }
 regex = "1.12"
 serde_json = "1.0"

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changelog history
 
+## 15th April 2026
+
+- **DOC:** Added README section on running without a secure credential store
+  (`string://` usage for dev/CI without keyring or AWS Secrets Manager)
+
 ## 1st April 2026
 
 ### 0.13.0 — VTA Integration

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -112,6 +112,40 @@ The wizard accepts a **Context Provision Bundle** from `pnm contexts provision`
 (recommended) and auto-configures the credential, context, DID, and
 `mediator.toml` in a single flow.
 
+### Quick Start without a Secure Credential Store
+
+If you don't have access to AWS Secrets Manager or an OS keyring (e.g. in CI/CD,
+Docker containers, or quick local testing), you can pass the VTA credential
+directly as a `string://` value. No extra feature flags are required.
+
+**Option A: In `mediator.toml`**
+
+```toml
+mediator_did = "vta://mediator"
+
+[security]
+mediator_secrets = "vta://mediator"
+
+[vta]
+credential = "string://<paste-your-base64url-credential-here>"
+context = "mediator"
+```
+
+**Option B: Via environment variables**
+
+```bash
+export VTA_CREDENTIAL="string://eyJkaWQ..."
+export VTA_CONTEXT="mediator"
+export MEDIATOR_DID="vta://mediator"
+export MEDIATOR_SECRETS="vta://mediator"
+cargo run
+```
+
+> **Note:** With `string://`, VTA secrets are **not cached** between restarts.
+> Every restart will re-fetch secrets from the VTA. For production deployments,
+> use `aws_secrets://` or `keyring://` which enable local secret caching for
+> offline resilience.
+
 ### Manual Configuration
 
 Set `mediator_did` and `mediator_secrets` to use the `vta://` scheme, and add a

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -27,12 +27,12 @@ chrono = "0.4"
 circular-queue = { version = "0.2", features = ["serde_support"] }
 # Crossterm must match the version used in ratatui
 crossterm = { version = "0.28", features = ["event-stream"] }
-image = "0.25"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "rayon"] }
 log = "0.4"
 qrcode = "0.14"
 rand = "0.10"
 ratatui = "0.29"
-ratatui-image = { version = "8", features = ["crossterm", "image-defaults"] }
+ratatui-image = { version = "8", default-features = false, features = ["crossterm"] }
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

Remove the yanked `core2` crate from the entire dependency tree.

### Changes

- **`affinidi-secrets-resolver` (0.5.2 → 0.5.3):** Replace `multihash` crate with inline varint encoding using the existing `unsigned-varint` dep (byte-identical output)
- **`affinidi-messaging-text-client`:** Disable default features on `image` and `ratatui-image` to drop the `avif` → `rav1e` → `bitstream-io` → `core2` chain
- **Workspace `Cargo.toml`:** Add `did-scid` to `[patch.crates-io]` so the workspace uses local v0.1.5 (with `didwebvh-rs 0.4.2`) instead of published v0.1.4 (which pulled `didwebvh-rs 0.3.1` → `multihash` → `core2`)
- **`affinidi-messaging-mediator`:** Add README section documenting `string://` credential usage without a secure backend (no version bump — doc only)

### Dependency chains eliminated

| Chain | Before | After |
|---|---|---|
| `multihash` → `core2` (via `affinidi-secrets-resolver`) | Direct dep | Removed — inline varint encoding |
| `image` → `ravif` → `rav1e` → `bitstream-io` → `core2` | Default features | Trimmed to `png`, `jpeg`, `rayon` only |
| `did-scid@0.1.4` → `didwebvh-rs@0.3.1` → `multihash` → `core2` | Published v0.1.4 from crates.io | Patched to local v0.1.5 (uses `didwebvh-rs 0.4.2`) |

`core2` is now **completely absent** from the workspace dependency tree.

## Checklist
- [x] All tests pass (full workspace)
- [x] CHANGELOG.md updated (affinidi-secrets-resolver, affinidi-messaging-mediator)
- [x] No clippy warnings
- [x] Documentation builds cleanly
- [x] `cargo fmt` clean
- [x] `cargo tree -i core2` returns empty