### PR TITLE
fix: mediator-setup 0.1.2 — clipboard OSC 52 hardening

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.1"
+version = "0.1.2"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -706,6 +706,10 @@ impl WizardApp {
     /// clipboard. Hotkey `[c]` on the Summary panel.
     pub fn copy_config_path_to_clipboard(&mut self) {
         let path = self.config.config_path.clone();
+        if path.is_empty() {
+            self.clipboard_status = Some("No config path set yet".into());
+            return;
+        }
         self.copy_text_to_clipboard(&path, "config path");
     }
 
@@ -714,6 +718,10 @@ impl WizardApp {
     /// clipboard. Hotkey `[b]` on the Summary panel.
     pub fn copy_backend_url_to_clipboard(&mut self) {
         let url = crate::config_writer::build_backend_url(&self.config);
+        if url.is_empty() {
+            self.clipboard_status = Some("Backend URL not yet resolved".into());
+            return;
+        }
         self.copy_text_to_clipboard(&url, "backend URL");
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/clipboard.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/clipboard.rs
@@ -24,10 +24,46 @@
 //!   fallback for headless desktops where `arboard` finds no
 //!   clipboard daemon.
 //!
+//! ## Empty payloads are refused
+//!
+//! Several terminals treat OSC 52 with an empty base64 payload as
+//! "clear the clipboard". A code path that accidentally hands us
+//! an empty string would silently wipe whatever the operator just
+//! copied — and every subsequent paste would look "blank". The
+//! dispatcher rejects empty / whitespace-only input up front with
+//! a clear error so the caller can surface a friendlier "nothing
+//! to copy" message instead of clobbering the clipboard.
+//!
+//! ## Multiplexer passthrough
+//!
+//! Bare OSC 52 dies at a `tmux` or GNU `screen` pane boundary unless
+//! the operator has explicitly enabled clipboard forwarding. For
+//! both multiplexers we emit a DCS-passthrough-wrapped variant in
+//! *addition* to the bare sequence — the multiplexer eats one form
+//! and forwards the other, and the outer terminal receives exactly
+//! one OSC 52 either way.
+//!
+//! - tmux: `\x1bPtmux;\x1b<OSC52>\x1b\\` — requires `set -g
+//!   allow-passthrough on` (off by default in tmux 3.3+) or
+//!   `set -g set-clipboard on`. We send both shapes so either
+//!   setting works.
+//! - screen: `\x1bP<OSC52 with inner ST replaced by \x1b\\>\x1b\\` —
+//!   GNU screen's DCS passthrough convention.
+//!
+//! ## Terminal transport
+//!
+//! Under the wizard's TUI, `ratatui` owns `io::stdout()` through a
+//! buffered `CrosstermBackend`. Direct writes to `io::stdout()` can
+//! race against ratatui's buffered draw cycle. We emit OSC 52 to
+//! `/dev/tty` instead — the controlling terminal of the process,
+//! reached through a fresh file handle that bypasses ratatui's
+//! buffer entirely. Falls back to `io::stdout()` if `/dev/tty`
+//! can't be opened (rare: headless CI, non-TTY runs).
+//!
 //! ## Honesty about confirmation
 //!
 //! Neither path can confirm the clipboard was *actually* set. OSC 52
-//! emits to stdout and trusts the terminal; `arboard` opens a handle
+//! emits to the TTY and trusts the terminal; `arboard` opens a handle
 //! and trusts the OS. The returned [`CopyMethod`] reports which path
 //! was *attempted successfully* — an error from the underlying
 //! library means we could not even attempt that path. Operators
@@ -75,20 +111,60 @@ impl CopyMethod {
 /// SSH.
 ///
 /// Returns the [`CopyMethod`] that successfully attempted the copy,
-/// or an error string naming both failure reasons when neither path
-/// could even be attempted.
+/// or an error string. Empty / whitespace-only `text` is rejected
+/// without dispatching to either transport — see the module docs
+/// for why.
 pub fn copy_to_clipboard(text: &str) -> Result<CopyMethod, String> {
-    copy_with(text, is_ssh_environment(), try_arboard, try_osc52_to_stdout)
+    copy_with(text, Env::from_process(), try_arboard, try_osc52_with_env)
+}
+
+/// Subset of the process environment that influences clipboard
+/// dispatch. Bundled so tests can stub the whole thing without
+/// touching real env vars (which would race across parallel tests).
+#[derive(Debug, Clone, Default)]
+struct Env {
+    on_ssh: bool,
+    /// Value of `$TMUX`, when set + non-empty. Drives DCS-passthrough
+    /// wrapping for the tmux clipboard path.
+    tmux: Option<String>,
+    /// Value of `$STY`, when set + non-empty. Drives GNU screen DCS
+    /// passthrough wrapping. Detected separately from tmux so the
+    /// (very rare) nested screen-in-tmux case still emits both
+    /// wrappers.
+    screen: Option<String>,
+}
+
+impl Env {
+    fn from_process() -> Self {
+        Self::from_getter(|k| std::env::var(k).ok())
+    }
+
+    fn from_getter<F: Fn(&str) -> Option<String>>(getter: F) -> Self {
+        let nonempty = |k: &str| getter(k).filter(|v| !v.is_empty());
+        Self {
+            on_ssh: ["SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"]
+                .iter()
+                .any(|k| nonempty(k).is_some()),
+            tmux: nonempty("TMUX"),
+            screen: nonempty("STY"),
+        }
+    }
 }
 
 /// Internal dispatch point — visible for tests so we can stub the
 /// two transports independently and exercise both fallback paths
 /// without touching the real OS clipboard or stdout.
-fn copy_with<A, O>(text: &str, on_ssh: bool, arboard: A, osc52: O) -> Result<CopyMethod, String>
+fn copy_with<A, O>(text: &str, env: Env, arboard: A, osc52: O) -> Result<CopyMethod, String>
 where
     A: FnOnce(&str) -> Result<(), String>,
-    O: FnOnce(&str) -> Result<(), String>,
+    O: FnOnce(&str, &Env) -> Result<(), String>,
 {
+    if text.is_empty() {
+        return Err("nothing to copy (empty payload)".to_string());
+    }
+    if text.chars().all(char::is_whitespace) {
+        return Err("nothing to copy (whitespace only)".to_string());
+    }
     if text.len() > MAX_PAYLOAD_BYTES {
         return Err(format!(
             "payload {} bytes exceeds OSC 52 cap of {} bytes — truncate before copying",
@@ -96,8 +172,8 @@ where
             MAX_PAYLOAD_BYTES
         ));
     }
-    if on_ssh {
-        match osc52(text) {
+    if env.on_ssh {
+        match osc52(text, &env) {
             Ok(()) => Ok(CopyMethod::Osc52),
             Err(osc52_err) => match arboard(text) {
                 Ok(()) => Ok(CopyMethod::Arboard),
@@ -107,31 +183,12 @@ where
     } else {
         match arboard(text) {
             Ok(()) => Ok(CopyMethod::Arboard),
-            Err(arboard_err) => match osc52(text) {
+            Err(arboard_err) => match osc52(text, &env) {
                 Ok(()) => Ok(CopyMethod::Osc52),
                 Err(osc52_err) => Err(format!("arboard: {arboard_err}; OSC 52: {osc52_err}")),
             },
         }
     }
-}
-
-/// Detect whether the wizard appears to be running over SSH by
-/// inspecting standard environment variables.
-///
-/// `SSH_CONNECTION` is the most reliable signal (set by the SSH
-/// daemon itself); `SSH_TTY` and `SSH_CLIENT` are commonly set in
-/// the same context but can be filtered out by some shell configs.
-/// We OR all three so a missing variable on one path doesn't
-/// suppress the SSH-aware behaviour.
-fn is_ssh_environment() -> bool {
-    is_ssh_environment_with(|k| std::env::var(k).ok())
-}
-
-/// Pure, env-injectable variant for parallel-safe testing.
-fn is_ssh_environment_with<F: Fn(&str) -> Option<String>>(getter: F) -> bool {
-    ["SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"]
-        .iter()
-        .any(|k| getter(k).is_some_and(|v| !v.is_empty()))
 }
 
 /// Build the OSC 52 escape sequence for `text`. Pure — separated
@@ -147,17 +204,85 @@ fn format_osc52(text: &str) -> String {
     format!("\x1b]52;c;{encoded}\x1b\\")
 }
 
+/// Wrap an OSC 52 sequence in tmux DCS passthrough. Inside the DCS
+/// payload, every literal `\x1b` is replaced with `\x1b\x1b` per
+/// the tmux passthrough protocol — otherwise the inner ST would
+/// terminate the outer DCS prematurely.
+///
+/// Works when the operator has `set -g allow-passthrough on` in
+/// tmux. tmux 3.3+ defaults this off for security, so we ALSO
+/// send the bare OSC 52 (see [`build_osc52_payload`]) — the
+/// other branch covers operators relying on `set -g set-clipboard
+/// on` instead.
+fn wrap_tmux(osc52: &str) -> String {
+    let inner = osc52.replace('\x1b', "\x1b\x1b");
+    format!("\x1bPtmux;{inner}\x1b\\")
+}
+
+/// Wrap an OSC 52 sequence in GNU screen's DCS passthrough. screen's
+/// passthrough swallows the inner ST, so we rewrite the inner
+/// `\x1b\\` (the OSC 52 ST) into the screen-specific `\x1b\\`
+/// sequence inside a DCS frame. Implementation matches the
+/// `terminfo` / vim / neovim convention for screen passthrough.
+fn wrap_screen(osc52: &str) -> String {
+    // screen's DCS payload may not contain a raw ST. Re-emit the
+    // inner OSC 52 with its ST stripped, wrap with the outer DCS,
+    // and re-add a single ST at the end.
+    let stripped = osc52.trim_end_matches("\x1b\\");
+    format!("\x1bP{stripped}\x1b\\")
+}
+
+/// Build the full byte stream we'll write to the terminal:
+/// the bare OSC 52, optionally followed by tmux / screen DCS
+/// passthrough variants. Each is a no-op on terminals that don't
+/// recognise it, so emitting both forms is safe and gives us the
+/// widest reach across tmux configurations.
+fn build_osc52_payload(text: &str, env: &Env) -> String {
+    let bare = format_osc52(text);
+    let mut out = String::with_capacity(bare.len() * 2);
+    out.push_str(&bare);
+    if env.tmux.is_some() {
+        out.push_str(&wrap_tmux(&bare));
+    }
+    if env.screen.is_some() {
+        out.push_str(&wrap_screen(&bare));
+    }
+    out
+}
+
 /// Write the OSC 52 sequence to `w` and flush.
-fn emit_osc52_to<W: Write>(text: &str, w: &mut W) -> std::io::Result<()> {
-    let seq = format_osc52(text);
+fn emit_osc52_to<W: Write>(text: &str, env: &Env, w: &mut W) -> std::io::Result<()> {
+    let seq = build_osc52_payload(text, env);
     w.write_all(seq.as_bytes())?;
     w.flush()
 }
 
-/// Production OSC 52 emitter — writes to stdout. Errors from the
-/// underlying write are stringified for the dispatcher.
-fn try_osc52_to_stdout(text: &str) -> Result<(), String> {
-    emit_osc52_to(text, &mut std::io::stdout()).map_err(|e| e.to_string())
+/// Production OSC 52 emitter — writes to `/dev/tty` when available,
+/// falling back to `io::stdout()`. Going via `/dev/tty` keeps the
+/// escape sequence off ratatui's `BufWriter` so it can't race with
+/// a buffered TUI redraw.
+fn try_osc52_with_env(text: &str, env: &Env) -> Result<(), String> {
+    if let Some(mut tty) = open_tty_writer() {
+        return emit_osc52_to(text, env, &mut tty).map_err(|e| format!("/dev/tty: {e}"));
+    }
+    emit_osc52_to(text, env, &mut std::io::stdout()).map_err(|e| format!("stdout: {e}"))
+}
+
+/// Open `/dev/tty` for writing. Returns `None` on Windows (no
+/// `/dev/tty`) or when the file can't be opened — typically a
+/// non-interactive run (cron, CI) where there is no controlling
+/// terminal. Callers fall back to stdout in that case.
+#[cfg(unix)]
+fn open_tty_writer() -> Option<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .ok()
+}
+
+#[cfg(not(unix))]
+fn open_tty_writer() -> Option<std::fs::File> {
+    None
 }
 
 /// Production arboard caller. Constructs a fresh clipboard handle
@@ -174,45 +299,57 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn env(map: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    fn env_with(map: &[(&str, &str)]) -> Env {
         let owned: HashMap<String, String> = map
             .iter()
             .map(|(k, v)| ((*k).into(), (*v).into()))
             .collect();
-        move |k| owned.get(k).cloned()
+        Env::from_getter(move |k| owned.get(k).cloned())
     }
 
     #[test]
     fn ssh_env_detected_via_ssh_connection() {
-        assert!(is_ssh_environment_with(env(&[(
-            "SSH_CONNECTION",
-            "10.0.0.1 22 10.0.0.2 5000",
-        )])));
+        assert!(env_with(&[("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 5000")]).on_ssh);
     }
 
     #[test]
     fn ssh_env_detected_via_ssh_tty() {
-        assert!(is_ssh_environment_with(env(&[("SSH_TTY", "/dev/pts/3")])));
+        assert!(env_with(&[("SSH_TTY", "/dev/pts/3")]).on_ssh);
     }
 
     #[test]
     fn ssh_env_detected_via_ssh_client() {
-        assert!(is_ssh_environment_with(env(&[(
-            "SSH_CLIENT",
-            "10.0.0.1 5000 22"
-        )])));
+        assert!(env_with(&[("SSH_CLIENT", "10.0.0.1 5000 22")]).on_ssh);
     }
 
     #[test]
     fn ssh_env_returns_false_when_no_vars_set() {
-        assert!(!is_ssh_environment_with(env(&[])));
+        assert!(!env_with(&[]).on_ssh);
     }
 
     #[test]
     fn ssh_env_ignores_empty_string_values() {
         // Some shells export the var as empty when not actually
         // inside an SSH session; treat that as "not SSH".
-        assert!(!is_ssh_environment_with(env(&[("SSH_CONNECTION", "")])));
+        assert!(!env_with(&[("SSH_CONNECTION", "")]).on_ssh);
+    }
+
+    #[test]
+    fn tmux_detected_when_var_set() {
+        let env = env_with(&[("TMUX", "/tmp/tmux-1000/default,12345,0")]);
+        assert!(env.tmux.is_some());
+    }
+
+    #[test]
+    fn tmux_ignored_when_empty() {
+        let env = env_with(&[("TMUX", "")]);
+        assert!(env.tmux.is_none());
+    }
+
+    #[test]
+    fn screen_detected_via_sty() {
+        let env = env_with(&[("STY", "12345.pts-0.host")]);
+        assert!(env.screen.is_some());
     }
 
     #[test]
@@ -225,20 +362,69 @@ mod tests {
     }
 
     #[test]
-    fn osc52_emits_to_writer() {
+    fn osc52_emits_to_writer_bare_when_no_multiplexer() {
         let mut buf: Vec<u8> = Vec::new();
-        emit_osc52_to("hi", &mut buf).unwrap();
+        emit_osc52_to("hi", &env_with(&[]), &mut buf).unwrap();
         let written = String::from_utf8(buf).unwrap();
         assert_eq!(written, format_osc52("hi"));
+    }
+
+    #[test]
+    fn tmux_wrap_doubles_inner_escape_bytes() {
+        let inner = format_osc52("hi");
+        let wrapped = wrap_tmux(&inner);
+        assert!(wrapped.starts_with("\x1bPtmux;"));
+        assert!(wrapped.ends_with("\x1b\\"));
+        // The inner OSC 52's leading \x1b]52;c; becomes
+        // \x1b\x1b]52;c; under tmux DCS passthrough.
+        assert!(wrapped.contains("\x1b\x1b]52;c;"));
+        // And the inner ST gets its \x1b doubled too.
+        assert!(wrapped.contains("aGk=\x1b\x1b\\"));
+    }
+
+    #[test]
+    fn screen_wrap_drops_inner_st_and_re_adds_outer() {
+        let inner = format_osc52("hi");
+        let wrapped = wrap_screen(&inner);
+        assert!(wrapped.starts_with("\x1bP\x1b]52;c;"));
+        assert!(wrapped.ends_with("\x1b\\"));
+        // Exactly one ST at the end — the inner one is consumed.
+        assert_eq!(wrapped.matches("\x1b\\").count(), 1);
+    }
+
+    #[test]
+    fn osc52_payload_includes_tmux_wrap_when_tmux_set() {
+        let env = env_with(&[("TMUX", "/tmp/tmux/sock,1,0")]);
+        let payload = build_osc52_payload("hi", &env);
+        // Bare form first…
+        assert!(payload.starts_with(&format_osc52("hi")));
+        // …then the tmux DCS passthrough.
+        assert!(payload.contains("\x1bPtmux;\x1b\x1b]52;c;"));
+    }
+
+    #[test]
+    fn osc52_payload_includes_screen_wrap_when_sty_set() {
+        let env = env_with(&[("STY", "12345.pts-0.host")]);
+        let payload = build_osc52_payload("hi", &env);
+        assert!(payload.contains("\x1bP\x1b]52;c;"));
+    }
+
+    #[test]
+    fn osc52_payload_skips_wrappers_outside_multiplexers() {
+        let env = env_with(&[]);
+        let payload = build_osc52_payload("hi", &env);
+        assert!(!payload.contains("\x1bPtmux;"));
+        // Outside screen we shouldn't see a leading DCS introducer.
+        assert!(!payload.contains("\x1bP\x1b]"));
     }
 
     #[test]
     fn dispatch_on_ssh_tries_osc52_first() {
         let result = copy_with(
             "test",
-            true, // on_ssh
+            env_with(&[("SSH_CONNECTION", "1.1.1.1 22 2.2.2.2 5000")]),
             |_| Err("arboard would have been called".into()),
-            |_| Ok(()),
+            |_, _| Ok(()),
         );
         assert_eq!(result, Ok(CopyMethod::Osc52));
     }
@@ -247,9 +433,9 @@ mod tests {
     fn dispatch_on_ssh_falls_back_to_arboard_when_osc52_fails() {
         let result = copy_with(
             "test",
-            true,
+            env_with(&[("SSH_CONNECTION", "1.1.1.1 22 2.2.2.2 5000")]),
             |_| Ok(()),
-            |_| Err("terminal does not support OSC 52".into()),
+            |_, _| Err("terminal does not support OSC 52".into()),
         );
         assert_eq!(result, Ok(CopyMethod::Arboard));
     }
@@ -258,9 +444,9 @@ mod tests {
     fn dispatch_locally_tries_arboard_first() {
         let result = copy_with(
             "test",
-            false, // local
+            env_with(&[]),
             |_| Ok(()),
-            |_| Err("osc52 would have been called".into()),
+            |_, _| Err("osc52 would have been called".into()),
         );
         assert_eq!(result, Ok(CopyMethod::Arboard));
     }
@@ -269,9 +455,9 @@ mod tests {
     fn dispatch_locally_falls_back_to_osc52_when_arboard_fails() {
         let result = copy_with(
             "test",
-            false,
+            env_with(&[]),
             |_| Err("no clipboard daemon".into()),
-            |_| Ok(()),
+            |_, _| Ok(()),
         );
         assert_eq!(result, Ok(CopyMethod::Osc52));
     }
@@ -280,13 +466,40 @@ mod tests {
     fn dispatch_returns_combined_err_when_both_methods_fail() {
         let err = copy_with(
             "test",
-            true,
+            env_with(&[("SSH_CONNECTION", "1.1.1.1 22 2.2.2.2 5000")]),
             |_| Err("no clipboard daemon".into()),
-            |_| Err("OSC 52 not supported".into()),
+            |_, _| Err("OSC 52 not supported".into()),
         )
         .unwrap_err();
         assert!(err.contains("OSC 52: OSC 52 not supported"));
         assert!(err.contains("arboard: no clipboard daemon"));
+    }
+
+    #[test]
+    fn dispatch_rejects_empty_payload() {
+        // Empty payload would emit an OSC 52 with empty base64, which
+        // many terminals interpret as "clear the clipboard". The
+        // dispatcher catches it before either transport runs.
+        let err = copy_with(
+            "",
+            env_with(&[]),
+            |_| panic!("arboard called for empty payload"),
+            |_, _| panic!("osc52 called for empty payload"),
+        )
+        .unwrap_err();
+        assert!(err.contains("nothing to copy"));
+    }
+
+    #[test]
+    fn dispatch_rejects_whitespace_payload() {
+        let err = copy_with(
+            "   \t\n",
+            env_with(&[]),
+            |_| panic!("arboard called for whitespace payload"),
+            |_, _| panic!("osc52 called for whitespace payload"),
+        )
+        .unwrap_err();
+        assert!(err.contains("nothing to copy"));
     }
 
     #[test]
@@ -297,9 +510,9 @@ mod tests {
         // regression that bypasses the guard.
         let err = copy_with(
             &huge,
-            true,
+            env_with(&[("SSH_CONNECTION", "1.1.1.1 22 2.2.2.2 5000")]),
             |_| panic!("arboard called despite oversized payload"),
-            |_| panic!("osc52 called despite oversized payload"),
+            |_, _| panic!("osc52 called despite oversized payload"),
         )
         .unwrap_err();
         assert!(err.contains("exceeds"));

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/sealed_handoff.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/sealed_handoff.rs
@@ -506,7 +506,10 @@ impl SealedHandoffState {
     /// Hotkey `[m]` on the Complete panel.
     pub fn copy_mediator_did_to_clipboard(&mut self) {
         match self.session.as_ref().and_then(|s| s.integration_did()) {
-            Some(did) => self.set_clipboard(did.to_string(), "mediator DID"),
+            Some(did) if !did.is_empty() => self.set_clipboard(did.to_string(), "mediator DID"),
+            Some(_) => {
+                self.clipboard_status = Some("Mediator DID slot is empty in this bundle".into());
+            }
             None => {
                 self.clipboard_status =
                     Some("No mediator DID in this bundle (AdminOnly handoff)".into());
@@ -521,19 +524,31 @@ impl SealedHandoffState {
             self.clipboard_status = Some("No session yet — open the bundle first".into());
             return;
         };
-        let did = session.admin_did().to_string();
-        self.set_clipboard(did, "admin DID");
+        let did = session.admin_did();
+        if did.is_empty() {
+            self.clipboard_status = Some("Admin DID is empty in this bundle".into());
+            return;
+        }
+        self.set_clipboard(did.to_string(), "admin DID");
     }
 
     /// Copy the VTA DID to the clipboard. Hotkey `[v]` on the
-    /// Complete panel — every reply variant carries this.
+    /// Complete panel — every reply variant carries this *slot*,
+    /// but a `ContextExport` bundle whose producer didn't populate
+    /// `vta_did` will resolve to an empty string (see
+    /// [`VtaSession::context_export`]). Treat empty as "not in this
+    /// bundle" rather than silently clearing the operator's clipboard
+    /// (which is what an empty OSC 52 payload does on some terminals).
     pub fn copy_vta_did_to_clipboard(&mut self) {
         let Some(session) = self.session.as_ref() else {
             self.clipboard_status = Some("No session yet — open the bundle first".into());
             return;
         };
-        let did = session.vta_did.clone();
-        self.set_clipboard(did, "VTA DID");
+        if session.vta_did.is_empty() {
+            self.clipboard_status = Some("No VTA DID in this bundle".into());
+            return;
+        }
+        self.set_clipboard(session.vta_did.clone(), "VTA DID");
     }
 
     /// Copy the wizard-computed bundle digest to the clipboard.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
@@ -380,6 +380,10 @@ impl VtaConnectState {
             SdkVtaReply::Full(p) => p.admin_did().to_string(),
             SdkVtaReply::AdminOnly(a) => a.admin_did.clone(),
         };
+        if did.is_empty() {
+            self.clipboard_status = Some("Admin DID is empty in this reply".into());
+            return;
+        }
         self.copy_text_to_clipboard(&did, "admin DID");
     }
 


### PR DESCRIPTION
## Summary

Wizard copy hotkeys were unreliable inside `tmux`/`screen` and could silently wipe the operator's clipboard. This PR fixes the transport layer + adds per-site emptiness guards.

- **OSC 52 now writes to `/dev/tty`** when available, bypassing ratatui's buffered stdout so it can't race with the TUI's draw cycle.
- **Wrap OSC 52 in tmux DCS passthrough** (`\ePtmux;…\e\\`) when `$TMUX` is set, and in GNU screen DCS when `$STY` is set, *in addition* to the bare sequence. Covers both `set -g set-clipboard on` and `set -g allow-passthrough on` tmux configurations — bare OSC 52 dies at a tmux pane boundary on default tmux 3.3+ configs.
- **Reject empty / whitespace-only payloads** at the dispatcher. An empty OSC 52 (`\e]52;c;\e\\`) is interpreted as *"clear the clipboard"* on several terminals — a single accidental empty copy was enough to wipe the operator's clipboard and make every subsequent paste look blank, masking real bugs.
- **One real call-site bug**: `[v]` on the sealed-handoff Complete screen in OfflineExport mode resolved `session.vta_did` to `""` when the producer's `ContextProvision` bundle had no `vta_did` (via `unwrap_or_default()` in `VtaSession::context_export`). That would have wiped the clipboard. Now surfaces "No VTA DID in this bundle" instead.
- **Defensive emptiness guards** added to the remaining DID / config-path / backend-URL copy sites so a future regression can't silently empty the clipboard.

## Test plan

- [x] `cargo fmt -p affinidi-messaging-mediator-setup`
- [x] `cargo test -p affinidi-messaging-mediator-setup` — 327 passed, 0 failed (24 new/updated clipboard tests)
- [x] `cargo clippy -p affinidi-messaging-mediator-setup --bin mediator-setup --all-features --tests -- -D warnings` — clean
- [ ] Manual: run the wizard over SSH inside tmux, hit `[m]`/`[a]`/`[v]` on sealed-handoff Complete, confirm paste returns the right DID at the operator's local clipboard
- [ ] Manual: run locally outside tmux, confirm arboard path still works
- [ ] Manual: OfflineExport flow with a bundle missing `vta_did`, confirm `[v]` surfaces "No VTA DID in this bundle" instead of wiping the clipboard