### PR TITLE
fix: harden affinidi-crypto 0.1.7, affinidi-secrets-resolver 0.5.6, affinidi-tdk-common 0.6.2

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi Crypto Changelog
 
+## 28th May 2026 (0.1.7)
+
+- **SECURITY (HIGH):** Redact the private `d` scalar in `Debug` output for
+  `ECParams` (P-256 / P-384 / secp256k1) and `OctectParams` (Ed25519 /
+  X25519). Both structs derived `Debug`, so any `{:?}` format of a JWK
+  that carried a private key would print the base64url private scalar
+  verbatim — `ZeroizeOnDrop` covered heap lifetime but not the print-side
+  leak. Manual `Debug` impls now print the public coordinates and render
+  `d` as `<redacted>` when present. Regression test asserts the private
+  scalar never appears in formatted output.
+
 ## 24th May 2026 (0.1.6)
 
 - **FIX:** Build against stable `ml-dsa 0.1.0`. The `KeyGen` trait was

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.6"
+version = "0.1.7"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/src/jwk.rs
+++ b/crates/core/affinidi-crypto/src/jwk.rs
@@ -70,7 +70,7 @@ pub enum Params {
 }
 
 /// Elliptic Curve parameters (P-256, P-384, secp256k1)
-#[derive(Debug, Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
+#[derive(Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
 pub struct ECParams {
     #[serde(rename = "crv")]
     pub curve: String,
@@ -79,13 +79,34 @@ pub struct ECParams {
     pub d: Option<String>,
 }
 
+impl std::fmt::Debug for ECParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ECParams")
+            .field("curve", &self.curve)
+            .field("x", &self.x)
+            .field("y", &self.y)
+            .field("d", &self.d.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
 /// Octet Key Pair parameters (Ed25519, X25519)
-#[derive(Debug, Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
+#[derive(Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
 pub struct OctectParams {
     #[serde(rename = "crv")]
     pub curve: String,
     pub x: String,
     pub d: Option<String>,
+}
+
+impl std::fmt::Debug for OctectParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OctectParams")
+            .field("curve", &self.curve)
+            .field("x", &self.x)
+            .field("d", &self.d.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 #[cfg(test)]
@@ -134,6 +155,28 @@ mod tests {
                 d: Some("kQrTUKhBU-6bHbCdiY0dIfg3knd5U2-1FlLGGHSbF6U".to_string())
             })
         );
+    }
+
+    #[test]
+    fn debug_redacts_private_d() {
+        let okp = OctectParams {
+            curve: "Ed25519".to_string(),
+            x: "Xx4_L89E6RsyvDTzN9wuN3cDwgifPkXMgFJv_HMIxdk".to_string(),
+            d: Some("jybTAuX6NlN7cJLWNCSOLUnJpblpsGr05TTp7scjSvE".to_string()),
+        };
+        let dbg = format!("{okp:?}");
+        assert!(!dbg.contains("jybTAuX6NlN7cJLWNCSOLUnJpblpsGr05TTp7scjSvE"));
+        assert!(dbg.contains("<redacted>"));
+
+        let ec = ECParams {
+            curve: "P-256".to_string(),
+            x: "sl56LMzaiR5efwwWU1jzC_dfbxQ8gzyLj_N1q2cJmkE".to_string(),
+            y: "UnAimUtlHMPj_T_wIDVPoJAolKHy8DoXXTb8wch4hgU".to_string(),
+            d: Some("kQrTUKhBU-6bHbCdiY0dIfg3knd5U2-1FlLGGHSbF6U".to_string()),
+        };
+        let dbg = format!("{ec:?}");
+        assert!(!dbg.contains("kQrTUKhBU-6bHbCdiY0dIfg3knd5U2-1FlLGGHSbF6U"));
+        assert!(dbg.contains("<redacted>"));
     }
 
     #[test]

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Affinidi Secrets Manager
 
+## 28th May 2026 (0.5.6)
+
+- **SECURITY (HIGH):** Redact private key material in `Debug` output for
+  both `Secret` and `SecretMaterial`. `Secret` derived `Debug` while
+  holding `private_bytes` (raw key) and `secret_material` (the JWK
+  including `d`), so any `{:?}` in a tracing span, error context, panic
+  message, or stray `dbg!()` would dump the key to logs. `SecretMaterial`
+  is `pub` and every variant (`JWK` with `d`, `PrivateKeyMultibase`,
+  `Base58`, `Multibase`) carries the raw private key, so a direct `{:?}`
+  on a value would leak there too. Manual `Debug` impls now print
+  identifying metadata (id / type / key_type / variant name) and render
+  the key bytes as `[REDACTED]`. `ZeroizeOnDrop` continues to cover heap
+  lifetime; this closes the print-side leak.
+
 ## 18th April 2026 (0.5.5)
 
 - **FEATURE:** `post-quantum` Cargo feature (off by default) with

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.5"
+version = "0.5.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/core/affinidi-secrets-resolver/src/secrets.rs
@@ -41,7 +41,7 @@ struct SecretShadow {
 }
 
 /// Public Structure that manages everything to do with Keys and Secrets
-#[derive(Debug, Clone, Deserialize, Serialize, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, Deserialize, Serialize, Zeroize, ZeroizeOnDrop)]
 #[serde(try_from = "SecretShadow")]
 pub struct Secret {
     /// A key ID identifying a secret (private key).
@@ -66,6 +66,19 @@ pub struct Secret {
     /// What crypto type is this secret
     #[serde(skip)]
     pub(crate) key_type: KeyType,
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Secret")
+            .field("id", &self.id)
+            .field("type_", &self.type_)
+            .field("key_type", &self.key_type)
+            .field("secret_material", &"[REDACTED]")
+            .field("private_bytes", &"[REDACTED]")
+            .field("public_bytes", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// Converts the inner Secret Shadow to a public Shadow Struct
@@ -462,7 +475,7 @@ pub enum SecretType {
 // KeyType is re-exported from affinidi_crypto
 
 /// Represents secret crypto material.
-#[derive(Debug, Clone, Deserialize, Serialize, Zeroize)]
+#[derive(Clone, Deserialize, Serialize, Zeroize)]
 #[serde(rename_all = "camelCase")]
 pub enum SecretMaterial {
     #[serde(rename = "privateKeyJwk")]
@@ -479,6 +492,19 @@ pub enum SecretMaterial {
     Multibase {
         private_key_multibase: String,
     },
+}
+
+impl std::fmt::Debug for SecretMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Every variant carries private key bytes; never print them.
+        let variant = match self {
+            SecretMaterial::JWK(_) => "JWK",
+            SecretMaterial::PrivateKeyMultibase(_) => "PrivateKeyMultibase",
+            SecretMaterial::Base58 { .. } => "Base58",
+            SecretMaterial::Multibase { .. } => "Multibase",
+        };
+        f.debug_tuple(variant).field(&"[REDACTED]").finish()
+    }
 }
 
 #[cfg(test)]

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,19 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.2 — 2026-05-28
+
+### Security
+
+- **`TDKEnvironments::save()` now opens the environments file with `0600`
+  permissions on Unix** (medium severity). The file serialises every
+  `TDKProfile` — including its `secrets: Vec<Secret>` (DID private keys) —
+  and previously used `File::create()`, which honours the process umask
+  and typically yields a world-readable (0644) file. On a multi-user host
+  any local account could read every profile's signing keys. Windows
+  paths fall back to `File::create()` as before; ACL behaviour there is
+  governed by the parent directory.
+
 ## 0.6.1 — 2026-05-02
 
 Ergonomic additions to soften the 0.6 migration. No breaking changes.

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/tdk/affinidi-tdk-common/src/environments.rs
+++ b/crates/tdk/affinidi-tdk-common/src/environments.rs
@@ -254,6 +254,23 @@ impl TDKEnvironments {
             TDKError::Profile(format!("Failed to serialise TDKEnvironments: {err}"))
         })?;
 
+        // TDKEnvironments serialises `TDKProfile.secrets` (DID private keys);
+        // restrict to owner-only on Unix so other local users can't read them.
+        // `File::create` would honour the process umask (typically 0644).
+        #[cfg(unix)]
+        let mut f = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(file_name)
+                .map_err(|err| {
+                    TDKError::Profile(format!("Couldn't create file ({file_name}): {err}"))
+                })?
+        };
+        #[cfg(not(unix))]
         let mut f = File::create(file_name).map_err(|err| {
             TDKError::Profile(format!(
                 "Failed to create environments file ({file_name}): {err}"


### PR DESCRIPTION
## Summary

PR A of the security-batch series triaged from `~/Downloads/patches/affinidi-tdk-rs` (see `APPLIED.md` / `SUMMARY.md`). Three core/TDK crates, all sharing the same risk class: **stop leaking private key material**.

| Crate | Bump | Class | Source patch |
|---|---|---|---|
| `affinidi-crypto` | 0.1.6 → **0.1.7** | private `d` in `Debug` | `0025` |
| `affinidi-secrets-resolver` | 0.5.5 → **0.5.6** | `Secret` + `SecretMaterial` in `Debug` | `0004`, `0012` |
| `affinidi-tdk-common` | 0.6.1 → **0.6.2** | environments file world-readable on disk | `0017` |

### Severity

- **HIGH** — any `{:?}` of a `JWK`, `Secret`, or `SecretMaterial` in a tracing span, error chain, or stray `dbg!()` previously dumped the raw private key to logs. `ZeroizeOnDrop` covers heap lifetime but not print-side leaks.
- **MEDIUM** — `TDKEnvironments::save()` previously wrote profile secrets (DID private keys) with umask-default 0644, making them readable by any local user on a multi-user host. Now `0o600` on Unix; Windows unchanged (no `mode()` available; relies on parent dir ACLs).

### What changed

- `affinidi-crypto::jwk::{ECParams, OctectParams}` — replaced derived `Debug` with manual impl that prints `curve`/`x`/`y` and renders `d` as `<redacted>` when present. New regression test asserts the private scalar never appears in formatted output.
- `affinidi-secrets-resolver::secrets::Secret` — manual `Debug` redacts `secret_material`, `private_bytes`, and `public_bytes`; keeps `id`/`type_`/`key_type` visible for debugging.
- `affinidi-secrets-resolver::secrets::SecretMaterial` — every variant carries private bytes; manual `Debug` prints only the variant name plus `[REDACTED]`.
- `affinidi-tdk-common::environments::TDKEnvironments::save()` — Unix path opens via `OpenOptions::new().mode(0o600)`; non-Unix path retains `File::create()`.

### Dependency-cascade notes

All internal consumers pin via `major.minor` (`0.1` / `0.5` / `0.6`) per repo convention, so the patch bumps are picked up through workspace path resolution with **no cascading Cargo.toml edits** in dependents.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --all-targets` — builds (8m 00s)
- [x] `cargo test -p affinidi-crypto --lib` — **30 passed**, 0 failed (incl. new `jwk::tests::debug_redacts_private_d`)
- [x] `cargo test -p affinidi-secrets-resolver --lib` — **16 passed**, 0 failed
- [x] `cargo test -p affinidi-tdk-common --lib` — **26 passed**, 0 failed
- [ ] Workspace clippy / coverage / wiz-cli — deferred to CI

## Source patch mapping

- `0025-fix-security-affinidi-crypto-redact-private-d-scalar.patch` → commit 1
- `0004-affinidi-secrets-resolver-redact-private-key-materia.patch` + `0012-affinidi-secrets-resolver-redact-SecretMaterial-in-D.patch` → commit 2 (folded; same risk class, same file)
- `0017-affinidi-tdk-common-write-environments-file-with-060.patch` → commit 3
- version + CHANGELOG bumps → commit 4

Part of the security-batch series. Follow-up PRs (B/C/D) cover identity SSRF, credentials verification, and OID4VC token leaks respectively.