### PR TITLE
chore: release affinidi-tdk-common v0.5.3 — keyring-core + rustls-platform-verifier 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+## 2026-05-02 — `affinidi-tdk-common` 0.5.3 — keyring-core migration, rustls-platform-verifier 0.7
+
+### Changed
+
+- **`affinidi-tdk-common` 0.5.2 → 0.5.3** — Replaced the bundled `keyring 3.x`
+  dependency with the new split-out
+  [`keyring-core 1.0`](https://crates.io/crates/keyring-core) plus per-target
+  platform store crates: `apple-native-keyring-store` (macOS `keychain`, iOS
+  `protected`), `windows-native-keyring-store`, and
+  `dbus-secret-service-keyring-store` (`crypto-rust`). The public
+  `secrets::{save_secrets_locally, delete_did_secret, TDKSharedState::load_secrets}`
+  surface is unchanged — a `OnceLock`-guarded
+  `keyring_core::set_default_store(...)` runs lazily on the first secret op
+  and is a no-op if the host application has already registered its own
+  default store, so callers do not need an init step at startup.
+- **`affinidi-tdk-common`** — Bumped `rustls-platform-verifier` 0.6 → 0.7 to
+  pick up the upstream patch line.
+- **`affinidi-tdk-common`** — Retired the empty `messaging` Cargo feature. It
+  only gated the `use_atm: bool` field on `TDKConfig` / `TDKConfigBuilder`
+  while the actually meaningful gate lives on `affinidi-tdk` (which carries
+  the `dep:affinidi-messaging-sdk` linkage). `use_atm` is now unconditionally
+  present, matching `affinidi-tdk`'s already-unconditional read of it. Four
+  dead `#[cfg(feature = "messaging")]` annotations in `config.rs` removed.
+
 ## 2026-04-20 — `did:key` raw-bytes helpers for HPKE / sealed transfer
 
 ### Added

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -12,10 +12,6 @@ repository.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 
-[features]
-default = ["messaging"]
-messaging = []
-
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-authentication = "0.3"
@@ -25,20 +21,28 @@ affinidi-data-integrity = "0.6"
 
 ahash = "0.8"
 base64 = "0.22"
-keyring = { version = "3", features = [
-  "apple-native",
-  "windows-native",
-  "sync-secret-service",
-] }
+keyring-core = "1"
 moka = { version = "0.12", features = ["future"] }
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
   "tls12",
 ] }
-rustls-platform-verifier = "0.6"
+rustls-platform-verifier = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { version = "1", features = ["keychain"] }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+apple-native-keyring-store = { version = "1", features = ["protected"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = "1"
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
+dbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }

--- a/crates/tdk/affinidi-tdk-common/src/config.rs
+++ b/crates/tdk/affinidi-tdk-common/src/config.rs
@@ -72,7 +72,6 @@ pub struct TDKConfigBuilder {
     /// Default: 1000
     authentication_cache_limit: usize,
 
-    #[cfg(feature = "messaging")]
     /// Use Affinidi Trusted Messaging
     /// Default: true
     /// NOTE: You can specify an externally configured ATM instance when instantiating TDK which will override this
@@ -92,7 +91,6 @@ impl Default for TDKConfigBuilder {
             load_environment: true,
             environment_name: None,
             authentication_cache_limit: 1_000,
-            #[cfg(feature = "messaging")]
             use_atm: true,
             custom_auth_handlers: None,
         }
@@ -117,7 +115,6 @@ impl TDKConfigBuilder {
             load_environment: self.load_environment,
             environment_name: self.environment_name.unwrap_or("default".into()),
             authentication_cache_limit: self.authentication_cache_limit,
-            #[cfg(feature = "messaging")]
             use_atm: self.use_atm,
             custom_auth_handlers: self.custom_auth_handlers,
         })
@@ -244,7 +241,6 @@ impl TDKConfigBuilder {
         self
     }
 
-    #[cfg(feature = "messaging")]
     /// Should TDK create an ATM instance internally?
     /// Defaults: true
     /// Example:

--- a/crates/tdk/affinidi-tdk-common/src/secrets.rs
+++ b/crates/tdk/affinidi-tdk-common/src/secrets.rs
@@ -5,10 +5,69 @@
 use crate::{TDKSharedState, errors::TDKError};
 use affinidi_secrets_resolver::{SecretsResolver, secrets::Secret};
 use base64::{Engine, prelude::BASE64_STANDARD_NO_PAD};
-use keyring::Entry;
+use keyring_core::Entry;
+use std::sync::OnceLock;
+
+/// Registers the platform-native credential store as keyring-core's default
+/// the first time a secret operation runs in this process. Idempotent and
+/// no-ops if a default store has already been set by the host application.
+fn ensure_default_store() -> Result<(), TDKError> {
+    static INIT: OnceLock<Result<(), String>> = OnceLock::new();
+    INIT.get_or_init(|| {
+        if keyring_core::get_default_store().is_some() {
+            return Ok(());
+        }
+        let store = build_platform_store()?;
+        keyring_core::set_default_store(store);
+        Ok(())
+    })
+    .clone()
+    .map_err(TDKError::Secrets)
+}
+
+#[cfg(target_os = "macos")]
+fn build_platform_store() -> Result<std::sync::Arc<keyring_core::api::CredentialStore>, String> {
+    apple_native_keyring_store::keychain::Store::new()
+        .map(|s| s as std::sync::Arc<keyring_core::api::CredentialStore>)
+        .map_err(|e| format!("Failed to initialise macOS Keychain store: {e}"))
+}
+
+#[cfg(target_os = "ios")]
+fn build_platform_store() -> Result<std::sync::Arc<keyring_core::api::CredentialStore>, String> {
+    apple_native_keyring_store::protected::Store::new()
+        .map(|s| s as std::sync::Arc<keyring_core::api::CredentialStore>)
+        .map_err(|e| format!("Failed to initialise iOS protected-data store: {e}"))
+}
+
+#[cfg(target_os = "windows")]
+fn build_platform_store() -> Result<std::sync::Arc<keyring_core::api::CredentialStore>, String> {
+    windows_native_keyring_store::Store::new()
+        .map(|s| s as std::sync::Arc<keyring_core::api::CredentialStore>)
+        .map_err(|e| format!("Failed to initialise Windows Credential Manager store: {e}"))
+}
+
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+fn build_platform_store() -> Result<std::sync::Arc<keyring_core::api::CredentialStore>, String> {
+    dbus_secret_service_keyring_store::Store::new()
+        .map(|s| s as std::sync::Arc<keyring_core::api::CredentialStore>)
+        .map_err(|e| format!("Failed to initialise Secret Service store: {e}"))
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+)))]
+fn build_platform_store() -> Result<std::sync::Arc<keyring_core::api::CredentialStore>, String> {
+    Err("No keyring-core platform store is bundled for this target OS".to_string())
+}
 
 /// Need to create a new entry to identify secrets for a specific service and DID
 fn entry(service_id: &str, did: &str) -> Result<Entry, TDKError> {
+    ensure_default_store()?;
     Entry::new(service_id, did).map_err(|e| {
         TDKError::Secrets(format!(
             "Failed to generate entry for service_id: {service_id}, did: {did}. Error: {e}",


### PR DESCRIPTION
## Summary

- Replaces `keyring 3.x` (single bundled crate) with the new split-out
  `keyring-core 1.0` plus per-target platform store crates
  (`apple-native-keyring-store`, `windows-native-keyring-store`,
  `dbus-secret-service-keyring-store`). Public `secrets` API surface is
  unchanged; a `OnceLock`-guarded `set_default_store(...)` runs lazily on
  first use and no-ops if the host has already registered its own store.
- Bumps `rustls-platform-verifier` 0.6 → 0.7.
- Retires the empty `messaging` Cargo feature in `affinidi-tdk-common`. It
  only gated `use_atm: bool` on the config builder, while the meaningful
  feature gate (with `dep:affinidi-messaging-sdk`) lives on `affinidi-tdk`.
  `use_atm` is now unconditionally present — matching what
  `affinidi-tdk` already does at `tdk/src/lib.rs:145`.

Patch bump only — caret-pinned consumers (`affinidi-tdk = "0.5"`) pick this
up automatically.

## Test plan

- [x] `cargo build -p affinidi-tdk-common` passes
- [x] `cargo check --workspace` passes (all consumers compile)
- [x] `cargo test -p affinidi-tdk-common --no-run` compiles cleanly
- [ ] Manual smoke test: save / load / delete a secret on macOS Keychain
- [ ] Manual smoke test: save / load / delete a secret via Secret Service on Linux
- [ ] Manual smoke test: save / load / delete a secret on Windows Credential Manager

## Out of scope

`affinidi-messaging-mediator` still uses `keyring 3.x` behind its
`vta-keyring` feature (`setup_vta.rs`, `vta_cache.rs`, `helpers.rs`). Same
migration pattern applies — left for a follow-up branch to keep this PR
scoped to the tdk-common 0.5.3 release.