### PR TITLE
chore: release affinidi-crypto v0.1.5 — did:key raw-bytes helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+## 2026-04-20 — `did:key` raw-bytes helpers for HPKE / sealed transfer
+
+### Added
+
+- **`affinidi-crypto` 0.1.4 → 0.1.5** — New `did_key` module (gated on the
+  `ed25519` feature) exposes a raw-bytes API for apps doing HPKE, sealed
+  transfer, or other non-DIDComm key agreement:
+  `ed25519_pub_to_did_key`, `did_key_to_ed25519_pub`, and
+  `ed25519_pub_to_x25519_bytes`. The existing multikey-string helpers in
+  `ed25519.rs` remain for multikey-native callers such as
+  `affinidi-secrets-resolver`. Purely additive — no existing APIs changed.
+
 ## 2026-04-17 — TLS/webpki fix, MSRV 1.94, workspace dep hygiene (PR #292)
 
 ### Security

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -15,6 +15,15 @@
     key without round-tripping through a multikey string.
   The existing multikey-string helpers in `ed25519.rs` are retained
   for multikey-native callers such as `affinidi-secrets-resolver`.
+- **TESTS:** Backfilled `ed25519_public_to_x25519` coverage — parity
+  check vs. the new `did_key::ed25519_pub_to_x25519_bytes`, plus the
+  three error paths (missing `z` multibase prefix, wrong multicodec,
+  wrong payload length).
+- **DOCS:** Crate-level docs and README now advertise the post-quantum
+  features (ML-DSA / SLH-DSA) and the new `did:key` raw-bytes helpers.
+- **HYGIENE:** Dropped the unused direct `rand_core` 0.10 dep —
+  transitively pulled in via `ml-dsa` / `slh-dsa`'s own `rand_core`
+  feature, never imported here.
 
 ## 18th April 2026 (0.1.4)
 

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi Crypto Changelog
 
+## 20th April 2026 (0.1.5)
+
+- **FEATURE:** `did_key` module (behind the `ed25519` feature) adds a
+  raw-bytes API for apps doing HPKE, sealed transfer, or other non-
+  DIDComm key agreement:
+  - `ed25519_pub_to_did_key(&[u8; 32]) -> String` encodes an Ed25519
+    public key as a `did:key:z6Mk…` identifier.
+  - `did_key_to_ed25519_pub(&str) -> Result<[u8; 32], CryptoError>`
+    decodes a `did:key:z6Mk…` string, validating the `did:key:`
+    prefix, multibase `z`, Ed25519-pub multicodec, and 32-byte length.
+  - `ed25519_pub_to_x25519_bytes(&[u8; 32]) -> Result<[u8; 32],
+    CryptoError>` derives the X25519 public key from an Ed25519 public
+    key without round-tripping through a multikey string.
+  The existing multikey-string helpers in `ed25519.rs` are retained
+  for multikey-native callers such as `affinidi-secrets-resolver`.
+
 ## 18th April 2026 (0.1.4)
 
 - **FEATURE:** `post-quantum` Cargo feature (off by default) with

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -22,8 +22,8 @@ ed25519 = ["dep:ed25519-dalek"]
 # `post-quantum` is the umbrella flag; `ml-dsa` and `slh-dsa` can be enabled
 # individually. Off by default.
 post-quantum = ["ml-dsa", "slh-dsa"]
-ml-dsa = ["dep:ml-dsa", "dep:rand_core_10", "dep:rand_10"]
-slh-dsa = ["dep:slh-dsa", "dep:rand_core_10", "dep:rand_10"]
+ml-dsa = ["dep:ml-dsa", "dep:rand_10"]
+slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
 
 [dependencies]
 affinidi-encoding = "0.1"
@@ -47,9 +47,9 @@ p384 = { version = "0.13", features = [
 ], optional = true }
 ml-dsa = { version = "0.1.0-rc.8", features = ["rand_core", "zeroize"], optional = true }
 slh-dsa = { version = "0.2.0-rc.4", features = ["zeroize"], optional = true }
-# PQC crates (ml-dsa, slh-dsa) require rand_core 0.10 via `signature` v3. A
-# second copy of rand_core coexists with the 0.6 one used by other primitives.
-rand_core_10 = { package = "rand_core", version = "0.10", optional = true }
+# PQC crates (ml-dsa, slh-dsa) pull rand_core 0.10 transitively via
+# `signature` v3. A second copy coexists with the 0.6 one used by other
+# primitives; we never import it directly, so no explicit dep is needed.
 rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "thread_rng"], optional = true }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.4"
+version = "0.1.5"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/README.md
+++ b/crates/core/affinidi-crypto/README.md
@@ -11,14 +11,29 @@ elliptic curve families.
 
 ## Supported Algorithms
 
-| Algorithm | Feature Flag | Curve |
+| Algorithm | Feature Flag | Curve / Family |
 |---|---|---|
 | Ed25519 / X25519 | `ed25519` | Curve25519 |
 | P-256 (secp256r1) | `p256` | NIST P-256 |
 | P-384 | `p384` | NIST P-384 |
 | secp256k1 | `k256` | secp256k1 |
+| ML-DSA-44 / 65 / 87 | `ml-dsa` | FIPS 204 (post-quantum) |
+| SLH-DSA-SHA2-128s | `slh-dsa` | FIPS 205 (post-quantum) |
 
-All features are enabled by default.
+The four classical curves are enabled by default. Post-quantum signatures
+are off by default — enable `post-quantum` for both, or `ml-dsa` /
+`slh-dsa` individually.
+
+## `did:key` Raw-Bytes Helpers
+
+Under the `ed25519` feature, the [`did_key`] module exposes a raw-bytes
+API for apps doing HPKE, sealed transfer, or other non-DIDComm key
+agreement: encode / decode between a `did:key:z6Mk…` identifier and a
+`[u8; 32]` Ed25519 public key, and derive an X25519 public key without
+round-tripping through a multikey string. The multikey-string helpers in
+`ed25519.rs` remain for multikey-native callers.
+
+[`did_key`]: https://docs.rs/affinidi-crypto/latest/affinidi_crypto/did_key/index.html
 
 ## Installation
 

--- a/crates/core/affinidi-crypto/src/did_key.rs
+++ b/crates/core/affinidi-crypto/src/did_key.rs
@@ -1,0 +1,197 @@
+//! `did:key` helpers for Ed25519 / X25519 with raw-bytes ergonomics.
+//!
+//! This module sits on top of [`crate::ed25519`] and gives callers doing
+//! HPKE, sealed transfer, or other non-DIDComm key agreement a clean
+//! `&[u8; 32]` API for going between a `did:key:z6Mk…` identifier and
+//! the Ed25519 / X25519 keys they need for ECDH.
+//!
+//! The existing multikey-string helpers in [`crate::ed25519`] stay for
+//! multikey-native callers (e.g. `affinidi-secrets-resolver`); these
+//! helpers are purely additive for crypto-native callers that already
+//! have raw bytes.
+//!
+//! Only `did:key` encodings for Ed25519 public keys (multicodec `0xed`)
+//! are handled here. Other key types (P-256, secp256k1, X25519, ML-DSA)
+//! can be added when needed — their multicodec values already live in
+//! [`crate::KeyType`] / `affinidi_encoding`.
+
+use affinidi_encoding::{ED25519_PUB, MultiEncoded, MultiEncodedBuf};
+use base58::{FromBase58, ToBase58};
+use ed25519_dalek::VerifyingKey;
+
+use crate::{CryptoError, error::Result};
+
+const DID_KEY_PREFIX: &str = "did:key:";
+
+/// Encode a 32-byte Ed25519 public key as a `did:key:z6Mk…` identifier.
+pub fn ed25519_pub_to_did_key(pubkey: &[u8; 32]) -> String {
+    let multikey = MultiEncodedBuf::encode_bytes(ED25519_PUB, pubkey)
+        .into_bytes()
+        .to_base58();
+    format!("{DID_KEY_PREFIX}z{multikey}")
+}
+
+/// Decode a `did:key:z6Mk…` string to its raw 32-byte Ed25519 public key.
+///
+/// Errors on a missing `did:key:` prefix, missing multibase `z` prefix,
+/// a multicodec other than Ed25519-pub (`0xed`), or payload bytes not 32
+/// long. The returned bytes are not validated as a well-formed Ed25519
+/// point; use [`ed25519_pub_to_x25519_bytes`] or `VerifyingKey::from_bytes`
+/// to perform that check when it matters.
+pub fn did_key_to_ed25519_pub(did: &str) -> Result<[u8; 32]> {
+    let multibase = did
+        .strip_prefix(DID_KEY_PREFIX)
+        .ok_or_else(|| CryptoError::Decoding(format!("Expected '{DID_KEY_PREFIX}' prefix")))?;
+    let base58 = multibase.strip_prefix('z').ok_or_else(|| {
+        CryptoError::Decoding("Expected multibase 'z' prefix after 'did:key:'".into())
+    })?;
+    let decoded = base58
+        .from_base58()
+        .map_err(|_| CryptoError::Decoding("Couldn't decode base58".into()))?;
+
+    let multicodec = MultiEncoded::new(decoded.as_slice())?;
+    if multicodec.codec() != ED25519_PUB {
+        return Err(CryptoError::KeyError(format!(
+            "Expected Ed25519 public key, instead received codec 0x{:x}",
+            multicodec.codec()
+        )));
+    }
+    let data = multicodec.data();
+    if data.len() != 32 {
+        return Err(CryptoError::KeyError(format!(
+            "Invalid public key byte length: expected 32, got {}",
+            data.len()
+        )));
+    }
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(data);
+    Ok(out)
+}
+
+/// Derive the X25519 public key for an Ed25519 public key, returning raw
+/// bytes. Convenience wrapper around
+/// [`crate::ed25519::ed25519_public_to_x25519`] for callers that have
+/// raw bytes (HPKE, ECDH) rather than a multikey string.
+pub fn ed25519_pub_to_x25519_bytes(pubkey: &[u8; 32]) -> Result<[u8; 32]> {
+    let vk = VerifyingKey::from_bytes(pubkey)
+        .map_err(|e| CryptoError::KeyError(format!("Couldn't create Ed25519 VerifyingKey: {e}")))?;
+    Ok(vk.to_montgomery().to_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ed25519::{ed25519_private_to_x25519, generate};
+    use affinidi_encoding::X25519_PUB;
+    use ed25519_dalek::SigningKey;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    // Ed25519 secret key from the lifted `check_x25519` vector
+    // (affinidi-secrets-resolver/src/secrets.rs).
+    const ED25519_SK: [u8; 32] = [
+        202, 104, 239, 81, 53, 110, 80, 252, 198, 23, 155, 162, 215, 98, 223, 173, 227, 188, 110,
+        54, 127, 45, 185, 206, 174, 29, 44, 147, 76, 66, 196, 195,
+    ];
+    const CURVE25519_SK: [u8; 32] = [
+        200, 255, 64, 61, 17, 52, 112, 33, 205, 71, 186, 13, 131, 12, 241, 136, 223, 5, 152, 40,
+        95, 187, 83, 168, 142, 10, 234, 215, 70, 210, 148, 104,
+    ];
+
+    #[test]
+    fn ed25519_pub_to_did_key_roundtrip() {
+        let kp = generate(None);
+        let pubkey: [u8; 32] = kp.public_bytes.as_slice().try_into().unwrap();
+
+        let did = ed25519_pub_to_did_key(&pubkey);
+        // Ed25519 multicodec 0xed01 always renders with the `z6Mk` prefix
+        // under base58btc.
+        assert!(
+            did.starts_with("did:key:z6Mk"),
+            "expected did:key:z6Mk prefix, got {did}"
+        );
+
+        let back = did_key_to_ed25519_pub(&did).unwrap();
+        assert_eq!(back, pubkey);
+    }
+
+    #[test]
+    fn ed25519_pub_to_did_key_deterministic_for_seed() {
+        // Two encodings of the same pubkey must match exactly.
+        let signing = SigningKey::from_bytes(&ED25519_SK);
+        let pub_bytes: [u8; 32] = signing.verifying_key().to_bytes();
+
+        let a = ed25519_pub_to_did_key(&pub_bytes);
+        let b = ed25519_pub_to_did_key(&pub_bytes);
+        assert_eq!(a, b);
+        assert!(a.starts_with("did:key:z6Mk"));
+    }
+
+    #[test]
+    fn did_key_to_ed25519_pub_missing_did_key_prefix() {
+        let no_prefix = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+        let err = did_key_to_ed25519_pub(no_prefix).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::Decoding(ref m) if m.contains("did:key:")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_ed25519_pub_missing_multibase_prefix() {
+        let bad = "did:key:6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+        let err = did_key_to_ed25519_pub(bad).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::Decoding(ref m) if m.contains('z')),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_ed25519_pub_wrong_multicodec() {
+        // Build a did:key-shaped string carrying an X25519 public key
+        // multicodec (0xec) — valid multibase, wrong algorithm.
+        let payload = MultiEncodedBuf::encode_bytes(X25519_PUB, &[0u8; 32])
+            .into_bytes()
+            .to_base58();
+        let did = format!("did:key:z{payload}");
+
+        let err = did_key_to_ed25519_pub(&did).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("codec")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_ed25519_pub_wrong_length() {
+        // Ed25519 multicodec but a 16-byte payload instead of 32.
+        let payload = MultiEncodedBuf::encode_bytes(ED25519_PUB, &[0u8; 16])
+            .into_bytes()
+            .to_base58();
+        let did = format!("did:key:z{payload}");
+
+        let err = did_key_to_ed25519_pub(&did).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("length") || m.contains("32")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn ed25519_pub_to_x25519_bytes_matches_private_derivation() {
+        // Lifted from affinidi-secrets-resolver check_x25519: the Ed25519
+        // secret maps to CURVE25519_SK. Deriving the X25519 public key two
+        // ways (from the converted secret, and directly from the Ed25519
+        // public via Montgomery) must agree.
+        let signing = SigningKey::from_bytes(&ED25519_SK);
+        let ed_pub: [u8; 32] = signing.verifying_key().to_bytes();
+
+        let x_sk = ed25519_private_to_x25519(&ED25519_SK);
+        assert_eq!(x_sk, CURVE25519_SK);
+
+        let expected = PublicKey::from(&StaticSecret::from(x_sk)).to_bytes();
+        let actual = ed25519_pub_to_x25519_bytes(&ed_pub).unwrap();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/core/affinidi-crypto/src/ed25519.rs
+++ b/crates/core/affinidi-crypto/src/ed25519.rs
@@ -211,4 +211,71 @@ mod tests {
                 .unwrap()
         );
     }
+
+    // Helper: encode an Ed25519 public key as a multikey string
+    // (multicodec 0xed, base58btc with `z` prefix). Mirrors the encoding
+    // expected by `ed25519_public_to_x25519` without pulling in `did_key`.
+    fn ed25519_multikey(pubkey: &[u8]) -> String {
+        format!(
+            "z{}",
+            MultiEncodedBuf::encode_bytes(ED25519_PUB, pubkey)
+                .into_bytes()
+                .to_base58()
+        )
+    }
+
+    #[test]
+    fn multikey_and_bytes_x25519_agree() {
+        // The multikey-string `ed25519_public_to_x25519` and the bytes
+        // `did_key::ed25519_pub_to_x25519_bytes` helpers must produce the
+        // same X25519 public key for the same Ed25519 input.
+        let kp = generate(None);
+        let pub_bytes: [u8; 32] = kp.public_bytes.as_slice().try_into().unwrap();
+
+        let (_, from_multikey) = ed25519_public_to_x25519(&ed25519_multikey(&pub_bytes)).unwrap();
+        let from_bytes = crate::did_key::ed25519_pub_to_x25519_bytes(&pub_bytes).unwrap();
+
+        assert_eq!(from_multikey.as_slice(), from_bytes.as_slice());
+        assert_eq!(from_bytes.len(), 32);
+    }
+
+    #[test]
+    fn ed25519_public_to_x25519_rejects_missing_z_prefix() {
+        // Valid base58 payload but no multibase `z` prefix.
+        let raw = MultiEncodedBuf::encode_bytes(ED25519_PUB, &[0u8; 32])
+            .into_bytes()
+            .to_base58();
+        let err = ed25519_public_to_x25519(&raw).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::Decoding(ref m) if m.contains('z')),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ed25519_public_to_x25519_rejects_wrong_codec() {
+        // X25519 multicodec (0xec) where Ed25519 (0xed) is expected.
+        let multikey = format!(
+            "z{}",
+            MultiEncodedBuf::encode_bytes(X25519_PUB, &[0u8; 32])
+                .into_bytes()
+                .to_base58()
+        );
+        let err = ed25519_public_to_x25519(&multikey).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("codec")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ed25519_public_to_x25519_rejects_wrong_length() {
+        // Ed25519 multicodec with a 16-byte payload.
+        let multikey = ed25519_multikey(&[0u8; 16]);
+        let err = ed25519_public_to_x25519(&multikey).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("length") || m.contains("32")),
+            "got {err:?}"
+        );
+    }
 }

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -4,10 +4,14 @@
 //! - JWK (JSON Web Key) types per RFC 7517
 //! - Key generation for various curves (Ed25519, X25519, P-256, P-384, secp256k1)
 //! - Key conversion utilities (e.g., Ed25519 → X25519)
+//! - `did:key` encode/decode helpers for raw-bytes APIs (HPKE, ECDH)
 
 mod error;
 mod jwk;
 mod key_type;
+
+#[cfg(feature = "ed25519")]
+pub mod did_key;
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519;

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -4,7 +4,11 @@
 //! - JWK (JSON Web Key) types per RFC 7517
 //! - Key generation for various curves (Ed25519, X25519, P-256, P-384, secp256k1)
 //! - Key conversion utilities (e.g., Ed25519 → X25519)
-//! - `did:key` encode/decode helpers for raw-bytes APIs (HPKE, ECDH)
+//! - `did:key` encode/decode helpers for raw-bytes APIs (HPKE, ECDH) —
+//!   see [`did_key`]
+//! - Post-quantum signatures (FIPS 204 ML-DSA, FIPS 205 SLH-DSA) behind
+//!   the `post-quantum` feature (off by default; also available
+//!   individually as `ml-dsa` / `slh-dsa`)
 
 mod error;
 mod jwk;


### PR DESCRIPTION
## Summary

- Bump `affinidi-crypto` from 0.1.4 → 0.1.5.
- Add new `did_key` module (behind the `ed25519` feature) exposing a raw-bytes API for HPKE, sealed-transfer, and other non-DIDComm key-agreement callers:
  - `ed25519_pub_to_did_key(&[u8; 32]) -> String`
  - `did_key_to_ed25519_pub(&str) -> Result<[u8; 32], CryptoError>`
  - `ed25519_pub_to_x25519_bytes(&[u8; 32]) -> Result<[u8; 32], CryptoError>`
- Purely additive: the existing multikey-string helpers in `ed25519.rs` are untouched and still used by `affinidi-secrets-resolver`. Only `affinidi-crypto` bumps — caret `0.1` pins in consumers pick up 0.1.5 transparently, so no cascading bumps needed.

## Why

Apps doing HPKE / sealed transfer / ECDH want `&[u8; 32]` at the boundaries. Going through multikey strings just to hand bytes to the next call is unnecessary friction. Both forms now coexist: multikey for multikey-native callers, raw bytes for crypto-native callers.

## Out of scope

`did:key` decoding for other key types (P-256, secp256k1, X25519, ML-DSA). Add when needed — the multicodec values already live in `affinidi-crypto::key_type` / `affinidi-encoding`.

## Checklist

- [x] All tests pass (`cargo test --workspace` — 1349 tests, 0 failures)
- [x] CHANGELOG.md updated (workspace + crate)
- [x] Version references in README.md — none needed (caret `"0.1"` pin covers 0.1.5)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation builds cleanly (`cargo doc --workspace --no-deps`)

## Test plan

- 7 new unit tests in `did_key.rs` cover the happy path (roundtrip, deterministic encoding) and every error branch called out in the spec: missing `did:key:` prefix, missing multibase `z`, wrong multicodec, wrong payload length.
- `ed25519_pub_to_x25519_bytes` tested for consistency against the lifted `check_x25519` vector from `affinidi-secrets-resolver/src/secrets.rs` — deriving X25519 pub via Montgomery must match basepoint·(ed25519→x25519 sk).