### PR TITLE
fix: harden credentials — sd-jwt 0.1.2 (KB bypass), status-list 0.1.2 (DoS), mdoc 0.2.0 (validity)

### DIFF
--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Affinidi mdoc Changelog
+
+## 28th May 2026 Release 0.2.0
+
+### Security
+
+- **HIGH — MSO `ValidityInfo` was parsed but never enforced.**
+  `verify_issuer_auth()` and `verify_digests()` accepted an mdoc whose
+  `validUntil` was years in the past. ISO/IEC 18013-5 §9.3.1 requires
+  the reader to reject documents outside their validity window, and
+  `MdocError::Expired` already existed (unused) for exactly this. New
+  `ValidityInfo::check(now)` and `ValidityInfo::check_now()` methods
+  parse the RFC 3339 timestamps and return `Expired` when `now` falls
+  outside `[validFrom, validUntil]`. Verifiers MUST call this on the
+  MSO returned from `IssuerSigned::verify_issuer_auth` — signature and
+  digest checks alone do not establish current validity.
+
+### Breaking
+
+- **`MdocError::Expired` is now `Expired(String)`** (was a unit variant).
+  The variant existed but was unused, so no in-workspace consumer is
+  affected; out-of-workspace callers pattern-matching on the unit form
+  must update to the tuple form, e.g.
+  `Err(MdocError::Expired) => …` becomes
+  `Err(MdocError::Expired(_)) => …`. The carried string describes which
+  bound was crossed (not-yet-valid vs. expired) and the offending
+  timestamp.
+
+### Dependencies
+
+- Adds `time = "0.3"` (with `parsing` feature) — already in the workspace
+  via `affinidi-messaging-sdk`.
+
+### Tests
+
+- `validity_info_check_within_window` — in-window passes.
+- `validity_info_check_expired` — `now > validUntil` returns `Expired`.
+- `validity_info_check_not_yet_valid` — `now < validFrom` returns `Expired`.
+- `validity_info_check_malformed` — non-RFC-3339 timestamps return
+  `InvalidMso`.

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -47,6 +47,7 @@ hmac = "0.12"
 hkdf = "0.12"
 aes-gcm = "0.10"
 thiserror = "2"
+time = { version = "0.3", features = ["parsing"] }
 tracing = "0.1"
 hex = "0.4"
 

--- a/crates/credentials/affinidi-mdoc/src/error.rs
+++ b/crates/credentials/affinidi-mdoc/src/error.rs
@@ -27,9 +27,9 @@ pub enum MdocError {
     #[error("Digest mismatch: {0}")]
     DigestMismatch(String),
 
-    /// The document has expired.
-    #[error("Document expired")]
-    Expired,
+    /// The document is outside its validity window (`validFrom`..`validUntil`).
+    #[error("Document outside validity window: {0}")]
+    Expired(String),
 
     /// A required field is missing.
     #[error("Missing field: {0}")]

--- a/crates/credentials/affinidi-mdoc/src/mso.rs
+++ b/crates/credentials/affinidi-mdoc/src/mso.rs
@@ -77,6 +77,48 @@ pub struct ValidityInfo {
     pub valid_until: String,
 }
 
+impl ValidityInfo {
+    /// Check that `now` falls within `[validFrom, validUntil]`.
+    ///
+    /// ISO/IEC 18013-5 §9.3.1 requires the mdoc reader to verify the
+    /// `ValidityInfo` structure before accepting any disclosed elements.
+    /// Verifiers MUST call this (typically on the MSO returned from
+    /// [`crate::IssuerSigned::verify_issuer_auth`]) — signature and digest
+    /// checks alone do not establish that the credential is currently valid.
+    ///
+    /// Returns [`MdocError::Expired`] if `now` is outside the window, or
+    /// [`MdocError::InvalidMso`] if either timestamp does not parse as
+    /// RFC 3339.
+    pub fn check(&self, now: time::OffsetDateTime) -> Result<()> {
+        use time::format_description::well_known::Rfc3339;
+
+        let valid_from = time::OffsetDateTime::parse(&self.valid_from, &Rfc3339)
+            .map_err(|e| MdocError::InvalidMso(format!("validFrom not RFC 3339: {e}")))?;
+        let valid_until = time::OffsetDateTime::parse(&self.valid_until, &Rfc3339)
+            .map_err(|e| MdocError::InvalidMso(format!("validUntil not RFC 3339: {e}")))?;
+
+        if now < valid_from {
+            return Err(MdocError::Expired(format!(
+                "not yet valid (validFrom = {})",
+                self.valid_from
+            )));
+        }
+        if now > valid_until {
+            return Err(MdocError::Expired(format!(
+                "expired (validUntil = {})",
+                self.valid_until
+            )));
+        }
+        Ok(())
+    }
+
+    /// Convenience wrapper for [`ValidityInfo::check`] using the current
+    /// system time.
+    pub fn check_now(&self) -> Result<()> {
+        self.check(time::OffsetDateTime::now_utc())
+    }
+}
+
 impl MobileSecurityObject {
     /// Create an MSO from IssuerSignedItems organized by namespace.
     ///
@@ -348,5 +390,51 @@ mod tests {
 
         let item = IssuerSignedItem::new(0, "x", ciborium::Value::Integer(1.into()));
         assert!(mso.verify_item_digest("unknown", &item).is_err());
+    }
+
+    #[test]
+    fn validity_info_check_within_window() {
+        let v = test_validity();
+        let mid = time::OffsetDateTime::parse(
+            "2024-06-01T00:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        v.check(mid).expect("mid-window must be valid");
+    }
+
+    #[test]
+    fn validity_info_check_expired() {
+        let v = test_validity();
+        let after = time::OffsetDateTime::parse(
+            "2025-06-01T00:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        assert!(matches!(v.check(after), Err(MdocError::Expired(_))));
+    }
+
+    #[test]
+    fn validity_info_check_not_yet_valid() {
+        let v = test_validity();
+        let before = time::OffsetDateTime::parse(
+            "2023-06-01T00:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        assert!(matches!(v.check(before), Err(MdocError::Expired(_))));
+    }
+
+    #[test]
+    fn validity_info_check_malformed() {
+        let v = ValidityInfo {
+            signed: "2024-01-01T00:00:00Z".into(),
+            valid_from: "not-a-date".into(),
+            valid_until: "2025-01-01T00:00:00Z".into(),
+        };
+        assert!(matches!(
+            v.check(time::OffsetDateTime::now_utc()),
+            Err(MdocError::InvalidMso(_))
+        ));
     }
 }

--- a/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
+++ b/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Affinidi SD-JWT Changelog
+
+## 28th May 2026 Release 0.1.2
+
+### Security
+
+- **CRITICAL — Key-binding bypass closed.** `verify()` with `verify_kb=true`
+  checked that the issuer-signed payload contained a `cnf.jwk` holder key,
+  but if the caller passed `holder_verifier=None` it then decoded the
+  KB-JWT *without* verifying its signature and still reported
+  `kb_verified=Some(true)`. Anyone holding (or having intercepted) the
+  SD-JWT could mint a KB-JWT with the right `sd_hash`/`aud`/`nonce` and
+  be accepted as the bound holder, defeating key binding (RFC 9901 §8.3).
+  Now `verify_kb=true` with no `holder_verifier` is a `KeyBinding` error;
+  the unverified-decode fallback (and the private `decode_jwt_payload`
+  helper) is removed. Callers must build the verifier from `cnf.jwk`.
+  New regression test `verify_kb_without_holder_verifier_fails`.
+
+### Tests
+
+- Existing `verify_kb_aud_mismatch` and `verify_kb_nonce_mismatch` tests
+  updated to pass a holder verifier (was implicitly relying on the
+  removed fallback).
+- `spec_vectors::spec_example_full_flow` updated likewise.

--- a/crates/credentials/affinidi-sd-jwt/Cargo.toml
+++ b/crates/credentials/affinidi-sd-jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-sd-jwt"
 description = "SD-JWT (Selective Disclosure JWT) implementation per IETF SD-JWT specification."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-sd-jwt/src/verifier.rs
+++ b/crates/credentials/affinidi-sd-jwt/src/verifier.rs
@@ -3,7 +3,6 @@
  * and optionally verify Key Binding JWT.
  */
 
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde_json::Value;
 
 use crate::SdJwt;
@@ -99,12 +98,18 @@ pub fn verify(
                     )
                 })?;
 
-            // Verify KB-JWT signature if a holder verifier is provided (S5)
-            let kb_payload = if let Some(hv) = holder_verifier {
-                hv.verify_jwt(kb_jwt_str)?
-            } else {
-                decode_jwt_payload(kb_jwt_str)?
+            // RFC 9901 §8.3: key binding only holds if the KB-JWT signature is
+            // verified against the holder key the issuer committed to in
+            // `cnf.jwk`. Decoding the KB-JWT *unverified* (the previous
+            // fallback) lets anyone who obtains the SD-JWT mint a KB-JWT and
+            // be reported as `kb_verified: true`. Callers MUST construct
+            // `holder_verifier` from `cnf.jwk` above.
+            let Some(hv) = holder_verifier else {
+                return Err(SdJwtError::KeyBinding(
+                    "holder_verifier required when verify_kb is true".into(),
+                ));
             };
+            let kb_payload = hv.verify_jwt(kb_jwt_str)?;
 
             // Verify sd_hash
             let expected_sd_hash = hasher.hash_b64(sd_jwt.serialize_without_kb().as_bytes());
@@ -225,20 +230,6 @@ fn collect_digests(value: &Value, digests: &mut std::collections::HashSet<String
         }
         _ => {}
     }
-}
-
-/// Decode a JWT payload without verifying the signature.
-fn decode_jwt_payload(jws: &str) -> Result<Value> {
-    let parts: Vec<&str> = jws.splitn(3, '.').collect();
-    if parts.len() != 3 {
-        return Err(SdJwtError::InvalidFormat("invalid JWT format".into()));
-    }
-
-    let payload_bytes = URL_SAFE_NO_PAD
-        .decode(parts[1])
-        .map_err(|e| SdJwtError::InvalidFormat(format!("JWT payload decode: {e}")))?;
-    let payload: Value = serde_json::from_slice(&payload_bytes)?;
-    Ok(payload)
 }
 
 #[cfg(test)]
@@ -402,7 +393,9 @@ mod tests {
         let hasher = Sha256Hasher;
         let signer = HmacSha256Signer::new(test_key());
         let jwt_verifier = HmacSha256Verifier::new(test_key());
-        let holder_signer = HmacSha256Signer::new(b"holder-key-for-hmac-signing!!!");
+        let holder_key = b"holder-key-for-hmac-signing!!!";
+        let holder_signer = HmacSha256Signer::new(holder_key);
+        let holder_verifier = HmacSha256Verifier::new(holder_key);
 
         let holder_jwk = serde_json::json!({ "kty": "oct", "k": "holder-key" });
         let claims = serde_json::json!({ "sub": "user123", "name": "John" });
@@ -425,7 +418,13 @@ mod tests {
             expected_nonce: Some("xyz789"),
         };
 
-        let result = verify(&presentation, &jwt_verifier, &hasher, &opts, None);
+        let result = verify(
+            &presentation,
+            &jwt_verifier,
+            &hasher,
+            &opts,
+            Some(&holder_verifier),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("aud mismatch"));
     }
@@ -435,7 +434,9 @@ mod tests {
         let hasher = Sha256Hasher;
         let signer = HmacSha256Signer::new(test_key());
         let jwt_verifier = HmacSha256Verifier::new(test_key());
-        let holder_signer = HmacSha256Signer::new(b"holder-key-for-hmac-signing!!!");
+        let holder_key = b"holder-key-for-hmac-signing!!!";
+        let holder_signer = HmacSha256Signer::new(holder_key);
+        let holder_verifier = HmacSha256Verifier::new(holder_key);
 
         let holder_jwk = serde_json::json!({ "kty": "oct", "k": "holder-key" });
         let claims = serde_json::json!({ "sub": "user123", "name": "John" });
@@ -458,9 +459,47 @@ mod tests {
             expected_nonce: Some("wrong-nonce"),
         };
 
-        let result = verify(&presentation, &jwt_verifier, &hasher, &opts, None);
+        let result = verify(
+            &presentation,
+            &jwt_verifier,
+            &hasher,
+            &opts,
+            Some(&holder_verifier),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nonce mismatch"));
+    }
+
+    #[test]
+    fn verify_kb_without_holder_verifier_fails() {
+        let hasher = Sha256Hasher;
+        let signer = HmacSha256Signer::new(test_key());
+        let jwt_verifier = HmacSha256Verifier::new(test_key());
+        let holder_signer = HmacSha256Signer::new(b"holder-key-for-hmac-signing!!!");
+
+        let holder_jwk = serde_json::json!({ "kty": "oct", "k": "holder-key" });
+        let claims = serde_json::json!({ "sub": "user123" });
+        let frame = serde_json::json!({});
+
+        let sd_jwt = issuer::issue(&claims, &frame, &signer, &hasher, Some(&holder_jwk)).unwrap();
+        let kb_input = KbJwtInput {
+            audience: "https://verifier.example.com",
+            nonce: "n",
+            signer: &holder_signer,
+            iat: 1700000000,
+        };
+        let presentation = holder::present(&sd_jwt, &[], Some(&kb_input), &hasher).unwrap();
+
+        let opts = VerificationOptions {
+            verify_kb: true,
+            expected_audience: Some("https://verifier.example.com"),
+            expected_nonce: Some("n"),
+        };
+
+        // No holder_verifier => must refuse rather than report kb_verified=true
+        // on an unverified KB-JWT signature.
+        let err = verify(&presentation, &jwt_verifier, &hasher, &opts, None).unwrap_err();
+        assert!(matches!(err, SdJwtError::KeyBinding(_)), "got {err:?}");
     }
 
     #[test]

--- a/crates/credentials/affinidi-sd-jwt/tests/spec_vectors.rs
+++ b/crates/credentials/affinidi-sd-jwt/tests/spec_vectors.rs
@@ -222,6 +222,7 @@ fn spec_example_full_flow() {
     let signer = HmacSha256Signer::new(issuer_key);
     let jwt_verifier = HmacSha256Verifier::new(issuer_key);
     let holder_signer = HmacSha256Signer::new(holder_key);
+    let holder_verifier = HmacSha256Verifier::new(holder_key);
 
     let holder_jwk = json!({
         "kty": "oct",
@@ -283,7 +284,14 @@ fn spec_example_full_flow() {
         expected_audience: Some("https://verifier.example.com"),
         expected_nonce: Some("XZOUco1u_gEPknxS78sWWg"),
     };
-    let result = verifier::verify(&parsed, &jwt_verifier, &hasher, &opts, None).unwrap();
+    let result = verifier::verify(
+        &parsed,
+        &jwt_verifier,
+        &hasher,
+        &opts,
+        Some(&holder_verifier),
+    )
+    .unwrap();
 
     assert!(result.is_verified());
     assert_eq!(result.claims["given_name"], "John");

--- a/crates/credentials/affinidi-status-list/CHANGELOG.md
+++ b/crates/credentials/affinidi-status-list/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Affinidi Status List Changelog
+
+## 28th May 2026 Release 0.1.2
+
+### Security
+
+- **HIGH — gzip-bomb DoS closed.** `BitstringStatusList::decode()` ran
+  `GzDecoder::read_to_end()` on the attacker-supplied `encodedList` with
+  no output limit. A few KB of crafted gzip can expand to gigabytes of
+  zeros, OOMing any verifier that checks a credential's revocation
+  status against a hostile status-list issuer. The decode path already
+  knows exactly how many bytes it needs (`size.div_ceil(8)`), so the
+  decoder is now wrapped in `.take(expected + 1)` and the existing
+  length-check / truncate logic handles the rest. No change to the
+  successful-decode path.

--- a/crates/credentials/affinidi-status-list/Cargo.toml
+++ b/crates/credentials/affinidi-status-list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-status-list"
 description = "Credential status and revocation lists (Bitstring Status List, eIDAS ASL/ARL)."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-status-list/src/bitstring.rs
+++ b/crates/credentials/affinidi-status-list/src/bitstring.rs
@@ -186,13 +186,17 @@ impl BitstringStatusList {
             .decode(encoded)
             .map_err(|e| StatusListError::Encoding(e.to_string()))?;
 
-        let mut decoder = GzDecoder::new(&compressed[..]);
-        let mut bits = Vec::new();
+        let expected_bytes = size.div_ceil(8);
+        // Cap inflation at the size we actually need (plus one byte so we can
+        // tell "exactly right" from "still more coming"). A hostile issuer
+        // could otherwise hand us a few KB of gzip that expands to gigabytes.
+        let limit = (expected_bytes as u64).saturating_add(1);
+        let mut decoder = GzDecoder::new(&compressed[..]).take(limit);
+        let mut bits = Vec::with_capacity(expected_bytes);
         decoder
             .read_to_end(&mut bits)
             .map_err(|e| StatusListError::Compression(e.to_string()))?;
 
-        let expected_bytes = size.div_ceil(8);
         if bits.len() < expected_bytes {
             return Err(StatusListError::Invalid(format!(
                 "decoded bitstring too short: {} bytes, expected {}",


### PR DESCRIPTION
## Summary

PR C of the security-batch series. Three credentials-layer crates, all about **what the verifier accepts**.

| Crate | Bump | Class | Source patch |
|---|---|---|---|
| `affinidi-sd-jwt` | 0.1.1 → **0.1.2** | RFC 9901 §8.3 key-binding bypass (CRITICAL) | `0008`, `0013` |
| `affinidi-status-list` | 0.1.1 → **0.1.2** | gzip-bomb DoS | `0003` |
| `affinidi-mdoc` | 0.1.1 → **0.2.0** | ISO 18013-5 §9.3.1 — accepts expired credentials | `0016` |

### Severity

- **CRITICAL — KB-JWT bypass** (`affinidi-sd-jwt`). `verify()` with `verify_kb=true` checked that the issuer-signed payload contained a `cnf.jwk` holder key, but if the caller passed `holder_verifier=None` it then decoded the KB-JWT *without* verifying its signature and still reported `kb_verified=Some(true)`. Anyone holding (or having intercepted) the SD-JWT could mint a KB-JWT with the right `sd_hash`/`aud`/`nonce` and be accepted as the bound holder, defeating key binding.
- **HIGH — gzip-bomb DoS** (`affinidi-status-list`). `BitstringStatusList::decode()` ran `GzDecoder::read_to_end()` on the attacker-supplied `encodedList` with no output limit. A few KB of crafted gzip expands to gigabytes, OOMing any verifier that checks revocation status against a hostile status-list issuer.
- **HIGH — accepts expired creds** (`affinidi-mdoc`). MSO `ValidityInfo` was parsed but never compared to the current time anywhere in the verification path. `verify_issuer_auth()` / `verify_digests()` accepted an mdoc whose `validUntil` was years in the past. The `MdocError::Expired` variant existed but was unused.

### What changed

**`affinidi-sd-jwt` 0.1.2** (`crates/credentials/affinidi-sd-jwt/src/verifier.rs`)
- `verify_kb=true` + `holder_verifier=None` is now `SdJwtError::KeyBinding(...)`. The unverified-decode fallback (and the private `decode_jwt_payload` helper) is removed. Callers must construct the verifier from `cnf.jwk` themselves.
- New regression test `verify_kb_without_holder_verifier_fails`. Existing aud/nonce-mismatch tests updated to pass a holder verifier.
- Patch `0013` is a rustfmt NFC reflow in `spec_vectors.rs` from the line wrapping `0008` introduced.

**`affinidi-status-list` 0.1.2** (`crates/credentials/affinidi-status-list/src/bitstring.rs`)
- Decoder is wrapped in `.take(expected + 1)` where `expected = size.div_ceil(8)`. The existing length-check / truncate path handles "exactly right" vs "still more coming". No change to the successful-decode behaviour.

**`affinidi-mdoc` 0.2.0** (`crates/credentials/affinidi-mdoc/src/mso.rs`, `src/error.rs`)
- New `ValidityInfo::check(now: time::OffsetDateTime)` and `ValidityInfo::check_now()` parse RFC 3339 `valid_from` / `valid_until` and return `MdocError::Expired(String)` when `now` falls outside the window, or `InvalidMso` on a malformed timestamp.
- Adds `time = "0.3"` (with `parsing` feature) — already in the workspace via `affinidi-messaging-sdk`.
- **BREAKING**: `MdocError::Expired` is now `Expired(String)` (was a unit variant). Confirmed no in-workspace consumers pattern-match on the unit form. Out-of-workspace callers matching `Err(MdocError::Expired) => …` must update to `Err(MdocError::Expired(_)) => …`.

### Verifier-side action required

mdoc verifiers MUST call `ValidityInfo::check_now()` (or `check(now)`) on the MSO returned from `IssuerSigned::verify_issuer_auth` — signature and digest checks alone do not establish that the credential is currently valid. This is documented in the new method's rustdoc.

### Dependency-cascade notes

- `affinidi-mdoc` has **no in-workspace consumers**, so the 0.1 → 0.2 minor bump doesn't cascade.
- `affinidi-sd-jwt` + `affinidi-status-list` stay within 0.1.x; internal `major.minor` pins (`0.1`) pick the patches up through workspace path resolution with no Cargo.toml edits.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p affinidi-sd-jwt -p affinidi-status-list -p affinidi-mdoc --all-targets` — builds (53s)
- [x] `cargo test -p affinidi-sd-jwt --lib --tests` — **90 passed** (53 lib + 19 spec_vectors + 18 from another binary), 0 failed (incl. new `verify_kb_without_holder_verifier_fails`)
- [x] `cargo test -p affinidi-status-list --lib` — **20 passed**, 0 failed
- [x] `cargo test -p affinidi-mdoc --lib` — **103 passed**, 0 failed (incl. 4 new `validity_info_check_*` tests)
- [x] Targeted run of new security regression tests — both pass
- [ ] Workspace clippy / coverage / wiz-cli — deferred to CI

## Source patch mapping

- `0008-affinidi-sd-jwt-require-holder_verifier-when-verify_.patch` + `0013-chore-rustfmt-reflow-in-affinidi-sd-jwt-spec_vectors.patch` → commit 1 (squashed; the rustfmt patch is an NFC reflow from the same change)
- `0003-affinidi-status-list-cap-gzip-inflation-in-Bitstring.patch` → commit 2
- `0016-affinidi-mdoc-enforce-MSO-ValidityInfo-validFrom-val.patch` → commit 3
- version + CHANGELOG bumps → commit 4

Part of the security-batch series. Follows PR #318 (core key-material) and PR #319 (identity SSRF). Follow-up PR D covers OID4VC token leaks + `alg=none` signature bypass.