### PR TITLE
ci: drop workspace_publish so partial releases skip already-published crates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,13 @@ jobs:
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       release_debug: true
-      workspace_publish: true
+      # `workspace_publish: true` uses `cargo publish --workspace`, which errors on
+      # the first crate whose current version is already on crates.io instead of
+      # skipping it. When we ship a targeted patch (e.g. four-of-many crates for a
+      # security fix), that behaviour blocks the whole release. The legacy
+      # per-crate path in pipeline-rust compares local vs. remote versions and
+      # skips already-published crates, which is what we want for partial releases.
+      # Re-enable workspace_publish once pipeline-rust grows a skip-already-published
+      # option (or when a release genuinely bumps every workspace member).
+      workspace_publish: false
       release_dry_run: false


### PR DESCRIPTION
## Summary

Answers #289's follow-up: `cargo publish --workspace` does **not** skip already-published crates. It errors on the first one it sees.

PR #289 shipped four targeted patch bumps (`affinidi-crypto`, `affinidi-messaging-didcomm`, `affinidi-tsp`, `affinidi-oid4vc-core`). The post-merge release run failed immediately:

```
error: crate affinidi-cesr@0.1.0 already exists on crates.io index
```

`affinidi-cesr 0.1.0` has been on the registry for a while — we did not bump it because nothing in it changed. `cargo publish --workspace` still tries to publish it and bails.

Failing run: https://github.com/affinidi/affinidi-tdk-rs/actions/runs/24549726755/job/71772932292

## Fix

Flip `workspace_publish: false`. pipeline-rust's legacy per-crate path (still present in `@main`) compares the local manifest version against `cargo search` for each member and only runs `cargo publish` when they differ:

```bash
if [[ "${local_version}" != "${remote_version}" ]]
then
    cargo publish ...
else
    echo "No release needed for ${crate_name} as version [${remote_version}] was already released."
fi
```

This is what we want for the "bump four, leave the other 40 alone" pattern of a security patch release.

## Once merged

The push to `main` will retrigger the release workflow. It should publish `affinidi-crypto 0.1.2`, `affinidi-messaging-didcomm 0.13.1`, `affinidi-tsp 0.1.1`, and `affinidi-oid4vc-core 0.1.1`, and skip everything else.

## Follow-up (not in this PR)

If we want `workspace_publish: true` back, pipeline-rust needs a "skip-already-published" mode on the workspace path — e.g. read `cargo metadata`, query the registry for each publishable member, and pass `--exclude` for matches before running `cargo publish --workspace`. Worth an upstream issue on `affinidi/pipeline-rust`.

## Checklist

- [x] DCO sign-off
- [x] Comment in the workflow explains why we opted out and the condition for re-enabling