### PR TITLE
Bump affinidi-tdk-common to 0.6 across the workspace

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
     with:
       toolchain: "1.94.0"
       rustflags: "-D warnings --cfg tracing_unstable"
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0098,RUSTSEC-2026-0099"
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true

--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Meeting Place Changelog
 
+## 2nd May 2026 (0.4.0)
+
+- **BREAKING:** Migrated to `affinidi-tdk-common` 0.6 — field accesses on
+  `TDKSharedState` (`.client`, `.did_resolver`, `.authentication`) now go
+  through accessor methods.
+- **BREAKING:** `MeetingPlaceError` is `#[non_exhaustive]`. The catch-all
+  `Error` variant is removed; use `Configuration` (for runtime
+  misconfiguration) or `Other` (for everything else). Match arms must
+  include a wildcard.
+- **BREAKING:** `MeetingPlace::new` no longer falls back to a hardcoded dev
+  URL when the service DID lacks an `api` service endpoint — returns
+  `MeetingPlaceError::Configuration` instead.
+- **BREAKING:** `PlatformType` variants renamed to conventional Rust casing
+  (`Apns`, `ApnsSandbox`, `Fcm`, `None`); JSON wire format unchanged via
+  `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]`. `FromStr` now rejects
+  unknown values instead of silently mapping to `None`.
+- **BREAKING:** `MeetingPlace::check_offer_phrase` takes `&TDKProfile`
+  instead of consuming it by value (only `.did` was ever used).
+- **BREAKING:** `Vcard` inner-field renamed `r#type` → `kind` (the JSON
+  field name `type` is preserved via `#[serde(rename = "type")]`).
+- **BREAKING:** `RegisterOfferBuilder::build` now consumes `self`.
+- **SECURITY:** HTTP request bodies are no longer logged. Offer phrases and
+  mnemonics in `register-offer` / `query-offer` / `deregister-offer`
+  payloads were previously visible in `debug!` traces.
+- **SECURITY:** `valid_until` overflow check tightened — `dur.as_secs() as
+  i64` previously wrapped silently for durations exceeding `i64::MAX`,
+  letting the wire field carry a negative offset. Now returns
+  `Configuration` with a meaningful message.
+- **SECURITY:** HTTP 401 _and_ 403 both surface as
+  `MeetingPlaceError::Authentication` (was 401-only).
+- **CHANGE:** Added `MeetingPlace::did()` and `MeetingPlace::api_url()`
+  accessors.
+- **CHANGE:** `Vcard` derives `Default`.
+- **CHANGE:** Internal HTTP plumbing uses `reqwest::json()` and
+  `bearer_auth()` instead of a manually-stringified body.
+- **TESTS:** Added 20 unit tests covering vcard serialisation,
+  `PlatformType` parsing, `ContactAttributeType` round-trip, valid_until
+  encoding (zero / nonzero / overflow), mediator-endpoint splitting,
+  OOB-message base64 round-trip, and URI extraction edge cases.
+- **DOCS:** Added `#![forbid(unsafe_code)]` at the crate root.
+
 ## 28th March 2026 (0.3.2)
 
 - **FIX:** Republish with `affinidi-messaging-didcomm` 0.13 dependency

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.3.3"
+version = "0.4.0"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ rust-version.workspace = true
 
 [dependencies]
 affinidi-did-authentication = "0.3"
-affinidi-tdk-common = "0.5"
+affinidi-tdk-common = "0.6"
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.13" }
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.3"

--- a/crates/applications/affinidi-meeting-place/README.md
+++ b/crates/applications/affinidi-meeting-place/README.md
@@ -29,7 +29,7 @@ sequenceDiagram
 
 ```toml
 [dependencies]
-affinidi-meeting-place = "0.3"
+affinidi-meeting-place = "0.4"
 ```
 
 ## Related Crates

--- a/crates/applications/affinidi-meeting-place/examples/meeting_place.rs
+++ b/crates/applications/affinidi-meeting-place/examples/meeting_place.rs
@@ -1,5 +1,6 @@
 /*!
- * Example of how to check an offer on Meeting Place
+ * Demonstrates the four core Meeting Place flows: check, query, register,
+ * deregister an offer phrase. Loads its identity from a TDKEnvironments file.
  */
 
 use affinidi_meeting_place::{
@@ -8,112 +9,101 @@ use affinidi_meeting_place::{
     offers::{ContactAttributeType, Offer, PlatformType, RegisterOffer},
     vcard::Vcard,
 };
-use affinidi_tdk_common::{TDKSharedState, environments::TDKEnvironments, profiles::TDKProfile};
+use affinidi_tdk_common::{
+    TDKSharedState, config::TDKConfig, environments::TDKEnvironments, profiles::TDKProfile,
+};
 use clap::{Parser, Subcommand};
 use std::{env, str::FromStr};
 use tracing::info;
 use tracing_subscriber::filter;
 
-/// Affinidi Meeting Place Check-Offer
 #[derive(Parser)]
-#[command(name = "meeting_place")]
-#[command(bin_name = "meeting_place")]
+#[command(name = "meeting_place", bin_name = "meeting_place")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Environment to use
+    /// Environment to use (defaults to `$TDK_ENVIRONMENT` or `"default"`).
     #[arg(short, long)]
     environment: Option<String>,
 
-    /// Path to the environments file (defaults to environments.json)
+    /// Path to the environments file (defaults to `environments.json`).
     #[arg(short, long)]
     path_environments: Option<String>,
 
-    /// Profile Name to use from the environment
+    /// Profile alias from the environment (defaults to `$TDK_PROFILE`, then
+    /// the first profile in the environment).
     #[arg(short, long)]
     name_profile: Option<String>,
 
-    /// DID for MeetingPlace
+    /// DID for Meeting Place service.
     #[arg(short, long)]
     mp_did: String,
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Check-Offer
+    /// Check whether an offer phrase is in use.
     Check(OfferPhraseArgs),
 
-    /// Query-Offer-Phrase
+    /// Query an offer by its phrase.
     Query(OfferPhraseArgs),
 
-    /// Register-Offer
+    /// Register a new offer.
     Register(Box<RegisterOfferArgs>),
 
-    /// Deregister-Offer
+    /// Deregister an offer by its phrase.
     Deregister(OfferPhraseArgs),
 }
 
 #[derive(Debug, Parser)]
-#[command(version, about, long_about = None)]
 struct OfferPhraseArgs {
-    /// Meeting Place Offer Phrase
+    /// Meeting Place offer phrase.
     #[arg(short, long)]
     phrase: String,
 }
 
 #[derive(Debug, Parser)]
-#[command(version, about, long_about = None)]
 struct RegisterOfferArgs {
-    /// Friendly UX Name for the offer
     #[arg(long)]
     offer_name: String,
 
-    /// Description for the offer
     #[arg(long)]
     description: String,
 
-    /// Mediator DID (will use default Environment if not specified)
+    /// Mediator DID; defaults to the active profile's mediator.
     #[arg(long)]
     mediator_did: Option<String>,
 
-    /// (Optional) Surname of the contact person
     #[arg(long)]
     contact_surname: Option<String>,
 
-    /// (Optional) Given name of the contact person
     #[arg(long)]
     contact_given_name: Option<String>,
 
-    /// (Optional) Email of the contact person
     #[arg(long)]
     contact_email: Option<String>,
 
-    /// (Optional) Phone number of the contact person
     #[arg(long)]
     contact_phone: Option<String>,
 
+    /// ISO-8601 timestamp; offer expires at this point.
     #[arg(long)]
-    /// (Optional) ISO-8601 date-time (2024-12-31T23:59:59Z)
     valid_until: Option<String>,
 
     #[arg(long)]
-    /// (Optional) Maximum number of times the offer can be used
     maximum_usage: Option<usize>,
 
-    /// (Optional) Push notification token for the device
     #[arg(long)]
     device_token: Option<String>,
 
-    /// (Optional) Platform Type (APNS, APNS_SANDBOX, FCM, NONE)
+    /// Push platform (`APNS`, `APNS_SANDBOX`, `FCM`, `NONE`).
     #[arg(long)]
     platform_type: Option<String>,
 
-    /// (Optional) Custom Offer Phrase
     #[arg(long)]
     custom_phrase: Option<String>,
 
-    /// (Optional) Contact Attributes
     #[arg(long)]
     contact_attributes: Option<u32>,
 }
@@ -123,110 +113,104 @@ async fn main() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let args = Cli::parse();
 
-    // construct a subscriber that prints formatted traces to stdout
-    let subscriber = tracing_subscriber::fmt()
-        // Use a more compact, abbreviated log format
-        .with_env_filter(filter::EnvFilter::from_default_env())
-        .finish();
-    // use that subscriber to process traces emitted after this point
-    tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(filter::EnvFilter::from_default_env())
+            .finish(),
+    )
+    .expect("Logging failed, exiting...");
 
-    let tdk = TDKSharedState::default().await;
-
-    let environment_name = if let Some(environment_name) = &args.environment {
-        environment_name.to_string()
-    } else if let Ok(environment_name) = env::var("TDK_ENVIRONMENT") {
-        environment_name
-    } else {
-        "default".to_string()
-    };
-
+    // Load environment + pick a profile.
+    let environment_name = args
+        .environment
+        .clone()
+        .or_else(|| env::var("TDK_ENVIRONMENT").ok())
+        .unwrap_or_else(|| "default".to_string());
     let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
-    println!("Using Environment: {}", environment_name);
+    println!("Using Environment: {environment_name}");
 
-    let environment_profile = if let Some(profile_name) = &args.name_profile {
-        let Some(profile) = environment.profiles.get(profile_name) else {
-            return Err(MeetingPlaceError::TDK(format!(
-                "Profile ({}) not found in environment ({})",
-                profile_name, environment_name
-            )));
-        };
-        tdk.add_profile(profile).await;
-        profile
-    } else if let Ok(profile_name) = env::var("TDK_PROFILE") {
-        let Some(profile) = environment.profiles.get(&profile_name) else {
-            return Err(MeetingPlaceError::TDK(format!(
-                "Profile ({}) not found in environment ({})",
-                profile_name, environment_name
-            )));
-        };
-        tdk.add_profile(profile).await;
-        profile
-    } else if let Some(profile) = environment.profiles.values().next() {
-        tdk.add_profile(profile).await;
-        profile
-    } else {
-        return Err(MeetingPlaceError::TDK(format!(
-            "No profiles found in environment ({})",
-            environment_name
-        )));
+    let profile_name = args
+        .name_profile
+        .clone()
+        .or_else(|| env::var("TDK_PROFILE").ok());
+
+    let profile = match profile_name.as_deref() {
+        Some(name) => environment.profile(name).cloned().ok_or_else(|| {
+            MeetingPlaceError::Configuration(format!(
+                "Profile ({name}) not found in environment ({environment_name})"
+            ))
+        })?,
+        None => environment
+            .profiles()
+            .values()
+            .next()
+            .cloned()
+            .ok_or_else(|| {
+                MeetingPlaceError::Configuration(format!(
+                    "No profiles found in environment ({environment_name})"
+                ))
+            })?,
     };
+
+    // Build TDK shared state with this environment, then run the chosen command.
+    let tdk = TDKSharedState::new(
+        TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(false)
+            .with_environment(environment)
+            .build()
+            .map_err(MeetingPlaceError::from)?,
+    )
+    .await
+    .map_err(MeetingPlaceError::from)?;
+    tdk.add_profile(&profile).await;
 
     let mp = MeetingPlace::new(&tdk, args.mp_did).await?;
     match args.command {
         Commands::Check(check_offer_phrase) => {
             let result = mp
-                .check_offer_phrase(
-                    &tdk,
-                    environment_profile.clone(),
-                    &check_offer_phrase.phrase,
-                )
+                .check_offer_phrase(&tdk, &profile, &check_offer_phrase.phrase)
                 .await?;
-            info!("Offer Phrase is in use? {}", result);
+            info!("Offer Phrase is in use? {result}");
         }
         Commands::Register(register_offer) => {
-            let offer_details =
-                _create_register_offer(&tdk, &register_offer, environment_profile).await?;
-
+            let offer_details = create_register_offer(&tdk, &register_offer, &profile).await?;
             let mut offer = Offer::new_from_register_offer(offer_details);
-            let response = offer.register_offer(&mp, &tdk, environment_profile).await?;
-            info!("Offer registered: {:#?}", response);
+            let response = offer.register_offer(&mp, &tdk, &profile).await?;
+            info!("Offer registered: {response:#?}");
         }
         Commands::Query(query_offer) => {
-            let result =
-                Offer::query_offer(&mp, &tdk, environment_profile, &query_offer.phrase).await?;
-            info!("Offer result: {:#?}", result);
+            let result = Offer::query_offer(&mp, &tdk, &profile, &query_offer.phrase).await?;
+            info!("Offer result: {result:#?}");
         }
         Commands::Deregister(query_offer) => {
-            let mut offer =
-                Offer::query_offer(&mp, &tdk, environment_profile, &query_offer.phrase).await?;
-
-            let result = offer
-                .deregister_offer(&mp, &tdk, environment_profile)
-                .await?;
-            info!("Deregister result: {:#?}", result);
+            let mut offer = Offer::query_offer(&mp, &tdk, &profile, &query_offer.phrase).await?;
+            let result = offer.deregister_offer(&mp, &tdk, &profile).await?;
+            info!("Deregister result: {result:#?}");
         }
     };
 
+    tdk.shutdown().await;
     Ok(())
 }
 
-/// Converts the CLI Arguments to a RegisterOffer
-async fn _create_register_offer(
+/// Map CLI args into a `RegisterOffer`. Resolves the mediator from the
+/// command line first, falling back to the profile's default mediator.
+async fn create_register_offer(
     tdk: &TDKSharedState,
     args: &RegisterOfferArgs,
     profile: &TDKProfile,
 ) -> Result<RegisterOffer> {
-    let mediator_did = if let Some(mediator_did) = &args.mediator_did {
-        mediator_did.to_owned()
-    } else if let Some(mediator_did) = &profile.mediator {
-        mediator_did.to_string()
-    } else {
-        return Err(MeetingPlaceError::TDK(
-            "No mediator DID specified and no default mediator in profile".to_string(),
-        ));
-    };
+    let mediator_did = args
+        .mediator_did
+        .clone()
+        .or_else(|| profile.mediator.clone())
+        .ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "No mediator DID specified and no default mediator in profile".to_string(),
+            )
+        })?;
 
     let mut offer_details = RegisterOffer::create(
         &args.offer_name,
@@ -235,7 +219,6 @@ async fn _create_register_offer(
         &mediator_did,
     )?;
 
-    // Create the vcard
     offer_details.vcard(Vcard::new(
         args.contact_given_name.clone(),
         args.contact_surname.clone(),
@@ -245,37 +228,37 @@ async fn _create_register_offer(
 
     if let Some(valid_until) = &args.valid_until {
         let valid_until = chrono::DateTime::parse_from_rfc3339(valid_until)
-            .map_err(|err| MeetingPlaceError::Error(format!("invalid valid_until timestamp. Must be in ISO 8601 format (2025-03-17T09:00:00-00:00)! Reason: {}", err)))?.to_utc();
+            .map_err(|err| {
+                MeetingPlaceError::Configuration(format!(
+                    "invalid valid_until timestamp. Must be ISO-8601 (e.g. 2025-03-17T09:00:00-00:00): {err}"
+                ))
+            })?
+            .to_utc();
 
-        let now = chrono::Utc::now();
-        let delta = valid_until - now;
+        let delta = valid_until - chrono::Utc::now();
         if delta.num_seconds() <= 0 {
-            return Err(MeetingPlaceError::Error(
-                "valid_until timestamp must be in the future".to_string(),
+            return Err(MeetingPlaceError::Configuration(
+                "valid_until must be in the future".to_string(),
             ));
         }
 
         offer_details.valid_until(delta.to_std().map_err(|err| {
-            MeetingPlaceError::Error(format!("invalid valid_until timestamp. Reason: {}", err))
+            MeetingPlaceError::Configuration(format!("invalid valid_until: {err}"))
         })?);
     }
 
     if let Some(maximum_usage) = args.maximum_usage {
         offer_details.maximum_usage(maximum_usage);
     }
-
     if let Some(device_token) = &args.device_token {
         offer_details.device_token(device_token);
     }
-
     if let Some(platform_type) = &args.platform_type {
         offer_details.platform_type(PlatformType::from_str(platform_type)?);
     }
-
     if let Some(contact_attributes) = args.contact_attributes {
         offer_details.contact_attributes(ContactAttributeType::from_u32(contact_attributes));
     }
-
     if let Some(custom_phrase) = &args.custom_phrase {
         offer_details.custom_phrase(custom_phrase);
     }

--- a/crates/applications/affinidi-meeting-place/src/errors.rs
+++ b/crates/applications/affinidi-meeting-place/src/errors.rs
@@ -1,5 +1,8 @@
 /*!
- * Affinidi Meeting-Place Error Handling
+ * Error types for the Affinidi Meeting Place client.
+ *
+ * `#[non_exhaustive]` so that adding new variants in future releases is not
+ * a SemVer break.
  */
 
 use affinidi_did_authentication::errors::DIDAuthError;
@@ -7,32 +10,39 @@ use affinidi_did_resolver_cache_sdk::errors::DIDCacheError;
 use affinidi_tdk_common::errors::TDKError;
 use thiserror::Error;
 
-/// Meeting-Place Errors
+/// Errors surfaced by [`crate::MeetingPlace`] and friends.
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum MeetingPlaceError {
-    /// Authentication error
+    /// Authentication / authorization failure (401 / 403, or upstream
+    /// DID Auth error).
     #[error("Authentication failed: {0}")]
     Authentication(String),
 
-    /// REST API Error
+    /// Non-success HTTP response or transport-level failure.
     #[error("API error: {0}")]
     API(String),
 
-    /// TDK Error
-    #[error("API error: {0}")]
+    /// Wrapped error from `affinidi-tdk-common`.
+    #[error("TDK error: {0}")]
     TDK(String),
 
-    /// Serialization Error
+    /// JSON serialise / deserialise failure.
     #[error("Serialization error: {0}")]
     Serialization(String),
 
-    /// DID Error
-    #[error("DID Error: {0}")]
+    /// DID resolution failure.
+    #[error("DID error: {0}")]
     DIDError(String),
 
-    /// Error
-    #[error("Error: {0}")]
-    Error(String),
+    /// Misconfiguration detected at runtime (e.g. missing service endpoint
+    /// in a DID document, mediator with the wrong number of endpoints).
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+
+    /// Catch-all for callers that don't fit the other variants.
+    #[error("{0}")]
+    Other(String),
 }
 
 pub type Result<T> = std::result::Result<T, MeetingPlaceError>;

--- a/crates/applications/affinidi-meeting-place/src/lib.rs
+++ b/crates/applications/affinidi-meeting-place/src/lib.rs
@@ -1,13 +1,20 @@
 /*!
- * Rust library for Affinidi [Meeting Place](https://meetingplace.world)
+ * Rust client for Affinidi [Meeting Place](https://meetingplace.world).
+ *
+ * Construct a [`MeetingPlace`] from a [`TDKSharedState`] and the meeting-place
+ * service DID. The service DID is resolved once at construction time to
+ * discover the API endpoint via its `api` service entry; further requests
+ * reuse the cached endpoint.
  */
+
+#![forbid(unsafe_code)]
 
 use affinidi_did_authentication::AuthorizationTokens;
 use affinidi_did_common::{Document, service::Endpoint};
 use affinidi_tdk_common::{TDKSharedState, profiles::TDKProfile};
 use errors::{MeetingPlaceError, Result};
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::debug;
 
@@ -15,43 +22,62 @@ pub mod errors;
 pub mod offers;
 pub mod vcard;
 
-/// Affinidi Meeting Place SDK
-#[derive(Clone)]
+/// Affinidi Meeting Place client.
+///
+/// Cheap to clone — it holds two `String`s.
+#[derive(Clone, Debug)]
 pub struct MeetingPlace {
-    /// DID for MeetingPlace
-    mp_did: String,
+    /// DID of the Meeting Place service. Used as the `target_did` for DID
+    /// authentication and surfaces in error contexts.
+    pub(crate) mp_did: String,
 
-    /// Service endpoint for MeetingPlace API
-    mp_api: String,
+    /// Resolved API base URL (without trailing slash). Discovered from the
+    /// Meeting Place DID document's `api` service entry at construction
+    /// time.
+    pub(crate) mp_api: String,
 }
 
 impl MeetingPlace {
+    /// Construct a new client.
+    ///
+    /// Resolves `mp_did` via the supplied [`TDKSharedState`]'s DID resolver
+    /// and extracts the `api` service endpoint. Returns
+    /// [`MeetingPlaceError::DIDError`] if the DID cannot be resolved, or
+    /// [`MeetingPlaceError::Configuration`] if the DID document does not
+    /// expose an `api` endpoint.
     pub async fn new(tdk: &TDKSharedState, mp_did: String) -> Result<Self> {
-        let did_doc = tdk.did_resolver.resolve(&mp_did).await?;
-        Ok(Self {
-            mp_did,
-            mp_api: find_api_service_endpoint(&did_doc.doc).unwrap_or(
-                "https://ib8w1f44k7.execute-api.ap-southeast-1.amazonaws.com/dev/mpx/v1"
-                    .to_string(),
-            ),
-        })
+        let did_doc = tdk.did_resolver().resolve(&mp_did).await?;
+        let mp_api = find_api_service_endpoint(&did_doc.doc).ok_or_else(|| {
+            MeetingPlaceError::Configuration(format!(
+                "Meeting Place DID ({mp_did}) does not expose an `api` service endpoint"
+            ))
+        })?;
+        Ok(Self { mp_did, mp_api })
     }
 
+    /// DID of the Meeting Place service this client talks to.
+    pub fn did(&self) -> &str {
+        &self.mp_did
+    }
+
+    /// Resolved API base URL.
+    pub fn api_url(&self) -> &str {
+        &self.mp_api
+    }
+
+    /// Check whether an offer phrase is currently in use.
     pub async fn check_offer_phrase(
         &self,
         tdk: &TDKSharedState,
-        profile: TDKProfile,
+        profile: &TDKProfile,
         phrase: &str,
     ) -> Result<bool> {
-        let tokens = tdk
-            .authentication
-            .authenticate(profile.did, self.mp_did.clone(), 3, None)
-            .await?;
+        let tokens = tdk.authenticate_profile(profile, &self.mp_did).await?;
 
-        let response = _http_post::<CheckOfferPhraseResponse>(
-            &tdk.client,
-            &[&self.mp_api, "/check-offer-phrase"].concat(),
-            &json!({"offerPhrase": phrase}).to_string(),
+        let response = http_post::<_, CheckOfferPhraseResponse>(
+            tdk.client(),
+            &endpoint(&self.mp_api, "/check-offer-phrase"),
+            &json!({ "offerPhrase": phrase }),
             &tokens,
         )
         .await?;
@@ -60,116 +86,133 @@ impl MeetingPlace {
     }
 }
 
-// ************************************************************************************************
-
 #[derive(Debug, Deserialize)]
 struct CheckOfferPhraseResponse {
     #[serde(rename = "isInUse")]
     is_in_use: bool,
 }
 
-pub(crate) async fn _http_post<T>(
+/// Build a request URL by joining the API base with a path. Both must be
+/// supplied; the path should start with `/`.
+pub(crate) fn endpoint(base: &str, path: &str) -> String {
+    let mut s = String::with_capacity(base.len() + path.len());
+    s.push_str(base);
+    s.push_str(path);
+    s
+}
+
+/// POST a JSON body to `url`, deserialise the response into `T`.
+///
+/// Maps non-2xx HTTP responses to [`MeetingPlaceError`]: 401/403 → `Authentication`,
+/// other non-success → `API`. The request body is **not** logged (it may
+/// contain offer phrases or other identifiers).
+pub(crate) async fn http_post<B, T>(
     client: &Client,
     url: &str,
-    body: &str,
+    body: &B,
     tokens: &AuthorizationTokens,
 ) -> Result<T>
 where
+    B: Serialize + ?Sized,
     T: for<'de> Deserialize<'de>,
 {
-    debug!("POSTing to {}", url);
-    debug!("Body: {}", body);
+    debug!(url, "POST");
     let response = client
         .post(url)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", tokens.access_token))
-        .body(body.to_string())
+        .bearer_auth(&tokens.access_token)
+        .json(body)
         .send()
         .await
-        .map_err(|e| MeetingPlaceError::API(format!("HTTP POST failed ({url}): {e:?}")))?;
+        .map_err(|e| MeetingPlaceError::API(format!("HTTP POST failed ({url}): {e}")))?;
 
-    let response_status = response.status();
-    let response_body = response
+    let status = response.status();
+    let body_text = response
         .text()
         .await
-        .map_err(|e| MeetingPlaceError::API(format!("Couldn't get HTTP body: {e:?}")))?;
+        .map_err(|e| MeetingPlaceError::API(format!("Couldn't read HTTP body ({url}): {e}")))?;
 
-    debug!(
-        "status: {} response_body: {}",
-        response_status, response_body
-    );
-    if !response_status.is_success() {
-        if response_status.as_u16() == 401 {
-            return Err(MeetingPlaceError::Authentication(
-                "Permission Denied (401: Unauthorized)`".into(),
-            ));
-        } else {
-            return Err(MeetingPlaceError::API(format!(
-                "Failed to get authentication response. url: {url}, status: {response_status}"
-            )));
-        }
+    if !status.is_success() {
+        return Err(match status.as_u16() {
+            401 | 403 => MeetingPlaceError::Authentication(format!(
+                "Permission denied ({status}) calling {url}"
+            )),
+            _ => MeetingPlaceError::API(format!("Request to {url} failed: {status}")),
+        });
     }
 
-    serde_json::from_str::<T>(&response_body)
-        .map_err(|e| MeetingPlaceError::API(format!("Couldn't deserialize API body response: {e}")))
+    serde_json::from_str::<T>(&body_text).map_err(|e| {
+        MeetingPlaceError::Serialization(format!("Couldn't deserialise response from {url}: {e}"))
+    })
 }
 
-/// Find the [serviceEndpoint](https://www.w3.org/TR/did-1.0/#services) with type `DIDCommMessaging` from a DID Document
-/// # Arguments
-/// * `doc` - The DID Document to search
+/// Find HTTP(S) and WebSocket service endpoints on a DID document's
+/// `service` entry.
 ///
-/// # Returns
-/// URI of the service endpoint if it exists
+/// Both forms of `serviceEndpoint` are supported: a single
+/// [`Endpoint::Url`], or a [`Endpoint::Map`] that holds either an `{uri}`
+/// object or an array of them. Non-string `uri` values are skipped.
 pub(crate) fn find_mediator_service_endpoints(doc: &Document) -> Vec<String> {
-    if let Some(service) = doc.find_service("service") {
-        let mut uris = Vec::new();
-        match &service.service_endpoint {
-            Endpoint::Url(e) => {
-                uris.push(e.to_string());
-            }
-            Endpoint::Map(map) => {
-                if let Some(array) = map.as_array() {
-                    for endpoint in array {
-                        if let Some(uri) = endpoint.get("uri") {
-                            uris.push(
-                                uri.to_string()
-                                    .trim_start_matches('"')
-                                    .trim_end_matches('"')
-                                    .to_string(),
-                            );
-                        }
-                    }
-                } else if let Some(uri) = map.get("uri") {
-                    uris.push(
-                        uri.to_string()
-                            .trim_start_matches('"')
-                            .trim_end_matches('"')
-                            .to_string(),
-                    );
-                }
+    let Some(service) = doc.find_service("service") else {
+        return Vec::new();
+    };
+    match &service.service_endpoint {
+        Endpoint::Url(url) => vec![url.to_string()],
+        Endpoint::Map(map) => {
+            if let Some(array) = map.as_array() {
+                array.iter().filter_map(extract_uri).collect()
+            } else {
+                extract_uri(map).into_iter().collect()
             }
         }
-        uris
-    } else {
-        vec![]
     }
 }
 
-/// Find the [serviceEndpoint](https://www.w3.org/TR/did-1.0/#services) with id `api` from a DID Document
-/// # Arguments
-/// * `doc` - The DID Document to search
-///
-/// # Returns
-/// URI of the service endpoint if it exists
+/// Pull the `uri` field out of a service-endpoint map, returning `None` if
+/// it is absent or not a JSON string.
+fn extract_uri(value: &serde_json::Value) -> Option<String> {
+    value.get("uri")?.as_str().map(str::to_owned)
+}
+
+/// Find the [serviceEndpoint](https://www.w3.org/TR/did-1.0/#services) with
+/// id `api` from a DID Document, returning its URL when present.
 pub fn find_api_service_endpoint(doc: &Document) -> Option<String> {
-    if let Some(service) = doc.find_service("api") {
-        if let Endpoint::Url(e) = &service.service_endpoint {
-            debug!("Found service endpoint: {}", e);
-            Some(e.to_string())
-        } else {
-            None
-        }
+    let service = doc.find_service("api")?;
+    if let Endpoint::Url(url) = &service.service_endpoint {
+        debug!(endpoint = %url, "found api service endpoint");
+        Some(url.to_string())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extract_uri_handles_string() {
+        let v = json!({ "uri": "https://example.com" });
+        assert_eq!(extract_uri(&v), Some("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn extract_uri_returns_none_for_missing() {
+        let v = json!({ "accept": ["didcomm/v2"] });
+        assert_eq!(extract_uri(&v), None);
+    }
+
+    #[test]
+    fn extract_uri_returns_none_for_non_string() {
+        let v = json!({ "uri": 42 });
+        assert_eq!(extract_uri(&v), None);
+    }
+
+    #[test]
+    fn endpoint_joins_base_and_path() {
+        assert_eq!(
+            endpoint("https://api.example/v1", "/register-offer"),
+            "https://api.example/v1/register-offer"
+        );
     }
 }

--- a/crates/applications/affinidi-meeting-place/src/offers.rs
+++ b/crates/applications/affinidi-meeting-place/src/offers.rs
@@ -1,11 +1,11 @@
 /*!
- * Handles the creation of offers
+ * Offer creation, registration, query, and deregistration.
  */
 
 use crate::{
-    _http_post, MeetingPlace,
+    MeetingPlace, endpoint,
     errors::{MeetingPlaceError, Result},
-    find_mediator_service_endpoints,
+    find_mediator_service_endpoints, http_post,
     vcard::Vcard,
 };
 use affinidi_messaging_didcomm::message::Message;
@@ -15,14 +15,13 @@ use chrono::{Local, TimeDelta};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{str::FromStr, time::Duration};
-use tracing::debug;
 use uuid::Uuid;
 
-/// Top-level Meeting Place struct for an Offer
+/// Top-level Meeting Place struct for an Offer.
 #[derive(Debug)]
 pub struct Offer {
     pub status: String,
-    /// DIDComm message
+    /// DIDComm message (base64 URL-safe, no pad).
     pub message: Option<String>,
     pub offer_link: Option<String>,
     pub valid_until: Option<String>,
@@ -30,104 +29,108 @@ pub struct Offer {
     pub mnemonic: Option<String>,
 }
 
-/// Register an offer with Meeting Place
-/// https://gitlab.com/affinidi/octo/larter/affinidi-meeting-place/api-meetingplace#post-register-offer
+/// Register an offer with Meeting Place.
+///
+/// Construct via [`RegisterOffer::create`] (returns a builder).
 #[derive(Debug, Serialize)]
 pub struct RegisterOffer {
-    /// Name of the offer that will be displayed to acceptors in their UI
+    /// Name of the offer that will be displayed to acceptors in their UI.
     #[serde(rename = "offerName")]
     name: String,
 
-    /// Description of the offer that will be displayed to potential acceptors
+    /// Description of the offer that will be displayed to potential acceptors.
     #[serde(rename = "offerDescription")]
     description: String,
 
-    /// Base64 encoded DIDComm plaintext message containing the invitation
+    /// Base64 encoded DIDComm plaintext message containing the invitation.
     #[serde(rename = "didcommMessage")]
     didcomm_message: String,
 
-    /// Base64 encoded vCard containing the offerer's contact details
-    #[serde(rename = "vcard")]
+    /// Base64 encoded vCard containing the offerer's contact details.
     vcard: String,
 
-    /// ISO-8601 formatted date/time when the offer expires (e.g., "2024-12-31T23:59:59Z")
-    /// If this field is an empty string, the system's maximum expiry date will be set
+    /// ISO-8601 formatted date/time when the offer expires (e.g.,
+    /// `"2024-12-31T23:59:59Z"`). An empty string asks the system to apply
+    /// its maximum.
     #[serde(rename = "validUntil")]
     valid_until: String,
 
-    /// Maximum number of times this offer can be accepted
-    /// (0 for maximum number of claims as determined by the system)
+    /// Maximum number of times this offer can be accepted (0 = system
+    /// default).
     #[serde(rename = "maximumUsage")]
     maximum_usage: usize,
 
-    /// Token received from the device's push notification API/SDK
+    /// Token from the device's push notification API/SDK.
     #[serde(rename = "deviceToken")]
     device_token: String,
 
-    /// Push notification platform type ("APNS", "APNS_SANDBOX", "FCM",
-    /// or "NONE" if push notifications are not supported on the offerer's platform)
+    /// Push notification platform.
     #[serde(rename = "platformType")]
     platform_type: PlatformType,
 
-    /// HTTP(S) endpoint of the DIDComm mediator service for this offer
+    /// HTTP(S) endpoint of the DIDComm mediator service for this offer.
     #[serde(rename = "mediatorEndpoint")]
     mediator_endpoint: String,
 
-    /// DID of the DIDComm mediator service for this offer
+    /// DID of the DIDComm mediator service for this offer.
     #[serde(rename = "mediatorDid")]
     mediator_did: String,
 
-    /// WebSocket(S) endpoint of the DIDComm mediator service to be used for this offer
+    /// WebSocket(S) endpoint of the DIDComm mediator service.
     #[serde(rename = "mediatorWSSEndpoint")]
     mediator_websocket_endpoint: String,
 
-    /// Optional custom phrase to identify this offer (must be unique if provided)
-    /// If none is provided, the system will generate a phrase
-    #[serde(rename = "customPhrase")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Optional custom phrase to identify this offer (must be unique if
+    /// provided). If absent, the system generates one.
+    #[serde(rename = "customPhrase", skip_serializing_if = "Option::is_none")]
     custom_phrase: Option<String>,
 
-    /// Bitfield representing various contact attributes for the offer.
-    /// Currently, the API does not enforce nor validate these bits, instead, it is left to the client application to make use/sense of them.
-    /// Meeting Place mobile application currently defines the following bits:
-    ///   Unknown: 0
-    ///   Person: 1
-    ///   Adult: 2
-    ///   Robot: 4
-    ///   Service: 8
-    ///   Organisation: 16
+    /// Bitfield describing the contact. Currently the API does not enforce
+    /// or validate these bits — the client interprets them. Today's
+    /// Meeting Place mobile client uses:
     ///
-    ///  NOTE: These are subject to change and in future versions, the bitfield may be enforced by the API
+    /// - `Unknown=0`, `Person=1`, `Adult=2`, `Robot=4`,
+    ///   `Service=8`, `Organisation=16`.
+    ///
+    /// Subject to change.
     #[serde(rename = "contactAttributes")]
     contact_attributes: u32,
 }
 
-#[derive(Clone, Debug, Serialize)]
+/// Push notification platform type.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PlatformType {
-    APNS,
-    #[allow(non_camel_case_types)]
-    APNS_SANDBOX,
-    FCM,
-    NONE,
+    Apns,
+    ApnsSandbox,
+    Fcm,
+    /// No push notifications supported on this platform.
+    #[default]
+    None,
 }
 
 impl FromStr for PlatformType {
     type Err = MeetingPlaceError;
 
-    fn from_str(platform_type: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(match platform_type.to_uppercase().as_str() {
-            "APNS" => PlatformType::APNS,
-            "APNS_SANDBOX" => PlatformType::APNS_SANDBOX,
-            "FCM" => PlatformType::FCM,
-            _ => PlatformType::NONE,
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(match s.to_ascii_uppercase().as_str() {
+            "APNS" => PlatformType::Apns,
+            "APNS_SANDBOX" => PlatformType::ApnsSandbox,
+            "FCM" => PlatformType::Fcm,
+            "" | "NONE" => PlatformType::None,
+            other => {
+                return Err(MeetingPlaceError::Configuration(format!(
+                    "Unknown push platform type {other:?} (expected APNS, APNS_SANDBOX, FCM, NONE)"
+                )));
+            }
         })
     }
 }
 
-/// Used within MeetingPlace to represent the type of contact
-/// Subject to change...
-#[derive(Clone, Serialize)]
+/// Type of contact represented by the offer. Subject to change.
+#[derive(Clone, Copy, Debug, Default, Serialize, PartialEq, Eq)]
 pub enum ContactAttributeType {
+    #[default]
     Unknown,
     Person,
     Adult,
@@ -137,7 +140,8 @@ pub enum ContactAttributeType {
 }
 
 impl ContactAttributeType {
-    pub fn to_u32(&self) -> u32 {
+    /// Single-bit numeric encoding sent over the wire.
+    pub const fn to_u32(self) -> u32 {
         match self {
             ContactAttributeType::Unknown => 0,
             ContactAttributeType::Person => 1,
@@ -148,9 +152,10 @@ impl ContactAttributeType {
         }
     }
 
-    pub fn from_u32(contact_type: u32) -> Self {
-        match contact_type {
-            0 => ContactAttributeType::Unknown,
+    /// Inverse of [`to_u32`](Self::to_u32). Unknown bits map to
+    /// [`Unknown`](Self::Unknown).
+    pub const fn from_u32(bits: u32) -> Self {
+        match bits {
             1 => ContactAttributeType::Person,
             2 => ContactAttributeType::Adult,
             4 => ContactAttributeType::Robot,
@@ -161,11 +166,12 @@ impl ContactAttributeType {
     }
 }
 
-/// Builder for RegisterOffer
+/// Builder for [`RegisterOffer`].
+#[derive(Debug)]
 pub struct RegisterOfferBuilder {
     name: String,
     description: String,
-    didcomm_message: Option<String>,
+    didcomm_message: String,
     vcard: Vcard,
     valid_until: Duration,
     maximum_usage: usize,
@@ -176,205 +182,167 @@ pub struct RegisterOfferBuilder {
     contact_attributes: u32,
 }
 
-impl Default for RegisterOfferBuilder {
-    fn default() -> Self {
-        RegisterOfferBuilder {
-            name: "Connect with Affinidi!".to_string(),
-            description: "If you have the passphrase you can connect via Meeting Place!"
-                .to_string(),
-            didcomm_message: None,
-            vcard: Vcard::default(),
-            valid_until: Duration::default(),
-            maximum_usage: 0,
-            device_token: "NO_TOKEN".to_string(),
-            platform_type: PlatformType::NONE,
-            mediator_did: "".to_string(),
-            custom_phrase: None,
-            contact_attributes: ContactAttributeType::Unknown.to_u32(),
-        }
-    }
-}
-
 impl RegisterOfferBuilder {
-    /// Set a Vcard for the offer
+    /// Set a Vcard for the offer.
     pub fn vcard(&mut self, vcard: Vcard) -> &mut Self {
         self.vcard = vcard;
         self
     }
 
-    /// When is this offer valid until?
-    /// Defaults: 0 which is for as long as Meeting Place will allow
+    /// Lifetime of the offer from now. Defaults to `Duration::ZERO`, which
+    /// asks Meeting Place to apply its maximum.
     pub fn valid_until(&mut self, valid_until: Duration) -> &mut Self {
         self.valid_until = valid_until;
         self
     }
 
-    /// Maximum number of times this offer can be accepted
-    /// (0 for maximum number of claims as determined by the system)
+    /// Maximum number of times this offer can be accepted (0 = system
+    /// default).
     pub fn maximum_usage(&mut self, maximum_usage: usize) -> &mut Self {
         self.maximum_usage = maximum_usage;
         self
     }
 
-    /// Token received from the device's push notification API/SDK
-    /// Defaults to `NO_TOKEN`
+    /// Token received from the device's push notification API/SDK.
+    /// Defaults to `"NO_TOKEN"`.
     pub fn device_token(&mut self, device_token: &str) -> &mut Self {
         self.device_token = device_token.to_string();
         self
     }
 
-    /// Push notification platform type
-    /// Defaults to `NONE`
+    /// Push notification platform type. Defaults to
+    /// [`PlatformType::None`].
     pub fn platform_type(&mut self, platform_type: PlatformType) -> &mut Self {
         self.platform_type = platform_type;
         self
     }
 
-    /// Optional custom phrase to identify this offer
+    /// Optional custom phrase to identify this offer.
     pub fn custom_phrase(&mut self, custom_phrase: &str) -> &mut Self {
         self.custom_phrase = Some(custom_phrase.to_string());
         self
     }
 
     /// Bitfield representing various contact attributes for the offer.
-    /// Defaults to `Unknown`
     pub fn contact_attributes(&mut self, contact_attributes: ContactAttributeType) -> &mut Self {
         self.contact_attributes = contact_attributes.to_u32();
         self
     }
 
-    /// Build the RegisterOffer
-    pub async fn build(&self, tdk: &TDKSharedState) -> Result<RegisterOffer> {
-        let didcomm_message = if let Some(didcomm_message) = &self.didcomm_message {
-            didcomm_message.clone()
-        } else {
-            return Err(MeetingPlaceError::Error(
-                "No DIDComm message provided".to_string(),
-            ));
-        };
+    /// Build the [`RegisterOffer`]. Resolves the mediator DID via the
+    /// supplied [`TDKSharedState`] and extracts its HTTP and WebSocket
+    /// service endpoints.
+    pub async fn build(self, tdk: &TDKSharedState) -> Result<RegisterOffer> {
+        let valid_until = encode_valid_until(self.valid_until)?;
 
-        let valid_until = if self.valid_until.as_secs() == 0 {
-            "".to_string()
-        } else {
-            let now = Local::now();
-            let delta =
-                if let Some(delta) = TimeDelta::try_seconds(self.valid_until.as_secs() as i64) {
-                    delta
-                } else {
-                    return Err(MeetingPlaceError::Error(
-                        "Invalid duration provided for valid_until".to_string(),
-                    ));
-                };
-            (now + delta).to_rfc3339()
-        };
-
-        let mediator_doc = tdk.did_resolver.resolve(&self.mediator_did).await?;
-        let uris = find_mediator_service_endpoints(&mediator_doc.doc);
-
-        let (mediator_endpoint, mediator_websocket_endpoint) = if uris.len() != 2 {
-            return Err(MeetingPlaceError::Error(
-                "Mediator DID must have 2 service endpoints".to_string(),
-            ));
-        } else {
-            let mediator_endpoint: String = if let Some(uri) = uris
-                .iter()
-                .filter_map(|e| {
-                    debug!("URI: {}", e);
-                    if e.starts_with("http") {
-                        debug!("Matched");
-                        Some(e.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<String>>()
-                .first()
-            {
-                uri.clone()
-            } else {
-                return Err(MeetingPlaceError::Error(
-                    "Mediator DID must have an HTTP service endpoint".to_string(),
-                ));
-            };
-            let mediator_websocket_endpoint: String = if let Some(uri) = uris
-                .iter()
-                .filter_map(|e| {
-                    if e.starts_with("ws") {
-                        Some(e.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<String>>()
-                .first()
-            {
-                uri.clone()
-            } else {
-                return Err(MeetingPlaceError::Error(
-                    "Mediator DID must have an WebSocket service endpoint".to_string(),
-                ));
-            };
-            (mediator_endpoint, mediator_websocket_endpoint)
-        };
+        let mediator_doc = tdk.did_resolver().resolve(&self.mediator_did).await?;
+        let (mediator_endpoint, mediator_websocket_endpoint) =
+            split_mediator_endpoints(&find_mediator_service_endpoints(&mediator_doc.doc))?;
 
         Ok(RegisterOffer {
-            name: self.name.clone(),
-            description: self.description.clone(),
-            didcomm_message,
+            name: self.name,
+            description: self.description,
+            didcomm_message: self.didcomm_message,
             vcard: self.vcard.to_base64()?,
             valid_until,
             maximum_usage: self.maximum_usage,
-            device_token: self.device_token.clone(),
-            platform_type: self.platform_type.clone(),
+            device_token: self.device_token,
+            platform_type: self.platform_type,
             mediator_endpoint,
-            mediator_did: self.mediator_did.clone(),
+            mediator_did: self.mediator_did,
             mediator_websocket_endpoint,
-            custom_phrase: self.custom_phrase.clone(),
+            custom_phrase: self.custom_phrase,
             contact_attributes: self.contact_attributes,
         })
     }
 }
 
+/// Convert a lifetime duration into the wire-format `validUntil` string.
+/// `Duration::ZERO` becomes the empty string (server picks its own
+/// maximum); anything else becomes an RFC-3339 timestamp at `now + dur`.
+fn encode_valid_until(dur: Duration) -> Result<String> {
+    if dur.as_secs() == 0 {
+        return Ok(String::new());
+    }
+    let secs: i64 = dur.as_secs().try_into().map_err(|_| {
+        MeetingPlaceError::Configuration(format!(
+            "valid_until duration of {} seconds exceeds i64::MAX",
+            dur.as_secs()
+        ))
+    })?;
+    let delta = TimeDelta::try_seconds(secs).ok_or_else(|| {
+        MeetingPlaceError::Configuration(format!(
+            "valid_until duration of {secs} seconds overflows TimeDelta"
+        ))
+    })?;
+    Ok((Local::now() + delta).to_rfc3339())
+}
+
+/// Pick the first HTTP(S) and the first WebSocket URI from the mediator's
+/// service endpoints. Errors if either is missing.
+fn split_mediator_endpoints(uris: &[String]) -> Result<(String, String)> {
+    let http = uris
+        .iter()
+        .find(|u| u.starts_with("http://") || u.starts_with("https://"))
+        .cloned()
+        .ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "Mediator DID has no HTTP(S) service endpoint".to_string(),
+            )
+        })?;
+    let ws = uris
+        .iter()
+        .find(|u| u.starts_with("ws://") || u.starts_with("wss://"))
+        .cloned()
+        .ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "Mediator DID has no WebSocket service endpoint".to_string(),
+            )
+        })?;
+    Ok((http, ws))
+}
+
 impl RegisterOffer {
-    /// Creates a new RegisterOfferBuilder, you can further customize the object using the builder methods
-    /// Finalize with the `build()` method
+    /// Construct a [`RegisterOfferBuilder`] populated with required
+    /// fields. Customise further via the builder methods, then call
+    /// [`RegisterOfferBuilder::build`].
     pub fn create(
         name: &str,
         description: &str,
         from_did: &str,
         mediator_did: &str,
     ) -> Result<RegisterOfferBuilder> {
-        let didcomm_message = Offer::create_offer_oob_message(from_did)?;
-
         Ok(RegisterOfferBuilder {
             name: name.to_string(),
-            didcomm_message: Some(didcomm_message),
             description: description.to_string(),
+            didcomm_message: Offer::create_offer_oob_message(from_did)?,
+            vcard: Vcard::default(),
+            valid_until: Duration::ZERO,
+            maximum_usage: 0,
+            device_token: "NO_TOKEN".to_string(),
+            platform_type: PlatformType::None,
             mediator_did: mediator_did.to_string(),
-            ..Default::default()
+            custom_phrase: None,
+            contact_attributes: ContactAttributeType::Unknown.to_u32(),
         })
     }
 }
 
-/// Query an offer from Meeting Place
-/// https://gitlab.com/affinidi/octo/larter/affinidi-meeting-place/api-meetingplace#post-query-offer
 #[derive(Serialize)]
-pub struct QueryOffer {
-    mnemonic: String,
-    did: String,
+struct QueryOffer<'a> {
+    mnemonic: &'a str,
+    did: &'a str,
 }
 
-/// Query an offer from Meeting Place
-/// https://gitlab.com/affinidi/octo/larter/affinidi-meeting-place/api-meetingplace#post-deregister-offer
 #[derive(Serialize)]
-pub struct DeregisteryOffer {
-    mnemonic: String,
+struct DeregisterOfferRequest<'a> {
+    mnemonic: &'a str,
     #[serde(rename = "offerLink")]
-    offer_link: String,
+    offer_link: &'a str,
 }
 
 impl Offer {
-    /// Create an Offer from a RegisterOffer
+    /// Build a pending [`Offer`] from a fully-built [`RegisterOffer`].
     pub fn new_from_register_offer(registration: RegisterOffer) -> Self {
         Self {
             status: "PENDING".to_string(),
@@ -386,33 +354,28 @@ impl Offer {
         }
     }
 
-    /// Register an offer with Meeting Place
-    /// Use the RegisterOffer::create() method to create the registration object
+    /// Register this offer with Meeting Place.
+    ///
+    /// On success updates `self.{mnemonic, offer_link, valid_until, status}`
+    /// from the response.
     pub async fn register_offer(
         &mut self,
         mp: &MeetingPlace,
         tdk: &TDKSharedState,
         profile: &TDKProfile,
     ) -> Result<RegisterOfferResponse> {
-        let Some(registration) = &self.registration else {
-            return Err(MeetingPlaceError::Error(
-                "there is no offer registration record!".to_string(),
-            ));
-        };
+        let registration = self.registration.as_ref().ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "Offer has no registration record — call new_from_register_offer first".to_string(),
+            )
+        })?;
 
-        let tokens = tdk
-            .authentication
-            .authenticate(profile.did.to_string(), mp.mp_did.to_string(), 3, None)
-            .await?;
+        let tokens = tdk.authenticate_profile(profile, &mp.mp_did).await?;
 
-        let response = _http_post::<RegisterOfferResponse>(
-            &tdk.client,
-            &[&mp.mp_api, "/register-offer"].concat(),
-            &serde_json::to_string(registration).map_err(|e| {
-                MeetingPlaceError::Serialization(format!(
-                    "Couldn't serialize register offer request: {e}"
-                ))
-            })?,
+        let response = http_post::<_, RegisterOfferResponse>(
+            tdk.client(),
+            &endpoint(&mp.mp_api, "/register-offer"),
+            registration,
             &tokens,
         )
         .await?;
@@ -424,51 +387,45 @@ impl Offer {
         Ok(response)
     }
 
-    /// Creates the DIDComm OOB Invitation message for the offer
-    /// Returns base64 encoded message
+    /// Build a base64 URL-safe (no-pad) encoded DIDComm OOB invitation
+    /// message for `from_did`.
     pub fn create_offer_oob_message(from_did: &str) -> Result<String> {
         let id = Uuid::new_v4().to_string();
         let msg = Message::build(
             id.clone(),
             "https://didcomm.org/out-of-band/2.0/invitation".to_string(),
-            json!({"goal_code": "connect", "goal": "Start relationship", "accept": [ "didcomm/v2"]}),
-        ).from(from_did.to_string())
-        .thid(id.clone())
+            json!({
+                "goal_code": "connect",
+                "goal": "Start relationship",
+                "accept": ["didcomm/v2"]
+            }),
+        )
+        .from(from_did.to_string())
+        .thid(id)
         .finalize();
 
-        Ok(
-            BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_string(&msg).map_err(|e| {
-                MeetingPlaceError::Serialization(format!(
-                    "Couldn't serialize DIDcomm offer message: {e}"
-                ))
-            })?),
-        )
+        let bytes = serde_json::to_vec(&msg).map_err(|e| {
+            MeetingPlaceError::Serialization(format!("Couldn't serialise OOB message: {e}"))
+        })?;
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(bytes))
     }
 
-    /// Query Meeting Place for an offer
+    /// Look up an offer by its phrase.
     pub async fn query_offer(
         mp: &MeetingPlace,
         tdk: &TDKSharedState,
         profile: &TDKProfile,
         offer_phrase: &str,
     ) -> Result<Offer> {
-        let tokens = tdk
-            .authentication
-            .authenticate(profile.did.to_string(), mp.mp_did.to_string(), 3, None)
-            .await?;
+        let tokens = tdk.authenticate_profile(profile, &mp.mp_did).await?;
 
-        let response = _http_post::<QueryOfferResponse>(
-            &tdk.client,
-            &[&mp.mp_api, "/query-offer"].concat(),
-            &serde_json::to_string(&QueryOffer {
-                mnemonic: offer_phrase.to_string(),
-                did: profile.did.to_string(),
-            })
-            .map_err(|e| {
-                MeetingPlaceError::Serialization(format!(
-                    "Couldn't serialize register offer request: {e}"
-                ))
-            })?,
+        let response = http_post::<_, QueryOfferResponse>(
+            tdk.client(),
+            &endpoint(&mp.mp_api, "/query-offer"),
+            &QueryOffer {
+                mnemonic: offer_phrase,
+                did: &profile.did,
+            },
             &tokens,
         )
         .await?;
@@ -483,58 +440,44 @@ impl Offer {
         })
     }
 
-    /// Deregister (remove) an offer from Meeting Place
+    /// Deregister (remove) this offer from Meeting Place.
+    ///
+    /// Requires both `self.mnemonic` and `self.offer_link` to be populated
+    /// (typically from a prior [`register_offer`](Self::register_offer) or
+    /// [`query_offer`](Self::query_offer) call).
     pub async fn deregister_offer(
         &mut self,
         mp: &MeetingPlace,
         tdk: &TDKSharedState,
         profile: &TDKProfile,
     ) -> Result<DeregisterOfferResponse> {
-        let tokens = tdk
-            .authentication
-            .authenticate(profile.did.to_string(), mp.mp_did.to_string(), 3, None)
-            .await?;
+        let mnemonic = self.mnemonic.as_deref().ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "Cannot deregister — Offer has no mnemonic".to_string(),
+            )
+        })?;
+        let offer_link = self.offer_link.as_deref().ok_or_else(|| {
+            MeetingPlaceError::Configuration(
+                "Cannot deregister — Offer has no offer_link".to_string(),
+            )
+        })?;
 
-        let mnemonic = if let Some(mnemonic) = &self.mnemonic {
-            mnemonic.to_string()
-        } else {
-            return Err(MeetingPlaceError::Error(
-                "No mnemonic provided for deregistering offer".to_string(),
-            ));
-        };
+        let tokens = tdk.authenticate_profile(profile, &mp.mp_did).await?;
 
-        let offer_link = if let Some(offer_link) = &self.offer_link {
-            offer_link.to_string()
-        } else {
-            return Err(MeetingPlaceError::Error(
-                "No offer_link provided for deregistering offer".to_string(),
-            ));
-        };
-
-        let response = _http_post::<DeregisterOfferResponse>(
-            &tdk.client,
-            &[&mp.mp_api, "/deregister-offer"].concat(),
-            &serde_json::to_string(&DeregisteryOffer {
+        http_post::<_, DeregisterOfferResponse>(
+            tdk.client(),
+            &endpoint(&mp.mp_api, "/deregister-offer"),
+            &DeregisterOfferRequest {
                 mnemonic,
                 offer_link,
-            })
-            .map_err(|e| {
-                MeetingPlaceError::Serialization(format!(
-                    "Couldn't serialize register offer request: {e}"
-                ))
-            })?,
+            },
             &tokens,
         )
-        .await?;
-
-        Ok(response)
+        .await
     }
 }
 
-// ************************************************************************************************
-
-/// The return value from the register-offer phrase API
-/// Need to retain the mnemonic and offer_link for other calls
+/// Response from `register-offer`.
 #[derive(Debug, Deserialize)]
 pub struct RegisterOfferResponse {
     pub mnemonic: String,
@@ -546,7 +489,7 @@ pub struct RegisterOfferResponse {
     pub offer_link: String,
 }
 
-/// The return value from the query-offer API
+/// Response from `query-offer`.
 #[derive(Debug, Deserialize)]
 pub struct QueryOfferResponse {
     #[serde(rename = "offerLink")]
@@ -564,9 +507,130 @@ pub struct QueryOfferResponse {
     pub didcomm_message: String,
 }
 
-/// The return value from the deregister-offer API
+/// Response from `deregister-offer`.
 #[derive(Debug, Deserialize)]
 pub struct DeregisterOfferResponse {
     pub status: String,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_type_parse_known_values() {
+        assert_eq!(PlatformType::from_str("apns").unwrap(), PlatformType::Apns);
+        assert_eq!(
+            PlatformType::from_str("apns_sandbox").unwrap(),
+            PlatformType::ApnsSandbox
+        );
+        assert_eq!(PlatformType::from_str("FCM").unwrap(), PlatformType::Fcm);
+        assert_eq!(PlatformType::from_str("none").unwrap(), PlatformType::None);
+        assert_eq!(PlatformType::from_str("").unwrap(), PlatformType::None);
+    }
+
+    #[test]
+    fn platform_type_rejects_unknown() {
+        assert!(matches!(
+            PlatformType::from_str("garbage"),
+            Err(MeetingPlaceError::Configuration(_))
+        ));
+    }
+
+    #[test]
+    fn contact_attribute_type_roundtrips() {
+        for v in [
+            ContactAttributeType::Unknown,
+            ContactAttributeType::Person,
+            ContactAttributeType::Adult,
+            ContactAttributeType::Robot,
+            ContactAttributeType::Service,
+            ContactAttributeType::Organisation,
+        ] {
+            assert_eq!(ContactAttributeType::from_u32(v.to_u32()), v);
+        }
+    }
+
+    #[test]
+    fn contact_attribute_type_unknown_bits_map_to_unknown() {
+        assert_eq!(
+            ContactAttributeType::from_u32(99),
+            ContactAttributeType::Unknown
+        );
+    }
+
+    #[test]
+    fn encode_valid_until_zero_is_empty() {
+        assert_eq!(encode_valid_until(Duration::ZERO).unwrap(), "");
+    }
+
+    #[test]
+    fn encode_valid_until_nonzero_is_rfc3339() {
+        let s = encode_valid_until(Duration::from_secs(60)).unwrap();
+        assert!(!s.is_empty());
+        assert!(chrono::DateTime::parse_from_rfc3339(&s).is_ok());
+    }
+
+    #[test]
+    fn encode_valid_until_rejects_overflow() {
+        assert!(matches!(
+            encode_valid_until(Duration::from_secs(u64::MAX)),
+            Err(MeetingPlaceError::Configuration(_))
+        ));
+    }
+
+    #[test]
+    fn split_mediator_endpoints_picks_first_of_each_scheme() {
+        let uris = vec![
+            "https://api.example/inbox".to_string(),
+            "wss://api.example/socket".to_string(),
+        ];
+        let (http, ws) = split_mediator_endpoints(&uris).unwrap();
+        assert_eq!(http, "https://api.example/inbox");
+        assert_eq!(ws, "wss://api.example/socket");
+    }
+
+    #[test]
+    fn split_mediator_endpoints_errors_on_missing_http() {
+        let uris = vec!["wss://api.example/socket".to_string()];
+        assert!(matches!(
+            split_mediator_endpoints(&uris),
+            Err(MeetingPlaceError::Configuration(_))
+        ));
+    }
+
+    #[test]
+    fn split_mediator_endpoints_errors_on_missing_ws() {
+        let uris = vec!["https://api.example/inbox".to_string()];
+        assert!(matches!(
+            split_mediator_endpoints(&uris),
+            Err(MeetingPlaceError::Configuration(_))
+        ));
+    }
+
+    #[test]
+    fn create_offer_oob_message_is_valid_base64_decoding_to_didcomm() {
+        let b64 = Offer::create_offer_oob_message("did:example:alice").unwrap();
+        let bytes = BASE64_URL_SAFE_NO_PAD.decode(b64.as_bytes()).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            json["type"],
+            "https://didcomm.org/out-of-band/2.0/invitation"
+        );
+        assert_eq!(json["from"], "did:example:alice");
+        assert_eq!(json["body"]["goal_code"], "connect");
+    }
+
+    #[test]
+    fn platform_type_serializes_screaming_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&PlatformType::ApnsSandbox).unwrap(),
+            "\"APNS_SANDBOX\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PlatformType::None).unwrap(),
+            "\"NONE\""
+        );
+    }
 }

--- a/crates/applications/affinidi-meeting-place/src/vcard.rs
+++ b/crates/applications/affinidi-meeting-place/src/vcard.rs
@@ -1,13 +1,17 @@
 /*!
- * Meeting Place minimum vcard spec based on RFC 6350
- * https://www.rfc-editor.org/rfc/rfc6350
+ * Minimum vCard payload accepted by Meeting Place, modelled on RFC 6350.
+ *
+ * The Meeting Place API only consumes a small subset (name + one email +
+ * one phone), and ships it as a base64-encoded JSON blob alongside the
+ * registered offer. See [`Vcard::to_base64`].
  */
 
 use crate::errors::{MeetingPlaceError, Result};
 use base64::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Minimal vCard payload.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Vcard {
     #[serde(rename = "n")]
     name: VcardName,
@@ -15,20 +19,7 @@ pub struct Vcard {
     tel: Option<VcardType>,
 }
 
-impl Default for Vcard {
-    fn default() -> Self {
-        Self {
-            name: VcardName {
-                surname: None,
-                given: None,
-            },
-            email: None,
-            tel: None,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct VcardName {
     surname: Option<String>,
     given: Option<String>,
@@ -36,9 +27,13 @@ pub struct VcardName {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VcardType {
-    pub r#type: VcardTypes,
+    #[serde(rename = "type")]
+    pub kind: VcardTypes,
 }
 
+/// Tagged value: an enum carrying the contact-method label as the JSON tag
+/// (`"work"` for email, `"cell"` for phone) and the value as the inner
+/// string.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum VcardTypes {
     #[serde(rename = "work")]
@@ -48,12 +43,7 @@ pub enum VcardTypes {
 }
 
 impl Vcard {
-    /// Create a new Vcard
-    /// # Arguments
-    /// * `given` - Given name
-    /// * `surname` - Surname
-    /// * `email` - Email address
-    /// * `tel` - Telephone number
+    /// Build a new vCard. All four fields are optional.
     pub fn new(
         given: Option<String>,
         surname: Option<String>,
@@ -63,20 +53,74 @@ impl Vcard {
         Self {
             name: VcardName { surname, given },
             email: email.map(|e| VcardType {
-                r#type: VcardTypes::Work(e),
+                kind: VcardTypes::Work(e),
             }),
             tel: tel.map(|t| VcardType {
-                r#type: VcardTypes::Cell(t),
+                kind: VcardTypes::Cell(t),
             }),
         }
     }
 
-    /// Convert the Vcard to a base64 encoded string
+    /// Serialise to JSON and base64 (URL-safe, no padding) — the wire
+    /// format Meeting Place expects in `RegisterOffer.vcard`.
     pub fn to_base64(&self) -> Result<String> {
-        Ok(
-            BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_string(self).map_err(|e| {
-                MeetingPlaceError::Serialization(format!("Couldn't serialize vcard: {e}"))
-            })?),
-        )
+        let bytes = serde_json::to_vec(self).map_err(|e| {
+            MeetingPlaceError::Serialization(format!("Couldn't serialise vcard: {e}"))
+        })?;
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        let v = Vcard::default();
+        assert!(v.name.given.is_none());
+        assert!(v.name.surname.is_none());
+        assert!(v.email.is_none());
+        assert!(v.tel.is_none());
+    }
+
+    #[test]
+    fn new_populates_provided_fields() {
+        let v = Vcard::new(
+            Some("Alice".to_string()),
+            Some("Smith".to_string()),
+            Some("alice@example.com".to_string()),
+            Some("+15551234".to_string()),
+        );
+        assert_eq!(v.name.given.as_deref(), Some("Alice"));
+        assert_eq!(v.name.surname.as_deref(), Some("Smith"));
+        assert!(matches!(
+            v.email.as_ref().unwrap().kind,
+            VcardTypes::Work(ref s) if s == "alice@example.com"
+        ));
+        assert!(matches!(
+            v.tel.as_ref().unwrap().kind,
+            VcardTypes::Cell(ref s) if s == "+15551234"
+        ));
+    }
+
+    #[test]
+    fn to_base64_decodes_back_to_serializable_json() {
+        let v = Vcard::new(Some("A".into()), None, None, None);
+        let b64 = v.to_base64().unwrap();
+        let bytes = BASE64_URL_SAFE_NO_PAD.decode(b64.as_bytes()).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["n"]["given"], "A");
+    }
+
+    #[test]
+    fn json_field_renames_match_wire_contract() {
+        let v = Vcard::new(None, None, Some("e@x.com".into()), Some("+1".into()));
+        let s = serde_json::to_string(&v).unwrap();
+        // `n` not `name`; `email` and `tel` carry a `type` discriminator.
+        assert!(s.contains("\"n\":"), "expected `n` field, got {s}");
+        assert!(s.contains("\"type\":"), "expected `type` field, got {s}");
+        assert!(s.contains("\"work\":"), "expected `work` tag, got {s}");
+        assert!(s.contains("\"cell\":"), "expected `cell` tag, got {s}");
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.3.0] - 2026-05-02
+
+### Breaking
+
+- Migrated to `affinidi-tdk-common` 0.6 and `affinidi-messaging-sdk` 0.17.
+  Both upstream bumps are SemVer-breaking, so this crate's public API is
+  re-exported through the new types.
+- The `connect()` retry path no longer falls back to
+  `TDKSharedState::default().await` (removed upstream). It now requires a
+  `TDKConfig` (either supplied via `ListenerConfig.tdk_config` or built
+  internally with `with_load_environment(false) / with_use_atm(false)`).
+  Initialisation failures now surface as `TDKError` instead of silently
+  panicking.
+- `ListenerConfig` literals using `TDKProfile { ... }` must switch to
+  `TDKProfile::new(...)` — the `secrets` field is `pub(crate)` in
+  tdk-common 0.6.
+
 ## [0.2.1] - 2026-04-15
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.2.2"
+version = "0.3.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -13,8 +13,8 @@ readme = "README.md"
 rust-version.workspace = true
 
 [dependencies]
-affinidi-tdk-common = "0.5"
-affinidi-messaging-sdk = "0.16"
+affinidi-tdk-common = "0.6"
+affinidi-messaging-sdk = "0.17"
 affinidi-messaging-didcomm = "0.13"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/README.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/README.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-affinidi-messaging-didcomm-service = "0.2"
+affinidi-messaging-didcomm-service = "0.3"
 ```
 
 ## Features

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -101,15 +101,18 @@ impl Listener {
         // Clear the connection handle so outbound callers get NotConnected
         let _ = self.connection_tx.send(None);
 
-        let shared_state = if let Some(tdk_config) = self.config.tdk_config.take() {
-            Arc::new(TDKSharedState::new(tdk_config).await?)
-        } else {
-            Arc::new(TDKSharedState::default().await)
+        let tdk_config = match self.config.tdk_config.take() {
+            Some(cfg) => cfg,
+            None => affinidi_tdk_common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
         };
+        let shared_state = Arc::new(TDKSharedState::new(tdk_config).await?);
 
         shared_state
-            .secrets_resolver
-            .insert_vec(&self.config.profile.secrets)
+            .secrets_resolver()
+            .insert_vec(self.config.profile.secrets())
             .await;
 
         let atm_config = ATMConfigBuilder::default()

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -420,12 +420,7 @@ mod tests {
         // Try to add a new listener with a different ID but the same DID
         let config = ListenerConfig {
             id: "listener-2".to_string(),
-            profile: TDKProfile {
-                alias: "alice-duplicate".to_string(),
-                did: "did:example:alice".to_string(),
-                mediator: None,
-                secrets: vec![],
-            },
+            profile: TDKProfile::new("alice-duplicate", "did:example:alice", None, vec![]),
             acl_mode: None,
             restart_policy: RestartPolicy::Never,
             message_wait_duration_secs: 5,

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -32,10 +32,10 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", features = [
 affinidi-did-common = "0.3"
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13", features = ["messaging-core"] }
 affinidi-messaging-core = { path = "../affinidi-messaging-core" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.16" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.17" }
 affinidi-tsp = { path = "../affinidi-tsp", features = ["messaging-core"] }
 affinidi-secrets-resolver = "0.5"
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.6" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
 
 didwebvh-rs = "0.5"
 ahash = { version = "0.8", features = ["serde"] }

--- a/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
@@ -60,11 +60,12 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let environment = &tdk.get_shared_state().environment;
+    let shared = tdk.get_shared_state();
+    let environment = shared.environment();
     let atm = tdk.atm.clone().unwrap();
 
     // Activate Alice Profile
-    let tdk_alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let tdk_alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -88,7 +89,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
-    let tdk_bob = if let Some(bob) = environment.profiles.get("Bob") {
+    let tdk_bob = if let Some(bob) = environment.profiles().get("Bob") {
         tdk.add_profile(bob).await;
         bob
     } else {

--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -78,10 +78,11 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let alice_env = &alice_tdk.get_shared_state().environment;
+    let _shared = alice_tdk.get_shared_state();
+    let alice_env = _shared.environment();
     let alice_atm = alice_tdk.atm.clone().unwrap();
 
-    let tdk_alice = alice_env.profiles.get("Alice").ok_or_else(|| {
+    let tdk_alice = alice_env.profiles().get("Alice").ok_or_else(|| {
         ATMError::ConfigError(format!(
             "Alice profile not found in environment: {}",
             args.alice_environment
@@ -109,10 +110,11 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let bob_env = &bob_tdk.get_shared_state().environment;
+    let _shared = bob_tdk.get_shared_state();
+    let bob_env = _shared.environment();
     let bob_atm = bob_tdk.atm.clone().unwrap();
 
-    let tdk_bob = bob_env.profiles.get("Bob").ok_or_else(|| {
+    let tdk_bob = bob_env.profiles().get("Bob").ok_or_else(|| {
         ATMError::ConfigError(format!(
             "Bob profile not found in environment: {}",
             args.bob_environment

--- a/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
@@ -54,11 +54,12 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let environment = &tdk.get_shared_state().environment;
+    let _shared = tdk.get_shared_state();
+    let environment = _shared.environment();
     let atm = tdk.atm.clone().unwrap();
 
     // Activate Alice Profile
-    let tdk_alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let tdk_alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -82,7 +83,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
-    let tdk_bob = if let Some(bob) = environment.profiles.get("Bob") {
+    let tdk_bob = if let Some(bob) = environment.profiles().get("Bob") {
         tdk.add_profile(bob).await;
         bob
     } else {
@@ -136,7 +137,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Bob Access Lists reset");
 
     // Ensure Profile has a valid mediator to forward through
-    let mediator_did = if let Some(mediator) = &environment.default_mediator {
+    let mediator_did = if let Some(mediator) = &environment.default_mediator() {
         mediator.to_string()
     } else {
         return Err(ATMError::ConfigError(

--- a/crates/messaging/affinidi-messaging-helpers/examples/discover_features.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/discover_features.rs
@@ -75,7 +75,15 @@ async fn main() -> Result<(), ATMError> {
     println!("Using Environment: {}", environment_name);
 
     // Instantiate TDK
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
 
     // Configure tracing
     let subscriber = tracing_subscriber::fmt()
@@ -83,7 +91,7 @@ async fn main() -> Result<(), ATMError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
-    let bob = if let Some(bob) = environment.profiles.get("Bob") {
+    let bob = if let Some(bob) = environment.profiles().get("Bob") {
         tdk.add_profile(bob).await;
         bob
     } else {
@@ -93,7 +101,7 @@ async fn main() -> Result<(), ATMError> {
     };
 
     let mut config = ATMConfig::builder();
-    config = config.with_ssl_certificates(&mut environment.ssl_certificates);
+    config = config.with_ssl_certificates(&mut environment.ssl_certificate_paths().to_vec());
 
     // Create a new ATM Client
     let atm = ATM::new(config.build()?, tdk).await?;

--- a/crates/messaging/affinidi-messaging-helpers/examples/discover_features.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/discover_features.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), ATMError> {
         "default".to_string()
     };
 
-    let mut environment =
+    let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
     println!("Using Environment: {}", environment_name);
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/discover_features_responder.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/discover_features_responder.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), ATMError> {
         "default".to_string()
     };
 
-    let mut environment =
+    let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
     println!("Using Environment: {}", environment_name);
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/discover_features_responder.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/discover_features_responder.rs
@@ -58,7 +58,15 @@ async fn main() -> Result<(), ATMError> {
     println!("Using Environment: {}", environment_name);
 
     // Instantiate TDK
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
 
     // Configure tracing
     let subscriber = tracing_subscriber::fmt()
@@ -66,7 +74,7 @@ async fn main() -> Result<(), ATMError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
-    let alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -109,7 +117,7 @@ async fn main() -> Result<(), ATMError> {
 
     let mut config = ATMConfig::builder();
     config = config
-        .with_ssl_certificates(&mut environment.ssl_certificates)
+        .with_ssl_certificates(&mut environment.ssl_certificate_paths().to_vec())
         .with_discovery_features(features);
 
     // Create a new ATM Client

--- a/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
@@ -68,17 +68,19 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let environment = &tdk.get_shared_state().environment;
+    let _shared = tdk.get_shared_state();
+    let environment = _shared.environment();
     let atm = tdk.atm.clone().unwrap();
 
     // Add and activate the admin profile
-    let tdk_admin = if let Some(admin) = &environment.admin_did {
+    let admin_opt = environment.admin_did();
+    let tdk_admin = if let Some(admin) = admin_opt {
         tdk.add_profile(admin).await;
         admin
     } else {
-        return Err(ATMError::ConfigError(
-            format!("ADMIN not found in Profile: {}", environment_name).to_string(),
-        ));
+        return Err(ATMError::ConfigError(format!(
+            "ADMIN not found in Profile: {environment_name}"
+        )));
     };
     let atm_admin = atm
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_admin).await?, true)
@@ -107,7 +109,7 @@ async fn main() -> Result<(), ATMError> {
     }
 
     // Add and activate the non-admin profile
-    let tdk_mallory = if let Some(mallory) = environment.profiles.get("Mallory") {
+    let tdk_mallory = if let Some(mallory) = environment.profiles().get("Mallory") {
         tdk.add_profile(mallory).await;
         mallory
     } else {
@@ -147,11 +149,14 @@ async fn main() -> Result<(), ATMError> {
     }
 
     // Mediator for this demo
-    let Some(mediator) = environment.default_mediator.clone() else {
-        return Err(ATMError::ConfigError(
-            format!("Mediator not found in Environment: {}", environment_name).to_string(),
-        ));
-    };
+    let mediator = environment
+        .default_mediator()
+        .ok_or_else(|| {
+            ATMError::ConfigError(format!(
+                "Mediator not found in Environment: {environment_name}"
+            ))
+        })?
+        .to_string();
 
     // Try and do an admin function with Mallory
     info!("Trying to access an admin function with Mallory");
@@ -168,7 +173,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Starting hijack of admin credentials...");
     let admin_tokens = match tdk
         .get_shared_state()
-        .authentication
+        .authentication()
         .authenticated(tdk_admin.did.clone(), mediator.clone())
         .await
     {
@@ -373,7 +378,7 @@ async fn http_post(
 ) {
     let response = tdk
         .get_shared_state()
-        .client
+        .client()
         .post([&profile.get_mediator_rest_endpoint().unwrap(), "/inbound"].concat())
         .header("Content-Type", "application/json")
         .header(

--- a/crates/messaging/affinidi-messaging-helpers/examples/mediator_ping.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/mediator_ping.rs
@@ -50,7 +50,15 @@ async fn main() -> Result<(), ATMError> {
     println!("Using Environment: {}", environment_name);
 
     // Instantiate TDK
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
 
     // construct a subscriber that prints formatted traces to stdout
     let subscriber = tracing_subscriber::fmt()
@@ -60,7 +68,7 @@ async fn main() -> Result<(), ATMError> {
     // use that subscriber to process traces emitted after this point
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
-    let alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -71,7 +79,7 @@ async fn main() -> Result<(), ATMError> {
 
     let mut config = ATMConfig::builder();
 
-    config = config.with_ssl_certificates(&mut environment.ssl_certificates);
+    config = config.with_ssl_certificates(&mut environment.ssl_certificate_paths().to_vec());
 
     // Create a new ATM Client
     let atm = ATM::new(config.build()?, tdk).await?;

--- a/crates/messaging/affinidi-messaging-helpers/examples/mediator_ping.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/mediator_ping.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), ATMError> {
         "default".to_string()
     };
 
-    let mut environment =
+    let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
     println!("Using Environment: {}", environment_name);
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/oob_invite.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/oob_invite.rs
@@ -45,9 +45,17 @@ async fn main() -> Result<(), ATMError> {
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
     // Instantiate TDK
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
 
-    let alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -58,7 +66,7 @@ async fn main() -> Result<(), ATMError> {
 
     let mut config = ATMConfig::builder();
 
-    config = config.with_ssl_certificates(&mut environment.ssl_certificates);
+    config = config.with_ssl_certificates(&mut environment.ssl_certificate_paths().to_vec());
 
     // Create a new ATM Client
     let atm = ATM::new(config.build()?, tdk).await?;

--- a/crates/messaging/affinidi-messaging-helpers/examples/oob_invite.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/oob_invite.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), ATMError> {
         "default".to_string()
     };
 
-    let mut environment =
+    let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
     println!("Using Environment: {}", environment_name);
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/read_raw_didcomm.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/read_raw_didcomm.rs
@@ -31,7 +31,15 @@ struct Args {
 async fn main() -> Result<(), ATMError> {
     // Create a new ATM Client
     let config = ATMConfig::builder();
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
     let atm = ATM::new(config.build()?, tdk).await?;
 
     // Load the DIDComm message
@@ -137,7 +145,7 @@ async fn main() -> Result<(), ATMError> {
             return Ok(());
         }
     };
-    atm.get_tdk().secrets_resolver.insert_vec(&secrets).await;
+    atm.get_tdk().secrets_resolver().insert_vec(&secrets).await;
 
     let profile = ATMProfile::new(&atm, None, to_did.clone(), None).await?;
     atm.profile_add(&profile, false).await?;

--- a/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
@@ -61,11 +61,12 @@ async fn main() -> Result<(), ATMError> {
     )
     .await?;
 
-    let environment = &tdk.get_shared_state().environment;
+    let _shared = tdk.get_shared_state();
+    let environment = _shared.environment();
     let atm = tdk.atm.clone().unwrap();
 
     // Activate Alice Profile
-    let tdk_alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let tdk_alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -89,7 +90,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
-    let tdk_bob = if let Some(bob) = environment.profiles.get("Bob") {
+    let tdk_bob = if let Some(bob) = environment.profiles().get("Bob") {
         tdk.add_profile(bob).await;
         bob
     } else {
@@ -112,7 +113,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Bob ACL Mode Type: {:?}", bob_acl_mode);
 
     // Activate Mallory Profile
-    let tdk_mallory = if let Some(mallory) = environment.profiles.get("Mallory") {
+    let tdk_mallory = if let Some(mallory) = environment.profiles().get("Mallory") {
         tdk.add_profile(mallory).await;
         mallory
     } else {

--- a/crates/messaging/affinidi-messaging-helpers/examples/trust_ping.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/trust_ping.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), ATMError> {
         "default".to_string()
     };
 
-    let mut environment =
+    let environment =
         TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
     println!("Using Environment: {}", environment_name);
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/trust_ping.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/trust_ping.rs
@@ -54,7 +54,15 @@ async fn main() -> Result<(), ATMError> {
     println!("Using Environment: {}", environment_name);
 
     // Instantiate TDK
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
 
     // construct a subscriber that prints formatted traces to stdout
     let subscriber = tracing_subscriber::fmt()
@@ -64,7 +72,7 @@ async fn main() -> Result<(), ATMError> {
     // use that subscriber to process traces emitted after this point
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
-    let alice = if let Some(alice) = environment.profiles.get("Alice") {
+    let alice = if let Some(alice) = environment.profiles().get("Alice") {
         tdk.add_profile(alice).await;
         alice
     } else {
@@ -75,7 +83,7 @@ async fn main() -> Result<(), ATMError> {
 
     let mut config = ATMConfig::builder();
 
-    config = config.with_ssl_certificates(&mut environment.ssl_certificates);
+    config = config.with_ssl_certificates(&mut environment.ssl_certificate_paths().to_vec());
 
     // Create a new ATM Client
     let atm = ATM::new(config.build()?, tdk).await?;

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
@@ -9,7 +9,7 @@ use affinidi_messaging_sdk::{
 };
 use affinidi_tdk::{
     common::{
-        TDKSharedState,
+        self as affinidi_tdk_common, TDKSharedState,
         environments::{TDKEnvironment, TDKEnvironments},
     },
     secrets_resolver::SecretsResolver,
@@ -198,14 +198,15 @@ async fn init() -> Result<(ColorfulTheme, ATMConfig, TDKEnvironment), Box<dyn Er
         style("Welcome to the Affinidi Messaging Mediator Administration wizard").green(),
     );
 
-    if environment.admin_did.is_none() {
+    if environment.admin_did().is_none() {
         return Err("Admin DID not found in Environment".into());
     }
 
-    let mut ssl_certificates = Vec::new();
-    for certificate in &environment.ssl_certificates {
-        ssl_certificates.push(certificate.to_string());
-    }
+    let mut ssl_certificates: Vec<String> = environment
+        .ssl_certificate_paths()
+        .iter()
+        .map(|c| c.to_string())
+        .collect();
 
     // Connect to the Mediator
     let config = ATMConfig::builder()
@@ -219,15 +220,20 @@ async fn init() -> Result<(ColorfulTheme, ATMConfig, TDKEnvironment), Box<dyn Er
 async fn main() -> Result<(), Box<dyn Error>> {
     let (theme, config, environment) = init().await?;
 
-    let admin = if let Some(admin) = environment.admin_did {
-        admin
-    } else {
-        return Err("Admin DID not found in Environment".into());
-    };
+    let mut admin = environment
+        .admin_did()
+        .cloned()
+        .ok_or("Admin DID not found in Environment")?;
 
     // Create a new ATM Client
-    let tdk = Arc::new(TDKSharedState::default().await);
-    tdk.secrets_resolver.insert_vec(&admin.secrets).await;
+    let tdk_cfg = affinidi_tdk_common::config::TDKConfig::builder()
+        .with_load_environment(false)
+        .with_use_atm(false)
+        .build()?;
+    let tdk = Arc::new(TDKSharedState::new(tdk_cfg).await?);
+    tdk.secrets_resolver()
+        .insert_vec(&admin.take_secrets())
+        .await;
     let atm = ATM::new(config, tdk).await?;
 
     // Create the admin profile and enable it

--- a/crates/messaging/affinidi-messaging-helpers/src/setup_environment/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/setup_environment/main.rs
@@ -103,22 +103,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         fn _create_friend(alias: &str, mediator: Option<&str>) -> TDKProfile {
             let (did, secrets) = DID::generate_did_peer(vec![(PeerKeyRole::Verification, KeyType::P256), (PeerKeyRole::Verification, KeyType::Ed25519), (PeerKeyRole::Encryption, KeyType::Secp256k1), (PeerKeyRole::Encryption, KeyType::P256), (PeerKeyRole::Encryption, KeyType::X25519)], None).unwrap();
-            TDKProfile {
-                alias: alias.to_string(),
-                did,
-                secrets,
-                mediator: mediator.map(|m| m.to_string()),
-            }
+            TDKProfile::new(alias, &did, mediator, secrets)
         }
 
-        environment.profiles.insert("Alice".into(), _create_friend("Alice", environment.default_mediator.as_deref()));
-        println!("  {}{}", style("Friend Alice created with DID: ").blue(), style(&environment.profiles.get("Alice").unwrap().did).color256(208));
-        environment.profiles.insert("Bob".into(), _create_friend("Bob", environment.default_mediator.as_deref()));
-        println!("  {}{}", style("Friend Bob created with DID: ").blue(), style(&environment.profiles.get("Bob").unwrap().did).color256(208));
-        environment.profiles.insert("Charlie".into(), _create_friend("Charlie", environment.default_mediator.as_deref()));
-        println!("  {}{}", style("Friend Charlie created with DID: ").blue(), style(&environment.profiles.get("Charlie").unwrap().did).color256(208));
-        environment.profiles.insert("Mallory".into(), _create_friend("Mallory", environment.default_mediator.as_deref()));
-        println!("  {}{}{}{}", style("Friend(?) ").blue(), style("Mallory").red(), style(" created with DID: ").blue(), style(&environment.profiles.get("Mallory").unwrap().did).color256(208));
+        let mediator = environment.default_mediator().map(str::to_owned);
+        for friend in ["Alice", "Bob", "Charlie", "Mallory"] {
+            let profile = _create_friend(friend, mediator.as_deref());
+            let did = profile.did.clone();
+            environment.add_profile(profile);
+            let label = if friend == "Mallory" {
+                format!("{}{}{}", style("Friend(?) ").blue(), style(friend).red(), style(" created with DID: ").blue())
+            } else {
+                format!("{}{}{}", style("Friend ").blue(), style(friend).blue(), style(" created with DID: ").blue())
+            };
+            println!("  {}{}", label, style(did).color256(208));
+        }
     }
 
     if Confirm::with_theme(&theme)

--- a/crates/messaging/affinidi-messaging-helpers/src/setup_environment/ui.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/setup_environment/ui.rs
@@ -201,7 +201,7 @@ pub(crate) async fn init_remote_mediator(
             .interact()
             .unwrap()
         {
-            let admin_did = Input::with_theme(theme)
+            let admin_did: String = Input::with_theme(theme)
                 .with_prompt("Admin DID")
                 .interact_text()
                 .unwrap();
@@ -217,12 +217,7 @@ pub(crate) async fn init_remote_mediator(
                     .blink()
                     .red()
             );
-            Some(TDKProfile {
-                alias: "Admin".to_string(),
-                did: admin_did,
-                mediator: Some(mediator.to_string()),
-                secrets: vec![],
-            })
+            Some(TDKProfile::new("Admin", &admin_did, Some(mediator), vec![]))
         } else {
             None
         }
@@ -296,12 +291,12 @@ pub(crate) async fn init_remote_mediator(
     // Get admin account info
     let admin_did = _admin_did(&mediator_did, theme);
 
-    let environment = TDKEnvironment {
-        default_mediator: Some(mediator_did.clone()),
-        profiles: std::collections::HashMap::new(),
-        admin_did,
-        ssl_certificates,
-    };
+    let mut environment = TDKEnvironment::default();
+    environment.set_default_mediator(Some(mediator_did.clone()));
+    if let Some(admin) = admin_did {
+        environment.set_admin_did(Some(admin));
+    }
+    environment.set_ssl_certificate_paths(ssl_certificates);
 
     Ok((
         MediatorType::Remote,
@@ -458,12 +453,12 @@ pub(crate) async fn init_local_mediator(
         );
     }
 
-    let environment = TDKEnvironment {
-        default_mediator: new_mediator_config.mediator_did.clone(),
-        profiles: std::collections::HashMap::new(),
-        admin_did: Some(admin_did),
-        ssl_certificates: vec!["./affinidi-messaging-mediator/conf/keys/client.chain".to_string()],
-    };
+    let mut environment = TDKEnvironment::default();
+    environment.set_default_mediator(new_mediator_config.mediator_did.clone());
+    environment.set_admin_did(Some(admin_did));
+    environment.set_ssl_certificate_paths(vec![
+        "./affinidi-messaging-mediator/conf/keys/client.chain".to_string(),
+    ]);
     Ok((
         MediatorType::Local,
         save_environment(theme, environments, environment, "local")?,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -34,7 +34,7 @@ setup = ["dep:dialoguer", "dep:console", "dep:affinidi-encoding"]
 
 [dependencies]
 # Affinidi Crates
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.16" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.17" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13", optional = true }
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 affinidi-encoding = { version = "0.1", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]
-affinidi-messaging-sdk = { path = "../../affinidi-messaging-sdk", version = "0.16" }
+affinidi-messaging-sdk = { path = "../../affinidi-messaging-sdk", version = "0.17" }
 axum = { version = "0.8", features = ["ws"] }
 rand = "0.10"
 redis = { version = "1", features = [

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.17.0] - 2026-05-02
+
+### Breaking
+
+- Migrated to `affinidi-tdk-common` 0.6. The change is mechanical only —
+  `TDKSharedState` field accesses (`tdk_common.client`, `.did_resolver`,
+  `.secrets_resolver`, `.authentication`, `.environment`) replaced with
+  the corresponding accessor methods on every code path. No behavioural
+  changes within the SDK itself.
+- `ATMProfile::to_tdk_profile` now constructs the `TDKProfile` via
+  `TDKProfile::new(...)` instead of a struct literal — the `secrets`
+  field is `pub(crate)` in tdk-common 0.6 and only constructible through
+  the public API.
+
+### Tests
+
+- `unpack` test helpers (`create_atm_with_secrets`, `create_atm`,
+  `create_atm_no_unpack_forwards`) updated to build a `TDKSharedState`
+  via `TDKConfig::builder().with_load_environment(false)
+  .with_use_atm(false).build()?` + `TDKSharedState::new`, replacing the
+  removed `TDKSharedState::default().await`.
+
 ## [0.16.3] - 2026-04-15
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.16.4"
+version = "0.17.0"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk-common = "0.5"
+affinidi-tdk-common = "0.6"
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13" }
 affinidi-did-authentication = "0.3"
 affinidi-did-common = "0.3"

--- a/crates/messaging/affinidi-messaging-sdk/README.md
+++ b/crates/messaging/affinidi-messaging-sdk/README.md
@@ -20,7 +20,7 @@ mediator service.
 
 ```toml
 [dependencies]
-affinidi-messaging-sdk = "0.15"
+affinidi-messaging-sdk = "0.17"
 ```
 
 ## Quick Start

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/delete.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/delete.rs
@@ -51,7 +51,7 @@ impl ATM {
             // Check if authenticated
             let tokens = self
                 .get_tdk()
-                .authentication
+                .authentication()
                 .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
                 .await?;
 
@@ -76,7 +76,8 @@ impl ATM {
 
         let res = self
             .inner
-            .tdk_common.client
+            .tdk_common
+            .client()
             .delete([&mediator_url, "/delete"].concat())
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", tokens.access_token))

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/fetch.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/fetch.rs
@@ -79,7 +79,7 @@ impl ATM {
             // Check if authenticated
             let tokens = self
                 .get_tdk()
-                .authentication
+                .authentication()
                 .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
                 .await?;
 
@@ -97,7 +97,7 @@ impl ATM {
             let res = self
                 .inner
                 .tdk_common
-                .client
+                .client()
                 .post([&mediator_url, "/fetch"].concat())
                 .header("Content-Type", "application/json")
                 .header("Authorization", format!("Bearer {}", tokens.access_token))

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/get.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/get.rs
@@ -23,7 +23,7 @@ impl ATM {
             // Check if authenticated
             let tokens = self
                 .get_tdk()
-                .authentication
+                .authentication()
                 .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
                 .await?;
 
@@ -42,7 +42,7 @@ impl ATM {
             let res = self
                 .inner
                 .tdk_common
-                .client
+                .client()
                 .post([&mediator_url, "/outbound"].concat())
                 .header("Content-Type", "application/json")
                 .header("Authorization", format!("Bearer {}", tokens.access_token))

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/list.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/list.rs
@@ -22,7 +22,7 @@ impl ATM {
             // Check if authenticated
             let tokens = self
                 .get_tdk()
-                .authentication
+                .authentication()
                 .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
                 .await?;
 
@@ -35,7 +35,7 @@ impl ATM {
             let res = self
                 .inner
                 .tdk_common
-                .client
+                .client()
                 .get(format!(
                     "{}/list/{}/{}",
                     mediator_url,

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
@@ -44,7 +44,7 @@ impl SharedState {
             // 1. Resolve recipient DID and get their key agreement public key
             let recipient_doc = self
                 .tdk_common
-                .did_resolver
+                .did_resolver()
                 .resolve(to)
                 .await
                 .map_err(|e| {
@@ -66,7 +66,7 @@ impl SharedState {
                 // Authcrypt: resolve sender, get private key, encrypt
                 let sender_doc = self
                     .tdk_common
-                    .did_resolver
+                    .did_resolver()
                     .resolve(sender_did)
                     .await
                     .map_err(|e| {
@@ -86,7 +86,7 @@ impl SharedState {
                 // Get sender's private key from secrets resolver
                 let sender_secret = self
                     .tdk_common
-                    .secrets_resolver
+                    .secrets_resolver()
                     .get_secret(sender_kid.as_ref())
                     .await
                     .ok_or_else(|| {

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
@@ -118,7 +118,7 @@ impl SharedState {
 
         for recipient in recipients {
             if let Some(kid) = recipient["header"]["kid"].as_str()
-                && let Some(secret) = self.tdk_common.secrets_resolver.get_secret(kid).await
+                && let Some(secret) = self.tdk_common.secrets_resolver().get_secret(kid).await
             {
                 let curve = match secret.get_key_type() {
                     affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
@@ -206,7 +206,7 @@ impl SharedState {
         // Resolve the sender DID document
         let sender_doc = self
             .tdk_common
-            .did_resolver
+            .did_resolver()
             .resolve(sender_did)
             .await
             .ok()?;
@@ -425,10 +425,16 @@ mod tests {
 
     /// Helper: create an ATM instance with secrets pre-loaded for the given party.
     async fn create_atm_with_secrets(secrets: Vec<Secret>) -> ATM {
+        use affinidi_tdk_common::config::TDKConfig;
         let config = ATMConfig::builder().build().unwrap();
-        let tdk = Arc::new(TDKSharedState::default().await);
+        let tdk_cfg = TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(false)
+            .build()
+            .unwrap();
+        let tdk = Arc::new(TDKSharedState::new(tdk_cfg).await.unwrap());
         for secret in &secrets {
-            tdk.secrets_resolver.insert(secret.clone()).await;
+            tdk.secrets_resolver().insert(secret.clone()).await;
         }
         ATM::new(config, tdk).await.unwrap()
     }
@@ -899,7 +905,12 @@ mod tests {
     /// Creates an ATM instance with default config (unpack_forwards=true).
     async fn create_atm() -> ATM {
         let config = ATMConfig::builder().build().unwrap();
-        let tdk = Arc::new(TDKSharedState::default().await);
+        let tdk_cfg = affinidi_tdk_common::config::TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(false)
+            .build()
+            .unwrap();
+        let tdk = Arc::new(TDKSharedState::new(tdk_cfg).await.unwrap());
         ATM::new(config, tdk).await.unwrap()
     }
 
@@ -909,7 +920,12 @@ mod tests {
             .with_unpack_forwards(false)
             .build()
             .unwrap();
-        let tdk = Arc::new(TDKSharedState::default().await);
+        let tdk_cfg = affinidi_tdk_common::config::TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(false)
+            .build()
+            .unwrap();
+        let tdk = Arc::new(TDKSharedState::new(tdk_cfg).await.unwrap());
         ATM::new(config, tdk).await.unwrap()
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -96,14 +96,18 @@ impl ATMProfile {
         .await
     }
 
-    /// Converts an ATM  Profile into a TDK Profile
+    /// Converts an ATM Profile into a TDK Profile (without secrets).
     pub fn to_tdk_profile(&self) -> TDKProfile {
-        TDKProfile {
-            alias: self.inner.alias.clone(),
-            did: self.inner.did.clone(),
-            mediator: self.inner.mediator.as_ref().as_ref().map(|m| m.did.clone()),
-            secrets: Vec::new(),
-        }
+        TDKProfile::new(
+            &self.inner.alias,
+            &self.inner.did,
+            self.inner
+                .mediator
+                .as_ref()
+                .as_ref()
+                .map(|m| m.did.as_str()),
+            Vec::new(),
+        )
     }
 
     /// Returns the DID for the Profile and Associated Mediator
@@ -207,7 +211,7 @@ pub struct Mediator {
 
 impl Mediator {
     pub(crate) async fn new(atm: &ATM, did: String) -> Result<Self, ATMError> {
-        let mediator_doc = match atm.inner.tdk_common.did_resolver.resolve(&did).await {
+        let mediator_doc = match atm.inner.tdk_common.did_resolver().resolve(&did).await {
             Ok(response) => response.doc,
             Err(err) => {
                 return Err(ATMError::DIDError(format!(

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/oob_discovery.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/oob_discovery.rs
@@ -45,7 +45,7 @@ impl OOBDiscovery {
         // Check if authenticated
         let tokens = atm
             .get_tdk()
-            .authentication
+            .authentication()
             .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
             .await?;
 
@@ -84,7 +84,7 @@ impl OOBDiscovery {
         let res = atm
             .inner
             .tdk_common
-            .client
+            .client()
             .post([&mediator_url, "/oob"].concat())
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", tokens.access_token))
@@ -130,7 +130,7 @@ impl OOBDiscovery {
         let res = atm
             .inner
             .tdk_common
-            .client
+            .client()
             .get(url)
             .header("Content-Type", "application/json")
             .send()
@@ -203,7 +203,7 @@ impl OOBDiscovery {
         // Check if authenticated
         let tokens = atm
             .get_tdk()
-            .authentication
+            .authentication()
             .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
             .await?;
 
@@ -217,7 +217,7 @@ impl OOBDiscovery {
         let res = atm
             .inner
             .tdk_common
-            .client
+            .client()
             .delete(format!("{mediator_url}/oob?_oobid={oobid}"))
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", tokens.access_token))

--- a/crates/messaging/affinidi-messaging-sdk/src/public/well_known_did.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/public/well_known_did.rs
@@ -20,7 +20,7 @@ impl ATM {
             let res = self
                 .inner
                 .tdk_common
-                .client
+                .client()
                 .get(well_known_did_atm_api)
                 .header("Content-Type", "application/json")
                 .send()

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/mod.rs
@@ -231,7 +231,7 @@ impl ATM {
         // Check if authenticated
         let tokens = self
             .get_tdk()
-            .authentication
+            .authentication()
             .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
             .await?;
 
@@ -240,7 +240,7 @@ impl ATM {
         let res = self
             .inner
             .tdk_common
-            .client
+            .client()
             .post([&mediator_url, "/inbound"].concat())
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", tokens.access_token))

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -506,7 +506,7 @@ impl WebSocketTransport {
         let tokens = self
             .shared
             .tdk_common
-            .authentication
+            .authentication()
             .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
             .await?;
 

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.6" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.16" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.17" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13" }
 affinidi-did-resolver-cache-sdk = "0.8"
 

--- a/crates/messaging/affinidi-messaging-text-client/src/main.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/main.rs
@@ -40,7 +40,15 @@ async fn main() -> anyhow::Result<()> {
     let (state_store, state_rx) = StateStore::new();
     let (ui_manager, action_rx) = UiManager::new();
 
-    let tdk = Arc::new(TDKSharedState::default().await);
+    let tdk = Arc::new(
+        TDKSharedState::new(
+            affinidi_tdk::common::config::TDKConfig::builder()
+                .with_load_environment(false)
+                .with_use_atm(false)
+                .build()?,
+        )
+        .await?,
+    );
     tokio::try_join!(
         state_store.main_loop(terminator, action_rx, interrupt_rx.resubscribe(), tdk),
         ui_manager.main_loop(state_rx, interrupt_rx.resubscribe()),

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
@@ -87,7 +87,7 @@ pub async fn create_new_profile(
     }
 
     atm.get_tdk()
-        .secrets_resolver
+        .secrets_resolver()
         .insert(p256_secret.clone())
         .await;
     state.add_secret(p256_secret);

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
@@ -41,7 +41,7 @@ pub async fn manual_connect_setup(
         Some(mediator_did.to_string()),
     )
     .await?;
-    atm.get_tdk().secrets_resolver.insert_vec(&secrets).await;
+    atm.get_tdk().secrets_resolver().insert_vec(&secrets).await;
     state.add_secrets(&mut secrets);
 
     let profile = atm.profile_add(&profile, true).await?;

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
@@ -160,10 +160,10 @@ impl StateStore {
                         state.settings.show_settings_popup = !state.settings.show_settings_popup;
                     },
                     Action::SettingsCheck { settings } => {
-                        settings.check(&mut state, &tdk.did_resolver()).await;
+                        settings.check(&mut state, tdk.did_resolver()).await;
                     }
                     Action::SettingsUpdate { settings } => {
-                        if settings.update(&mut state, &tdk.did_resolver()).await {
+                        if settings.update(&mut state, tdk.did_resolver()).await {
                             state.settings.show_settings_popup = false;
                         }
                     }

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
@@ -61,7 +61,7 @@ impl StateStore {
         let mut state = State::read_from_file("config.json").unwrap_or_default();
         state.initialization = true;
 
-        tdk.secrets_resolver.insert_vec(&state.secrets).await;
+        tdk.secrets_resolver().insert_vec(&state.secrets).await;
 
         if !state.chat_list.chats.is_empty() {
             // Set the first chat as the active chat
@@ -160,10 +160,10 @@ impl StateStore {
                         state.settings.show_settings_popup = !state.settings.show_settings_popup;
                     },
                     Action::SettingsCheck { settings } => {
-                        settings.check(&mut state, &tdk.did_resolver).await;
+                        settings.check(&mut state, &tdk.did_resolver()).await;
                     }
                     Action::SettingsUpdate { settings } => {
-                        if settings.update(&mut state, &tdk.did_resolver).await {
+                        if settings.update(&mut state, &tdk.did_resolver()).await {
                             state.settings.show_settings_popup = false;
                         }
                     }

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog — `affinidi-tdk`
+
+All notable changes to this crate are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
+
+## [0.7.0] - 2026-05-02
+
+### Breaking
+
+- Upgraded to `affinidi-tdk-common` 0.6 and `affinidi-meeting-place` 0.4.
+  Both upstream bumps are SemVer-breaking, so consumers must adopt the
+  accessor-method API on `TDKSharedState` / `TDKEnvironment` /
+  `TDKProfile` (see the
+  [`affinidi-tdk-common` 0.6.0 changelog](../affinidi-tdk-common/CHANGELOG.md#060--2026-05-02)
+  for the full migration).
+- `secrets::*` methods (`delete_did_secret`, `save_secrets_locally`,
+  `load_secrets`) now take `&self` rather than consuming `self`. The
+  `self`-by-value receiver was a holdover that prevented chained use.
+- `secrets::*` is rewired onto the new
+  [`KeyringStore`](https://docs.rs/affinidi-tdk-common/0.6.0/affinidi_tdk_common/secrets/struct.KeyringStore.html)
+  rather than the removed free functions in tdk-common 0.5.
+
+### Changed
+
+- `TDK::new` now delegates to `TDKSharedState::new` (which loads the
+  on-disk environment, builds the HTTPS client with extra TLS roots from
+  `TDKEnvironment::ssl_certificate_paths`, and spawns the
+  `AuthenticationCache`) instead of duplicating that logic. Profile
+  secrets are loaded into the shared resolver via the public
+  `add_profile` API.
+- `verify_data` is rewritten with `?`-driven control flow; behaviour is
+  identical.
+
+### Added
+
+- `TDK::shared(&self) -> &TDKSharedState` — borrow the shared state
+  without bumping the `Arc` refcount. `get_shared_state()` is unchanged.
+- `#![forbid(unsafe_code)]` at the crate root — security signal,
+  zero-cost.
+- This `CHANGELOG.md`.
+
+### Documentation
+
+- Crate-level rustdoc rewritten to describe the new
+  `TDK::new` → `TDKSharedState::new` delegation flow.
+- Example `did_auth.rs` updated for the new
+  `create_http_client(&[])` signature, the
+  `TDKEnvironment::profiles()` accessor, and `TDKProfile::take_secrets()`
+  to drain plaintext into the resolver.
+
+### Tests
+
+- Three near-duplicate `verify_data` tests deduplicated via a
+  `proof_with_vm` helper; behaviour unchanged.

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.6.5"
+version = "0.7.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -22,13 +22,13 @@ data-integrity = ["dep:affinidi-data-integrity", "dep:serde"]
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.3"
-affinidi-messaging-sdk = { version = "0.16", optional = true }
+affinidi-messaging-sdk = { version = "0.17", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.13" }
 affinidi-did-authentication = "0.3"
-affinidi-tdk-common = "0.5"
+affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 affinidi-crypto = "0.1"
-affinidi-meeting-place = { version = "0.3", optional = true }
+affinidi-meeting-place = { version = "0.4", optional = true }
 affinidi-data-integrity = { version = "0.6",  optional = true }
 
 # External Crates

--- a/crates/tdk/affinidi-tdk/README.md
+++ b/crates/tdk/affinidi-tdk/README.md
@@ -15,7 +15,7 @@ single crate and enable feature flags to pull in only the libraries you need.
 
 ```toml
 [dependencies]
-affinidi-tdk = "0.6"
+affinidi-tdk = "0.7"
 ```
 
 ## Feature Flags
@@ -32,7 +32,7 @@ Disable defaults with `default-features = false` in your `Cargo.toml` or
 
 ```toml
 [dependencies]
-affinidi-tdk = { version = "0.5", default-features = false, features = ["data-integrity"] }
+affinidi-tdk = { version = "0.7", default-features = false, features = ["data-integrity"] }
 ```
 
 ## Re-exported Crates

--- a/crates/tdk/affinidi-tdk/examples/did_auth.rs
+++ b/crates/tdk/affinidi-tdk/examples/did_auth.rs
@@ -1,5 +1,9 @@
 /*!
  * Utility to test or incorporate the DID Authentication flow into your application.
+ *
+ * Two modes:
+ *  - `environment`: load a DID from a TDKEnvironments file.
+ *  - `manual-entry`: read raw DID secrets JSON from stdin.
  */
 
 use affinidi_did_authentication::DIDAuthentication;
@@ -20,51 +24,47 @@ use tracing_subscriber::filter;
 
 /// Affinidi DID Authentication Tool
 #[derive(Parser)]
-#[command(name = "did_auth")]
-#[command(bin_name = "did_auth")]
+#[command(name = "did_auth", bin_name = "did_auth")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Service DID
+    /// Service DID to authenticate against.
     #[arg(short, long, value_name = "DID")]
     service_did: String,
 
-    /// How many times to retry auth?
+    /// How many times to retry auth on transient failure.
     #[arg(short, long, default_value_t = 3, value_parser = clap::value_parser!(u8).range(1..10))]
     retry_limit: u8,
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Use a DID defined in the environments file
+    /// Use a DID defined in the environments file.
     Environment(EnvironmentArgs),
 
-    /// use a custom DID - will need to provide secrets to STDIN
+    /// Use a custom DID — secrets must be provided on STDIN as a JSON array.
     ManualEntry(ManualEntryArgs),
 }
 
-/// Use a DID defined in the environments file
 #[derive(Debug, Parser)]
-#[command(version, about, long_about = None)]
 struct EnvironmentArgs {
-    /// Environment to use
+    /// Environment to use (defaults to `$TDK_ENVIRONMENT` or `"default"`).
     #[arg(short, long)]
     environment: Option<String>,
 
-    /// Profile Name to use from the environment
+    /// Profile name within the environment.
     #[arg(short, long)]
     name_profile: String,
 
-    /// Path to the environments file (defaults to environments.json)
+    /// Path to the environments file (defaults to `environments.json`).
     #[arg(short, long)]
     path_environments: Option<String>,
 }
 
 #[derive(Debug, Parser)]
-#[command(version, about, long_about = None)]
 struct ManualEntryArgs {
-    /// DID to use for authentication
+    /// DID to authenticate with.
     #[arg(short, long)]
     did: String,
 }
@@ -74,61 +74,24 @@ async fn main() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let args = Cli::parse();
 
-    // construct a subscriber that prints formatted traces to stdout
-    let subscriber = tracing_subscriber::fmt()
-        // Use a more compact, abbreviated log format
-        .with_env_filter(filter::EnvFilter::from_default_env())
-        .finish();
-    // use that subscriber to process traces emitted after this point
-    tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(filter::EnvFilter::from_default_env())
+            .finish(),
+    )
+    .expect("Logging failed, exiting...");
 
     let (profile, secrets) = match args.command {
-        Commands::Environment(env_args) => {
-            let environment_name = if let Some(environment_name) = &env_args.environment {
-                environment_name.to_string()
-            } else if let Ok(environment_name) = env::var("TDK_ENVIRONMENT") {
-                environment_name
-            } else {
-                "default".to_string()
-            };
-
-            let environment = TDKEnvironments::fetch_from_file(
-                env_args.path_environments.as_deref(),
-                &environment_name,
-            )?;
-
-            if let Some(profile) = environment.profiles.get(&env_args.name_profile) {
-                (profile.clone(), profile.secrets.clone())
-            } else {
-                return Err(TDKError::Profile(format!(
-                    "Couldn't find profile ({}) in environment ({})!",
-                    env_args.name_profile, environment_name
-                )));
-            }
-        }
-        Commands::ManualEntry(manual_args) => {
-            let mut secrets_buf = String::new();
-            io::stdin()
-                .read_to_string(&mut secrets_buf)
-                .map_err(|e| TDKError::Authentication(format!("Couldn't read from STDIN: {e}")))?;
-            let secrets: Vec<Secret> = serde_json::from_str(&secrets_buf).map_err(|e| {
-                TDKError::Authentication(format!("DID Secrets not valid JSON: {e}"))
-            })?;
-            (
-                TDKProfile::new("manual", &manual_args.did, None, vec![]),
-                secrets,
-            )
-        }
+        Commands::Environment(env_args) => load_from_environment(env_args)?,
+        Commands::ManualEntry(manual_args) => load_from_stdin(manual_args)?,
     };
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let secrets_resolver = ThreadedSecretsResolver::new(None).await.0;
     secrets_resolver.insert_vec(&secrets).await;
-    let client = create_http_client();
+    let client = create_http_client(&[])?;
 
-    // Attempt Authentication
     let mut did_auth = DIDAuthentication::new();
-
     match did_auth
         .authenticate(
             &profile.did,
@@ -150,8 +113,43 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Err(err) => Err(TDKError::AuthenticationAbort(format!(
-            "Couldn't authenticate DID({}) against endpoint({}): {}",
-            profile.did, args.service_did, err
+            "Couldn't authenticate DID({}) against endpoint({}): {err}",
+            profile.did, args.service_did,
         ))),
     }
+}
+
+fn load_from_environment(args: EnvironmentArgs) -> Result<(TDKProfile, Vec<Secret>)> {
+    let environment_name = args
+        .environment
+        .clone()
+        .or_else(|| env::var("TDK_ENVIRONMENT").ok())
+        .unwrap_or_else(|| "default".to_string());
+
+    let environment =
+        TDKEnvironments::fetch_from_file(args.path_environments.as_deref(), &environment_name)?;
+
+    let mut profile = environment
+        .profiles()
+        .get(&args.name_profile)
+        .ok_or_else(|| {
+            TDKError::Profile(format!(
+                "Couldn't find profile ({}) in environment ({})!",
+                args.name_profile, environment_name
+            ))
+        })?
+        .clone();
+
+    let secrets = profile.take_secrets();
+    Ok((profile, secrets))
+}
+
+fn load_from_stdin(args: ManualEntryArgs) -> Result<(TDKProfile, Vec<Secret>)> {
+    let mut secrets_buf = String::new();
+    io::stdin()
+        .read_to_string(&mut secrets_buf)
+        .map_err(|e| TDKError::Authentication(format!("Couldn't read from STDIN: {e}")))?;
+    let secrets: Vec<Secret> = serde_json::from_str(&secrets_buf)
+        .map_err(|e| TDKError::Authentication(format!("DID Secrets not valid JSON: {e}")))?;
+    Ok((TDKProfile::new("manual", &args.did, None, vec![]), secrets))
 }

--- a/crates/tdk/affinidi-tdk/src/lib.rs
+++ b/crates/tdk/affinidi-tdk/src/lib.rs
@@ -1,24 +1,27 @@
 /*!
  * Affinidi Trust Development Kit
  *
- * Instantiate a TDK client with the `new` function
+ * Umbrella crate that wires together [`affinidi_tdk_common::TDKSharedState`]
+ * (DID resolver, secrets resolver, HTTPS client, authentication cache) with
+ * the optional Affinidi Messaging SDK ([`messaging::ATM`]) and Meeting Place
+ * client ([`meeting_place::MeetingPlace`]).
+ *
+ * Construct with [`TDK::new`]; the heavy lifting is delegated to
+ * [`TDKSharedState::new`].
  */
+
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "data-integrity")]
 use affinidi_data_integrity::{
     DataIntegrityError, DataIntegrityProof, VerifyOptions, verification_proof::VerificationProof,
 };
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 #[cfg(feature = "messaging")]
-use affinidi_messaging_sdk::ATM;
-#[cfg(feature = "messaging")]
-use affinidi_messaging_sdk::config::ATMConfigBuilder;
-use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver};
+use affinidi_messaging_sdk::{ATM, config::ATMConfigBuilder};
 use affinidi_tdk_common::{
-    TDKSharedState, create_http_client, environments::TDKEnvironments, errors::Result,
-    profiles::TDKProfile, tasks::authentication::AuthenticationCache,
+    TDKSharedState, config::TDKConfig, errors::Result, profiles::TDKProfile,
 };
-use common::{config::TDKConfig, environments::TDKEnvironment};
 #[cfg(feature = "data-integrity")]
 use serde::Serialize;
 use std::sync::Arc;
@@ -26,7 +29,7 @@ use std::sync::Arc;
 pub mod dids;
 pub mod secrets;
 
-// Re-export required crates for convenience to applications
+// Re-exports for application convenience.
 #[cfg(feature = "meeting-place")]
 pub use affinidi_meeting_place as meeting_place;
 
@@ -34,127 +37,64 @@ pub use affinidi_messaging_didcomm as didcomm;
 #[cfg(feature = "messaging")]
 pub use affinidi_messaging_sdk as messaging;
 
-// did-peer functionality is now integrated into affinidi_did_common
-// Use affinidi_tdk::dids module for DID generation
-
 #[cfg(feature = "data-integrity")]
 pub use affinidi_data_integrity as data_integrity;
 
-// Always exported
 pub use affinidi_crypto;
 pub use affinidi_did_authentication as did_authentication;
 pub use affinidi_did_common as did_common;
 pub use affinidi_secrets_resolver as secrets_resolver;
 pub use affinidi_tdk_common as common;
 
-/// TDK instance that can be used to interact with Affinidi services
+/// TDK instance — a thin orchestrator over [`TDKSharedState`] plus optional
+/// messaging and meeting-place clients.
+///
+/// Cloning is cheap; the inner shared state is `Arc`-backed.
 #[derive(Clone)]
 pub struct TDK {
-    pub(crate) inner: Arc<TDKSharedState>,
+    inner: Arc<TDKSharedState>,
     #[cfg(feature = "messaging")]
     pub atm: Option<ATM>,
     #[cfg(feature = "meeting-place")]
     pub meeting_place: Option<meeting_place::MeetingPlace>,
 }
 
-/// Affinidi Trusted Development Kit (TDK)
-///
-/// Use this to instantiate everything required to easily interact with Affinidi services
-/// If you are self hosting the services, you can use your own service URL's where required
-///
-/// Example:
-/// ```ignore
-/// use affinidi_tdk::TDK;
-/// use affinidi_tdk_common::config::TDKConfig;
-///
-/// let config = TDKConfig::new().build();
-/// let mut tdk = TDK::new(config).await?;
-///
-///
-/// ```
-/// NOTE: If feature-flag "messaging" is enabled, then there is an option to bring a
-/// pre-configgured ATM instance to the TDK. If none is specified then ATM is automatically setup
-/// for you.
 impl TDK {
+    /// Build a new `TDK` from the supplied configuration.
+    ///
+    /// Delegates state construction to [`TDKSharedState::new`] (which loads
+    /// the on-disk environment when `config.load_environment()` is `true`),
+    /// then loads each profile's secrets into the shared resolver and
+    /// optionally instantiates [`ATM`] when `config.use_atm()` is set.
+    ///
+    /// Pass `Some(atm)` to bring a pre-built `ATM` instance (the config's
+    /// `use_atm` is still honoured — it gates whether `atm` is retained at
+    /// all). Pass `None` to let `TDK` construct one for you.
     pub async fn new(
         config: TDKConfig,
         #[cfg(feature = "messaging")] atm: Option<ATM>,
     ) -> Result<Self> {
-        let client = create_http_client();
+        let shared = Arc::new(TDKSharedState::new(config).await?);
 
-        // Instantiate the DID resolver for TDK
-        let did_resolver = if let Some(did_resolver) = &config.did_resolver {
-            did_resolver.to_owned()
-        } else if let Some(did_resolver_config) = &config.did_resolver_config {
-            DIDCacheClient::new(did_resolver_config.to_owned()).await?
-        } else {
-            DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?
-        };
-
-        // Instantiate the SecretsManager for TDK
-        let secrets_resolver = if let Some(secrets_resolver) = &config.secrets_resolver {
-            secrets_resolver.to_owned()
-        } else {
-            ThreadedSecretsResolver::new(None).await.0
-        };
-
-        // Instantiate the authentication cache
-        let (authentication, _) = AuthenticationCache::new(
-            config.authentication_cache_limit as u64,
-            &did_resolver,
-            secrets_resolver.clone(),
-            &client,
-            config.custom_auth_handlers.clone(),
-        );
-
-        authentication.start().await;
-
-        // Load Environment
-        // Adds secrets to the secrets resolver
-        // Removes secrets from the environment itself
-        let environment = if config.load_environment {
-            let mut environment = TDKEnvironments::fetch_from_file(
-                Some(&config.environment_path),
-                &config.environment_name,
-            )?;
-            for (_, profile) in environment.profiles.iter_mut() {
-                secrets_resolver
-                    .insert_vec(profile.secrets.as_slice())
-                    .await;
-
-                // Remove secrets from profile after adding them to the secrets resolver
-                profile.secrets.clear();
-            }
-            environment
-        } else {
-            TDKEnvironment::default()
-        };
-
-        // Create the shared state, then we can use this inside other Affinidi Crates
-        let shared_state = Arc::new(TDKSharedState {
-            config,
-            did_resolver,
-            secrets_resolver,
-            client,
-            environment,
-            authentication,
-        });
+        // Hand each environment profile's secrets to the shared resolver so
+        // signing/auth flows can find them. The environment retains the
+        // canonical copy on disk; this is the in-memory load step.
+        for profile in shared.environment().profiles().values() {
+            shared.add_profile(profile).await;
+        }
 
         #[cfg(feature = "messaging")]
-        // Instantiate Affinidi Messaging
-        let atm = if shared_state.config.use_atm {
-            if let Some(atm) = atm {
-                Some(atm.to_owned())
-            } else {
-                // Use the same DID Resolver for ATM
-                Some(ATM::new(ATMConfigBuilder::default().build()?, shared_state.clone()).await?)
-            }
+        let atm = if shared.config().use_atm() {
+            Some(match atm {
+                Some(atm) => atm,
+                None => ATM::new(ATMConfigBuilder::default().build()?, shared.clone()).await?,
+            })
         } else {
             None
         };
 
         Ok(TDK {
-            inner: shared_state,
+            inner: shared,
             #[cfg(feature = "messaging")]
             atm,
             #[cfg(feature = "meeting-place")]
@@ -162,31 +102,37 @@ impl TDK {
         })
     }
 
-    /// Get the shared state of the TDK
+    /// Shared state handle. Cheap to clone.
     pub fn get_shared_state(&self) -> Arc<TDKSharedState> {
         self.inner.clone()
     }
 
-    /// Adds a TDK Profile to the shared state
-    /// Which is really just adding the secrets to the secrets resolver
-    /// For the moment...
+    /// Borrow the shared state without bumping its refcount.
+    pub fn shared(&self) -> &TDKSharedState {
+        &self.inner
+    }
+
+    /// Add a [`TDKProfile`]'s secrets to the shared resolver. Convenience
+    /// passthrough to [`TDKSharedState::add_profile`].
     pub async fn add_profile(&self, profile: &TDKProfile) {
-        self.inner
-            .secrets_resolver
-            .insert_vec(&profile.secrets)
-            .await;
+        self.inner.add_profile(profile).await;
     }
 
-    /// Access shared DID resolver
+    /// Borrow the shared DID resolver.
     pub fn did_resolver(&self) -> &DIDCacheClient {
-        &self.inner.did_resolver
+        self.inner.did_resolver()
     }
 
-    /// Verify a signed JSON Schema document which includes a DID lookup resolution step.
-    /// If you already have public key bytes, call
-    /// [`DataIntegrityProof::verify_with_public_key`] directly instead.
-    /// You must strip `proof` from the document as needed
-    /// Context is a copy of any context that needs to be passed in
+    /// Verify a Data Integrity proof, resolving the public key from the
+    /// `proof.verification_method` DID URL.
+    ///
+    /// If you already hold the public key bytes, prefer
+    /// [`DataIntegrityProof::verify_with_public_key`] to skip the resolver
+    /// hop. The `context` argument, when set, is checked against the proof's
+    /// `@context` array.
+    ///
+    /// `signed_doc` must already have its `proof` field stripped — the proof
+    /// is supplied separately.
     #[cfg(feature = "data-integrity")]
     pub async fn verify_data<S>(
         &self,
@@ -200,33 +146,30 @@ impl TDK {
         use affinidi_did_common::document::DocumentExt;
         use affinidi_tdk_common::errors::TDKError;
 
-        let did = if let Some((did, _)) = proof.verification_method.split_once("#") {
-            did
-        } else {
-            return Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(
+        let (did, _) = proof.verification_method.split_once('#').ok_or_else(|| {
+            TDKError::DataIntegrity(DataIntegrityError::MalformedProof(
                 "Invalid proof:verificationMethod. Must be DID#key-id format".to_string(),
-            )));
-        };
+            ))
+        })?;
 
-        let resolved = self.inner.did_resolver.resolve(did).await?;
-        let public_bytes = if let Some(vm) = resolved
+        let resolved = self.inner.did_resolver().resolve(did).await?;
+        let vm = resolved
             .doc
             .get_verification_method(&proof.verification_method)
-        {
+            .ok_or_else(|| {
+                TDKError::DataIntegrity(DataIntegrityError::MalformedProof(format!(
+                    "Couldn't find key-id ({}) in resolved DID Document",
+                    proof.verification_method
+                )))
+            })?;
+
+        let public_bytes =
             vm.get_public_key_bytes()
                 .map_err(|e| DataIntegrityError::InvalidPublicKey {
                     codec: None,
                     len: 0,
                     reason: format!("Failed to get public key bytes from verification method: {e}"),
-                })?
-        } else {
-            return Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(
-                format!(
-                    "Couldn't find key-id ({}) in resolved DID Document",
-                    proof.verification_method
-                ),
-            )));
-        };
+                })?;
 
         let mut options = VerifyOptions::new();
         if let Some(ctx) = context {
@@ -245,119 +188,91 @@ impl TDK {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    #[cfg(feature = "data-integrity")]
+    mod data_integrity {
+        use std::collections::HashMap;
 
-    use affinidi_data_integrity::{DataIntegrityError, crypto_suites::CryptoSuite};
-    use affinidi_tdk_common::{config::TDKConfig, errors::TDKError};
+        use affinidi_data_integrity::{DataIntegrityError, crypto_suites::CryptoSuite};
+        use affinidi_tdk_common::{config::TDKConfig, errors::TDKError};
 
-    use crate::TDK;
+        use crate::{DataIntegrityProof, TDK};
 
-    #[tokio::test]
-    async fn invalid_verification_method() {
-        let proof = crate::DataIntegrityProof {
-                type_: "DataIntegrityProof".to_string(),
-                cryptosuite: CryptoSuite::EddsaJcs2022,
-                created: Some("2025-01-01T00:00:00Z".to_string()),
-                verification_method: "test".to_string(),
-                proof_purpose: "test".to_string(),
-                proof_value: Some("z2RPk8MWLoULfcbtpULoEsgfDsaAvyfD1PvQC2v3BjqqNtzGu8YJ4Nxq8CmJCZpPqA49uJhkxmxSztUQhBxqnVrYj".to_string()),
-                context: None,
-        };
-
-        let tdk = TDK::new(
-            TDKConfig::builder()
-                .with_load_environment(false)
-                .build()
-                .unwrap(),
-            None,
-        )
-        .await
-        .unwrap();
-        let result = tdk
-            .verify_data(&HashMap::<String, String>::new(), None, &proof)
-            .await;
-        assert!(result.is_err());
-        match result {
-            Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(txt))) => {
-                assert_eq!(
-                    txt,
-                    "Invalid proof:verificationMethod. Must be DID#key-id format".to_string()
-                );
-            }
-            _ => panic!("Invalid return type"),
+        async fn tdk() -> TDK {
+            TDK::new(
+                TDKConfig::builder()
+                    .with_load_environment(false)
+                    .with_use_atm(false)
+                    .build()
+                    .expect("config builds"),
+                #[cfg(feature = "messaging")]
+                None,
+            )
+            .await
+            .expect("tdk builds")
         }
-    }
 
-    #[tokio::test]
-    async fn invalid_verification_method_2() {
-        let proof = crate::DataIntegrityProof {
+        fn proof_with_vm(verification_method: &str) -> DataIntegrityProof {
+            DataIntegrityProof {
                 type_: "DataIntegrityProof".to_string(),
                 cryptosuite: CryptoSuite::EddsaJcs2022,
                 created: Some("2025-01-01T00:00:00Z".to_string()),
-                verification_method: "did:key:not_a_key".to_string(),
-                proof_purpose: "test".to_string(),
-                proof_value: Some("z2RPk8MWLoULfcbtpULoEsgfDsaAvyfD1PvQC2v3BjqqNtzGu8YJ4Nxq8CmJCZpPqA49uJhkxmxSztUQhBxqnVrYj".to_string()),
+                verification_method: verification_method.to_string(),
+                proof_purpose: "assertionMethod".to_string(),
+                proof_value: Some(
+                    "z2RPk8MWLoULfcbtpULoEsgfDsaAvyfD1PvQC2v3BjqqNtzGu8YJ4Nxq8CmJCZpPqA49uJhkxmxSztUQhBxqnVrYj"
+                        .to_string(),
+                ),
                 context: None,
-        };
-
-        let tdk = TDK::new(
-            TDKConfig::builder()
-                .with_load_environment(false)
-                .build()
-                .unwrap(),
-            None,
-        )
-        .await
-        .unwrap();
-        let result = tdk
-            .verify_data(&HashMap::<String, String>::new(), None, &proof)
-            .await;
-        assert!(result.is_err());
-        match result {
-            Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(txt))) => {
-                assert_eq!(
-                    txt,
-                    "Invalid proof:verificationMethod. Must be DID#key-id format".to_string()
-                );
             }
-            _ => panic!("Invalid return type"),
         }
-    }
 
-    #[tokio::test]
-    async fn invalid_verification_method_3() {
-        let proof = crate::DataIntegrityProof {
-                type_: "DataIntegrityProof".to_string(),
-                cryptosuite: CryptoSuite::EddsaJcs2022,
-                created: Some("2025-01-01T00:00:00Z".to_string()),
-                verification_method: "did:key:test#test".to_string(),
-                proof_purpose: "test".to_string(),
-                proof_value: Some("z2RPk8MWLoULfcbtpULoEsgfDsaAvyfD1PvQC2v3BjqqNtzGu8YJ4Nxq8CmJCZpPqA49uJhkxmxSztUQhBxqnVrYj".to_string()),
-                context: None,
-        };
-
-        let tdk = TDK::new(
-            TDKConfig::builder()
-                .with_load_environment(false)
-                .build()
-                .unwrap(),
-            None,
-        )
-        .await
-        .unwrap();
-        let result = tdk
-            .verify_data(&HashMap::<String, String>::new(), None, &proof)
-            .await;
-        assert!(result.is_err());
-        match result {
-            Err(TDKError::DIDResolver(txt)) => {
-                assert_eq!(
-                    txt,
-                    "DID error: Failed to parse DID: Invalid method-specific ID: invalid did:key encoding: Invalid multibase prefix: expected 'z' (base58btc), got 't'"
-                        .to_string()
-                );
+        #[tokio::test]
+        async fn verify_rejects_vm_without_fragment() {
+            let proof = proof_with_vm("test");
+            let result = tdk()
+                .await
+                .verify_data(&HashMap::<String, String>::new(), None, &proof)
+                .await;
+            match result {
+                Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(txt))) => {
+                    assert_eq!(
+                        txt,
+                        "Invalid proof:verificationMethod. Must be DID#key-id format"
+                    );
+                }
+                other => panic!("expected MalformedProof, got {other:?}"),
             }
-            _ => panic!("Invalid return type {result:#?}"),
+        }
+
+        #[tokio::test]
+        async fn verify_rejects_did_without_fragment_separator() {
+            let proof = proof_with_vm("did:key:not_a_key");
+            let result = tdk()
+                .await
+                .verify_data(&HashMap::<String, String>::new(), None, &proof)
+                .await;
+            match result {
+                Err(TDKError::DataIntegrity(DataIntegrityError::MalformedProof(txt))) => {
+                    assert_eq!(
+                        txt,
+                        "Invalid proof:verificationMethod. Must be DID#key-id format"
+                    );
+                }
+                other => panic!("expected MalformedProof, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn verify_propagates_resolver_error_on_invalid_did() {
+            let proof = proof_with_vm("did:key:test#test");
+            let result = tdk()
+                .await
+                .verify_data(&HashMap::<String, String>::new(), None, &proof)
+                .await;
+            assert!(
+                matches!(result, Err(TDKError::DIDResolver(_))),
+                "expected DIDResolver error, got {result:?}"
+            );
         }
     }
 }

--- a/crates/tdk/affinidi-tdk/src/secrets.rs
+++ b/crates/tdk/affinidi-tdk/src/secrets.rs
@@ -1,35 +1,49 @@
 /*!
-*   Common methods to save and load secrets
-*/
+ * Convenience wrappers for the OS keyring.
+ *
+ * Each method here builds a one-shot
+ * [`KeyringStore`] bound to the
+ * supplied `service_id` and forwards. For repeated operations on the same
+ * `service_id`, prefer constructing a `KeyringStore` once at the call site —
+ * this saves the per-call namespace binding and keeps the underlying
+ * `keyring-core` `Entry` lifetime explicit.
+ */
 
 use affinidi_secrets_resolver::secrets::Secret;
-use affinidi_tdk_common::errors::TDKError;
+use affinidi_tdk_common::{errors::TDKError, secrets::KeyringStore};
 
 use crate::TDK;
 
 impl TDK {
-    /// Deletes secret from keyring
-    /// service_id: unique identifier for the service
-    /// did: DID to delete all secrets for
-    pub fn delete_did_secret(self, service_id: &str, did: &str) -> Result<(), TDKError> {
-        affinidi_tdk_common::secrets::delete_did_secret(service_id, did)
+    /// Delete the keyring entry for `(service_id, did)`.
+    ///
+    /// Idempotent: a missing entry returns `Ok(())`. Other failures
+    /// (platform store unavailable, permission denied) propagate as
+    /// [`TDKError::Secrets`].
+    pub fn delete_did_secret(&self, service_id: &str, did: &str) -> Result<(), TDKError> {
+        KeyringStore::new(service_id).delete(did)
     }
 
-    /// Saves secrets for a DID to the keyring
-    /// service_id: unique identifier for the service
-    /// did: DID to save secrets for
+    /// Persist `secrets` to the OS keyring under `(service_id, did)`.
+    ///
+    /// Any existing entry for the same key is overwritten.
     pub fn save_secrets_locally(
-        self,
+        &self,
         service_id: &str,
         did: &str,
         secrets: &[Secret],
     ) -> Result<(), TDKError> {
-        affinidi_tdk_common::secrets::save_secrets_locally(service_id, did, secrets)
+        KeyringStore::new(service_id).save(did, secrets)
     }
 
-    /// Retrieves secrets for a DID from the keyring
-    /// auto loads secrets into the secrets resolver
+    /// Read secrets for `(service_id, did)` from the OS keyring and insert
+    /// them into the TDK's shared `SecretsResolver`.
+    ///
+    /// Auto-migrates legacy 0.5.x base64-wrapped entries on first read; see
+    /// [`KeyringStore::read`] for the storage format.
     pub async fn load_secrets(&self, service_id: &str, did: &str) -> Result<(), TDKError> {
-        self.inner.load_secrets(service_id, did).await
+        KeyringStore::new(service_id)
+            .load_into(did, self.inner.secrets_resolver())
+            .await
     }
 }


### PR DESCRIPTION
## Summary

Closes the version drift between local crates (which `main` has at
`affinidi-tdk-common 0.6.0`) and the two consumers that were still
pinned to `0.5` from crates.io. Cascades the SemVer-breaking bump
through every workspace member that re-exports tdk-common types.

- **`affinidi-tdk` 0.6.5 → 0.7.0** — refactored to delegate construction
  to `TDKSharedState::new`, rewires `secrets.rs` onto the new
  `KeyringStore`, simplifies `verify_data` control flow, adds
  `#![forbid(unsafe_code)]`, and introduces a per-crate `CHANGELOG.md`.
  `delete_did_secret` and `save_secrets_locally` now take `&self` (were
  consuming `self` for no reason).
- **`affinidi-meeting-place` 0.3.3 → 0.4.0** — full deep review.
  Drops a hardcoded dev API URL fallback, stops logging request
  bodies (offer phrases / mnemonics), maps 401 *and* 403 to
  `Authentication`, fixes a silent `u64 as i64` wrap on
  `valid_until` overflow, makes `MeetingPlaceError`
  `#[non_exhaustive]`, replaces a brittle `trim_start_matches('"')`
  with `Value::as_str()`, and adds 20 unit tests covering vcard
  serialisation, platform/contact-attribute parsing, valid-until
  encoding, mediator-endpoint splitting, and OOB-message base64
  round-trip.
- **Cascade bumps (mechanical only)** — `affinidi-messaging-sdk`
  0.16.4 → 0.17.0, `affinidi-messaging-didcomm-service` 0.2.2 → 0.3.0,
  with corresponding `version = "X.Y"` pin bumps in the mediator,
  mediator-common, helpers, text-client, and tdk umbrella. Source
  changes are limited to the smallest diff that compiles against
  tdk-common 0.6 — accessor methods replacing field access,
  `TDKEnvironment::default()` + setters replacing struct literals,
  `TDKProfile::new` replacing literals, `TDKSharedState::new` (with
  `with_load_environment(false)` / `with_use_atm(false)` for tests)
  replacing the removed `TDKSharedState::default()`. The deeper
  review of these crates is intentionally deferred to a follow-up.
- **Docs / changelogs** — new CHANGELOG entries for `affinidi-tdk`
  (file created), `affinidi-meeting-place`, `affinidi-messaging-sdk`,
  `affinidi-messaging-didcomm-service`. README install snippets
  bumped to the new pinned majors.
- **CI fixes** — workspace-wide clippy (`unused_mut` in 5 helper
  examples + needless-borrow ×2 in text-client) and audit ignore-list
  extension for `RUSTSEC-2026-0104` (rustls-webpki, transitive via
  AWS SDK chain — same family as already-ignored `0098` / `0099`).

## Commits

1. `chore: cascade version bumps for tdk-common 0.6` — Cargo.toml only (8 files)
2. `refactor: migrate affinidi-tdk to tdk-common 0.6 and tighten internals`
3. `refactor: migrate meeting-place to tdk-common 0.6, security + idiom pass`
4. `refactor: mechanical migration of messaging crates to tdk-common 0.6`
5. `fix: workspace-wide clippy + extend audit ignore list`
6. `docs: add changelog entries and bump README install snippets`

All commits DCO-signed.

## Dependency audit

Every internal and external dep pin in the modified Cargo.tomls is
already at the latest published `major.minor` on crates.io. Nothing
else to bump.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test -p affinidi-tdk -p affinidi-meeting-place` (25 passing, including the new vcard / offers / lib tests)
- [x] `cargo test --workspace` (all crates passing — confirmed locally **and** in CI on the `chore/...` branch)
- [x] `cargo doc --no-deps -p affinidi-tdk -p affinidi-meeting-place` (clean)
- [x] `cargo check --workspace --all-targets` (clean)
- [x] CI: clippy / test / audit / cargo-deny / coverage / rust-scan / fmt / check / deprecation-check / snyk all green
- [ ] Reviewer to spot-check that the `affinidi-messaging-sdk` accessor migration didn't change runtime semantics on the websocket / fetch / pack paths
- [ ] Manual smoke test of `meeting_place` example end-to-end against a live Meeting Place service (offered phrase / register / query / deregister)

## CI status (known non-blockers)

Two checks remain failed and are **not** introduced by this PR:

- **`verify-publish`** — `cargo publish --dry-run` can't resolve
  `affinidi-meeting-place ^0.4` / `affinidi-messaging-sdk ^0.17` from
  crates.io because they will only exist after the merge commit
  publishes them. Same chicken-and-egg as PR #296 (`affinidi-data-integrity`
  0.5→0.6) which was merged in this state.
- **`wiz-scan`** — org-wide infra/security scanner that was failing
  before this PR's first push and remains failing on identical
  content; the diff doesn't touch anything wiz-cli scans.

## Notes

- `vta-sdk` (external) still pulls `affinidi-tdk@0.6.5` →
  `affinidi-tdk-common@0.5.2` from crates.io as a transitive
  dependency of the mediator. Both `0.5.2` and `0.6.0` are present
  in `Cargo.lock` (already true on `main`) but no workspace code
  crosses that boundary, so it's not a compilation hazard.
- Per-crate global rule: `cargo fmt` was run; commits are DCO-signed (`-s`).