### PR TITLE
fix: mediator 0.15.1 + test-mediator 0.2.2 — routing fix, mediator-common feature gating, ACL/admin surface

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ## 5th May 2026
 
+### 0.15.1 — IPv6 host normalization + wildcard-bind warning
+
+Patch follow-up to 0.15.0 fixing two real-world holes in the
+self-loopback routing fix.
+
+- **FIX:** IPv6 host normalization. `Url::host_str()` returns IPv6
+  literals wrapped in brackets (`"[::1]"`) while
+  `SocketAddr::ip().to_string()` returns them bare (`"::1"`). The
+  routing handler's lookup and the startup-time authority cache now
+  funnel both forms through a shared `normalize_host` helper, so a
+  `http://[::1]:7037/` DID-Doc URI matches a `[::1]:7037` bind
+  address. Without this, IPv6-bound mediators silently never matched
+  themselves and devolved to remote forwarding.
+- **FEAT:** Startup warning when `listen_address` is bound to a
+  wildcard (`0.0.0.0` / `::`) and `local_endpoints` is empty.
+  Service endpoints in DID Docs essentially never use the literal
+  `0.0.0.0`, so the default deployment shape silently rendered the
+  loopback fix a no-op. The warning points operators at the
+  `local_endpoints` config field.
+- **DOC:** `local_endpoints` is now documented in the sample
+  `conf/mediator.toml` with a commented example.
+- **TEST:** Routing test coverage extended — IPv6 (both bracketed
+  and bare host forms), `wss://`, query/path/fragment URIs, and a
+  `compute_self_authorities` integration test that round-trips an
+  IPv6 listen address through the lookup path.
+- **REFACTOR:** `compute_self_authorities` and `default_port_for`
+  hoisted to `pub(crate)` so the routing tests can drive them
+  directly. New `compute_self_authorities_from(listen, endpoints)`
+  takes the two relevant fields rather than a full `Config`.
+
 ### 0.15.0 — Self-loopback routing fix + `local_endpoints` config
 
 Fixes a subtle routing-2.0 bug where a `forward` envelope whose

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.0"
+version = "0.15.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -70,7 +70,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.14", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15", path = "affinidi-messaging-mediator-common" }
 ## Humantime for the VTA cache TTL (`[secrets].cache_ttl = "30d"`).
 humantime = "2"
 ## CLI parsing for the mediator binary's subcommands (`mediator`,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,40 @@
 
 ## 5th May 2026
 
+### 0.15.0 — Feature-gated server stack + `ACLError` non-exhaustive
+
+Reorganizes this crate's dependency graph so the SDK and other
+client-side consumers don't pay for the server's compile-time deps.
+Existing server-side consumers (mediator binary, mediator-setup,
+mediator-processors, test-mediator) are unaffected because the
+new `server` feature is on by default.
+
+- **BREAKING (recompile-only for non-default consumers):** Heavy
+  server-side deps — `axum`, `redis`, `reqwest`, `tokio-tungstenite`,
+  `aes-gcm`, `argon2`, `metrics`, etc. — are now optional and gated
+  behind `server` (default-on) or `redis-backend` (Redis client).
+  Default builds compile exactly as before. SDK-style consumers
+  (`default-features = false`) get just the lean `types` module
+  with `serde`/`serde_json`/`thiserror`/`regex` and nothing else
+  — axum/redis/reqwest no longer flow into their build graph
+  via this crate.
+- **BREAKING:** `ACLError` is now `#[non_exhaustive]`. New variants
+  added in future minor releases will be a non-breaking change.
+  Downstream code matching on `ACLError` must include a wildcard
+  arm. The SDK's `From<ACLError> for ATMError` was updated; outside
+  the workspace, callers that exhaustively-matched `Config | Denied`
+  must add `_ => …` (or migrate to the SDK's wrapper).
+- **NOTE:** `impl GenericDataStruct for String` (introduced in 0.14)
+  is a foreign-crate blanket on `String`. If you have your own
+  `GenericDataStruct` impl on `String` in a downstream crate, drop
+  it — the orphan-rule fence won't bite, but the impl is now
+  redundant.
+- **FEAT:** `mediator-setup` consumers should depend on this crate
+  with `default-features = false, features = ["server"]` (or just
+  let `default = ["server"]` apply) to get the secrets module.
+  Cloud-secret backends (`secrets-{aws,gcp,azure,vault,keyring}`)
+  now imply `server` automatically.
+
 ### 0.14.0 — Protocol-vocabulary types relocated here
 
 The mediator's `MediatorStore` trait used to import its protocol

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.14.0"
+version = "0.15.0"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -13,151 +13,183 @@ rust-version.workspace = true
 repository.workspace = true
 
 [features]
-# Each backend is opt-in so downstream consumers compile without pulling
-# the whole cloud-SDK world. The mediator binary enables whichever backends
-# its deployment target needs; the mediator-setup wizard enables the
-# superset so operators can pick any.
-default = []
+# Default to the full server stack so the mediator binary, mediator-setup
+# wizard, mediator-processors, and the test-mediator all compile
+# unchanged. SDK-style consumers (lean DTO-only) take this crate with
+# `default-features = false` and pick up `types` only — without axum,
+# redis, reqwest, tokio-tungstenite, aes-gcm, argon2, metrics, etc.
+default = ["server"]
+
+# ── Server umbrella ─────────────────────────────────────────────────
+## Activates every server-side module: `circuit_breaker`, `database`,
+## `errors`, `secrets`, `store`, `tasks`, `time`. Pulls every
+## non-types crate this package needs.
+server = [
+  # secrets module + envelope encryption + cache HMAC + freshness
+  "dep:async-trait",
+  "dep:base64",
+  "dep:url",
+  "dep:uuid",
+  "dep:hkdf",
+  "dep:hmac",
+  "dep:sha2",
+  "dep:hex",
+  "dep:humantime",
+  "dep:aes-gcm",
+  "dep:argon2",
+  "dep:zeroize",
+  # store / database / circuit-breaker / time module support
+  "dep:ahash",
+  "dep:metrics",
+  "dep:num-format",
+  "dep:rand",
+  "dep:semver",
+  "dep:sha256",
+  "dep:tokio",
+  "dep:tracing",
+  # axum-flavored error types (`AppError`, `IntoResponse` impls)
+  "dep:axum",
+  # forwarding processor (HTTP / WS to remote mediators)
+  "dep:reqwest",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:tokio-stream",
+]
 
 # ── Storage backends ────────────────────────────────────────────────
 ## `RedisStore` — multi-mediator clusters and the standalone-binary
-## horizontal-scaling story. Brings in the `database/` Redis-implementation
-## modules; consumers that don't enable the feature get only the
-## `MediatorStore` trait + types.
-redis-backend = []
+## horizontal-scaling story. Implies `server` (the trait + types live
+## there) and pulls the redis client + helpers used by the impl.
+redis-backend = [
+  "server",
+  "dep:redis",
+  "dep:rustls",
+  "dep:itertools",
+  "dep:subtle",
+]
 
 # ── Secret backends ─────────────────────────────────────────────────
-secrets-keyring = ["dep:keyring"]
-secrets-aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
-secrets-gcp = ["dep:google-cloud-secretmanager-v1", "dep:google-cloud-gax"]
+## Each backend implies `server` (so the secrets module is compiled in)
+## and pulls the matching cloud SDK.
+secrets-keyring = ["server", "dep:keyring"]
+secrets-aws = ["server", "dep:aws-config", "dep:aws-sdk-secretsmanager"]
+secrets-gcp = [
+  "server",
+  "dep:google-cloud-secretmanager-v1",
+  "dep:google-cloud-gax",
+]
 secrets-azure = [
+  "server",
   "dep:azure_security_keyvault_secrets",
   "dep:azure_identity",
   "dep:azure_core",
 ]
-secrets-vault = ["dep:vaultrs"]
+secrets-vault = ["server", "dep:vaultrs"]
 
 [dependencies]
-# ── Secrets module: core ─────────────────────────────────────────────────
-async-trait = "0.1"
-base64 = "0.22"
-url = "2"
-uuid = { version = "1", features = ["v4"] }
+# ── Always-on: lean types module deps ───────────────────────────────
+## Used by `types/*` (acls, problem_report, messages, accounts,
+## administration, acls_handler). SDK consumers see only these.
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = "1"
+thiserror = "2"
+regex = "1"
+
+# ── Secrets module: core (gated on `server`) ────────────────────────
+async-trait = { version = "0.1", optional = true }
+base64 = { version = "0.22", optional = true }
+url = { version = "2", optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
 
 # ── Secrets module: cache integrity (HMAC-SHA256 keyed via HKDF from the
 ## admin credential's private key) + freshness ──────────────────────────
-hkdf = "0.12"
-hmac = "0.12"
-sha2 = "0.10"
-hex = "0.4"
-humantime = "2"
+hkdf = { version = "0.12", optional = true }
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+hex = { version = "0.4", optional = true }
+humantime = { version = "2", optional = true }
 
 # ── Secrets module: file:// envelope encryption (`?encrypt=1`) ──────────
 ## AES-256-GCM with 12-byte nonces per write; passphrase-derived key via
-## Argon2id. Always built — file backend is in `default = []`-friendly
-## territory and these crates are tiny + zero-dep beyond `aes` / `cipher`.
-aes-gcm = "0.10"
-argon2 = "0.5"
-zeroize = { version = "1", features = ["zeroize_derive"] }
+## Argon2id.
+aes-gcm = { version = "0.10", optional = true }
+argon2 = { version = "0.5", optional = true }
+zeroize = { version = "1", features = ["zeroize_derive"], optional = true }
 
-# ── Secrets module: optional backends ────────────────────────────────────
-keyring = { version = "3", features = ["apple-native", "linux-native"], optional = true }
+# ── Secrets module: optional cloud backends ─────────────────────────
+keyring = { version = "3", features = [
+  "apple-native",
+  "linux-native",
+], optional = true }
 aws-config = { version = "1", optional = true }
 aws-sdk-secretsmanager = { version = "1", optional = true }
 ## GCP Secret Manager (official googleapis/google-cloud-rust crate).
 ## gRPC client via tonic; uses rustls (via `default-rustls-provider`)
 ## so it joins the workspace TLS story without pulling native-tls.
-## Auth flows through google-cloud-gax's ADC chain
-## (GOOGLE_APPLICATION_CREDENTIALS, workload identity, etc.).
 google-cloud-secretmanager-v1 = { version = "1.8", optional = true }
 ## Transitive dep of `google-cloud-secretmanager-v1`; reached directly
-## so the GCP backend can classify errors by their rpc::Code (NotFound,
-## Unavailable, ResourceExhausted, …) without string-matching the
-## Display form.
+## so the GCP backend can classify errors by their rpc::Code.
 google-cloud-gax = { version = "1.9", optional = true }
 ## Azure Key Vault Secrets (official Microsoft crate). Paired with
-## `azure_identity` for the credential chain. Both pulled with
-## default-features kept on — they already target rustls via
-## `azure_core::http::RustlsClient` on recent versions.
+## `azure_identity` for the credential chain.
 azure_security_keyvault_secrets = { version = "0.14", optional = true }
 azure_identity = { version = "0.35", optional = true }
 azure_core = { version = "0.35", optional = true }
-## Pager iteration over Azure's `list_secret_properties` Stream — only the
-## `TryStreamExt::try_next` adapter is used. Now also used by the
-## forwarding processor below, so it's no longer optional. The
-## `secrets-azure` feature still depends on it but the dep is
-## unconditionally enabled.
-## (Unified declaration lives further down in the dependency block.)
 ## HashiCorp Vault KV v2 (rustify-based async REST client). Token auth
-## via VAULT_TOKEN env. Default features bring in the rustls HTTP
-## stack; pin to `0.8` so future breaking bumps don't land silently.
-vaultrs = { version = "0.8", default-features = false, features = ["rustls"], optional = true }
+## via VAULT_TOKEN env. Default features bring in the rustls HTTP stack.
+vaultrs = { version = "0.8", default-features = false, features = [
+  "rustls",
+], optional = true }
 
 # ── Async stream helpers (used by the redis-store pubsub bridge) ─────────
-## Unconditional because `futures-util` was already optional via
-## `secrets-azure`; promote it to non-optional with `default-features = false`
-## so the redis-backend code path picks up `StreamExt::next` without
-## affecting other secret-backend builds.
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", optional = true }
 
 # ── Forwarding processor deps (used by `tasks::forwarding::processor`) ──
-## HTTP / WS delivery to remote mediators + sink/stream traits used by
-## the connection pools. The processor itself is gated on
-## `redis-backend`, so memory- and fjall-only consumers don't pull
-## these in at runtime — but cargo can't conditionally enable a
-## non-optional dep, so the deps stay declared here unconditionally
-## (cheap when the processor module is gated out: the compiler still
-## elides the unused crates from the link step).
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
-tokio-tungstenite = { version = "0.29", default-features = false, features = ["rustls-tls-native-roots"] }
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+reqwest = { version = "0.13", default-features = false, features = [
+  "rustls",
+  "json",
+], optional = true }
+tokio-tungstenite = { version = "0.29", default-features = false, features = [
+  "rustls-tls-native-roots",
+], optional = true }
+futures-util = { version = "0.3", default-features = false, features = [
+  "sink",
+  "std",
+], optional = true }
 
-# ── Web Framework (for HTTP status codes and WebSocket types) ────────────
-axum = { version = "0.8", features = ["ws"] }
+# ── Web Framework (HTTP status codes + WebSocket types in `errors`) ─
+axum = { version = "0.8", features = ["ws"], optional = true }
 
-# ── Database ─────────────────────────────────────────────────────────────
-## Auto-reconnecting multiplexed Redis connection with TLS support
+# ── Database (RedisStore impl, gated on `redis-backend`) ────────────
 redis = { version = "1.1", features = [
   "tokio-rustls-comp",
   "tls-rustls-insecure",
   "connection-manager",
   "ahash",
-] }
+], optional = true }
+itertools = { version = "0.14", optional = true }
+## Constant-time DID-hash comparisons.
+subtle = { version = "2", optional = true }
 
-# ── RedisStore impl helpers (gated by `redis-backend`) ───────────────────
-## Used by `database/{fetch,get,list,stats}.rs` for chunking pipeline replies.
-itertools = "0.14"
-## Constant-time DID-hash comparisons in the redis-store call sites.
-subtle = "2"
+# ── TLS (Redis TLS provider initialization) ─────────────────────────
+rustls = { version = "0.23", default-features = false, features = [
+  "aws_lc_rs",
+  "tls12",
+], optional = true }
 
-# ── TLS (for Redis TLS provider initialization) ─────────────────────────
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "tls12"] }
+# ── Async Runtime (tokio::time::sleep in retry loops, etc.) ─────────
+tokio = { workspace = true, features = ["time"], optional = true }
 
-# ── Async Runtime (for tokio::time::sleep in retry loops) ────────────────
-tokio = { workspace = true, features = ["time"] }
+# ── Utilities used across server modules ────────────────────────────
+ahash = { version = "0.8", features = ["serde"], optional = true }
+num-format = { version = "0.4", optional = true }
+rand = { version = "0.10", optional = true }
+semver = { version = "1", optional = true }
+sha256 = { version = "1", optional = true }
+tracing = { version = "0.1", features = ["valuable"], optional = true }
 
-# ── Serialization ────────────────────────────────────────────────────────
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-
-# ── Protocol-vocabulary types: regex used by `ProblemReport::interpolation` ─
-regex = "1"
-
-# ── Utilities ────────────────────────────────────────────────────────────
-ahash = { version = "0.8", features = ["serde"] }
-num-format = "0.4"
-rand = "0.10"
-semver = "1"
-sha256 = "1"
-thiserror = "2"
-tracing = { version = "0.1", features = ["valuable"] }
-
-# ── Metrics ──────────────────────────────────────────────────────────────
-## CircuitBreaker emits a gauge + counter for ops. Records to whichever
-## global recorder the binary installs (the mediator installs Prometheus
-## via the `init_metrics` setup; standalone binaries that don't install
-## a recorder get no-op metric writes).
-metrics = "0.24"
+# ── Metrics (CircuitBreaker gauge + counter) ────────────────────────
+metrics = { version = "0.24", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/mod.rs
@@ -1,23 +1,40 @@
+// `DatabaseConfig` (the serde struct in `config.rs`) is always available
+// under the `server` feature — the mediator binary parses it regardless
+// of which storage backend the deployment selects. `DatabaseHandler`
+// and the redis-using helpers below are gated on `redis-backend`.
+pub mod config;
+
+#[cfg(feature = "redis-backend")]
+pub mod delete;
+
+#[cfg(feature = "redis-backend")]
 use crate::errors::MediatorError;
+#[cfg(feature = "redis-backend")]
 use crate::types::problem_report::{ProblemReportScope, ProblemReportSorter};
+#[cfg(feature = "redis-backend")]
 use axum::http::StatusCode;
+#[cfg(feature = "redis-backend")]
 use config::DatabaseConfig;
+#[cfg(feature = "redis-backend")]
 use redis::AsyncConnectionConfig;
+#[cfg(feature = "redis-backend")]
 use redis::aio::{ConnectionManager, ConnectionManagerConfig, MultiplexedConnection, PubSub};
 
+#[cfg(feature = "redis-backend")]
 use semver::{Version, VersionReq};
+#[cfg(feature = "redis-backend")]
 use std::time::Duration;
+#[cfg(feature = "redis-backend")]
 use tokio::time::sleep;
+#[cfg(feature = "redis-backend")]
 use tracing::{Level, event, info, warn};
-
-pub mod config;
-pub mod delete;
 
 /// Low-level Redis connection handler used by the mediator.
 ///
 /// Uses a single multiplexed connection (via `ConnectionManager` for auto-reconnect)
 /// instead of a connection pool. `MultiplexedConnection` handles concurrent commands
 /// over one TCP connection, making a pool unnecessary.
+#[cfg(feature = "redis-backend")]
 #[derive(Clone)]
 pub struct DatabaseHandler {
     /// Auto-reconnecting multiplexed connection for normal Redis operations.
@@ -26,8 +43,10 @@ pub struct DatabaseHandler {
     redis_url: String,
 }
 
+#[cfg(feature = "redis-backend")]
 const REDIS_VERSION_REQ: &str = ">=7.1, <9.0";
 
+#[cfg(feature = "redis-backend")]
 impl DatabaseHandler {
     /// Creates a new `DatabaseHandler`, establishing a multiplexed connection and verifying
     /// that the Redis server version is compatible. Retries on connection failure.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -1,14 +1,52 @@
-pub mod circuit_breaker;
-pub mod database;
-pub mod errors;
-pub mod secrets;
-pub mod store;
-pub mod tasks;
-pub mod time;
+//! Shared types and runtime infrastructure for the mediator.
+//!
+//! ## Feature layout
+//!
+//! - **types** (always built) — protocol-vocabulary types (ACL bits,
+//!   problem-report shape, message envelopes, account records). Lean
+//!   deps: `serde`, `thiserror`, `regex`. Suitable for the SDK and
+//!   any client-side consumer.
+//! - **`server`** (default) — full server-side stack: error wrappers
+//!   tied to axum, the `MediatorStore` trait, secrets backends,
+//!   circuit breaker, forwarding processor, time helpers. Pulls
+//!   axum, redis, reqwest, tokio-tungstenite, aes-gcm/argon2/zeroize,
+//!   metrics, etc. Required by the mediator binary and the
+//!   mediator-setup wizard.
+//! - **`redis-backend`** — implies `server`, plus the RedisStore impl.
+//! - **`secrets-{keyring,aws,gcp,azure,vault}`** — each implies `server`
+//!   and pulls in the matching cloud SDK.
+//!
+//! Downstream client crates (the SDK, third-party tooling) should
+//! depend on this crate with `default-features = false` to avoid
+//! pulling the server stack into their build graph.
+
 pub mod types;
 
+#[cfg(feature = "server")]
+pub mod circuit_breaker;
+/// Database wiring: the lean `DatabaseConfig` serde struct is always
+/// available under `server` (the mediator's main config parses it
+/// regardless of which storage backend is selected). The
+/// `DatabaseHandler` and its redis-specific helpers are gated inside
+/// the module on `redis-backend`.
+#[cfg(feature = "server")]
+pub mod database;
+#[cfg(feature = "server")]
+pub mod errors;
+#[cfg(feature = "server")]
+pub mod secrets;
+#[cfg(feature = "server")]
+pub mod store;
+#[cfg(feature = "server")]
+pub mod tasks;
+#[cfg(feature = "server")]
+pub mod time;
+
+#[cfg(feature = "server")]
 pub use secrets::backends::{PASSPHRASE_ENV, PASSPHRASE_FILE_ENV};
+#[cfg(feature = "server")]
 pub use secrets::well_known::OPERATING_SECRETS;
+#[cfg(feature = "server")]
 pub use secrets::{
     ADMIN_CREDENTIAL, AdminCredential, BOOTSTRAP_EPHEMERAL_SEED_PREFIX, BOOTSTRAP_SEED_INDEX,
     BootstrapSeedIndex, BootstrapSeedIndexEntry, JWT_SECRET, MediatorSecrets,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/acls.rs
@@ -16,7 +16,12 @@ use thiserror::Error;
 /// `MediatorError`. Defining the error here keeps `MediatorACLSet`
 /// owned by mediator-common and avoids an SDK dependency from the
 /// storage trait crate.
+///
+/// Marked `#[non_exhaustive]` so adding new ACL failure modes in
+/// future releases is a non-breaking change. Downstream code should
+/// always include a wildcard arm when matching.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ACLError {
     /// Malformed input (string ruleset, hex string, etc.).
     #[error("ACL configuration error: {0}")]

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Changelog history
 
+## 5th May 2026
+
+### 0.13.1
+
+- **CHORE:** Bumped internal pin on
+  `affinidi-messaging-mediator-common` to `0.15` to track the
+  feature-gating rework. The processors enable `redis-backend`
+  (which now implies the `server` umbrella), so no source change
+  is needed.
+
 ## 24th April 2026
 
 ### 0.13.0

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-processors"
-version = "0.13.0"
+version = "0.13.1"
 description = "Standalone background processor binaries for the Affinidi Messaging Mediator (Redis-only, horizontal scaling)"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ path = "src/forwarding/main.rs"
 ## Standalone binaries here are Redis-only by design, so the
 ## `redis-backend` feature is always enabled. The unified processor
 ## logic now lives in this crate; no duplicated implementation here.
-affinidi-messaging-mediator-common = { version = "0.14", path = "../affinidi-messaging-mediator-common", features = ["redis-backend"] }
+affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator-common", features = ["redis-backend"] }
 
 # ── CLI ──────────────────────────────────────────────────────────────────
 clap = { version = "4", features = ["derive"] }

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -77,6 +77,22 @@ admin_did = "did://did:peer:2.Vz6MkksX9huJxJwvLtj9vc3gXbT2m1WVy4Uoi3ssEiSSH2ZYJ.
 ### When enabled, adds a did:web route at /.well-known/did.json
 did_web_self_hosted = "file://./conf/did.jsonl"
 
+### Public service URL(s) at which this mediator is reachable. The
+### Routing 2.0 forward handler uses these (plus `listen_address`) to
+### detect when an outbound forward's next hop is itself, and short-
+### circuits to local delivery instead of opening a remote socket.
+###
+### When `listen_address` is bound to a wildcard (`0.0.0.0` / `::`)
+### — which is the default — DID-Doc service URIs will never literally
+### match the bind address, so set this to the public URL(s) you publish
+### in the mediator's DID Doc. Each entry must be a parseable URL with
+### scheme + host (port optional; falls back to the scheme default).
+###
+### Hostnames are compared case-insensitively; IPv6 literals are
+### normalized so a bracketed URL form (`http://[::1]:7037`) matches a
+### bind address recorded as `::1`.
+# local_endpoints = ["https://mediator.example.com", "https://mediator.example.com:7037"]
+
 ### ****************************************************************************************************************************
 ### Database configuration
 ### ****************************************************************************************************************************

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -788,8 +788,11 @@ fn service_endpoint_for_remote(state: &SharedData, next_doc: &Document) -> Optio
 }
 
 /// Parse `uri` and return `true` when its `(host, port)` matches any
-/// entry in `self_authorities`. Hostnames are compared case-insensitively;
-/// the URL's port falls back to the scheme default (80/443) when omitted.
+/// entry in `self_authorities`. Hostnames are normalized via
+/// [`crate::server::normalize_host`] (strips outer `[ ]` from IPv6
+/// literals, lowercases) so the lookup matches the form inserted by
+/// [`crate::server::compute_self_authorities`]. Port falls back to the
+/// scheme default via [`crate::server::default_port_for`].
 /// Returns `false` for unparseable URLs or schemes without a default port.
 fn uri_points_at_self(
     uri: &str,
@@ -801,25 +804,26 @@ fn uri_points_at_self(
     let Some(host) = url.host_str() else {
         return false;
     };
-    let Some(port) = url.port().or_else(|| match url.scheme() {
-        "http" | "ws" => Some(80),
-        "https" | "wss" => Some(443),
-        _ => None,
-    }) else {
+    let Some(port) = crate::server::default_port_for(&url) else {
         return false;
     };
-    self_authorities.contains(&(host.to_ascii_lowercase(), port))
+    self_authorities.contains(&(crate::server::normalize_host(host), port))
 }
 
 #[cfg(test)]
 mod tests {
     use super::uri_points_at_self;
+    use crate::server::{compute_self_authorities_from, normalize_host};
     use std::collections::HashSet;
 
+    /// Build an authorities set the same way `compute_self_authorities`
+    /// does — normalizing each host — so tests stay consistent with the
+    /// production insertion path. Tests that want to assert the
+    /// normalization itself should use `compute_self_authorities_from`.
     fn authorities(entries: &[(&str, u16)]) -> HashSet<(String, u16)> {
         entries
             .iter()
-            .map(|(host, port)| ((*host).to_string(), *port))
+            .map(|(host, port)| (normalize_host(host), *port))
             .collect()
     }
 
@@ -845,6 +849,12 @@ mod tests {
     fn ws_url_with_default_port_matches() {
         let auth = authorities(&[("mediator.example.com", 80)]);
         assert!(uri_points_at_self("ws://mediator.example.com/ws", &auth));
+    }
+
+    #[test]
+    fn wss_url_with_default_port_matches() {
+        let auth = authorities(&[("mediator.example.com", 443)]);
+        assert!(uri_points_at_self("wss://mediator.example.com/ws", &auth));
     }
 
     #[test]
@@ -881,5 +891,149 @@ mod tests {
     fn empty_authority_set_never_matches() {
         let auth = authorities(&[]);
         assert!(!uri_points_at_self("http://127.0.0.1:7037/", &auth));
+    }
+
+    // ── IPv6 ─────────────────────────────────────────────────────────────
+
+    /// `Url::host_str()` returns IPv6 literals wrapped in brackets
+    /// (`"[::1]"`), but `SocketAddr::ip().to_string()` returns them bare
+    /// (`"::1"`). Both forms must funnel through `normalize_host` so a
+    /// bracketed URL host matches a bare authority key.
+    #[test]
+    fn ipv6_bracketed_url_matches_bare_authority() {
+        let auth = authorities(&[("::1", 7037)]);
+        assert!(uri_points_at_self("http://[::1]:7037/mediator/v1/", &auth));
+    }
+
+    /// And the reverse — a bracketed authority entry (e.g. one already
+    /// pre-normalized by the operator) must also match a bracketed URL.
+    #[test]
+    fn ipv6_bracketed_authority_matches_bracketed_url() {
+        let auth = authorities(&[("[::1]", 7037)]);
+        assert!(uri_points_at_self("http://[::1]:7037/mediator/v1/", &auth));
+    }
+
+    /// Full IPv6 address with default https port (no explicit port in URL).
+    #[test]
+    fn ipv6_full_address_with_default_port_matches() {
+        let auth = authorities(&[("2001:db8::1", 443)]);
+        assert!(uri_points_at_self(
+            "https://[2001:db8::1]/mediator/v1/",
+            &auth
+        ));
+    }
+
+    /// Different IPv6 address must not match.
+    #[test]
+    fn ipv6_different_address_does_not_match() {
+        let auth = authorities(&[("::1", 7037)]);
+        assert!(!uri_points_at_self(
+            "http://[2001:db8::1]:7037/mediator/v1/",
+            &auth
+        ));
+    }
+
+    // ── URI shape variants — query, path, fragment ──────────────────────
+
+    /// Path components are irrelevant to authority matching.
+    #[test]
+    fn path_does_not_affect_match() {
+        let auth = authorities(&[("mediator.example.com", 443)]);
+        assert!(uri_points_at_self(
+            "https://mediator.example.com/very/deep/path/",
+            &auth
+        ));
+    }
+
+    /// Query strings are irrelevant.
+    #[test]
+    fn query_does_not_affect_match() {
+        let auth = authorities(&[("mediator.example.com", 443)]);
+        assert!(uri_points_at_self(
+            "https://mediator.example.com/mediator/v1/?foo=bar&baz=1",
+            &auth
+        ));
+    }
+
+    /// Fragments are irrelevant.
+    #[test]
+    fn fragment_does_not_affect_match() {
+        let auth = authorities(&[("mediator.example.com", 443)]);
+        assert!(uri_points_at_self(
+            "https://mediator.example.com/mediator/v1/#section",
+            &auth
+        ));
+    }
+
+    /// Scheme without a known default port (and no explicit port) is rejected.
+    #[test]
+    fn unknown_scheme_without_explicit_port_does_not_match() {
+        let auth = authorities(&[("mediator.example.com", 443)]);
+        assert!(!uri_points_at_self(
+            "ftp://mediator.example.com/mediator/v1/",
+            &auth
+        ));
+    }
+
+    // ── compute_self_authorities_from integration ──────────────────────
+
+    /// `listen_address` and `local_endpoints` together populate the
+    /// authority set with normalized keys.
+    #[test]
+    fn compute_self_authorities_combines_bind_and_endpoints() {
+        let auth = compute_self_authorities_from(
+            "127.0.0.1:7037",
+            &["https://mediator.example.com".to_string()],
+        );
+        assert!(auth.contains(&("127.0.0.1".to_string(), 7037)));
+        assert!(auth.contains(&("mediator.example.com".to_string(), 443)));
+        assert_eq!(auth.len(), 2);
+    }
+
+    /// IPv6 listen_address round-trips: a `[::1]`-shaped DID-Doc URI
+    /// finds the `"::1"` authority cached from the bind address. This
+    /// is the regression test for the IPv6 host-normalization bug.
+    #[test]
+    fn ipv6_listen_address_round_trips_through_authorities() {
+        let auth = compute_self_authorities_from("[::1]:7037", &[]);
+        assert!(uri_points_at_self("http://[::1]:7037/mediator/v1/", &auth));
+    }
+
+    /// Full IPv6 listen_address with operator-declared bracketed alias —
+    /// both should normalize to the same key set.
+    #[test]
+    fn compute_self_authorities_normalizes_ipv6_endpoints() {
+        let auth = compute_self_authorities_from(
+            "[2001:db8::1]:7037",
+            &["http://[2001:db8::1]:7037".to_string()],
+        );
+        // Single entry — the bracketed endpoint normalizes to match the bind.
+        assert_eq!(auth.len(), 1);
+        assert!(auth.contains(&("2001:db8::1".to_string(), 7037)));
+    }
+
+    /// Malformed `local_endpoints` entries are skipped, not fatal.
+    #[test]
+    fn compute_self_authorities_skips_malformed_endpoints() {
+        let auth = compute_self_authorities_from(
+            "127.0.0.1:7037",
+            &[
+                "not-a-url".to_string(),
+                "ftp://no-default-port-known/".to_string(),
+                "https://valid.example.com".to_string(),
+            ],
+        );
+        // Only the bind address + the one valid HTTPS endpoint survive.
+        assert!(auth.contains(&("127.0.0.1".to_string(), 7037)));
+        assert!(auth.contains(&("valid.example.com".to_string(), 443)));
+        assert_eq!(auth.len(), 2);
+    }
+
+    /// An empty bind + empty endpoints yields an empty authority set,
+    /// which by construction never matches anything.
+    #[test]
+    fn compute_self_authorities_with_empty_inputs_is_empty() {
+        let auth = compute_self_authorities_from("", &[]);
+        assert!(auth.is_empty());
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -482,6 +482,25 @@ pub async fn serve_internal(
         );
     }
 
+    // Wildcard binds (`0.0.0.0` / `::`) almost never appear as a literal
+    // host in a peer's DID Doc service endpoint. When the bind is wildcard
+    // and the operator hasn't declared any `local_endpoints` aliases, the
+    // self-authority set will never match an inbound forward → loopback
+    // delivery silently devolves to "remote" forwarding. Surface this so
+    // the operator notices before they ship.
+    if let Ok(addr) = config.listen_address.parse::<SocketAddr>()
+        && addr.ip().is_unspecified()
+        && config.local_endpoints.is_empty()
+    {
+        warn!(
+            "listen_address is bound to wildcard {} and no `local_endpoints` are configured — \
+             Routing 2.0 self-loopback delivery will not match any DID-Doc URI. \
+             Add the mediator's public service URL(s) to `local_endpoints` (e.g. \
+             `local_endpoints = [\"https://mediator.example.com\"]`) to enable local routing.",
+            addr.ip()
+        );
+    }
+
     let shared_state = SharedData {
         config: config.clone(),
         service_start_timestamp: chrono::Utc::now(),
@@ -791,21 +810,30 @@ async fn shutdown_signal() {
 /// causing startup to fail — a typo'd alias should not block the
 /// mediator from booting.
 pub(crate) fn compute_self_authorities(config: &Config) -> HashSet<(String, u16)> {
+    compute_self_authorities_from(&config.listen_address, &config.local_endpoints)
+}
+
+/// Field-level core of [`compute_self_authorities`] — kept separate so
+/// unit tests can exercise it without standing up a full [`Config`].
+pub(crate) fn compute_self_authorities_from(
+    listen_address: &str,
+    local_endpoints: &[String],
+) -> HashSet<(String, u16)> {
     let mut out = HashSet::new();
 
     // Bind address: parse as a SocketAddr and record (ip, port). When
     // the bind is `0.0.0.0` or `::` we still record the literal —
     // operators relying on `INADDR_ANY` should declare their public
     // hostname(s) via `local_endpoints` for the comparison to match.
-    if let Ok(addr) = config.listen_address.parse::<SocketAddr>() {
-        out.insert((addr.ip().to_string().to_ascii_lowercase(), addr.port()));
+    if let Ok(addr) = listen_address.parse::<SocketAddr>() {
+        out.insert((normalize_host(&addr.ip().to_string()), addr.port()));
     }
 
-    for raw in &config.local_endpoints {
+    for raw in local_endpoints {
         match Url::parse(raw) {
             Ok(url) => match (url.host_str(), default_port_for(&url)) {
                 (Some(host), Some(port)) => {
-                    out.insert((host.to_ascii_lowercase(), port));
+                    out.insert((normalize_host(host), port));
                 }
                 _ => warn!(
                     "Skipping local_endpoints entry {:?}: missing host or port",
@@ -822,9 +850,23 @@ pub(crate) fn compute_self_authorities(config: &Config) -> HashSet<(String, u16)
     out
 }
 
+/// Normalize a host string for self-authority comparison.
+///
+/// `Url::host_str()` returns IPv6 literals wrapped in `[ ]` (e.g. `"[::1]"`)
+/// while `std::net::SocketAddr::ip().to_string()` returns them bare
+/// (`"::1"`). Strip the outer brackets so the two paths produce the same
+/// key, and lowercase for case-insensitive matching.
+pub(crate) fn normalize_host(host: &str) -> String {
+    let stripped = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+    stripped.to_ascii_lowercase()
+}
+
 /// Resolve the effective port for a URL, falling back to the
 /// scheme-specific default when the URL omits an explicit port.
-fn default_port_for(url: &Url) -> Option<u16> {
+pub(crate) fn default_port_for(url: &Url) -> Option<u16> {
     if let Some(port) = url.port() {
         return Some(port);
     }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -71,7 +71,9 @@ affinidi-crypto = "0.1"
 ## mediator finds them at startup without any inline config plumbing.
 ## Backend selection flows through the wizard's own `secrets-*` features
 ## declared at the top of this file; no hardcoded list here.
-affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator-common", default-features = false }
+affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator-common", default-features = false, features = [
+  "server",
+] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
 didwebvh-rs = "0.5"

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.18.1] - 2026-05-05
+
+### Changed
+
+- `From<ACLError> for ATMError` now includes a wildcard arm because
+  `mediator-common 0.15.0` marked `ACLError` as `#[non_exhaustive]`.
+  Future ACL variants surface as `ATMError::ACLConfigError` until
+  the SDK adds a more specific mapping. No behavior change for
+  existing `Config` and `Denied` variants.
+- Bumped `mediator-common` caret pin to `"0.15"` to pick up the
+  feature-gating rework. The SDK already takes
+  `default-features = false`, so this build no longer pulls
+  `axum`, `redis`, or `aes-gcm`/`argon2` via mediator-common.
+
 ## [0.18.0] - 2026-05-05
 
 ### Breaking

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.0"
+version = "0.18.1"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 ## Source of truth for the mediator protocol vocabulary (ACLs, accounts,
 ## message types, problem reports). The SDK re-exports these so existing
 ## call sites continue to resolve their old paths.
-affinidi-messaging-mediator-common = { path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", version = "0.14", default-features = false }
+affinidi-messaging-mediator-common = { path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", version = "0.15", default-features = false }
 affinidi-did-authentication = "0.3"
 affinidi-did-common = "0.3"
 affinidi-encoding = "0.1"

--- a/crates/messaging/affinidi-messaging-sdk/src/errors.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/errors.rs
@@ -96,6 +96,11 @@ impl From<ACLError> for ATMError {
         match err {
             ACLError::Config(msg) => ATMError::ACLConfigError(msg),
             ACLError::Denied(msg) => ATMError::ACLDenied(msg),
+            // ACLError is `#[non_exhaustive]` from mediator-common 0.15;
+            // surface any future variant as a generic ACL error so the
+            // SDK keeps compiling against unmodified consumers when
+            // mediator-common lands new ACL failure modes.
+            other => ATMError::ACLConfigError(other.to_string()),
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Affinidi Messaging Test Mediator
+
+## Changelog history
+
+## 5th May 2026
+
+### 0.2.2 — ACL / security mode simulation + admin identity
+
+Significant additive surface for tests that need to simulate
+non-default mediator deployments. Defaults match prior releases —
+existing tests run unchanged.
+
+- **FEAT:** `acl` preset module — typed `allow_all()` and `deny_all()`
+  constructors that mirror the production
+  `MediatorACLSet::from_string_ruleset` parser arm-by-arm via the
+  public bit-setter API. Avoids string-ruleset parsing in test code;
+  ruleset typos can no longer hide as runtime errors.
+- **FEAT:** Re-exports of `AccessListModeType`, `MediatorACLSet`, and
+  `ACLError` from `mediator-common` so consumers don't need a direct
+  dep just to construct an `acl_mode(...)` argument or inspect a
+  `get_acl(...)` return.
+- **FEAT:** `TestMediatorBuilder` ACL knobs — `acl_mode`,
+  `global_acl_default`, `local_direct_delivery`,
+  `block_anonymous_outer_envelope`, `force_session_did_match`,
+  `block_remote_admin_msgs`, `jwt_expiry`, `local_endpoints`. All
+  Option-typed; `None` keeps the production default.
+- **FEAT:** `TestMediatorHandle::add_user_with_acl(alias, acls)`,
+  `set_acl(did, acls)`, `get_acl(did) -> Option<MediatorACLSet>` for
+  per-user ACL CRUD. `set_acl` and `get_acl` go through the underlying
+  `MediatorStore` directly — the **fixture-bypass** path. Use this
+  for verifying admin-protocol writes; for testing protocol
+  enforcement itself, drive the SDK's `acls_set` from an admin-
+  authenticated profile (see `add_admin`).
+- **FEAT:** `AdminIdentity` struct + `TestMediator::random_admin_identity()`
+  associated function. Mints a fresh `did:peer:2` admin with usable
+  secrets; pair with `TestMediatorBuilder::admin_identity(...)` to
+  pin the mediator to a known admin DID.
+- **FEAT:** `TestEnvironment::add_admin(AdminIdentity)` wires an SDK
+  profile authenticated as the configured admin DID. Validates
+  `identity.did == mediator.admin_did()` to surface misuse early
+  (returns `TestEnvironmentError::AdminMismatch`). Admin secrets are
+  inserted into the SDK resolver but **not** the mediator's own
+  server-side resolver — the admin authenticates via DID resolution
+  + signature verification, so the private key never crosses the
+  fixture boundary.
+- **FEAT:** `did_hash()` on both `TestUser` and `TestMediatorUser` —
+  SHA-256 of the DID, the canonical key shape used by admin-protocol
+  calls (`acls_set`, `access_list_add`, `account_remove`). Removes a
+  leak of internals from every admin-protocol test.
+- **REFACTOR:** Internal `register_local_did` now uses
+  `acl::allow_all()` instead of `MediatorACLSet::from_string_ruleset("ALLOW_ALL")`.
+  Minor code cleanup; behavior unchanged.
+- **TEST:** 11 new lifecycle tests covering the new surface — ACL
+  CRUD, `add_admin` happy / mismatch paths, security-knob plumbing,
+  preset constructors, and a `did_hash` round-trip.
+
+### 0.2.1 — Routing-fix test additions (bundled with mediator 0.15.1)
+
+- **TEST:** `add_user_dids_have_mediator_did_as_service_uri` and
+  `with_users_dids_have_mediator_did_as_service_uri` — resolve a
+  minted user DID and assert its DIDCommMessaging service URI is the
+  mediator's DID. The architectural contract the routing-2.0
+  self-loopback fix relies on.
+- **TEST:** `enable_external_forwarding_disabled_spawns_successfully` —
+  smoke-tests the builder option.
+- **CHORE:** Bumped internal pin on
+  `affinidi-messaging-mediator-common` to `0.15` to track the
+  feature-gating rework.
+
+### 0.2.0 — Initial public release
+
+- Embedded mediator fixture with `MemoryStore` default backend
+  (Redis-free spawn) and an optional `fjall-backend` feature for
+  on-disk persistence tests.
+- `TestEnvironment` for end-to-end tests with a wired SDK client.
+- `TestMediator::with_users` / `add_user` for one-shot multi-user
+  setup against the routing-2.0 service-URI shape.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.0"
+version = "0.2.1"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ fjall-backend = ["affinidi-messaging-mediator/fjall-backend", "dep:tempfile"]
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
 affinidi-messaging-mediator = { version = "0.15", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
-affinidi-messaging-mediator-common = { version = "0.14", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
 
 # ── Optional: Fjall on-disk backend support (gated on `fjall-backend`) ──
 ## Wraps each FjallStore in a temp directory that's cleaned up when the

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.1"
+version = "0.2.2"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/README.md
@@ -170,6 +170,144 @@ let mediator = TestMediator::builder()
 Then the SDK's `profile_add(_, /* live_stream */ true)` flow completes
 the JWT handshake and opens the WebSocket without hitting the 403.
 
+For finer control over per-user ACLs, use
+[`add_user_with_acl`](TestMediatorHandle::add_user_with_acl) (see
+"Simulating different ACL modes" below).
+
+## Simulating different ACL modes
+
+Production deployments configure the mediator with a few interrelated
+ACL knobs:
+
+- `mediator_acl_mode` — `ExplicitDeny` (denylist; default) or
+  `ExplicitAllow` (allowlist).
+- `global_acl_default` — the `MediatorACLSet` applied to any DID that
+  authenticates without a pre-existing account.
+- per-DID `MediatorACLSet` — overrides the global default for
+  registered accounts.
+
+The fixture exposes typed setters for all three. **Defaults match
+`SecurityConfig::default`** so tests that don't touch these knobs are
+unaffected; today's `ExplicitDeny` + `MediatorACLSet::default()` +
+per-user `ALLOW_ALL` shape is preserved.
+
+```rust,ignore
+use affinidi_messaging_test_mediator::{
+    AccessListModeType, TestMediator, acl,
+};
+
+// Allowlist deployment + strict global default. Non-registered DIDs
+// authenticate fine but every send/receive permission is denied until
+// an admin grants them.
+let mediator = TestMediator::builder()
+    .acl_mode(AccessListModeType::ExplicitAllow)
+    .global_acl_default(acl::deny_all())
+    .spawn()
+    .await
+    .expect("spawn");
+
+// Mint alice with a custom per-DID ACL — typed presets cover the
+// common cases; build a `MediatorACLSet` directly for finer control.
+let alice = mediator
+    .add_user_with_acl("alice", acl::allow_all())
+    .await
+    .expect("add alice");
+
+// Revoke mid-flow without going through the admin protocol — the
+// fixture-bypass path. Use this when you're testing client behavior
+// against a denied path, not the admin protocol itself.
+mediator
+    .set_acl(&alice.did, acl::deny_all())
+    .await
+    .expect("set_acl");
+
+// Read back via the same bypass path.
+let observed = mediator
+    .get_acl(&alice.did)
+    .await
+    .expect("get_acl")
+    .expect("alice has ACL record");
+assert_eq!(observed.to_u64(), acl::deny_all().to_u64());
+```
+
+The [`acl`](crate::acl) module exports `allow_all()` and `deny_all()`
+as typed equivalents of the production string presets. For
+fine-grained ACLs, build a `MediatorACLSet` directly via
+`MediatorACLSet::default()` plus the bit setters — both
+[`MediatorACLSet`] and [`AccessListModeType`] are re-exported from
+this crate so consumers don't need a direct dep on
+`affinidi-messaging-mediator-common`.
+
+Other security flags exposed on the builder for completeness:
+[`local_direct_delivery`](TestMediatorBuilder::local_direct_delivery),
+[`block_anonymous_outer_envelope`](TestMediatorBuilder::block_anonymous_outer_envelope),
+[`force_session_did_match`](TestMediatorBuilder::force_session_did_match),
+[`block_remote_admin_msgs`](TestMediatorBuilder::block_remote_admin_msgs),
+[`jwt_expiry`](TestMediatorBuilder::jwt_expiry),
+[`local_endpoints`](TestMediatorBuilder::local_endpoints).
+
+## Admin protocol tests
+
+The mediator's admin DID is configured at startup via
+`MediatorBuilder::admin_did`. By default the fixture mints an opaque
+`did:key:z6Mk{uuid}` shape with no usable secrets — fine for tests that
+don't authenticate as admin. To drive the mediator-administration
+protocol from a real SDK client, mint a usable admin identity and
+attach it to the builder:
+
+```rust,ignore
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, acl};
+
+// Step 1 — mint admin DID + secrets. The same `AdminIdentity` value
+// can drive multiple test-mediator instances if needed.
+let admin = TestMediator::random_admin_identity().expect("admin identity");
+
+// Step 2 — pin the mediator to that admin.
+let mediator = TestMediator::builder()
+    .admin_identity(admin.clone())
+    .spawn()
+    .await
+    .expect("spawn");
+let env = TestEnvironment::new(mediator).await.expect("env new");
+
+// Step 3 — wire an SDK profile authenticated as that admin. The
+// admin's secrets are inserted into the SDK resolver here (so it can
+// sign auth challenges); they are NOT inserted into the mediator's
+// own server-side resolver.
+let admin_user = env.add_admin(admin).await.expect("add_admin");
+
+// Step 4 — drive the admin-protocol surface. The protocol takes
+// hashed DIDs, exposed on TestUser / TestMediatorUser as
+// `did_hash()`.
+let alice = env.add_user("alice").await.expect("add alice");
+env.atm
+    .protocols()
+    .mediator()
+    .acls()
+    .acls_set(&env.atm, &admin_user.profile, &alice.did_hash(), &acl::deny_all())
+    .await
+    .expect("admin acls_set");
+
+// Step 5 — verify via the fixture-bypass read path. Independent
+// verification of a write that went through the protocol.
+let observed = env
+    .mediator
+    .get_acl(&alice.did)
+    .await
+    .expect("get_acl")
+    .expect("alice has ACL record");
+assert_eq!(observed.to_u64(), acl::deny_all().to_u64());
+```
+
+**Secrets ownership.** `AdminIdentity::secrets` stays with the caller.
+[`add_admin`](TestEnvironment::add_admin) inserts them into the SDK's
+secrets resolver so the SDK can sign on the admin's behalf. The
+mediator's own server-side secrets resolver is **not** touched — that
+resolver holds the mediator's operating keys, not its admin's. The
+admin authenticates via DID resolution + signature verification of
+the HTTP-auth challenge, so the private key never crosses the fixture
+boundary.
+
 ## Crypto provider
 
 The fixture installs rustls' `aws_lc_rs` `CryptoProvider` as the

--- a/crates/messaging/affinidi-messaging-test-mediator/src/acl.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/acl.rs
@@ -1,0 +1,138 @@
+//! Typed ACL presets for the test-mediator fixture.
+//!
+//! The production mediator config parses ACL settings from a comma-
+//! separated string ruleset (e.g. `"ALLOW_ALL"`, `"DENY_ALL"`,
+//! `"MODE_EXPLICIT_DENY, LOCAL, RECEIVE_MESSAGES"`). That format is
+//! convenient in `mediator.toml` but error-prone in test code: typos
+//! turn into runtime parse errors that only surface when the test
+//! actually spins up the fixture.
+//!
+//! This module exposes the same presets as plain Rust functions
+//! returning a [`MediatorACLSet`]. Each function mirrors the
+//! corresponding arm of `MediatorACLSet::from_string_ruleset` exactly,
+//! constructed via the public bit-setter API. Use these for the common
+//! cases; for fine-grained ACLs, build a `MediatorACLSet` directly
+//! with `MediatorACLSet::default()` plus the bit setters.
+//!
+//! ```ignore
+//! use affinidi_messaging_test_mediator::{TestMediator, acl};
+//!
+//! let mediator = TestMediator::builder()
+//!     .global_acl_default(acl::deny_all())     // typed, no string parsing
+//!     .spawn().await?;
+//!
+//! let alice = mediator
+//!     .add_user_with_acl("alice", acl::allow_all())
+//!     .await?;
+//! ```
+//!
+//! Any failure returned from the underlying bit-setters surfaces as
+//! [`crate::TestMediatorError::Acl`]. In practice the presets here
+//! cannot fail — they pass `admin = true` to every setter — but we
+//! propagate the type signature so the construction stays honest.
+
+use crate::{AccessListModeType, MediatorACLSet, TestMediatorError};
+
+/// Equivalent of the production `"ALLOW_ALL"` preset.
+///
+/// - `mode = ExplicitDeny` (denylist semantics)
+/// - `local = true` (DID can complete WS upgrade)
+/// - every send/receive/forward/invite/anon-receive flag granted
+/// - every self-management flag enabled (DID can change its own ACL,
+///   queue limits, access list)
+///
+/// This is what `add_user` mints for every test user today, and what
+/// most happy-path tests want.
+pub fn allow_all() -> MediatorACLSet {
+    let mut acls = MediatorACLSet::default();
+    apply_allow_all(&mut acls)
+        .expect("allow_all preset is infallible: every setter is invoked with admin=true");
+    acls
+}
+
+/// Equivalent of the production `"DENY_ALL"` preset.
+///
+/// - `mode = ExplicitAllow` (allowlist semantics)
+/// - `local = false`
+/// - every send/receive/forward/invite/anon-receive flag denied
+/// - no self-management — only an admin can change anything
+///
+/// Use for testing the strict-allowlist deployment shape, or as the
+/// `global_acl_default` to verify the mediator rejects unregistered
+/// DIDs.
+pub fn deny_all() -> MediatorACLSet {
+    let mut acls = MediatorACLSet::default();
+    apply_deny_all(&mut acls)
+        .expect("deny_all preset is infallible: every setter is invoked with admin=true");
+    acls
+}
+
+// ─── Internal helpers — kept as `Result` so the preset bodies match
+// the production `from_string_ruleset` arms exactly and any future
+// behavior change in the bit setters surfaces here, not silently. ──
+
+fn apply_allow_all(acls: &mut MediatorACLSet) -> Result<(), TestMediatorError> {
+    acls.set_access_list_mode(AccessListModeType::ExplicitDeny, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_local(true);
+    acls.set_send_messages(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_receive_messages(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_send_forwarded(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_receive_forwarded(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_create_invites(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_anon_receive(true, true, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_self_manage_list(true);
+    acls.set_self_manage_send_queue_limit(true);
+    acls.set_self_manage_receive_queue_limit(true);
+    Ok(())
+}
+
+fn apply_deny_all(acls: &mut MediatorACLSet) -> Result<(), TestMediatorError> {
+    acls.set_access_list_mode(AccessListModeType::ExplicitAllow, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_local(false);
+    acls.set_send_messages(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_receive_messages(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_send_forwarded(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_receive_forwarded(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_create_invites(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_anon_receive(false, false, true)
+        .map_err(TestMediatorError::Acl)?;
+    acls.set_self_manage_list(false);
+    acls.set_self_manage_send_queue_limit(false);
+    acls.set_self_manage_receive_queue_limit(false);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `allow_all()` and `deny_all()` should produce the same bitmask
+    /// the production `from_string_ruleset` parser does. Locks the
+    /// invariant in case either side drifts.
+    #[test]
+    fn allow_all_matches_production_ruleset() {
+        let typed = allow_all();
+        let parsed = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
+        assert_eq!(typed.to_u64(), parsed.to_u64());
+    }
+
+    #[test]
+    fn deny_all_matches_production_ruleset() {
+        let typed = deny_all();
+        let parsed = MediatorACLSet::from_string_ruleset("DENY_ALL").unwrap();
+        assert_eq!(typed.to_u64(), parsed.to_u64());
+    }
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -35,7 +35,7 @@ use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
 
-use crate::{TestMediator, TestMediatorHandle};
+use crate::{AdminIdentity, TestMediator, TestMediatorHandle};
 
 /// Errors specific to the e2e test environment, as opposed to the
 /// mediator-only fixture in [`crate::TestMediatorError`].
@@ -55,6 +55,20 @@ pub enum TestEnvironmentError {
         /// Underlying TDK / crypto error from `DID::generate_did_peer`.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// `add_admin` was called with an `AdminIdentity` whose DID does
+    /// not match the mediator's configured admin DID. Authenticating
+    /// against this mismatched identity would succeed but the session
+    /// would never receive the admin role — surfacing the misuse here
+    /// catches the bug at fixture setup, not at protocol time.
+    #[error(
+        "admin identity DID ({supplied}) does not match mediator's configured admin_did ({configured})"
+    )]
+    AdminMismatch {
+        /// Admin DID the mediator was started with.
+        configured: String,
+        /// Admin DID supplied to `add_admin`.
+        supplied: String,
     },
 }
 
@@ -88,6 +102,16 @@ pub struct TestUser {
     /// the shared resolver — kept here for tests that want to inspect
     /// or copy them.
     pub secrets: Vec<Secret>,
+}
+
+impl TestUser {
+    /// SHA-256 hash of the DID string — the canonical key shape used
+    /// by the mediator's account / ACL / queue stores. Pass this to
+    /// admin-protocol calls (e.g. `acls_set`, `access_list_add`,
+    /// `account_remove`) that operate on hashed DIDs.
+    pub fn did_hash(&self) -> String {
+        sha256::digest(&self.did)
+    }
 }
 
 impl TestEnvironment {
@@ -191,6 +215,75 @@ impl TestEnvironment {
             alias: alias.to_string(),
             profile,
             secrets,
+        })
+    }
+
+    /// Wire an SDK profile authenticated as the mediator's admin DID.
+    ///
+    /// `identity.did` MUST equal `self.mediator.admin_did()` —
+    /// otherwise the resulting profile would authenticate fine but the
+    /// session would never receive the admin role, and admin-protocol
+    /// calls would silently fall through to `Standard`-tier
+    /// permissions. This method returns
+    /// [`TestEnvironmentError::AdminMismatch`] in that case to surface
+    /// the misuse early.
+    ///
+    /// Differences from [`add_user`](Self::add_user):
+    /// - **Does not register the admin DID as a LOCAL account** on the
+    ///   mediator — the admin is recognized by the `admin_did` config
+    ///   match performed at session-establishment, not by ACL.
+    /// - **Does insert** `identity.secrets` into the shared SDK
+    ///   resolver, so the SDK can sign HTTP-auth challenges and
+    ///   DIDComm envelopes on the admin's behalf. The mediator's own
+    ///   server-side secrets resolver is **not** touched (that
+    ///   resolver holds the mediator's operating keys, not its
+    ///   admin's).
+    /// - Returns a [`TestUser`]-shaped value (same struct — admin-ness
+    ///   is a property of the DID-to-config match, not the type).
+    ///
+    /// Pair with [`TestMediator::random_admin_identity`] +
+    /// [`crate::TestMediatorBuilder::admin_identity`] for the full
+    /// "stand up a mediator with a usable admin" flow.
+    pub async fn add_admin(
+        &self,
+        identity: AdminIdentity,
+    ) -> Result<TestUser, TestEnvironmentError> {
+        if identity.did != self.mediator.admin_did() {
+            return Err(TestEnvironmentError::AdminMismatch {
+                configured: self.mediator.admin_did().to_string(),
+                supplied: identity.did,
+            });
+        }
+
+        // Make the admin's secrets available to the SDK so it can
+        // sign auth challenges and pack outbound admin-protocol
+        // messages. NOT inserted into the mediator's own resolver —
+        // see the doc comment above.
+        self.tdk
+            .secrets_resolver()
+            .insert_vec(&identity.secrets)
+            .await;
+
+        let mediator_did = self.mediator.did().to_string();
+        let profile = ATMProfile::new(
+            &self.atm,
+            Some("admin".to_string()),
+            identity.did.clone(),
+            Some(mediator_did),
+        )
+        .await
+        .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        let profile = self
+            .atm
+            .profile_add(&profile, false)
+            .await
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+
+        Ok(TestUser {
+            did: identity.did,
+            alias: "admin".to_string(),
+            profile,
+            secrets: identity.secrets,
         })
     }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -75,8 +75,16 @@
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]
 
+pub mod acl;
 pub mod environment;
 pub use environment::{TestEnvironment, TestEnvironmentError, TestUser};
+
+// Re-exports so consumers don't have to add a direct dep on
+// mediator-common just to construct an `acl_mode(...)` argument or
+// inspect a `MediatorACLSet` returned by `get_acl(...)`.
+pub use affinidi_messaging_mediator_common::types::acls::{
+    ACLError, AccessListModeType, MediatorACLSet,
+};
 
 use std::{
     net::{SocketAddr, TcpListener},
@@ -91,7 +99,6 @@ use affinidi_messaging_mediator_common::{
     MediatorSecrets, errors::MediatorError, secrets::backends::MemoryStore as SecretsMemoryStore,
     store::MediatorStore,
 };
-use affinidi_messaging_sdk::protocols::mediator::acls::MediatorACLSet;
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
 use affinidi_tdk::dids::{
     DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
@@ -120,6 +127,13 @@ pub enum TestMediatorError {
     /// The underlying mediator returned an error.
     #[error(transparent)]
     Mediator(#[from] MediatorError),
+    /// An ACL bit-setter rejected an operation, or a preset
+    /// constructor surfaced one. In practice the presets in
+    /// [`crate::acl`] never fail (they pass `admin = true`); this
+    /// variant exists so future tightening of the production setters
+    /// surfaces here rather than via panic.
+    #[error("ACL operation failed: {0}")]
+    Acl(#[from] ACLError),
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -138,6 +152,29 @@ impl TestMediator {
     /// default in-memory store and an ephemeral 127.0.0.1 port.
     pub async fn spawn() -> Result<TestMediatorHandle, TestMediatorError> {
         Self::builder().spawn().await
+    }
+
+    /// Generate a fresh `did:peer:2` identity (Ed25519 verification +
+    /// X25519 key agreement) suitable for use as the mediator's admin
+    /// DID via [`TestMediatorBuilder::admin_identity`]. Mirrors the
+    /// `add_user` flow, minus the secrets-resolver insertion — the
+    /// admin's secrets stay with the caller. Pair with
+    /// [`TestEnvironment::add_admin`] to wire up an SDK profile that
+    /// authenticates as admin.
+    ///
+    /// The returned [`AdminIdentity`] can be cloned freely; the same
+    /// identity can drive multiple test-mediator instances or external
+    /// SDK clients.
+    pub fn random_admin_identity() -> Result<AdminIdentity, TestMediatorError> {
+        let (did, secrets) = DID::generate_did_peer(
+            vec![
+                (PeerKeyRole::Verification, KeyType::Ed25519),
+                (PeerKeyRole::Encryption, KeyType::X25519),
+            ],
+            None,
+        )
+        .map_err(|e| TestMediatorError::DidGeneration(e.to_string()))?;
+        Ok(AdminIdentity { did, secrets })
     }
 
     /// Spawn a default test mediator and pre-create one
@@ -188,6 +225,43 @@ pub struct TestMediatorUser {
     pub secrets: Vec<Secret>,
 }
 
+impl TestMediatorUser {
+    /// SHA-256 hash of the DID string — the canonical key shape used
+    /// by the mediator's account / ACL / queue stores. Pass this to
+    /// admin-protocol calls (e.g. `acls_set`, `access_list_add`,
+    /// `account_remove`) that operate on hashed DIDs.
+    pub fn did_hash(&self) -> String {
+        digest(&self.did)
+    }
+}
+
+/// A stable admin identity for the test mediator. The `did` is set
+/// as the mediator's `admin_did` (via
+/// [`TestMediatorBuilder::admin_identity`]) and the `secrets` are
+/// returned to the caller so they can sign DIDComm messages and
+/// HTTP-auth challenges as admin.
+///
+/// Construct via [`TestMediator::random_admin_identity`] for a
+/// freshly generated `did:peer:2`. Build your own when a test needs
+/// a stable DID across runs (e.g. to reuse cached resolver state).
+///
+/// **Secrets ownership.** The `secrets` field stays with the caller.
+/// Unlike [`TestMediatorHandle::add_user`], the test-mediator does
+/// **not** insert these into its own server-side secrets resolver
+/// (that resolver holds the mediator's operating keys, not its
+/// admin's). The admin authenticates via DID resolution + signature
+/// verification of the HTTP-auth challenge, so the private key never
+/// crosses the fixture boundary. Pass the secrets to whatever
+/// DIDComm or SDK auth client you're driving from the test —
+/// [`TestEnvironment::add_admin`] handles this for you.
+#[derive(Debug, Clone)]
+pub struct AdminIdentity {
+    /// `did:peer:2.*` admin DID.
+    pub did: String,
+    /// Verification + key-agreement secrets for `did`.
+    pub secrets: Vec<Secret>,
+}
+
 /// Configuration knobs for the test mediator.
 ///
 /// All fields have sensible defaults for the most common test scenario:
@@ -209,6 +283,35 @@ pub struct TestMediatorBuilder {
     /// here — the WS upgrade handler refuses connections from sessions
     /// without the LOCAL ACL bit set.
     local_dids: Vec<String>,
+    /// Public service URLs to forward to `MediatorBuilder::local_endpoints`
+    /// (mediator 0.15.0+). Empty by default; set this when the mediator
+    /// is reachable via additional hostnames or ports beyond
+    /// `listen_addr`.
+    local_endpoints: Vec<String>,
+    /// Override for `SecurityConfig.mediator_acl_mode`. `None` keeps the
+    /// production default (`ExplicitDeny`).
+    acl_mode: Option<AccessListModeType>,
+    /// Override for `SecurityConfig.global_acl_default`. `None` keeps the
+    /// production default (`MediatorACLSet::default()`).
+    global_acl_default: Option<MediatorACLSet>,
+    /// Override for `SecurityConfig.local_direct_delivery_allowed`.
+    local_direct_delivery_allowed: Option<bool>,
+    /// Override for `SecurityConfig.local_direct_delivery_allow_anon`.
+    local_direct_delivery_allow_anon: Option<bool>,
+    /// Override for `SecurityConfig.block_anonymous_outer_envelope`.
+    block_anonymous_outer_envelope: Option<bool>,
+    /// Override for `SecurityConfig.force_session_did_match`.
+    force_session_did_match: Option<bool>,
+    /// Override for `SecurityConfig.block_remote_admin_msgs`.
+    block_remote_admin_msgs: Option<bool>,
+    /// Override for `SecurityConfig.jwt_access_expiry` (seconds).
+    jwt_access_expiry_secs: Option<u64>,
+    /// Override for `SecurityConfig.jwt_refresh_expiry` (seconds).
+    jwt_refresh_expiry_secs: Option<u64>,
+    /// Stable admin identity for the mediator. `None` mints the
+    /// historical opaque `did:key:z6Mk{uuid}` shape with no usable
+    /// secrets — suitable for tests that don't authenticate as admin.
+    admin_identity: Option<AdminIdentity>,
     /// Temp directory backing a Fjall store, kept alive for the lifetime
     /// of the resulting handle so the partition files don't get cleaned
     /// up while the mediator is still using them.
@@ -226,6 +329,17 @@ impl Default for TestMediatorBuilder {
             enable_message_expiry: false,
             enable_streaming: true,
             local_dids: Vec::new(),
+            local_endpoints: Vec::new(),
+            acl_mode: None,
+            global_acl_default: None,
+            local_direct_delivery_allowed: None,
+            local_direct_delivery_allow_anon: None,
+            block_anonymous_outer_envelope: None,
+            force_session_did_match: None,
+            block_remote_admin_msgs: None,
+            jwt_access_expiry_secs: None,
+            jwt_refresh_expiry_secs: None,
+            admin_identity: None,
             #[cfg(feature = "fjall-backend")]
             fjall_dir: None,
         }
@@ -325,6 +439,107 @@ impl TestMediatorBuilder {
         self
     }
 
+    // ─── ACL / security knobs ────────────────────────────────────────
+
+    /// Override the mediator's access-list mode. Defaults to
+    /// `ExplicitDeny` (matching `SecurityConfig::default`). Set to
+    /// `ExplicitAllow` to simulate an allowlist deployment, where DIDs
+    /// without an explicit `LOCAL` ACL bit are rejected.
+    pub fn acl_mode(mut self, mode: AccessListModeType) -> Self {
+        self.acl_mode = Some(mode);
+        self
+    }
+
+    /// Override the global ACL applied to any DID that authenticates
+    /// without a pre-existing account. Pair with [`crate::acl`]
+    /// presets (`acl::allow_all()`, `acl::deny_all()`) for the common
+    /// cases, or build a [`MediatorACLSet`] directly via
+    /// `MediatorACLSet::default()` plus the bit setters for fine-grained
+    /// control. Defaults to `MediatorACLSet::default()`.
+    pub fn global_acl_default(mut self, acls: MediatorACLSet) -> Self {
+        self.global_acl_default = Some(acls);
+        self
+    }
+
+    /// Override `local_direct_delivery_allowed` and
+    /// `local_direct_delivery_allow_anon`. Defaults match
+    /// `SecurityConfig` (both `false`).
+    pub fn local_direct_delivery(mut self, allowed: bool, allow_anon: bool) -> Self {
+        self.local_direct_delivery_allowed = Some(allowed);
+        self.local_direct_delivery_allow_anon = Some(allow_anon);
+        self
+    }
+
+    /// Override `block_anonymous_outer_envelope`. Defaults to the
+    /// production value (the headless config currently keeps anon
+    /// envelopes enabled).
+    pub fn block_anonymous_outer_envelope(mut self, block: bool) -> Self {
+        self.block_anonymous_outer_envelope = Some(block);
+        self
+    }
+
+    /// Override `force_session_did_match`. Defaults to the production
+    /// value.
+    pub fn force_session_did_match(mut self, force: bool) -> Self {
+        self.force_session_did_match = Some(force);
+        self
+    }
+
+    /// Override `block_remote_admin_msgs`. Defaults to the production
+    /// value.
+    pub fn block_remote_admin_msgs(mut self, block: bool) -> Self {
+        self.block_remote_admin_msgs = Some(block);
+        self
+    }
+
+    /// Override JWT expiries. Defaults: 900 s access, 86 400 s refresh.
+    /// Useful for testing token-refresh flows by shrinking access
+    /// expiry to a few seconds.
+    pub fn jwt_expiry(mut self, access: std::time::Duration, refresh: std::time::Duration) -> Self {
+        self.jwt_access_expiry_secs = Some(access.as_secs());
+        self.jwt_refresh_expiry_secs = Some(refresh.as_secs());
+        self
+    }
+
+    // ─── Routing / endpoint config ───────────────────────────────────
+
+    /// Declare additional URLs at which the mediator is reachable.
+    /// Forwarded to `MediatorBuilder::local_endpoints` (mediator
+    /// 0.15.0+) so the routing-2.0 self-loopback handler treats
+    /// forwards to those URLs as local. The bind address is always
+    /// treated as local — only set this when the mediator is reachable
+    /// via additional hostnames or ports beyond the bind address.
+    pub fn local_endpoints<I, S>(mut self, endpoints: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.local_endpoints
+            .extend(endpoints.into_iter().map(Into::into));
+        self
+    }
+
+    // ─── Admin identity ──────────────────────────────────────────────
+
+    /// Use a specific admin identity. Defaults to a random
+    /// `did:key:z6Mk{uuid}` shape with no usable secrets — fine for
+    /// tests that don't authenticate as admin. Pass an
+    /// [`AdminIdentity`] (see [`TestMediator::random_admin_identity`])
+    /// when admin-protocol or account-management tests need to sign
+    /// as admin.
+    ///
+    /// **Secrets are NOT inserted into the mediator's secrets resolver.**
+    /// The caller owns `identity.secrets`. The mediator authenticates
+    /// the admin via DID resolution (peer:2 resolves locally) and
+    /// signature verification of the HTTP-auth challenge — the private
+    /// key never crosses the fixture boundary. Pass the secrets to
+    /// whatever DIDComm or SDK auth client you're driving from the
+    /// test ([`TestEnvironment::add_admin`] handles this for you).
+    pub fn admin_identity(mut self, identity: AdminIdentity) -> Self {
+        self.admin_identity = Some(identity);
+        self
+    }
+
     /// Run this test mediator against an on-disk Fjall backend instead
     /// of the default in-memory store. The data lives in a temporary
     /// directory tied to the resulting handle — when the handle drops,
@@ -363,7 +578,13 @@ impl TestMediatorBuilder {
 
         let (mediator_did, mediator_secrets, secrets_resolver) =
             generate_mediator_identity(&service_uri).await?;
-        let admin_did = format!("did:key:z6Mk{}", uuid::Uuid::new_v4().simple());
+        // Honor an operator-supplied admin identity if present —
+        // otherwise fall back to the historical opaque shape so tests
+        // that don't authenticate as admin keep working unchanged.
+        let admin_did = match self.admin_identity.as_ref() {
+            Some(id) => id.did.clone(),
+            None => format!("did:key:z6Mk{}", uuid::Uuid::new_v4().simple()),
+        };
 
         // JWT signing key — Ed25519 PKCS8, same shape as the production
         // path's `JWT_SECRET` well-known.
@@ -378,6 +599,36 @@ impl TestMediatorBuilder {
         security.jwt_encoding_key = jwt_encoding_key;
         security.jwt_decoding_key = jwt_decoding_key;
         security.use_ssl = false;
+        // Apply Option-typed overrides — `None` keeps the headless
+        // default, so behavior for callers that don't touch these
+        // setters is unchanged from earlier releases.
+        if let Some(mode) = self.acl_mode {
+            security.mediator_acl_mode = mode;
+        }
+        if let Some(acls) = self.global_acl_default.clone() {
+            security.global_acl_default = acls;
+        }
+        if let Some(b) = self.local_direct_delivery_allowed {
+            security.local_direct_delivery_allowed = b;
+        }
+        if let Some(b) = self.local_direct_delivery_allow_anon {
+            security.local_direct_delivery_allow_anon = b;
+        }
+        if let Some(b) = self.block_anonymous_outer_envelope {
+            security.block_anonymous_outer_envelope = b;
+        }
+        if let Some(b) = self.force_session_did_match {
+            security.force_session_did_match = b;
+        }
+        if let Some(b) = self.block_remote_admin_msgs {
+            security.block_remote_admin_msgs = b;
+        }
+        if let Some(secs) = self.jwt_access_expiry_secs {
+            security.jwt_access_expiry = secs;
+        }
+        if let Some(secs) = self.jwt_refresh_expiry_secs {
+            security.jwt_refresh_expiry = secs;
+        }
 
         // Disable processors that aren't useful in most tests.
         let mut processors =
@@ -406,6 +657,7 @@ impl TestMediatorBuilder {
             .security(security)
             .processors(processors)
             .streaming_enabled(self.enable_streaming)
+            .local_endpoints(self.local_endpoints.clone())
             .tls(TlsMode::Plain)
             .start(token.clone())
             .await?;
@@ -530,7 +782,27 @@ impl TestMediatorHandle {
         &self,
         alias: impl Into<String>,
     ) -> Result<TestMediatorUser, TestMediatorError> {
-        let alias = alias.into();
+        self.mint_user(alias.into(), acl::allow_all()).await
+    }
+
+    /// Mint a fresh `did:peer:2.*` user (same shape as [`add_user`])
+    /// but register it with `acls` instead of the typed `ALLOW_ALL`
+    /// preset. Useful for testing denied paths without reaching into
+    /// the underlying store.
+    pub async fn add_user_with_acl(
+        &self,
+        alias: impl Into<String>,
+        acls: MediatorACLSet,
+    ) -> Result<TestMediatorUser, TestMediatorError> {
+        self.mint_user(alias.into(), acls).await
+    }
+
+    /// Common implementation for [`add_user`] and [`add_user_with_acl`].
+    async fn mint_user(
+        &self,
+        alias: String,
+        acls: MediatorACLSet,
+    ) -> Result<TestMediatorUser, TestMediatorError> {
         let (did, secrets) = DID::generate_did_peer(
             vec![
                 (PeerKeyRole::Verification, KeyType::Ed25519),
@@ -541,13 +813,40 @@ impl TestMediatorHandle {
         .map_err(|e| TestMediatorError::DidGeneration(e.to_string()))?;
 
         self.secrets_resolver.insert_vec(&secrets).await;
-        self.register_local_did(&did).await?;
+        register_local_did_with_acl(&self.store, &did, &acls).await?;
 
         Ok(TestMediatorUser {
             did,
             alias,
             secrets,
         })
+    }
+
+    /// Replace a registered DID's ACL bitmask. Goes directly through
+    /// the underlying [`MediatorStore::set_did_acl`] — no admin session
+    /// is required, no permission checks run. Tests use this to
+    /// simulate ACL changes mid-flow ("mint user, run code, revoke
+    /// ACL, run more code") without round-tripping through the
+    /// admin protocol.
+    ///
+    /// Note this is the **fixture bypass** path. To validate that the
+    /// production mediator-administration protocol enforces
+    /// admin-only ACL changes correctly, drive
+    /// `env.atm.protocols().mediator().acls().acls_set(...)` from an
+    /// admin-authenticated SDK profile (see
+    /// [`TestEnvironment::add_admin`]) and use [`Self::get_acl`] to
+    /// read back the result.
+    pub async fn set_acl(&self, did: &str, acls: MediatorACLSet) -> Result<(), TestMediatorError> {
+        let did_hash = digest(did);
+        self.store.set_did_acl(&did_hash, &acls).await?;
+        Ok(())
+    }
+
+    /// Read the current ACL bitmask for `did`. Returns `None` when the
+    /// DID has no account record on the mediator.
+    pub async fn get_acl(&self, did: &str) -> Result<Option<MediatorACLSet>, TestMediatorError> {
+        let did_hash = digest(did);
+        Ok(self.store.get_did_acl(&did_hash).await?)
     }
 }
 
@@ -672,31 +971,30 @@ async fn generate_mediator_identity(
     Ok((did, secrets, Arc::new(resolver)))
 }
 
-/// Insert a single DID into the mediator's account store as a LOCAL,
-/// non-admin, ALLOW_ALL account. Idempotent — a DID that already has
-/// an account record is left untouched.
-///
-/// Uses the `ALLOW_ALL` ruleset so the registered DID can fully
-/// exercise the mediator (send / receive / forward / WS upgrade)
-/// without being granted admin role. Tests that want stricter ACLs
-/// can register the DID directly via the underlying store.
-async fn register_local_did(
+/// Insert a single DID into the mediator's account store with the
+/// supplied ACL bitmask. Idempotent — a DID that already has an
+/// account record is left untouched.
+async fn register_local_did_with_acl(
     store: &Arc<dyn MediatorStore>,
     did: &str,
+    acls: &MediatorACLSet,
 ) -> Result<(), TestMediatorError> {
-    let acls = MediatorACLSet::from_string_ruleset("ALLOW_ALL").map_err(|e| {
-        TestMediatorError::Mediator(MediatorError::ConfigError(
-            12,
-            "test-mediator".into(),
-            format!("failed to build ALLOW_ALL ACL set: {e}"),
-        ))
-    })?;
     let did_hash = digest(did);
     if store.account_exists(&did_hash).await? {
         return Ok(());
     }
-    store.account_add(&did_hash, &acls, None).await?;
+    store.account_add(&did_hash, acls, None).await?;
     Ok(())
+}
+
+/// Convenience wrapper: register `did` with the typed `acl::allow_all()`
+/// preset. Mirrors the historical "register as LOCAL ALLOW_ALL" flow
+/// without going through string-ruleset parsing.
+async fn register_local_did(
+    store: &Arc<dyn MediatorStore>,
+    did: &str,
+) -> Result<(), TestMediatorError> {
+    register_local_did_with_acl(store, did, &acl::allow_all()).await
 }
 
 /// Insert each DID via [`register_local_did`]. Used by the builder to

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/lifecycle.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/lifecycle.rs
@@ -14,7 +14,9 @@ mod common;
 
 use std::time::Duration;
 
-use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator};
+use affinidi_messaging_test_mediator::{
+    AccessListModeType, MediatorACLSet, TestEnvironment, TestEnvironmentError, TestMediator, acl,
+};
 use common::{init_tracing, skip_if_no_redis};
 
 /// Smoke test: spawning and shutting down a mediator runs to
@@ -413,4 +415,303 @@ async fn enable_external_forwarding_disabled_spawns_successfully() {
 
     mediator.shutdown();
     let _ = mediator.join().await;
+}
+
+// ─── New 0.2.2 surface ───────────────────────────────────────────────
+
+/// `did_hash()` on TestUser and TestMediatorUser returns the SHA-256
+/// hash of the DID — the canonical key shape used by the mediator's
+/// account / ACL / queue stores. Catches accidental drift if either
+/// helper changes its hashing algorithm.
+#[tokio::test]
+async fn did_hash_returns_sha256_of_did() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("env spawn");
+    let alice = env.add_user("alice").await.expect("add alice");
+
+    let expected = sha256::digest(&alice.did);
+    assert_eq!(alice.did_hash(), expected);
+
+    // Same contract on the lower-level TestMediatorUser handle.
+    let user = env
+        .mediator
+        .add_user("bob")
+        .await
+        .expect("add bob via handle");
+    let expected = sha256::digest(&user.did);
+    assert_eq!(user.did_hash(), expected);
+
+    env.shutdown().await.unwrap();
+}
+
+/// `random_admin_identity()` mints a `did:peer:2.*` admin with two
+/// secrets (Ed25519 verification + X25519 key agreement). Sanity-checks
+/// the helper before any test relies on it.
+#[test]
+fn random_admin_identity_minted_with_secrets() {
+    let id = TestMediator::random_admin_identity().expect("admin identity");
+    assert!(id.did.starts_with("did:peer:2."), "admin DID: {}", id.did);
+    assert_eq!(id.secrets.len(), 2, "Ed25519 + X25519 = 2 secrets");
+    // Cloning must preserve the same DID and secrets.
+    let clone = id.clone();
+    assert_eq!(clone.did, id.did);
+    assert_eq!(clone.secrets.len(), id.secrets.len());
+}
+
+/// `add_user_with_acl(alias, deny_all)` registers the user with
+/// exactly the bitmask `acl::deny_all()` produces, observable via
+/// the fixture-bypass `get_acl` read path.
+#[tokio::test]
+async fn add_user_with_acl_custom_round_trips_through_get_acl() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::spawn().await.expect("spawn");
+    let alice = mediator
+        .add_user_with_acl("alice", acl::deny_all())
+        .await
+        .expect("add alice with deny_all");
+
+    let observed = mediator
+        .get_acl(&alice.did)
+        .await
+        .expect("get_acl")
+        .expect("alice has an ACL record");
+    assert_eq!(observed.to_u64(), acl::deny_all().to_u64());
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `set_acl(did, …)` replaces a previously-registered DID's ACL.
+/// Mint with `ALLOW_ALL`, swap to `DENY_ALL`, read back via `get_acl`.
+#[tokio::test]
+async fn set_acl_replaces_existing_acl() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::spawn().await.expect("spawn");
+    let alice = mediator.add_user("alice").await.expect("add alice");
+
+    // Sanity: starts as ALLOW_ALL.
+    let before = mediator
+        .get_acl(&alice.did)
+        .await
+        .expect("get_acl before")
+        .expect("alice has ACL after add_user");
+    assert_eq!(before.to_u64(), acl::allow_all().to_u64());
+
+    mediator
+        .set_acl(&alice.did, acl::deny_all())
+        .await
+        .expect("set_acl");
+
+    let after = mediator
+        .get_acl(&alice.did)
+        .await
+        .expect("get_acl after")
+        .expect("alice still has an ACL record");
+    assert_eq!(after.to_u64(), acl::deny_all().to_u64());
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `admin_identity(...)` plumbs the supplied DID through to the
+/// mediator's `admin_did` config. Without an override, the mediator
+/// uses the historical opaque `did:key:z6Mk{uuid}` shape — this test
+/// pins the override semantics.
+#[tokio::test]
+async fn admin_identity_overrides_default_admin_did() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let admin = TestMediator::random_admin_identity().expect("admin identity");
+    let expected_did = admin.did.clone();
+
+    let mediator = TestMediator::builder()
+        .admin_identity(admin)
+        .spawn()
+        .await
+        .expect("spawn with admin_identity");
+
+    assert_eq!(mediator.admin_did(), expected_did);
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `add_admin` rejects an `AdminIdentity` whose DID does not match the
+/// mediator's configured `admin_did` — the misuse surfaces at fixture
+/// setup, not at protocol time.
+#[tokio::test]
+async fn add_admin_rejects_mismatched_identity() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    // Spawn without `admin_identity` — mediator picks the historical
+    // random `did:key:z6Mk{uuid}` shape, which won't match the peer
+    // DID we mint below.
+    let env = TestEnvironment::spawn().await.expect("env spawn");
+    let stranger = TestMediator::random_admin_identity().expect("stranger identity");
+
+    let err = env
+        .add_admin(stranger)
+        .await
+        .expect_err("must error on mismatch");
+    match err {
+        TestEnvironmentError::AdminMismatch {
+            configured,
+            supplied,
+        } => {
+            assert_eq!(configured, env.mediator.admin_did());
+            assert!(supplied.starts_with("did:peer:2."));
+        }
+        other => panic!("expected AdminMismatch, got {other:?}"),
+    }
+
+    env.shutdown().await.unwrap();
+}
+
+/// `local_endpoints(...)` is plumbed through to `MediatorBuilder`.
+/// Smoke-tests that the fixture spawns cleanly with extra endpoints
+/// declared and that the resulting handle answers `healthchecker`.
+/// The actual self-loopback matching is covered by the mediator's
+/// own routing tests; here we only assert the wiring doesn't panic.
+#[tokio::test]
+async fn local_endpoints_passed_through_to_mediator_builder() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::builder()
+        .local_endpoints([
+            "https://mediator.example.com".to_string(),
+            "https://mediator.example.com:7037".to_string(),
+        ])
+        .spawn()
+        .await
+        .expect("spawn with local_endpoints");
+
+    let url = format!("{}healthchecker", mediator.endpoint());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client");
+    let resp = client.get(&url).send().await.expect("healthchecker");
+    assert!(resp.status().is_success());
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `acl_mode(ExplicitAllow)` and `global_acl_default(...)` are plumbed
+/// through to `SecurityConfig`. Smoke-tests the spawn path with a
+/// non-default ACL config — the actual enforcement (e.g. allowlist
+/// rejecting unregistered DIDs) is exercised by the mediator's own
+/// authentication tests.
+#[tokio::test]
+async fn acl_mode_and_global_acl_default_plumbing() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::builder()
+        .acl_mode(AccessListModeType::ExplicitAllow)
+        .global_acl_default(acl::deny_all())
+        .spawn()
+        .await
+        .expect("spawn with non-default ACL config");
+
+    // Spawn-success + healthchecker is the smoke test. Anything more
+    // requires reading SecurityConfig back out — not exposed today.
+    let url = format!("{}healthchecker", mediator.endpoint());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client");
+    let resp = client.get(&url).send().await.expect("healthchecker");
+    assert!(resp.status().is_success());
+
+    // A user we add explicitly should still get the ACL we ask for —
+    // confirms that the global default (DENY_ALL) doesn't override the
+    // per-user ACL passed to add_user_with_acl.
+    let alice = mediator
+        .add_user_with_acl("alice", acl::allow_all())
+        .await
+        .expect("add alice");
+    let observed = mediator
+        .get_acl(&alice.did)
+        .await
+        .expect("get_acl")
+        .expect("alice has ACL");
+    assert_eq!(observed.to_u64(), acl::allow_all().to_u64());
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `add_admin` happy path — spawn with a fresh admin identity, wrap
+/// in `TestEnvironment`, and wire an SDK profile authenticated as
+/// admin. Asserts the resulting `TestUser` reports the configured
+/// admin DID and carries the admin's secrets.
+#[tokio::test]
+async fn add_admin_wires_sdk_profile_for_configured_admin() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let admin_identity = TestMediator::random_admin_identity().expect("admin identity");
+    let configured_did = admin_identity.did.clone();
+    let secret_count = admin_identity.secrets.len();
+
+    let mediator = TestMediator::builder()
+        .admin_identity(admin_identity.clone())
+        .spawn()
+        .await
+        .expect("spawn with admin_identity");
+    let env = TestEnvironment::new(mediator).await.expect("env new");
+
+    let admin = env
+        .add_admin(admin_identity)
+        .await
+        .expect("add_admin happy path");
+
+    assert_eq!(admin.did, configured_did);
+    assert_eq!(admin.secrets.len(), secret_count);
+    // The profile should round-trip the configured admin DID via
+    // `dids()`, the same path the SDK uses to learn its own identity.
+    let (profile_did, mediator_did) = admin
+        .profile
+        .dids()
+        .expect("admin profile has DIDs configured");
+    assert_eq!(profile_did, configured_did);
+    assert_eq!(mediator_did, env.mediator.did());
+
+    env.shutdown().await.unwrap();
+}
+
+/// `acl::deny_all()` produces the same all-zeros bitmask as
+/// `MediatorACLSet::default()` — both encode "ExplicitAllow mode, no
+/// LOCAL bit, every permission denied, no self-management". Docs this
+/// invariant so a future reader doesn't add a setter to `deny_all()`
+/// thinking it must differ from default.
+#[test]
+fn deny_all_equals_default_bitmask() {
+    assert_eq!(MediatorACLSet::default().to_u64(), acl::deny_all().to_u64());
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/lifecycle.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/lifecycle.rs
@@ -268,3 +268,149 @@ async fn environment_wires_sdk_profile_to_mediator() {
 
     env.shutdown().await.expect("env shutdown");
 }
+
+/// Resolve `did` and return the URI of its first DIDCommMessaging service.
+/// The `did:peer:2` representation produced by the test-mediator stores the
+/// URI inside `service_endpoint` as a JSON map with a `uri` key (the long
+/// form of the peer-DID service block).
+///
+/// Inspects the resolved Document via JSON serialization rather than
+/// importing `affinidi_did_common::service::Endpoint`, so the test crate
+/// doesn't need a fresh dev-dependency just to peek at one field.
+async fn resolve_didcomm_service_uri(did: &str) -> Option<String> {
+    use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .expect("DID resolver");
+    let resolved = resolver.resolve(did).await.expect("resolve user DID");
+
+    let doc = serde_json::to_value(&resolved.doc).expect("serialize Document");
+    let services = doc.get("service")?.as_array()?;
+    for service in services {
+        // Filter on type — DID-Doc service types can be a string or an array
+        let type_field = service.get("type")?;
+        let is_didcomm = match type_field {
+            serde_json::Value::String(s) => s == "DIDCommMessaging",
+            serde_json::Value::Array(arr) => {
+                arr.iter().any(|v| v.as_str() == Some("DIDCommMessaging"))
+            }
+            _ => false,
+        };
+        if !is_didcomm {
+            continue;
+        }
+        let endpoint = service.get("serviceEndpoint")?;
+        // Endpoint may be a plain URL string, an object with `uri`, or
+        // an array of either. Peel the first URI we find.
+        let candidates: Vec<&serde_json::Value> = match endpoint {
+            serde_json::Value::Array(arr) => arr.iter().collect(),
+            other => vec![other],
+        };
+        for c in candidates {
+            if let Some(s) = c.as_str() {
+                return Some(s.to_string());
+            }
+            if let Some(uri) = c.get("uri").and_then(|v| v.as_str()) {
+                return Some(uri.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// `add_user` mints a `did:peer:2` whose DIDCommMessaging service URI is
+/// the mediator's DID. This is the architectural contract the routing-2.0
+/// self-loopback path relies on — without it, the routing handler would
+/// classify the user's next-hop as remote and push the forward onto the
+/// remote-delivery queue.
+#[tokio::test]
+async fn add_user_dids_have_mediator_did_as_service_uri() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::spawn().await.expect("spawn");
+    let alice = mediator.add_user("alice").await.expect("add alice");
+
+    let uri = resolve_didcomm_service_uri(&alice.did)
+        .await
+        .expect("alice's DID has a DIDCommMessaging service URI");
+    assert_eq!(
+        uri,
+        mediator.did(),
+        "minted user DID must point at the mediator's DID, not its HTTP URL"
+    );
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// Same contract for `with_users`. The two paths share an
+/// implementation today but the assertion guards against drift.
+#[tokio::test]
+async fn with_users_dids_have_mediator_did_as_service_uri() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let (mediator, users) = TestMediator::with_users(["alice", "bob"])
+        .await
+        .expect("with_users");
+
+    for user in &users {
+        let uri = resolve_didcomm_service_uri(&user.did)
+            .await
+            .unwrap_or_else(|| panic!("{} has no DIDCommMessaging service URI", user.alias));
+        assert_eq!(
+            uri,
+            mediator.did(),
+            "{}'s DID must point at the mediator's DID",
+            user.alias
+        );
+    }
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `enable_external_forwarding(false)` is honored by the builder and
+/// produces a working mediator. With external forwarding off, the
+/// routing handler delivers every forward locally regardless of the
+/// next-hop's DID Document — which is what tests want when their user
+/// DIDs were minted with the mediator's HTTP URL (rather than its DID)
+/// as the service endpoint.
+///
+/// This test only verifies the builder/spawn surface; the actual
+/// "routes locally" behavior is covered by routing.rs unit tests and
+/// the SDK's e2e suite. Adding a true round-trip assertion (alice
+/// forwards to bob, bob receives) is tracked as followup.
+#[tokio::test]
+async fn enable_external_forwarding_disabled_spawns_successfully() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(false)
+        .spawn()
+        .await
+        .expect("spawn with external forwarding disabled");
+
+    // Sanity: handle is fully populated and the mediator answers HTTP.
+    assert!(mediator.bound_addr().port() > 0);
+    let url = format!("{}healthchecker", mediator.endpoint());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client");
+    let resp = client.get(&url).send().await.expect("healthchecker");
+    assert!(resp.status().is_success());
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}


### PR DESCRIPTION
## Summary

Two batches of changes against the same branch:

1. **`mediator 0.15.1`** — IPv6 routing fix + mediator-common feature-gating + ACLError non-exhaustive (the original PR scope, driven by external review of 0.15.0).
2. **`test-mediator 0.2.2`** — ACL / security mode simulation + admin identity + `did_hash` (followup; lets third-party consumers test the full matrix of mediator deployments).

Both batches are additive on the public surface; defaults preserved end-to-end.

---

## Batch 1 — `mediator 0.15.1`

Patch follow-up to 0.15.0 addressing two real-world holes in the self-loopback routing fix and reorganizing `mediator-common`'s dep graph so SDK consumers stop transitively pulling `axum`/`redis`/`aes-gcm`/etc.

### Routing fixes
- **FIX** — IPv6 host normalization. `Url::host_str()` returns IPv6 literals bracketed (`"[::1]"`); `SocketAddr::ip().to_string()` returns them bare (`"::1"`). Both sides now funnel through a shared `normalize_host` helper. Empirically verified against `url 2.x`. Without this, IPv6-bound mediators silently never matched themselves.
- **FEAT** — Startup `warn!` when `listen_address` binds to a wildcard (`0.0.0.0`/`::`) and `local_endpoints` is empty — without this the loopback fix is a silent no-op for default deployments.
- **DOC** — `local_endpoints` documented in `conf/mediator.toml`.
- **TEST** — Routing tests went from 8 → 21. Adds IPv6 (bracketed + bare host forms), `wss://`, query/path/fragment URIs, unknown scheme, plus a `compute_self_authorities` integration test that round-trips an IPv6 listen address.
- **REFACTOR** — `compute_self_authorities`, `default_port_for`, and `normalize_host` are `pub(crate)`. New `compute_self_authorities_from(listen, endpoints)` for cleaner test calls.

### Feature-gated server stack (`mediator-common 0.15.0`)
- Heavy server-side deps (`axum`, `redis`, `reqwest`, `tokio-tungstenite`, `aes-gcm`, `argon2`, `metrics`, etc.) are now optional and gated behind a `server` umbrella feature (default-on) or `redis-backend`. The mediator binary, `mediator-setup`, `mediator-processors`, and `test-mediator` are unaffected.
- SDK consumers (`default-features = false`) compile against just the lean `types` module. `cargo tree` confirms `axum`/`redis` no longer flow into the SDK's build graph via this crate.
- `redis-backend` implies `server`; `DatabaseHandler` and redis-using helpers gated within the module so memory- and Fjall-only deployments don't pull the redis client.
- `secrets-{keyring,aws,gcp,azure,vault}` features each imply `server`.

### `ACLError` non-exhaustive
- `ACLError` is now `#[non_exhaustive]` — brand-new public API in 0.14 with low uptake; better to land the fence now than after 1.0.
- SDK's `From<ACLError> for ATMError` gets a wildcard arm so future variants surface as `ACLConfigError` instead of breaking the build.

---

## Batch 2 — `test-mediator 0.2.2` — ACL / security mode + admin identity

Designed by writing the consumer test code first ("if you were to plan out a client using this new API…"); the surface that landed is the surface that survived contact with that exercise.

### Typed ACL presets (no string parsing)

```rust
use affinidi_messaging_test_mediator::{TestMediator, acl, AccessListModeType};

let mediator = TestMediator::builder()
    .acl_mode(AccessListModeType::ExplicitAllow)
    .global_acl_default(acl::deny_all())     // typed, mirrors prod ruleset
    .spawn().await?;

let alice = mediator.add_user_with_acl("alice", acl::allow_all()).await?;
mediator.set_acl(&alice.did, acl::deny_all()).await?;
let observed = mediator.get_acl(&alice.did).await?;        // fixture-bypass read
```

- New `acl` module — typed `allow_all()`/`deny_all()` constructors that mirror the production `MediatorACLSet::from_string_ruleset` parser arm-by-arm via the public bit-setter API. Locked against drift by unit tests that compare bitmasks.
- Re-exports of `AccessListModeType`, `MediatorACLSet`, `ACLError` from `mediator-common` (consumers don't need a direct dep).
- New `TestMediatorBuilder` knobs (all `Option`-typed; `None` = production default): `acl_mode`, `global_acl_default`, `local_direct_delivery`, `block_anonymous_outer_envelope`, `force_session_did_match`, `block_remote_admin_msgs`, `jwt_expiry`, `local_endpoints`.
- New `TestMediatorHandle` ACL CRUD helpers: `add_user_with_acl`, `set_acl`, `get_acl` (fixture-bypass path; for protocol enforcement use the SDK).

### Admin identity end-to-end

```rust
let admin = TestMediator::random_admin_identity()?;
let mediator = TestMediator::builder().admin_identity(admin.clone()).spawn().await?;
let env = TestEnvironment::new(mediator).await?;
let admin_user = env.add_admin(admin).await?;        // wired SDK profile

let alice = env.add_user("alice").await?;
env.atm.protocols().mediator().acls()
    .acls_set(&env.atm, &admin_user.profile, &alice.did_hash(), &acl::deny_all())
    .await?;
```

- New `AdminIdentity { did, secrets }` struct + `TestMediator::random_admin_identity()` mints a fresh `did:peer:2` admin with usable Ed25519 + X25519 secrets.
- `TestMediatorBuilder::admin_identity(...)` pins the mediator to a known admin DID; defaults preserved when unset.
- `TestEnvironment::add_admin(AdminIdentity)` wires an SDK profile authenticated as that admin. Validates the supplied DID matches `mediator.admin_did()` — returns `TestEnvironmentError::AdminMismatch` on misuse so the bug surfaces at fixture setup, not at protocol time.
- **Secrets ownership.** Admin secrets go into the SDK resolver only; the mediator's own server-side resolver is never touched. The admin authenticates via DID resolution + HTTP-auth challenge signature verification, so the private key never crosses the fixture boundary.
- `did_hash()` on `TestUser` and `TestMediatorUser` returns the SHA-256 of the DID — the canonical key shape used by admin-protocol calls. Removes a leak of internals from every admin-protocol test.

### Internal cleanup
- `register_local_did` now uses `acl::allow_all()` instead of `from_string_ruleset("ALLOW_ALL")`. Behavior unchanged; test-mediator no longer relies on string parsing internally.

### Tests + docs
- 11 new lifecycle tests + 2 unit tests in the `acl` module locking the preset bitmasks against the production ruleset parser.
- README: new sections **Simulating different ACL modes** and **Admin protocol tests** walking through the full consumer flow.
- New `CHANGELOG.md` for the test-mediator crate (was implicit in mediator's previously).

---

## Versions

| Crate | From | To |
|---|---|---|
| `affinidi-messaging-mediator-common` | 0.14.0 | **0.15.0** (feature reorg + `non_exhaustive`) |
| `affinidi-messaging-mediator` | 0.15.0 | **0.15.1** |
| `affinidi-messaging-mediator-processors` | 0.13.0 | **0.13.1** |
| `affinidi-messaging-test-mediator` | 0.2.0 | **0.2.2** (0.2.1 + 0.2.2 in this PR) |
| `affinidi-messaging-sdk` | 0.18.0 | **0.18.1** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo check -p affinidi-messaging-mediator-common --no-default-features` (lean — only `serde`/`serde_json`/`thiserror`/`regex` pulled)
- [x] `cargo check -p affinidi-messaging-mediator --no-default-features --features didcomm,memory-backend` (memory-only mediator)
- [x] `cargo test -p affinidi-messaging-mediator --lib` — 69 passed (21 routing tests, was 8)
- [x] `cargo test -p affinidi-messaging-mediator-common` — 110 passed
- [x] `cargo test -p affinidi-messaging-sdk --lib` — 53 passed
- [x] `cargo test -p affinidi-messaging-test-mediator` — 5 lib + 22 lifecycle + 2 fjall + 6 streaming/forwarding/ACL passed
- [x] `cargo tree -p affinidi-messaging-sdk` confirms no `axum`/`redis` via `mediator-common`
- [x] `cargo test --workspace --lib` — all green

## Out of scope (deferred)

- **No new `affinidi-messaging-mediator-vocab` crate.** The reviewer's preferred fix for batch 1 was a separate vocab crate; we kept everything inside `mediator-common` via features per design call. SDK consumer dep weight reduced equivalently.
- **Full alice→bob forwarding round-trip in `test-mediator`.** The `add_admin_wires_sdk_profile_for_configured_admin` test exercises the SDK profile machinery end-to-end; deeper protocol-flow round-trips (alice sends, bob receives via WebSocket) are followup work — they require WebSocket subscription orchestration that's out of scope for this PR.
- **`TestEnvironment::with_admin()` convenience constructor.** Sugar over the explicit four-line flow; easy to add later if a real test asks.

## Breaking changes

`ACLError` non-exhaustive (batch 1) is the only true semver-breaking surface change; covered by the `mediator-common` 0.14 → 0.15 minor bump. SDK already updated. External consumers exhaustively-matching `ACLError::{Config, Denied}` need to add a wildcard arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)