### PR TITLE
fix: websocket reconnect loop and duplicate DID listener check (0.16.3 / 0.2.1)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2026-04-15
+
+### Fixed
+
+- Reject duplicate DID listeners: `add_listener()` and `start()` now return `DuplicateDid` error when attempting to register a listener with a DID that is already in use by another listener, preventing mediator connection conflicts.
+
 ## [0.2.0] - 2026-04-13
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.2.0"
+version = "0.2.1"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
@@ -68,6 +68,12 @@ pub enum DIDCommServiceError {
     #[error("Listener '{0}' already exists")]
     ListenerAlreadyExists(String),
 
+    #[error("DID '{did}' is already registered by listener '{existing_listener}'")]
+    DuplicateDid {
+        did: String,
+        existing_listener: String,
+    },
+
     #[error("Listener '{0}' not found")]
     ListenerNotFound(String),
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -2,7 +2,7 @@ mod listener;
 mod mediator;
 mod restart;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -89,6 +89,24 @@ impl DIDCommService {
             events_tx,
         };
 
+        // Validate no duplicate listener IDs or DIDs in initial config
+        {
+            let mut seen_ids = HashSet::new();
+            let mut seen_dids: HashMap<&str, &str> = HashMap::new();
+            for cfg in &config.listeners {
+                if !seen_ids.insert(cfg.id.as_str()) {
+                    return Err(DIDCommServiceError::ListenerAlreadyExists(cfg.id.clone()));
+                }
+                if let Some(existing) = seen_dids.get(cfg.profile.did.as_str()) {
+                    return Err(DIDCommServiceError::DuplicateDid {
+                        did: cfg.profile.did.clone(),
+                        existing_listener: existing.to_string(),
+                    });
+                }
+                seen_dids.insert(&cfg.profile.did, &cfg.id);
+            }
+        }
+
         for listener_config in config.listeners {
             service.spawn_listener(listener_config).await?;
         }
@@ -110,6 +128,12 @@ impl DIDCommService {
             return Err(DIDCommServiceError::ListenerAlreadyExists(
                 config.id.clone(),
             ));
+        }
+        if let Some(handle) = listeners.values().find(|h| h.did == config.profile.did) {
+            return Err(DIDCommServiceError::DuplicateDid {
+                did: config.profile.did.clone(),
+                existing_listener: handle.id.clone(),
+            });
         }
         drop(listeners);
 
@@ -288,7 +312,9 @@ impl DIDCommService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{ListenerConfig, RestartPolicy};
     use affinidi_messaging_didcomm::Message;
+    use affinidi_tdk_common::profiles::TDKProfile;
     use serde_json::json;
 
     fn make_service() -> DIDCommService {
@@ -367,6 +393,58 @@ mod tests {
         assert!(
             matches!(err, DIDCommServiceError::NotConnected(ref id) if id == "test-listener"),
             "expected NotConnected, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_listener_rejects_duplicate_did() {
+        let service = make_service();
+
+        // Pre-insert a listener handle with did:example:alice
+        let (_tx, rx) = watch::channel(None);
+        let handle = ListenerHandle {
+            id: "listener-1".to_string(),
+            did: "did:example:alice".to_string(),
+            task: tokio::spawn(async {}),
+            token: CancellationToken::new(),
+            started_at: Instant::now(),
+            restart_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            connection_rx: rx,
+        };
+        service
+            .listeners
+            .write()
+            .await
+            .insert("listener-1".to_string(), handle);
+
+        // Try to add a new listener with a different ID but the same DID
+        let config = ListenerConfig {
+            id: "listener-2".to_string(),
+            profile: TDKProfile {
+                alias: "alice-duplicate".to_string(),
+                did: "did:example:alice".to_string(),
+                mediator: None,
+                secrets: vec![],
+            },
+            acl_mode: None,
+            restart_policy: RestartPolicy::Never,
+            message_wait_duration_secs: 5,
+            auto_delete: true,
+            tdk_config: None,
+        };
+
+        let result = service.add_listener(config).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DIDCommServiceError::DuplicateDid {
+                    ref did,
+                    ref existing_listener,
+                } if did == "did:example:alice" && existing_listener == "listener-1"
+            ),
+            "expected DuplicateDid, got: {err}"
         );
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.16.3] - 2026-04-15
+
+### Fixed
+
+- Add exponential backoff (1s-60s cap) on WebSocket reconnection after server-initiated disconnects. Previously, server-initiated Close frames (including mediator `duplicate-channel` rejections), protocol resets, and connection errors triggered immediate reconnection with zero delay, causing an infinite reconnect loop between two profiles sharing the same DID.
+- Missed pong timeout now immediately drops the WebSocket and applies backoff, instead of leaving a half-closed connection.
+
 ## [0.16.2] - 2026-03-28
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.16.2"
+version = "0.16.3"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -205,10 +205,12 @@ impl WebSocketTransport {
                     },
                     _ = watchdog.tick(), if self.web_socket.is_some() => {
                         if self.awaiting_pong {
-                            debug!("Missed Pong, closing connection");
+                            warn!("Missed Pong, closing connection");
                             if let Some(web_socket) = self.web_socket.as_mut() {
                                 let _ = web_socket.close(None).await;
                             }
+                            self.web_socket = None;
+                            self.backoff_delay();
                         } else if let Some(web_socket) = self.web_socket.as_mut() {
                             let _ = web_socket.send(Message::Ping(Bytes::new())).await;
                         }
@@ -347,8 +349,9 @@ impl WebSocketTransport {
                     self.awaiting_pong = false;
                 }
                 Message::Close(_) => {
-                    debug!("WebSocket connection closed");
+                    debug!("WebSocket connection closed by server");
                     self.web_socket = None;
+                    self.backoff_delay();
                 }
                 _ => {
                     warn!("Received unknown message type: {:?}", ws_msg);
@@ -360,10 +363,12 @@ impl WebSocketTransport {
                 // Connection Dropped
                 warn!("WebSocket connection dropped");
                 self.web_socket = None;
+                self.backoff_delay();
             }
             Err(e) => {
                 error!("Generic websocket error: {:?}", e);
                 self.web_socket = None;
+                self.backoff_delay();
             }
         }
     }
@@ -439,28 +444,25 @@ impl WebSocketTransport {
         }
     }
 
+    /// Calculate exponential backoff delay: 0→1→2→4→8→16→32→60s (capped)
+    fn backoff_delay(&mut self) {
+        self.connect_delay = match self.connect_delay {
+            0 => 1,
+            d if d < 60 => (d * 2).min(60),
+            _ => 60,
+        };
+        self.connect_delay_timer = None;
+    }
+
     // Wrapper that handles all of the logic of setting up a connection to the mediator
     async fn _handle_connection(&mut self, atm: &ATM) -> Option<WebSocket> {
         debug!("Starting websocket connection");
-
-        fn _calculate_delay(delay: u8) -> u8 {
-            let delay = if delay == 0 {
-                1
-            } else if delay < 60 {
-                delay * 2
-            } else {
-                delay
-            };
-
-            if delay > 60 { 60 } else { delay }
-        }
 
         let mut web_socket = match self._create_socket().await {
             Ok(ws) => ws,
             Err(e) => {
                 error!("Error creating websocket connection: {:?}", e);
-                self.connect_delay = _calculate_delay(self.connect_delay);
-                self.connect_delay_timer = None;
+                self.backoff_delay();
                 return None;
             }
         };
@@ -490,8 +492,7 @@ impl WebSocketTransport {
                 Err(e) => {
                     error!("Error enabling live streaming: {:?}", e);
                     let _ = web_socket.close(None).await;
-                    self.connect_delay = _calculate_delay(self.connect_delay);
-                    self.connect_delay_timer = None;
+                    self.backoff_delay();
                     None
                 }
             }


### PR DESCRIPTION
## Summary
- **affinidi-messaging-sdk** (0.16.2 → 0.16.3): Fix infinite WebSocket reconnect loop caused by zero-delay reconnection after server-initiated disconnects. When the mediator closed a connection with `duplicate-channel`, the SDK immediately reconnected, evicting the other connection, creating a ping-pong loop. Now applies exponential backoff (1s→60s cap) on all disconnect paths (server Close, protocol reset, errors, missed pong).
- **affinidi-messaging-didcomm-service** (0.2.0 → 0.2.1): Reject duplicate DID listeners — `add_listener()` and `start()` now return `DuplicateDid` error when attempting to register a listener with a DID already in use by another listener.

## Checklist
- [x] All tests pass
- [x] CHANGELOG.md updated for both crates
- [x] No clippy warnings
- [x] Documentation builds cleanly