### PR TITLE
Remove redundant mediator Cargo config

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/.cargo/config.toml
+++ b/crates/messaging/affinidi-messaging-mediator/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tracing_unstable"] # needed for object logging


### PR DESCRIPTION
Drop `crates/messaging/affinidi-messaging-mediator/.cargo/config.toml` since the same `--cfg tracing_unstable` rustflag is already set in the workspace root `.cargo/config.toml`. This centralizes build flags and prevents config drift.