### PR TITLE
feat: mediator 0.15.6 — CORS policy in setup wizard + sub-domain wildcards

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Changelog history
 
+## 31st May 2026
+
+### 0.15.6 — CORS policy in the setup wizard + sub-domain wildcards
+
+Additive, backward-compatible release. Existing `cors_allow_origin`
+configs keep their current behaviour; no configuration changes are
+required.
+
+#### Added
+
+- **CORS policy question in `mediator-setup`.** The Security series of
+  the setup wizard now asks for the browser CORS policy and writes the
+  result to `[security].cors_allow_origin`. Three choices:
+  - **Deny all cross-origin** (default) — leaves `cors_allow_origin`
+    unset (the mediator's existing default-closed posture).
+  - **Allow any origin** — writes `cors_allow_origin = "*"`. Suggested
+    for public mediators; safe because the endpoints gate on a bearer
+    token, not an ambient cookie.
+  - **Specific domains** — collects a validated, comma-separated
+    allowlist (written verbatim).
+  The choice is also surfaced on the review screen and round-trips
+  through the build-recipe (`[security].cors` / `cors_domains`).
+- **Sub-domain wildcard origins.** `cors_allow_origin` now accepts
+  leftmost-label wildcards such as `https://*.affinidi.com` alongside
+  exact origins. A wildcard matches any sub-domain of the suffix (at any
+  depth) with an exact scheme and port; the matched request `Origin` is
+  echoed back, so responses stay CORS-spec compliant (the
+  `Access-Control-Allow-Origin` header itself has no wildcard form). A
+  wildcard does **not** cover its own apex — add `https://affinidi.com`
+  explicitly if needed. The same matcher backs both the REST `CorsLayer`
+  and the WebSocket `Origin` defence-in-depth check, so the two cannot
+  drift apart.
+
 ## 24th May 2026
 
 ### 0.15.5 — vta-sdk 0.7 + messaging security fixes

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.5"
+version = "0.15.6"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -184,10 +184,22 @@ jwt_refresh_expiry = "86400"
 ### unset (the default) to disable cross-origin access entirely.
 ###
 ### Accepts either:
-###   - a comma-separated list of explicit, scheme-qualified origins,
-###     each echoed back in `Access-Control-Allow-Origin` only for a
-###     matching request Origin, e.g.
-###     "https://affinidi.com,https://example2.com"; or
+###   - a comma-separated allowlist whose entries are each one of:
+###       * an exact, scheme-qualified origin, echoed back in
+###         `Access-Control-Allow-Origin` only for a matching request
+###         Origin, e.g. "https://affinidi.com,https://example2.com"; or
+###       * a leftmost-label sub-domain wildcard, e.g.
+###         "https://*.affinidi.com". This matches any sub-domain of
+###         affinidi.com at any depth (app.affinidi.com, a.b.affinidi.com)
+###         and echoes back the exact request Origin that matched. The
+###         scheme and port must match exactly (pin a port with
+###         "https://*.affinidi.com:8443"); the '*' is only valid as the
+###         entire leftmost host label. NOTE: a wildcard does NOT cover
+###         its own apex — "https://*.affinidi.com" does not match
+###         "https://affinidi.com"; add the apex explicitly if needed.
+###     (The CORS spec's Access-Control-Allow-Origin header has no
+###     wildcard-subdomain form; the mediator implements "*.suffix" by
+###     matching the request Origin and echoing the exact match.)
 ###   - a single "*" to allow ANY origin. A wildcard is safe here only
 ###     because these endpoints authenticate with a bearer token in the
 ###     `Authorization` header (not an ambient cookie): a cross-origin

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -35,8 +35,137 @@ pub enum CorsOriginPolicy {
     /// need a valid token to do anything. Emits `Access-Control-Allow-
     /// Origin: *` and never sets `allow_credentials`.
     Any,
-    /// An explicit allowlist of scheme-qualified origins.
-    List(Vec<HeaderValue>),
+    /// An explicit allowlist of origin matchers. Each entry is either an
+    /// exact, scheme-qualified origin or a `scheme://*.suffix` wildcard
+    /// (see [`OriginMatcher`]). A request `Origin` is permitted iff it
+    /// matches at least one entry; the matched origin is echoed back, so
+    /// the response stays CORS-spec compliant (one exact origin, never a
+    /// literal `*.…`).
+    List(Vec<OriginMatcher>),
+}
+
+/// A single entry in a [`CorsOriginPolicy::List`] allowlist.
+///
+/// The CORS spec's `Access-Control-Allow-Origin` header only carries a
+/// bare `*`, a single exact origin, or `null` — there is no
+/// wildcard-subdomain token. We support `*.suffix` patterns by matching
+/// the *request* `Origin` against the pattern and echoing back the exact
+/// origin that matched (which is what [`AllowOrigin::predicate`] does).
+#[derive(Clone, Debug)]
+pub enum OriginMatcher {
+    /// An exact, scheme-qualified origin, compared byte-for-byte against
+    /// the request `Origin` (e.g. `https://app.affinidi.com`).
+    Exact(HeaderValue),
+    /// A `scheme://*.suffix[:port]` wildcard (e.g. `https://*.affinidi.com`).
+    ///
+    /// Matches a request origin iff the scheme and port match exactly and
+    /// the request host is a sub-domain of `suffix` — i.e. it ends with
+    /// `.suffix` and has at least one label in front of that boundary
+    /// dot. The boundary dot is mandatory, so `https://*.affinidi.com`
+    /// matches `https://app.affinidi.com` and `https://a.b.affinidi.com`
+    /// but NOT the apex `https://affinidi.com` (add it explicitly) nor a
+    /// look-alike like `https://evilaffinidi.com`.
+    WildcardSubdomain {
+        /// Lower-cased scheme, e.g. `https`.
+        scheme: String,
+        /// Lower-cased registrable suffix the sub-domain must sit under,
+        /// e.g. `affinidi.com`.
+        suffix: String,
+        /// Explicit port the request origin must carry, if the pattern
+        /// pinned one (`https://*.x.com:8443`). `None` means the origin
+        /// must carry no port either.
+        port: Option<u16>,
+    },
+}
+
+/// A request `Origin` decomposed into the three parts that matter for
+/// matching: scheme (lower-cased), host (lower-cased), optional port.
+/// Origins are serialised without a path/query, so this is a total parse
+/// of a well-formed `Origin` header; anything that doesn't fit the
+/// `scheme://host[:port]` shape returns `None` and never matches.
+struct ParsedOrigin<'a> {
+    scheme: String,
+    host: String,
+    port: Option<&'a str>,
+}
+
+impl<'a> ParsedOrigin<'a> {
+    fn parse(origin: &'a str) -> Option<Self> {
+        let (scheme, rest) = origin.split_once("://")?;
+        if scheme.is_empty() || rest.is_empty() {
+            return None;
+        }
+        // An Origin carries no path/userinfo/query. Reject anything that
+        // smuggles one in rather than silently matching on a prefix.
+        if rest.contains(['/', '?', '#', '@', '\\']) {
+            return None;
+        }
+        let (host, port) = match rest.rsplit_once(':') {
+            // A ':' that isn't followed by an all-digit port isn't a port
+            // separator (defensive — Origin hosts are never IPv6-bracketed
+            // here, but treat a non-numeric tail as "no port" so it can't
+            // masquerade as one).
+            Some((h, p)) if !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) => (h, Some(p)),
+            _ => (rest, None),
+        };
+        if host.is_empty() {
+            return None;
+        }
+        Some(ParsedOrigin {
+            scheme: scheme.to_ascii_lowercase(),
+            host: host.to_ascii_lowercase(),
+            port,
+        })
+    }
+}
+
+impl OriginMatcher {
+    /// Whether this matcher admits the given request `Origin` header.
+    fn matches(&self, origin: &HeaderValue) -> bool {
+        match self {
+            // Exact origins are compared byte-for-byte, exactly as the
+            // previous `AllowOrigin::list` did — no normalisation.
+            OriginMatcher::Exact(expected) => expected == origin,
+            OriginMatcher::WildcardSubdomain {
+                scheme,
+                suffix,
+                port,
+            } => {
+                let Ok(origin) = origin.to_str() else {
+                    return false;
+                };
+                let Some(parsed) = ParsedOrigin::parse(origin) else {
+                    return false;
+                };
+                // Scheme and port must match exactly — a wildcard widens
+                // only the host, never the scheme/port. Compare ports by
+                // their string form so `:08443` can't slip past `:8443`.
+                if &parsed.scheme != scheme
+                    || parsed.port.map(str::to_string) != port.as_ref().map(u16::to_string)
+                {
+                    return false;
+                }
+                // Sub-domain check with a mandatory boundary dot: the host
+                // must end with ".<suffix>" and have ≥1 label in front, so
+                // neither the apex (`suffix`) nor a look-alike
+                // (`evil<suffix>`) can match.
+                parsed
+                    .host
+                    .strip_suffix(suffix)
+                    .and_then(|head| head.strip_suffix('.'))
+                    .is_some_and(|label| !label.is_empty())
+            }
+        }
+    }
+}
+
+/// Whether `origin` is admitted by any matcher in `matchers`.
+///
+/// Shared by the REST [`CorsLayer`] predicate and the WebSocket
+/// defence-in-depth `Origin` check so the two enforcement points can
+/// never drift apart.
+pub fn origin_matches(matchers: &[OriginMatcher], origin: &HeaderValue) -> bool {
+    matchers.iter().any(|m| m.matches(origin))
 }
 
 /// Build the mediator's [`CorsLayer`] for the given origin policy. The
@@ -57,7 +186,15 @@ fn build_cors_layer(policy: &CorsOriginPolicy) -> CorsLayer {
         // Default-closed: an empty allowlist never echoes an origin.
         CorsOriginPolicy::None => base,
         CorsOriginPolicy::Any => base.allow_origin(AllowOrigin::any()),
-        CorsOriginPolicy::List(origins) => base.allow_origin(origins.clone()),
+        // A predicate (rather than `AllowOrigin::list`) so `*.suffix`
+        // wildcards can match; `AllowOrigin::predicate` echoes back the
+        // exact request origin on a match and sets `Vary: Origin`.
+        CorsOriginPolicy::List(matchers) => {
+            let matchers = matchers.clone();
+            base.allow_origin(AllowOrigin::predicate(move |origin, _parts| {
+                origin_matches(&matchers, origin)
+            }))
+        }
     }
 }
 
@@ -188,11 +325,12 @@ impl SecurityConfigRaw {
     /// [`CorsOriginPolicy`].
     ///
     /// - empty / whitespace-only ⇒ [`CorsOriginPolicy::None`]
-    /// - a `*` token ⇒ [`CorsOriginPolicy::Any`] (a bare wildcard;
-    ///   `tower_http`'s origin list would otherwise *panic* on `*`).
-    ///   If `*` is mixed with explicit origins the explicit entries are
-    ///   redundant and a warning is logged.
-    /// - otherwise ⇒ [`CorsOriginPolicy::List`] of the explicit origins.
+    /// - a bare `*` token ⇒ [`CorsOriginPolicy::Any`] (`tower_http`'s
+    ///   origin list would otherwise *panic* on `*`). If `*` is mixed
+    ///   with explicit origins the explicit entries are redundant and a
+    ///   warning is logged.
+    /// - otherwise ⇒ [`CorsOriginPolicy::List`] of matchers, each an
+    ///   exact origin or a `scheme://*.suffix[:port]` wildcard.
     fn parse_cors_origins(cors_allow_origin: &str) -> Result<CorsOriginPolicy, MediatorError> {
         let tokens: Vec<&str> = cors_allow_origin
             .split(',')
@@ -214,20 +352,83 @@ impl SecurityConfigRaw {
             return Ok(CorsOriginPolicy::Any);
         }
 
-        let origins = tokens
+        let matchers = tokens
             .iter()
-            .map(|o| {
-                o.parse::<HeaderValue>().map_err(|err| {
-                    MediatorError::ConfigError(
-                        12,
-                        "NA".into(),
-                        format!("Invalid CORS origin '{o}': {err}"),
-                    )
-                })
-            })
+            .map(|o| Self::parse_origin_matcher(o))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(CorsOriginPolicy::List(origins))
+        Ok(CorsOriginPolicy::List(matchers))
+    }
+
+    /// Parse a single allowlist entry into an [`OriginMatcher`].
+    ///
+    /// Wildcard entries have the shape `scheme://*.suffix[:port]` — the
+    /// `*` must be the entire leftmost host label (i.e. immediately
+    /// followed by `.`) and is the only `*` allowed. Everything *without*
+    /// a `*` is treated as an exact origin and parsed as a [`HeaderValue`]
+    /// exactly as before this matcher existed (so existing exact-origin
+    /// configs are unaffected).
+    fn parse_origin_matcher(token: &str) -> Result<OriginMatcher, MediatorError> {
+        let config_err = |msg: String| MediatorError::ConfigError(12, "NA".into(), msg);
+
+        // Fast path: no '*' ⇒ exact origin, parsed verbatim (unchanged
+        // legacy behaviour — scheme requirement is enforced by the
+        // wizard, not here, so we don't reject pre-existing configs).
+        if !token.contains('*') {
+            let value = token
+                .parse::<HeaderValue>()
+                .map_err(|err| config_err(format!("Invalid CORS origin '{token}': {err}")))?;
+            return Ok(OriginMatcher::Exact(value));
+        }
+
+        // Wildcard form: must be exactly `scheme://*.suffix[:port]`.
+        let Some((scheme, rest)) = token.split_once("://") else {
+            return Err(config_err(format!(
+                "Invalid CORS origin '{token}': '*' is only supported as a leftmost \
+                 sub-domain wildcard, e.g. 'https://*.example.com'"
+            )));
+        };
+        let Some(suffix) = rest.strip_prefix("*.") else {
+            return Err(config_err(format!(
+                "Invalid CORS origin '{token}': '*' is only allowed as the leftmost host \
+                 label, written as '{scheme}://*.suffix'"
+            )));
+        };
+        if scheme.is_empty() {
+            return Err(config_err(format!(
+                "Invalid CORS origin '{token}': missing scheme before '://'"
+            )));
+        }
+        // Only the single leftmost `*` is permitted.
+        if suffix.contains('*') {
+            return Err(config_err(format!(
+                "Invalid CORS origin '{token}': only one leftmost '*' wildcard is allowed"
+            )));
+        }
+        // Split an optional :port off the suffix.
+        let (host_suffix, port) = match suffix.rsplit_once(':') {
+            Some((h, p)) => {
+                let port: u16 = p.parse().map_err(|_| {
+                    config_err(format!("Invalid CORS origin '{token}': bad port '{p}'"))
+                })?;
+                (h, Some(port))
+            }
+            None => (suffix, None),
+        };
+        if host_suffix.is_empty()
+            || host_suffix.starts_with('.')
+            || host_suffix.contains(['/', '?', '#', '@', '\\'])
+        {
+            return Err(config_err(format!(
+                "Invalid CORS origin '{token}': '{host_suffix}' is not a valid wildcard \
+                 suffix (expected e.g. 'https://*.example.com')"
+            )));
+        }
+        Ok(OriginMatcher::WildcardSubdomain {
+            scheme: scheme.to_ascii_lowercase(),
+            suffix: host_suffix.to_ascii_lowercase(),
+            port,
+        })
     }
 
     /// Build the runtime `SecurityConfig` from the raw TOML values.
@@ -461,7 +662,26 @@ impl SecurityConfigRaw {
 
 #[cfg(test)]
 mod tests {
-    use super::{CorsOriginPolicy, SecurityConfigRaw};
+    use super::{CorsOriginPolicy, OriginMatcher, SecurityConfigRaw, origin_matches};
+    use http::HeaderValue;
+
+    /// Parse `spec` into a `List` policy and return its matchers, or panic
+    /// with the actual variant for a clearer failure than `unwrap`.
+    fn matchers(spec: &str) -> Vec<OriginMatcher> {
+        match SecurityConfigRaw::parse_cors_origins(spec).unwrap() {
+            CorsOriginPolicy::List(m) => m,
+            other => panic!("expected List for {spec:?}, got {other:?}"),
+        }
+    }
+
+    fn hv(s: &str) -> HeaderValue {
+        HeaderValue::from_str(s).unwrap()
+    }
+
+    /// Does `spec`'s allowlist admit request origin `origin`?
+    fn allows(spec: &str, origin: &str) -> bool {
+        origin_matches(&matchers(spec), &hv(origin))
+    }
 
     #[test]
     fn empty_origins_parse_to_none() {
@@ -496,15 +716,120 @@ mod tests {
 
     #[test]
     fn explicit_origins_parse_to_list() {
-        let policy =
-            SecurityConfigRaw::parse_cors_origins("https://a.example, https://b.example").unwrap();
-        match policy {
-            CorsOriginPolicy::List(origins) => {
-                assert_eq!(origins.len(), 2);
-                assert_eq!(origins[0], "https://a.example");
-                assert_eq!(origins[1], "https://b.example");
+        let origins = matchers("https://a.example, https://b.example");
+        assert_eq!(origins.len(), 2);
+        assert!(matches!(&origins[0], OriginMatcher::Exact(v) if v == "https://a.example"));
+        assert!(matches!(&origins[1], OriginMatcher::Exact(v) if v == "https://b.example"));
+    }
+
+    #[test]
+    fn exact_origin_matches_byte_for_byte() {
+        assert!(allows("https://a.example", "https://a.example"));
+        // No normalisation — a trailing slash, differing case in the
+        // host, or an extra port are all distinct origins.
+        assert!(!allows("https://a.example", "https://a.example/"));
+        assert!(!allows("https://a.example", "https://a.example:443"));
+        assert!(!allows("https://a.example", "http://a.example"));
+    }
+
+    #[test]
+    fn wildcard_parses_and_lowercases() {
+        let m = matchers("HTTPS://*.Affinidi.COM");
+        assert_eq!(m.len(), 1);
+        match &m[0] {
+            OriginMatcher::WildcardSubdomain {
+                scheme,
+                suffix,
+                port,
+            } => {
+                assert_eq!(scheme, "https");
+                assert_eq!(suffix, "affinidi.com");
+                assert_eq!(*port, None);
             }
-            other => panic!("expected List, got {other:?}"),
+            other => panic!("expected WildcardSubdomain, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn wildcard_matches_subdomains_at_any_depth() {
+        assert!(allows("https://*.affinidi.com", "https://app.affinidi.com"));
+        assert!(allows("https://*.affinidi.com", "https://a.b.affinidi.com"));
+        // Case-insensitive host comparison.
+        assert!(allows("https://*.affinidi.com", "https://App.Affinidi.Com"));
+    }
+
+    #[test]
+    fn wildcard_rejects_apex_and_lookalikes() {
+        // The boundary dot is mandatory: the apex needs an explicit entry.
+        assert!(!allows("https://*.affinidi.com", "https://affinidi.com"));
+        // A look-alike registrable domain must not slip through.
+        assert!(!allows(
+            "https://*.affinidi.com",
+            "https://evilaffinidi.com"
+        ));
+        assert!(!allows(
+            "https://*.affinidi.com",
+            "https://affinidi.com.evil.com"
+        ));
+        // An empty leftmost label ("https://.affinidi.com") isn't a
+        // sub-domain.
+        assert!(!allows("https://*.affinidi.com", "https://.affinidi.com"));
+    }
+
+    #[test]
+    fn wildcard_requires_exact_scheme_and_port() {
+        assert!(!allows("https://*.affinidi.com", "http://app.affinidi.com"));
+        // Pattern pins no port → an origin carrying one is rejected.
+        assert!(!allows(
+            "https://*.affinidi.com",
+            "https://app.affinidi.com:8443"
+        ));
+        // Pattern pins a port → it must match exactly.
+        assert!(allows(
+            "https://*.affinidi.com:8443",
+            "https://app.affinidi.com:8443"
+        ));
+        assert!(!allows(
+            "https://*.affinidi.com:8443",
+            "https://app.affinidi.com:8444"
+        ));
+        assert!(!allows(
+            "https://*.affinidi.com:8443",
+            "https://app.affinidi.com"
+        ));
+    }
+
+    #[test]
+    fn wildcard_rejects_path_smuggling_in_request_origin() {
+        // A malformed Origin that smuggles a path/userinfo must never
+        // match — these aren't valid serialised origins.
+        assert!(!allows(
+            "https://*.affinidi.com",
+            "https://app.affinidi.com/../evil.com"
+        ));
+        assert!(!allows(
+            "https://*.affinidi.com",
+            "https://evil.com@app.affinidi.com"
+        ));
+    }
+
+    #[test]
+    fn exact_and_wildcard_entries_coexist() {
+        let spec = "https://*.affinidi.com, https://affinidi.com";
+        assert!(allows(spec, "https://app.affinidi.com")); // wildcard
+        assert!(allows(spec, "https://affinidi.com")); // exact apex
+        assert!(!allows(spec, "https://other.com"));
+    }
+
+    #[test]
+    fn invalid_entries_are_rejected_at_parse_time() {
+        // Wildcard not in the leftmost-label position.
+        assert!(SecurityConfigRaw::parse_cors_origins("https://app.*.com").is_err());
+        // More than one wildcard.
+        assert!(SecurityConfigRaw::parse_cors_origins("https://*.*.com").is_err());
+        // Bad port on a wildcard.
+        assert!(SecurityConfigRaw::parse_cors_origins("https://*.affinidi.com:notaport").is_err());
+        // Empty suffix.
+        assert!(SecurityConfigRaw::parse_cors_origins("https://*.").is_err());
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -4,7 +4,7 @@ use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat;
 use crate::{
     SharedData,
-    common::config::CorsOriginPolicy,
+    common::config::{CorsOriginPolicy, origin_matches},
     common::jwt_auth::{AuthError, authenticate_token},
     common::session::Session,
     messages::inbound::handle_inbound,
@@ -112,7 +112,10 @@ fn ws_origin_allowed(policy: &CorsOriginPolicy, origin: Option<&HeaderValue>) ->
         None => true,
         Some(origin) => match policy {
             CorsOriginPolicy::Any => true,
-            CorsOriginPolicy::List(allowed) => allowed.iter().any(|a| a == origin),
+            // Reuse the *same* matcher the REST CORS layer uses so the
+            // two enforcement points (incl. `*.suffix` wildcards) can't
+            // drift apart.
+            CorsOriginPolicy::List(matchers) => origin_matches(matchers, origin),
             // No cross-origin browser access configured ⇒ refuse any
             // request that announces an Origin.
             CorsOriginPolicy::None => false,
@@ -502,10 +505,15 @@ mod tests {
     use super::{
         CorsOriginPolicy, app_subprotocols, extract_bearer_subprotocol, ws_origin_allowed,
     };
+    use crate::common::config::OriginMatcher;
     use http::HeaderValue;
 
     fn hv(s: &str) -> HeaderValue {
         HeaderValue::from_str(s).expect("valid header value")
+    }
+
+    fn exact(s: &str) -> OriginMatcher {
+        OriginMatcher::Exact(hv(s))
     }
 
     #[test]
@@ -567,7 +575,7 @@ mod tests {
         assert!(ws_origin_allowed(&CorsOriginPolicy::None, None));
         assert!(ws_origin_allowed(&CorsOriginPolicy::Any, None));
         assert!(ws_origin_allowed(
-            &CorsOriginPolicy::List(vec![hv("https://app.example")]),
+            &CorsOriginPolicy::List(vec![exact("https://app.example")]),
             None
         ));
     }
@@ -586,10 +594,33 @@ mod tests {
 
     #[test]
     fn origin_check_list_policy_matches_allowlist() {
-        let policy = CorsOriginPolicy::List(vec![hv("https://app.example")]);
+        let policy = CorsOriginPolicy::List(vec![exact("https://app.example")]);
         let allowed = hv("https://app.example");
         let denied = hv("https://other.example");
         assert!(ws_origin_allowed(&policy, Some(&allowed)));
         assert!(!ws_origin_allowed(&policy, Some(&denied)));
+    }
+
+    #[test]
+    fn origin_check_list_policy_honours_wildcards() {
+        // Parity with the REST CORS layer: the WS check must accept the
+        // same `*.suffix` wildcards (and reject the apex / look-alikes).
+        let policy = CorsOriginPolicy::List(vec![OriginMatcher::WildcardSubdomain {
+            scheme: "https".into(),
+            suffix: "affinidi.com".into(),
+            port: None,
+        }]);
+        assert!(ws_origin_allowed(
+            &policy,
+            Some(&hv("https://app.affinidi.com"))
+        ));
+        assert!(!ws_origin_allowed(
+            &policy,
+            Some(&hv("https://affinidi.com"))
+        ));
+        assert!(!ws_origin_allowed(
+            &policy,
+            Some(&hv("https://evilaffinidi.com"))
+        ));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.3"
+version = "0.1.4"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
@@ -110,6 +110,21 @@ admin = "generate"
 #              local_direct_delivery_allowed = "true"
 network_mode = "open"
 
+# cors: "none" (default) | "any" | "list"
+#   none — deny all cross-origin browser access. `cors_allow_origin` is left
+#          unset. Right for mediators with no browser-based clients.
+#   any  — allow any origin. Wizard emits `cors_allow_origin = "*"`. Suggested
+#          for public mediators (endpoints gate on a bearer token, so a
+#          wildcard is not a CSRF risk).
+#   list — allow only the origins in `cors_domains` (required for this mode).
+#          Each entry is an exact, scheme-qualified origin
+#          (https://app.affinidi.com) or a leftmost-label sub-domain wildcard
+#          (https://*.affinidi.com, optionally with a :port). Scheme and port
+#          must match exactly; a wildcard does NOT cover its apex domain.
+cors = "none"
+# Required when cors = "list":
+# cors_domains = "https://app.affinidi.com,https://*.affinidi.com"
+
 
 # ── Database ────────────────────────────────────────────────────────────────
 [database]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -269,8 +269,15 @@ pub enum SecurityPhase {
     /// Pick the mediator's network posture — Open (any DID can message
     /// any other; per-DID overrides flip individual flags) vs Closed
     /// (every cross-DID exchange needs an explicit ACL grant). Renders
-    /// after `JwtMode` and before the step advances to `Database`.
+    /// after `JwtMode` and before `CorsPolicy`.
     NetworkMode,
+    /// Pick the browser CORS policy for the REST/WebSocket endpoints —
+    /// Any (`*`) / None (default, deny all) / Specific domains. The
+    /// "Specific" choice drops into a text-input sub-phase (still
+    /// `CorsPolicy`, `InputMode::TextInput`) collecting the allowlist.
+    /// Renders after `NetworkMode`; confirming it (or the domains input)
+    /// is what finally advances the step to `Database`.
+    CorsPolicy,
 }
 
 /// Sub-phases of the `Database` step. The wizard now asks up to three
@@ -402,6 +409,17 @@ pub struct WizardConfig {
     /// `global_acl_default`, and `local_direct_delivery_allowed` that
     /// `config_writer::write_config` emits.
     pub network_mode: String,
+    /// Browser CORS policy mode written to `[security].cors_allow_origin`:
+    /// `"none"` (default — key unset, deny all cross-origin), `"any"`
+    /// (`*`), or `"list"` (the [`Self::cors_domains`] allowlist). See
+    /// [`crate::consts::CORS_MODE_NONE`] / `_ANY` / `_LIST`.
+    pub cors_mode: String,
+    /// Comma-separated CORS origin allowlist, meaningful only when
+    /// `cors_mode == "list"`. Each entry is an exact, scheme-qualified
+    /// origin (`https://app.affinidi.com`) or a leftmost-label sub-domain
+    /// wildcard (`https://*.affinidi.com`). Validated by
+    /// [`validate_cors_domains`] before the wizard accepts it.
+    pub cors_domains: String,
     pub database_url: String,
     /// Storage backend the generated `mediator.toml` selects:
     /// `"redis"` (default) or `"fjall"`. Mirrors `[storage].backend`
@@ -520,6 +538,8 @@ impl Default for WizardConfig {
             vta_webvh_self_host_url: String::new(),
             jwt_mode: JWT_MODE_GENERATE.into(),
             network_mode: crate::consts::DEFAULT_NETWORK_MODE.into(),
+            cors_mode: crate::consts::DEFAULT_CORS_MODE.into(),
+            cors_domains: String::new(),
             database_url: DEFAULT_REDIS_URL.into(),
             storage_backend: crate::consts::DEFAULT_STORAGE_BACKEND.into(),
             fjall_data_dir: crate::consts::DEFAULT_FJALL_DATA_DIR.into(),
@@ -552,6 +572,111 @@ pub(crate) fn validate_fjall_data_dir(path: &str) -> Result<(), String> {
     if p.exists() && !p.is_dir() {
         return Err(format!(
             "'{trimmed}' exists but is not a directory — pick another path.",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the CORS "Specific domains" allowlist the operator typed and
+/// return its normalised (trimmed, comma-joined) form.
+///
+/// Each comma-separated entry must be one of:
+///   * an exact, scheme-qualified origin — `https://app.affinidi.com`; or
+///   * a leftmost-label sub-domain wildcard — `https://*.affinidi.com`
+///     (optionally with a port: `https://*.affinidi.com:8443`).
+///
+/// Unlike the mediator's lenient server-side parse, the wizard *requires*
+/// a scheme on every entry (per the operator's chosen validation policy)
+/// and rejects a bare `*` — that's the separate "Allow any origin"
+/// choice, not a domain. The matching semantics enforced at runtime live
+/// in `affinidi_messaging_mediator`'s `OriginMatcher`; this function
+/// mirrors its accepted syntax so typos surface at wizard time rather
+/// than on first mediator boot.
+pub fn validate_cors_domains(input: &str) -> Result<String, String> {
+    let entries: Vec<&str> = input
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if entries.is_empty() {
+        return Err(
+            "Enter at least one origin (e.g. https://app.affinidi.com), or go back and pick \
+             \"Allow any origin\" / \"Deny all\"."
+                .into(),
+        );
+    }
+
+    for entry in &entries {
+        validate_cors_entry(entry)?;
+    }
+
+    Ok(entries.join(","))
+}
+
+/// Validate a single CORS allowlist entry. See [`validate_cors_domains`].
+fn validate_cors_entry(entry: &str) -> Result<(), String> {
+    if entry == "*" {
+        return Err(
+            "A bare '*' is not a domain — go back and pick \"Allow any origin\" instead.".into(),
+        );
+    }
+
+    let Some((scheme, host_port)) = entry.split_once("://") else {
+        return Err(format!(
+            "'{entry}' is missing a scheme — write e.g. 'https://app.affinidi.com' or \
+             'https://*.affinidi.com'."
+        ));
+    };
+    if scheme.is_empty() {
+        return Err(format!("'{entry}' is missing a scheme before '://'."));
+    }
+    if host_port.is_empty() {
+        return Err(format!("'{entry}' is missing a host after '://'."));
+    }
+    // No path / query / fragment / userinfo — an Origin is scheme + host
+    // (+ optional port) only.
+    if host_port.contains(['/', '?', '#', '@', '\\']) {
+        return Err(format!(
+            "'{entry}' must be an origin only (scheme + host [+ :port]) — drop any path, \
+             query, or '@'."
+        ));
+    }
+
+    // Wildcard form: '*' is allowed only as the entire leftmost label.
+    if entry.contains('*') {
+        let Some(suffix) = host_port.strip_prefix("*.") else {
+            return Err(format!(
+                "'{entry}': '*' is only allowed as the leftmost host label, written as \
+                 '{scheme}://*.suffix'."
+            ));
+        };
+        if suffix.contains('*') {
+            return Err(format!(
+                "'{entry}': only one leftmost '*' wildcard is allowed."
+            ));
+        }
+        // Validate the suffix shape. We intentionally do NOT require the
+        // suffix to contain a dot — `https://*.localhost` and other
+        // single-label internal hosts are legitimate, and this keeps the
+        // wizard in step with the mediator's own (dot-agnostic) matcher.
+        let host_suffix = suffix.rsplit_once(':').map_or(suffix, |(h, _)| h);
+        if host_suffix.is_empty() || host_suffix.starts_with('.') {
+            return Err(format!(
+                "'{entry}': '{host_suffix}' is not a valid wildcard suffix — use e.g. \
+                 '{scheme}://*.example.com'."
+            ));
+        }
+    }
+
+    // Final shape check: an origin carries no whitespace or control
+    // characters (the mediator parses exact origins into an HTTP
+    // `HeaderValue`, which rejects exactly these). Checked here without
+    // pulling in the `http` crate — the setup tool intentionally has no
+    // dependency on the mediator runtime.
+    if entry.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(format!(
+            "'{entry}' contains whitespace or control characters that aren't valid in an origin."
         ));
     }
     Ok(())
@@ -649,6 +774,11 @@ pub struct WizardApp {
     /// Cleared on a successful confirm or when the operator backs
     /// out of the step.
     pub database_validation_error: Option<String>,
+    /// Inline validation error surfaced on the Security step's CORS
+    /// "Specific domains" text-input screen when an entered origin isn't
+    /// a valid scheme-qualified origin or `*.subdomain` wildcard. Cleared
+    /// on a successful confirm or when re-entering the CORS phase.
+    pub cors_validation_error: Option<String>,
     /// First passphrase typed on the [`KeyStoragePhase::FilePassphrase`]
     /// screen. Held just long enough for the operator to retype it on
     /// the [`KeyStoragePhase::FilePassphraseConfirm`] screen — cleared
@@ -697,6 +827,7 @@ impl WizardApp {
             discovery_rx: None,
             clipboard_status: None,
             database_validation_error: None,
+            cors_validation_error: None,
             pending_passphrase: None,
             passphrase_validation_error: None,
         }
@@ -2231,7 +2362,25 @@ impl WizardApp {
                 ]
             }
             WizardStep::Security => {
-                if self.security_phase == Some(SecurityPhase::NetworkMode) {
+                if self.security_phase == Some(SecurityPhase::CorsPolicy) {
+                    // Order: index 0 = None (the mediator's default-closed
+                    // posture), so the first Enter keeps cross-origin
+                    // access off unless the operator opts in.
+                    vec![
+                        SelectionOption::new(
+                            "Deny all cross-origin (default)",
+                            "No browser may call the REST/WebSocket API cross-origin. Pick this for mediators with no browser-based clients.",
+                        ),
+                        SelectionOption::new(
+                            "Allow any origin (*)",
+                            "Any website may call the API. Suggested for public mediators — endpoints gate on a bearer token, not a cookie, so a wildcard is not a CSRF risk.",
+                        ),
+                        SelectionOption::new(
+                            "Specific domains",
+                            "Only listed origins are allowed. Next screen collects the allowlist (exact origins and/or *.subdomain wildcards).",
+                        ),
+                    ]
+                } else if self.security_phase == Some(SecurityPhase::NetworkMode) {
                     // Order matches the wizard default — Open is index 0
                     // so the operator's first Enter confirms the recommended
                     // posture without re-selecting.
@@ -2462,7 +2611,14 @@ impl WizardApp {
                 }
             }
             WizardStep::Security => {
-                if self.security_phase == Some(SecurityPhase::NetworkMode) {
+                if self.security_phase == Some(SecurityPhase::CorsPolicy) {
+                    match self.selection_index {
+                        0 => "Leaves `cors_allow_origin` unset. Browsers carrying an `Origin` header are refused on both the REST API and the WebSocket upgrade. Native clients (no Origin) are unaffected. This is the mediator's default.".into(),
+                        1 => "Emits `cors_allow_origin = \"*\"`. The mediator echoes `Access-Control-Allow-Origin: *` and never sets credentials. Safe here because every endpoint requires a bearer token — a wildcard does not enable CSRF.".into(),
+                        2 => "Emits `cors_allow_origin = \"<your list>\"`. The next screen collects a comma-separated allowlist. Each request Origin must match an entry exactly, or fall under a `*.subdomain` wildcard; the matched origin is echoed back.".into(),
+                        _ => String::new(),
+                    }
+                } else if self.security_phase == Some(SecurityPhase::NetworkMode) {
                     match self.selection_index {
                         0 => "Open mode emits `mediator_acl_mode = \"explicit_deny\"`, `global_acl_default = \"ALLOW_ALL\"`, and `local_direct_delivery_allowed = \"true\"`. Any DID may reach any other by default; use the ACL to deny on a per-DID basis.".into(),
                         1 => "Closed mode keeps the historical posture: `mediator_acl_mode = \"explicit_allow\"` with a denying default ACL. Every cross-DID exchange requires an explicit ACL grant. Pick this for restricted or invitation-only deployments.".into(),
@@ -2771,18 +2927,43 @@ impl WizardApp {
                 }
             }
             WizardStep::Security => {
-                // Three-phase step: SSL → JWT mode → Network mode. Each
-                // sub-phase reuses `selection_index` for its own pick;
-                // the last one (NetworkMode) is what finally advances
-                // to `Database`.
+                // Four-phase step: SSL → JWT mode → Network mode → CORS
+                // policy. Each sub-phase reuses `selection_index` for its
+                // own pick; the last one (CorsPolicy) is what finally
+                // advances to `Database`.
+                if self.security_phase == Some(SecurityPhase::CorsPolicy) {
+                    match self.selection_index {
+                        0 => {
+                            self.config.cors_mode = crate::consts::CORS_MODE_NONE.into();
+                            self.security_phase = None;
+                            self.advance();
+                        }
+                        1 => {
+                            self.config.cors_mode = crate::consts::CORS_MODE_ANY.into();
+                            self.security_phase = None;
+                            self.advance();
+                        }
+                        2 => {
+                            // Specific domains: stay in the CorsPolicy
+                            // phase but switch to the text-input widget to
+                            // collect the allowlist. `confirm_text_input`
+                            // validates and advances.
+                            self.config.cors_mode = crate::consts::CORS_MODE_LIST.into();
+                            self.cors_validation_error = None;
+                            self.mode = InputMode::TextInput;
+                            self.text_input = Input::new(self.config.cors_domains.clone());
+                        }
+                        _ => {}
+                    }
+                    return;
+                }
                 if self.security_phase == Some(SecurityPhase::NetworkMode) {
                     self.config.network_mode = match self.selection_index {
                         0 => crate::consts::NETWORK_MODE_OPEN.into(),
                         1 => crate::consts::NETWORK_MODE_CLOSED.into(),
                         _ => return,
                     };
-                    self.security_phase = None;
-                    self.advance();
+                    self.enter_cors_policy_phase();
                     return;
                 }
                 if self.security_phase == Some(SecurityPhase::JwtMode) {
@@ -3368,6 +3549,22 @@ impl WizardApp {
         };
     }
 
+    /// Enter the CORS-policy sub-phase. Runs after network mode has been
+    /// settled and is the final Security sub-phase before the step
+    /// advances. Pre-selects the operator's last choice so re-entry is
+    /// idempotent; defaults to None (index 0) on a fresh run — the
+    /// mediator's default-closed cross-origin posture.
+    fn enter_cors_policy_phase(&mut self) {
+        self.security_phase = Some(SecurityPhase::CorsPolicy);
+        self.mode = InputMode::Selecting;
+        self.cors_validation_error = None;
+        self.selection_index = match self.config.cors_mode.as_str() {
+            crate::consts::CORS_MODE_ANY => 1,
+            crate::consts::CORS_MODE_LIST => 2,
+            _ => 0,
+        };
+    }
+
     /// Strip any URL path so the stripped `<scheme>://<host>[:port]`
     /// lands on the VTA's `CreateDidWebvhRequest.url`. webvh resolves
     /// to `<url>/.well-known/did.jsonl`, so a trailing `/mediator/v1`
@@ -3491,6 +3688,26 @@ impl WizardApp {
                 self.advance();
             }
             WizardStep::Security => {
+                // The CORS "Specific domains" allowlist runs as a
+                // text-input sub-phase of CorsPolicy. Validate before
+                // accepting; a bad entry surfaces inline and keeps the
+                // operator on the input screen.
+                if self.security_phase == Some(SecurityPhase::CorsPolicy) {
+                    let value = self.text_input.value().trim().to_string();
+                    match validate_cors_domains(&value) {
+                        Ok(normalised) => {
+                            self.config.cors_domains = normalised;
+                            self.cors_validation_error = None;
+                            self.security_phase = None;
+                            self.mode = InputMode::Selecting;
+                            self.advance();
+                        }
+                        Err(err) => {
+                            self.cors_validation_error = Some(err);
+                        }
+                    }
+                    return;
+                }
                 // First text input: cert path, then key path. After the
                 // key path is saved, drop into the JWT-mode selection
                 // rather than advancing straight to Database.
@@ -5321,9 +5538,17 @@ mod tests {
         assert_eq!(app.security_phase, Some(SecurityPhase::NetworkMode));
         assert_eq!(app.current_step, WizardStep::Security);
 
-        // Default network-mode selection is "open" (index 0).
+        // Default network-mode selection is "open" (index 0). Confirming
+        // it now transitions to the CORS sub-phase rather than advancing.
         app.select_current();
         assert_eq!(app.config.network_mode, crate::consts::NETWORK_MODE_OPEN);
+        assert_eq!(app.security_phase, Some(SecurityPhase::CorsPolicy));
+        assert_eq!(app.current_step, WizardStep::Security);
+
+        // Default CORS selection is "none" (index 0) — confirming lands
+        // on Database.
+        app.select_current();
+        assert_eq!(app.config.cors_mode, crate::consts::CORS_MODE_NONE);
         assert!(app.security_phase.is_none());
         assert_eq!(app.current_step, WizardStep::Database);
     }
@@ -5343,17 +5568,23 @@ mod tests {
         assert_eq!(app.security_phase, Some(SecurityPhase::NetworkMode));
         assert_eq!(app.current_step, WizardStep::Security);
 
-        // Confirm the default open posture to land on Database.
+        // Confirm the default open posture; the CORS sub-phase follows.
         app.selection_index = 0;
         app.select_current();
         assert_eq!(app.config.network_mode, crate::consts::NETWORK_MODE_OPEN);
+        assert_eq!(app.security_phase, Some(SecurityPhase::CorsPolicy));
+
+        // Default CORS = none → Database.
+        app.selection_index = 0;
+        app.select_current();
+        assert_eq!(app.config.cors_mode, crate::consts::CORS_MODE_NONE);
         assert_eq!(app.current_step, WizardStep::Database);
     }
 
     #[test]
     fn security_network_mode_closed_records_choice() {
         // Walk through the full Security flow and pick Closed at the
-        // last sub-phase to confirm the choice persists.
+        // network sub-phase to confirm the choice persists.
         let mut app = WizardApp::new("test.toml".into());
         app.current_step = WizardStep::Security;
         app.selection_index = 0; // No SSL
@@ -5364,7 +5595,95 @@ mod tests {
         app.selection_index = 1; // Closed
         app.select_current();
         assert_eq!(app.config.network_mode, crate::consts::NETWORK_MODE_CLOSED);
+        // Network mode now hands off to the CORS sub-phase.
+        assert_eq!(app.security_phase, Some(SecurityPhase::CorsPolicy));
+
+        // Confirm default CORS = none to land on Database.
+        app.selection_index = 0;
+        app.select_current();
+        assert_eq!(app.config.cors_mode, crate::consts::CORS_MODE_NONE);
         assert_eq!(app.current_step, WizardStep::Database);
+    }
+
+    // ── Security CORS sub-phase tests ────────────────────────────────
+
+    /// Advance an app to the CORS sub-phase via the common SSL-none /
+    /// JWT-generate / network-open path.
+    fn app_at_cors_phase() -> WizardApp {
+        let mut app = WizardApp::new("test.toml".into());
+        app.current_step = WizardStep::Security;
+        app.selection_index = 0; // No SSL
+        app.select_current();
+        app.select_current(); // JWT default = generate
+        app.select_current(); // Network default = open
+        assert_eq!(app.security_phase, Some(SecurityPhase::CorsPolicy));
+        app
+    }
+
+    #[test]
+    fn security_cors_any_advances() {
+        let mut app = app_at_cors_phase();
+        app.selection_index = 1; // Allow any origin
+        app.select_current();
+        assert_eq!(app.config.cors_mode, crate::consts::CORS_MODE_ANY);
+        assert!(app.security_phase.is_none());
+        assert_eq!(app.current_step, WizardStep::Database);
+    }
+
+    #[test]
+    fn security_cors_specific_collects_and_validates_domains() {
+        let mut app = app_at_cors_phase();
+        app.selection_index = 2; // Specific domains
+        app.select_current();
+        // We're now in the domains text-input sub-phase, still CorsPolicy.
+        assert_eq!(app.config.cors_mode, crate::consts::CORS_MODE_LIST);
+        assert_eq!(app.security_phase, Some(SecurityPhase::CorsPolicy));
+        assert_eq!(app.mode, InputMode::TextInput);
+
+        // An invalid entry keeps us on the screen with an error.
+        app.text_input = Input::new("app.affinidi.com".into());
+        app.confirm_text_input();
+        assert!(app.cors_validation_error.is_some());
+        assert_eq!(app.current_step, WizardStep::Security);
+
+        // A valid mixed exact + wildcard list advances and normalises.
+        app.text_input = Input::new("https://app.affinidi.com, https://*.affinidi.com".into());
+        app.confirm_text_input();
+        assert!(app.cors_validation_error.is_none());
+        assert_eq!(
+            app.config.cors_domains,
+            "https://app.affinidi.com,https://*.affinidi.com"
+        );
+        assert!(app.security_phase.is_none());
+        assert_eq!(app.current_step, WizardStep::Database);
+    }
+
+    #[test]
+    fn validate_cors_domains_accepts_exact_and_wildcard() {
+        assert_eq!(
+            validate_cors_domains("https://app.affinidi.com").unwrap(),
+            "https://app.affinidi.com"
+        );
+        assert_eq!(
+            validate_cors_domains(" https://*.affinidi.com:8443 ").unwrap(),
+            "https://*.affinidi.com:8443"
+        );
+        // Trims + normalises whitespace around the comma separator.
+        assert_eq!(
+            validate_cors_domains("https://a.com ,  https://b.com").unwrap(),
+            "https://a.com,https://b.com"
+        );
+    }
+
+    #[test]
+    fn validate_cors_domains_rejects_bad_input() {
+        assert!(validate_cors_domains("").is_err()); // empty
+        assert!(validate_cors_domains("app.affinidi.com").is_err()); // no scheme
+        assert!(validate_cors_domains("*").is_err()); // bare wildcard
+        assert!(validate_cors_domains("https://app.*.com").is_err()); // misplaced *
+        assert!(validate_cors_domains("https://*.").is_err()); // empty suffix
+        assert!(validate_cors_domains("https://app.affinidi.com/path").is_err()); // path
+        assert!(validate_cors_domains("https://a b.com").is_err()); // whitespace
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -236,6 +236,26 @@ fn generate_toml(config: &WizardConfig, generated: &GeneratedValues) -> anyhow::
                 sec["local_direct_delivery_allowed"] = toml_edit::value("true");
             }
         }
+
+        // CORS policy. `none` (default) leaves `cors_allow_origin` unset
+        // so the mediator's default-closed posture applies — actively
+        // remove any key the template ships so a recipe round-trip can
+        // turn an allowlist back off. `any` emits `*`; `list` emits the
+        // validated allowlist verbatim.
+        match config.cors_mode.as_str() {
+            crate::consts::CORS_MODE_ANY => {
+                sec["cors_allow_origin"] = toml_edit::value("*");
+            }
+            crate::consts::CORS_MODE_LIST => {
+                sec["cors_allow_origin"] = toml_edit::value(&config.cors_domains);
+            }
+            // `none` and any unrecognised value → no cross-origin access.
+            _ => {
+                if let Some(table) = sec.as_table_mut() {
+                    table.remove("cors_allow_origin");
+                }
+            }
+        }
     }
 
     Ok(doc.to_string())
@@ -545,6 +565,47 @@ mod tests {
         let toml = generate_toml(&config, &test_generated()).unwrap();
         assert!(toml.contains("mediator_acl_mode = \"explicit_deny\""));
         assert!(toml.contains("global_acl_default = \"ALLOW_ALL\""));
+    }
+
+    #[test]
+    fn cors_mode_none_leaves_origin_unset() {
+        // Default-closed: no active `cors_allow_origin` assignment lands
+        // in the generated config (the template only carries it as a
+        // commented example).
+        let config = WizardConfig {
+            cors_mode: crate::consts::CORS_MODE_NONE.into(),
+            ..WizardConfig::default()
+        };
+        let toml = generate_toml(&config, &test_generated()).unwrap();
+        assert!(
+            !toml.contains("\ncors_allow_origin ="),
+            "expected no active cors_allow_origin assignment, got:\n{toml}"
+        );
+    }
+
+    #[test]
+    fn cors_mode_any_emits_wildcard() {
+        let config = WizardConfig {
+            cors_mode: crate::consts::CORS_MODE_ANY.into(),
+            ..WizardConfig::default()
+        };
+        let toml = generate_toml(&config, &test_generated()).unwrap();
+        assert!(toml.contains("cors_allow_origin = \"*\""));
+    }
+
+    #[test]
+    fn cors_mode_list_emits_domains_verbatim() {
+        let config = WizardConfig {
+            cors_mode: crate::consts::CORS_MODE_LIST.into(),
+            cors_domains: "https://app.affinidi.com,https://*.affinidi.com".into(),
+            ..WizardConfig::default()
+        };
+        let toml = generate_toml(&config, &test_generated()).unwrap();
+        assert!(
+            toml.contains(
+                "cors_allow_origin = \"https://app.affinidi.com,https://*.affinidi.com\""
+            )
+        );
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/consts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/consts.rs
@@ -59,6 +59,26 @@ pub const DEFAULT_NETWORK_MODE: &str = NETWORK_MODE_OPEN;
 pub const JWT_MODE_GENERATE: &str = "generate";
 pub const JWT_MODE_PROVIDE: &str = "provide";
 
+/// CORS policy mode for the mediator's REST/WebSocket endpoints. Drives
+/// the `[security].cors_allow_origin` value the wizard writes:
+///
+/// - `none` (default) ⇒ key left unset ⇒ no cross-origin browser access.
+///   The right choice for mediators with no browser clients.
+/// - `any` ⇒ `cors_allow_origin = "*"` ⇒ any origin allowed. Suggested
+///   for public mediators (the endpoints gate on a bearer token, not an
+///   ambient cookie, so a wildcard does not expose them to CSRF).
+/// - `list` ⇒ `cors_allow_origin = "<comma-separated origins>"` ⇒ only
+///   the listed origins. Entries are exact, scheme-qualified origins
+///   (`https://app.affinidi.com`) or leftmost-label sub-domain wildcards
+///   (`https://*.affinidi.com`). See [`crate::app::validate_cors_domains`].
+pub const CORS_MODE_NONE: &str = "none";
+pub const CORS_MODE_ANY: &str = "any";
+pub const CORS_MODE_LIST: &str = "list";
+/// Default CORS mode for fresh wizard runs and recipes that omit
+/// `[security].cors` — default-closed, matching the mediator's own
+/// default when `cors_allow_origin` is unset.
+pub const DEFAULT_CORS_MODE: &str = CORS_MODE_NONE;
+
 /// Admin DID mode display strings
 pub const ADMIN_GENERATE: &str = "Generate did:key";
 pub const ADMIN_PASTE: &str = "Paste existing";

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -184,6 +184,16 @@ pub struct SecuritySection {
     /// `mediator.toml`.
     #[serde(default = "default_network_mode")]
     pub network_mode: String,
+    /// Browser CORS policy: `none` (default — deny all cross-origin),
+    /// `any` (`*`), or `list` (allow [`Self::cors_domains`]). Drives the
+    /// `[security].cors_allow_origin` value the writer emits.
+    #[serde(default = "default_cors")]
+    pub cors: String,
+    /// Comma-separated CORS origin allowlist, required when `cors =
+    /// "list"`. Entries are exact, scheme-qualified origins
+    /// (`https://app.affinidi.com`) or leftmost-label sub-domain
+    /// wildcards (`https://*.affinidi.com`).
+    pub cors_domains: Option<String>,
 }
 
 fn default_ssl() -> String {
@@ -202,6 +212,10 @@ fn default_network_mode() -> String {
     crate::consts::DEFAULT_NETWORK_MODE.into()
 }
 
+fn default_cors() -> String {
+    crate::consts::DEFAULT_CORS_MODE.into()
+}
+
 impl Default for SecuritySection {
     fn default() -> Self {
         Self {
@@ -212,6 +226,8 @@ impl Default for SecuritySection {
             admin_did: None,
             jwt_mode: default_jwt_mode(),
             network_mode: default_network_mode(),
+            cors: default_cors(),
+            cors_domains: None,
         }
     }
 }
@@ -521,6 +537,25 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
         }
     };
 
+    config.cors_mode = match recipe.security.cors.as_str() {
+        crate::consts::CORS_MODE_NONE | "" => crate::consts::CORS_MODE_NONE.into(),
+        crate::consts::CORS_MODE_ANY => crate::consts::CORS_MODE_ANY.into(),
+        crate::consts::CORS_MODE_LIST => {
+            // `list` is only meaningful with an allowlist — validate it
+            // here (same syntax the TUI enforces) so a bad recipe fails
+            // fast rather than emitting a config the mediator rejects.
+            let domains = recipe.security.cors_domains.clone().ok_or_else(|| {
+                anyhow::anyhow!("security.cors_domains is required when cors = 'list'")
+            })?;
+            config.cors_domains = crate::app::validate_cors_domains(&domains)
+                .map_err(|e| anyhow::anyhow!("Invalid security.cors_domains: {e}"))?;
+            crate::consts::CORS_MODE_LIST.into()
+        }
+        other => {
+            anyhow::bail!("Invalid security.cors '{other}': expected 'none', 'any', or 'list'")
+        }
+    };
+
     // Database
     config.database_url = recipe.database.url.clone();
 
@@ -694,7 +729,19 @@ pub fn from_wizard_config(config: &WizardConfig) -> String {
         // wizard's default `open` posture.
         _ => crate::consts::NETWORK_MODE_OPEN,
     };
-    out.push_str(&format!("network_mode = \"{network_mode}\"\n\n"));
+    out.push_str(&format!("network_mode = \"{network_mode}\"\n"));
+    let cors = match config.cors_mode.as_str() {
+        crate::consts::CORS_MODE_ANY => crate::consts::CORS_MODE_ANY,
+        crate::consts::CORS_MODE_LIST => crate::consts::CORS_MODE_LIST,
+        // Anything else (including unset / typo) round-trips as the
+        // default-closed `none` posture.
+        _ => crate::consts::CORS_MODE_NONE,
+    };
+    out.push_str(&format!("cors = \"{cors}\"\n"));
+    if cors == crate::consts::CORS_MODE_LIST {
+        out.push_str(&format!("cors_domains = \"{}\"\n", config.cors_domains));
+    }
+    out.push('\n');
 
     // Database — strip any embedded credentials
     out.push_str("[database]\n");
@@ -950,6 +997,72 @@ did_method = "did:peer"
         // the operator's chosen posture.
         let toml = from_wizard_config(&config);
         assert!(toml.contains("network_mode = \"closed\""));
+    }
+
+    #[test]
+    fn cors_defaults_to_none_when_unspecified() {
+        let recipe = minimal_recipe();
+        assert_eq!(recipe.security.cors, crate::consts::CORS_MODE_NONE);
+        let config = to_wizard_config(&recipe).unwrap();
+        assert_eq!(config.cors_mode, crate::consts::CORS_MODE_NONE);
+    }
+
+    #[test]
+    fn cors_any_round_trips() {
+        let mut recipe = minimal_recipe();
+        recipe.security.cors = crate::consts::CORS_MODE_ANY.into();
+        let config = to_wizard_config(&recipe).unwrap();
+        assert_eq!(config.cors_mode, crate::consts::CORS_MODE_ANY);
+
+        let toml = from_wizard_config(&config);
+        assert!(toml.contains("cors = \"any\""));
+    }
+
+    #[test]
+    fn cors_list_round_trips_with_domains() {
+        let mut recipe = minimal_recipe();
+        recipe.security.cors = crate::consts::CORS_MODE_LIST.into();
+        recipe.security.cors_domains =
+            Some("https://app.affinidi.com,https://*.affinidi.com".into());
+        let config = to_wizard_config(&recipe).unwrap();
+        assert_eq!(config.cors_mode, crate::consts::CORS_MODE_LIST);
+        assert_eq!(
+            config.cors_domains,
+            "https://app.affinidi.com,https://*.affinidi.com"
+        );
+
+        let toml = from_wizard_config(&config);
+        assert!(toml.contains("cors = \"list\""));
+        assert!(
+            toml.contains("cors_domains = \"https://app.affinidi.com,https://*.affinidi.com\"")
+        );
+    }
+
+    #[test]
+    fn cors_list_without_domains_errors() {
+        let mut recipe = minimal_recipe();
+        recipe.security.cors = crate::consts::CORS_MODE_LIST.into();
+        recipe.security.cors_domains = None;
+        let err = to_wizard_config(&recipe).unwrap_err();
+        assert!(err.to_string().contains("cors_domains"));
+    }
+
+    #[test]
+    fn cors_list_with_invalid_domain_errors() {
+        let mut recipe = minimal_recipe();
+        recipe.security.cors = crate::consts::CORS_MODE_LIST.into();
+        // Missing scheme — rejected by the shared validator.
+        recipe.security.cors_domains = Some("app.affinidi.com".into());
+        let err = to_wizard_config(&recipe).unwrap_err();
+        assert!(err.to_string().contains("cors_domains"));
+    }
+
+    #[test]
+    fn cors_invalid_mode_errors() {
+        let mut recipe = minimal_recipe();
+        recipe.security.cors = "everyone".into();
+        let err = to_wizard_config(&recipe).unwrap_err();
+        assert!(err.to_string().contains("cors"));
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
@@ -853,6 +853,40 @@ fn render_step_content(frame: &mut Frame, area: Rect, app: &WizardApp) {
                 );
                 return;
             }
+            // Security step: the CORS "Specific domains" allowlist is
+            // collected in a text-input sub-phase of CorsPolicy. Render
+            // the supported syntax with examples; a failed validation
+            // surfaces as an accented tip line above the prompt and keeps
+            // the operator here until every entry is well-formed.
+            if app.current_step == crate::app::WizardStep::Security
+                && app.security_phase == Some(crate::app::SecurityPhase::CorsPolicy)
+            {
+                let tip = app
+                    .cors_validation_error
+                    .as_ref()
+                    .map(|e| format!("\u{26A0} {e}"));
+                prompt::render_prompt(
+                    frame,
+                    chunks[0],
+                    "CORS allowed origins",
+                    "Comma-separated origins permitted to call the mediator API from a browser.",
+                    tip.as_deref(),
+                    &app.text_input,
+                    "https://app.affinidi.com, https://*.affinidi.com",
+                    "Each entry is matched against the browser's Origin header; the matched \
+                     origin is echoed back.\n\n\
+                     Accepted forms:\n  \
+                     https://app.affinidi.com       exact, scheme-qualified origin\n  \
+                     https://*.affinidi.com         any sub-domain of affinidi.com (any depth)\n  \
+                     https://*.affinidi.com:8443    pin a non-default port\n\n\
+                     Notes:\n  \
+                     - scheme and port must match exactly; '*' is only the leftmost label.\n  \
+                     - '*.affinidi.com' does NOT cover the apex 'affinidi.com' — add it \
+                     explicitly if needed.\n  \
+                     - to allow every origin instead, go back and pick \"Allow any origin\".",
+                );
+                return;
+            }
             // Database step: render the prompt that matches the
             // backend the operator picked on the prior screen. Redis
             // gets the URL prompt with auth/TLS/partition examples;

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/summary.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/summary.rs
@@ -7,8 +7,8 @@ use crate::{
     app::WizardConfig,
     config_writer::build_backend_url,
     consts::{
-        JWT_MODE_GENERATE, NETWORK_MODE_CLOSED, NETWORK_MODE_OPEN, SSL_EXISTING, SSL_SELF_SIGNED,
-        STORAGE_BACKEND_FJALL,
+        CORS_MODE_ANY, CORS_MODE_LIST, CORS_MODE_NONE, JWT_MODE_GENERATE, NETWORK_MODE_CLOSED,
+        NETWORK_MODE_OPEN, SSL_EXISTING, SSL_SELF_SIGNED, STORAGE_BACKEND_FJALL,
     },
     ui::theme,
     vta::{VtaReply, VtaSession},
@@ -193,6 +193,13 @@ pub fn render_summary(
     );
     add_field(
         &mut lines,
+        "  CORS policy",
+        &cors_policy_display(config),
+        label_style,
+        value_style,
+    );
+    add_field(
+        &mut lines,
         "  Admin DID",
         &config.admin_did_mode,
         label_style,
@@ -333,6 +340,18 @@ fn jwt_mode_display(mode: &str) -> String {
         // hasn't run yet (e.g. truncated wizard state in tests).
         "" => "—".into(),
         "provide" => "Operator provides at boot (env / file)".into(),
+        other => other.to_string(),
+    }
+}
+
+/// Friendly label for `WizardConfig::cors_mode`. For the allowlist mode
+/// the chosen domains are appended so the operator can audit them on the
+/// review screen. Same fall-through rule as `network_mode_display`.
+fn cors_policy_display(config: &WizardConfig) -> String {
+    match config.cors_mode.as_str() {
+        CORS_MODE_NONE | "" => "Deny all cross-origin (default)".into(),
+        CORS_MODE_ANY => "Allow any origin (*)".into(),
+        CORS_MODE_LIST => format!("Allowlist: {}", config.cors_domains),
         other => other.to_string(),
     }
 }


### PR DESCRIPTION
## Summary

Adds a **CORS policy** question to the `mediator-setup` wizard's Security series and wires the result through to the generated `mediator.toml`. Also adds **sub-domain wildcard** support to the mediator's `cors_allow_origin` so the "specific domains" option can use `https://*.affinidi.com`-style entries.

### Wizard (Security series, after Network mode)
Three choices:
1. **Deny all cross-origin** (default) — leaves `cors_allow_origin` unset (the mediator's existing default-closed posture).
2. **Allow any origin (`*`)** — writes `cors_allow_origin = "*"`. Suggested for public mediators (endpoints gate on a bearer token, not a cookie).
3. **Specific domains** — opens a secondary text input collecting a validated, comma-separated allowlist, with on-screen syntax examples.

The choice is shown on the review screen and round-trips through build recipes (`[security].cors` / `cors_domains`).

### Server — sub-domain wildcards (security-sensitive)
The CORS spec's `Access-Control-Allow-Origin` header has no wildcard-subdomain form, and the mediator previously only did exact matching. This PR adds `https://*.suffix[:port]` matching:

- New `OriginMatcher` (`Exact` | `WildcardSubdomain`) with a **single shared** `origin_matches()` used by **both** the REST `CorsLayer` (now an `AllowOrigin::predicate`) and the WebSocket `Origin` defence-in-depth check — so the two enforcement points can't drift.
- Matches any sub-domain depth, **exact scheme + port**, mandatory boundary dot (no `evil<suffix>` bypass), and **does not** cover the apex (add it explicitly).
- Exact origins parse exactly as before → **no behavior change for existing configs**.

## Version bumps
- `affinidi-messaging-mediator` 0.15.5 → **0.15.6**
- `affinidi-messaging-mediator-setup` 0.1.3 → **0.1.4**

Patch bump (not 0.16.0): the change is backward-compatible and `affinidi-messaging-test-mediator` pins `version = "0.15"`, which a minor bump would break.

## Testing
- `cargo fmt` ✅
- `cargo test` ✅ — server 23 (incl. apex / look-alike / path-smuggling / scheme+port / WS-parity cases), wizard 340, + 13 CORS-specific
- `cargo clippy --all-targets -- -D warnings` ✅ clean
- `cargo deny` — only **pre-existing** advisory failures (`proc-macro-error`, `serde_cbor` unmaintained; `metrics` yanked); **0 new dependencies** added.