### PR TITLE
feat: publish affinidi-messaging-test-mediator + local_dids setter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ affinidi-encoding = { path = "crates/core/affinidi-encoding" }
 affinidi-data-integrity = { path = "crates/credentials/affinidi-data-integrity" }
 affinidi-messaging-didcomm = { path = "crates/messaging/affinidi-messaging-didcomm" }
 affinidi-messaging-sdk = { path = "crates/messaging/affinidi-messaging-sdk" }
+affinidi-messaging-mediator = { path = "crates/messaging/affinidi-messaging-mediator" }
+affinidi-messaging-mediator-common = { path = "crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
+affinidi-messaging-test-mediator = { path = "crates/messaging/affinidi-messaging-test-mediator" }
 affinidi-did-authentication = { path = "crates/identity/affinidi-did-authentication" }
 affinidi-tdk-common = { path = "crates/tdk/affinidi-tdk-common" }
 affinidi-tdk = { path = "crates/tdk/affinidi-tdk" }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Secure, private messaging built on [DIDComm v2](https://identity.foundation/didc
 | [`affinidi-messaging-didcomm`](./crates/affinidi-messaging/affinidi-messaging-didcomm/) | DIDComm v2.1 protocol implementation for Rust |
 | [`affinidi-messaging-core`](./crates/affinidi-messaging/affinidi-messaging-core/) | Protocol-agnostic messaging traits |
 | [`affinidi-messaging-mediator`](./crates/affinidi-messaging/affinidi-messaging-mediator/) | Mediator & relay service (DIDComm and TSP via feature flags) |
+| [`affinidi-messaging-test-mediator`](./crates/affinidi-messaging/affinidi-messaging-test-mediator/) | Embedded mediator fixture for integration tests |
 | [`affinidi-messaging-helpers`](./crates/affinidi-messaging/affinidi-messaging-helpers/) | Setup tools, environment config, and examples |
 | [`affinidi-messaging-text-client`](./crates/affinidi-messaging/affinidi-messaging-text-client/) | Terminal-based DIDComm chat client |
 
@@ -191,6 +192,80 @@ let config = Config::builder()
     .build()?;
 let mut atm = ATM::new(config, vec![]).await?;
 atm.send_ping("did:peer:2...", true, true).await?;
+```
+
+## Using affinidi-* crates from outside this workspace
+
+This workspace's root `Cargo.toml` defines a non-trivial
+[`[patch.crates-io]` table](./Cargo.toml#L85). Cargo's patch tables
+are only honoured by the workspace that *defines* them — when an
+external repository depends on any affinidi-* crate via a git rev or
+local path, that consumer must replicate the same patch table
+verbatim, or different parts of the dependency closure will end up
+resolving the affinidi-* crates from a mix of crates.io and the
+git/path source. Type-graph divergence shows up as confusing trait
+mismatches at compile time (`expected MediatorACLSet, found
+MediatorACLSet`).
+
+This is a known cargo limitation — see
+[rust-lang/cargo#4452](https://github.com/rust-lang/cargo/issues/4452).
+
+### Recommended path: depend on crates.io releases
+
+The simplest approach is to depend on published versions only:
+
+```toml
+[dependencies]
+affinidi-tdk = "0.7"
+affinidi-messaging-sdk = "0.17"
+
+[dev-dependencies]
+affinidi-messaging-test-mediator = "0.1"
+```
+
+No patch table is needed — cargo resolves a single version of each
+affinidi-* crate from crates.io and the type graph is unified by
+construction.
+
+### When you must use a git rev (unreleased fixes)
+
+If you need a patch that hasn't reached crates.io yet, pin the
+relevant affinidi-* crates to the same git rev, *and* mirror the
+workspace's patch table so transitive deps go through the same rev:
+
+```toml
+[patch.crates-io]
+# Pick a single rev that all affinidi-* deps resolve through.
+# Bump this when you bump any affinidi-* dep above.
+affinidi-secrets-resolver = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-did-resolver-cache-sdk = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-did-common = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-crypto = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-encoding = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-data-integrity = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-messaging-didcomm = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-messaging-sdk = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-messaging-mediator = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-messaging-mediator-common = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-did-authentication = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-tdk-common = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-tdk = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-meeting-place = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-tsp = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+affinidi-did-web = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+did-scid = { git = "https://github.com/affinidi/affinidi-tdk-rs", rev = "<rev>" }
+```
+
+The rev must match — and stay matched — to the version constraints
+in your own `[dependencies]`. If you bump `affinidi-tdk` above, bump
+the rev too; otherwise cargo may fall back to crates.io for crates
+not in the patch table.
+
+A regenerator helper is provided to emit the patch block for a
+specific commit on this repo:
+
+```bash
+./tools/generate-consumer-patch.sh <git-rev>
 ```
 
 ## Support & Feedback

--- a/crates/messaging/README.md
+++ b/crates/messaging/README.md
@@ -37,6 +37,7 @@ mediator routes and stores messages but **cannot** read their content.
 | [`affinidi-messaging-mediator`](./affinidi-messaging-mediator/) | Mediator & relay service (DIDComm and TSP support via feature flags) |
 | [`affinidi-messaging-didcomm-service`](./affinidi-messaging-didcomm-service/) | Framework for building always-online DIDComm services with mediator connectivity, message routing, middleware, and handler dispatch |
 | [`affinidi-messaging-helpers`](./affinidi-messaging-helpers/) | Setup tools, environment config, and example runners |
+| [`affinidi-messaging-test-mediator`](./affinidi-messaging-test-mediator/) | Embedded mediator fixture for integration tests against the mediator |
 | [`affinidi-tsp`](./affinidi-tsp/) | Trust Spanning Protocol implementation (HPKE-Auth, CESR) |
 | [`affinidi-messaging-text-client`](./affinidi-messaging-text-client/) | Terminal-based DIDComm chat client |
 

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-test-mediator"
 version = "0.1.0"
-description = "Embedded mediator fixture for integration tests"
+description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
@@ -9,8 +9,8 @@ keywords.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
-# Internal-only test fixture; do not publish to crates.io.
-publish = false
+readme = "README.md"
+publish = true
 
 [features]
 default = []
@@ -22,8 +22,13 @@ fjall-backend = ["affinidi-messaging-mediator/fjall-backend", "dep:tempfile"]
 
 [dependencies]
 # ── Mediator: the thing we're spawning ───────────────────────────────────
-affinidi-messaging-mediator = { path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
-affinidi-messaging-mediator-common = { path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
+##
+## Sister-crate path deps carry an explicit `version =` so the package
+## is publishable to crates.io while still using the in-tree path for
+## workspace dev-builds. Pins follow the workspace's caret-pin policy
+## (major.minor only) so transitive patch fixes resolve automatically.
+affinidi-messaging-mediator = { version = "0.14", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator-common = { version = "0.13", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
 
 # ── Optional: Fjall on-disk backend support (gated on `fjall-backend`) ──
 ## Wraps each FjallStore in a temp directory that's cleaned up when the
@@ -32,16 +37,22 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
-affinidi-secrets-resolver = { path = "../../core/affinidi-secrets-resolver" }
-affinidi-did-resolver-cache-sdk = { path = "../../identity/affinidi-did-resolver-cache-sdk" }
+affinidi-tdk = { version = "0.7", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
+affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.17", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 ring = { version = "0.17", features = ["std"] }
+
+# ── rustls: needed to install a `CryptoProvider` at fixture startup so
+##     downstream test code that mixes provider features doesn't panic
+##     on the first WS handshake. Tracks the mediator's pinned version
+##     so the provider type matches across the workspace.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "tls12"] }
 
 # ── Async + lifecycle ───────────────────────────────────────────────────
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }
@@ -53,6 +64,9 @@ thiserror = "2"
 tracing = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
+## Used to hash DIDs into their canonical account-store key shape when
+## pre-registering local DIDs at startup.
+sha256 = "1"
 
 [dev-dependencies]
 ## Used by integration tests to hit the mediator's HTTP endpoints

--- a/crates/messaging/affinidi-messaging-test-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/README.md
@@ -1,0 +1,135 @@
+# affinidi-messaging-test-mediator
+
+[![Crates.io](https://img.shields.io/crates/v/affinidi-messaging-test-mediator.svg)](https://crates.io/crates/affinidi-messaging-test-mediator)
+[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://github.com/affinidi/affinidi-tdk-rs/blob/main/LICENSE)
+
+Embedded mediator fixture for integration tests against
+[`affinidi-messaging-mediator`]. Spins up a fully-functional mediator
+on `127.0.0.1:0` (ephemeral port) with a freshly-generated `did:peer`
+identity, a random JWT signing key, and the caller's choice of
+storage backend — `MemoryStore` by default, optional `FjallStore` for
+on-disk persistence semantics.
+
+## When to use
+
+Anywhere you need an in-process mediator for tests:
+- SDK round-trip tests that exercise the full DIDComm v2.1 pickup,
+  routing, and trust-ping flows.
+- Auth flow tests (challenge/response, JWT, WebSocket upgrade).
+- Multi-mediator forwarding scenarios (run two test mediators in
+  the same process and route a message through both).
+- ACL coverage for the mediator's own access-list logic.
+
+## Quick start
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+affinidi-messaging-test-mediator = "0.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+```rust,ignore
+use affinidi_messaging_test_mediator::TestMediator;
+
+#[tokio::test]
+async fn end_to_end_round_trip() {
+    let mediator = TestMediator::spawn()
+        .await
+        .expect("test mediator spawn");
+
+    let endpoint = mediator.endpoint();
+    let did = mediator.did();
+    // ... use SDK against `endpoint` and `did` ...
+
+    mediator.shutdown();
+    mediator.join().await.unwrap();
+}
+```
+
+For the full e2e flow with an SDK client and named users, use
+[`TestEnvironment`]:
+
+```rust,ignore
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+#[tokio::test]
+async fn alice_sends_to_bob() {
+    let env = TestEnvironment::spawn().await.unwrap();
+    let alice = env.add_user("Alice").await.unwrap();
+    let bob = env.add_user("Bob").await.unwrap();
+
+    // Exercise the SDK against `env.atm`, `alice.profile`, `bob.profile` ...
+
+    env.shutdown().await.unwrap();
+}
+```
+
+## Authenticating non-admin DIDs over WebSocket
+
+The mediator's WebSocket handler refuses upgrades unless the
+authenticated session has the `LOCAL` ACL bit set. By default, a DID
+that authenticates fresh against the test mediator is auto-registered
+with `global_acl_default` — which has `local = false` for the test
+fixture. Tests that open a WS connection from a non-admin DID need to
+register the DID at startup:
+
+```rust,ignore
+let mediator = TestMediator::builder()
+    .local_did(client_did.clone())
+    .spawn()
+    .await
+    .expect("spawn");
+```
+
+Then the SDK's `profile_add(_, /* live_stream */ true)` flow completes
+the JWT handshake and opens the WebSocket without hitting the 403.
+
+## Crypto provider
+
+The fixture installs rustls' `aws_lc_rs` `CryptoProvider` as the
+process-wide default during `spawn`. This avoids the dual-provider
+panic that bites consumers who depend on both this crate (built
+against `aws_lc_rs`) and another crate that activates the
+`rust_crypto` rustls provider. The install is idempotent — call
+[`install_default_crypto_provider`] yourself if you need it before
+the first `spawn`.
+
+If your test crate transitively pulls in conflicting providers, run
+`cargo tree -e features` and pin to `aws_lc_rs` everywhere — the
+mediator (and therefore this fixture) is not built or tested against
+`rust_crypto`.
+
+## Storage backends
+
+`MemoryStore` is the default — fastest, no I/O, automatic cleanup.
+Pass a custom store via [`TestMediatorBuilder::store`] for tests
+that need different semantics:
+
+- **Fjall** (on-disk LSM) — compile with the `fjall-backend` feature
+  and call [`TestMediatorBuilder::fjall_backend`]. The fixture
+  manages a temp directory whose lifetime is tied to the handle, so
+  no partition files leak.
+- **Redis** — supply an `Arc<RedisStore>` via `store(...)`. Useful
+  for tests that exercise multi-mediator coordination, but requires
+  a reachable Redis instance.
+
+## Cross-workspace consumption
+
+When using this crate from outside the `affinidi-tdk-rs` workspace
+(via crates.io or git pin), be aware of the
+[`[patch.crates-io]` gotcha](../README.md#using-affinidi--crates-from-outside-this-workspace)
+documented in the workspace README. In short: consumers using *any*
+affinidi-* crate via git/path need to mirror the workspace's patch
+table so the type graph stays unified across the dependency closure.
+The crates.io build is self-consistent and needs no patches.
+
+## License
+
+[Apache-2.0](https://github.com/affinidi/affinidi-tdk-rs/blob/main/LICENSE)
+
+[`affinidi-messaging-mediator`]: https://crates.io/crates/affinidi-messaging-mediator
+[`TestMediatorBuilder::store`]: https://docs.rs/affinidi-messaging-test-mediator/latest/affinidi_messaging_test_mediator/struct.TestMediatorBuilder.html#method.store
+[`TestMediatorBuilder::fjall_backend`]: https://docs.rs/affinidi-messaging-test-mediator/latest/affinidi_messaging_test_mediator/struct.TestMediatorBuilder.html#method.fjall_backend
+[`TestEnvironment`]: https://docs.rs/affinidi-messaging-test-mediator/latest/affinidi_messaging_test_mediator/struct.TestEnvironment.html
+[`install_default_crypto_provider`]: https://docs.rs/affinidi-messaging-test-mediator/latest/affinidi_messaging_test_mediator/fn.install_default_crypto_provider.html

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -78,12 +78,14 @@ use affinidi_messaging_mediator_common::{
     MediatorSecrets, errors::MediatorError, secrets::backends::MemoryStore as SecretsMemoryStore,
     store::MediatorStore,
 };
+use affinidi_messaging_sdk::protocols::mediator::acls::MediatorACLSet;
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
 use affinidi_tdk::dids::{
     DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
 };
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use ring::{rand::SystemRandom, signature::Ed25519KeyPair, signature::KeyPair};
+use sha256::digest;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -141,6 +143,11 @@ pub struct TestMediatorBuilder {
     enable_forwarding: bool,
     enable_message_expiry: bool,
     enable_streaming: bool,
+    /// Additional DIDs to register as LOCAL accounts at startup. Tests
+    /// that authenticate over WebSocket must include their client DID
+    /// here — the WS upgrade handler refuses connections from sessions
+    /// without the LOCAL ACL bit set.
+    local_dids: Vec<String>,
     /// Temp directory backing a Fjall store, kept alive for the lifetime
     /// of the resulting handle so the partition files don't get cleaned
     /// up while the mediator is still using them.
@@ -156,6 +163,7 @@ impl Default for TestMediatorBuilder {
             enable_forwarding: false,
             enable_message_expiry: false,
             enable_streaming: true,
+            local_dids: Vec::new(),
             #[cfg(feature = "fjall-backend")]
             fjall_dir: None,
         }
@@ -206,6 +214,36 @@ impl TestMediatorBuilder {
         self
     }
 
+    /// Register `did` as a LOCAL account on the mediator at startup.
+    ///
+    /// The mediator's WebSocket handler refuses upgrades unless the
+    /// authenticated session has the LOCAL ACL bit. By default, a DID
+    /// that authenticates against the test mediator is auto-registered
+    /// with `global_acl_default` — which has `local = false` for the
+    /// test fixture. Tests that need to open a WS connection from a
+    /// non-admin DID must register that DID here so it lands in the
+    /// account store with the LOCAL bit set.
+    ///
+    /// Repeated calls accumulate. The DID is stored as the raw
+    /// `did:`-shaped string; the SHA-256 hash used by the account
+    /// store is computed at spawn time.
+    pub fn local_did(mut self, did: impl Into<String>) -> Self {
+        self.local_dids.push(did.into());
+        self
+    }
+
+    /// Register multiple DIDs as LOCAL accounts. See [`local_did`].
+    ///
+    /// [`local_did`]: Self::local_did
+    pub fn local_dids<I, S>(mut self, dids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.local_dids.extend(dids.into_iter().map(Into::into));
+        self
+    }
+
     /// Run this test mediator against an on-disk Fjall backend instead
     /// of the default in-memory store. The data lives in a temporary
     /// directory tied to the resulting handle — when the handle drops,
@@ -230,6 +268,14 @@ impl TestMediatorBuilder {
     /// Spawn the mediator and wait until it's listening. Returns the
     /// handle once the listener is bound and ready.
     pub async fn spawn(self) -> Result<TestMediatorHandle, TestMediatorError> {
+        // Pick the rustls + jsonwebtoken default `CryptoProvider`s
+        // before any handshake has a chance to run. When a downstream
+        // test crate transitively activates the `rust_crypto` feature
+        // alongside the mediator's `aws_lc_rs`, rustls refuses to pick
+        // a default and panics on first use; installing here is
+        // idempotent and removes that boilerplate from consumers.
+        install_default_crypto_provider();
+
         let bound_addr = bind_ephemeral_listener(self.listen_addr)?;
         let api_prefix = "/mediator/v1/".to_string();
         let service_uri = format!("http://{bound_addr}{api_prefix}");
@@ -262,6 +308,9 @@ impl TestMediatorBuilder {
         // shared or persistent backend pass their own via `store()`.
         let store: Arc<dyn MediatorStore> =
             self.store.unwrap_or_else(|| Arc::new(MemoryStore::new()));
+        // Hold a clone so we can register pre-declared local DIDs after
+        // the mediator has finished initialising the store.
+        let store_for_local_accounts = store.clone();
 
         let token = CancellationToken::new();
         let inner = MediatorBuilder::new(secrets_resolver.clone())
@@ -278,6 +327,12 @@ impl TestMediatorBuilder {
             .tls(TlsMode::Plain)
             .start(token.clone())
             .await?;
+
+        // Register caller-supplied DIDs as LOCAL accounts so they can
+        // complete the WebSocket upgrade after authenticating. The
+        // store is initialised by `MediatorBuilder::start` above, so
+        // `account_add` is safe to call here regardless of backend.
+        register_local_dids(&store_for_local_accounts, &self.local_dids).await?;
 
         Ok(TestMediatorHandle {
             inner,
@@ -372,6 +427,28 @@ impl std::fmt::Debug for TestMediatorHandle {
     }
 }
 
+// ─── Crypto provider bootstrap ───────────────────────────────────────────────
+
+/// Install rustls' `aws_lc_rs` provider as the process-wide default,
+/// idempotently. Safe to call multiple times — once a default is
+/// registered, subsequent calls are no-ops.
+///
+/// Test crates that depend on both this fixture (which builds against
+/// `aws_lc_rs`) and another crate that activates the `rust_crypto`
+/// rustls provider end up with two providers in the feature graph and
+/// no automatic default; rustls panics on the first handshake. Calling
+/// this once at process start (or letting `TestMediator::spawn` call
+/// it for you) resolves the ambiguity.
+///
+/// Also installs jsonwebtoken's `aws_lc_rs` provider for the same
+/// reason. Errors from already-installed providers are ignored.
+pub fn install_default_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+    let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+}
+
 // ─── Internals ───────────────────────────────────────────────────────────────
 
 /// Bind an ephemeral listener, capture the address, then drop it so
@@ -458,6 +535,39 @@ async fn generate_mediator_identity(
     // we'd have to track and join — overkill for a test fixture.
 
     Ok((did, secrets, Arc::new(resolver)))
+}
+
+/// Insert each DID into the mediator's account store as a LOCAL,
+/// non-admin account. Idempotent — a DID that already has an account
+/// record is left untouched, matching the auto-registration path used
+/// by the JWT challenge handler.
+///
+/// Uses the `ALLOW_ALL` ruleset so the registered DID can fully
+/// exercise the mediator (send / receive / forward / WS upgrade)
+/// without being granted admin role. Tests that want stricter ACLs
+/// can register the DID directly via the underlying store.
+async fn register_local_dids(
+    store: &Arc<dyn MediatorStore>,
+    dids: &[String],
+) -> Result<(), TestMediatorError> {
+    if dids.is_empty() {
+        return Ok(());
+    }
+    let acls = MediatorACLSet::from_string_ruleset("ALLOW_ALL").map_err(|e| {
+        TestMediatorError::Mediator(MediatorError::ConfigError(
+            12,
+            "test-mediator".into(),
+            format!("failed to build ALLOW_ALL ACL set: {e}"),
+        ))
+    })?;
+    for did in dids {
+        let did_hash = digest(did);
+        if store.account_exists(&did_hash).await? {
+            continue;
+        }
+        store.account_add(&did_hash, &acls, None).await?;
+    }
+    Ok(())
 }
 
 /// Generate a fresh Ed25519 keypair for JWT signing. Mirrors the

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -14,9 +14,7 @@
 //!
 //! #[tokio::test]
 //! async fn end_to_end_round_trip() {
-//!     let mediator = TestMediator::builder()
-//!         .redis_url("redis://localhost:6379")
-//!         .spawn()
+//!     let mediator = TestMediator::spawn()
 //!         .await
 //!         .expect("test mediator spawn");
 //!
@@ -28,6 +26,21 @@
 //!     mediator.join().await.unwrap();
 //! }
 //! ```
+//!
+//! Tests that authenticate a non-admin client over WebSocket must
+//! pre-register the client's DID — the WS handler refuses upgrades
+//! without the LOCAL ACL bit, and the fixture's default
+//! `global_acl_default` doesn't grant it on first auth:
+//!
+//! ```ignore
+//! let mediator = TestMediator::builder()
+//!     .local_did(client_did.clone())
+//!     .spawn()
+//!     .await
+//!     .expect("spawn");
+//! ```
+//!
+//! See [`TestMediatorBuilder::local_did`] / [`TestMediatorBuilder::local_dids`].
 //!
 //! # Storage backends
 //!

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/local_did_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/local_did_websocket.rs
@@ -1,0 +1,101 @@
+//! Verifies that DIDs registered via
+//! [`TestMediatorBuilder::local_did`] / [`local_dids`] can complete
+//! the WebSocket authentication handshake.
+//!
+//! The mediator's WS handler refuses upgrades unless the authenticated
+//! session has the LOCAL ACL bit set. The default `global_acl_default`
+//! used by the test fixture has `local = false`, so a DID that
+//! authenticates fresh against the mediator gets registered as a
+//! non-local account and cannot upgrade. This test demonstrates the
+//! escape hatch — pre-register the DID as LOCAL and the upgrade
+//! succeeds end-to-end.
+
+mod common;
+
+use affinidi_messaging_sdk::profiles::ATMProfile;
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator};
+use affinidi_secrets_resolver::SecretsResolver;
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use common::{init_tracing, skip_if_no_redis};
+
+#[tokio::test]
+async fn local_did_completes_websocket_authentication() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    // Generate the user DID up front so we can pre-register it as a
+    // LOCAL account at mediator startup. The DID needs no service
+    // endpoint — the SDK uses the mediator's DID document for routing,
+    // not the user's.
+    let (user_did, user_secrets) = DID::generate_did_peer(
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ],
+        None,
+    )
+    .expect("generate user DID");
+
+    let mediator = TestMediator::builder()
+        .local_did(user_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire test environment");
+
+    // The user's secrets must be available to the SDK's resolver so it
+    // can sign the auth response and decrypt mediator-bound traffic.
+    env.tdk.secrets_resolver().insert_vec(&user_secrets).await;
+
+    let profile = ATMProfile::new(
+        &env.atm,
+        Some("LocalUser".to_string()),
+        user_did.clone(),
+        Some(env.mediator.did().to_string()),
+    )
+    .await
+    .expect("create profile");
+
+    // `profile_add(_, true)` does the JWT auth + WS upgrade. If the
+    // pre-registered LOCAL ACL bit weren't honoured, the upgrade would
+    // fail with HTTP 403 and bubble up as a transport error.
+    let added = env
+        .atm
+        .profile_add(&profile, true)
+        .await
+        .expect("profile_add with live_stream must succeed for a LOCAL DID");
+
+    let (profile_did, mediator_did) = added.dids().expect("profile has mediator");
+    assert_eq!(profile_did, user_did);
+    assert_eq!(mediator_did, env.mediator.did());
+
+    env.shutdown().await.expect("env shutdown");
+}
+
+#[tokio::test]
+async fn local_dids_setter_accepts_iterable() {
+    // Just exercise the IntoIterator setter — registration is
+    // covered by the round-trip test above.
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let dids = vec![
+        "did:key:z6MkExample1".to_string(),
+        "did:key:z6MkExample2".to_string(),
+    ];
+    let mediator = TestMediator::builder()
+        .local_dids(dids)
+        .spawn()
+        .await
+        .expect("spawn with iterable local_dids");
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/local_did_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/local_did_websocket.rs
@@ -78,24 +78,56 @@ async fn local_did_completes_websocket_authentication() {
 }
 
 #[tokio::test]
-async fn local_dids_setter_accepts_iterable() {
-    // Just exercise the IntoIterator setter — registration is
-    // covered by the round-trip test above.
+async fn local_dids_setter_registers_each_did() {
+    // Verify the IntoIterator setter actually registers every DID it
+    // receives (not just the first). Each DID independently completes
+    // the JWT auth + WS upgrade through its own SDK profile — if any
+    // one weren't registered as LOCAL, its `profile_add(_, true)`
+    // would surface the 403 as a transport error.
     init_tracing();
     if skip_if_no_redis() {
         return;
     }
 
-    let dids = vec![
-        "did:key:z6MkExample1".to_string(),
-        "did:key:z6MkExample2".to_string(),
-    ];
+    let users: Vec<_> = (0..3)
+        .map(|i| {
+            let (did, secrets) = DID::generate_did_peer(
+                vec![
+                    (PeerKeyRole::Verification, KeyType::Ed25519),
+                    (PeerKeyRole::Encryption, KeyType::X25519),
+                ],
+                None,
+            )
+            .expect("generate user DID");
+            (format!("User{i}"), did, secrets)
+        })
+        .collect();
+
     let mediator = TestMediator::builder()
-        .local_dids(dids)
+        .local_dids(users.iter().map(|(_, did, _)| did.clone()))
         .spawn()
         .await
         .expect("spawn with iterable local_dids");
 
-    mediator.shutdown();
-    let _ = mediator.join().await;
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire test environment");
+
+    for (alias, did, secrets) in &users {
+        env.tdk.secrets_resolver().insert_vec(secrets).await;
+        let profile = ATMProfile::new(
+            &env.atm,
+            Some(alias.clone()),
+            did.clone(),
+            Some(env.mediator.did().to_string()),
+        )
+        .await
+        .expect("create profile");
+        env.atm
+            .profile_add(&profile, true)
+            .await
+            .unwrap_or_else(|err| panic!("profile_add for {alias} failed: {err:?}"));
+    }
+
+    env.shutdown().await.expect("env shutdown");
 }

--- a/tools/generate-consumer-patch.sh
+++ b/tools/generate-consumer-patch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Emit a `[patch.crates-io]` block that downstream consumers can drop
+# into their own Cargo.toml when depending on affinidi-* crates via
+# a git rev pin instead of crates.io.
+#
+# Usage:
+#     tools/generate-consumer-patch.sh [<git-rev>]
+#
+# `<git-rev>` defaults to the current HEAD commit. Pass a tag, branch,
+# or full SHA to lock to a specific point in history.
+#
+# The list of crates to emit is read from this workspace's own
+# [patch.crates-io] table — keeping the two in sync. If you add a new
+# affinidi-* crate to the workspace patch table, this script picks it
+# up automatically.
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+rev="${1:-$(git rev-parse HEAD)}"
+url="https://github.com/affinidi/affinidi-tdk-rs"
+
+# Extract the bare crate names from the workspace's [patch.crates-io]
+# block so we don't drift from the canonical list. Uses awk so the
+# script runs on macOS's default bash 3.x (no `mapfile`).
+crates=$(
+    awk '
+        /^\[patch\.crates-io\]/ { in_block = 1; next }
+        /^\[/                   { in_block = 0 }
+        in_block && /^[a-zA-Z0-9_-]+[[:space:]]*=/ { print $1 }
+    ' Cargo.toml
+)
+
+if [[ -z "$crates" ]]; then
+    echo "error: no [patch.crates-io] entries found in Cargo.toml" >&2
+    exit 1
+fi
+
+cat <<EOF
+# Mirror of affinidi-tdk-rs's [patch.crates-io] table at rev ${rev}.
+# Keep this rev in sync with whichever affinidi-* version constraints
+# your own [dependencies] resolves to — when you bump one, bump the
+# rev to match.
+[patch.crates-io]
+EOF
+while IFS= read -r crate; do
+    [[ -z "$crate" ]] && continue
+    printf '%s = { git = "%s", rev = "%s" }\n' "$crate" "$url" "$rev"
+done <<< "$crates"


### PR DESCRIPTION
## Summary

Makes `affinidi-messaging-test-mediator` consumable as a plain crates.io dev-dependency, and adds the API surface external test harnesses need to authenticate non-admin DIDs over WebSocket. Unblocks downstream consumers (e.g. OpenVTC `verifiable-trust-infrastructure`'s `e2e-tests-pending-mediator` branch) so they can drop their git-rev pins and `[patch.crates-io]` boilerplate.

## Changes

### `TestMediatorBuilder::local_dids` (BLOCKER — task 1)

The mediator's WS handler refuses upgrades unless the authenticated session has the LOCAL ACL bit set. The default `global_acl_default` used by the test fixture has `local = false`, so any external test that mints a DID and tries to open a WS gets `403 Forbidden`. New fluent setters:

```rust
let mediator = TestMediator::builder()
    .local_did(client_did.clone())   // single
    .local_dids(other_dids.iter())   // iterable
    .spawn()
    .await
    .expect(\"spawn\");
```

Each registered DID is inserted into the mediator's account store with the `ALLOW_ALL` ruleset (LOCAL bit, no admin role). New `tests/local_did_websocket.rs` exercises the full JWT auth + WebSocket upgrade end-to-end.

### Crypto-provider bootstrap (task 5)

`TestMediator::spawn` now calls `install_default_crypto_provider()` (idempotent) before any handshake. Removes the boilerplate consumers had to write at process start when their dep graph mixed `aws_lc_rs` and `rust_crypto` rustls providers.

### Publish prep (task 2)

- `publish = false` → `publish = true`.
- Sister-crate path deps gain `version = \"...\"` (caret pins, `major.minor`).
- New README.md, linked from workspace README + messaging README.
- Adds `affinidi-messaging-mediator`, `affinidi-messaging-mediator-common`, and `affinidi-messaging-test-mediator` to the workspace `[patch.crates-io]` table.

### Cross-workspace consumption docs (task 4)

- New \"Using affinidi-* crates from outside this workspace\" README section. Calls out the [`[patch.crates-io]` gotcha](https://github.com/rust-lang/cargo/issues/4452) and provides copy-paste blocks for both crates.io (no patches) and git-rev pins (full patch block).
- New `tools/generate-consumer-patch.sh` — reads the workspace's patch table and emits the consumer-side block at any rev. Stays in sync by construction.

## Release order

Full `cargo publish --dry-run -p affinidi-messaging-test-mediator` verifies clean only after `affinidi-messaging-mediator` 0.14.1 (companion PR #302 — drop `--cfg tracing_unstable`) is published to crates.io. `cargo package --no-verify` succeeds today, and the workspace test suite passes against the unmodified mediator on this branch.

## Test plan

- [x] `cargo test -p affinidi-messaging-test-mediator` — 15 tests pass (lifecycle, streaming, new local_did_websocket round-trip)
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check`
- [x] `cargo package --no-verify -p affinidi-messaging-test-mediator` succeeds
- [ ] `cargo publish --dry-run -p affinidi-messaging-test-mediator` — pending mediator 0.14.1 publish
- [x] `tools/generate-consumer-patch.sh <rev>` emits the expected block

## Skipped

Task 6 (typed handshake error) — the `wait_connected failed: Timeout` stringification mentioned in the task description lives in the downstream test harness's own error type, not in any tdk-rs API. Skipped per the task brief's \"Skip if the affected handshake API isn't owned by tdk-rs\" guidance.