### PR TITLE
chore: mediator 0.14.1 — drop --cfg tracing_unstable requirement

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tracing_unstable"] # needed for object logging

--- a/crates/messaging/affinidi-messaging-mediator/.cargo/config.toml
+++ b/crates/messaging/affinidi-messaging-mediator/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tracing_unstable"] # needed for object logging

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Changelog history
 
+## 5th May 2026
+
+### 0.14.1 — Drop `--cfg tracing_unstable` requirement
+
+The statistics task previously logged its `tags` HashMap as a
+`valuable::Valuable` field, which required the unstable `valuable`
+support in `tracing-core` and forced every consumer to set
+`rustflags = ["--cfg", "tracing_unstable"]` in their own
+`.cargo/config.toml`. Now the tags are logged via standard `Debug`
+formatting (`?tags`), so the cfg flag is no longer needed.
+
+- Removed `valuable` features from the `tracing` and
+  `tracing-subscriber` dependencies.
+- Removed the workspace and crate-level `.cargo/config.toml` files
+  that set `--cfg tracing_unstable`.
+- External consumers of the mediator crate can drop the same
+  `.cargo/config.toml` from their own repositories.
+
+The user-facing log shape is unchanged in spirit; tags now render
+as Debug output instead of a structured object. Operators relying
+on machine-parseable tag fields in JSON logs should switch to
+including the relevant tag values as individual `info!` fields if
+they need typed access — none of the affinidi-* deployments did so
+when this change landed.
+
 ## 24th April 2026
 
 ### 0.14.0 — Setup Wizard, Monitoring, Unified Secret Backend

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.14.0"
+version = "0.14.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -146,8 +146,8 @@ futures-util = "0.3"
 ## Prometheus metrics via /metrics endpoint
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
-tracing = { version = "0.1", features = ["valuable"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json", "valuable"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 # ── Rate Limiting & Resilience ───────────────────────────────────────────
 ## Per-IP and per-DID rate limiting (in-memory, not distributed)

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -5,7 +5,6 @@ use affinidi_messaging_mediator_common::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::field::valuable;
 use tracing::{Instrument, Level, debug, info, span};
 
 /// Periodically logs statistics about the database.
@@ -28,7 +27,7 @@ pub async fn statistics(
             let delta = stats.delta(&previous_stats);
             info!(
                 event_type = "UpdateStats",
-                tags = valuable(&tags),
+                ?tags,
                 received_bytes = stats.received_bytes,
                 sent_bytes = stats.sent_bytes,
                 deleted_bytes = stats.deleted_bytes,
@@ -45,7 +44,7 @@ pub async fn statistics(
 
             info!(
                 event_type = "UpdateDeltaStats",
-                tags = valuable(&tags),
+                ?tags,
                 received_bytes = delta.received_bytes,
                 sent_bytes = delta.sent_bytes,
                 deleted_bytes = delta.deleted_bytes,


### PR DESCRIPTION
## Summary

- Replace `tracing::field::valuable(&tags)` with the standard `?tags` Debug formatter in `tasks::statistics` — the only `valuable()` call in the workspace.
- Drop the `valuable` feature from `tracing` and `tracing-subscriber` deps.
- Delete both `.cargo/config.toml` files (workspace + mediator crate) that set `rustflags = ["--cfg", "tracing_unstable"]`.
- Bump `affinidi-messaging-mediator` to **0.14.1** (additive, non-breaking).

## Why

Until now, every external crate depending on `affinidi-messaging-mediator` had to mirror this in their own `.cargo/config.toml`:

```toml
[build]
rustflags = ["--cfg", "tracing_unstable"]
```

Without it, the mediator failed to compile on the consumer side with a confusing error pointing into `tracing-core`. `.cargo/config.toml` is repo-scoped and easy to lose to gitignore patterns, so this was a recurring sharp edge for downstream consumers (e.g. the OpenVTC `verifiable-trust-infrastructure` repo).

The `valuable` field rendered the `tags` HashMap as a structured object in subscribers that supported it; with `?tags` it renders as Debug output (`{"key": "value"}`-style). Operators who need machine-parseable tag access should pull tag values into individual `info!` fields.

## Release order

This PR ships mediator **0.14.1**. Once merged and published to crates.io, the companion PR (test-mediator publish prep, #TBD) can land cleanly.

## Test plan

- [x] `cargo build --workspace` clean (no rustflags)
- [x] `cargo test -p affinidi-messaging-mediator` — 47 unit tests pass
- [x] `cargo fmt --check`
- [x] `cargo publish --dry-run -p affinidi-messaging-mediator` — verifies clean against crates.io