### PR TITLE
fix(mediator-setup): air-gapped FullSetup UX — emit --create-context and surface webvh-server precondition

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/sealed_handoff.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/sealed_handoff.rs
@@ -497,9 +497,17 @@ impl SealedHandoffState {
                 cmd
             }
             VtaIntent::FullSetup => format!(
+                // `--create-context` is idempotent on the VTA: if the
+                // context already exists, the flag is a no-op; if it
+                // doesn't, the producer creates it before minting
+                // instead of erroring. Always emitting it covers the
+                // air-gapped first-run case (operator hasn't pre-created
+                // the context on the VTA host) without penalising
+                // re-runs.
                 "vta bootstrap provision-integration \
                  --request {} \
                  --context {} \
+                 --create-context \
                  --assertion pinned-only \
                  --out bundle.armor",
                 file, self.context_id,
@@ -1026,6 +1034,7 @@ mod tests {
         assert!(cmd.starts_with("vta bootstrap provision-integration"));
         assert!(cmd.contains("--request bootstrap-request-vp.json"));
         assert!(cmd.contains("--context prod-mediator"));
+        assert!(cmd.contains("--create-context"));
         assert!(cmd.contains("--assertion pinned-only"));
         assert!(cmd.contains("--out bundle.armor"));
         // Sanity: FullSetup has no fallback.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
@@ -323,7 +323,11 @@ fn render_step_content(frame: &mut Frame, area: Rect, app: &WizardApp) {
                     chunks[0],
                     "Sealed handoff — webvh server (optional)",
                     "Pin a webvh hosting server for this DID's log (optional).",
-                    None,
+                    Some(
+                        "Precondition: the id must already exist on the VTA — \
+                         register it first with `vta webvh add-server --id <id> \
+                         --did <webvh-did>` on the VTA host.",
+                    ),
                     &app.text_input,
                     "webvh-prod-1",
                     &hint,


### PR DESCRIPTION
## Summary
Two UX fixes for the air-gapped sealed-mint flow in the mediator setup wizard, both reported by an operator running `mediator-setup` in `FullSetup` intent:

- **Always emit `--create-context`** in the rendered `vta bootstrap provision-integration` command. The flag is idempotent on the VTA — a no-op if the context exists, creates it otherwise — so always emitting it covers the air-gapped first-run case (operator hasn't pre-created the context on the VTA host) without penalising re-runs. Previously, first-run operators had to retry the producer command by hand. (`AdminOnly` / `OfflineExport` arms unchanged.)

- **Set webvh-server precondition expectations up front** on the `CollectWebvhServer` prompt. The id must already exist on the VTA (registered via `vta webvh add-server --id <id> --did <webvh-did>` on the VTA host) — the wizard now states this in a one-line tip beneath the prompt header. No client-side validation: the VTA's error remains authoritative; this just stops operators discovering the requirement deep in the producer command's output.

## Test plan
- [x] `cargo test -p affinidi-messaging-mediator-setup` — 241 passed, 0 failed
- [x] `cargo fmt -p affinidi-messaging-mediator-setup` — no diff
- [x] Updated `full_setup_primary_command_renders_provision_integration` to assert `--create-context` is present
- [ ] (Reviewer) Eyeball the `CollectWebvhServer` screen in the wizard — tip text wraps cleanly on a standard terminal width