### PR TITLE
fix: affinidi-crypto 0.1.6 — build against stable ml-dsa 0.1.0; pin slh-dsa to =0.2.0-rc.5

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Affinidi Crypto Changelog
 
+## 24th May 2026 (0.1.6)
+
+- **FIX:** Build against stable `ml-dsa 0.1.0`. The `KeyGen` trait was
+  removed from `ml-dsa`'s root module between `0.1.0-rc.8` and the
+  `0.1.0` stable release; switched the six callsites to
+  `SigningKey::<P>::from_seed()` and pinned the dependency to
+  `0.1.0`. No public-API change — `generate_ml_dsa_{44,65,87}`,
+  `sign_ml_dsa_{44,65,87}`, `verify_ml_dsa_{44,65,87}`, and
+  `MlDsaExpandedKey::from_seed` keep the same signatures and produce
+  the same bytes (NIST ACVP keygen KATs unchanged).
+- **HARDENING:** Locked `slh-dsa` to exactly `=0.2.0-rc.5`. The crate
+  is still pre-release upstream; an exact pin prevents the same kind
+  of rc-to-rc API drift that just bit `ml-dsa`. To be relaxed when
+  `slh-dsa 0.2.0` ships stable.
+
 ## 20th April 2026 (0.1.5)
 
 - **FEATURE:** `did_key` module (behind the `ed25519` feature) adds a

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.5"
+version = "0.1.6"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -45,8 +45,8 @@ p384 = { version = "0.13", features = [
   "ecdsa-core",
   "arithmetic",
 ], optional = true }
-ml-dsa = { version = "0.1.0-rc.8", features = ["rand_core", "zeroize"], optional = true }
-slh-dsa = { version = "0.2.0-rc.4", features = ["zeroize"], optional = true }
+ml-dsa = { version = "0.1.0", features = ["rand_core", "zeroize"], optional = true }
+slh-dsa = { version = "=0.2.0-rc.5", features = ["zeroize"], optional = true }
 # PQC crates (ml-dsa, slh-dsa) pull rand_core 0.10 transitively via
 # `signature` v3. A second copy coexists with the 0.6 one used by other
 # primitives; we never import it directly, so no explicit dep is needed.

--- a/crates/core/affinidi-crypto/src/ml_dsa.rs
+++ b/crates/core/affinidi-crypto/src/ml_dsa.rs
@@ -1,11 +1,11 @@
 //! ML-DSA (FIPS 204) key operations.
 //!
 //! Private key material is stored as the 32-byte seed `xi`; the expanded
-//! signing key is derived on demand via `<Params as KeyGen>::from_seed`.
+//! signing key is derived on demand via `SigningKey::<P>::from_seed`.
 //! Public key material is the FIPS 204 encoded verifying key.
 
 use ml_dsa::signature::{Keypair, Signer, Verifier};
-use ml_dsa::{B32, KeyGen, MlDsa44, MlDsa65, MlDsa87, Signature};
+use ml_dsa::{B32, MlDsa44, MlDsa65, MlDsa87, Signature, SigningKey};
 use rand_10::RngExt;
 
 use crate::{CryptoError, KeyType, error::Result};
@@ -35,7 +35,7 @@ fn seed_from(seed: Option<&[u8; 32]>) -> B32 {
 /// Generates an ML-DSA-44 key pair, optionally from a 32-byte seed.
 pub fn generate_ml_dsa_44(seed: Option<&[u8; 32]>) -> KeyPair {
     let xi = seed_from(seed);
-    let sk = <MlDsa44 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa44>::from_seed(&xi);
     let vk_bytes: &[u8] = &sk.verifying_key().encode();
     // The caller is expected to move the returned private_bytes into a
     // ZeroizeOnDrop container (e.g. `Secret`) for proper cleanup. `xi`
@@ -50,7 +50,7 @@ pub fn generate_ml_dsa_44(seed: Option<&[u8; 32]>) -> KeyPair {
 /// Generates an ML-DSA-65 key pair, optionally from a 32-byte seed.
 pub fn generate_ml_dsa_65(seed: Option<&[u8; 32]>) -> KeyPair {
     let xi = seed_from(seed);
-    let sk = <MlDsa65 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa65>::from_seed(&xi);
     let vk_bytes: &[u8] = &sk.verifying_key().encode();
     KeyPair {
         key_type: KeyType::MlDsa65,
@@ -62,7 +62,7 @@ pub fn generate_ml_dsa_65(seed: Option<&[u8; 32]>) -> KeyPair {
 /// Generates an ML-DSA-87 key pair, optionally from a 32-byte seed.
 pub fn generate_ml_dsa_87(seed: Option<&[u8; 32]>) -> KeyPair {
     let xi = seed_from(seed);
-    let sk = <MlDsa87 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa87>::from_seed(&xi);
     let vk_bytes: &[u8] = &sk.verifying_key().encode();
     KeyPair {
         key_type: KeyType::MlDsa87,
@@ -113,9 +113,15 @@ impl MlDsaExpandedKey {
     pub fn from_seed(key_type: KeyType, seed: &[u8]) -> Result<Self> {
         let xi = seed_to_b32(seed)?;
         match key_type {
-            KeyType::MlDsa44 => Ok(Self::MlDsa44(Box::new(<MlDsa44 as KeyGen>::from_seed(&xi)))),
-            KeyType::MlDsa65 => Ok(Self::MlDsa65(Box::new(<MlDsa65 as KeyGen>::from_seed(&xi)))),
-            KeyType::MlDsa87 => Ok(Self::MlDsa87(Box::new(<MlDsa87 as KeyGen>::from_seed(&xi)))),
+            KeyType::MlDsa44 => Ok(Self::MlDsa44(Box::new(SigningKey::<MlDsa44>::from_seed(
+                &xi,
+            )))),
+            KeyType::MlDsa65 => Ok(Self::MlDsa65(Box::new(SigningKey::<MlDsa65>::from_seed(
+                &xi,
+            )))),
+            KeyType::MlDsa87 => Ok(Self::MlDsa87(Box::new(SigningKey::<MlDsa87>::from_seed(
+                &xi,
+            )))),
             other => Err(CryptoError::UnsupportedKeyType(format!(
                 "MlDsaExpandedKey::from_seed called with non-ML-DSA key type {other:?}"
             ))),
@@ -156,7 +162,7 @@ impl MlDsaExpandedKey {
 /// Signs `data` with ML-DSA-44, given a 32-byte seed.
 pub fn sign_ml_dsa_44(seed: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let xi = seed_to_b32(seed)?;
-    let sk = <MlDsa44 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa44>::from_seed(&xi);
     let sig: Signature<MlDsa44> = sk.sign(data);
     let bytes: &[u8] = &sig.encode();
     Ok(bytes.to_vec())
@@ -165,7 +171,7 @@ pub fn sign_ml_dsa_44(seed: &[u8], data: &[u8]) -> Result<Vec<u8>> {
 /// Signs `data` with ML-DSA-65, given a 32-byte seed.
 pub fn sign_ml_dsa_65(seed: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let xi = seed_to_b32(seed)?;
-    let sk = <MlDsa65 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa65>::from_seed(&xi);
     let sig: Signature<MlDsa65> = sk.sign(data);
     let bytes: &[u8] = &sig.encode();
     Ok(bytes.to_vec())
@@ -174,7 +180,7 @@ pub fn sign_ml_dsa_65(seed: &[u8], data: &[u8]) -> Result<Vec<u8>> {
 /// Signs `data` with ML-DSA-87, given a 32-byte seed.
 pub fn sign_ml_dsa_87(seed: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let xi = seed_to_b32(seed)?;
-    let sk = <MlDsa87 as KeyGen>::from_seed(&xi);
+    let sk = SigningKey::<MlDsa87>::from_seed(&xi);
     let sig: Signature<MlDsa87> = sk.sign(data);
     let bytes: &[u8] = &sig.encode();
     Ok(bytes.to_vec())


### PR DESCRIPTION
## Summary

- Fix `affinidi-crypto` build against the stable `ml-dsa 0.1.0` release. `KeyGen` was removed from `ml-dsa`'s root module between `0.1.0-rc.8` and `0.1.0`; switch the six callsites to `SigningKey::<P>::from_seed()` (same input, same output) and pin `ml-dsa = "0.1.0"`.
- Lock `slh-dsa` to exactly `=0.2.0-rc.5` to prevent the same kind of rc-to-rc API drift on the SLH-DSA side. Relax when `slh-dsa 0.2.0` ships stable.
- Bump `affinidi-crypto` `0.1.5` → `0.1.6`. No public-API change.

## Why now

Downstream consumers (notably `didwebvh-rs` `experimental-pqc`, see [decentralized-identity/didwebvh-rs#40](https://github.com/decentralized-identity/didwebvh-rs/pull/40)) started failing to build once `ml-dsa 0.1.0` shipped to crates.io. The `^0.1.0-rc.8` caret happily picks up the stable release, and `KeyGen` no longer exists at the root.

## Scope

- Touched: `crates/core/affinidi-crypto/{src/ml_dsa.rs, Cargo.toml, CHANGELOG.md}`.
- Workspace consumers (`affinidi-data-integrity`, `affinidi-secrets-resolver`, `affinidi-tdk`, `affinidi-did-common`, `affinidi-did-resolver-cache-sdk`, `mediator-setup`) all pin `affinidi-crypto = "0.1"` — caret resolves to `0.1.6` automatically. No cascade bump.
- `slh_dsa.rs` already used `SigningKey` directly; no code change there, only the version pin.
- All other crate deps audited — only `slh-dsa` was on a pre-release; everything else (`base58`, `base64`, `multibase`, `ed25519-dalek`, `k256/p256/p384`, `x25519-dalek`, `rand`, `rand_core`, `serde`, `sha2`, `thiserror`, `zeroize`, `getrandom`) is on a stable release.

## Test plan

- [x] `cargo build -p affinidi-crypto --features ml-dsa`
- [x] `cargo test -p affinidi-crypto --features ml-dsa` — 39 pass
- [x] `cargo build -p affinidi-crypto --features post-quantum`
- [x] `cargo test -p affinidi-crypto --features post-quantum` — 42 pass (incl. NIST ACVP keygen KATs for ML-DSA-44/65/87, which byte-pin the seed→pk derivation and would fail on any semantic drift)
- [x] `cargo clippy -p affinidi-crypto --features post-quantum --all-targets -- -D warnings`
- [x] `cargo fmt -p affinidi-crypto --check`
- [x] `cargo build --workspace --all-features`

## Follow-ups (out of scope for this PR)

- Publish `affinidi-crypto 0.1.6` to crates.io.
- Notify `didwebvh-rs` maintainer so PR #40 can re-enable `experimental-pqc` in CI.
- Revisit the `slh-dsa` pin when `0.2.0` stable lands upstream.