### PR TITLE
fix: harden identity layer — did-web 0.1.1, did-ebsi 0.1.2, did-resolver-cache-server 0.7.5, did-authentication 0.3.3

### DIFF
--- a/crates/affinidi-did-resolver/CHANGELOG.md
+++ b/crates/affinidi-did-resolver/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Changelog history
 
+### 28th May 2026
+
+#### did-ebsi (0.1.2)
+
+- **SECURITY (HIGH — SSRF + path injection):** `resolve_ebsi_did()`
+  interpolated the caller-supplied DID string straight into the request
+  path and used `reqwest::get()`, which follows up to 10 redirects with
+  no timeout. A DID embedded in untrusted input could inject path/query
+  components, and a 3xx from the registry (or anything on-path) could
+  pivot the resolver to an internal address and serve a forged DID
+  document. The resolver now strips the `did:ebsi:` prefix and runs
+  `validate_ebsi_identifier()` (base58btc, fixed length, version byte)
+  before building the URL, and uses an explicit `Client` with
+  `redirect::Policy::none()` and a 20 s timeout.
+
+#### affinidi-did-resolver-cache-server (0.7.5)
+
+- **SECURITY (HIGH — SSRF reflection + body DoS):** `fetch_webvh_log()`
+  derives the target host from the caller-supplied
+  `did:webvh:{scid}:{host}` and was duplicated in `handlers/http.rs` and
+  `handlers/websocket.rs`. Both copies built a `reqwest::Client` with the
+  default redirect policy (10 hops) and read the body with unbounded
+  `.text().await`, then reflected the body to the requesting client in
+  the `_did_log` / `did_witness_log` response fields. An attacker
+  hosting a valid `did:webvh` log could have their endpoint return a 3xx
+  to an internal address (cloud metadata, RFC1918, loopback) on the
+  second fetch — the cache server followed it, buffered the response,
+  and handed it back to the attacker. The unbounded read also let a
+  hostile endpoint OOM the resolver. Consolidated into `handlers/mod.rs`
+  with `redirect::Policy::none()` and a streaming 1 MiB body cap
+  (`read_text_limited`).
+
 ### 15th March 2026
 
 #### did-scid (0.1.4)

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi DID Authentication
 
+## 28th May 2026 (0.3.3)
+
+- **SECURITY (HIGH):** Redact bearer / refresh tokens in `Debug` output for
+  three sibling structs. Each derived `Debug` while holding `access_token`
+  and the long-lived (or rotated one-time) `refresh_token`. Any
+  `debug!`/`warn!("{:?}", x)` on either side of the wire — client session
+  state, threaded SDK profiles, mediator refresh handlers — would leak full
+  session credentials to logs.
+  - `AuthorizationTokens` — primary client-side session credential.
+  - `MPAuthorizationTokens` — Meeting Place auth flow.
+  - `AuthRefreshResponse` — server-side response wrapping the rotated
+    refresh + new access token.
+  Manual `Debug` impls now keep the `*_expires_at` timestamps visible and
+  render the token values as `[REDACTED]`. `Serialize`/`Deserialize`
+  unchanged — wire format and persistence are unaffected.
+
 ## 28th March 2026 (0.3.1)
 
 - **FIX:** Republish with `affinidi-messaging-didcomm` 0.13 dependency

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -39,12 +39,23 @@ pub mod errors;
 pub use custom_auth::{CustomAuthHandler, CustomAuthHandlers, CustomRefreshHandler};
 
 /// The authorization tokens received in the fourth step of the DID authentication process
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AuthorizationTokens {
     pub access_token: String,
     pub access_expires_at: u64,
     pub refresh_token: String,
     pub refresh_expires_at: u64,
+}
+
+impl std::fmt::Debug for AuthorizationTokens {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthorizationTokens")
+            .field("access_token", &"[REDACTED]")
+            .field("access_expires_at", &self.access_expires_at)
+            .field("refresh_token", &"[REDACTED]")
+            .field("refresh_expires_at", &self.refresh_expires_at)
+            .finish()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -119,7 +130,7 @@ struct HTTPResponse<T> {
 }
 
 /// The authorization tokens received in the fourth step of the DID authentication process
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct MPAuthorizationTokens {
     pub access_token: String,
     pub access_expires_at: String,
@@ -127,9 +138,20 @@ pub struct MPAuthorizationTokens {
     pub refresh_expires_at: String,
 }
 
+impl std::fmt::Debug for MPAuthorizationTokens {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MPAuthorizationTokens")
+            .field("access_token", &"[REDACTED]")
+            .field("access_expires_at", &self.access_expires_at)
+            .field("refresh_token", &"[REDACTED]")
+            .field("refresh_expires_at", &self.refresh_expires_at)
+            .finish()
+    }
+}
+
 /// Refresh tokens response from the authentication service.
 /// Includes rotated refresh token (one-time use).
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct AuthRefreshResponse {
     pub access_token: String,
     pub access_expires_at: u64,
@@ -137,6 +159,17 @@ pub struct AuthRefreshResponse {
     pub refresh_token: String,
     #[serde(default)]
     pub refresh_expires_at: u64,
+}
+
+impl std::fmt::Debug for AuthRefreshResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthRefreshResponse")
+            .field("access_token", &"[REDACTED]")
+            .field("access_expires_at", &self.access_expires_at)
+            .field("refresh_token", &"[REDACTED]")
+            .field("refresh_expires_at", &self.refresh_expires_at)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.7.4"
+version = "0.7.5"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
@@ -1,4 +1,4 @@
-use crate::SharedData;
+use crate::{SharedData, handlers::fetch_webvh_log};
 use affinidi_did_resolver_cache_sdk::DIDMethod;
 use axum::{
     Json,
@@ -6,72 +6,7 @@ use axum::{
 };
 use http::StatusCode;
 use serde_json::{Value, json};
-use tracing::{error, warn};
-
-/// For did:webvh DIDs, fetch the raw DID log from the source HTTP endpoint
-/// so clients can independently verify the cryptographic chain.
-async fn fetch_webvh_log(did: &str) -> (Option<String>, Option<String>) {
-    let parsed_url = match didwebvh_rs::url::WebVHURL::parse_did_url(did) {
-        Ok(url) => url,
-        Err(e) => {
-            warn!("Failed to parse WebVH DID URL for log fetch: {e}");
-            return (None, None);
-        }
-    };
-
-    let log_url = match parsed_url.get_http_url(Some("did.jsonl")) {
-        Ok(url) => url,
-        Err(e) => {
-            warn!("Failed to construct log URL for WebVH DID: {e}");
-            return (None, None);
-        }
-    };
-
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("Failed to create HTTP client for WebVH log fetch: {e}");
-            return (None, None);
-        }
-    };
-
-    let did_log = match client.get(log_url).send().await {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(text) => Some(text),
-            Err(e) => {
-                warn!("Failed to read WebVH log response body: {e}");
-                None
-            }
-        },
-        Ok(resp) => {
-            warn!("WebVH log fetch returned HTTP {}: {}", resp.status(), did);
-            None
-        }
-        Err(e) => {
-            warn!("Failed to fetch WebVH log for {}: {e}", did);
-            None
-        }
-    };
-
-    // Fetch witness proofs if log was successfully retrieved
-    let did_witness_log = if did_log.is_some() {
-        let witness_url = match parsed_url.get_http_url(Some("did-witness.json")) {
-            Ok(url) => url,
-            Err(_) => return (did_log, None),
-        };
-        match client.get(witness_url).send().await {
-            Ok(resp) if resp.status().is_success() => resp.text().await.ok(),
-            _ => None,
-        }
-    } else {
-        None
-    };
-
-    (did_log, did_witness_log)
-}
+use tracing::error;
 
 pub async fn resolver_handler(
     State(state): State<SharedData>,

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
@@ -1,10 +1,101 @@
 use crate::{SharedData, config::Config};
 use axum::{Json, Router, extract::State, response::IntoResponse, routing::get};
-use tracing::info;
+use tracing::{info, warn};
 
 pub(crate) mod http;
 #[cfg(feature = "network")]
 pub(crate) mod websocket;
+
+const MAX_WEBVH_LOG_BYTES: usize = 1024 * 1024;
+
+/// Read a response body as UTF-8 text, refusing anything larger than `limit` bytes.
+async fn read_text_limited(mut resp: reqwest::Response, limit: usize) -> Option<String> {
+    let mut buf = Vec::new();
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                if buf.len() + chunk.len() > limit {
+                    warn!("WebVH log body exceeded {limit} byte cap; dropping");
+                    return None;
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                warn!("Failed to read WebVH log response body: {e}");
+                return None;
+            }
+        }
+    }
+    String::from_utf8(buf).ok()
+}
+
+/// For did:webvh DIDs, fetch the raw DID log + witness file from the source
+/// HTTP endpoint so clients can independently verify the cryptographic chain.
+///
+/// The target host is derived from the caller-supplied DID, so this client
+/// refuses redirects and caps the response body to avoid being used as an SSRF
+/// pivot / reflection oracle or memory-exhaustion vector.
+pub(crate) async fn fetch_webvh_log(did: &str) -> (Option<String>, Option<String>) {
+    let parsed_url = match didwebvh_rs::url::WebVHURL::parse_did_url(did) {
+        Ok(url) => url,
+        Err(e) => {
+            warn!("Failed to parse WebVH DID URL for log fetch: {e}");
+            return (None, None);
+        }
+    };
+
+    let log_url = match parsed_url.get_http_url(Some("did.jsonl")) {
+        Ok(url) => url,
+        Err(e) => {
+            warn!("Failed to construct log URL for WebVH DID: {e}");
+            return (None, None);
+        }
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to create HTTP client for WebVH log fetch: {e}");
+            return (None, None);
+        }
+    };
+
+    let did_log = match client.get(log_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            read_text_limited(resp, MAX_WEBVH_LOG_BYTES).await
+        }
+        Ok(resp) => {
+            warn!("WebVH log fetch returned HTTP {}: {}", resp.status(), did);
+            None
+        }
+        Err(e) => {
+            warn!("Failed to fetch WebVH log for {}: {e}", did);
+            None
+        }
+    };
+
+    let did_witness_log = if did_log.is_some() {
+        let witness_url = match parsed_url.get_http_url(Some("did-witness.json")) {
+            Ok(url) => url,
+            Err(_) => return (did_log, None),
+        };
+        match client.get(witness_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                read_text_limited(resp, MAX_WEBVH_LOG_BYTES).await
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    (did_log, did_witness_log)
+}
 
 pub fn application_routes(shared_data: &SharedData, config: &Config) -> Router {
     let mut app = Router::new();

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
@@ -12,74 +12,7 @@ use axum::{
 use tokio::select;
 use tracing::{Instrument, debug, info, span, warn};
 
-use crate::SharedData;
-
-/// For did:webvh DIDs, fetch the raw DID log (did.jsonl) from the source HTTP endpoint.
-/// This log is sent alongside the resolved document so clients can independently
-/// verify the cryptographic chain, preventing a compromised cache server from
-/// serving tampered DID documents.
-async fn fetch_webvh_log(did: &str) -> (Option<String>, Option<String>) {
-    let parsed_url = match didwebvh_rs::url::WebVHURL::parse_did_url(did) {
-        Ok(url) => url,
-        Err(e) => {
-            warn!("Failed to parse WebVH DID URL for log fetch: {e}");
-            return (None, None);
-        }
-    };
-
-    let log_url = match parsed_url.get_http_url(Some("did.jsonl")) {
-        Ok(url) => url,
-        Err(e) => {
-            warn!("Failed to construct log URL for WebVH DID: {e}");
-            return (None, None);
-        }
-    };
-
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("Failed to create HTTP client for WebVH log fetch: {e}");
-            return (None, None);
-        }
-    };
-
-    let did_log = match client.get(log_url).send().await {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(text) => Some(text),
-            Err(e) => {
-                warn!("Failed to read WebVH log response body: {e}");
-                None
-            }
-        },
-        Ok(resp) => {
-            warn!("WebVH log fetch returned HTTP {}: {}", resp.status(), did);
-            None
-        }
-        Err(e) => {
-            warn!("Failed to fetch WebVH log for {}: {e}", did);
-            None
-        }
-    };
-
-    // Fetch witness proofs if log was successfully retrieved
-    let did_witness_log = if did_log.is_some() {
-        let witness_url = match parsed_url.get_http_url(Some("did-witness.json")) {
-            Ok(url) => url,
-            Err(_) => return (did_log, None),
-        };
-        match client.get(witness_url).send().await {
-            Ok(resp) if resp.status().is_success() => resp.text().await.ok(),
-            _ => None,
-        }
-    } else {
-        None
-    };
-
-    (did_log, did_witness_log)
-}
+use crate::{SharedData, handlers::fetch_webvh_log};
 
 /// Build a WSResponse, fetching the raw DID log for WebVH DIDs.
 async fn build_response(response: ResolveResponse) -> WSResponseType {

--- a/crates/identity/did-methods/did-ebsi/Cargo.toml
+++ b/crates/identity/did-methods/did-ebsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ebsi"
-version = "0.1.1"
+version = "0.1.2"
 description = "Implementation of did:ebsi (EBSI DID method for legal entities) in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-ebsi/src/lib.rs
+++ b/crates/identity/did-methods/did-ebsi/src/lib.rs
@@ -130,9 +130,29 @@ pub async fn resolve_ebsi_did(
     did: &str,
     api_base: &str,
 ) -> Result<affinidi_did_common::Document, EbsiError> {
-    let url = format!("{api_base}/{did}");
+    // Validate before interpolating into the URL: a did:ebsi method-specific
+    // id is base58btc, so once validated it can only contain [1-9A-HJ-NP-Za-km-z]
+    // and cannot inject `/`, `?`, `#`, `..` etc. into the request path.
+    let identifier = did
+        .strip_prefix("did:ebsi:")
+        .ok_or_else(|| EbsiError::InvalidDid("must start with did:ebsi:".into()))?;
+    validate_ebsi_identifier(identifier)?;
 
-    let response = reqwest::get(&url)
+    let url = format!("{api_base}/did:ebsi:{identifier}");
+
+    // The EBSI registry is the trust anchor here; following a 3xx would let
+    // it (or anything on-path) pivot the resolver to an arbitrary internal
+    // address (SSRF) and serve a forged DID document.
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("affinidi-did-ebsi/", env!("CARGO_PKG_VERSION")))
+        .timeout(std::time::Duration::from_secs(20))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| EbsiError::Http(format!("building HTTP client: {e}")))?;
+
+    let response = client
+        .get(&url)
+        .send()
         .await
         .map_err(|e| EbsiError::Http(format!("GET {url}: {e}")))?;
 

--- a/crates/identity/did-methods/did-web/CHANGELOG.md
+++ b/crates/identity/did-methods/did-web/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Changelog history
 
+## 28th May 2026
+
+### Affinidi DID Web (0.1.1)
+
+- **SECURITY (HIGH — SSRF):** The default reqwest client follows up to
+  10 redirects. A hostile `did:web` origin could 302 the resolver to
+  `169.254.169.254`, `127.0.0.1`, or any internal address — an SSRF
+  pivot that bypasses whatever host-level filtering a deployer puts in
+  front of the DID string. The default client now sets
+  `redirect::Policy::none()`; callers passing their own
+  `reqwest::Client` via `DIDWeb::with_client` are responsible for their
+  own redirect policy.
+- **SECURITY (HIGH — path traversal):** `build_url()` percent-decoded
+  each colon-separated segment and appended it verbatim, so e.g.
+  `did:web:example.com:%2E%2E:admin` produced
+  `https://example.com/../admin/did.json` and
+  `did:web:example.com:a%2Fb` produced `https://example.com/a/b/did.json`
+  — a crafted DID could escape the expected `/{segments}/did.json`
+  shape. `build_url` now rejects decoded segments that are empty, `.`,
+  `..`, or contain `/` or `\`. New regression test
+  `url_rejects_path_traversal_segments`.
+
 ## 17th April 2026
 
 ### Affinidi DID Web (0.1.0) — initial release

--- a/crates/identity/did-methods/did-web/Cargo.toml
+++ b/crates/identity/did-methods/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-web"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minimal did:web DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-web/src/lib.rs
+++ b/crates/identity/did-methods/did-web/src/lib.rs
@@ -99,6 +99,9 @@ impl DIDWeb {
         let client = reqwest::Client::builder()
             .user_agent(concat!("affinidi-did-web/", env!("CARGO_PKG_VERSION")))
             .timeout(DEFAULT_TIMEOUT)
+            // The DID names the host. Following a 3xx lets that host pivot the
+            // resolver to an arbitrary internal address (SSRF), so refuse.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("reqwest client with default config");
         Self { client }
@@ -199,6 +202,18 @@ pub fn build_url(domain: &str, path_segments: &[String]) -> Result<String, DidWe
             let decoded_segment = percent_decode_str(segment).decode_utf8().map_err(|e| {
                 DidWebError::InvalidDid(format!("path segment {segment:?} is not valid UTF-8: {e}"))
             })?;
+            // A decoded segment must stay a single path component. `%2E%2E`
+            // (`..`), `%2F` (`/`), `%5C` (`\`), etc. would otherwise let a
+            // crafted DID escape the expected `/{segments}/did.json` shape.
+            if decoded_segment.is_empty()
+                || decoded_segment == "."
+                || decoded_segment == ".."
+                || decoded_segment.contains(['/', '\\'])
+            {
+                return Err(DidWebError::InvalidDid(format!(
+                    "path segment {segment:?} is not a valid single path component"
+                )));
+            }
             url.push('/');
             url.push_str(&decoded_segment);
         }
@@ -234,6 +249,17 @@ mod tests {
     fn url_decodes_percent_encoded_port() {
         let url = build_url("example.com%3A8443", &[]).unwrap();
         assert_eq!(url, "https://example.com:8443/.well-known/did.json");
+    }
+
+    #[test]
+    fn url_rejects_path_traversal_segments() {
+        for seg in ["%2E%2E", "..", ".", "", "a%2Fb", "a%5Cb"] {
+            let err = build_url("example.com", &[seg.to_string()]).unwrap_err();
+            assert!(
+                matches!(err, DidWebError::InvalidDid(_)),
+                "segment {seg:?} should be rejected, got {err:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR B of the security-batch series. Four identity-layer crates, two themes: **SSRF hardening** (don't follow redirects to internal addresses) and **session-token redaction** (don't print bearer / refresh tokens in `Debug`).

| Crate | Bump | Class | Source patch |
|---|---|---|---|
| `affinidi-did-web` | 0.1.0 → **0.1.1** | SSRF + path traversal | `0002` |
| `did-ebsi` | 0.1.1 → **0.1.2** | SSRF + path injection | `0009` |
| `affinidi-did-resolver-cache-server` | 0.7.4 → **0.7.5** | SSRF reflection + body DoS | `0022` |
| `affinidi-did-authentication` | 0.3.2 → **0.3.3** | bearer / refresh token in `Debug` | `0006`, `0019` |

### Severity

- **HIGH (SSRF / path traversal)** — three crates make outbound HTTPS to caller-controlled hosts. Default `reqwest::Client` follows up to 10 redirects, so a hostile origin (or anything on-path) can 302 the resolver to `169.254.169.254`, `127.0.0.1`, or any RFC1918 address — bypassing whatever host-level filtering a deployer puts in front of the DID string. Two of them additionally let the caller inject path/`..` components into the request URL.
- **HIGH (token leak)** — `AuthorizationTokens`, `MPAuthorizationTokens`, `AuthRefreshResponse` each derived `Debug` while holding `access_token` + `refresh_token`. Any `debug!`/`warn!("{:?}", x)` in tracing spans, error chains, or panic formats would leak full-session credentials to logs.

### What changed

**`affinidi-did-web` 0.1.1** (`crates/identity/did-methods/did-web/src/lib.rs`)
- `DIDWeb::new()` default client: `redirect::Policy::none()`. Callers passing their own client via `with_client` keep responsibility for their own redirect policy.
- `build_url`: reject decoded path segments that are empty, `.`, `..`, or contain `/` or `\` — closes `did:web:example.com:%2E%2E:admin → /../admin/did.json`. New test `url_rejects_path_traversal_segments`.

**`did-ebsi` 0.1.2** (`crates/identity/did-methods/did-ebsi/src/lib.rs`)
- Strip `did:ebsi:` prefix and run `validate_ebsi_identifier()` (base58btc, fixed length, version byte) **before** URL interpolation.
- Replace bare `reqwest::get()` with an explicit `Client::builder()` carrying `redirect::Policy::none()` and a 20 s timeout.

**`affinidi-did-resolver-cache-server` 0.7.5** (`crates/identity/affinidi-did-resolver-cache-server/src/handlers/`)
- Consolidate the two duplicated `fetch_webvh_log()` copies (one in `http.rs`, one in `websocket.rs`) into `handlers/mod.rs`.
- The unified client sets `redirect::Policy::none()`.
- New `read_text_limited()` enforces a 1 MiB streaming body cap — replaces unbounded `.text().await`. The body was being reflected to the requesting client in `_did_log` / `did_witness_log`, so the cap also closes the SSRF reflection oracle + OOM vector.

**`affinidi-did-authentication` 0.3.3** (`crates/identity/affinidi-did-authentication/src/lib.rs`)
- Manual `Debug` impls for `AuthorizationTokens`, `MPAuthorizationTokens`, and `AuthRefreshResponse`. Keep `*_expires_at` timestamps; render token values as `[REDACTED]`. `Serialize`/`Deserialize` unchanged — wire format and persistence are unaffected.

### Dependency-cascade notes

All internal consumers pin via `major.minor` (`0.1` / `0.3` / `0.7`) per repo convention, so the patch bumps are picked up through workspace path resolution with **no cascading Cargo.toml edits** in dependents.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p affinidi-did-web -p did-ebsi -p affinidi-did-resolver-cache-server -p affinidi-did-authentication --all-targets` — builds (1m 26s)
- [x] `cargo test -p affinidi-did-web --lib` — **9 passed** (incl. new `url_rejects_path_traversal_segments`)
- [x] `cargo test -p did-ebsi --lib` — **7 passed**, 0 failed
- [x] `cargo test -p affinidi-did-resolver-cache-server --lib` — **0 passed** (no lib tests; integration tests deferred to CI)
- [x] `cargo test -p affinidi-did-authentication --lib` — **3 passed**, 0 failed
- [ ] Workspace clippy / coverage / wiz-cli — deferred to CI
- [ ] Smoke: resolve a real `did:web` against an HTTP server that redirects to `127.0.0.1` — should now fail with a 3xx-not-followed error rather than touching loopback (could be added as an integration test in a follow-up)

## Source patch mapping

- `0002-did-web-refuse-redirects-and-reject-path-traversal-s.patch` → commit 1
- `0009-did-ebsi-validate-identifier-and-refuse-redirects-in.patch` → commit 2
- `0022-affinidi-did-resolver-cache-server-harden-WebVH-log-.patch` → commit 3
- `0006-affinidi-did-authentication-redact-tokens-in-Authori.patch` + `0019-affinidi-did-authentication-redact-MPAuthorizationTo.patch` → commit 4 (folded; same risk class, same file)
- version + CHANGELOG bumps → commit 5

Part of the security-batch series. Follows PR #318 (core key-material redaction). Follow-ups C/D cover credentials verification and OID4VC token leaks respectively.