### PR TITLE
chore: bump didwebvh-rs to 0.5 and patch-bump affected crates

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 18th April 2026
+
+### DID Resolver Cache SDK (0.8.6)
+
+- **CHANGED:** Bumped `didwebvh-rs` dependency from `0.4` to `0.5`. Public
+  resolver API unchanged; enables the `data-integrity 0.5.4` migration
+  downstream.
+
 ## 17th April 2026
 
 ### DID Resolver Cache SDK (0.8.5)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.5"
+version = "0.8.6"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
-didwebvh-rs = { version = "0.4", optional = true }
+didwebvh-rs = { version = "0.5", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.7.3"
+version = "0.7.4"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -25,7 +25,7 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 affinidi-did-resolver-cache-sdk = { version = "0.8", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.3"
 
-didwebvh-rs = "0.4"
+didwebvh-rs = "0.5"
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.6"
+version = "0.1.7"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.3"
 
-didwebvh-rs = { version = "0.4", optional = true }
+didwebvh-rs = { version = "0.5", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-helpers"
-version = "0.12.2"
+version = "0.12.3"
 description = "Affinidi Messaging Helpers"
 edition.workspace = true
 authors.workspace = true
@@ -37,7 +37,7 @@ affinidi-tsp = { path = "../affinidi-tsp", features = ["messaging-core"] }
 affinidi-secrets-resolver = "0.5"
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.6" }
 
-didwebvh-rs = "0.4"
+didwebvh-rs = "0.5"
 ahash = { version = "0.8", features = ["serde"] }
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 18th April 2026
+
+### 0.13.2
+
+- **CHANGED:** Bumped `didwebvh-rs` dependency from `0.4` to `0.5` for the
+  data-integrity API refactor and PQC support in `affinidi-data-integrity 0.5.4`.
+  No behavioural change to the mediator — wire format is unchanged.
+
 ## 15th April 2026
 
 - **DOC:** Added README section on running without a secure credential store

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.13.1"
+version = "0.13.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -46,7 +46,7 @@ affinidi-secrets-resolver = "0.5"
 vta-sdk = { version = "0.3", features = ["integration"] }
 
 # External Crates
-didwebvh-rs = "0.4"
+didwebvh-rs = "0.5"
 ahash = { version = "0.8", features = ["serde"] }
 async-convert = "1"
 aws-config = "1"


### PR DESCRIPTION
## Summary
- Bumps the `didwebvh-rs` dependency pin from `0.4` to `0.5` across the 5 crates that pin it directly. didwebvh-rs 0.5.0 migrated to the new `affinidi-data-integrity 0.5.4` API (unified sign/verify entry points, `#[non_exhaustive]` enums, PQC-ready `Signer` trait).
- No call-site changes were required in this workspace — the bump is a pure Cargo.toml update.
- Patch-bumps the 5 affected crates so the new versions are publishable.

## Version bumps
| Crate | From | To |
|---|---|---|
| `did-scid` | 0.1.6 | 0.1.7 |
| `affinidi-did-resolver-cache-sdk` | 0.8.5 | 0.8.6 |
| `affinidi-did-resolver-cache-server` | 0.7.3 | 0.7.4 |
| `affinidi-messaging-mediator` | 0.13.1 | 0.13.2 |
| `affinidi-messaging-helpers` | 0.12.2 | 0.12.3 |

## Test plan
- [x] `cargo check --workspace --all-features` — clean
- [x] `cargo clippy --workspace --all-features --no-deps` — clean (only pre-existing collapsible-if warnings in setup_vta.rs)
- [x] `cargo test --workspace --all-features` — zero failures
- [x] `cargo fmt --check` — clean