### PR TITLE
fix: mediator 0.15.3 — gate /admin/status behind admin auth, redact /readyz

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Changelog history
 
+## 9th May 2026
+
+### 0.15.3 — `/admin/status` auth + `/readyz` redaction
+
+Defensive hardening of the public HTTP surface. **No secret material
+was ever disclosed** by either endpoint — what was exposed was
+infrastructure metadata (uptime/throughput/queue depth/masked Redis
+URL on `/admin/status`; `secrets_backend_url` and probe-error text on
+`/readyz`) that helps an attacker fingerprint a deployment. This
+release closes that reconnaissance channel.
+
+- **BREAKING (HTTP):** `GET /admin/status` is now gated on an
+  admin-tier session. Unauthenticated requests get 401 from the
+  existing JWT extractor; authenticated non-admin sessions get 403.
+  Admin tier = `Admin`, `RootAdmin`, or `Mediator` account_type.
+  External tooling that scrapes `/admin/status` without auth must
+  update — the in-tree `mediator-monitor` ships a matching update in
+  this PR.
+- **FIX:** `GET /readyz` no longer echoes `secrets_backend_url` (was
+  in three places: per-check success entry, per-check failure entry,
+  top-level field). The probe failure message is now generic
+  (`"Secret backend probe failed"`) and the underlying error is
+  surfaced via a `warn!` log instead of the response body so it
+  doesn't leak hostnames / ARNs / Vault paths / project IDs to an
+  unauthenticated probe path. The boolean `secrets_backend_reachable`
+  is still returned so k8s / load-balancer readiness probes work
+  unchanged.
+- **CHORE:** Doc comments on `Config::secrets_backend_url`,
+  `MediatorBuilder::secrets_backend_url`, and the in-builder default
+  comment updated to reflect the new exposure surface (startup logs
+  + authenticated `/admin/status` only — never `/readyz`).
+- **CHORE:** `MemoryStore::account_add` rewritten to use the
+  struct-update form so it stops tripping
+  `clippy::field_reassign_with_default`.
+- **TEST:** Integration test `admin_status_returns_metrics_json`
+  renamed to `admin_status_requires_authentication` and rewritten to
+  assert 401 on an unauthenticated GET (was: assert 2xx + JSON
+  shape, exactly the behaviour this release removes). The existing
+  `mediator_serves_readyz` test continues to pass — it only asserts
+  200/503, not specific JSON fields.
+
 ## 6th May 2026
 
 ### 0.15.2 — `api_prefix` normalisation + startup-panic fix

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.2"
+version = "0.15.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Changelog history
 
+## 9th May 2026
+
+### 0.15.1 — `MediatorStore` access-list signatures take `&[String]`
+
+Trivia release: cleans up four pre-existing clippy lints that get
+promoted to errors under `RUSTFLAGS=-D warnings` (which the workspace
+CI uses). Surfaced incidentally during PR #311's
+`/admin/status` hardening work — the lints had been accumulating on
+recent merges because clippy was failing-but-merged on every PR.
+
+- **BREAKING (recompile-only for out-of-tree impls):**
+  `MediatorStore::access_list_{add,remove,get}` now take
+  `hashes: &[String]` instead of `&Vec<String>`. Callers that pass
+  `&vec![...]` keep working (deref-coercion); only out-of-tree
+  implementations of the trait need to update their method signatures
+  to match. In-tree impls (`RedisStore`, `MemoryStore`, `FjallStore`)
+  updated synchronously.
+- **FIX:** `clippy::collapsible_match` in `AzureRetryPolicy::classify`
+  suppressed inline with a justification comment — the nested
+  `match err.kind() { HttpResponse { status } => match *status { ... }`
+  form is more readable than the collapsed alternative which splits
+  transport-level arms (`Connection`/`Io`) away from HTTP-status
+  arms.
+- **FIX:** `clippy::uninlined_format_args` in
+  `types/problem_report.rs` test code — `panic!("...{}", err)`
+  → `panic!("...{err}")`.
+
 ## 5th May 2026
 
 ### 0.15.0 — Feature-gated server stack + `ACLError` non-exhaustive

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.0"
+version = "0.15.1"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/azure.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/azure.rs
@@ -151,6 +151,12 @@ pub(crate) struct AzureRetryPolicy;
 
 #[cfg(feature = "secrets-azure")]
 impl RetryPolicy<AzureError> for AzureRetryPolicy {
+    // The nested match keeps the "HttpResponse → status code triage" intent
+    // visible at a glance. The collapsed form (a single match with status
+    // patterns inside HttpResponse destructuring) prevents the natural
+    // "transport-level" arms (Connection / Io) from sitting next to the
+    // status arms in source order, hurting readability for a lint-only win.
+    #[allow(clippy::collapsible_match)]
     fn classify(&self, err: &AzureError) -> Retryable {
         match err.kind() {
             AzureErrorKind::HttpResponse { status, .. } => match *status {

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -345,7 +345,7 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
         &self,
         access_list_limit: usize,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListAddResponse, MediatorError>;
 
     /// Remove `hashes` from a DID's access list. Returns the number of
@@ -353,7 +353,7 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
     async fn access_list_remove(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<usize, MediatorError>;
 
     /// Drop the entire access list for a DID.
@@ -363,7 +363,7 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
     async fn access_list_get(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListGetResponse, MediatorError>;
 
     // ─── Admin accounts ─────────────────────────────────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/acls.rs
@@ -289,7 +289,7 @@ impl Database {
         &self,
         access_list_limit: usize,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListAddResponse, MediatorError> {
         let _span = span!(
             Level::DEBUG,
@@ -344,7 +344,7 @@ impl Database {
     pub(crate) async fn access_list_remove(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<usize, MediatorError> {
         let _span = span!(
             Level::DEBUG,
@@ -411,7 +411,7 @@ impl Database {
     pub(crate) async fn access_list_get(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListGetResponse, MediatorError> {
         let _span = span!(
             Level::DEBUG,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -703,7 +703,7 @@ impl MediatorStore for RedisStore {
         &self,
         access_list_limit: usize,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListAddResponse, MediatorError> {
         self.access_list_add(access_list_limit, did_hash, hashes)
             .await
@@ -712,7 +712,7 @@ impl MediatorStore for RedisStore {
     async fn access_list_remove(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<usize, MediatorError> {
         self.access_list_remove(did_hash, hashes).await
     }
@@ -724,7 +724,7 @@ impl MediatorStore for RedisStore {
     async fn access_list_get(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListGetResponse, MediatorError> {
         self.access_list_get(did_hash, hashes).await
     }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/problem_report.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/problem_report.rs
@@ -188,12 +188,12 @@ mod tests {
 
         let ser = match serde_json::to_string(&problem_report) {
             Ok(ser) => ser,
-            Err(err) => panic!("Error serializing ProblemReport: {}", err),
+            Err(err) => panic!("Error serializing ProblemReport: {err}"),
         };
 
         let pr: ProblemReport = match serde_json::from_str(&ser) {
             Ok(pr) => pr,
-            Err(err) => panic!("Error deserializing ProblemReport: {}", err),
+            Err(err) => panic!("Error deserializing ProblemReport: {err}"),
         };
 
         assert_eq!(problem_report, pr);

--- a/crates/messaging/affinidi-messaging-mediator/src/builder.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/builder.rs
@@ -312,8 +312,10 @@ impl MediatorBuilder {
     }
 
     /// Set a human-readable URL for the secrets backend. Surfaced in
-    /// `/readyz` so operators can see which backend the mediator is
-    /// using. Defaults to `"(programmatic)"` when not set.
+    /// startup logs and the authenticated `/admin/status` endpoint so
+    /// operators can see which backend the mediator is using. Not
+    /// echoed in `/readyz` (unauthenticated). Defaults to
+    /// `"(programmatic)"` when not set.
     pub fn secrets_backend_url(mut self, url: impl Into<String>) -> Self {
         self.config.secrets_backend_url = url.into();
         self
@@ -515,7 +517,8 @@ impl MediatorBuilder {
             self.config.listen_address = default.to_string();
         }
 
-        // Default secrets_backend_url so /readyz has something to show.
+        // Default secrets_backend_url so startup logs and /admin/status
+        // have something to show. Not exposed in /readyz.
         if self.config.secrets_backend_url.is_empty() {
             self.config.secrets_backend_url = "(programmatic)".to_string();
         }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -193,9 +193,11 @@ pub struct Config {
     pub limits: LimitsConfig,
     pub tags: HashMap<String, String>,
     /// URL of the unified secret backend (`[secrets].backend` from
-    /// the config file). Surfaced in `/readyz` so operators can
-    /// confirm the mediator is talking to the backend they expect
-    /// without having to read the on-disk TOML.
+    /// the config file). Used by the secret-backend probe and surfaced
+    /// in startup logs and the authenticated `/admin/status` endpoint
+    /// so operators can confirm the mediator is talking to the backend
+    /// they expect. Intentionally NOT echoed in `/readyz`, which is
+    /// unauthenticated and must not leak backend identity.
     #[serde(skip_serializing)]
     pub secrets_backend_url: String,
     /// Open handle to the unified secret backend. Cloned cheaply (it

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/admin_status.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/admin_status.rs
@@ -4,12 +4,22 @@
 //! connections, throughput, queue depths, circuit breaker state, uptime, etc.
 //!
 //! Designed to be polled by the mediator-monitor TUI or any monitoring tool.
+//!
+//! ## Authorisation
+//!
+//! Requires a valid mediator JWT for an account whose `account_type`
+//! is admin-tier (`Admin`, `RootAdmin`, or `Mediator`). Unauthenticated
+//! requests are rejected by the `Session` extractor with 401; authenticated
+//! non-admin sessions are rejected with 403. Operational metrics (uptime,
+//! message counts, queue depth, masked Redis URL) leak fingerprintable
+//! infra detail and historically were public — that's been corrected here.
 
-use crate::SharedData;
+use crate::{SharedData, common::session::Session};
 use axum::{Json, extract::State};
 use chrono::Utc;
 use http::StatusCode;
 use serde::Serialize;
+use tracing::warn;
 
 #[derive(Serialize)]
 pub struct AdminStatus {
@@ -86,7 +96,18 @@ fn mask_redis_url(url: &str) -> String {
 
 pub async fn admin_status_handler(
     State(state): State<SharedData>,
+    session: Session,
 ) -> Result<(StatusCode, Json<AdminStatus>), StatusCode> {
+    if !session.account_type.is_admin() {
+        warn!(
+            session_id = %session.session_id,
+            did_hash = %session.did_hash,
+            account_type = %session.account_type,
+            "Non-admin session attempted to access /admin/status",
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
     let now = Utc::now();
     let uptime = now
         .signed_duration_since(state.service_start_timestamp)

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -8,6 +8,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use http::StatusCode;
+use tracing::warn;
 
 pub mod admin_status;
 #[cfg(feature = "didcomm")]
@@ -209,22 +210,28 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
     // likely still reachable here. Re-probing on every /readyz catches
     // mid-flight credential expiries / network blips that the boot-
     // time probe couldn't.
+    //
+    // /readyz is unauthenticated, so the response must not echo the
+    // backend URL or the underlying probe error: those can leak
+    // internal hostnames, ARNs, Vault paths, or credential-shaped
+    // strings to anyone who can reach the load-balancer probe path.
+    // Keep a boolean `secrets_backend_reachable` for monitoring; log
+    // the detailed error at warn level for operators.
     let backend_reachable = match state.config.secrets_backend.probe().await {
         Ok(()) => {
             checks.push(serde_json::json!({
                 "name": "secrets_backend",
                 "status": "pass",
-                "url": state.config.secrets_backend_url,
             }));
             true
         }
         Err(e) => {
             all_ok = false;
+            warn!(error = %e, "Secret backend probe failed");
             checks.push(serde_json::json!({
                 "name": "secrets_backend",
                 "status": "fail",
-                "url": state.config.secrets_backend_url,
-                "message": format!("Secret backend probe failed: {e}"),
+                "message": "Secret backend probe failed",
             }));
             false
         }
@@ -271,8 +278,11 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
         "checks": checks,
         // Top-level fields (alongside `checks`) so ops dashboards can
         // pluck them without parsing the variable-length checks list.
+        // The secrets backend URL is intentionally NOT exposed here —
+        // /readyz is unauthenticated and an attacker scraping it should
+        // not learn the backend's identity. Operators can read the URL
+        // from logs or the authenticated /admin/status endpoint.
         "secrets_backend_reachable": backend_reachable,
-        "secrets_backend_url": state.config.secrets_backend_url,
         "vta_cache_age_secs": vta_cache_age_secs,
         "operating_keys_loaded": state.config.operating_keys_loaded,
     });

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -1577,7 +1577,7 @@ impl MediatorStore for FjallStore {
         &self,
         access_list_limit: usize,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListAddResponse, MediatorError> {
         let _guard = self.write_lock.lock().await;
         let current = self.access_list_count_inner(did_hash)?;
@@ -1587,7 +1587,7 @@ impl MediatorStore for FjallStore {
             let allowed = access_list_limit.saturating_sub(current);
             hashes.iter().take(allowed).cloned().collect()
         } else {
-            hashes.clone()
+            hashes.to_vec()
         };
         let mut batch = self.db.batch();
         for h in &to_add {
@@ -1607,7 +1607,7 @@ impl MediatorStore for FjallStore {
     async fn access_list_remove(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<usize, MediatorError> {
         let _guard = self.write_lock.lock().await;
         let mut batch = self.db.batch();
@@ -1649,7 +1649,7 @@ impl MediatorStore for FjallStore {
     async fn access_list_get(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListGetResponse, MediatorError> {
         let mut found = Vec::new();
         for h in hashes {

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -1094,7 +1094,7 @@ impl MediatorStore for MemoryStore {
         &self,
         access_list_limit: usize,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListAddResponse, MediatorError> {
         let mut state = self.state.lock().await;
         let list = state.access_lists.entry(did_hash.to_string()).or_default();
@@ -1105,7 +1105,7 @@ impl MediatorStore for MemoryStore {
             let allowed = access_list_limit.saturating_sub(current);
             hashes.iter().take(allowed).cloned().collect()
         } else {
-            hashes.clone()
+            hashes.to_vec()
         };
         for h in &to_add {
             if !list.iter().any(|d| d == h) {
@@ -1121,7 +1121,7 @@ impl MediatorStore for MemoryStore {
     async fn access_list_remove(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<usize, MediatorError> {
         let mut state = self.state.lock().await;
         let Some(list) = state.access_lists.get_mut(did_hash) else {
@@ -1140,7 +1140,7 @@ impl MediatorStore for MemoryStore {
     async fn access_list_get(
         &self,
         did_hash: &str,
-        hashes: &Vec<String>,
+        hashes: &[String],
     ) -> Result<MediatorAccessListGetResponse, MediatorError> {
         let state = self.state.lock().await;
         let list = state.access_lists.get(did_hash);
@@ -1907,7 +1907,7 @@ mod tests {
             .expect("add");
 
         let resp = store
-            .access_list_add(100, "alice", &vec!["bob".into(), "charlie".into()])
+            .access_list_add(100, "alice", &["bob".into(), "charlie".into()])
             .await
             .expect("add");
         assert_eq!(resp.did_hashes.len(), 2);
@@ -1915,13 +1915,13 @@ mod tests {
         assert_eq!(store.access_list_count("alice").await.unwrap(), 2);
 
         let got = store
-            .access_list_get("alice", &vec!["bob".into(), "eve".into()])
+            .access_list_get("alice", &["bob".into(), "eve".into()])
             .await
             .expect("get");
         assert_eq!(got.did_hashes, vec!["bob"]);
 
         let removed = store
-            .access_list_remove("alice", &vec!["bob".into()])
+            .access_list_remove("alice", &["bob".into()])
             .await
             .expect("remove");
         assert_eq!(removed, 1);

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -864,8 +864,10 @@ impl MediatorStore for MemoryStore {
         if !state.known_dids.iter().any(|d| d == did_hash) {
             state.known_dids.push(did_hash.to_string());
         }
-        let mut record = AccountRecord::default();
-        record.acls = acls.clone();
+        let mut record = AccountRecord {
+            acls: acls.clone(),
+            ..AccountRecord::default()
+        };
         if let Some(limit) = queue_limit {
             record.queue_send_limit = Some(limit as i32);
             record.queue_receive_limit = Some(limit as i32);

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-monitor"
-version = "0.1.0"
+version = "0.1.1"
 description = "Real-time TUI monitoring dashboard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -28,6 +28,13 @@ tokio-stream = "0.1"
 
 # ── HTTP Client (polls mediator /admin/status endpoint) ──────────────────
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+
+# ── DIDComm auth (mediator's /admin/status is gated on admin JWT) ────────
+## Path-pinned to the workspace copy via [patch.crates-io] in the workspace
+## root Cargo.toml; the version specs here are upper-bound contracts only.
+affinidi-messaging-sdk = "0.18"
+affinidi-tdk-common = "0.6"
+affinidi-secrets-resolver = "0.5"
 
 # ── Serialization ────────────────────────────────────────────────────────
 serde = { version = "1", features = ["derive"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/auth.rs
@@ -1,0 +1,119 @@
+//! Authenticated session against the mediator's `/admin/status` endpoint.
+//!
+//! The mediator gates `/admin/status` on a valid admin-tier JWT. mediator-monitor
+//! mints those JWTs by running the standard SDK auth handshake against an
+//! admin DID + secrets supplied by the operator. Tokens are cached and
+//! refreshed by the SDK's authentication actor; this module just hands the
+//! current access token back to the HTTP poller on each request.
+//!
+//! ## Admin profile file format
+//!
+//! A JSON file with [`affinidi_tdk_common::profiles::TDKProfile`] shape:
+//!
+//! ```json
+//! {
+//!   "alias": "admin",
+//!   "did": "did:peer:2.Vz6Mk...",
+//!   "mediator": "did:peer:2.Vz6Mk...",
+//!   "secrets": [
+//!     { "id": "did:peer:2.Vz6Mk...#key-1", "type": "...", "privateKeyJwk": { ... } },
+//!     { "id": "did:peer:2.Vz6Mk...#key-2", "type": "...", "privateKeyJwk": { ... } }
+//!   ]
+//! }
+//! ```
+//!
+//! `mediator` is the mediator's DID (the audience for the JWT), not its URL —
+//! the URL comes from `--url` on the CLI.
+
+use std::{path::Path, sync::Arc};
+
+use affinidi_messaging_sdk::{ATM, config::ATMConfig, profiles::ATMProfile};
+use affinidi_secrets_resolver::SecretsResolver;
+use affinidi_tdk_common::{TDKSharedState, config::TDKConfig, profiles::TDKProfile};
+use anyhow::{Context, Result};
+
+/// Owns the authenticated session and produces fresh bearer tokens on demand.
+pub struct AdminAuth {
+    atm: ATM,
+    profile_did: String,
+    mediator_did: String,
+}
+
+impl AdminAuth {
+    /// Build an authenticated session from an admin profile JSON file.
+    ///
+    /// The file must declare a non-empty `mediator` DID — `/admin/status`
+    /// authentication is between the admin DID and the mediator DID,
+    /// independent of the HTTP URL the monitor is polling.
+    pub async fn from_profile_path(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("failed to read admin profile file: {}", path.display()))?;
+        let mut profile: TDKProfile = serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse admin profile JSON: {}", path.display()))?;
+
+        let mediator_did = profile.mediator.clone().with_context(|| {
+            format!(
+                "admin profile {} is missing a `mediator` field — required to mint admin JWTs",
+                path.display()
+            )
+        })?;
+        let profile_did = profile.did.clone();
+
+        let tdk_cfg = TDKConfig::headless().context("building TDK headless config")?;
+        let tdk = Arc::new(
+            TDKSharedState::new(tdk_cfg)
+                .await
+                .context("initialising TDK shared state")?,
+        );
+        // `take_secrets` drains the plaintext into the resolver and zeroizes
+        // the source vector promptly.
+        tdk.secrets_resolver()
+            .insert_vec(&profile.take_secrets())
+            .await;
+
+        let atm_config = ATMConfig::builder()
+            .build()
+            .context("building ATM config")?;
+        let atm = ATM::new(atm_config, tdk).await.context("starting ATM")?;
+
+        let atm_profile = ATMProfile::from_tdk_profile(&atm, &profile)
+            .await
+            .context("constructing ATM profile from admin profile")?;
+        // `live_stream=false` — the monitor only needs REST auth, not a
+        // websocket. Errors here would surface a misconfigured admin DID
+        // (e.g. mediator DID does not resolve). The returned profile Arc
+        // is also held inside ATM's profile map; we don't need a second
+        // handle on it for token minting.
+        atm.profile_add(&atm_profile, false)
+            .await
+            .context("registering admin profile with ATM")?;
+
+        Ok(Self {
+            atm,
+            profile_did,
+            mediator_did,
+        })
+    }
+
+    /// Mint or refresh an access token for the admin DID against the
+    /// mediator DID. The SDK auth actor caches valid tokens and triggers
+    /// refresh when the access token nears expiry, so calling this on
+    /// every poll is cheap.
+    pub async fn bearer_token(&self) -> Result<String> {
+        let tokens = self
+            .atm
+            .get_tdk()
+            .authentication()
+            .authenticate(self.profile_did.clone(), self.mediator_did.clone(), 3, None)
+            .await
+            .context("admin DID auth handshake failed")?;
+        Ok(tokens.access_token)
+    }
+
+    /// Drop SDK background tasks cleanly. The TUI runs `Drop`-only
+    /// at exit; calling this gives the auth/deletion actors a chance
+    /// to shut down before the runtime tears down.
+    pub async fn shutdown(&self) {
+        self.atm.graceful_shutdown().await;
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/main.rs
@@ -1,8 +1,11 @@
+mod auth;
 mod status;
 mod ui;
 
 use std::{
     io::{self, Stdout},
+    path::PathBuf,
+    sync::Arc,
     time::Duration,
 };
 
@@ -19,6 +22,7 @@ use ratatui::{
 };
 use tokio_stream::StreamExt;
 
+use auth::AdminAuth;
 use status::StatusPoller;
 
 #[derive(Parser)]
@@ -38,6 +42,18 @@ struct Args {
     /// Poll interval in seconds
     #[arg(long, short = 'i', default_value_t = 2)]
     interval: u64,
+
+    /// Path to a JSON file describing the admin profile to authenticate as.
+    ///
+    /// File shape mirrors `affinidi_tdk_common::profiles::TDKProfile`:
+    /// `{ "alias": "...", "did": "...", "mediator": "...", "secrets": [...] }`.
+    /// The `mediator` field must be the mediator's DID (the JWT audience),
+    /// not its URL — the URL comes from `--url`.
+    ///
+    /// Required because the mediator's `/admin/status` endpoint is gated on
+    /// an admin-tier JWT.
+    #[arg(long, short = 'a', value_name = "PATH")]
+    admin_profile: PathBuf,
 }
 
 #[tokio::main]
@@ -47,13 +63,27 @@ async fn main() -> anyhow::Result<()> {
     let url = args.url.trim_end_matches('/').to_string();
     let poll_interval = Duration::from_secs(args.interval);
 
-    let mut poller = StatusPoller::new(&url);
+    // Build the auth session before opening the TUI: a bad admin profile
+    // path or unparseable JSON should fail fast on the terminal the user
+    // launched from, not buried inside the alternate screen.
+    let auth = Arc::new(
+        AdminAuth::from_profile_path(&args.admin_profile)
+            .await
+            .context("loading admin profile")?,
+    );
+
+    let mut poller = StatusPoller::new(&url, auth.clone());
 
     let mut terminal = setup_terminal()?;
 
     let result = run_event_loop(&mut terminal, &mut poller, poll_interval).await;
 
     restore_terminal(&mut terminal)?;
+
+    // Best-effort SDK shutdown — tears down deletion handler and any
+    // websocket tasks (we use none, but the deletion handler runs
+    // unconditionally on `ATM::new`).
+    auth.shutdown().await;
 
     result
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/status.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/src/status.rs
@@ -1,8 +1,10 @@
 //! Polls the mediator's /admin/status endpoint and maintains history for rate calculations.
 
+use crate::auth::AdminAuth;
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Instant;
 
 /// Mirrors the JSON structure from the mediator's /admin/status endpoint.
@@ -60,6 +62,10 @@ struct Snapshot {
 pub struct StatusPoller {
     client: Client,
     status_url: String,
+    /// Admin auth handle. Required — `/admin/status` is auth-gated.
+    /// Held as `Arc` so the poller is cheap to clone if we ever need to
+    /// hand it across tasks; today it lives on the main task.
+    auth: Arc<AdminAuth>,
     pub current: AdminStatus,
     pub error: Option<String>,
     pub connected: bool,
@@ -71,13 +77,14 @@ pub struct StatusPoller {
 }
 
 impl StatusPoller {
-    pub fn new(base_url: &str) -> Self {
+    pub fn new(base_url: &str, auth: Arc<AdminAuth>) -> Self {
         Self {
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(5))
                 .build()
                 .unwrap_or_default(),
             status_url: format!("{base_url}/admin/status"),
+            auth,
             current: AdminStatus::default(),
             error: None,
             connected: false,
@@ -88,44 +95,88 @@ impl StatusPoller {
     }
 
     pub async fn poll(&mut self) {
-        match self.client.get(&self.status_url).send().await {
-            Ok(response) => match response.json::<AdminStatus>().await {
-                Ok(status) => {
-                    let now = Instant::now();
+        let token = match self.auth.bearer_token().await {
+            Ok(t) => t,
+            Err(e) => {
+                // Auth failure is distinct from a transport / parse error —
+                // surface it as such so the operator knows the credential
+                // path is wrong, not the URL.
+                self.error = Some(format!("Auth error: {e}"));
+                self.connected = false;
+                return;
+            }
+        };
 
-                    // Calculate rates from oldest snapshot in window
-                    if let Some(oldest) = self.history.front() {
-                        let elapsed = now.duration_since(oldest.taken_at).as_secs_f64();
-                        if elapsed > 0.5 {
-                            let msg_delta = (status.messages.received_count
-                                - oldest.status.messages.received_count)
-                                as f64;
-                            let bytes_delta = (status.messages.received_bytes
-                                - oldest.status.messages.received_bytes)
-                                as f64;
-                            self.msg_per_sec = msg_delta / elapsed;
-                            self.bytes_per_sec = bytes_delta / elapsed;
-                        }
-                    }
+        let request = self
+            .client
+            .get(&self.status_url)
+            .header("Authorization", format!("Bearer {token}"));
 
-                    // Keep last 30 snapshots (~60 seconds at 2s interval)
-                    if self.history.len() >= 30 {
-                        self.history.pop_front();
-                    }
-                    self.history.push_back(Snapshot {
-                        status: status.clone(),
-                        taken_at: now,
-                    });
-
-                    self.current = status;
-                    self.connected = true;
-                    self.error = None;
-                }
-                Err(e) => {
-                    self.error = Some(format!("Parse error: {e}"));
+        match request.send().await {
+            Ok(response) => {
+                let status_code = response.status();
+                if status_code == reqwest::StatusCode::UNAUTHORIZED {
+                    self.error = Some(
+                        "Unauthorized (401) — admin JWT was rejected by the mediator. Check that \
+                         the admin profile's `did` and `mediator` match the mediator's config and \
+                         that the secrets are current."
+                            .into(),
+                    );
                     self.connected = false;
+                    return;
                 }
-            },
+                if status_code == reqwest::StatusCode::FORBIDDEN {
+                    self.error = Some(
+                        "Forbidden (403) — DID authenticated but is not admin-tier. \
+                         /admin/status requires Admin, RootAdmin, or Mediator account_type."
+                            .into(),
+                    );
+                    self.connected = false;
+                    return;
+                }
+                if !status_code.is_success() {
+                    self.error = Some(format!("Mediator returned {status_code}"));
+                    self.connected = false;
+                    return;
+                }
+                match response.json::<AdminStatus>().await {
+                    Ok(status) => {
+                        let now = Instant::now();
+
+                        // Calculate rates from oldest snapshot in window
+                        if let Some(oldest) = self.history.front() {
+                            let elapsed = now.duration_since(oldest.taken_at).as_secs_f64();
+                            if elapsed > 0.5 {
+                                let msg_delta = (status.messages.received_count
+                                    - oldest.status.messages.received_count)
+                                    as f64;
+                                let bytes_delta = (status.messages.received_bytes
+                                    - oldest.status.messages.received_bytes)
+                                    as f64;
+                                self.msg_per_sec = msg_delta / elapsed;
+                                self.bytes_per_sec = bytes_delta / elapsed;
+                            }
+                        }
+
+                        // Keep last 30 snapshots (~60 seconds at 2s interval)
+                        if self.history.len() >= 30 {
+                            self.history.pop_front();
+                        }
+                        self.history.push_back(Snapshot {
+                            status: status.clone(),
+                            taken_at: now,
+                        });
+
+                        self.current = status;
+                        self.connected = true;
+                        self.error = None;
+                    }
+                    Err(e) => {
+                        self.error = Some(format!("Parse error: {e}"));
+                        self.connected = false;
+                    }
+                }
+            }
             Err(e) => {
                 self.error = Some(format!("Connection error: {e}"));
                 self.connected = false;

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/streaming_forwarding_acl.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/streaming_forwarding_acl.rs
@@ -63,11 +63,18 @@ async fn websocket_endpoint_rejects_unauthenticated_handshake() {
     let _ = mediator.join().await;
 }
 
-/// `/admin/status` returns operational metrics as JSON. We don't
-/// assert specific field values — only that the endpoint serves
-/// well-formed JSON containing the expected top-level keys.
+/// `/admin/status` is gated behind admin auth. Operational metrics
+/// (uptime, message counts, queue depth, masked Redis URL) are
+/// fingerprintable infra detail and historically were exposed
+/// publicly; this test verifies the auth gate is in place by
+/// asserting an unauthenticated GET returns 401.
+///
+/// A full "200 with admin auth" verification requires running the
+/// SDK auth handshake to mint a JWT, which is exercised by SDK-level
+/// integration tests and by `mediator-monitor` once it's updated to
+/// authenticate. The wire-shape of `AdminStatus` is checked there.
 #[tokio::test]
-async fn admin_status_returns_metrics_json() {
+async fn admin_status_requires_authentication() {
     init_tracing();
     if skip_if_no_redis() {
         return;
@@ -81,20 +88,21 @@ async fn admin_status_returns_metrics_json() {
         .build()
         .expect("client");
     let resp = client.get(&url).send().await.expect("admin status");
-    assert!(
-        resp.status().is_success(),
-        "admin status returned: {}",
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "/admin/status must reject unauthenticated GETs (got {})",
         resp.status()
     );
 
+    // The 401 body comes from the JWT auth extractor's IntoResponse
+    // and is JSON. Confirm it's well-formed so we catch accidental
+    // changes that produce empty / HTML bodies.
     let body: JsonValue = resp.json().await.expect("json body");
-    // The handler builds an `AdminStatus` struct; we just confirm a
-    // few load-bearing keys are present rather than mirroring the
-    // full schema (which evolves).
-    let obj = body.as_object().expect("admin status is a JSON object");
     assert!(
-        obj.contains_key("circuit_breaker") || obj.contains_key("queue_length"),
-        "admin status missing both circuit_breaker and queue_length: {body}"
+        body.as_object()
+            .is_some_and(|obj| obj.contains_key("error_code") || obj.contains_key("message")),
+        "401 body must be a structured ErrorResponse, got: {body}"
     );
 
     mediator.shutdown();


### PR DESCRIPTION
## Summary

Three coupled changes hardening the mediator's public HTTP surface, with the dependent ops tool updated alongside so nothing breaks on main.

## Disclosure scope (read first)

**No secret material was being disclosed.** No private keys, passwords, JWT signing material, or session tokens were ever returned by `/admin/status` or `/readyz`. The Redis password was already masked, secrets-backend authentication credentials are never serialised, and JWT keys live in memory only.

What *was* being returned without authentication was infrastructure metadata that helps an attacker fingerprint a target: deployment size, message throughput, queue depth, masked Redis URL, secrets backend URL (e.g. `gcp-secrets://project-id/secret-name`, AWS Secrets Manager ARN, Vault server + path), and the raw text of probe-failure errors which can include hostnames, IDs, and intermediary state. None of this grants access on its own — the backend has its own authentication — but it shortens reconnaissance time and narrows the search space for credential-stuffing or vulnerability targeting against the backend.

This PR is **defensive hygiene**, not a patch for an active credential leak. The motivation is least-privilege: an unauthenticated load-balancer probe path should not be a free reconnaissance channel. If a future bug ever does cause a real secret to bleed into one of these responses, this hardening keeps that bug from being silently public.

### `/admin/status` now requires admin-tier session

`GET /admin/status` returned operational metrics (uptime, message counts, queue depth, websocket counts, masked Redis URL, circuit-breaker state) without any authentication. The handler now takes a `Session` extractor (JWT) and returns **403** unless `session.account_type.is_admin()` (Admin / RootAdmin / Mediator). Unauthenticated requests get **401** from the existing JWT auth extractor.

### `/readyz` no longer leaks the secrets backend URL or probe error

`GET /readyz` embedded `state.config.secrets_backend_url` in three places (per-check success entry, per-check failure entry, top-level `secrets_backend_url` field) and additionally echoed the raw probe error via `format!("Secret backend probe failed: {e}")`. Stripped the URL from all three sites. Replaced the variable failure message with generic `"Secret backend probe failed"` and added a `warn!` log for the detailed error so operators keep visibility via logs. Kept the boolean `secrets_backend_reachable` so k8s/LB probes still work.

### `mediator-monitor` updated to authenticate as admin

The TUI now requires a `--admin-profile <PATH>` flag pointing at a JSON file (`TDKProfile` shape: `alias`, `did`, `mediator`, `secrets`) and uses the SDK's auth handshake to mint admin JWTs that it sends as `Authorization: Bearer <token>` on every `/admin/status` poll. Token refresh is delegated to the SDK's authentication actor.

Distinct error messaging surfaces 401 (rejected JWT — credentials wrong), 403 (authenticated but not admin-tier — wrong account type), transport, parse, and non-2xx separately, so an operator looking at the TUI can tell why polling is failing.

`--admin-profile` is required — there is intentionally no anonymous fallback (the previous behaviour) and no `--token <jwt>` flag (that would expire in 15 minutes by default and silently start failing mid-session).

## Breaking changes

- Any external operator tooling that scrapes `/admin/status` or relies on `/readyz` echoing `secrets_backend_url` will need to update.
- mediator-monitor users now need an admin profile JSON file. The same file the `mediator-administration` helper consumes works.

## Test plan

- [x] `cargo build -p affinidi-messaging-mediator -p affinidi-messaging-test-mediator -p affinidi-messaging-mediator-monitor` clean
- [x] `cargo clippy -p affinidi-messaging-mediator -p affinidi-messaging-mediator-monitor --all-targets` clean
- [x] `cargo test -p affinidi-messaging-mediator --lib` — 76 pass
- [x] `cargo test -p affinidi-messaging-test-mediator --test lifecycle` — 22 pass (incl. `mediator_serves_readyz`)
- [x] `cargo test -p affinidi-messaging-test-mediator --test streaming_forwarding_acl admin_status_requires_authentication` — passes
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `mediator-monitor --help` shows the new `--admin-profile` flag with helpful text
- [x] `mediator-monitor` (no args) errors out with usage hint pointing at `--admin-profile`
- [x] All in-workspace `affinidi-*` deps in `affinidi-messaging-mediator/Cargo.toml` confirmed at latest major.minor (sdk 0.18, didcomm 0.13, tsp 0.1, encoding 0.1, mediator-common 0.15, did-resolver-cache-sdk 0.8, did-common 0.3, secrets-resolver 0.5; all caret pins resolve to the current local + crates.io versions)
- [ ] CI green
- [ ] After merge: confirm `affinidi-messaging-mediator@0.15.3` publishes (assumes pipeline-rust PR #75 has landed; otherwise see that PR for context). `mediator-monitor` is `publish = false` so no registry impact.

## Tests changed

- `admin_status_returns_metrics_json` → `admin_status_requires_authentication`. The old test asserted 2xx + JSON shape on unauthenticated GET, which is exactly the behaviour this PR removes. The new test asserts the auth gate (401 unauth, well-formed JSON error body). A "200 with admin auth" test requires running the full SDK auth handshake against `TestMediator` to mint an admin JWT — left as follow-up; the wire shape of `AdminStatus` is also exercised by `mediator-monitor`'s deserializer in real use.

## Versions

- `affinidi-messaging-mediator`: 0.15.2 → **0.15.3**
- `affinidi-messaging-mediator-monitor`: 0.1.0 → **0.1.1** (`publish = false`, workspace-internal)