### PR TITLE
fix: mediator 0.15.2 — foolproof api_prefix normalisation

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Changelog history
 
+## 6th May 2026
+
+### 0.15.2 — `api_prefix` normalisation + startup-panic fix
+
+Foolproof handling of `api_prefix`. Previously, certain configurations
+caused a deterministic startup panic before the listener bound (which
+manifested as a permanent 502 from any reverse proxy fronting the
+mediator) or silently produced wrong route paths.
+
+- **FIX:** Setting `api_prefix = ""` no longer panics at startup.
+  The health/readiness/admin/metrics route registration in `server.rs`
+  was string-concatenating the prefix into the path, producing
+  `"healthchecker"` (no leading `/`) which axum rejects. With the
+  empty prefix now normalised to `""` and a `join_api_path` helper
+  used to build full paths, the resulting route is always
+  `/healthchecker` (or `/foo/healthchecker` when prefixed).
+- **FIX:** `api_prefix = "/foo"` (no trailing slash) no longer
+  silently produces glued-together routes like `/fooreadyz`. All
+  routes go through `join_api_path` which inserts the separator
+  correctly.
+- **FIX:** WebSocket endpoint URL builder no longer emits
+  `ws://host:portws` when the prefix is empty — uses `join_api_path`
+  for the WS suffix, producing `ws://host:port/ws`.
+- **FEAT:** New helpers `normalize_api_prefix` and `join_api_path` in
+  `common::config::helpers`. The canonical form is `""` (mount at
+  root) or `"/<segment>"` with no trailing slash — the form axum's
+  `Router::nest` requires. All of `"/foo/"`, `"/foo"`, `"foo/"`,
+  `"foo"`, `"  /foo/  "` normalise to the same canonical value.
+- **FEAT:** Config-load emits an `INFO` log line when normalisation
+  changes the configured value, so operators can spot config drift.
+- **CHG:** `MediatorBuilder::api_prefix(...)` now accepts any of the
+  above forms and normalises internally. The previous validation
+  (`api_prefix must end with '/'`) is removed since normalisation
+  makes it unnecessary.
+- **CHG:** Default `Config::api_prefix` is now `"/mediator/v1"`
+  (canonical) rather than `"/mediator/v1/"`. The published
+  `http_endpoint` URL still ends with `/` (preserved contract for
+  callers that concatenate suffixes).
+- **TEST:** 7 new unit tests covering normalisation edge cases —
+  empty/whitespace/`/`/multi-slash collapse, leading/trailing slash
+  stripping, idempotence, and `join_api_path` always returning a
+  valid axum path.
+- **DOC:** `conf/mediator.toml` documents the accepted forms inline.
+
+Existing configs using `api_prefix = "/mediator/v1/"` are
+byte-for-byte compatible — same routes, same URLs, same DID-Doc
+service endpoints. The change is purely additive: it accepts more
+inputs without changing any working ones.
+
 ## 5th May 2026
 
 ### 0.15.1 — IPv6 host normalization + wildcard-bind warning

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.1"
+version = "0.15.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -59,7 +59,10 @@ backend = "keyring://affinidi-mediator"
 listen_address = "0.0.0.0:7037"
 
 ### Env: API_PREFIX
-### API prefix
+### API prefix the mediator's HTTP routes mount under. Leading/trailing slashes
+### are normalised, so all of the following are accepted and equivalent:
+###   "/mediator/v1/"  "/mediator/v1"  "mediator/v1"
+### Use ""  or "/"  to mount routes at the host root (no prefix).
 api_prefix = "/mediator/v1/"
 
 ### Env: ADMIN_DID

--- a/crates/messaging/affinidi-messaging-mediator/src/builder.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/builder.rs
@@ -12,7 +12,7 @@
 //! The mediator binary's `start(config_path)` continues to work and
 //! routes through this same code path internally.
 
-use crate::common::config::{Config, LimitsConfig, ProcessorsConfig, SecurityConfig};
+use crate::common::config::{Config, LimitsConfig, ProcessorsConfig, SecurityConfig, helpers};
 use affinidi_did_resolver_cache_sdk::config::{DIDCacheConfig, DIDCacheConfigBuilder};
 use affinidi_messaging_mediator_common::{
     MediatorSecrets, database::config::DatabaseConfig, errors::MediatorError, store::MediatorStore,
@@ -341,9 +341,13 @@ impl MediatorBuilder {
     }
 
     /// Set the URL prefix for mediator routes. Defaults to
-    /// `/mediator/v1/`. Must end with `/`.
+    /// `/mediator/v1`. The supplied value is normalised to canonical
+    /// form (`""` for root, otherwise `"/<segment>"` with no trailing
+    /// slash) — leading/trailing slashes and surrounding whitespace are
+    /// stripped, so `"/foo/"`, `"foo"`, and `"/foo"` all behave the
+    /// same.
     pub fn api_prefix(mut self, prefix: impl Into<String>) -> Self {
-        self.config.api_prefix = prefix.into();
+        self.config.api_prefix = helpers::normalize_api_prefix(&prefix.into());
         self
     }
 
@@ -562,13 +566,6 @@ fn validate(config: &Config, has_store: bool) -> Result<(), MediatorError> {
             "database is required (call MediatorBuilder::database with a DatabaseConfig, \
              or supply a pre-built store via MediatorBuilder::store)"
                 .into(),
-        ));
-    }
-    if !config.api_prefix.ends_with('/') {
-        return Err(MediatorError::ConfigError(
-            12,
-            "builder".into(),
-            format!("api_prefix must end with '/' (got {:?})", config.api_prefix),
         ));
     }
     Ok(())

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -502,6 +502,51 @@ pub(crate) async fn read_document(
     Ok(content)
 }
 
+/// Normalise an operator-supplied `api_prefix` to a canonical form.
+///
+/// Returns either the empty string (mount at root) or `"/<segment>"` with
+/// exactly one leading `/` and no trailing `/`. This is the form axum's
+/// [`Router::nest`](axum::Router::nest) accepts and the form the path-join
+/// helper in this module assumes.
+///
+/// All of the following normalise to `""`:
+/// `""`, `"/"`, `"//"`, whitespace-only.
+///
+/// All of the following normalise to `"/mediator/v1"`:
+/// `"/mediator/v1"`, `"/mediator/v1/"`, `"mediator/v1"`, `"mediator/v1/"`,
+/// `"//mediator/v1//"`.
+pub fn normalize_api_prefix(input: &str) -> String {
+    let bare = input.trim().trim_matches('/');
+    if bare.is_empty() {
+        String::new()
+    } else {
+        format!("/{bare}")
+    }
+}
+
+/// Join a normalised `api_prefix` and a route suffix into a single
+/// well-formed axum path. The prefix is expected to already be in the
+/// form returned by [`normalize_api_prefix`] (`""` or `"/foo"`). The
+/// suffix may or may not have a leading `/`.
+///
+/// The result always starts with exactly one `/`:
+///
+/// ```ignore
+/// assert_eq!(join_api_path("",         "readyz"),  "/readyz");
+/// assert_eq!(join_api_path("",         "/readyz"), "/readyz");
+/// assert_eq!(join_api_path("/foo",     "readyz"),  "/foo/readyz");
+/// assert_eq!(join_api_path("/foo",     "/readyz"), "/foo/readyz");
+/// assert_eq!(join_api_path("/mediator/v1", "admin/status"), "/mediator/v1/admin/status");
+/// ```
+pub fn join_api_path(prefix: &str, suffix: &str) -> String {
+    let suffix = suffix.trim_start_matches('/');
+    if prefix.is_empty() {
+        format!("/{suffix}")
+    } else {
+        format!("{prefix}/{suffix}")
+    }
+}
+
 /// Creates a set of URI's that can be used to detect if forwarding loopbacks to the mediator could occur
 pub(crate) async fn load_forwarding_protection_blocks(
     did_resolver: &DIDCacheClient,
@@ -572,4 +617,75 @@ pub(crate) async fn load_forwarding_protection_blocks(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_api_path, normalize_api_prefix};
+
+    #[test]
+    fn normalize_empty_forms_collapse_to_root() {
+        assert_eq!(normalize_api_prefix(""), "");
+        assert_eq!(normalize_api_prefix("/"), "");
+        assert_eq!(normalize_api_prefix("//"), "");
+        assert_eq!(normalize_api_prefix("///"), "");
+        assert_eq!(normalize_api_prefix("   "), "");
+        assert_eq!(normalize_api_prefix(" / "), "");
+    }
+
+    #[test]
+    fn normalize_strips_wrapping_slashes_and_whitespace() {
+        assert_eq!(normalize_api_prefix("foo"), "/foo");
+        assert_eq!(normalize_api_prefix("/foo"), "/foo");
+        assert_eq!(normalize_api_prefix("foo/"), "/foo");
+        assert_eq!(normalize_api_prefix("/foo/"), "/foo");
+        assert_eq!(normalize_api_prefix("//foo//"), "/foo");
+        assert_eq!(normalize_api_prefix("  /foo/  "), "/foo");
+    }
+
+    #[test]
+    fn normalize_preserves_internal_segments() {
+        assert_eq!(normalize_api_prefix("/mediator/v1/"), "/mediator/v1");
+        assert_eq!(normalize_api_prefix("mediator/v1"), "/mediator/v1");
+        assert_eq!(normalize_api_prefix("/a/b/c"), "/a/b/c");
+    }
+
+    #[test]
+    fn normalize_is_idempotent() {
+        for input in ["", "/", "/foo", "/foo/bar", "foo/", "  /foo/bar/  "] {
+            let once = normalize_api_prefix(input);
+            let twice = normalize_api_prefix(&once);
+            assert_eq!(once, twice, "not idempotent for {input:?}");
+        }
+    }
+
+    #[test]
+    fn join_api_path_handles_empty_prefix() {
+        assert_eq!(join_api_path("", "readyz"), "/readyz");
+        assert_eq!(join_api_path("", "/readyz"), "/readyz");
+        assert_eq!(join_api_path("", "admin/status"), "/admin/status");
+    }
+
+    #[test]
+    fn join_api_path_handles_non_empty_prefix() {
+        assert_eq!(join_api_path("/foo", "readyz"), "/foo/readyz");
+        assert_eq!(join_api_path("/foo", "/readyz"), "/foo/readyz");
+        assert_eq!(
+            join_api_path("/mediator/v1", "admin/status"),
+            "/mediator/v1/admin/status"
+        );
+    }
+
+    #[test]
+    fn join_api_path_always_returns_leading_slash() {
+        for prefix in ["", "/foo", "/mediator/v1"] {
+            for suffix in ["readyz", "/readyz", "admin/status"] {
+                let joined = join_api_path(prefix, suffix);
+                assert!(
+                    joined.starts_with('/'),
+                    "join_api_path({prefix:?}, {suffix:?}) = {joined:?} did not start with /"
+                );
+            }
+        }
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -282,7 +282,7 @@ impl Config {
             streaming_enabled: true,
             streaming_uuid: "".into(),
             did_resolver_config,
-            api_prefix: "/mediator/v1/".into(),
+            api_prefix: "/mediator/v1".into(),
             // The default config is only used inside the early-startup
             // path before we've parsed `[secrets].backend`. Stub with
             // an empty URL + an in-memory store so the field is always
@@ -713,7 +713,17 @@ impl TryFrom<ConfigRaw> for Config {
                 true
             }),
             did_resolver_config: raw.did_resolver.convert(),
-            api_prefix: raw.server.api_prefix,
+            api_prefix: {
+                let normalized = helpers::normalize_api_prefix(&raw.server.api_prefix);
+                if normalized != raw.server.api_prefix {
+                    info!(
+                        original = %raw.server.api_prefix,
+                        normalized = %normalized,
+                        "api_prefix normalized — empty/`/` means mount at root, otherwise canonical form is `/<segment>` with no trailing slash"
+                    );
+                }
+                normalized
+            },
             security: raw
                 .security
                 .convert(

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -70,13 +70,11 @@ pub fn application_routes(api_prefix: &str, shared_data: &SharedData) -> Router 
             .route("/oob", delete(oob_discovery::delete_oobid_handler));
     }
 
-    // The variable name reads inverted but the body is correct: `has_prefix == true` means
-    // there is no prefix to nest under (operator left it blank or set it to `/`), so the
-    // app routes are mounted at the router root. Otherwise the inner routes nest under
-    // the operator's `api_prefix` (e.g. `/mediator/v1`).
-    let has_prefix = api_prefix.is_empty() || api_prefix == "/";
-
-    let api_router = if has_prefix {
+    // `api_prefix` arrives in the canonical form produced by
+    // `config::helpers::normalize_api_prefix`: either `""` (mount at
+    // root) or `"/<segment>"` with no trailing slash (the form axum's
+    // `Router::nest` requires).
+    let api_router = if api_prefix.is_empty() {
         Router::new().merge(app)
     } else {
         Router::new().nest(api_prefix, app)

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -2,7 +2,7 @@ use crate::{
     SharedData,
     builder::{MediatorHandle, StartOpts, TlsMode, TracingMode},
     common::{
-        config::{Config, init},
+        config::{Config, helpers::join_api_path, init},
         did_rate_limiter::DidRateLimiter,
         error_codes,
         metrics::{self, metrics_handler},
@@ -540,21 +540,21 @@ pub async fn serve_internal(
         .layer(RateLimitLayer::new(rate_limiter))
         .layer(RequestIdLayer::new())
         .route(
-            format!("{}healthchecker", &api_prefix).as_str(),
+            join_api_path(&api_prefix, "healthchecker").as_str(),
             get(health_checker_handler).with_state(shared_state.clone()),
         )
         .route(
-            format!("{}readyz", &api_prefix).as_str(),
+            join_api_path(&api_prefix, "readyz").as_str(),
             get(readiness_handler).with_state(shared_state.clone()),
         )
         .route(
-            format!("{}admin/status", &api_prefix).as_str(),
+            join_api_path(&api_prefix, "admin/status").as_str(),
             get(admin_status::admin_status_handler).with_state(shared_state),
         );
 
     let app = if let Some(handle) = metrics_handle {
         app.route(
-            format!("{}metrics", &api_prefix).as_str(),
+            join_api_path(&api_prefix, "metrics").as_str(),
             get(metrics_handler).with_state(handle),
         )
     } else {
@@ -670,22 +670,28 @@ pub async fn serve_internal(
         }
     };
 
+    // `api_prefix` is canonical (`""` or `"/foo"` with no trailing
+    // slash). The published `http_endpoint` is documented as a base URL
+    // that callers can concatenate suffixes onto (and that `Url::join`
+    // can resolve relative paths against), so it always ends with `/`.
+    // The WS endpoint is built via `join_api_path` for the same
+    // slash-safety guarantee.
     let http_endpoint =
-        Url::parse(&format!("{scheme}://{bound_addr}{api_prefix}")).map_err(|e| {
+        Url::parse(&format!("{scheme}://{bound_addr}{api_prefix}/")).map_err(|e| {
             MediatorError::InternalError(
                 error_codes::INTERNAL_ERROR,
                 "NA".into(),
                 format!("Failed to build http endpoint URL: {e}"),
             )
         })?;
-    let ws_endpoint =
-        Url::parse(&format!("{ws_scheme}://{bound_addr}{api_prefix}ws")).map_err(|e| {
-            MediatorError::InternalError(
-                error_codes::INTERNAL_ERROR,
-                "NA".into(),
-                format!("Failed to build ws endpoint URL: {e}"),
-            )
-        })?;
+    let ws_path = join_api_path(&api_prefix, "ws");
+    let ws_endpoint = Url::parse(&format!("{ws_scheme}://{bound_addr}{ws_path}")).map_err(|e| {
+        MediatorError::InternalError(
+            error_codes::INTERNAL_ERROR,
+            "NA".into(),
+            format!("Failed to build ws endpoint URL: {e}"),
+        )
+    })?;
 
     Ok(MediatorHandle::__from_internals(
         http_endpoint,


### PR DESCRIPTION
## Summary
- Foolproof `api_prefix` normalisation: any of `"/foo/"`, `"/foo"`, `"foo/"`, `"foo"`, `""`, `"/"` or whitespace-padded variants now produce the same canonical mount and the same published URLs.
- Fixes a deterministic startup panic when `api_prefix = ""` (axum rejected the no-leading-slash route paths the old `format!`-based registration produced — manifests as a permanent 502 from any reverse proxy fronting the mediator).
- Fixes silently-glued routes (`/fooreadyz`) and malformed WS URLs (`ws://host:portws`) on edge-case prefixes.
- Existing configs using the documented default `api_prefix = "/mediator/v1/"` are byte-for-byte compatible — same routes, same `http_endpoint`/`ws_endpoint`, same DID-Doc service URLs.

Canonical form (produced by the new `normalize_api_prefix`): `""` (mount at root) or `"/<segment>"` with no trailing slash — the form axum's `Router::nest` requires. All paths are built via a new `join_api_path` helper so the separator is always correct.

## Test plan
- [x] 7 new unit tests cover normalisation edge cases (empty/`/`/multi-slash collapse, leading/trailing slash stripping, idempotence, `join_api_path` always returns leading-slash paths)
- [x] All 76 mediator unit tests pass
- [x] All 35 test-mediator integration tests pass (healthchecker, admin/status, authenticate/challenge, websocket, forwarding, ACL, lifecycle)
- [x] `cargo build --workspace` clean
- [x] `cargo clippy -p affinidi-messaging-mediator --all-targets` no new warnings
- [x] `cargo fmt` clean