### PR TITLE
fix: bump release versions past crates.io collisions

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Affinidi Crypto Changelog
 
-## 18th April 2026 (0.1.3)
+## 18th April 2026 (0.1.4)
 
 - **FEATURE:** `post-quantum` Cargo feature (off by default) with
   `ml-dsa` and `slh-dsa` sub-flags. Adds:

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.3"
+version = "0.1.4"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-encoding/CHANGELOG.md
+++ b/crates/core/affinidi-encoding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Affinidi Encoding Changelog
 
-## 18th April 2026 (0.1.2)
+## 18th April 2026 (0.1.3)
 
 - **FEATURE:** Added post-quantum multicodec constants aligned with the
   official multicodec registry (all currently `draft`):

--- a/crates/core/affinidi-encoding/Cargo.toml
+++ b/crates/core/affinidi-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-encoding"
 description = "Multibase and multicodec encoding utilities for Affinidi TDK"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Affinidi Secrets Manager
 
-## 18th April 2026 (0.5.4)
+## 18th April 2026 (0.5.5)
 
 - **FEATURE:** `post-quantum` Cargo feature (off by default) with
   `ml-dsa` and `slh-dsa` sub-flags. Adds `Secret::generate_ml_dsa_44`,

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"


### PR DESCRIPTION
## Summary

Publishing #293's release failed because three crates' version numbers collided with versions already on crates.io.

While #293 was in review, #292 landed and published dep-hygiene bumps:

| Crate | Published via #292 | #293 branch version |
|---|---|---|
| `affinidi-encoding` | 0.1.2 | 0.1.2 ❌ collision |
| `affinidi-crypto` | 0.1.3 | 0.1.3 ❌ collision |
| `affinidi-secrets-resolver` | 0.5.4 | 0.5.4 ❌ collision |
| `affinidi-data-integrity` | 0.5.1 | 0.5.4 ✅ fresh |

The remote 0.1.3 / 0.5.4 don't have the PQC features (`ml-dsa`, `slh-dsa`, `post-quantum`), so downstream crates that request those features can't resolve — and publish fails before the tarball gets uploaded.

## This PR

Bumps past the collisions:

- `affinidi-encoding` 0.1.2 → **0.1.3**
- `affinidi-crypto` 0.1.3 → **0.1.4**
- `affinidi-secrets-resolver` 0.5.4 → **0.5.5**

`affinidi-data-integrity` stays at **0.5.4** (not yet on crates.io).

Consumer-side caret version specifiers (`^0.1`, `^0.5`) auto-resolve to the new numbers — no Cargo.toml edits needed on dependents. CHANGELOG entries retitled to the new version numbers.

## Verified
- `cargo build --workspace` clean
- 124 PQC tests pass

## After merge

Publish in order (~30–60s between):

```
cargo publish -p affinidi-encoding          # 0.1.3
cargo publish -p affinidi-crypto            # 0.1.4
cargo publish -p affinidi-secrets-resolver  # 0.5.5
cargo publish -p affinidi-data-integrity    # 0.5.4
cargo publish -p affinidi-tdk               # 0.6.4
```