### PR TITLE
fix: messaging-sdk 0.18.2 + didcomm-service 0.3.1 — websocket transport orphan cleanup

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.0"
+version = "0.3.1"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -93,6 +93,12 @@ impl Listener {
         // Clean up any existing connection before reconnecting to prevent
         // orphaned websocket tasks that independently retry and cause
         // duplicate-channel floods when the mediator comes back online.
+        // The post-success-then-disconnect case is handled by stop_websocket
+        // on `self.profile`. The partial-init case (profile_add failed before
+        // returning a handle) is handled below by stop_websocket on the
+        // locally-built `atm_profile`, since `from_tdk_profile` returns an
+        // Arc and `profile_add(&atm_profile, true)` shares the same Mediator
+        // (and therefore the same `ws_channel_tx` slot).
         if let Some(ref profile) = self.profile {
             let _ = profile.stop_websocket().await;
         }
@@ -128,9 +134,19 @@ impl Listener {
         )
         .await
         {
-            Ok(result) => result?,
+            Ok(Ok(p)) => p,
+            Ok(Err(e)) => {
+                // Belt-and-braces against older SDK versions / future
+                // regressions: ensure a half-started websocket transport is
+                // torn down. With the SDK fix in profile_enable_websocket
+                // this is a no-op, but it prevents the duplicate-channel
+                // storm described in the bug report if that fix is missing.
+                let _ = atm_profile.stop_websocket().await;
+                return Err(e.into());
+            }
             Err(e) => {
                 warn!(profile = %self.config.profile.alias, error = %e, "Timeout adding profile");
+                let _ = atm_profile.stop_websocket().await;
                 return Err(DIDCommServiceError::Timeout(e));
             }
         };

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.1"
+version = "0.18.2"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -307,6 +307,23 @@ impl Mediator {
     pub(crate) fn get_tx_uuid(&self) -> u32 {
         self.tx_uuid.fetch_add(1, Ordering::Relaxed)
     }
+
+    /// Tear down a half-started websocket transport for this Mediator.
+    ///
+    /// Called from the error paths of `profile_enable_websocket` and
+    /// `profile_start_live_streaming`, which spawn a `WebSocketTransport`
+    /// task and store its command sender in `ws_channel_tx`. Without this
+    /// cleanup, the spawned task stays alive forever via an Arc cycle:
+    /// the task holds `Arc<ATMProfile>` → `Mediator` → `ws_channel_tx` →
+    /// `Sender`, so the channel never reaches zero senders and the run
+    /// loop never returns. Take the sender out of the slot and send
+    /// `Stop` so the task exits cleanly and drops its arcs on the way out.
+    pub(crate) async fn cleanup_failed_websocket(&self) {
+        let sender = self.ws_channel_tx.write().await.take();
+        if let Some(sender) = sender {
+            let _ = sender.send(WebSocketCommands::Stop).await;
+        }
+    }
 }
 
 /// Key is the alias of the profile
@@ -367,9 +384,13 @@ impl ATM {
         let _profile = self.inner.profiles.write().await.insert(profile.clone());
         debug!("Profile({}): Added to profiles", _profile.inner.alias);
 
-        if live_stream {
-            // Grab a copy of the wrapped Profile
-            self.profile_enable_websocket(&_profile).await?;
+        if live_stream && let Err(err) = self.profile_enable_websocket(&_profile).await {
+            // Roll back the insertion so a retry doesn't see a stale entry
+            // and so the map doesn't grow unbounded across reconnect attempts.
+            let alias = _profile.inner.alias.clone();
+            self.inner.profiles.write().await.0.remove(&alias);
+            debug!("Profile({alias}): removed from profiles after websocket startup failure");
+            return Err(err);
         }
         Ok(_profile)
     }
@@ -398,24 +419,19 @@ impl ATM {
         &self,
         profile: &Arc<ATMProfile>,
     ) -> Result<(), ATMError> {
-        let mediator = {
-            let Some(mediator) = &*profile.inner.mediator else {
-                return Err(ATMError::ConfigError(
-                    "No Mediator is configured for this Profile".to_string(),
-                ));
-            };
-            mediator
+        let Some(mediator) = &*profile.inner.mediator else {
+            return Err(ATMError::ConfigError(
+                "No Mediator is configured for this Profile".to_string(),
+            ));
         };
 
-        {
-            if mediator.ws_channel_tx.read().await.is_some() {
-                // Already connected
-                debug!(
-                    "Profile ({}): is already connected to the WebSocket",
-                    profile.inner.alias
-                );
-                return Ok(());
-            }
+        if mediator.ws_channel_tx.read().await.is_some() {
+            // Already connected
+            debug!(
+                "Profile ({}): is already connected to the WebSocket",
+                profile.inner.alias
+            );
+            return Ok(());
         }
 
         debug!("Profile({}): enabling...", profile.inner.alias);
@@ -426,60 +442,18 @@ impl ATM {
             self.inner.config.inbound_message_channel.clone(),
         )
         .await;
-        {
-            mediator.ws_channel_tx.write().await.replace(ws_channel);
-        }
+        mediator.ws_channel_tx.write().await.replace(ws_channel);
 
-        let (tx, rx) = oneshot::channel();
-
-        {
-            if let Some(channel_tx) = &*mediator.ws_channel_tx.read().await {
-                channel_tx
-                    .send(WebSocketCommands::NotifyConnection(tx))
-                    .await
-                    .map_err(|err| {
-                        ATMError::TransportError(format!(
-                            "Could not send websocket NotifyConnection? command: {err:?}"
-                        ))
-                    })?;
-            } else {
-                return Err(ATMError::TransportError(
-                    "No WebSocket channel is configured for this Profile".to_string(),
-                ));
+        // Every error path past WebSocketTransport::start MUST clear the
+        // sender slot and tell the spawned task to stop. Otherwise the task
+        // stays alive forever via an Arc cycle (see Mediator::cleanup_failed_websocket).
+        match Self::wait_for_websocket_ready(mediator, &profile.inner.alias).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                mediator.cleanup_failed_websocket().await;
+                Err(err)
             }
         }
-
-        let sleep = tokio::time::sleep(Duration::from_secs(10));
-        tokio::pin!(sleep);
-
-        select! {
-            _ = sleep => {
-                return Err(ATMError::TransportError(
-                    "WebSocket isActive? command timed out".to_string(),
-                ));
-            }
-            val = rx => {
-                match val {
-                    Ok(is_active) => {
-                        if is_active {
-                            debug!("Profile({}): WebSocket is active", profile.inner.alias);
-                        } else {
-                            debug!("Profile({}): WebSocket is not active", profile.inner.alias);
-                            return Err(ATMError::TransportError(
-                                "WebSocket is not active".to_string(),
-                            ));
-                        }
-                    }
-                    Err(err) => {
-                        return Err(ATMError::TransportError(format!(
-                            "Could not receive websocket NotifyConnection? response: {err:?}"
-                        )));
-                    }
-                }
-            }
-        }
-
-        Ok(())
     }
 
     /// Will create a websocket connection for the profile if one doesn't already exist
@@ -493,24 +467,19 @@ impl ATM {
         skip_toggle_live_delivery: bool,
         skip_unpack_messages: bool,
     ) -> Result<(), ATMError> {
-        let mediator = {
-            let Some(mediator) = &*profile.inner.mediator else {
-                return Err(ATMError::ConfigError(
-                    "No Mediator is configured for this Profile".to_string(),
-                ));
-            };
-            mediator
+        let Some(mediator) = &*profile.inner.mediator else {
+            return Err(ATMError::ConfigError(
+                "No Mediator is configured for this Profile".to_string(),
+            ));
         };
 
-        {
-            if mediator.ws_channel_tx.read().await.is_some() {
-                // Already connected
-                debug!(
-                    "Profile ({}): is already connected to the WebSocket",
-                    profile.inner.alias
-                );
-                return Ok(());
-            }
+        if mediator.ws_channel_tx.read().await.is_some() {
+            // Already connected
+            debug!(
+                "Profile ({}): is already connected to the WebSocket",
+                profile.inner.alias
+            );
+            return Ok(());
         }
 
         debug!("Profile({}): enabling...", profile.inner.alias);
@@ -523,60 +492,67 @@ impl ATM {
             skip_unpack_messages,
         )
         .await;
-        {
-            mediator.ws_channel_tx.write().await.replace(ws_channel);
-        }
+        mediator.ws_channel_tx.write().await.replace(ws_channel);
 
+        // Every error path past WebSocketTransport::start_with_options MUST
+        // clear the sender slot and tell the spawned task to stop. Otherwise
+        // the task stays alive forever via an Arc cycle (see
+        // Mediator::cleanup_failed_websocket).
+        match Self::wait_for_websocket_ready(mediator, &profile.inner.alias).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                mediator.cleanup_failed_websocket().await;
+                Err(err)
+            }
+        }
+    }
+
+    /// Send `NotifyConnection` to the spawned websocket task and wait up to
+    /// 10s for the response. Caller is responsible for tearing down the
+    /// transport via `Mediator::cleanup_failed_websocket` if this returns Err.
+    async fn wait_for_websocket_ready(mediator: &Mediator, alias: &str) -> Result<(), ATMError> {
         let (tx, rx) = oneshot::channel();
 
         {
-            if let Some(channel_tx) = &*mediator.ws_channel_tx.read().await {
-                channel_tx
-                    .send(WebSocketCommands::NotifyConnection(tx))
-                    .await
-                    .map_err(|err| {
-                        ATMError::TransportError(format!(
-                            "Could not send websocket NotifyConnection? command: {err:?}"
-                        ))
-                    })?;
-            } else {
+            let guard = mediator.ws_channel_tx.read().await;
+            let Some(channel_tx) = &*guard else {
                 return Err(ATMError::TransportError(
                     "No WebSocket channel is configured for this Profile".to_string(),
                 ));
-            }
+            };
+            channel_tx
+                .send(WebSocketCommands::NotifyConnection(tx))
+                .await
+                .map_err(|err| {
+                    ATMError::TransportError(format!(
+                        "Could not send websocket NotifyConnection? command: {err:?}"
+                    ))
+                })?;
         }
 
         let sleep = tokio::time::sleep(Duration::from_secs(10));
         tokio::pin!(sleep);
 
         select! {
-            _ = sleep => {
-                return Err(ATMError::TransportError(
-                    "WebSocket isActive? command timed out".to_string(),
-                ));
-            }
-            val = rx => {
-                match val {
-                    Ok(is_active) => {
-                        if is_active {
-                            debug!("Profile({}): WebSocket is active", profile.inner.alias);
-                        } else {
-                            debug!("Profile({}): WebSocket is not active", profile.inner.alias);
-                            return Err(ATMError::TransportError(
-                                "WebSocket is not active".to_string(),
-                            ));
-                        }
-                    }
-                    Err(err) => {
-                        return Err(ATMError::TransportError(format!(
-                            "Could not receive websocket NotifyConnection? response: {err:?}"
-                        )));
-                    }
+            _ = sleep => Err(ATMError::TransportError(
+                "WebSocket isActive? command timed out".to_string(),
+            )),
+            val = rx => match val {
+                Ok(true) => {
+                    debug!("Profile({}): WebSocket is active", alias);
+                    Ok(())
                 }
+                Ok(false) => {
+                    debug!("Profile({}): WebSocket is not active", alias);
+                    Err(ATMError::TransportError(
+                        "WebSocket is not active".to_string(),
+                    ))
+                }
+                Err(err) => Err(ATMError::TransportError(format!(
+                    "Could not receive websocket NotifyConnection? response: {err:?}"
+                ))),
             }
         }
-
-        Ok(())
     }
 
     /// Returns all active profiles within ATM
@@ -587,5 +563,117 @@ impl ATM {
     /// Returns a specific profile for a given DID
     pub async fn find_profile(&self, did: &str) -> Option<Arc<ATMProfile>> {
         self.inner.profiles.read().await.find_by_did(did)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ATM;
+    use crate::config::ATMConfig;
+    use affinidi_tdk_common::TDKSharedState;
+    use affinidi_tdk_common::config::TDKConfig;
+    use tokio::time::timeout;
+
+    /// Build an `ATMProfile` with a manually-constructed `Mediator` whose
+    /// endpoints point at a closed port. Bypasses `Mediator::new` (which
+    /// would resolve the DID) so we can test transport-level behaviour
+    /// without a real mediator.
+    fn fake_profile() -> Arc<ATMProfile> {
+        let mediator = Mediator {
+            did: "did:peer:fake-mediator".to_string(),
+            rest_endpoint: Some("http://127.0.0.1:1/".to_string()),
+            websocket_endpoint: Some("ws://127.0.0.1:1/".to_string()),
+            ws_channel_tx: RwLock::new(None),
+            tx_uuid: AtomicU32::new(0),
+        };
+        Arc::new(ATMProfile {
+            inner: Arc::new(ATMProfileInner {
+                did: "did:peer:fake-profile".to_string(),
+                alias: "test-orphan".to_string(),
+                mediator: Arc::new(Some(mediator)),
+            }),
+        })
+    }
+
+    fn mediator_of(profile: &Arc<ATMProfile>) -> &Mediator {
+        profile
+            .inner
+            .mediator
+            .as_ref()
+            .as_ref()
+            .expect("test profile has a mediator")
+    }
+
+    /// Regression test for the websocket orphan/Arc-cycle bug.
+    ///
+    /// Before the fix, when `profile_enable_websocket` failed after spawning
+    /// `WebSocketTransport`, the spawned task stayed alive forever: it held
+    /// `Arc<ATMProfile>` → `Mediator` → `ws_channel_tx` → `Sender`, so the
+    /// channel never reached zero senders and the run loop never returned.
+    ///
+    /// `Mediator::cleanup_failed_websocket` breaks the cycle by taking the
+    /// sender out of the slot and sending `Stop`, which causes the task's
+    /// run loop to break and drop its `Arc<ATMProfile>` clone.
+    #[tokio::test]
+    async fn cleanup_failed_websocket_terminates_orphan_task() {
+        let tdk_cfg = TDKConfig::headless().expect("headless tdk config");
+        let tdk = Arc::new(
+            TDKSharedState::new(tdk_cfg)
+                .await
+                .expect("tdk shared state"),
+        );
+        let atm_cfg = ATMConfig::builder().build().expect("atm config");
+        let atm = ATM::new(atm_cfg, tdk).await.expect("atm");
+
+        let profile = fake_profile();
+        let mediator = mediator_of(&profile);
+
+        // Start the transport directly — same call sequence
+        // `profile_enable_websocket` performs internally.
+        let (handle, ws_channel) =
+            crate::transports::websockets::websocket::WebSocketTransport::start(
+                profile.clone(),
+                atm.inner.clone(),
+                None,
+            )
+            .await;
+        mediator.ws_channel_tx.write().await.replace(ws_channel);
+
+        assert!(!handle.is_finished(), "task should be alive after start");
+        assert!(
+            mediator.ws_channel_tx.read().await.is_some(),
+            "sender slot should be populated after start",
+        );
+
+        // Trigger the cleanup that the fix invokes on every error path.
+        mediator.cleanup_failed_websocket().await;
+
+        assert!(
+            mediator.ws_channel_tx.read().await.is_none(),
+            "sender slot must be cleared after cleanup",
+        );
+
+        // The task must terminate. Without the fix it lives forever via the
+        // Arc cycle. Bound generously to allow for an in-flight authenticate
+        // (default timeout 10s) before the run loop processes Stop.
+        timeout(Duration::from_secs(15), handle)
+            .await
+            .expect("websocket task did not terminate within 15s")
+            .expect("websocket task panicked");
+
+        atm.graceful_shutdown().await;
+    }
+
+    /// `cleanup_failed_websocket` is a no-op when there is no transport
+    /// running (slot already empty). Guards against double-cleanup paths.
+    #[tokio::test]
+    async fn cleanup_failed_websocket_is_idempotent_when_slot_empty() {
+        let profile = fake_profile();
+        let mediator = mediator_of(&profile);
+
+        assert!(mediator.ws_channel_tx.read().await.is_none());
+        mediator.cleanup_failed_websocket().await;
+        assert!(mediator.ws_channel_tx.read().await.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Fixes a confirmed orphan/leak in `affinidi-messaging-sdk`'s WebSocket transport that produces a `w.websocket.duplicate-channel` storm against the mediator whenever the mediator's HTTP auth endpoint is briefly unreachable at startup (e.g. 502 Bad Gateway behind a load balancer, gateway warming up). Each failed `profile_enable_websocket` attempt leaks one `WebSocketTransport` task; once the gateway recovers, every leaked task authenticates and opens a websocket, the mediator kicks all but one off, and the kicked-off ones reconnect — infinite ping-pong.

### Root cause

`profile_enable_websocket` (and `profile_start_live_streaming`) spawn a `WebSocketTransport` task and store its command sender in `mediator.ws_channel_tx`. The spawned task captures `Arc<ATMProfile>`, which transitively owns the `Mediator`, which owns the slot holding the `Sender` end of the task's own command channel. As long as the task is alive, the channel has at least one sender, so `task_rx.recv()` never returns `None`. If startup fails between `WebSocketTransport::start` and the function's successful return, no `Stop` is sent — the task is in a self-sustaining Arc cycle and runs forever.

### Fix — SDK (primary)

- New `Mediator::cleanup_failed_websocket()` helper that `take`s the sender out of the slot and sends `Stop`.
- `profile_enable_websocket` and `profile_start_live_streaming` now factor the post-start "wait for ready" logic into `wait_for_websocket_ready`, and route **every** error path (timeout, send error, rx error, `is_active=false`) through the cleanup helper. This is a stronger invariant than just the timeout case.
- `profile_add` now removes the profile from `self.inner.profiles` if `profile_enable_websocket` errors, so the map doesn't grow unbounded on retry.

### Fix — didcomm-service (defense in depth)

- `Listener::connect` now calls `stop_websocket()` on the locally-built `atm_profile` for both the `profile_add` error and timeout arms. With the SDK fix this is a no-op, but it protects against older SDK versions and future regressions. Per-arm match destructuring replaces the single `Ok(result) => result?` pattern.

### Tests

- New SDK regression test `cleanup_failed_websocket_terminates_orphan_task` spawns a real `WebSocketTransport` against a fake mediator (closed port), calls the cleanup helper, and verifies (a) `ws_channel_tx` is `None`, (b) the spawned task terminates within a generous bound. Without the fix the task runs forever.
- New SDK test `cleanup_failed_websocket_is_idempotent_when_slot_empty` covers the no-op case.
- Existing 55 SDK lib tests + 73 didcomm-service tests pass unchanged.

The framework integration test sketched in the bug report (fake mediator that 502s for 30s then accepts, asserting only one websocket connects) is intentionally not included — the SDK regression test is what proves the fix; the framework path is defense-in-depth that the SDK fix already obviates.

### Versions

- `affinidi-messaging-sdk`: 0.18.1 → **0.18.2**
- `affinidi-messaging-didcomm-service`: 0.3.0 → **0.3.1**

No public API changes. All in-workspace consumers caret-pin to `0.18` / `0.3` so no consumer Cargo.toml edits are required.

## Test plan

- [x] `cargo build -p affinidi-messaging-sdk -p affinidi-messaging-didcomm-service`
- [x] `cargo clippy -p affinidi-messaging-sdk -p affinidi-messaging-didcomm-service --all-targets`
- [x] `cargo test -p affinidi-messaging-sdk --lib` (55 tests pass, including 2 new)
- [x] `cargo test -p affinidi-messaging-didcomm-service --lib` (73 tests pass)
- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [ ] Manual verification against the original repro (mediator gateway 502s for 30s at startup): exactly one websocket connects at recovery time, zero `w.websocket.duplicate-channel` problem-reports