### PR TITLE
fix: harden affinidi-messaging-didcomm 0.13.3 and affinidi-messaging-sdk 0.18.3

### DIFF
--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -8,6 +8,44 @@ we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our
 tooling.
 
+## 24th May 2026
+
+### DIDComm (0.13.3)
+
+Security fixes; no API changes.
+
+- **FIX (security):** `DIDCommAdapter::unpack` now derives the reported
+  `sender` from the cryptographically authenticated key (ECDH-1PU
+  `skid` for authcrypt, JWS `signer_kid` for signed) instead of
+  preferring the plaintext `from` header. When the authenticated
+  message's plaintext `from` disagrees with the authenticated sender
+  DID, unpack now errors. Previously an attacker who authcrypted with
+  their own key could set `from: did:victim` in the plaintext body and
+  the caller received `{ sender: "did:victim", verified: true }`.
+  Anoncrypt (`verified: false`) still passes the unverified `from`
+  through. Adds `adapter::tests::rejects_spoofed_from_in_authcrypt`.
+- **FIX (security):** `PrivateIdentity` no longer derives `Debug`. A
+  manual impl keeps `did` / kid fields visible and redacts the
+  Ed25519 `signing_private` seed. The derived impl previously printed
+  the raw 32-byte signing key any time a `PrivateIdentity` (or an
+  agent store holding one) was formatted with `{:?}`.
+
+### SDK (0.18.3)
+
+Security fixes; no API changes.
+
+- **FIX (security):** `OOBDiscovery::retrieve_invite` returns
+  `ATMError::TransportError` for malformed invitation responses
+  instead of panicking. Affects the response envelope parse,
+  base64url decode, UTF-8 decode and inner `Message` parse — a
+  misbehaving or hostile mediator could previously crash the SDK
+  client.
+- **FIX (security):** `AuthorizationResponse` no longer derives
+  `Debug`; a manual impl redacts `access_token` and `refresh_token`
+  while leaving `*_expires_at` visible. The derived impl leaked
+  full-session credentials into any `debug!`/`warn!("{:?}", resp)`
+  call or panic dump.
+
 ## 5th May 2026
 
 ### Test Mediator (0.2.0)

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.13.2"
+version = "0.13.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
@@ -115,11 +115,24 @@ impl MessagingProtocol for DIDCommAdapter {
                 // Extract payload from message body
                 let payload = extract_payload(&message.body);
 
+                // The cryptographically authenticated sender (from ECDH-1PU
+                // skid), not the plaintext `from` header which the sender can
+                // set to anything.
+                let auth_sender = sender_kid
+                    .as_ref()
+                    .map(|kid| kid.split('#').next().unwrap_or(kid).to_string());
+                if authenticated
+                    && let (Some(from), Some(auth)) = (&message.from, &auth_sender)
+                    && from != auth
+                {
+                    return Err(MessagingError::Unpack(format!(
+                        "plaintext `from` ({from}) does not match authenticated sender ({auth})"
+                    )));
+                }
+
                 Ok(ReceivedMessage {
                     id: message.id,
-                    sender: message.from.or_else(|| {
-                        sender_kid.map(|kid| kid.split('#').next().unwrap_or(&kid).to_string())
-                    }),
+                    sender: auth_sender.or(message.from),
                     recipient: message
                         .to
                         .and_then(|t| t.into_iter().next())
@@ -142,11 +155,20 @@ impl MessagingProtocol for DIDCommAdapter {
             } => {
                 let payload = extract_payload(&message.body);
 
+                let auth_sender = signer_kid
+                    .as_ref()
+                    .map(|kid| kid.split('#').next().unwrap_or(kid).to_string());
+                if let (Some(from), Some(auth)) = (&message.from, &auth_sender)
+                    && from != auth
+                {
+                    return Err(MessagingError::Unpack(format!(
+                        "plaintext `from` ({from}) does not match JWS signer ({auth})"
+                    )));
+                }
+
                 Ok(ReceivedMessage {
                     id: message.id,
-                    sender: message.from.or_else(|| {
-                        signer_kid.map(|kid| kid.split('#').next().unwrap_or(&kid).to_string())
-                    }),
+                    sender: auth_sender.or(message.from),
                     recipient: message
                         .to
                         .and_then(|t| t.into_iter().next())
@@ -356,6 +378,32 @@ mod tests {
         assert_eq!(
             std::str::from_utf8(&received.payload).unwrap(),
             "Hello from messaging-core!"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_spoofed_from_in_authcrypt() {
+        // Alice authcrypts with her own key (so skid == alice) but lies in the
+        // plaintext `from` header. Bob's adapter must refuse to surface this as
+        // a verified message claiming to be from the victim.
+        let (alice, bob) = setup();
+
+        let spoofed = crate::message::Message::new(
+            "https://didcomm.org/basicmessage/2.0/message",
+            serde_json::Value::String("hi".into()),
+        )
+        .from("did:example:victim")
+        .to(vec!["did:example:bob".to_string()]);
+
+        let packed = alice
+            .agent()
+            .pack_authcrypt(&spoofed, "did:example:alice", "did:example:bob")
+            .unwrap();
+
+        let err = bob.unpack(packed.as_bytes()).await.unwrap_err();
+        assert!(
+            matches!(err, MessagingError::Unpack(_)),
+            "expected Unpack error, got {err:?}"
         );
     }
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
@@ -5,7 +5,6 @@
 
 use crate::crypto::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
 /// A local identity with private keys for DIDComm operations.
-#[derive(Debug)]
 pub struct PrivateIdentity {
     /// The DID for this identity
     pub did: String,
@@ -17,6 +16,21 @@ pub struct PrivateIdentity {
     pub signing_kid: Option<String>,
     /// Ed25519 signing private key (32 bytes), if available
     pub signing_private: Option<[u8; 32]>,
+}
+
+impl std::fmt::Debug for PrivateIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrivateIdentity")
+            .field("did", &self.did)
+            .field("key_agreement_kid", &self.key_agreement_kid)
+            .field("key_agreement_private", &self.key_agreement_private)
+            .field("signing_kid", &self.signing_kid)
+            .field(
+                "signing_private",
+                &self.signing_private.map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl PrivateIdentity {

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.18.3] - 2026-05-24
+
+### Security
+
+- `OOBDiscovery::retrieve_invite` no longer panics on malformed
+  responses from the invitation endpoint. The four `.unwrap()` /
+  `.expect()` sites on the response envelope, base64url payload,
+  UTF-8 decode and inner `Message` parse now return
+  `ATMError::TransportError`. Previously a misbehaving or hostile
+  mediator could crash the SDK client.
+- `AuthorizationResponse` no longer derives `Debug`; a manual impl
+  redacts `access_token` and `refresh_token` while leaving the
+  `*_expires_at` fields visible. The derived impl printed both
+  tokens verbatim, so any `debug!`/`warn!("{:?}", resp)` or panic
+  dump leaked credentials granting a full authenticated session.
+  Matches the redaction already applied to the equivalent structs
+  in `affinidi-did-authentication`.
+
 ## [0.18.1] - 2026-05-05
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.2"
+version = "0.18.3"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/mod.rs
@@ -47,7 +47,7 @@ pub struct AuthenticationChallenge {
 }
 impl GenericDataStruct for AuthenticationChallenge {}
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AuthorizationResponse {
     pub access_token: String,
     pub access_expires_at: u64,
@@ -55,6 +55,17 @@ pub struct AuthorizationResponse {
     pub refresh_expires_at: u64,
 }
 impl GenericDataStruct for AuthorizationResponse {}
+
+impl std::fmt::Debug for AuthorizationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthorizationResponse")
+            .field("access_token", &"[REDACTED]")
+            .field("access_expires_at", &self.access_expires_at)
+            .field("refresh_token", &"[REDACTED]")
+            .field("refresh_expires_at", &self.refresh_expires_at)
+            .finish()
+    }
+}
 
 /// Response from message_delete
 /// - successful: Contains list of message_id's that were deleted successfully

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/oob_discovery.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/oob_discovery.rs
@@ -153,9 +153,9 @@ impl OOBDiscovery {
             )));
         }
 
-        let body = serde_json::from_str::<SuccessResponse<String>>(&body)
-            .ok()
-            .unwrap();
+        let body = serde_json::from_str::<SuccessResponse<String>>(&body).map_err(|e| {
+            ATMError::TransportError(format!("Couldn't parse OOB invitation response: {e}"))
+        })?;
 
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -164,14 +164,15 @@ impl OOBDiscovery {
 
         if let Some(data) = body.data {
             // base64 decode the output
-            let msg_str = String::from_utf8(
-                BASE64_URL_SAFE_NO_PAD
-                    .decode(data)
-                    .expect("base64 decoding issue"),
-            )
-            .unwrap();
-            let msg: Message =
-                serde_json::from_str(&msg_str).expect("Can't deserialize Invitation");
+            let msg_bytes = BASE64_URL_SAFE_NO_PAD.decode(data).map_err(|e| {
+                ATMError::TransportError(format!("OOB invitation is not valid base64url: {e}"))
+            })?;
+            let msg_str = String::from_utf8(msg_bytes).map_err(|e| {
+                ATMError::TransportError(format!("OOB invitation is not valid UTF-8: {e}"))
+            })?;
+            let msg: Message = serde_json::from_str(&msg_str).map_err(|e| {
+                ATMError::TransportError(format!("Couldn't deserialize OOB invitation: {e}"))
+            })?;
 
             if let Some(expires_time) = msg.expires_time
                 && expires_time <= now


### PR DESCRIPTION
## Summary

Four security fixes split across the two messaging client crates, plus the patch-release version bump.

### affinidi-messaging-didcomm 0.13.3

- **`DIDCommAdapter::unpack` — bind reported sender to the authenticated key.** Previously preferred the plaintext `from` header over the cryptographically authenticated `sender_kid` (ECDH-1PU `skid`) / `signer_kid` (JWS). An attacker who authcrypted with their own key could set `from: did:victim` in the plaintext body and the caller received `{ sender: "did:victim", verified: true }` — a full impersonation. Now derives the sender from the authenticated kid and errors if the plaintext `from` disagrees. Anoncrypt (`verified: false`) still passes the unverified `from` through. Includes `adapter::tests::rejects_spoofed_from_in_authcrypt`.
- **`PrivateIdentity` — redact Ed25519 seed in `Debug`.** The derived `Debug` impl printed the raw 32-byte `signing_private` seed (`key_agreement_private` was already redacted). Replaced with a manual impl that keeps `did` / kid fields visible and redacts the seed.

### affinidi-messaging-sdk 0.18.3

- **`OOBDiscovery::retrieve_invite` — don't panic on malformed responses.** Four `.unwrap()` / `.expect()` sites (response envelope JSON parse, base64url decode, UTF-8 decode, inner `Message` parse) could crash the SDK client when the mediator returned malformed data. All four now surface `ATMError::TransportError` with a descriptive message.
- **`AuthorizationResponse` — redact tokens in `Debug`.** The derived `Debug` impl printed `access_token` and `refresh_token` verbatim, so any `debug!`/`warn!("{:?}", resp)` or panic dump leaked credentials granting a full authenticated session. Manual impl now redacts both while leaving the `*_expires_at` timestamps visible. Matches the pattern already used in `affinidi-did-authentication`.

## Compatibility

No API breaks. Workspace dependents pin both crates on `0.13` / `0.18` (major.minor), so the patch is picked up via path deps with no cascading version bumps required.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p affinidi-messaging-didcomm -p affinidi-messaging-sdk`
- [x] `cargo test -p affinidi-messaging-didcomm --lib --features messaging-core` — 88 passed, including new `adapter::tests::rejects_spoofed_from_in_authcrypt`
- [ ] CI to confirm full workspace build + test suite
- [ ] Manual: verify `format!("{:?}", priv_identity)` no longer prints the Ed25519 seed
- [ ] Manual: verify `format!("{:?}", auth_resp)` no longer prints `access_token` / `refresh_token`