### PR TITLE
fix: harden OID4VC — oid4vc-core 0.1.2 (alg=none bypass), openid4vci 0.1.2 (pre_auth_code redact)

### DIFF
--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Affinidi OID4VC Core Changelog
+
+## 28th May 2026 Release 0.1.2
+
+### Security
+
+- **CRITICAL — `alg=none` / empty signature accepted as verified.**
+  `decode_compact_jws_verified()` handed the signing input straight to
+  the caller-supplied `JwtVerifier` without inspecting the protected
+  header. That made the security of every SIOPv2 / OID4VCI / OID4VP
+  token check depend on each verifier impl *happening to* reject a
+  zero-length input — true for `Es256Verifier` today, but one
+  permissive impl turns `{"alg":"none"}.<payload>.` into a verified
+  token. The header is now decoded first; `alg: none`
+  (case-insensitive), missing `alg`, and an empty signature segment
+  are refused **before any verifier is consulted**. New regression
+  test `jwt::tests::rejects_alg_none`.

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
@@ -108,6 +108,27 @@ pub fn decode_compact_jws_verified(
         ));
     }
 
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(parts[0])
+        .map_err(|e| JwtError::Base64(format!("header: {e}")))?;
+    let header: Value = serde_json::from_slice(&header_bytes)?;
+
+    // RFC 7515/7519: an Unsecured JWS (`alg: none`, empty signature) must
+    // never satisfy a verified decode. Don't rely on every JwtVerifier impl
+    // happening to reject a zero-length signature.
+    match header.get("alg").and_then(Value::as_str) {
+        Some(alg) if alg.eq_ignore_ascii_case("none") => {
+            return Err(JwtError::Verification("alg=none is not permitted".into()));
+        }
+        Some(_) => {}
+        None => {
+            return Err(JwtError::Verification("missing alg in JWS header".into()));
+        }
+    }
+    if parts[2].is_empty() {
+        return Err(JwtError::Verification("empty JWS signature".into()));
+    }
+
     let signing_input = format!("{}.{}", parts[0], parts[1]);
     let signature = URL_SAFE_NO_PAD
         .decode(parts[2])
@@ -115,14 +136,9 @@ pub fn decode_compact_jws_verified(
 
     verifier.verify(signing_input.as_bytes(), &signature)?;
 
-    let header_bytes = URL_SAFE_NO_PAD
-        .decode(parts[0])
-        .map_err(|e| JwtError::Base64(format!("header: {e}")))?;
     let payload_bytes = URL_SAFE_NO_PAD
         .decode(parts[1])
         .map_err(|e| JwtError::Base64(format!("payload: {e}")))?;
-
-    let header: Value = serde_json::from_slice(&header_bytes)?;
     let payload: Value = serde_json::from_slice(&payload_bytes)?;
 
     Ok((header, payload))
@@ -261,6 +277,16 @@ mod tests {
         let jws = encode_compact_jws(&json!({"alg": "HS256"}), &json!({"x": 1}), &signer).unwrap();
 
         assert!(decode_compact_jws_verified(&jws, &wrong_verifier).is_err());
+    }
+
+    #[test]
+    fn rejects_alg_none() {
+        let verifier = HmacTestVerifier::new(b"k");
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let jws = format!("{header}.{payload}.");
+        let err = decode_compact_jws_verified(&jws, &verifier).unwrap_err();
+        assert!(matches!(err, JwtError::Verification(_)), "got {err:?}");
     }
 
     #[test]

--- a/crates/protocols/affinidi-openid4vci/CHANGELOG.md
+++ b/crates/protocols/affinidi-openid4vci/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Affinidi OpenID4VCI Changelog
+
+## 28th May 2026 Release 0.1.2
+
+### Security
+
+- **HIGH — bearer credential in `Debug`.**
+  `PreAuthorizedCodeGrant::pre_authorized_code` is a bearer credential:
+  presenting it at the token endpoint is sufficient to obtain an access
+  token (and so the credential) on behalf of the holder
+  (OpenID4VCI §3.5). Deriving `Debug` meant any
+  `tracing::debug!("{:?}", offer)` or panic-on-unwrap would leak it
+  into logs. Manual `Debug` impl now redacts `pre_authorized_code`;
+  `tx_code` only carries config metadata (input mode, length,
+  description) and remains visible.
+- Picks up the `affinidi-oid4vc-core` 0.1.2 `alg=none` rejection
+  through the workspace path dep (no Cargo.toml edit required — pinned
+  on `0.1`).

--- a/crates/protocols/affinidi-openid4vci/Cargo.toml
+++ b/crates/protocols/affinidi-openid4vci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-openid4vci"
 description = "OpenID for Verifiable Credential Issuance (OpenID4VCI) implementation."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-openid4vci/src/types.rs
+++ b/crates/protocols/affinidi-openid4vci/src/types.rs
@@ -165,7 +165,7 @@ pub struct AuthorizationCodeGrant {
 }
 
 /// Pre-authorized code grant parameters.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct PreAuthorizedCodeGrant {
     /// The pre-authorized code.
     #[serde(rename = "pre-authorized_code")]
@@ -174,6 +174,17 @@ pub struct PreAuthorizedCodeGrant {
     /// Whether a user PIN is required.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_code: Option<TxCodeConfig>,
+}
+
+impl std::fmt::Debug for PreAuthorizedCodeGrant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `pre_authorized_code` is a bearer credential redeemable at the token
+        // endpoint (OpenID4VCI §3.5) — never let it land in logs.
+        f.debug_struct("PreAuthorizedCodeGrant")
+            .field("pre_authorized_code", &"[REDACTED]")
+            .field("tx_code", &self.tx_code)
+            .finish()
+    }
 }
 
 /// Transaction code (PIN) configuration.


### PR DESCRIPTION
## Summary

PR D (final) of the security-batch series. Two OID4VC protocol crates.

| Crate | Bump | Class | Source patch |
|---|---|---|---|
| `affinidi-oid4vc-core` | 0.1.1 → **0.1.2** | `alg=none` / empty signature accepted as verified (CRITICAL) | `0007` |
| `affinidi-openid4vci` | 0.1.1 → **0.1.2** | bearer credential in `Debug` | `0015` |

### Severity

- **CRITICAL — signature bypass** (`affinidi-oid4vc-core`). `decode_compact_jws_verified()` handed the signing input straight to the caller-supplied `JwtVerifier` without inspecting the protected header. The security of every SIOPv2 / OID4VCI / OID4VP token check depended on each verifier impl happening to reject a zero-length input — true for `Es256Verifier` today, but one permissive impl turns `{"alg":"none"}.<payload>.` into a verified token.
- **HIGH — bearer credential in `Debug`** (`affinidi-openid4vci`). `PreAuthorizedCodeGrant::pre_authorized_code` is sufficient on its own (or with the configured `tx_code` PIN) to redeem an access token at the issuer's token endpoint and obtain the credential. Deriving `Debug` meant any `tracing::debug!("{:?}", offer)` or panic-on-unwrap leaked it to logs.

### What changed

**`affinidi-oid4vc-core` 0.1.2** (`crates/protocols/affinidi-oid4vc-core/src/jwt.rs`)
- Decode the JWS protected header **before** any verifier is consulted.
- Refuse `alg: none` (case-insensitive), missing `alg`, and empty `parts[2]` (zero-length signature) with `JwtError::Verification`.
- The existing header/payload decode work that ran *after* `verifier.verify(...)` is moved up so the header decode isn't duplicated.
- New regression test `jwt::tests::rejects_alg_none`.

**`affinidi-openid4vci` 0.1.2** (`crates/protocols/affinidi-openid4vci/src/types.rs`)
- `PreAuthorizedCodeGrant` no longer derives `Debug`. Manual impl renders `pre_authorized_code` as `[REDACTED]` while keeping `tx_code` (input mode, length, description) visible for legitimate debugging.
- `Serialize` / `Deserialize` unchanged — wire format and persistence are unaffected.

### Dependency-cascade notes

- `affinidi-openid4vci` depends on `affinidi-oid4vc-core` via path with `version = "0.1"` — picks up the `alg=none` fix automatically. No Cargo.toml edit required.
- Both stay within 0.1.x.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p affinidi-oid4vc-core -p affinidi-openid4vci --all-targets` — builds (21s)
- [x] `cargo test -p affinidi-oid4vc-core --lib` — **21 passed**, 0 failed (incl. new `jwt::tests::rejects_alg_none`)
- [x] `cargo test -p affinidi-openid4vci --lib` — **16 passed**, 0 failed
- [ ] Workspace clippy / coverage / wiz-cli — deferred to CI

## Source patch mapping

- `0007-affinidi-oid4vc-core-reject-alg-none-empty-signature.patch` → commit 1
- `0015-affinidi-openid4vci-redact-pre_authorized_code-in-De.patch` → commit 2
- version + CHANGELOG bumps → commit 3

## Series summary

This closes out the 25-patch security batch dropped in `~/Downloads/patches/affinidi-tdk-rs`. The full series:

| PR | Scope | Crates |
|---|---|---|
| #316 (merged) | mediator + text-client | mediator 0.15.5, text-client 0.12.2 |
| #317 (merged) | messaging core | didcomm 0.13.3, sdk 0.18.3 |
| #318 | core key-material redaction | crypto 0.1.7, secrets-resolver 0.5.6, tdk-common 0.6.2 |
| #319 | identity SSRF + token hardening | did-web 0.1.1, did-ebsi 0.1.2, did-resolver-cache-server 0.7.5, did-authentication 0.3.3 |
| #320 | credentials verification + DoS cap | sd-jwt 0.1.2, status-list 0.1.2, mdoc 0.2.0 |
| **this PR** | OID4VC | oid4vc-core 0.1.2, openid4vci 0.1.2 |