### PR TITLE
fix: mediator 0.15.5 — vta-sdk 0.7 + 6 messaging security fixes + text-client 0.12.2

### DIFF
--- a/.github/workflows/checks-features.yaml
+++ b/.github/workflows/checks-features.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/checks-storage.yaml
+++ b/.github/workflows/checks-storage.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2
@@ -101,7 +101,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2
@@ -131,7 +131,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2
@@ -164,7 +164,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: affinidi/pipeline-rust/.github/workflows/checks.yaml@main
     secrets: inherit
     with:
-      toolchain: "1.94.0"
+      toolchain: "1.95.0"
       rustflags: "-D warnings --cfg tracing_unstable"
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: affinidi/pipeline-rust/.github/workflows/release.yaml@main
     secrets: inherit
     with:
-      toolchain: "1.94.0"
+      toolchain: "1.95.0"
       rustflags: "-D warnings --cfg tracing_unstable"
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ license = "Apache-2.0"
 keywords = ["ssi", "affinidi"]
 repository = "https://github.com/affinidi/affinidi-tdk-rs"
 publish = true
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 
 [workspace.dependencies]
 tokio = "1"

--- a/crates/credentials/affinidi-mdoc/src/es384_cose.rs
+++ b/crates/credentials/affinidi-mdoc/src/es384_cose.rs
@@ -64,7 +64,6 @@ impl Es384CoseSigner {
 
     /// Get the public key as uncompressed SEC1 bytes (97 bytes).
     pub fn public_key_bytes(&self) -> Vec<u8> {
-        use p384::elliptic_curve::sec1::ToEncodedPoint;
         VerifyingKey::from(&self.signing_key)
             .to_encoded_point(false)
             .to_bytes()

--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -46,6 +46,21 @@ Security fixes; no API changes.
   full-session credentials into any `debug!`/`warn!("{:?}", resp)`
   call or panic dump.
 
+### Text Client (0.12.2)
+
+Security fixes; no API changes.
+
+- **FIX (security):** `State::save_to_file` opens the state file
+  with mode `0o600` on Unix. The file holds `secrets: Vec<Secret>`
+  (DID private keys) but was previously created via `File::create()`,
+  which honours the process umask and typically left the file
+  world-readable (`0644`). No behavior change on non-Unix.
+- **FIX (security):** `send_invitation_accept` no longer panics on a
+  non-UTF-8 OOB invite payload. `String::from_utf8(invite).unwrap()`
+  on the base64-decoded bytes is replaced with the surrounding
+  warn-and-return pattern. A hostile invite endpoint returning valid
+  JSON wrapping base64 of non-UTF-8 bytes previously crashed the TUI.
+
 ## 5th May 2026
 
 ### Test Mediator (0.2.0)

--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -10,6 +10,47 @@ tooling.
 
 ## 24th May 2026
 
+### Mediator (0.15.5)
+
+Security fixes plus the coordinated `vta-sdk` 0.7 wire bump.
+
+- **FIX (security):** direct-delivery ACL bypass. On the direct-
+  delivery branch the mediator cannot decrypt the JWE, so
+  `envelope.from_did` (from the unverified `skid` / `apu`) was
+  trusted for the per-DID send ACL and the recipient's
+  `access_list_allowed` check. An authenticated session could set
+  `skid` to any allow-listed DID and bypass both checks. When
+  `force_session_did_match` is on, the same policy now applies to
+  direct delivery as already applied to the mediator-destined
+  branch — ACL checks operate on the authenticated session
+  identity.
+- **FIX (security):** unbounded `/outbound` request list.
+  `message_outbound_handler` iterated `body.message_ids` issuing one
+  database get (+ optional delete) per id with no cap, letting any
+  LOCAL-authenticated client pin a worker on database round-trips
+  with a single request. Now rejects requests over
+  `config.limits.listed_messages` (default 100), matching the
+  existing `message_delete` pattern.
+- **FIX (security):** WebSocket `ws_size` cap enforced too late.
+  `limits.ws_size` was checked only after `socket.recv()` returned;
+  tungstenite had already buffered the full message (defaults: 64
+  MiB max message, 16 MiB max frame). Now sets `max_message_size`
+  / `max_frame_size` on the `WebSocketUpgrade` from
+  `limits.ws_size` so oversized frames are dropped during framing.
+- **FIX (security):** redact tokens in `AuthRefreshResponse`
+  `Debug`. The refresh response carried the freshly minted bearer
+  `access_token` plus the rotated one-time `refresh_token`; the
+  derived `Debug` printed both in the clear. Manual impl now
+  redacts both fields, matching the treatment applied to
+  `AuthorizationResponse` in 0.18.3.
+- **CHORE:** Bumps `vta-sdk` from `0.6` to `0.7` (coordinated wire
+  bump with the mediator-setup wizard; trust-task wire URIs
+  renamed, `did → subject` threaded through the auth payloads —
+  intentional break, no external consumers yet).
+- **CHORE:** Workspace MSRV raised from `1.94.0` to `1.95.0` for
+  `vta-sdk@0.7.0`. Both `rust-toolchain.toml` and the four CI
+  workflows bumped together.
+
 ### DIDComm (0.13.3)
 
 Security fixes; no API changes.

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 ## Changelog history
 
+## 24th May 2026
+
+### 0.15.5 — vta-sdk 0.7 + messaging security fixes
+
+Security fixes plus the coordinated `vta-sdk` 0.7 wire bump. No
+configuration changes required — `vta-sdk` was an internal dep and
+the trust-task surface has no external consumers yet.
+
+#### Security
+
+- **FIX (security):** direct-delivery ACL bypass. On the direct-
+  delivery branch (envelope addressed to a local account, not the
+  mediator), the mediator cannot decrypt the JWE and so cannot
+  cryptographically verify the sender. `envelope.from_did` is read
+  from the unverified `skid`/`apu` and was then trusted for the
+  per-DID send ACL and the recipient's `access_list_allowed` check.
+  An authenticated session could therefore set `skid` to any
+  allow-listed DID and bypass both checks. When
+  `force_session_did_match` is enabled, the mediator-destined branch
+  already bound the verified sender kid to `session.did`; this
+  release applies the same policy to direct delivery so the ACL
+  checks operate on the authenticated session identity.
+- **FIX (security):** unbounded `/outbound` request list.
+  `message_outbound_handler` iterated `body.message_ids` issuing one
+  database get (and optionally a delete) per id, with no upper
+  bound, letting any LOCAL-authenticated client pin a worker on
+  database round-trips with a single request. Now rejects requests
+  over `config.limits.listed_messages` (default 100), matching the
+  existing `message_delete` pattern.
+- **FIX (security):** WebSocket `ws_size` cap enforced too late.
+  The `/ws` handler only checked `msg.len() > limits.ws_size` *after*
+  `socket.recv()` returned, by which point tungstenite had already
+  buffered the full message (default `max_message_size` 64 MiB,
+  `max_frame_size` 16 MiB). With the default `ws_size` of 10 MiB an
+  authenticated client could push frames ~6× the configured cap and
+  have them allocated before rejection. Sets `max_message_size` /
+  `max_frame_size` on the `WebSocketUpgrade` from `limits.ws_size`
+  so oversized frames are dropped during framing.
+- **FIX (security):** redact tokens in `AuthRefreshResponse` `Debug`.
+  The mediator-side response carries the freshly minted bearer
+  `access_token` plus the rotated one-time `refresh_token`. The
+  derived `Debug` impl printed both in the clear; any tracing of
+  the response struct (or a panic in the refresh handler that
+  captured it) would dump session credentials into the mediator's
+  logs. Replaces the derived `Debug` with a manual impl that
+  redacts both token fields while keeping the expiry timestamps
+  visible, matching the treatment applied in `affinidi-did-
+  authentication` and `affinidi-messaging-sdk`.
+
+#### Dependencies
+
+- **CHORE:** Bumps `vta-sdk` from `0.6` to `0.7` to stay on a single
+  wire version with the mediator-setup wizard. The 0.7 release
+  renames the trust-task wire URIs to the framework-canonical
+  `trusttasks.org/spec/...` form and threads `did → subject`
+  through the auth challenge / authenticate payloads. The wire
+  break is intentional — the trust-task surface has no external
+  consumers yet.
+- **CHORE:** Workspace MSRV raised from `1.94.0` to `1.95.0` to
+  satisfy `vta-sdk@0.7.0`'s MSRV (workspace `rust-toolchain.toml`
+  and the four GitHub Actions workflows that pin the toolchain).
+- **CHORE:** Picks up `affinidi-messaging-didcomm 0.13.3` and
+  `affinidi-messaging-sdk 0.18.3` via the workspace path deps
+  (released the same day for additional security hardening). All
+  dependents pin major.minor (`0.13` / `0.18`), so no
+  `Cargo.toml` edits required.
+
+`affinidi-messaging-test-mediator` re-exports the mediator with a
+caret `version = "0.15"` pin and picks up 0.15.5 automatically — no
+cascade bump needed.
+
 ## 21st May 2026
 
 ### 0.15.4 — browser-friendly WebSocket auth + configurable CORS wildcard

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.4"
+version = "0.15.5"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -82,7 +82,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.6", features = ["integration"] }
+vta-sdk = { version = "0.7", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/circuit_breaker.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/circuit_breaker.rs
@@ -98,17 +98,15 @@ impl CircuitBreaker {
         let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
 
         match self.state.load(Ordering::Relaxed) {
-            STATE_CLOSED => {
-                if failures >= self.failure_threshold {
-                    self.state.store(STATE_OPEN, Ordering::Release);
-                    self.opened_at.store(now_secs(), Ordering::Release);
-                    metrics::counter!(METRIC_CIRCUIT_BREAKER_TRIPS_TOTAL).increment(1);
-                    metrics::gauge!(METRIC_CIRCUIT_BREAKER_STATE).set(1.0);
-                    error!(
-                        "Circuit breaker: Closed → Open (threshold {} reached, {} consecutive failures)",
-                        self.failure_threshold, failures
-                    );
-                }
+            STATE_CLOSED if failures >= self.failure_threshold => {
+                self.state.store(STATE_OPEN, Ordering::Release);
+                self.opened_at.store(now_secs(), Ordering::Release);
+                metrics::counter!(METRIC_CIRCUIT_BREAKER_TRIPS_TOTAL).increment(1);
+                metrics::gauge!(METRIC_CIRCUIT_BREAKER_STATE).set(1.0);
+                error!(
+                    "Circuit breaker: Closed → Open (threshold {} reached, {} consecutive failures)",
+                    self.failure_threshold, failures
+                );
             }
             STATE_HALF_OPEN => {
                 self.state.store(STATE_OPEN, Ordering::Release);

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/mod.rs
@@ -30,7 +30,7 @@ impl GenericDataStruct for AuthenticationChallenge {}
 
 /// Refresh tokens response from the authentication service.
 /// Includes a rotated refresh token (one-time use).
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AuthRefreshResponse {
     pub access_token: String,
     pub access_expires_at: u64,
@@ -38,6 +38,17 @@ pub struct AuthRefreshResponse {
     pub refresh_expires_at: u64,
 }
 impl GenericDataStruct for AuthRefreshResponse {}
+
+impl std::fmt::Debug for AuthRefreshResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthRefreshResponse")
+            .field("access_token", &"[REDACTED]")
+            .field("access_expires_at", &self.access_expires_at)
+            .field("refresh_token", &"[REDACTED]")
+            .field("refresh_expires_at", &self.refresh_expires_at)
+            .finish()
+    }
+}
 
 /// Request body for POST /authenticate/challenge
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
@@ -48,6 +48,28 @@ pub async fn message_outbound_handler(
             body.message_ids.len()
         );
 
+        // Mirror the delete handler's per-request cap: each id is a database
+        // round-trip, so an unbounded list lets an authenticated client tie up
+        // the mediator with a single request.
+        if body.message_ids.len() > state.config.limits.listed_messages {
+            return Err(MediatorError::problem_with_log(
+                43,
+                session.session_id,
+                None,
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "api.message_outbound.limit",
+                "Invalid limit ({1}). Maximum of {2} messages can be fetched per transaction",
+                vec![
+                    body.message_ids.len().to_string(),
+                    state.config.limits.listed_messages.to_string(),
+                ],
+                StatusCode::BAD_REQUEST,
+                "Invalid limit",
+            )
+            .into());
+        }
+
         let mut messages = GetMessagesResponse::default();
 
         for msg_id in &body.message_ids {

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -215,6 +215,12 @@ pub async fn websocket_handler(
         ws.protocols(app_protocols)
     };
 
+    // 5. Enforce the configured `ws_size` cap at the tungstenite layer so
+    //    oversized frames are rejected during framing instead of being
+    //    buffered in full and only checked after `socket.recv()` returns.
+    let ws_size = state.config.limits.ws_size;
+    let ws = ws.max_message_size(ws_size).max_frame_size(ws_size);
+
     async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
         .instrument(_span)
         .await

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -178,6 +178,28 @@ async fn handle_inbound_didcomm(
                         ));
                     }
 
+                    // The mediator cannot decrypt a direct-delivery envelope, so the
+                    // claimed sender (JWE `skid` header) is unverified. When
+                    // session/sender matching is enforced, bind it to the
+                    // authenticated session DID before it is trusted for ACL checks.
+                    if state.config.security.force_session_did_match
+                        && envelope.from_did.as_deref() != Some(session.did.as_str())
+                    {
+                        let claimed = envelope.from_did.as_deref().unwrap_or("anonymous");
+                        return Err(MediatorError::problem_with_log(
+                            52,
+                            &session.session_id,
+                            None,
+                            ProblemReportSorter::Error,
+                            ProblemReportScope::Protocol,
+                            "authorization.did.session_mismatch",
+                            "Sender DID ({1}) doesn't match session DID",
+                            vec![claimed.to_string()],
+                            StatusCode::BAD_REQUEST,
+                            format!("Direct-delivery envelope sender ({claimed}) doesn't match session DID"),
+                        ));
+                    }
+
                     let from_hash = envelope.from_did.as_ref().map(digest);
                     // Check if the message will pass ACL Checks
                     if let Some(from) = &envelope.from_did {

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
@@ -194,10 +194,8 @@ pub(crate) async fn process(
 
                         // Creates a string placement for each error. E.g. {1}, {2}, {3}
                         let mut s = String::new();
-                        let mut i = 1;
-                        for _ in &errors {
+                        for (i, _) in (1..).zip(errors.iter()) {
                             s.push_str(&format!(" ({{{i}}})"));
-                            i += 1;
                         }
 
                         return Err(MediatorError::problem_with_log(

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -2657,7 +2657,7 @@ mod tests {
             .expect("add");
 
         let resp = store
-            .access_list_add(100, &alice, &vec![bob.clone(), charlie.clone()])
+            .access_list_add(100, &alice, &[bob.clone(), charlie.clone()])
             .await
             .expect("add");
         assert_eq!(resp.did_hashes.len(), 2);
@@ -2665,13 +2665,13 @@ mod tests {
         assert_eq!(store.access_list_count(&alice).await.unwrap(), 2);
 
         let got = store
-            .access_list_get(&alice, &vec![bob.clone(), hash("eve")])
+            .access_list_get(&alice, &[bob.clone(), hash("eve")])
             .await
             .expect("get");
         assert_eq!(got.did_hashes, vec![bob.clone()]);
 
         let removed = store
-            .access_list_remove(&alice, &vec![bob.clone()])
+            .access_list_remove(&alice, std::slice::from_ref(&bob))
             .await
             .expect("remove");
         assert_eq!(removed, 1);
@@ -2697,7 +2697,7 @@ mod tests {
             .await
             .expect("add alice");
         store
-            .access_list_add(100, &alice, &vec![bob.clone()])
+            .access_list_add(100, &alice, std::slice::from_ref(&bob))
             .await
             .expect("add bob to list");
         assert!(store.access_list_allowed(&alice, Some(&bob)).await);

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.2"
+version = "0.1.3"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.6", features = ["provision-client"] }
+vta-sdk = { version = "0.7", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.6", features = ["test-support"] }
+vta-sdk = { version = "0.7", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -3280,27 +3280,23 @@ impl WizardApp {
                 }
                 let max = items.len() - 1;
                 match code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if *cursor > 0 {
-                            *cursor -= 1;
-                            // Keep cursor visible — scroll up if we
-                            // walked past the top of the viewport.
-                            if *cursor < *scroll {
-                                *scroll = *cursor;
-                            }
+                    KeyCode::Up | KeyCode::Char('k') if *cursor > 0 => {
+                        *cursor -= 1;
+                        // Keep cursor visible — scroll up if we
+                        // walked past the top of the viewport.
+                        if *cursor < *scroll {
+                            *scroll = *cursor;
                         }
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if *cursor < max {
-                            *cursor += 1;
-                            // Viewport height is rendered-side knowledge;
-                            // we approximate with a generous 10-row
-                            // window. Worst case the renderer clips a
-                            // row — better than constraining input
-                            // logic to a magic-number height.
-                            if *cursor >= *scroll + 10 {
-                                *scroll = cursor.saturating_sub(9);
-                            }
+                    KeyCode::Down | KeyCode::Char('j') if *cursor < max => {
+                        *cursor += 1;
+                        // Viewport height is rendered-side knowledge;
+                        // we approximate with a generous 10-row
+                        // window. Worst case the renderer clips a
+                        // row — better than constraining input
+                        // logic to a magic-number height.
+                        if *cursor >= *scroll + 10 {
+                            *scroll = cursor.saturating_sub(9);
                         }
                     }
                     KeyCode::PageUp => {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -5900,9 +5900,6 @@ mod tests {
             id: id.into(),
             did: format!("did:webvh:{id}.example.com"),
             label: label.map(str::to_string),
-            access_token: None,
-            access_expires_at: None,
-            refresh_token: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -1750,10 +1750,8 @@ fn inline_select(prompt: &str, options: &[&str], default: usize) -> Option<usize
                 KeyCode::Up | KeyCode::Char('k') => {
                     selected = selected.saturating_sub(1);
                 }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    if selected < options.len() - 1 {
-                        selected += 1;
-                    }
+                KeyCode::Down | KeyCode::Char('j') if selected < options.len() - 1 => {
+                    selected += 1;
                 }
                 KeyCode::Enter => {
                     let _ = disable_raw_mode();

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/common/mod.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/common/mod.rs
@@ -6,6 +6,11 @@ use std::sync::Once;
 /// default `TestMediator` backend is now in-memory and tests don't
 /// need Redis to run. Retained so existing call sites
 /// (`if skip_if_no_redis() { return; }`) keep compiling without churn.
+///
+/// `#[allow(dead_code)]` because `tests/common/mod.rs` is built
+/// separately for each integration-test binary and not every binary
+/// calls this helper.
+#[allow(dead_code)]
 pub fn skip_if_no_redis() -> bool {
     false
 }

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.12.2] - 2026-05-24
+
+### Security
+
+- `State::save_to_file` now creates the state file with mode `0o600`
+  on Unix. The file serialises `secrets: Vec<Secret>` (DID private
+  keys), but was previously opened via `File::create()`, which honours
+  the process umask — typically leaving the file world-readable
+  (`0644`). On a multi-user host any local account could read the
+  keys. No behavior change on non-Unix platforms.
+- `send_invitation_accept` no longer panics on a non-UTF-8 OOB invite
+  payload. `String::from_utf8(invite).unwrap()` on the base64-decoded
+  bytes is replaced with the same warn-and-return pattern the
+  surrounding parse steps already use. A malicious invite endpoint
+  that returned valid JSON wrapping base64 of non-UTF-8 bytes
+  previously crashed the TUI.
+
+## [0.12.1] - 2026-03-28
+
+### Changed
+
+- Added explicit `major.minor` version specifiers for
+  `affinidi-messaging-sdk` and `affinidi-messaging-didcomm` path
+  dependencies.

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.1"
+version = "0.12.2"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-text-client/README.md
+++ b/crates/messaging/affinidi-messaging-text-client/README.md
@@ -1,11 +1,14 @@
 # affinidi-messaging-text-client
 
-[![Rust](https://img.shields.io/badge/rust-1.90.0%2B-blue.svg?maxAge=3600)](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/affinidi-messaging/affinidi-messaging-text-client)
+[![Rust](https://img.shields.io/badge/rust-1.95.0%2B-blue.svg?maxAge=3600)](https://github.com/affinidi/affinidi-tdk-rs/tree/main/crates/messaging/affinidi-messaging-text-client)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://github.com/affinidi/affinidi-tdk-rs/blob/main/LICENSE)
 
 A terminal-based DIDComm chat client for interacting with
 [Affinidi Messaging](../) mediators. Useful for testing, demos, and debugging
 message flows.
+
+This crate is `publish = false` — it's distributed via this repository, not
+crates.io. Build it from source.
 
 ## Running
 
@@ -13,8 +16,19 @@ Ensure a mediator is configured and running (see
 [mediator setup](../affinidi-messaging-mediator/)), then:
 
 ```bash
-cargo run
+cargo run -p affinidi-messaging-text-client
 ```
+
+## State file
+
+The client persists its DID, mediator connections, and chat history to a
+JSON state file managed by `State::save_to_file`. **The file contains the
+client's DID private keys** (the `secrets` array). As of 0.12.2 it is
+created with mode `0600` on Unix so only the owner can read it. On other
+platforms the file is created with the platform default — restrict it
+manually if running on a shared host.
+
+Don't copy the state file off the host or commit it to source control.
 
 ## Related Crates
 

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
@@ -145,11 +145,16 @@ pub async fn send_invitation_accept(
         return Ok(());
     };
 
-    let invite = if let Ok(invite) = BASE64_URL_SAFE_NO_PAD.decode(base64_invite) {
-        String::from_utf8(invite).unwrap()
-    } else {
-        warn!("Bas64 decoding failed on invite!");
-        return Ok(());
+    let invite = match BASE64_URL_SAFE_NO_PAD
+        .decode(base64_invite)
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+    {
+        Some(invite) => invite,
+        None => {
+            warn!("OOB invite is not valid base64url-encoded UTF-8");
+            return Ok(());
+        }
     };
 
     let invite_message = match serde_json::from_str::<Message>(&invite) {

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/state.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/state.rs
@@ -155,6 +155,20 @@ impl State {
     }
 
     pub fn save_to_file(&self, file_path: &str) -> Result<(), std::io::Error> {
+        // State serializes `secrets` (private keys); restrict to owner-only on
+        // Unix so other local users can't read them. `File::create` would use
+        // the process umask (typically 0644).
+        #[cfg(unix)]
+        let file = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(file_path)?
+        };
+        #[cfg(not(unix))]
         let file = std::fs::File::create(file_path)?;
 
         serde_json::to_writer_pretty(file, self)?;

--- a/crates/trust/affinidi-trust-lists/src/xml/mod.rs
+++ b/crates/trust/affinidi-trust-lists/src/xml/mod.rs
@@ -173,10 +173,8 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                     "TSLLocation" => {
                         current_pointer_location = text_buf.clone();
                     }
-                    "URI" => {
-                        if path_str.contains("TSPInformationURI") {
-                            current_tsp_uris.push(text_buf.clone());
-                        }
+                    "URI" if path_str.contains("TSPInformationURI") => {
+                        current_tsp_uris.push(text_buf.clone());
                     }
                     "X509Certificate" => {
                         in_x509_cert = false;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 # Pin to specific version to prevent drift between local dev and CI
-# Must be >= rust-version in Cargo.toml (currently 1.90.0)
+# Must be >= rust-version in Cargo.toml (currently 1.95.0, raised
+# from 1.94.0 to satisfy vta-sdk 0.7.0's MSRV)


### PR DESCRIPTION
## Summary

Mediator 0.15.5 release bundling the original `vta-sdk 0.7` wire bump
with 6 messaging-side security fixes added in this PR, plus a
text-client 0.12.2 patch release for two text-client security fixes.

Mediator pinned to 0.15.5 (no published 0.15.5 yet — these fixes
will be in the first released 0.15.5). Text-client bumped to 0.12.2
to flag the fixes in version history; `publish = false` is preserved
so it stays out of crates.io.

`affinidi-messaging-didcomm 0.13.3` and `affinidi-messaging-sdk 0.18.3`
are picked up automatically via the workspace path deps — all
dependents pin `0.13` / `0.18` (major.minor) per repo convention.

---

### 1. vta-sdk 0.7 bump (original scope)

- Bumps `vta-sdk` from `0.6` to `0.7` in both the mediator runtime and
  the `mediator-setup` wizard. 0.7 renames the trust-task wire URIs
  to `trusttasks.org/spec/...` and threads `did → subject` through the
  auth challenge / authenticate payloads — intentional wire break,
  trust-task surface has no external consumers yet.
- Raises the workspace Rust toolchain pin from `1.94.0` to `1.95.0`
  (workspace `rust-toolchain.toml` + the four GitHub Actions
  workflows that pin the toolchain) to satisfy vta-sdk 0.7.0's MSRV.
- Drops three removed fields (`access_token`, `access_expires_at`,
  `refresh_token`) from the wizard's `sample_webvh_server` test
  helper. `WebvhServerRecord` in 0.7 carries only id/did/label/
  created_at/updated_at.

`affinidi-messaging-test-mediator` re-exports the mediator with a
caret `version = "0.15"` pin and picks up 0.15.5 automatically — no
cascade bump needed.

### 2. Messaging security fixes

#### Critical — auth / identity bypass

- **`d58eb9c` mediator: enforce session/sender match on direct-delivery path**
  On the direct-delivery branch the mediator cannot decrypt the JWE,
  so `envelope.from_did` (from the unverified `skid` / `apu`) was
  trusted for both the per-DID send ACL and `access_list_allowed`.
  The mediator-destined branch already binds the verified kid to
  `session.did` when `force_session_did_match` is on; this applies
  the same policy to direct delivery so an authenticated session
  can't claim an arbitrary allow-listed DID in `skid`.

#### High — DoS / resource exhaustion

- **`8753c71` mediator: cap message_ids in /outbound handler**
  `/outbound` iterated `body.message_ids` issuing one DB get (+
  optional delete) per id with no cap. Mirrors the sibling `/delete`
  handler's `limits.deleted_messages` enforcement using
  `limits.listed_messages` (default 100, already in config).
- **`9f69931` mediator: enforce ws_size at the tungstenite layer**
  `limits.ws_size` was checked only *after* `socket.recv()`
  returned. tungstenite's defaults (`max_message_size` 64 MiB,
  `max_frame_size` 16 MiB) let an authenticated client push ~6× the
  configured cap and have it allocated before rejection. Now set on
  the `WebSocketUpgrade` from `limits.ws_size` so oversized frames
  are dropped during framing. (Re-applied manually at the new
  `on_upgrade` site after 0.15.4's subprotocol-auth refactor; the
  original patch context had drifted.)

#### Medium — credential leak in logs

- **`92038ac` mediator: redact tokens in AuthRefreshResponse Debug**
  Tracing of the refresh response previously dumped the rotated
  one-time refresh token and access token into mediator logs.
  Manual `Debug` impl redacts both, mirroring the treatment applied
  to `AuthorizationResponse` in #317.

#### Low — client robustness (text-client 0.12.2)

- **`a22bbfa` text-client: write state file with 0600 perms**
  `State::save_to_file` serialises `secrets: Vec<Secret>` (DID
  private keys) via `File::create()`, leaving them world-readable on
  multi-user hosts. Now opens with `mode(0o600)` on Unix.
- **`b6ecaf6` text-client: don't panic on non-UTF-8 OOB invite payload**
  `String::from_utf8(invite).unwrap()` on base64-decoded bytes — a
  hostile invite endpoint could crash the TUI. Now warns and returns.

### 3. Release housekeeping

- **`ecbbcee` chore: text-client 0.12.2 — CHANGELOG + README refresh**
  Bumps text-client to 0.12.2 (`publish = false` preserved), adds a
  per-crate CHANGELOG, adds a `### Text Client (0.12.2)` block to the
  suite-level CHANGELOG under the existing 24th May section. README
  refresh: stale Rust badge (1.90.0 → 1.95.0), broken repo path in
  badge link, new "State file" section noting the file contains DID
  private keys and is 0600 on Unix, one-liner that the crate is
  `publish = false`, `cargo run` updated to use `-p
  affinidi-messaging-text-client`.
- **`5fa454f` ci: bump rust toolchain to 1.95.0 in workflow files**
  The original vta-sdk-bump commit updated `rust-toolchain.toml` but
  missed the four `.github/workflows/*.yaml` files that pin the
  toolchain explicitly (the `rust-pipeline` reusable action passes
  `+1.94.0` to cargo, bypassing `rust-toolchain.toml`). This caused
  every workspace crate to fail `rustc 1.94.0 is not supported`.
  Bumps all 7 references to 1.95.0.
- **`663143e` fix: clippy lints surfaced by rust 1.95.0 toolchain bump**
  The toolchain bump turned on six new clippy lints (`-D warnings`)
  that fired on pre-existing code. All mechanical refactors that
  preserve behavior: `collapsible_match` × 5 (circuit_breaker, trust-
  lists xml URI arm, mediator-setup Up/Down/Down key arms),
  `explicit_counter_loop` × 1 (mediator ACL helper), `unused_imports`
  × 1 (mdoc `ToEncodedPoint`), `dead_code` × 1 (test-mediator
  `tests/common/mod.rs` shared helper), `useless_vec` +
  `cloned_ref_to_slice_refs` × 4 (fjall_store test sites).
- **`82fea63` docs: mediator 0.15.5 CHANGELOG — vta-sdk bump + security fixes**
  Adds the missing 0.15.5 entry to the per-crate
  `mediator/CHANGELOG.md` (top entry was still 0.15.4) and a matching
  `### Mediator (0.15.5)` block to the suite-level
  `crates/messaging/CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features` with
      `RUSTFLAGS="-D warnings --cfg tracing_unstable"` — clean (matches CI flags).
- [x] `cargo test -p affinidi-messaging-mediator` — 90 pass.
- [x] `cargo test -p affinidi-messaging-didcomm --features messaging-core` —
      6 adapter tests pass (incl. new `rejects_spoofed_from_in_authcrypt`).
- [x] `cargo test -p affinidi-messaging-mediator-setup` — 327 pass.
- [x] CI: 27/29 pass after the clippy fix. The two remaining failures
      are not from this PR's changes — `Coverage` is a pre-existing
      flake in `affinidi-status-list::bitstring::decoy_entries`
      (random decoy index can collide with an already-set index;
      `Test Suite` passed on the same SHA), and `Wiz-cli Directory
      Scan` is the recurring infra auth error
      (`failed authenticating with credentials`) that hit the first
      CI run on this PR too.
- [ ] End-to-end smoke against a vta-service 0.7+ instance (manual,
      post-merge).