### PR TITLE
feat: mediator 0.15.4 — browser-friendly WebSocket auth + configurable CORS wildcard

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ## Changelog history
 
+## 21st May 2026
+
+### 0.15.4 — browser-friendly WebSocket auth + configurable CORS wildcard
+
+Lets a browser-based DIDComm client talk to the mediator directly. All
+changes are additive for existing native clients — the
+`Authorization: Bearer` WebSocket path is unchanged and exercised by a
+regression test.
+
+- **FEAT (WebSocket auth):** the `/ws` upgrade now also accepts the
+  session JWT via the `Sec-WebSocket-Protocol` request header as a
+  `bearer.<jwt>` entry, because browsers can't set an `Authorization`
+  header on `new WebSocket(...)`. The server strips the literal
+  `bearer.` prefix (prefix-strip, not split, so the JWT's own `.`
+  separators survive) and validates the token identically to the
+  header path — same signature/claims/expiry/DID-match/ACL checks,
+  same `Session`, same JWT-expiry timeout. The 101 response **never**
+  echoes the bearer entry; only genuine (non-`bearer.`) application
+  subprotocols the client offered are echoed.
+  - Client call: `new WebSocket("wss://…/ws", ["bearer." + token])`.
+    Real browsers accept a 101 that selects no subprotocol; strict
+    non-browser clients that require subprotocol confirmation should
+    offer a benign app subprotocol alongside the bearer entry
+    (Kubernetes `base64url.bearer.authorization.k8s.io` convention),
+    which the server echoes.
+- **FEAT (CORS):** `security.cors_allow_origin` now accepts a single
+  `*` to allow ANY origin (maps to `AllowOrigin::any()`), in addition
+  to the existing comma-separated explicit allowlist. Safe here because
+  these endpoints authenticate with a bearer token, not an ambient
+  cookie — a wildcard creates no CSRF exposure, and `allow_credentials`
+  is never set. Previously a `*` value would **panic at startup**
+  (tower-http's origin list rejects wildcards); it is now parsed into
+  the allow-any policy. Default remains unset = no cross-origin access.
+- **FEAT / behavioural note (WebSocket `Origin` check):** as
+  defence-in-depth, `/ws` upgrades now enforce a server-side `Origin`
+  allowlist mirroring the CORS policy (WebSocket upgrades aren't subject
+  to CORS preflight, but browsers still send `Origin`). A browser
+  upgrade whose `Origin` isn't permitted is refused with 403 — the
+  check runs before auth, so a disallowed origin is rejected even with
+  a valid token. **Requests with no `Origin` header (all native
+  clients, incl. the Rust SDK) are unaffected.** With the default
+  (unset) CORS policy, any upgrade that announces an `Origin` is
+  refused; set `cors_allow_origin` (explicit origins or `*`) to permit
+  browser WebSocket clients. No released client could have relied on
+  the prior behaviour — browser WebSocket auth did not exist before
+  this release, and native clients send no `Origin`.
+- **DOCS:** `conf/mediator.toml` `cors_allow_origin` comment rewritten —
+  documents `*` support and its bearer-token safety rationale, the
+  WebSocket `Origin` check, and an operational note to redact the
+  `Sec-WebSocket-Protocol` request header at fronting proxies /
+  load-balancers (the JWT rides in it for the browser path; `wss://` +
+  short `jwt_access_expiry` mitigate; the mediator itself never logs
+  it).
+- **REFACTOR:** JWT token→`Session` validation extracted into a shared
+  `authenticate_token()` in `common/jwt_auth.rs`, called by both the
+  `Authorization` header extractor and the new WebSocket subprotocol
+  path so both apply byte-identical checks.
+- **TEST:** 14 unit tests (subprotocol token extraction, echo-filter,
+  `Origin` allowlist, CORS `*`/list/none parsing). End-to-end coverage
+  ships in `affinidi-messaging-test-mediator` 0.2.3.
+
 ## 9th May 2026
 
 ### 0.15.3 — `/admin/status` auth + `/readyz` redaction

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.3"
+version = "0.15.4"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -180,8 +180,32 @@ jwt_access_expiry = "900"
 jwt_refresh_expiry = "86400"
 
 ### Env: CORS_ALLOW_ORIGIN
-### Comma separated list of allowed origins. Use * for all origins
-### Example: "https://affinidi.com,https://example2.com"
+### Controls cross-origin browser access on the REST endpoints. Leave
+### unset (the default) to disable cross-origin access entirely.
+###
+### Accepts either:
+###   - a comma-separated list of explicit, scheme-qualified origins,
+###     each echoed back in `Access-Control-Allow-Origin` only for a
+###     matching request Origin, e.g.
+###     "https://affinidi.com,https://example2.com"; or
+###   - a single "*" to allow ANY origin. A wildcard is safe here only
+###     because these endpoints authenticate with a bearer token in the
+###     `Authorization` header (not an ambient cookie): a cross-origin
+###     page still needs a valid token, so "*" does not create CSRF
+###     exposure. `allow_credentials` is never set.
+###
+### The mediator also applies this allowlist as a defence-in-depth
+### `Origin` check on the WebSocket upgrade (/ws): browser upgrades
+### from non-allowlisted origins are refused (header-less native
+### clients are unaffected — for them the JWT is the gate).
+###
+### Operational note: with the browser WebSocket auth path the JWT
+### travels in the `Sec-WebSocket-Protocol` request header. Over wss://
+### it is TLS-encrypted in transit and the mediator never logs it, but
+### configure any fronting proxy/load-balancer NOT to log
+### `Sec-WebSocket-Protocol` request headers (as you would already
+### redact `Authorization`). Short access-token TTLs (jwt_access_expiry)
+### further limit exposure.
 # cors_allow_origin = "https://affinidi.com"
 
 ### Env: BLOCK_ANONYMOUS_OUTER_ENVELOPE

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -12,8 +12,54 @@ use std::{
     fmt::{self, Debug},
     sync::Arc,
 };
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use vta_sdk::did_secrets::DidSecretsBundle;
+
+/// Resolved cross-origin policy for browser clients.
+///
+/// Built from the `security.cors_allow_origin` config value. Held
+/// alongside the pre-built [`CorsLayer`] so the WebSocket handler can
+/// apply the *same* allowlist as a defence-in-depth `Origin` check
+/// (WebSocket upgrades aren't subject to CORS, but browsers still send
+/// an `Origin` header on them).
+#[derive(Clone, Debug)]
+pub enum CorsOriginPolicy {
+    /// No cross-origin browser access (the default — `cors_allow_origin`
+    /// unset). Browser requests/upgrades carrying an `Origin` are
+    /// refused; header-less native clients are unaffected.
+    None,
+    /// Any origin (`cors_allow_origin = "*"`). Defensible here because
+    /// these endpoints authenticate with a bearer token in the
+    /// `Authorization` header, not an ambient cookie — a wildcard does
+    /// not expose them to CSRF, since a cross-origin page would still
+    /// need a valid token to do anything. Emits `Access-Control-Allow-
+    /// Origin: *` and never sets `allow_credentials`.
+    Any,
+    /// An explicit allowlist of scheme-qualified origins.
+    List(Vec<HeaderValue>),
+}
+
+/// Build the mediator's [`CorsLayer`] for the given origin policy. The
+/// allowed methods/headers are fixed; only the origin matching varies.
+fn build_cors_layer(policy: &CorsOriginPolicy) -> CorsLayer {
+    let base = CorsLayer::new()
+        .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::OPTIONS,
+            Method::DELETE,
+            Method::PATCH,
+            Method::PUT,
+        ]);
+
+    match policy {
+        // Default-closed: an empty allowlist never echoes an origin.
+        CorsOriginPolicy::None => base,
+        CorsOriginPolicy::Any => base.allow_origin(AllowOrigin::any()),
+        CorsOriginPolicy::List(origins) => base.allow_origin(origins.clone()),
+    }
+}
 
 /// Security configuration for the mediator.
 ///
@@ -58,6 +104,10 @@ pub struct SecurityConfig {
     pub jwt_refresh_expiry: u64,
     #[serde(skip_serializing)]
     pub cors_allow_origin: CorsLayer,
+    /// The same origin policy the `cors_allow_origin` layer enforces,
+    /// kept in an inspectable form for the WebSocket `Origin` check.
+    #[serde(skip_serializing)]
+    pub cors_origins: CorsOriginPolicy,
     pub block_anonymous_outer_envelope: bool,
     pub force_session_did_match: bool,
     pub block_remote_admin_msgs: bool,
@@ -85,6 +135,7 @@ impl Debug for SecurityConfig {
             .field("jwt_access_expiry", &self.jwt_access_expiry)
             .field("jwt_refresh_expiry", &self.jwt_refresh_expiry)
             .field("cors_allow_origin", &self.cors_allow_origin)
+            .field("cors_origins", &self.cors_origins)
             .field(
                 "block_anonymous_outer_envelope",
                 &self.block_anonymous_outer_envelope,
@@ -122,16 +173,8 @@ impl SecurityConfig {
             jwt_decoding_key: DecodingKey::from_ed_der(&[0; 32]),
             jwt_access_expiry: 900,
             jwt_refresh_expiry: 86_400,
-            cors_allow_origin: CorsLayer::new()
-                .allow_headers([AUTHORIZATION, CONTENT_TYPE])
-                .allow_methods([
-                    Method::GET,
-                    Method::POST,
-                    Method::OPTIONS,
-                    Method::DELETE,
-                    Method::PATCH,
-                    Method::PUT,
-                ]),
+            cors_allow_origin: build_cors_layer(&CorsOriginPolicy::None),
+            cors_origins: CorsOriginPolicy::None,
             block_anonymous_outer_envelope: true,
             force_session_did_match: true,
             block_remote_admin_msgs: true,
@@ -141,22 +184,50 @@ impl SecurityConfig {
 }
 
 impl SecurityConfigRaw {
-    fn parse_cors_allow_origin(
-        &self,
-        cors_allow_origin: &str,
-    ) -> Result<Vec<HeaderValue>, MediatorError> {
-        cors_allow_origin
+    /// Parse the raw `cors_allow_origin` config value into a
+    /// [`CorsOriginPolicy`].
+    ///
+    /// - empty / whitespace-only ⇒ [`CorsOriginPolicy::None`]
+    /// - a `*` token ⇒ [`CorsOriginPolicy::Any`] (a bare wildcard;
+    ///   `tower_http`'s origin list would otherwise *panic* on `*`).
+    ///   If `*` is mixed with explicit origins the explicit entries are
+    ///   redundant and a warning is logged.
+    /// - otherwise ⇒ [`CorsOriginPolicy::List`] of the explicit origins.
+    fn parse_cors_origins(cors_allow_origin: &str) -> Result<CorsOriginPolicy, MediatorError> {
+        let tokens: Vec<&str> = cors_allow_origin
             .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if tokens.is_empty() {
+            return Ok(CorsOriginPolicy::None);
+        }
+
+        if tokens.contains(&"*") {
+            if tokens.len() > 1 {
+                tracing::warn!(
+                    "security.cors_allow_origin contains '*' alongside explicit origins; \
+                     treating as allow-any (the explicit entries are redundant)"
+                );
+            }
+            return Ok(CorsOriginPolicy::Any);
+        }
+
+        let origins = tokens
+            .iter()
             .map(|o| {
-                o.trim().parse::<HeaderValue>().map_err(|err| {
+                o.parse::<HeaderValue>().map_err(|err| {
                     MediatorError::ConfigError(
                         12,
                         "NA".into(),
-                        format!("Invalid CORS origin '{}': {}", o.trim(), err),
+                        format!("Invalid CORS origin '{o}': {err}"),
                     )
                 })
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(CorsOriginPolicy::List(origins))
     }
 
     /// Build the runtime `SecurityConfig` from the raw TOML values.
@@ -283,8 +354,9 @@ impl SecurityConfigRaw {
         })?;
 
         if let Some(cors_allow_origin) = &self.cors_allow_origin {
-            config.cors_allow_origin =
-                CorsLayer::new().allow_origin(self.parse_cors_allow_origin(cors_allow_origin)?);
+            let policy = Self::parse_cors_origins(cors_allow_origin)?;
+            config.cors_allow_origin = build_cors_layer(&policy);
+            config.cors_origins = policy;
         }
 
         // ── Populate the DIDComm secrets resolver ────────────────────────
@@ -384,5 +456,55 @@ impl SecurityConfigRaw {
         config.jwt_decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CorsOriginPolicy, SecurityConfigRaw};
+
+    #[test]
+    fn empty_origins_parse_to_none() {
+        assert!(matches!(
+            SecurityConfigRaw::parse_cors_origins("").unwrap(),
+            CorsOriginPolicy::None
+        ));
+        // Whitespace / stray commas collapse to nothing.
+        assert!(matches!(
+            SecurityConfigRaw::parse_cors_origins("  ,  ").unwrap(),
+            CorsOriginPolicy::None
+        ));
+    }
+
+    #[test]
+    fn bare_wildcard_parses_to_any() {
+        // A literal "*" must NOT reach tower_http's origin list (which
+        // panics on it) — it maps to the allow-any policy instead.
+        assert!(matches!(
+            SecurityConfigRaw::parse_cors_origins("*").unwrap(),
+            CorsOriginPolicy::Any
+        ));
+    }
+
+    #[test]
+    fn wildcard_mixed_with_origins_is_any() {
+        assert!(matches!(
+            SecurityConfigRaw::parse_cors_origins("https://a.example,*").unwrap(),
+            CorsOriginPolicy::Any
+        ));
+    }
+
+    #[test]
+    fn explicit_origins_parse_to_list() {
+        let policy =
+            SecurityConfigRaw::parse_cors_origins("https://a.example, https://b.example").unwrap();
+        match policy {
+            CorsOriginPolicy::List(origins) => {
+                assert_eq!(origins.len(), 2);
+                assert_eq!(origins[0], "https://a.example");
+                assert_eq!(origins[1], "https://b.example");
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -86,6 +86,92 @@ impl IntoResponse for AuthError {
     }
 }
 
+/// Validate a raw JWT bearer token and resolve it to an authenticated
+/// [`Session`].
+///
+/// This is the single source of truth for token validation. It is
+/// shared by two callers so both apply *identical* signature, claim,
+/// expiry, DID-match and ACL checks:
+/// - [`Session::from_request_parts`] — the `Authorization: Bearer`
+///   header path used by all REST endpoints and by native WebSocket
+///   clients (which can set request headers on the upgrade).
+/// - [`crate::handlers::websocket::websocket_handler`] — the
+///   `Sec-WebSocket-Protocol` subprotocol path used by browsers, which
+///   cannot set an `Authorization` header on `new WebSocket(...)`.
+///
+/// The token's origin (header vs. subprotocol) is irrelevant here: the
+/// same JWT yields the same `Session`.
+pub(crate) async fn authenticate_token(
+    state: &SharedData,
+    token: &str,
+) -> Result<Session, AuthError> {
+    let mut validation = Validation::new(jsonwebtoken::Algorithm::EdDSA);
+    validation.set_audience(&["ATM"]);
+    validation.set_required_spec_claims(&["exp", "sub", "aud", "session_id"]);
+
+    let token_data: TokenData<SessionClaims> = match jsonwebtoken::decode::<SessionClaims>(
+        token,
+        &state.config.security.jwt_decoding_key,
+        &validation,
+    ) {
+        Ok(token_data) => token_data,
+        Err(err) => {
+            event!(Level::WARN, "Decoding JWT failed {:?}", err);
+            return Err(AuthError::InvalidToken);
+        }
+    };
+
+    let session_id = token_data.claims.session_id.clone();
+    let did = token_data.claims.sub.clone();
+    let did_hash = digest(&did);
+
+    // Everything has passed token wise - expensive database operations happen here
+    let mut saved_session: Session = state
+        .database
+        .get_session(&session_id, &did)
+        .await
+        .map_err(|e| {
+            error!(
+                "{}: Couldn't get session from database! Reason: {}",
+                session_id, e
+            );
+            AuthError::InternalServerError(format!(
+                "Couldn't get session from database! Reason: {e}"
+            ))
+        })?
+        .into();
+
+    // Defence in depth: the session record's DID must match the
+    // JWT's `sub`. If they diverge, the session was either created
+    // with a different DID (storage corruption, replay across
+    // tenants) or get_session returned a partially populated
+    // record (legacy data, schema drift). Either way the handler
+    // would silently see the wrong DID — surface as InvalidToken
+    // here so the failure is loud and the client re-authenticates.
+    if saved_session.did != did {
+        warn!(
+            session_id = %session_id,
+            jwt_did = %did,
+            session_did = %saved_session.did,
+            "JWT sub does not match session DID — rejecting"
+        );
+        return Err(AuthError::InvalidToken);
+    }
+
+    // Check if ACL is satisfied
+    if saved_session.acls.get_blocked() {
+        info!("DID({}) is blocked from connecting", did);
+        return Err(AuthError::Blocked);
+    }
+
+    // Update the expires at time
+    saved_session.expires_at = token_data.claims.exp;
+
+    debug!(session_id, did_hash, "JWT auth accepted");
+
+    Ok(saved_session)
+}
+
 impl<S> FromRequestParts<S> for Session
 where
     SharedData: FromRef<S>,
@@ -115,10 +201,6 @@ where
             }
         };
 
-        let mut validation = Validation::new(jsonwebtoken::Algorithm::EdDSA);
-        validation.set_audience(&["ATM"]);
-        validation.set_required_spec_claims(&["exp", "sub", "aud", "session_id"]);
-
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
@@ -127,66 +209,6 @@ where
                 AuthError::MissingCredentials
             })?;
 
-        let token_data: TokenData<SessionClaims> = match jsonwebtoken::decode::<SessionClaims>(
-            bearer.token(),
-            &state.config.security.jwt_decoding_key,
-            &validation,
-        ) {
-            Ok(token_data) => token_data,
-            Err(err) => {
-                event!(Level::WARN, "Decoding JWT failed {:?}", err);
-                return Err(AuthError::InvalidToken);
-            }
-        };
-
-        let session_id = token_data.claims.session_id.clone();
-        let did = token_data.claims.sub.clone();
-        let did_hash = digest(&did);
-
-        // Everything has passed token wise - expensive database operations happen here
-        let mut saved_session: Session = state
-            .database
-            .get_session(&session_id, &did)
-            .await
-            .map_err(|e| {
-                error!(
-                    "{}: Couldn't get session from database! Reason: {}",
-                    session_id, e
-                );
-                AuthError::InternalServerError(format!(
-                    "Couldn't get session from database! Reason: {e}"
-                ))
-            })?
-            .into();
-
-        // Defence in depth: the session record's DID must match the
-        // JWT's `sub`. If they diverge, the session was either created
-        // with a different DID (storage corruption, replay across
-        // tenants) or get_session returned a partially populated
-        // record (legacy data, schema drift). Either way the handler
-        // would silently see the wrong DID — surface as InvalidToken
-        // here so the failure is loud and the client re-authenticates.
-        if saved_session.did != did {
-            warn!(
-                session_id = %session_id,
-                jwt_did = %did,
-                session_did = %saved_session.did,
-                "JWT sub does not match session DID — rejecting"
-            );
-            return Err(AuthError::InvalidToken);
-        }
-
-        // Check if ACL is satisfied
-        if saved_session.acls.get_blocked() {
-            info!("DID({}) is blocked from connecting", did);
-            return Err(AuthError::Blocked);
-        }
-
-        // Update the expires at time
-        saved_session.expires_at = token_data.claims.exp;
-
-        debug!(session_id, did_hash, "JWT auth accepted");
-
-        Ok(saved_session)
+        authenticate_token(&state, bearer.token()).await
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -4,6 +4,8 @@ use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat;
 use crate::{
     SharedData,
+    common::config::CorsOriginPolicy,
+    common::jwt_auth::{AuthError, authenticate_token},
     common::session::Session,
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{StreamingUpdate, StreamingUpdateState, WebSocketCommands},
@@ -19,9 +21,13 @@ use axum::{
         State, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
-    response::IntoResponse,
+    response::{IntoResponse, Response},
 };
-use http::StatusCode;
+use axum_extra::{
+    TypedHeader,
+    headers::{Authorization, authorization::Bearer},
+};
+use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN};
 use serde_json::json;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -32,24 +38,154 @@ use tokio::{
 use tracing::{Instrument, debug, info, span, warn};
 use uuid::Uuid;
 
-/// Handles the switching of the protocol to a websocket connection
-/// ACL_MODE: Requires LOCAL access
+/// Subprotocol prefix used to carry the bearer JWT through the
+/// `Sec-WebSocket-Protocol` request header.
+///
+/// Browsers cannot set an `Authorization` header on `new WebSocket(url,
+/// protocols)`, but they *can* offer subprotocols. By convention the
+/// browser offers a single entry of the form `bearer.<jwt>` (optionally
+/// alongside genuine application subprotocols). The server detects the
+/// entry carrying this prefix, strips the literal 7-character `bearer.`
+/// prefix, and treats the remainder as the raw JWT — identical to the
+/// token a native client would send in the `Authorization` header.
+///
+/// A *prefix strip* (not a `.`-split) is deliberate: a JWT is three
+/// base64url segments joined by `.`, so splitting on `.` would be
+/// ambiguous. Every JWT character (`[A-Za-z0-9-_]` plus `.`) is a valid
+/// RFC 6455 subprotocol token char, so no extra encoding is needed.
+///
+/// Browser client usage:
+/// ```js
+/// new WebSocket("wss://…/mediator/v1/ws", ["bearer." + accessToken]);
+/// ```
+const WS_BEARER_SUBPROTOCOL_PREFIX: &str = "bearer.";
+
+/// Extract the raw JWT from a `bearer.<jwt>` entry in the client's
+/// requested WebSocket subprotocols, returning the first match.
+///
+/// Returns `None` when no entry carries the `bearer.` prefix or the
+/// remainder is empty. Uses [`str::strip_prefix`] (not `split`) so the
+/// `.` separators inside the JWT are preserved verbatim.
+fn extract_bearer_subprotocol<'a, I>(protocols: I) -> Option<String>
+where
+    I: IntoIterator<Item = &'a HeaderValue>,
+{
+    protocols.into_iter().find_map(|p| {
+        p.to_str()
+            .ok()
+            .and_then(|s| s.strip_prefix(WS_BEARER_SUBPROTOCOL_PREFIX))
+            .filter(|token| !token.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// The subprotocols the server may safely echo back in the 101
+/// response: every requested entry that is **not** a bearer token.
+///
+/// Reflecting a `bearer.<jwt>` entry would leak the secret token in the
+/// `Sec-WebSocket-Protocol` response header, so those entries are
+/// filtered out here and never offered to [`WebSocketUpgrade::protocols`].
+fn app_subprotocols<'a, I>(protocols: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a HeaderValue>,
+{
+    protocols
+        .into_iter()
+        .filter_map(|p| p.to_str().ok())
+        .filter(|s| !s.starts_with(WS_BEARER_SUBPROTOCOL_PREFIX))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether a WebSocket upgrade carrying this `Origin` header is allowed
+/// by the configured CORS policy.
+///
+/// WebSocket upgrades aren't subject to CORS preflight, but browsers
+/// still send an `Origin` header on them. This mirrors the REST CORS
+/// allowlist ([`CorsOriginPolicy`]) as defence-in-depth: a browser from
+/// a non-allowlisted origin is refused even if it somehow holds a valid
+/// token. Native clients send no `Origin` header and are always allowed
+/// — for them the JWT is the only (and sufficient) gate.
+fn ws_origin_allowed(policy: &CorsOriginPolicy, origin: Option<&HeaderValue>) -> bool {
+    match origin {
+        // No Origin ⇒ not a browser cross-origin context (native client).
+        None => true,
+        Some(origin) => match policy {
+            CorsOriginPolicy::Any => true,
+            CorsOriginPolicy::List(allowed) => allowed.iter().any(|a| a == origin),
+            // No cross-origin browser access configured ⇒ refuse any
+            // request that announces an Origin.
+            CorsOriginPolicy::None => false,
+        },
+    }
+}
+
+/// Handles the switching of the protocol to a websocket connection.
+///
+/// ACL_MODE: Requires LOCAL access.
+///
+/// Authentication accepts the JWT from either channel, in priority
+/// order:
+/// 1. `Authorization: Bearer <jwt>` request header — the existing path
+///    used by native clients (e.g. the Rust SDK). Unchanged.
+/// 2. The `bearer.<jwt>` entry of the `Sec-WebSocket-Protocol` request
+///    header — the browser-friendly path (browsers can't set request
+///    headers on a WebSocket upgrade). See
+///    [`WS_BEARER_SUBPROTOCOL_PREFIX`].
+///
+/// Both channels validate the token identically via
+/// [`authenticate_token`]; the resulting [`Session`] (and therefore the
+/// per-connection JWT-expiry timeout enforced in [`handle_socket`]) is
+/// the same regardless of how the token arrived. If neither channel
+/// yields a valid token the upgrade is rejected, exactly as before.
 pub async fn websocket_handler(
-    session: Session,
-    ws: WebSocketUpgrade,
     State(state): State<SharedData>,
-) -> impl IntoResponse {
+    auth_header: Option<TypedHeader<Authorization<Bearer>>>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    // 0. Defence-in-depth Origin check. WebSocket upgrades aren't
+    //    subject to CORS, but browsers send an `Origin` header — refuse
+    //    cross-origin browsers outside the configured allowlist. Native
+    //    clients send no Origin and pass straight through.
+    let origin = headers.get(ORIGIN);
+    if !ws_origin_allowed(&state.config.security.cors_origins, origin) {
+        warn!(
+            ?origin,
+            "WebSocket upgrade rejected: Origin not permitted by CORS policy"
+        );
+        return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
+    }
+
+    // 1. Resolve the JWT: Authorization header first (native clients),
+    //    then the Sec-WebSocket-Protocol subprotocol (browsers).
+    let token = if let Some(TypedHeader(Authorization(bearer))) = &auth_header {
+        Some(bearer.token().to_string())
+    } else {
+        extract_bearer_subprotocol(ws.requested_protocols())
+    };
+
+    let Some(token) = token else {
+        warn!(
+            "WebSocket upgrade rejected: no bearer token in Authorization header or Sec-WebSocket-Protocol"
+        );
+        return AuthError::MissingCredentials.into_response();
+    };
+
+    // 2. Validate the token → Session (identical checks for both paths).
+    let session = match authenticate_token(&state, &token).await {
+        Ok(session) => session,
+        Err(e) => return e.into_response(),
+    };
+
     let _span = span!(
         tracing::Level::INFO,
         "websocket_handler",
         session = session.session_id
     );
-    // ACL Check (websockets only work on local DID's)
-    if session.acls.get_local() {
-        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
-            .instrument(_span)
-            .await
-    } else {
+
+    // 3. ACL Check (websockets only work on local DID's).
+    if !session.acls.get_local() {
         let error: AppError = MediatorError::problem(
             40,
             session.session_id,
@@ -63,8 +199,25 @@ pub async fn websocket_handler(
         )
         .into();
 
-        error.into_response()
+        return error.into_response();
     }
+
+    // 4. Echo back only genuine application subprotocols (if any) — and
+    //    NEVER the `bearer.<jwt>` entry, which would leak the token in
+    //    the 101 response header. When the client offered only the
+    //    bearer entry, no subprotocol is selected and the response
+    //    carries no `Sec-WebSocket-Protocol` header (RFC 6455 permits
+    //    this; browsers accept it).
+    let app_protocols = app_subprotocols(ws.requested_protocols());
+    let ws = if app_protocols.is_empty() {
+        ws
+    } else {
+        ws.protocols(app_protocols)
+    };
+
+    async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
+        .instrument(_span)
+        .await
 }
 
 /// WebSocket state machine. This is spawned per connection.
@@ -336,4 +489,101 @@ async fn _package_problem_report(
     })?;
 
     Ok(packed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CorsOriginPolicy, app_subprotocols, extract_bearer_subprotocol, ws_origin_allowed,
+    };
+    use http::HeaderValue;
+
+    fn hv(s: &str) -> HeaderValue {
+        HeaderValue::from_str(s).expect("valid header value")
+    }
+
+    #[test]
+    fn extract_strips_prefix_and_preserves_jwt_dots() {
+        // A JWT is three base64url segments joined by '.'. The bearer
+        // entry must be prefix-stripped, not split, so the inner dots
+        // survive intact.
+        let protos = [hv("bearer.aaa.bbb.ccc")];
+        assert_eq!(
+            extract_bearer_subprotocol(protos.iter()),
+            Some("aaa.bbb.ccc".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_finds_bearer_among_app_subprotocols() {
+        // The browser may offer a genuine app subprotocol alongside the
+        // bearer entry; the token must still be found regardless of order.
+        let protos = [hv("didcomm/v2"), hv("bearer.tok.en.value")];
+        assert_eq!(
+            extract_bearer_subprotocol(protos.iter()),
+            Some("tok.en.value".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_without_bearer_entry() {
+        let protos = [hv("didcomm/v2"), hv("soap")];
+        assert_eq!(extract_bearer_subprotocol(protos.iter()), None);
+    }
+
+    #[test]
+    fn extract_returns_none_for_empty_token() {
+        // "bearer." with nothing after it is not a usable token.
+        let protos = [hv("bearer.")];
+        assert_eq!(extract_bearer_subprotocol(protos.iter()), None);
+    }
+
+    #[test]
+    fn app_subprotocols_drops_bearer_entries() {
+        // Guards the "never echo the token" requirement: the bearer
+        // entry must be excluded from anything the server may reflect.
+        let protos = [hv("didcomm/v2"), hv("bearer.secret.jwt.here")];
+        assert_eq!(app_subprotocols(protos.iter()), vec!["didcomm/v2"]);
+    }
+
+    #[test]
+    fn app_subprotocols_empty_when_only_bearer() {
+        // Bearer-only offer ⇒ nothing safe to echo ⇒ no subprotocol
+        // selected in the 101 response.
+        let protos = [hv("bearer.secret.jwt.here")];
+        assert!(app_subprotocols(protos.iter()).is_empty());
+    }
+
+    #[test]
+    fn origin_check_allows_header_less_native_clients() {
+        // Native clients (SDK) send no Origin — must always pass,
+        // regardless of policy, since the JWT is their gate.
+        assert!(ws_origin_allowed(&CorsOriginPolicy::None, None));
+        assert!(ws_origin_allowed(&CorsOriginPolicy::Any, None));
+        assert!(ws_origin_allowed(
+            &CorsOriginPolicy::List(vec![hv("https://app.example")]),
+            None
+        ));
+    }
+
+    #[test]
+    fn origin_check_none_policy_rejects_browser_origins() {
+        let origin = hv("https://evil.example");
+        assert!(!ws_origin_allowed(&CorsOriginPolicy::None, Some(&origin)));
+    }
+
+    #[test]
+    fn origin_check_any_policy_allows_browser_origins() {
+        let origin = hv("https://anything.example");
+        assert!(ws_origin_allowed(&CorsOriginPolicy::Any, Some(&origin)));
+    }
+
+    #[test]
+    fn origin_check_list_policy_matches_allowlist() {
+        let policy = CorsOriginPolicy::List(vec![hv("https://app.example")]);
+        let allowed = hv("https://app.example");
+        let denied = hv("https://other.example");
+        assert!(ws_origin_allowed(&policy, Some(&allowed)));
+        assert!(!ws_origin_allowed(&policy, Some(&denied)));
+    }
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 21st May 2026
+
+### 0.2.3 — WebSocket subprotocol auth integration tests
+
+Test-only release — the shipped fixture API (`src/`) is unchanged.
+
+- **TEST:** new `websocket_subprotocol_auth` integration suite covering
+  the mediator's browser-friendly WebSocket auth (paired with
+  `affinidi-messaging-mediator` 0.15.4): subprotocol `bearer.<jwt>`
+  authentication, the `Authorization` header regression path, the 101
+  response not echoing the token, invalid-token rejection, and the
+  WebSocket `Origin` check. Uses raw `tokio-tungstenite` clients plus a
+  hand-rolled handshake for the bearer-only browser case (which
+  tokio-tungstenite's strict client can't express, since it errors when
+  the server selects no subprotocol).
+- **CHORE:** add the `tokio` `io-util` dev-dependency feature for the
+  raw-socket handshake test.
+
 ## 5th May 2026
 
 ### 0.2.2 — ACL / security mode simulation + admin identity

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.2"
+version = "0.2.3"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -76,6 +76,10 @@ reqwest = { version = "0.13", features = ["rustls", "json"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+## `io-util` for the raw-socket WebSocket handshake test (the bearer-only
+## browser scenario can't go through tokio-tungstenite's client, which
+## errors when it offers a subprotocol the server doesn't echo back).
+tokio = { workspace = true, features = ["io-util"] }
 serde_json = "1"
 
 [lints]

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/websocket_subprotocol_auth.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/websocket_subprotocol_auth.rs
@@ -1,0 +1,311 @@
+//! Browser-friendly WebSocket authentication.
+//!
+//! Browsers cannot set an `Authorization` header on `new WebSocket(url,
+//! protocols)`, so the mediator also accepts the JWT through the
+//! `Sec-WebSocket-Protocol` request header as a `bearer.<jwt>` entry.
+//! These tests drive raw clients (not the SDK, so we control the
+//! upgrade headers directly) against the embedded fixture and assert:
+//!
+//! 1. A `bearer.<jwt>` subprotocol authenticates and upgrades (101).
+//! 2. The 101 response never echoes the `bearer.<jwt>` value — echoing
+//!    it back would leak the token in the response header.
+//! 3. The existing `Authorization: Bearer` header path still upgrades —
+//!    regression guard for native clients (the SDK uses this path).
+//! 4. An invalid token in the subprotocol is rejected (401), exactly
+//!    like an invalid header token.
+//!
+//! Test 1 offers a benign application subprotocol alongside the bearer
+//! entry (`["affinidi.didcomm.v1", "bearer.<jwt>"]`) so the server has
+//! something safe to echo — this both confirms the negotiation and
+//! lets `tokio-tungstenite`'s strict client (which errors if it offered
+//! a subprotocol the server didn't select) complete the handshake.
+//!
+//! Test 2 exercises the *exact* documented browser call — a single
+//! `bearer.<jwt>` entry with nothing to echo — over a hand-rolled
+//! socket, because `tokio-tungstenite`'s client refuses a handshake
+//! where the server selects no subprotocol (real browsers accept it).
+
+mod common;
+
+use affinidi_messaging_test_mediator::{TestEnvironment, TestUser};
+use common::{init_tracing, skip_if_no_redis};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{ClientRequestBuilder, Error as WsError, http::Uri},
+};
+
+/// A genuine application subprotocol offered alongside the bearer entry.
+/// The server echoes this (never the bearer entry) in the 101 response.
+const APP_SUBPROTOCOL: &str = "affinidi.didcomm.v1";
+
+/// Authenticate `user` against the environment's mediator and return a
+/// fresh access token plus the mediator's `ws://…/ws` upgrade URI.
+///
+/// This is the same token a browser would obtain from the REST
+/// `/authenticate` flow; here we mint it through the SDK's auth task so
+/// the test doesn't reimplement the challenge/response handshake.
+async fn token_and_ws_uri(env: &TestEnvironment, user: &TestUser) -> (String, Uri) {
+    let mediator_did = env.mediator.did().to_string();
+    let tokens = env
+        .tdk
+        .authentication()
+        .authenticate(user.did.clone(), mediator_did, 3, None)
+        .await
+        .expect("authenticate user");
+
+    let ws_uri: Uri = env
+        .mediator
+        .ws_endpoint()
+        .as_str()
+        .parse()
+        .expect("parse ws endpoint");
+
+    (tokens.access_token, ws_uri)
+}
+
+#[tokio::test]
+async fn bearer_subprotocol_authenticates_and_does_not_echo_token() {
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let alice = env.add_user("Alice").await.expect("add user");
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &alice).await;
+
+    // Browser-shaped offer: a benign app subprotocol plus the
+    // `bearer.<jwt>` entry, and no Authorization header.
+    let request = ClientRequestBuilder::new(ws_uri)
+        .with_sub_protocol(APP_SUBPROTOCOL)
+        .with_sub_protocol(format!("bearer.{access_token}"));
+
+    let (stream, response) = connect_async(request)
+        .await
+        .expect("bearer subprotocol upgrade must succeed");
+
+    assert_eq!(
+        response.status().as_u16(),
+        101,
+        "expected 101 Switching Protocols"
+    );
+
+    // The server must echo the benign app subprotocol — and crucially
+    // NOT the bearer entry, which would leak the token.
+    let echoed = response
+        .headers()
+        .get("sec-websocket-protocol")
+        .expect("server should echo the app subprotocol")
+        .to_str()
+        .expect("subprotocol is ASCII");
+    assert_eq!(
+        echoed, APP_SUBPROTOCOL,
+        "must echo the benign app subprotocol"
+    );
+    assert!(
+        !echoed.contains("bearer."),
+        "the 101 response must never contain the bearer token"
+    );
+
+    // Dropping the stream tears down the connection.
+    drop(stream);
+
+    env.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn bearer_only_subprotocol_upgrades_without_echoing_anything() {
+    // The exact documented browser call: `new WebSocket(url, ["bearer."
+    // + token])` — a single bearer entry, nothing else to negotiate.
+    // The server authenticates from it and selects no subprotocol, so
+    // the 101 carries no `Sec-WebSocket-Protocol` header. Browsers
+    // accept this; tokio-tungstenite's client doesn't, so we hand-roll
+    // the handshake and inspect the raw response.
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let dave = env.add_user("Dave").await.expect("add user");
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &dave).await;
+
+    let (status, headers) = raw_ws_handshake(
+        &ws_uri,
+        &format!("Sec-WebSocket-Protocol: bearer.{access_token}\r\n"),
+    )
+    .await;
+
+    assert_eq!(status, 101, "bearer-only upgrade must switch protocols");
+    assert!(
+        !headers.lines().any(|l| l
+            .to_ascii_lowercase()
+            .starts_with("sec-websocket-protocol:")),
+        "bearer-only upgrade must not echo any Sec-WebSocket-Protocol header (would leak the token)"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn browser_origin_rejected_when_no_cors_configured() {
+    // Defence-in-depth Origin check. The fixture leaves
+    // `cors_allow_origin` unset (policy = None), so a browser-style
+    // upgrade that announces an `Origin` must be refused with 403 —
+    // even carrying an otherwise-valid token, because the Origin check
+    // runs before auth. Header-less native clients are unaffected (the
+    // other tests, which send no Origin, all still upgrade).
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let erin = env.add_user("Erin").await.expect("add user");
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &erin).await;
+
+    let (status, _) = raw_ws_handshake(
+        &ws_uri,
+        &format!(
+            "Origin: https://evil.example\r\n\
+             Sec-WebSocket-Protocol: bearer.{access_token}\r\n"
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status, 403,
+        "a browser Origin must be rejected when no CORS origins are configured"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn authorization_header_upgrade_still_works() {
+    // Regression guard: native clients authenticate the upgrade with an
+    // `Authorization: Bearer` header. This path must keep working with
+    // zero changes now that the subprotocol path exists.
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let bob = env.add_user("Bob").await.expect("add user");
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &bob).await;
+
+    let request = ClientRequestBuilder::new(ws_uri)
+        .with_header("Authorization", format!("Bearer {access_token}"));
+
+    let (stream, response) = connect_async(request)
+        .await
+        .expect("authorization header upgrade must succeed");
+
+    assert_eq!(
+        response.status().as_u16(),
+        101,
+        "header path must still upgrade"
+    );
+
+    drop(stream);
+
+    env.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn invalid_bearer_subprotocol_token_is_rejected() {
+    // A malformed/forged token in the subprotocol must be rejected with
+    // 401, identical to an invalid header token — the subprotocol path
+    // does not weaken validation.
+    init_tracing();
+    if skip_if_no_redis() {
+        return;
+    }
+
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    // A user must exist + be LOCAL so that the *only* reason the upgrade
+    // fails is the bad token, not the ACL check.
+    let _carol = env.add_user("Carol").await.expect("add user");
+    let ws_uri: Uri = env
+        .mediator
+        .ws_endpoint()
+        .as_str()
+        .parse()
+        .expect("parse ws endpoint");
+
+    let request =
+        ClientRequestBuilder::new(ws_uri).with_sub_protocol("bearer.not.a.valid.jwt".to_string());
+
+    let err = connect_async(request)
+        .await
+        .expect_err("invalid subprotocol token must be rejected");
+
+    match err {
+        WsError::Http(resp) => assert_eq!(
+            resp.status().as_u16(),
+            401,
+            "invalid subprotocol token must yield 401"
+        ),
+        other => panic!("expected HTTP 401 rejection, got: {other:?}"),
+    }
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// Perform a minimal HTTP/1.1 WebSocket upgrade handshake by hand and
+/// return `(status_code, raw_response_headers)`. `extra_header_lines`
+/// is inserted verbatim (each line CRLF-terminated) before the blank
+/// line — used here to inject `Sec-WebSocket-Protocol`.
+///
+/// We don't validate `Sec-WebSocket-Accept`; the test only cares about
+/// the status line and which response headers the server emitted.
+async fn raw_ws_handshake(uri: &Uri, extra_header_lines: &str) -> (u16, String) {
+    let host = uri.host().expect("ws uri has host");
+    let port = uri.port_u16().expect("ws uri has port");
+    let path = uri.path();
+
+    let mut stream = TcpStream::connect((host, port))
+        .await
+        .expect("connect to mediator");
+
+    let request = format!(
+        "GET {path} HTTP/1.1\r\n\
+         Host: {host}:{port}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         {extra_header_lines}\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write handshake");
+
+    // Read until the end of the response header block.
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut chunk).await.expect("read response");
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf).into_owned();
+    let status = text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .expect("parse status line");
+
+    (status, text)
+}


### PR DESCRIPTION
## Summary

Enables a **browser-based DIDComm client** to talk to the mediator directly. Two browser limitations blocked it: browsers can't set an `Authorization` header on `new WebSocket(...)`, and CORS must allow the web origin. Both are addressed. **All changes are additive** — the existing `Authorization: Bearer` WebSocket path (native/SDK clients) is unchanged and regression-tested.

## WebSocket subprotocol bearer auth

- `/ws` now accepts the session JWT two ways, in priority order:
  1. `Authorization: Bearer <jwt>` header — existing native path, **unchanged**.
  2. `Sec-WebSocket-Protocol: bearer.<jwt>` — browser path. The server strips the literal `bearer.` prefix (**prefix-strip, not split**, so the JWT's own `.` separators survive) and validates identically to the header path.
- Both paths share a new `authenticate_token()` in `common/jwt_auth.rs` — same signature/claims/expiry/DID-match/ACL checks, same `Session`, same JWT-expiry timeout.
- The **101 response never echoes the bearer entry** (that would leak the token). Only genuine, non-`bearer.` app subprotocols the client offered are echoed.

Client call this enables:
```js
new WebSocket("wss://…/mediator/v1/ws", ["bearer." + accessToken]);
```
Real browsers accept a 101 that selects no subprotocol. Strict non-browser clients that require subprotocol confirmation should offer a benign app subprotocol alongside the bearer entry (Kubernetes `base64url.bearer.authorization.k8s.io` convention), which the server echoes.

## CORS

- `security.cors_allow_origin` now accepts a single `*` (→ `AllowOrigin::any()`) in addition to the explicit comma-separated allowlist. Safe here because these endpoints authenticate with a **bearer token, not a cookie** — a wildcard creates no CSRF exposure and `allow_credentials` is never set.
- Previously a `*` value would **panic at startup** (tower-http rejects wildcards in an origin list); it's now parsed into the allow-any policy.
- Default remains **unset = no cross-origin access**.
- Configure via `cors_allow_origin = "https://app.example.com,…"` / `"*"` or the `CORS_ALLOW_ORIGIN` env var.

## WebSocket Origin check (defence-in-depth)

- WebSocket upgrades aren't subject to CORS preflight, but browsers send an `Origin` header. `/ws` now enforces a server-side `Origin` allowlist mirroring the CORS policy. A browser upgrade from a non-allowlisted origin is refused with **403, before auth** (so a bad origin is rejected even with a valid token).
- **Header-less native clients (incl. the Rust SDK) are unaffected** — the JWT remains the primary gate. No released client could have relied on the prior behaviour (browser WS auth didn't exist before this release).

## Security notes

- The 101 never reflects the token; the mediator never logs it.
- For the browser path the JWT rides in `Sec-WebSocket-Protocol`. Over `wss://` it's TLS-encrypted; `conf/mediator.toml` now advises redacting that request header at fronting proxies/LBs. Short `jwt_access_expiry` (default 900s) further limits exposure.

## Tests

- **14 unit tests** (subprotocol extraction, echo-filter, `Origin` allowlist, CORS `*`/list/none parsing).
- **5 integration tests** in `affinidi-messaging-test-mediator` 0.2.3: subprotocol auth, `Authorization` header regression, no-token-echo in the 101, invalid-token rejection, and Origin-based rejection. Uses raw `tokio-tungstenite` clients plus a hand-rolled handshake for the bearer-only browser case.
- All green; `cargo fmt` + `clippy` clean.

## Versions

- `affinidi-messaging-mediator` 0.15.3 → **0.15.4**
- `affinidi-messaging-test-mediator` 0.2.2 → **0.2.3** (test-only)

Dependents pin these at `version = "0.15"` / `"0.2"` (major.minor), so no cascade bump is needed. `mediator-common` is untouched.