### PR TITLE
ci: switch release workflow to pipeline-rust@main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   rust-pipeline:
-    # Waiting for https://github.com/affinidi/pipeline-rust/pull/71 to merge before using @main
-    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@feat/workspace-publish
+    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@main
     secrets: inherit
     with:
       toolchain: "1.94.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this workspace are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the workspace
+crates follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Per-crate version history is summarised here; for the full code history see
+`git log`.
+
+## [Unreleased]
+
+## 2026-04-17
+
+### Security
+
+- **`affinidi-crypto` 0.1.1 → 0.1.2** — Replaced the direct `rand 0.8`
+  dependency with `rand_core 0.6` (with the `getrandom` feature) to clear
+  [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc).
+  The advisory targets the `rand` crate (`>= 0.7.0, < 0.9.3`); the trait crate
+  `rand_core` is unaffected and remains compatible with `ed25519-dalek 2.x`,
+  `k256`/`p256`/`p384` 0.13.x, which all consume `rand_core 0.6` traits.
+  Closes [#287](https://github.com/affinidi/affinidi-tdk-rs/issues/287).
+- **`affinidi-messaging-didcomm` 0.13.0 → 0.13.1** — Same `rand 0.8` → `rand_core 0.6`
+  swap.
+- **`affinidi-tsp` 0.1.0 → 0.1.1** — Same `rand 0.8` → `rand_core 0.6` swap.
+- **`affinidi-oid4vc-core` 0.1.0 → 0.1.1** — Removed unused optional `rand 0.8`
+  dependency from the `es256` feature; `Es256Signer::generate` already used
+  `p256::elliptic_curve::rand_core::OsRng`.
+
+### Added
+
+- **`affinidi-crypto`** — Infallible `generate_random()` helpers on the `p256`,
+  `p384`, and `secp256k1` modules. The existing `generate(secret: Option<&[u8]>)`
+  API is unchanged; the new helper is a thin wrapper for the `None` case so
+  callers do not have to handle a `Result` that can never be `Err`.
+- **`affinidi-crypto`** — Crate-root type alias re-exports for the per-curve
+  `KeyPair` structs: `Ed25519KeyPair`, `P256KeyPair`, `P384KeyPair`,
+  `Secp256k1KeyPair`. Gated by the same feature flags as the source modules.
+- **`affinidi-oid4vc-core`** — `Es256Signer::generate_with_rng<R>(rng)` accepts
+  a caller-supplied RNG. Useful for tests that want a seeded RNG. The existing
+  `generate()` now delegates to it with `OsRng`.
+
+### Changed
+
+- Workspace transitive dependency refresh via `cargo update`: `tokio 1.50 → 1.52`,
+  `rand 0.9.2 → 0.9.4` (closes the `0.9.x` half of the same advisory),
+  `uuid 1.22 → 1.23`, plus minor bumps across `wasm-bindgen`, `serde_spanned`,
+  `webpki-roots`, etc. No source changes triggered by these updates.

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.1"
+version = "0.1.2"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -39,7 +39,7 @@ p384 = { version = "0.13", features = [
   "ecdsa-core",
   "arithmetic",
 ], optional = true }
-rand = "0.8"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/core/affinidi-crypto/src/ed25519.rs
+++ b/crates/core/affinidi-crypto/src/ed25519.rs
@@ -4,7 +4,7 @@ use affinidi_encoding::{ED25519_PUB, MultiEncoded, MultiEncodedBuf, X25519_PUB};
 use base58::{FromBase58, ToBase58};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use sha2::{Digest, Sha512};
 use x25519_dalek::{PublicKey, StaticSecret};
 

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -24,3 +24,12 @@ pub mod p384;
 pub use error::CryptoError;
 pub use jwk::{ECParams, JWK, OctectParams, Params};
 pub use key_type::KeyType;
+
+#[cfg(feature = "ed25519")]
+pub use ed25519::KeyPair as Ed25519KeyPair;
+#[cfg(feature = "p256")]
+pub use p256::KeyPair as P256KeyPair;
+#[cfg(feature = "p384")]
+pub use p384::KeyPair as P384KeyPair;
+#[cfg(feature = "k256")]
+pub use secp256k1::KeyPair as Secp256k1KeyPair;

--- a/crates/core/affinidi-crypto/src/p256.rs
+++ b/crates/core/affinidi-crypto/src/p256.rs
@@ -6,7 +6,7 @@ use p256::{
     ecdsa::{SigningKey, VerifyingKey},
     elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
 };
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -17,6 +17,13 @@ pub struct KeyPair {
     pub private_bytes: Vec<u8>,
     pub public_bytes: Vec<u8>,
     pub jwk: JWK,
+}
+
+/// Generates a random P-256 key pair using the OS RNG.
+///
+/// This is the infallible counterpart to [`generate`] when no seed is needed.
+pub fn generate_random() -> KeyPair {
+    generate(None).expect("generate(None) is infallible")
 }
 
 /// Generates a P-256 key pair

--- a/crates/core/affinidi-crypto/src/p384.rs
+++ b/crates/core/affinidi-crypto/src/p384.rs
@@ -6,7 +6,7 @@ use p384::{
     ecdsa::{SigningKey, VerifyingKey},
     elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
 };
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -17,6 +17,13 @@ pub struct KeyPair {
     pub private_bytes: Vec<u8>,
     pub public_bytes: Vec<u8>,
     pub jwk: JWK,
+}
+
+/// Generates a random P-384 key pair using the OS RNG.
+///
+/// This is the infallible counterpart to [`generate`] when no seed is needed.
+pub fn generate_random() -> KeyPair {
+    generate(None).expect("generate(None) is infallible")
 }
 
 /// Generates a P-384 key pair

--- a/crates/core/affinidi-crypto/src/secp256k1.rs
+++ b/crates/core/affinidi-crypto/src/secp256k1.rs
@@ -6,7 +6,7 @@ use k256::{
     ecdsa::{SigningKey, VerifyingKey},
     elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
 };
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -17,6 +17,13 @@ pub struct KeyPair {
     pub private_bytes: Vec<u8>,
     pub public_bytes: Vec<u8>,
     pub jwk: JWK,
+}
+
+/// Generates a random secp256k1 key pair using the OS RNG.
+///
+/// This is the infallible counterpart to [`generate`] when no seed is needed.
+pub fn generate_random() -> KeyPair {
+    generate(None).expect("generate(None) is infallible")
 }
 
 /// Generates a secp256k1 key pair

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -40,7 +40,7 @@ thiserror = "2"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 # Misc
-rand = "0.8"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 subtle = "2.6"
 zeroize = { version = "1.8", features = ["derive"] }
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/content_encryption.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/content_encryption.rs
@@ -6,7 +6,7 @@
 use aes::Aes256;
 use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 use hmac::{Hmac, Mac};
-use rand::RngCore;
+use rand_core::RngCore;
 use sha2::Sha512;
 
 use subtle::ConstantTimeEq;
@@ -28,14 +28,14 @@ pub const TAG_SIZE: usize = 32;
 /// Generate a random 64-byte CEK.
 pub fn generate_cek() -> [u8; CEK_SIZE] {
     let mut cek = [0u8; CEK_SIZE];
-    rand::rngs::OsRng.fill_bytes(&mut cek);
+    rand_core::OsRng.fill_bytes(&mut cek);
     cek
 }
 
 /// Generate a random 16-byte IV.
 pub fn generate_iv() -> [u8; IV_SIZE] {
     let mut iv = [0u8; IV_SIZE];
-    rand::rngs::OsRng.fill_bytes(&mut iv);
+    rand_core::OsRng.fill_bytes(&mut iv);
     iv
 }
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/key_agreement.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/key_agreement.rs
@@ -3,7 +3,7 @@
 //! The `KeyAgreement` enum provides curve-polymorphic ECDH operations,
 //! eliminating the combinatorial match-arm explosion of the legacy crate.
 
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/signing.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/signing.rs
@@ -34,7 +34,7 @@ pub fn public_key_from_private(private_key: &[u8; 32]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
 
     #[test]
     fn sign_verify_roundtrip() {

--- a/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
@@ -29,7 +29,7 @@ impl PrivateIdentity {
         let sig_kid = format!("{did}#key-signing-1");
 
         let ka_private = PrivateKeyAgreement::generate(Curve::X25519);
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
 
         Self {
             did,
@@ -47,7 +47,7 @@ impl PrivateIdentity {
         let sig_kid = format!("{did}#key-signing-1");
 
         let ka_private = PrivateKeyAgreement::generate(curve);
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
 
         Self {
             did,

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn sign_produces_valid_jws() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
 
         let jws_str = sign_ed25519(
             b"{\"type\":\"test\"}",

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn sign_verify_roundtrip() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
         let pk = sk.verifying_key().to_bytes();
 
         let payload = b"{\"type\":\"test\",\"body\":{}}";
@@ -88,8 +88,8 @@ mod tests {
 
     #[test]
     fn wrong_key_fails() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
-        let wrong_pk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng)
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let wrong_pk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng)
             .verifying_key()
             .to_bytes();
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/message/pack.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/message/pack.rs
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn pack_signed_roundtrip() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
 
         let msg =
             Message::new("test-type", serde_json::json!({"data": 42})).from("did:example:alice");
@@ -245,7 +245,7 @@ mod tests {
     /// as an attachment in a wrapper message.
     #[test]
     fn pack_signed_then_authcrypt() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
         let sender_ka = PrivateKeyAgreement::generate(Curve::X25519);
         let recipient_ka = PrivateKeyAgreement::generate(Curve::X25519);
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn unpack_signed() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
         let pk = sk.verifying_key().to_bytes();
 
         let msg = Message::new("test", serde_json::json!({}));

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -36,7 +36,7 @@ x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 hkdf = "0.12"
 sha2 = "0.10"
 aes-gcm = "0.10"
-rand = "0.8"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 zeroize = { version = "1.8", features = ["derive"] }
 blake2 = "0.10"
 

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -7,7 +7,7 @@
 
 use aes_gcm::{AeadInPlace, Aes128Gcm, KeyInit, aead::generic_array::GenericArray};
 use hkdf::Hkdf;
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::Zeroize;

--- a/crates/messaging/affinidi-tsp/src/crypto/signing.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/signing.rs
@@ -33,7 +33,7 @@ pub fn public_key_from_private(private_key: &[u8; 32]) -> [u8; 32] {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
 
     #[test]
     fn sign_verify_roundtrip() {

--- a/crates/messaging/affinidi-tsp/src/message/control.rs
+++ b/crates/messaging/affinidi-tsp/src/message/control.rs
@@ -3,7 +3,7 @@
 //! Control messages are sent as TSP message payloads with message type `Control`.
 //! They manage the explicit relationship lifecycle that distinguishes TSP from DIDComm.
 
-use rand::RngCore;
+use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::error::TspError;
@@ -11,7 +11,7 @@ use crate::error::TspError;
 /// Generate a cryptographically random 16-byte nonce.
 pub fn generate_nonce() -> [u8; 16] {
     let mut nonce = [0u8; 16];
-    rand::rngs::OsRng.fill_bytes(&mut nonce);
+    rand_core::OsRng.fill_bytes(&mut nonce);
     nonce
 }
 

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -178,7 +178,7 @@ pub fn message_digest(packed: &PackedMessage) -> [u8; 32] {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
     use x25519_dalek::{PublicKey, StaticSecret};
 
     struct TestKeys {

--- a/crates/messaging/affinidi-tsp/src/vid/mod.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/mod.rs
@@ -63,7 +63,7 @@ impl PrivateVid {
     /// Create a new PrivateVid with generated keys.
     pub fn generate(id: impl Into<String>) -> Self {
         use ed25519_dalek::SigningKey;
-        use rand::rngs::OsRng;
+        use rand_core::OsRng;
         use x25519_dalek::{PublicKey, StaticSecret};
 
         let ed_sk = SigningKey::generate(&mut OsRng);
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn from_keys_derives_public_correctly() {
         use ed25519_dalek::SigningKey;
-        use rand::rngs::OsRng;
+        use rand_core::OsRng;
 
         let sk = SigningKey::generate(&mut OsRng);
         let expected_pk = sk.verifying_key().to_bytes();

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -15,12 +15,11 @@ rust-version.workspace = true
 [features]
 default = ["es256"]
 _test-utils = []
-es256 = ["dep:p256", "dep:rand"]
+es256 = ["dep:p256"]
 
 [dependencies]
 base64 = "0.22"
 p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
-rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/protocols/affinidi-oid4vc-core/src/es256.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/es256.rs
@@ -30,9 +30,19 @@ impl Es256Signer {
         })
     }
 
-    /// Generate a new random P-256 key pair.
+    /// Generate a new random P-256 key pair using the OS RNG.
     pub fn generate() -> Self {
-        let signing_key = SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        Self::generate_with_rng(&mut p256::elliptic_curve::rand_core::OsRng)
+    }
+
+    /// Generate a new P-256 key pair using a caller-supplied RNG.
+    ///
+    /// Useful for tests that need deterministic keys via a seeded RNG.
+    pub fn generate_with_rng<R>(rng: &mut R) -> Self
+    where
+        R: p256::elliptic_curve::rand_core::CryptoRng + p256::elliptic_curve::rand_core::RngCore,
+    {
+        let signing_key = SigningKey::random(rng);
         Self {
             signing_key,
             kid: None,


### PR DESCRIPTION
## Summary

The release workflow for PR #289 failed at the workflow-parse level with no jobs executed. Root cause:

`.github/workflows/release.yaml` was temporarily pinned to `affinidi/pipeline-rust@feat/workspace-publish` in b6b8a8d, waiting for [pipeline-rust#71](https://github.com/affinidi/pipeline-rust/pull/71) to land on `main`.

That PR merged on 2026-04-16 and the feature branch was deleted, so our pin now references a ref that no longer exists. GitHub Actions returns the "workflow file issue" error and does not schedule any jobs.

## Fix

Switch the ref to `@main`. Verified `pipeline-rust@main`'s `release.yaml` already exposes the full input set we pass (`toolchain`, `rustflags`, `auditIgnore`, `ubuntu-rust-deps`, `release_debug`, `workspace_publish`, `release_dry_run`), so this is a drop-in swap.

## Reference

- Failing run: https://github.com/affinidi/affinidi-tdk-rs/actions/runs/24547046482
- Original pin commit: b6b8a8d
- pipeline-rust PR that unblocked `@main`: https://github.com/affinidi/pipeline-rust/pull/71

## Follow-up

The release for `affinidi-crypto 0.1.2` / `affinidi-messaging-didcomm 0.13.1` / `affinidi-tsp 0.1.1` / `affinidi-oid4vc-core 0.1.1` (PR #289) did not publish because of this workflow failure. Once this PR merges, the next push to `main` will trigger the release. If we want to re-trigger without waiting for another merge, we can re-run the workflow against the current `main` HEAD — but it will be a no-op for the publish step if nothing else has changed.

## Checklist

- [x] DCO sign-off
- [x] Verified pipeline-rust `main` accepts the inputs we use