### PR TITLE
fix: DIDComm v2.1 interop — ECDH-1PU KDF (#322), JWS kid (#323), sign-then-encrypt (#324)

### DIFF
--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Meeting Place Changelog
 
+## 31st May 2026 (0.4.1)
+
+- Bump `affinidi-messaging-didcomm` to 0.14 (DIDComm v2.1 interop fixes:
+  ECDH-1PU authcrypt KDF #322, JWS unprotected `kid` #323,
+  sign-then-encrypt unpack #324). No Meeting Place API change.
+
 ## 2nd May 2026 (0.4.0)
 
 - **BREAKING:** Migrated to `affinidi-tdk-common` 0.6 — field accesses on

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.4.0"
+version = "0.4.1"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 affinidi-did-authentication = "0.3"
 affinidi-tdk-common = "0.6"
-affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.13" }
+affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.14" }
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.3"
 

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -8,6 +8,10 @@
   spec-compliant peers; the 0.14 dual-KEK fallback preserves
   compatibility with not-yet-upgraded peers during rollout. No API
   change in this crate.
+- Internal: the key-agreement key extractor now delegates to
+  `affinidi-did-common`'s `VerificationMethod::decode_public_key`, so the
+  JWK/multibase parsing is shared with the messaging SDK rather than
+  duplicated here.
 
 ## 28th May 2026 (0.3.3)
 

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi DID Authentication
 
+## 31st May 2026 (0.3.4)
+
+- Bump `affinidi-messaging-didcomm` to 0.14. This crate authcrypts the
+  DID-authentication challenge/response (ECDH-1PU), so it directly picks
+  up the corrected authcrypt KDF (#322) and is now interoperable with
+  spec-compliant peers; the 0.14 dual-KEK fallback preserves
+  compatibility with not-yet-upgraded peers during rollout. No API
+  change in this crate.
+
 ## 28th May 2026 (0.3.3)
 
 - **SECURITY (HIGH):** Redact bearer / refresh tokens in `Debug` output for

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,7 +13,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.13" }
+affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.14" }
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -758,37 +758,27 @@ fn _resolve_public_key_agreement(doc: &Document, kid: &str) -> Result<PublicKeyA
         .or_else(|| doc.get_verification_method(kid))
         .ok_or_else(|| DIDAuthError::DIDComm(format!("verification method not found: {kid}")))?;
 
-    // Try publicKeyJwk first
-    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk") {
-        return PublicKeyAgreement::from_jwk(jwk_value)
-            .map_err(|e| DIDAuthError::DIDComm(format!("invalid JWK: {e}")));
-    }
+    // Decode the verification material (publicKeyJwk or
+    // publicKeyMultibase) via the shared `affinidi-did-common` decoder —
+    // one parser for the whole stack — then map the multicodec onto a
+    // key-agreement curve.
+    let (codec, key_bytes) = vm
+        .decode_public_key()
+        .map_err(|e| DIDAuthError::DIDComm(format!("invalid verification material: {e}")))?;
 
-    // Try publicKeyMultibase (Multikey format)
-    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
-        && let Some(multibase_str) = multibase_value.as_str()
-    {
-        let (codec, key_bytes) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
-            .map_err(|e| DIDAuthError::DIDComm(format!("invalid multikey: {e}")))?;
+    let curve = match codec {
+        affinidi_encoding::X25519_PUB => Curve::X25519,
+        affinidi_encoding::P256_PUB => Curve::P256,
+        affinidi_encoding::SECP256K1_PUB => Curve::K256,
+        _ => {
+            return Err(DIDAuthError::DIDComm(format!(
+                "unsupported multicodec for key agreement: 0x{codec:x}"
+            )));
+        }
+    };
 
-        let curve = match codec {
-            affinidi_encoding::X25519_PUB => Curve::X25519,
-            affinidi_encoding::P256_PUB => Curve::P256,
-            affinidi_encoding::SECP256K1_PUB => Curve::K256,
-            _ => {
-                return Err(DIDAuthError::DIDComm(format!(
-                    "unsupported multicodec for key agreement: 0x{codec:x}"
-                )));
-            }
-        };
-
-        return PublicKeyAgreement::from_raw_bytes(curve, &key_bytes)
-            .map_err(|e| DIDAuthError::DIDComm(format!("invalid key bytes: {e}")));
-    }
-
-    Err(DIDAuthError::DIDComm(format!(
-        "no supported key material in verification method: {kid}"
-    )))
+    PublicKeyAgreement::from_raw_bytes(curve, &key_bytes)
+        .map_err(|e| DIDAuthError::DIDComm(format!("invalid key bytes: {e}")))
 }
 
 /// Map from secrets resolver KeyType to DIDComm Curve.

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to `affinidi-did-common` are documented here. The
+format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.4] - 2026-05-31
+
+### Added
+
+- `VerificationMethod::decode_public_key() -> (multicodec, bytes)` —
+  a single decoder for verification material that handles both
+  `publicKeyMultibase` (Multikey) and `publicKeyJwk` (via
+  `affinidi-crypto`), returning the multicodec + raw key bytes (32 octets
+  for Ed25519/X25519, uncompressed SEC1 for the EC curves). This is the
+  shared source of truth used by the messaging SDK and the
+  DID-authentication layer, replacing their previously-duplicated
+  JWK/multibase parsing (which had drifted — see the ECDH-1PU interop
+  work in `affinidi-messaging-didcomm` 0.14).

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.3"
+version = "0.3.4"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-common/src/verification_method.rs
+++ b/crates/identity/affinidi-did-common/src/verification_method.rs
@@ -53,6 +53,79 @@ impl VerificationMethod {
             ))),
         }
     }
+
+    /// Extract this verification method's public key as a
+    /// `(multicodec, raw-bytes)` pair, handling **both**
+    /// `publicKeyMultibase` (Multikey) and `publicKeyJwk`.
+    ///
+    /// The multicodec is one of [`affinidi_encoding`]'s `*_PUB`
+    /// constants; the bytes are the raw public key (32 octets for
+    /// Ed25519/X25519, an SEC1 point for the EC curves). This is the
+    /// single place that turns DID verification material into key bytes,
+    /// so the messaging SDK and DID-authentication layers map *one*
+    /// result onto their key types instead of each re-parsing JWK /
+    /// multibase (which previously drifted — see the ECDH-1PU interop
+    /// work).
+    pub fn decode_public_key(&self) -> Result<(u64, Vec<u8>), DocumentError> {
+        // Prefer an explicit multibase Multikey; fall back to JWK.
+        if let Some(mb) = self
+            .property_set
+            .get("publicKeyMultibase")
+            .and_then(Value::as_str)
+        {
+            return affinidi_encoding::decode_multikey_with_codec(mb)
+                .map_err(|e| DocumentError::VM(format!("invalid publicKeyMultibase: {e}")));
+        }
+
+        if let Some(jwk_value) = self.property_set.get("publicKeyJwk") {
+            let jwk: affinidi_crypto::JWK = serde_json::from_value(jwk_value.clone())
+                .map_err(|e| DocumentError::VM(format!("invalid publicKeyJwk: {e}")))?;
+            return Self::jwk_to_codec_bytes(&jwk);
+        }
+
+        Err(DocumentError::VM(
+            "verification method has neither publicKeyMultibase nor publicKeyJwk".to_string(),
+        ))
+    }
+
+    /// Map an [`affinidi_crypto::JWK`] to `(multicodec, raw-bytes)`.
+    /// OKP `x` is the raw 32-octet key; EC `(x, y)` becomes an
+    /// uncompressed SEC1 point (`0x04 || x || y`).
+    fn jwk_to_codec_bytes(jwk: &affinidi_crypto::JWK) -> Result<(u64, Vec<u8>), DocumentError> {
+        use affinidi_crypto::{KeyType, Params};
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+
+        let b64 = |s: &str| {
+            URL_SAFE_NO_PAD
+                .decode(s)
+                .map_err(|e| DocumentError::VM(format!("invalid base64url in JWK: {e}")))
+        };
+        let sec1 = |x: &[u8], y: &[u8]| {
+            let mut v = Vec::with_capacity(1 + x.len() + y.len());
+            v.push(0x04);
+            v.extend_from_slice(x);
+            v.extend_from_slice(y);
+            v
+        };
+
+        match (&jwk.params, jwk.key_type()) {
+            (Params::OKP(p), KeyType::Ed25519) => Ok((affinidi_encoding::ED25519_PUB, b64(&p.x)?)),
+            (Params::OKP(p), KeyType::X25519) => Ok((affinidi_encoding::X25519_PUB, b64(&p.x)?)),
+            (Params::EC(p), KeyType::P256) => {
+                Ok((affinidi_encoding::P256_PUB, sec1(&b64(&p.x)?, &b64(&p.y)?)))
+            }
+            (Params::EC(p), KeyType::P384) => {
+                Ok((affinidi_encoding::P384_PUB, sec1(&b64(&p.x)?, &b64(&p.y)?)))
+            }
+            (Params::EC(p), KeyType::Secp256k1) => Ok((
+                affinidi_encoding::SECP256K1_PUB,
+                sec1(&b64(&p.x)?, &b64(&p.y)?),
+            )),
+            (_, kt) => Err(DocumentError::VM(format!(
+                "unsupported JWK key type for public key extraction: {kt:?}"
+            ))),
+        }
+    }
 }
 
 /// https://www.w3.org/TR/cid-1.0/#verification-relationships
@@ -100,6 +173,79 @@ mod tests {
         let result = vm.get_public_key_bytes().unwrap();
 
         assert_eq!(bytes, result.as_slice());
+    }
+
+    #[test]
+    fn decode_public_key_multibase_ed25519() {
+        let vm: VerificationMethod = serde_json::from_str(
+            r#"{ "controller": "did:example:1234",
+                "id": "did:example:1234#key-0",
+                "publicKeyMultibase": "z6MkwdwKx2P9X13goHtcowBBrPFRwqPNcnX1qWd39CnS4yjx",
+                "type": "Multikey"
+            }"#,
+        )
+        .unwrap();
+
+        let (codec, bytes) = vm.decode_public_key().unwrap();
+        assert_eq!(codec, affinidi_encoding::ED25519_PUB);
+        assert_eq!(bytes.len(), 32);
+    }
+
+    #[test]
+    fn decode_public_key_jwk_ed25519() {
+        // OKP/Ed25519 JWK → 32 raw octets, ED25519 multicodec.
+        let vm: VerificationMethod = serde_json::from_str(
+            r#"{ "controller": "did:example:1234",
+                "id": "did:example:1234#key-0",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "Xx4_L89E6RsyvDTzN9wuN3cDwgifPkXMgFJv_HMIxdk"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (codec, bytes) = vm.decode_public_key().unwrap();
+        assert_eq!(codec, affinidi_encoding::ED25519_PUB);
+        assert_eq!(bytes.len(), 32);
+    }
+
+    #[test]
+    fn decode_public_key_jwk_p256_is_uncompressed_sec1() {
+        // EC/P-256 JWK → uncompressed SEC1 point (0x04 || x || y).
+        let vm: VerificationMethod = serde_json::from_str(
+            r#"{ "controller": "did:example:1234",
+                "id": "did:example:1234#key-0",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "sl56LMzaiR5efwwWU1jzC_dfbxQ8gzyLj_N1q2cJmkE",
+                    "y": "UnAimUtlHMPj_T_wIDVPoJAolKHy8DoXXTb8wch4hgU"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (codec, bytes) = vm.decode_public_key().unwrap();
+        assert_eq!(codec, affinidi_encoding::P256_PUB);
+        assert_eq!(bytes.len(), 65, "uncompressed SEC1 point is 65 octets");
+        assert_eq!(bytes[0], 0x04, "uncompressed SEC1 marker");
+    }
+
+    #[test]
+    fn decode_public_key_missing_material_errors() {
+        let vm = VerificationMethod {
+            id: Url::parse("did:example:123#key-0").unwrap(),
+            type_: "JsonWebKey2020".to_string(),
+            controller: Url::parse("did:example:123").unwrap(),
+            expires: None,
+            revoked: None,
+            property_set: HashMap::new(),
+        };
+        assert!(vm.decode_public_key().is_err());
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.2] - 2026-05-31
+
+### Changed
+
+- Bump `affinidi-messaging-didcomm` to 0.14 (DIDComm v2.1 interop fixes:
+  ECDH-1PU authcrypt KDF #322, JWS unprotected `kid` #323,
+  sign-then-encrypt unpack #324). No service API change.
+
 ## [0.3.0] - 2026-05-02
 
 ### Breaking

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 affinidi-tdk-common = "0.6"
 affinidi-messaging-sdk = "0.18"
-affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm = "0.14"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to `affinidi-messaging-didcomm` are documented here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.14.0] - 2026-05-31
+
+DIDComm v2.1 interop fixes found via an interop matrix against
+[credo-ts](https://github.com/openwallet-foundation/credo-ts) (issues
+#322, #323, #324). Authcrypt is **wire-affecting** — see Migration.
+
+### Fixed
+
+- **ECDH-1PU Concat KDF: length-prefix the content-encryption tag
+  (#322).** `concat_kdf_1pu` fed `cc_tag` into the KDF without the 32-bit
+  big-endian length prefix that every other OtherInfo field carries,
+  yielding a key-encryption-key four bytes' worth of input different from
+  every spec-following implementation (credo-ts/Askar, SICPA
+  didcomm-python). `ECDH-1PU+A256KW` authcrypt now interoperates with
+  spec-compliant peers. Affects key-agreement keys (X25519, P-256,
+  K-256); anoncrypt (ECDH-ES) was never affected.
+- **JWS verification: honour `kid` in the per-signature *unprotected*
+  header (#323).** `JwsSignature` gained an optional unprotected `header`
+  (RFC 7515 §7.2.1). DIDComm / credo-ts / didcomm-python place the signer
+  `kid` there; it was previously dropped, so `signer_kid` came back
+  `None`. Verification reads the protected header first, then the
+  unprotected one.
+- **`unpack()`: auto-unwrap sign-then-encrypt (#324).** When a decrypted
+  JWE turns out to wrap a JWS (DIDComm v2.1 non-repudiation), the inner
+  signature is now verified instead of failing with a missing-field
+  error. `signer_public` is then required, and the result reports
+  `non_repudiation = true` with the inner `signer_kid`.
+
+### Added
+
+- **Dual-KEK decrypt fallback (transitional).** To keep working during a
+  staged rollout, decryption tries the spec-correct KEK first and, on
+  AES-Key-Wrap failure, retries with the legacy (pre-0.14, unprefixed)
+  KEK. `DecryptedJwe.legacy_kek_used` / `UnpackResult::Encrypted
+  { legacy_kek_used, .. }` report when the legacy path was taken — a
+  migration signal. Remove the fallback once it stops occurring.
+
+### Changed
+
+- `UnpackResult` is now `#[non_exhaustive]`; `UnpackResult::Encrypted`
+  gained `legacy_kek_used`, `non_repudiation`, and `signer_kid` fields.
+  Match with a `..` rest pattern.
+- `DecryptedJwe` gained `legacy_kek_used`.
+
+### Migration
+
+Packing now emits the **spec-correct** KEK, so a 0.14 sender's authcrypt
+cannot be decrypted by an un-upgraded 0.13 recipient. The dual-KEK
+fallback only helps the receive side. **Upgrade recipients before
+senders**: once all parties run ≥0.14 (they accept both old and new),
+senders are safe. The previous behaviour only interoperated with other
+affinidi 0.13 nodes — no working external interop is lost.

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.13.3"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
@@ -111,6 +111,10 @@ impl MessagingProtocol for DIDCommAdapter {
                 authenticated,
                 sender_kid,
                 recipient_kid,
+                // New fields (legacy_kek_used / non_repudiation /
+                // signer_kid) aren't surfaced through this adapter yet —
+                // adopting non-repudiation here is follow-up work.
+                ..
             } => {
                 // Extract payload from message body
                 let payload = extract_payload(&message.body);

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/ecdh_1pu.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/ecdh_1pu.rs
@@ -78,7 +78,43 @@ pub fn derive_key_1pu_recipient(
     concat_kdf_1pu(&z, alg, apu, apv, key_len, cc_tag)
 }
 
-/// Concat KDF with SuppPrivInfo for ECDH-1PU (includes cc_tag).
+/// Recipient-side ECDH-1PU derivation using the **legacy** (pre-0.14)
+/// Concat KDF that fed `cc_tag` without a length prefix.
+///
+/// Transitional: used only by the decrypt fallback so a fixed node can
+/// still receive authcrypt messages packed by an unpatched peer during
+/// rollout. Delete once the ecosystem has upgraded. See
+/// [`concat_kdf_1pu_legacy`] and issue #322.
+#[allow(clippy::too_many_arguments)]
+pub fn derive_key_1pu_recipient_legacy(
+    recipient_private: &PrivateKeyAgreement,
+    sender_public: &PublicKeyAgreement,
+    ephemeral_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, DIDCommError> {
+    let ze = recipient_private.diffie_hellman(ephemeral_public)?;
+    let zs = recipient_private.diffie_hellman(sender_public)?;
+    let mut z = Vec::with_capacity(ze.len() + zs.len());
+    z.extend_from_slice(&ze);
+    z.extend_from_slice(&zs);
+
+    concat_kdf_1pu_legacy(&z, alg, apu, apv, key_len, cc_tag)
+}
+
+/// Concat KDF for ECDH-1PU. The content-encryption authentication tag is
+/// fed as the final OtherInfo entry, **length-prefixed** with a 32-bit
+/// big-endian length exactly like every other variable-length field.
+///
+/// This matches the ECDH-1PU draft (draft-madden-jose-ecdh-1pu-04 §2.3 /
+/// Appendix B.9 test vector) and the askar / didcomm-python
+/// implementations. The draft concatenates the length-prefixed tag onto
+/// SuppPubInfo after `keydatalen`; because Concat KDF hashes
+/// `… ‖ SuppPubInfo ‖ SuppPrivInfo`, feeding `keydatalen ‖ len ‖ tag`
+/// (here) produces an identical byte stream and KEK.
 fn concat_kdf_1pu(
     z: &[u8],
     alg: &[u8],
@@ -87,8 +123,36 @@ fn concat_kdf_1pu(
     key_len_bits: u32,
     cc_tag: &[u8],
 ) -> Result<Vec<u8>, DIDCommError> {
+    concat_kdf_1pu_inner(z, alg, apu, apv, key_len_bits, cc_tag, false)
+}
+
+/// Pre-0.14 ECDH-1PU Concat KDF that fed `cc_tag` **without** a length
+/// prefix — non-conformant, see issue #322. Retained only for the
+/// decrypt fallback during migration; do not use for packing.
+fn concat_kdf_1pu_legacy(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+    cc_tag: &[u8],
+) -> Result<Vec<u8>, DIDCommError> {
+    concat_kdf_1pu_inner(z, alg, apu, apv, key_len_bits, cc_tag, true)
+}
+
+fn concat_kdf_1pu_inner(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+    cc_tag: &[u8],
+    legacy_tag_encoding: bool,
+) -> Result<Vec<u8>, DIDCommError> {
     if cc_tag.is_empty() {
-        // No tag — same as standard Concat KDF
+        // No tag — same as standard Concat KDF (matches ECDH-ES). The
+        // legacy/spec distinction only concerns the tag encoding, so an
+        // empty tag is identical either way.
         return concat_kdf(z, alg, apu, apv, key_len_bits);
     }
 
@@ -118,7 +182,12 @@ fn concat_kdf_1pu(
     // SuppPubInfo: key length in bits
     hasher.update(key_len_bits.to_be_bytes());
 
-    // SuppPrivInfo: cc_tag (the auth tag from content encryption)
+    // SuppPrivInfo: cc_tag (the auth tag from content encryption),
+    // length-prefixed per the ECDH-1PU draft. The legacy path omits the
+    // prefix (issue #322) and exists only for the decrypt fallback.
+    if !legacy_tag_encoding {
+        hasher.update((cc_tag.len() as u32).to_be_bytes());
+    }
     hasher.update(cc_tag);
 
     let hash = hasher.finalize();
@@ -148,6 +217,30 @@ pub fn derive_sender_key_1pu(
         .try_into()
         .map_err(|_| DIDCommError::KeyAgreement("derived key wrong size".into()))?;
     Ok(arr)
+}
+
+/// Test-only sender-side KEK using the **legacy** (pre-0.14, unprefixed
+/// tag) Concat KDF. Lets tests synthesise a JWE exactly as an unpatched
+/// peer would, so the recipient-side decrypt fallback can be exercised.
+/// Deliberately `cfg(test)` — no legacy *sender* derivation ships in
+/// production; only [`derive_key_1pu_recipient_legacy`] does.
+#[cfg(test)]
+pub(crate) fn derive_sender_key_1pu_legacy(
+    ephemeral: &EphemeralKeyPair,
+    sender_private: &PrivateKeyAgreement,
+    recipient_public: &PublicKeyAgreement,
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+) -> Result<[u8; 32], DIDCommError> {
+    let ze = ephemeral.private.diffie_hellman(recipient_public)?;
+    let zs = sender_private.diffie_hellman(recipient_public)?;
+    let mut z = Vec::with_capacity(ze.len() + zs.len());
+    z.extend_from_slice(&ze);
+    z.extend_from_slice(&zs);
+    let kek = concat_kdf_1pu_legacy(&z, b"ECDH-1PU+A256KW", apu, apv, 256, cc_tag)?;
+    kek.try_into()
+        .map_err(|_| DIDCommError::KeyAgreement("derived key wrong size".into()))
 }
 
 #[cfg(test)]
@@ -291,5 +384,88 @@ mod tests {
         .unwrap();
 
         assert_ne!(kek1, kek2);
+    }
+
+    /// Regression for #322: the spec-correct Concat KDF must
+    /// length-prefix `cc_tag` (32-bit big-endian) exactly like the other
+    /// OtherInfo fields, and must differ from the legacy (unprefixed)
+    /// derivation. Pins the byte-level encoding against a hand-built
+    /// hash so it can't silently regress.
+    #[test]
+    fn concat_kdf_1pu_length_prefixes_tag() {
+        use sha2::{Digest, Sha256};
+
+        let z = b"0123456789abcdef0123456789abcdef"; // 32 bytes
+        let alg = b"ECDH-1PU+A256KW".as_slice();
+        let apu = b"did:example:alice#key-1".as_slice();
+        let apv = b"apv-bytes".as_slice();
+        let tag = [0xABu8; 32];
+        let key_len_bits = 256u32;
+
+        // Independently build the spec-correct OtherInfo, with the tag
+        // length-prefixed (the bytes under test: `00 00 00 20`).
+        let mut h = Sha256::new();
+        h.update(1u32.to_be_bytes());
+        h.update(z);
+        h.update((alg.len() as u32).to_be_bytes());
+        h.update(alg);
+        h.update((apu.len() as u32).to_be_bytes());
+        h.update(apu);
+        h.update((apv.len() as u32).to_be_bytes());
+        h.update(apv);
+        h.update(key_len_bits.to_be_bytes());
+        h.update((tag.len() as u32).to_be_bytes());
+        h.update(tag);
+        let expected = h.finalize()[..32].to_vec();
+
+        let got = concat_kdf_1pu(z, alg, apu, apv, key_len_bits, &tag).unwrap();
+        assert_eq!(got, expected, "KDF must length-prefix the cc_tag");
+
+        let legacy = concat_kdf_1pu_legacy(z, alg, apu, apv, key_len_bits, &tag).unwrap();
+        assert_ne!(
+            got, legacy,
+            "the 4-byte length prefix must change the derived key"
+        );
+    }
+
+    /// Models the issue #322 interop break directly: a spec-correct
+    /// (length-prefixed) KEK — what credo-ts / didcomm-python and our own
+    /// fixed packer produce — must NOT equal the legacy (pre-0.14) KEK an
+    /// unpatched recipient would derive. I.e. an unpatched peer cannot
+    /// reconstruct the spec-correct KEK, which is exactly why authcrypt
+    /// failed bidirectionally before this fix.
+    #[test]
+    fn spec_correct_kek_differs_from_legacy_for_recipient() {
+        let sender = PrivateKeyAgreement::generate(Curve::X25519);
+        let recipient = PrivateKeyAgreement::generate(Curve::X25519);
+        let ephemeral = EphemeralKeyPair::generate(Curve::X25519);
+        let cc_tag = [0x5Au8; 32];
+
+        let correct = derive_key_1pu_recipient(
+            &recipient,
+            &sender.public_key(),
+            &ephemeral.public,
+            b"ECDH-1PU+A256KW",
+            b"did:example:alice#key-1",
+            b"apv",
+            &cc_tag,
+            256,
+        )
+        .unwrap();
+        let legacy = derive_key_1pu_recipient_legacy(
+            &recipient,
+            &sender.public_key(),
+            &ephemeral.public,
+            b"ECDH-1PU+A256KW",
+            b"did:example:alice#key-1",
+            b"apv",
+            &cc_tag,
+            256,
+        )
+        .unwrap();
+        assert_ne!(
+            correct, legacy,
+            "spec-correct and legacy KEKs must differ (the #322 interop break)"
+        );
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm/src/jwe/decrypt.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jwe/decrypt.rs
@@ -18,6 +18,12 @@ pub struct DecryptedJwe {
     pub sender_kid: Option<String>,
     /// The recipient KID that was used to decrypt.
     pub recipient_kid: String,
+    /// `true` if the message only decrypted under the legacy (pre-0.14,
+    /// issue #322) ECDH-1PU KEK — i.e. the sender is an unpatched peer.
+    /// Always `false` for anoncrypt and for spec-correct authcrypt.
+    /// Surfaced as a migration signal: once this stops occurring across
+    /// the deployment, the legacy fallback can be removed.
+    pub legacy_kek_used: bool,
 }
 
 /// Decrypt a JWE string.
@@ -90,8 +96,8 @@ pub fn decrypt(
     let apv_raw = Base64UrlUnpadded::decode_vec(&header.apv)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid apv: {e}")))?;
 
-    // Determine algorithm and unwrap CEK
-    let (kek, authenticated, sender_kid_str) = match header.alg.as_str() {
+    // Determine algorithm, derive the KEK, and unwrap the CEK.
+    let (cek_bytes, authenticated, sender_kid_str, legacy_kek_used) = match header.alg.as_str() {
         "ECDH-1PU+A256KW" => {
             let sender_pub = sender_public.ok_or_else(|| {
                 DIDCommError::InvalidMessage(
@@ -99,7 +105,10 @@ pub fn decrypt(
                 )
             })?;
 
-            let kek = ecdh_1pu::derive_key_1pu_recipient(
+            let sender_kid_str = String::from_utf8(apu_raw.clone()).ok();
+
+            // Derive the spec-correct KEK (length-prefixed cc_tag).
+            let kek: [u8; 32] = ecdh_1pu::derive_key_1pu_recipient(
                 recipient_private,
                 sender_pub,
                 &epk,
@@ -108,20 +117,49 @@ pub fn decrypt(
                 &apv_raw,
                 &tag,
                 256,
-            )?;
-            let sender_kid_str = String::from_utf8(apu_raw).ok();
-            (kek, true, sender_kid_str)
+            )?
+            .try_into()
+            .map_err(|_| DIDCommError::KeyAgreement("KEK wrong size".into()))?;
+
+            // Try the spec-correct KEK first. If AES-Key-Wrap integrity
+            // fails, the sender may be an unpatched peer that derived the
+            // legacy (pre-0.14, unprefixed-tag) KEK — retry with that so
+            // we stay interoperable during migration (issue #322). A
+            // genuinely bad message fails both and returns the second
+            // error.
+            match aes_kw::unwrap(&kek, &wrapped_key) {
+                Ok(cek) => (cek, true, sender_kid_str, false),
+                Err(_) => {
+                    let legacy_kek: [u8; 32] = ecdh_1pu::derive_key_1pu_recipient_legacy(
+                        recipient_private,
+                        sender_pub,
+                        &epk,
+                        b"ECDH-1PU+A256KW",
+                        &apu_raw,
+                        &apv_raw,
+                        &tag,
+                        256,
+                    )?
+                    .try_into()
+                    .map_err(|_| DIDCommError::KeyAgreement("KEK wrong size".into()))?;
+                    let cek = aes_kw::unwrap(&legacy_kek, &wrapped_key)?;
+                    (cek, true, sender_kid_str, true)
+                }
+            }
         }
         "ECDH-ES+A256KW" => {
-            let kek = ecdh_es::derive_key_es_recipient(
+            let kek: [u8; 32] = ecdh_es::derive_key_es_recipient(
                 recipient_private,
                 &epk,
                 b"ECDH-ES+A256KW",
                 &apu_raw,
                 &apv_raw,
                 256,
-            )?;
-            (kek, false, None)
+            )?
+            .try_into()
+            .map_err(|_| DIDCommError::KeyAgreement("KEK wrong size".into()))?;
+            let cek = aes_kw::unwrap(&kek, &wrapped_key)?;
+            (cek, false, None, false)
         }
         alg => {
             return Err(DIDCommError::UnsupportedAlgorithm(format!(
@@ -130,11 +168,6 @@ pub fn decrypt(
         }
     };
 
-    let kek_arr: [u8; 32] = kek
-        .try_into()
-        .map_err(|_| DIDCommError::KeyAgreement("KEK wrong size".into()))?;
-
-    let cek_bytes = aes_kw::unwrap(&kek_arr, &wrapped_key)?;
     let cek: [u8; 64] = cek_bytes
         .try_into()
         .map_err(|_| DIDCommError::KeyWrap("unwrapped CEK wrong size".into()))?;
@@ -148,6 +181,7 @@ pub fn decrypt(
         authenticated,
         sender_kid: sender_kid_str,
         recipient_kid: recipient_kid.to_string(),
+        legacy_kek_used,
     })
 }
 
@@ -527,5 +561,81 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    // ── #322: dual-KEK migration fallback ────────────────────────────
+
+    /// A JWE packed by an unpatched (legacy, unprefixed-tag) peer must
+    /// still decrypt via the fallback, with `legacy_kek_used == true`.
+    /// Covers all three ECDH-1PU curves.
+    fn legacy_sender_decrypts_via_fallback(curve: Curve) {
+        let sender = PrivateKeyAgreement::generate(curve);
+        let recipient = PrivateKeyAgreement::generate(curve);
+
+        let jwe_str = encrypt::authcrypt_legacy(
+            b"from a legacy peer",
+            "did:example:alice#key-1",
+            &sender,
+            "did:example:bob#key-1",
+            &recipient.public_key(),
+        )
+        .unwrap();
+
+        let result = decrypt(
+            &jwe_str,
+            "did:example:bob#key-1",
+            &recipient,
+            Some(&sender.public_key()),
+        )
+        .unwrap();
+
+        assert_eq!(result.plaintext, b"from a legacy peer");
+        assert!(result.authenticated);
+        assert!(
+            result.legacy_kek_used,
+            "legacy-packed JWE should decrypt only under the legacy KEK"
+        );
+    }
+
+    #[test]
+    fn legacy_fallback_x25519() {
+        legacy_sender_decrypts_via_fallback(Curve::X25519);
+    }
+
+    #[test]
+    fn legacy_fallback_p256() {
+        legacy_sender_decrypts_via_fallback(Curve::P256);
+    }
+
+    #[test]
+    fn legacy_fallback_k256() {
+        legacy_sender_decrypts_via_fallback(Curve::K256);
+    }
+
+    /// A spec-correct (current) authcrypt JWE must decrypt on the first
+    /// (correct) KEK — the fallback must NOT be engaged.
+    #[test]
+    fn spec_correct_authcrypt_does_not_use_legacy_fallback() {
+        let sender = PrivateKeyAgreement::generate(Curve::X25519);
+        let recipient = PrivateKeyAgreement::generate(Curve::X25519);
+
+        let jwe_str = encrypt::authcrypt(
+            b"spec-correct",
+            "did:example:alice#key-1",
+            &sender,
+            &[("did:example:bob#key-1", &recipient.public_key())],
+        )
+        .unwrap();
+
+        let result = decrypt(
+            &jwe_str,
+            "did:example:bob#key-1",
+            &recipient,
+            Some(&sender.public_key()),
+        )
+        .unwrap();
+
+        assert_eq!(result.plaintext, b"spec-correct");
+        assert!(!result.legacy_kek_used);
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm/src/jwe/encrypt.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jwe/encrypt.rs
@@ -173,6 +173,69 @@ pub fn anoncrypt(
     serde_json::to_string(&jwe).map_err(|e| DIDCommError::Serialization(format!("JWE: {e}")))
 }
 
+/// Test-only authcrypt that wraps the CEK under the **legacy** (pre-0.14,
+/// unprefixed-tag) ECDH-1PU KEK — i.e. a JWE exactly as an unpatched peer
+/// would emit it. Used to exercise the recipient-side decrypt fallback
+/// (issue #322). Mirrors [`authcrypt`] but for a single recipient.
+#[cfg(test)]
+pub(crate) fn authcrypt_legacy(
+    plaintext: &[u8],
+    sender_kid: &str,
+    sender_private: &PrivateKeyAgreement,
+    recipient_kid: &str,
+    recipient_pub: &PublicKeyAgreement,
+) -> Result<String, DIDCommError> {
+    let curve = recipient_pub.curve();
+    let ephemeral = EphemeralKeyPair::generate(curve);
+
+    let apu_raw = sender_kid.as_bytes();
+    let apv_raw = compute_apv(std::iter::once(recipient_kid));
+
+    let cek = content_encryption::generate_cek();
+    let iv = content_encryption::generate_iv();
+
+    let protected_header = ProtectedHeader {
+        typ: Some("application/didcomm-encrypted+json".into()),
+        alg: "ECDH-1PU+A256KW".into(),
+        enc: "A256CBC-HS512".into(),
+        skid: Some(sender_kid.to_string()),
+        apu: Some(Base64UrlUnpadded::encode_string(apu_raw)),
+        apv: Base64UrlUnpadded::encode_string(&apv_raw),
+        epk: ephemeral.public.to_jwk(),
+    };
+    let protected_str = serde_json::to_string(&protected_header)
+        .map_err(|e| DIDCommError::Serialization(format!("protected header: {e}")))?;
+    let protected_b64 = Base64UrlUnpadded::encode_string(protected_str.as_bytes());
+
+    let (ciphertext, tag) =
+        content_encryption::encrypt(plaintext, &cek, &iv, protected_b64.as_bytes())?;
+
+    let kek = ecdh_1pu::derive_sender_key_1pu_legacy(
+        &ephemeral,
+        sender_private,
+        recipient_pub,
+        apu_raw,
+        &apv_raw,
+        &tag,
+    )?;
+    let wrapped = aes_kw::wrap(&kek, &cek)?;
+
+    let jwe = Jwe {
+        protected: protected_b64,
+        recipients: vec![Recipient {
+            header: PerRecipientHeader {
+                kid: recipient_kid.to_string(),
+            },
+            encrypted_key: Base64UrlUnpadded::encode_string(&wrapped),
+        }],
+        iv: Base64UrlUnpadded::encode_string(&iv),
+        ciphertext: Base64UrlUnpadded::encode_string(&ciphertext),
+        tag: Base64UrlUnpadded::encode_string(&tag),
+    };
+
+    serde_json::to_string(&jwe).map_err(|e| DIDCommError::Serialization(format!("JWE: {e}")))
+}
+
 /// Compute APV: SHA-256 of sorted, dot-joined recipient KIDs.
 fn compute_apv<'a>(kids: impl Iterator<Item = &'a str>) -> Vec<u8> {
     let mut sorted: Vec<&str> = kids.collect();

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/envelope.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/envelope.rs
@@ -17,8 +17,25 @@ pub struct Jws {
 pub struct JwsSignature {
     /// BASE64URL(UTF8(JWS Protected Header))
     pub protected: String,
+    /// Per-signature JWS **unprotected** header (RFC 7515 §7.2.1). Not
+    /// integrity-protected, so never part of the signing input — but
+    /// DIDComm and several implementations (credo-ts, SICPA
+    /// didcomm-python) carry the signer `kid` here rather than in the
+    /// protected header, so it must be parsed to attribute the signer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<JwsUnprotectedHeader>,
     /// BASE64URL(JWS Signature)
     pub signature: String,
+}
+
+/// Per-signature JWS unprotected header members DIDComm cares about.
+/// Only `kid` is modelled today; unknown members deserialize and are
+/// ignored.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct JwsUnprotectedHeader {
+    /// Signer KID (DID URL), when carried unprotected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
 }
 
 /// JWS protected header for DIDComm signed messages.

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
@@ -37,6 +37,9 @@ pub fn sign_ed25519(
         payload: payload_b64,
         signatures: vec![JwsSignature {
             protected: header_b64,
+            // We carry kid in the protected header, so no unprotected
+            // header is emitted (verify reads either — issue #323).
+            header: None,
             signature: Base64UrlUnpadded::encode_string(&sig),
         }],
     };

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -10,7 +10,8 @@ use crate::jws::envelope::*;
 pub struct VerifiedJws {
     /// The raw payload bytes.
     pub payload: Vec<u8>,
-    /// The signer KID (if present in the protected header).
+    /// The signer KID, taken from the protected header if present,
+    /// otherwise from the per-signature unprotected header (issue #323).
     pub signer_kid: Option<String>,
 }
 
@@ -58,9 +59,17 @@ pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJw
     let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid payload base64: {e}")))?;
 
+    // Signer kid: prefer the protected header, fall back to the
+    // per-signature unprotected header (where DIDComm / credo-ts /
+    // didcomm-python place it). Verification itself doesn't depend on
+    // kid — the caller supplies the key — but attribution does.
+    let signer_kid = header
+        .kid
+        .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
+
     Ok(VerifiedJws {
         payload,
-        signer_kid: header.kid,
+        signer_kid,
     })
 }
 
@@ -97,5 +106,72 @@ mod tests {
             sign::sign_ed25519(b"test", "did:example:alice#key-1", &sk.to_bytes()).unwrap();
 
         assert!(verify_ed25519(&jws_str, &wrong_pk).is_err());
+    }
+
+    /// #323: a credo-ts / didcomm-python style JWS carries `kid` in the
+    /// per-signature *unprotected* header (the protected header has only
+    /// `typ`/`alg`). Verification must succeed AND attribute the signer
+    /// from the unprotected header.
+    #[test]
+    fn signer_kid_from_unprotected_header() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let pk = sk.verifying_key().to_bytes();
+        let payload = b"{\"type\":\"test\",\"body\":{}}";
+
+        // Protected header WITHOUT kid (only typ + alg).
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "EdDSA".into(),
+            kid: None,
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig = crate::crypto::signing::sign(signing_input.as_bytes(), &sk.to_bytes()).unwrap();
+
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: Some(JwsUnprotectedHeader {
+                    kid: Some("did:example:alice#key-1".into()),
+                }),
+                signature: Base64UrlUnpadded::encode_string(&sig),
+            }],
+        };
+        let jws_str = serde_json::to_string(&jws).unwrap();
+
+        let result = verify_ed25519(&jws_str, &pk).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#key-1"),
+            "signer_kid must come from the unprotected header when absent from protected"
+        );
+    }
+
+    /// When kid is present in BOTH headers, the protected one wins
+    /// (it's integrity-protected).
+    #[test]
+    fn protected_kid_takes_precedence_over_unprotected() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let pk = sk.verifying_key().to_bytes();
+
+        // sign_ed25519 puts kid in the protected header.
+        let jws_str =
+            sign::sign_ed25519(b"x", "did:example:alice#protected", &sk.to_bytes()).unwrap();
+        let mut jws: Jws = serde_json::from_str(&jws_str).unwrap();
+        jws.signatures[0].header = Some(JwsUnprotectedHeader {
+            kid: Some("did:example:mallory#unprotected".into()),
+        });
+        let jws_str = serde_json::to_string(&jws).unwrap();
+
+        let result = verify_ed25519(&jws_str, &pk).unwrap();
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#protected")
+        );
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
@@ -5,13 +5,29 @@ use crate::error::DIDCommError;
 use crate::message::Message;
 
 /// The result of unpacking a DIDComm message.
+///
+/// `#[non_exhaustive]` so future envelope shapes can be added without a
+/// breaking change — match with a `_ =>` arm.
+#[non_exhaustive]
 pub enum UnpackResult {
     /// An encrypted message was decrypted.
     Encrypted {
         message: Message,
+        /// Sender was cryptographically bound via authcrypt (ECDH-1PU).
         authenticated: bool,
+        /// Authcrypt sender KID (from the JWE `apu`/`skid`).
         sender_kid: Option<String>,
         recipient_kid: String,
+        /// `true` if decryption only succeeded under the legacy
+        /// (pre-0.14, issue #322) ECDH-1PU KEK — i.e. an unpatched
+        /// sender. A migration signal; see [`crate::jwe`].
+        legacy_kek_used: bool,
+        /// `true` if the encrypted payload was itself a signed JWS
+        /// (DIDComm v2.1 sign-then-encrypt) that was verified — i.e. the
+        /// message carries non-repudiation, not just authentication.
+        non_repudiation: bool,
+        /// Inner JWS signer KID, when `non_repudiation` is `true`.
+        signer_kid: Option<String>,
     },
     /// A signed message was verified.
     Signed {
@@ -32,6 +48,11 @@ pub enum UnpackResult {
 /// For encrypted messages, both `recipient_kid`/`recipient_private` are required.
 /// For authcrypt, `sender_public` is also required.
 /// For signed messages, `signer_public` is required.
+///
+/// If a decrypted JWE turns out to wrap a JWS (DIDComm v2.1
+/// sign-then-encrypt for non-repudiation), the inner signature is
+/// verified too — `signer_public` is then also required, and the result
+/// is [`UnpackResult::Encrypted`] with `non_repudiation = true`.
 pub fn unpack(
     input: &str,
     recipient_kid: Option<&str>,
@@ -52,6 +73,41 @@ pub fn unpack(
 
         let decrypted = crate::jwe::decrypt::decrypt(input, kid, private, sender_public)?;
 
+        // DIDComm v2.1 sign-then-encrypt (non-repudiation): the decrypted
+        // payload is itself a JWS, not a bare Message. Detect that and
+        // verify the inner signature rather than trying to parse the JWS
+        // envelope as a Message (issue #324). Detection is unambiguous —
+        // a plaintext DIDComm message has `id`/`type`, never
+        // `payload`+`signatures`.
+        let inner_is_jws = serde_json::from_slice::<serde_json::Value>(&decrypted.plaintext)
+            .ok()
+            .is_some_and(|v| v.get("payload").is_some() && v.get("signatures").is_some());
+
+        if inner_is_jws {
+            let pk = signer_public.ok_or_else(|| {
+                DIDCommError::InvalidMessage(
+                    "decrypted payload is a signed JWS (sign-then-encrypt); \
+                     signer_public is required to verify it"
+                        .into(),
+                )
+            })?;
+            let inner = std::str::from_utf8(&decrypted.plaintext).map_err(|e| {
+                DIDCommError::InvalidMessage(format!("inner JWS is not valid UTF-8: {e}"))
+            })?;
+            let verified = crate::jws::verify::verify_ed25519(inner, pk)?;
+            let message = Message::from_json(&verified.payload)?;
+
+            return Ok(UnpackResult::Encrypted {
+                message,
+                authenticated: decrypted.authenticated,
+                sender_kid: decrypted.sender_kid,
+                recipient_kid: decrypted.recipient_kid,
+                legacy_kek_used: decrypted.legacy_kek_used,
+                non_repudiation: true,
+                signer_kid: verified.signer_kid,
+            });
+        }
+
         let message = Message::from_json(&decrypted.plaintext)?;
 
         Ok(UnpackResult::Encrypted {
@@ -59,6 +115,9 @@ pub fn unpack(
             authenticated: decrypted.authenticated,
             sender_kid: decrypted.sender_kid,
             recipient_kid: decrypted.recipient_kid,
+            legacy_kek_used: decrypted.legacy_kek_used,
+            non_repudiation: false,
+            signer_kid: None,
         })
     } else if value.get("payload").is_some() && value.get("signatures").is_some() {
         // JWS — signed message
@@ -155,5 +214,87 @@ mod tests {
             }
             _ => panic!("expected Plaintext"),
         }
+    }
+
+    /// #324: DIDComm v2.1 sign-then-encrypt — a JWS wrapped in an
+    /// authcrypt JWE (credo-ts `packSignedAndEncrypted`). unpack() must
+    /// decrypt, verify the inner signature, and report non-repudiation +
+    /// the inner signer kid.
+    #[test]
+    fn unpack_sign_then_encrypt() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let signer_pk = sk.verifying_key().to_bytes();
+        let sender = PrivateKeyAgreement::generate(Curve::X25519);
+        let recipient = PrivateKeyAgreement::generate(Curve::X25519);
+
+        let msg = Message::new("test", serde_json::json!({"data": 42})).from("did:example:alice");
+
+        // Sign first, then encrypt the JWS bytes (sign-then-encrypt).
+        let jws = pack::pack_signed(&msg, "did:example:alice#sign-1", &sk.to_bytes()).unwrap();
+        let jwe = crate::jwe::encrypt::authcrypt(
+            jws.as_bytes(),
+            "did:example:alice#key-1",
+            &sender,
+            &[("did:example:bob#key-1", &recipient.public_key())],
+        )
+        .unwrap();
+
+        let result = unpack(
+            &jwe,
+            Some("did:example:bob#key-1"),
+            Some(&recipient),
+            Some(&sender.public_key()),
+            Some(&signer_pk),
+        )
+        .unwrap();
+
+        match result {
+            UnpackResult::Encrypted {
+                message,
+                authenticated,
+                non_repudiation,
+                signer_kid,
+                ..
+            } => {
+                assert!(authenticated);
+                assert!(
+                    non_repudiation,
+                    "sign-then-encrypt must set non_repudiation"
+                );
+                assert_eq!(signer_kid.as_deref(), Some("did:example:alice#sign-1"));
+                assert_eq!(message.body["data"], 42);
+            }
+            _ => panic!("expected Encrypted"),
+        }
+    }
+
+    /// A sign-then-encrypt message decrypts but cannot be verified
+    /// without the signer's public key — unpack() must surface that
+    /// rather than returning an unverified message.
+    #[test]
+    fn unpack_sign_then_encrypt_requires_signer_public() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sender = PrivateKeyAgreement::generate(Curve::X25519);
+        let recipient = PrivateKeyAgreement::generate(Curve::X25519);
+
+        let msg = Message::new("test", serde_json::json!({}));
+        let jws = pack::pack_signed(&msg, "did:example:alice#sign-1", &sk.to_bytes()).unwrap();
+        let jwe = crate::jwe::encrypt::authcrypt(
+            jws.as_bytes(),
+            "did:example:alice#key-1",
+            &sender,
+            &[("did:example:bob#key-1", &recipient.public_key())],
+        )
+        .unwrap();
+
+        // signer_public = None → must error, not return an unverified message.
+        let result = unpack(
+            &jwe,
+            Some("did:example:bob#key-1"),
+            Some(&recipient),
+            Some(&sender.public_key()),
+            None,
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-helpers"
-version = "0.13.0"
+version = "0.13.1"
 description = "CLI tools for Affinidi Messaging (mediator administration)"
 edition.workspace = true
 authors.workspace = true
@@ -25,7 +25,7 @@ affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" 
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
 ## DIDComm message types — used by example binaries
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13", features = ["messaging-core"] }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.14", features = ["messaging-core"] }
 ## Protocol-agnostic messaging-core traits — used by `unified_messaging` example
 affinidi-messaging-core = { path = "../affinidi-messaging-core" }
 ## TSP transport — used by `unified_messaging` and `protocol_comparison` examples

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 31st May 2026
 
+### 0.15.7 — DIDComm v2.1 interop fixes (via affinidi-messaging-didcomm 0.14)
+
+Picks up `affinidi-messaging-didcomm` 0.14, which corrects the ECDH-1PU
+authcrypt KDF (#322), reads the signer `kid` from the JWS unprotected
+header (#323), and auto-unwraps sign-then-encrypt messages (#324). The
+mediator's authcrypt — including the DID-authentication handshake — is
+now spec-correct and interoperable with credo-ts / didcomm-python. The
+0.14 dual-KEK decrypt fallback keeps the mediator able to receive from
+not-yet-upgraded peers during rollout. No mediator config or API change.
+
 ### 0.15.6 — CORS policy in the setup wizard + sub-domain wildcards
 
 Additive, backward-compatible release. Existing `cors_allow_origin`

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.6"
+version = "0.15.7"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -62,7 +62,7 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13", optional = true }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.14", optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Multibase/multicodec encoding helpers (needed by didcomm for key encoding)

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -2,14 +2,35 @@
 
 ## [0.18.4] - 2026-05-31
 
+### Security
+
+- **`unpack()` now verifies JWS signatures.** Previously a signed
+  (JWS) message was parsed *without* checking the signature and returned
+  with `non_repudiation: true` — i.e. a forged signature was accepted and
+  labelled non-repudiable. `unpack()` now resolves the signer's Ed25519
+  key from its `kid` (via the DID resolver) and verifies the signature;
+  an unresolvable signer or an invalid signature is an **error**. The
+  signer is attributed in `UnpackMetadata.sign_from`, read from the
+  protected header and falling back to the unprotected header (#323).
+  Behaviour change: flows that relied on the previous lax parsing of
+  unverified JWS will now receive an error instead of a message.
+
+### Added
+
+- **Sign-then-encrypt support (#324).** When a decrypted JWE wraps a JWS
+  (DIDComm v2.1 non-repudiation), `unpack()` verifies the inner signature
+  and reports `non_repudiation` + `sign_from` alongside the encryption
+  metadata, instead of failing to parse.
+
 ### Changed
 
-- Bump `affinidi-messaging-didcomm` to 0.14, which corrects the ECDH-1PU
-  authcrypt KDF and adds DIDComm v2.1 JWS/sign-then-encrypt interop fixes
-  (#322/#323/#324). The SDK's `unpack_jwe` decrypt path picks up the fix
-  and the transitional dual-KEK fallback transparently. No SDK API
-  change. (Note: the SDK's own unpack path does not yet auto-unwrap
-  sign-then-encrypt — tracked as follow-up.)
+- Bump `affinidi-messaging-didcomm` to 0.14 (corrected ECDH-1PU authcrypt
+  KDF + dual-KEK fallback, #322). The decrypt path picks these up
+  transparently.
+- Verification-material parsing now delegates to
+  `affinidi-did-common`'s `VerificationMethod::decode_public_key`,
+  removing the SDK's bespoke JWK/multibase branch (shared with the
+  DID-authentication layer).
 
 ## [0.18.3] - 2026-05-24
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.18.4] - 2026-05-31
+
+### Changed
+
+- Bump `affinidi-messaging-didcomm` to 0.14, which corrects the ECDH-1PU
+  authcrypt KDF and adds DIDComm v2.1 JWS/sign-then-encrypt interop fixes
+  (#322/#323/#324). The SDK's `unpack_jwe` decrypt path picks up the fix
+  and the transitional dual-KEK fallback transparently. No SDK API
+  change. (Note: the SDK's own unpack path does not yet auto-unwrap
+  sign-then-encrypt — tracked as follow-up.)
+
 ## [0.18.3] - 2026-05-24
 
 ### Security

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.3"
+version = "0.18.4"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ repository.workspace = true
 [dependencies]
 # Affinidi Crates
 affinidi-tdk-common = "0.6"
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13" }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.14" }
 ## Source of truth for the mediator protocol vocabulary (ACLs, accounts,
 ## message types, problem reports). The SDK re-exports these so existing
 ## call sites continue to resolve their old paths.

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
@@ -53,8 +53,10 @@ impl SharedState {
                         // JWE — encrypted message
                         self.unpack_jwe(&msg_string, &value, &sha256_hash).await?
                     } else if value.get("payload").is_some() && value.get("signatures").is_some() {
-                        // JWS — signed message (not yet fully supported, parse plaintext from payload)
-                        self.unpack_jws(&msg_string, &sha256_hash)?
+                        // JWS — signed message: verify the signature and
+                        // attribute the signer (resolving its key via the
+                        // DID resolver).
+                        self.unpack_jws(&value, &msg_string, &sha256_hash).await?
                     } else if value.get("type").is_some() {
                         // Plaintext DIDComm message
                         let msg = Message::from_json(msg_string.as_bytes()).map_err(|e| {
@@ -158,6 +160,34 @@ impl SharedState {
             ATMError::DidcommError("Couldn't unpack incoming message".into(), e.to_string())
         })?;
 
+        // DIDComm v2.1 sign-then-encrypt (non-repudiation): the decrypted
+        // payload may itself be a JWS, not a bare Message. Detect that,
+        // verify the inner signature, and surface non-repudiation + the
+        // signer — instead of trying to parse the JWS envelope as a
+        // Message (which would fail). Detection is unambiguous: a
+        // plaintext DIDComm message has `id`/`type`, never
+        // `payload`+`signatures`.
+        if let Ok(inner) = serde_json::from_slice::<serde_json::Value>(&decrypted.plaintext)
+            && inner.get("payload").is_some()
+            && inner.get("signatures").is_some()
+        {
+            let inner_str = std::str::from_utf8(&decrypted.plaintext)
+                .map_err(|e| ATMError::DidcommError("Invalid inner JWS".into(), e.to_string()))?;
+            let (msg, sign_from) = self.verify_inner_jws(inner_str, &inner).await?;
+            let metadata = UnpackMetadata {
+                encrypted: true,
+                authenticated: decrypted.authenticated,
+                anonymous_sender: !decrypted.authenticated,
+                encrypted_from_kid: decrypted.sender_kid,
+                encrypted_to_kids: vec![decrypted.recipient_kid],
+                non_repudiation: true,
+                sign_from: Some(sign_from),
+                sha256_hash: sha256_hash.to_string(),
+                ..Default::default()
+            };
+            return Ok((msg, metadata));
+        }
+
         let msg = Message::from_json(&decrypted.plaintext).map_err(|e| {
             ATMError::DidcommError("Cannot parse decrypted message".into(), e.to_string())
         })?;
@@ -242,64 +272,143 @@ impl SharedState {
             .next()
             .or_else(|| sender_doc.doc.get_verification_method(sender_kid))?;
 
-        if let Some(jwk_value) = vm.property_set.get("publicKeyJwk") {
-            return affinidi_messaging_didcomm::crypto::key_agreement::PublicKeyAgreement::from_jwk(jwk_value).ok();
-        }
-
-        if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
-            && let Some(multibase_str) = multibase_value.as_str()
-        {
-            let (codec, key_bytes) =
-                affinidi_encoding::decode_multikey_with_codec(multibase_str).ok()?;
-            let curve = match codec {
-                affinidi_encoding::X25519_PUB => {
-                    affinidi_messaging_didcomm::crypto::key_agreement::Curve::X25519
-                }
-                affinidi_encoding::P256_PUB => {
-                    affinidi_messaging_didcomm::crypto::key_agreement::Curve::P256
-                }
-                affinidi_encoding::SECP256K1_PUB => {
-                    affinidi_messaging_didcomm::crypto::key_agreement::Curve::K256
-                }
-                _ => return None,
-            };
-            return affinidi_messaging_didcomm::crypto::key_agreement::PublicKeyAgreement::from_raw_bytes(curve, &key_bytes).ok();
-        }
-
-        None
+        // Single source of truth for verification-material parsing lives
+        // in `affinidi-did-common` (`decode_public_key`); map its
+        // `(multicodec, bytes)` onto a key-agreement key here.
+        use affinidi_messaging_didcomm::crypto::key_agreement::{Curve, PublicKeyAgreement};
+        let (codec, key_bytes) = vm.decode_public_key().ok()?;
+        let curve = match codec {
+            affinidi_encoding::X25519_PUB => Curve::X25519,
+            affinidi_encoding::P256_PUB => Curve::P256,
+            affinidi_encoding::SECP256K1_PUB => Curve::K256,
+            _ => return None,
+        };
+        PublicKeyAgreement::from_raw_bytes(curve, &key_bytes).ok()
     }
 
-    /// Unpack a JWS (signed) message — basic support
-    fn unpack_jws(
+    /// Unpack a JWS (signed) message: verify the signature against the
+    /// signer's resolved key and attribute the signer. Unlike the prior
+    /// behaviour, this never returns an unverified message marked
+    /// non-repudiable — an unresolvable signer or a bad signature is an
+    /// error.
+    async fn unpack_jws(
         &self,
-        _msg_string: &str,
+        value: &serde_json::Value,
+        msg_string: &str,
         sha256_hash: &str,
     ) -> Result<(Message, UnpackMetadata), ATMError> {
-        // For JWS, we parse the payload directly without verification for now
-        // Full JWS verification would require resolving the signer's public key
-        let value: serde_json::Value = serde_json::from_str(_msg_string)
-            .map_err(|e| ATMError::DidcommError("Cannot parse JWS".into(), e.to_string()))?;
-
-        let payload_b64 = value["payload"].as_str().ok_or_else(|| {
-            ATMError::DidcommError("Invalid JWS".into(), "missing payload".into())
-        })?;
-
-        use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-        let payload_bytes = BASE64_URL_SAFE_NO_PAD.decode(payload_b64).map_err(|e| {
-            ATMError::DidcommError("Invalid JWS".into(), format!("invalid payload base64: {e}"))
-        })?;
-
-        let msg = Message::from_json(&payload_bytes).map_err(|e| {
-            ATMError::DidcommError("Cannot parse JWS payload".into(), e.to_string())
-        })?;
+        let (msg, sign_from) = self.verify_inner_jws(msg_string, value).await?;
 
         let metadata = UnpackMetadata {
             non_repudiation: true,
+            sign_from: Some(sign_from),
             sha256_hash: sha256_hash.to_string(),
             ..Default::default()
         };
 
         Ok((msg, metadata))
+    }
+
+    /// Verify a JWS — resolving the signer's Ed25519 key from its `kid`
+    /// — and return the decoded [`Message`] plus the signer kid. Shared
+    /// by top-level signed messages and the inner JWS of a
+    /// sign-then-encrypt envelope. Errors if the signer key can't be
+    /// resolved or the signature is invalid; we never surface an
+    /// unverified message.
+    async fn verify_inner_jws(
+        &self,
+        jws_str: &str,
+        jws_value: &serde_json::Value,
+    ) -> Result<(Message, String), ATMError> {
+        use affinidi_messaging_didcomm::jws::verify::verify_ed25519;
+
+        let signer_kid = Self::jws_signer_kid(jws_value).ok_or_else(|| {
+            ATMError::DidcommError("Invalid JWS".into(), "no signer kid in JWS headers".into())
+        })?;
+        let signer_pk = self
+            .try_resolve_signer_ed25519(&signer_kid)
+            .await
+            .ok_or_else(|| {
+                ATMError::DidcommError(
+                    "Couldn't verify JWS".into(),
+                    format!("could not resolve an Ed25519 verification key for '{signer_kid}'"),
+                )
+            })?;
+        let verified = verify_ed25519(jws_str, &signer_pk).map_err(|e| {
+            ATMError::DidcommError("JWS signature verification failed".into(), e.to_string())
+        })?;
+        let msg = Message::from_json(&verified.payload).map_err(|e| {
+            ATMError::DidcommError("Cannot parse verified JWS payload".into(), e.to_string())
+        })?;
+        // Prefer the kid the verifier extracted (protected, then
+        // unprotected header); fall back to the one we resolved against.
+        Ok((msg, verified.signer_kid.unwrap_or(signer_kid)))
+    }
+
+    /// Extract the signer `kid` from a JWS's first signature, preferring
+    /// the protected header and falling back to the per-signature
+    /// unprotected header (RFC 7515 §4.1.4 — where DIDComm / credo-ts /
+    /// didcomm-python place it).
+    fn jws_signer_kid(jws_value: &serde_json::Value) -> Option<String> {
+        use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+        let sig = jws_value.get("signatures")?.as_array()?.first()?;
+        if let Some(protected) = sig.get("protected").and_then(|v| v.as_str())
+            && let Ok(bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected)
+            && let Ok(header) = serde_json::from_slice::<serde_json::Value>(&bytes)
+            && let Some(kid) = header.get("kid").and_then(|v| v.as_str())
+        {
+            return Some(kid.to_string());
+        }
+        sig.get("header")?.get("kid")?.as_str().map(str::to_string)
+    }
+
+    /// Resolve the signer's Ed25519 verification key (32 octets) for a
+    /// `kid` by resolving its DID document. Looks in the `authentication`
+    /// relationship first (where DIDComm signing keys live), then any
+    /// verification method. Returns `None` if unresolvable or not
+    /// Ed25519. Mirrors [`Self::try_resolve_sender_public`] but for the
+    /// signing key, and shares the verification-material decoder
+    /// (`VerificationMethod::decode_public_key`).
+    async fn try_resolve_signer_ed25519(&self, kid: &str) -> Option<[u8; 32]> {
+        use affinidi_did_common::{
+            document::DocumentExt, verification_method::VerificationRelationship,
+        };
+
+        let did = kid.split('#').next().unwrap_or(kid);
+        let doc = self.tdk_common.did_resolver().resolve(did).await.ok()?;
+
+        // Fragment-qualified kid → that exact key; bare DID → first
+        // authentication key.
+        let lookup_owned: String;
+        let lookup_kid: &str = if kid.contains('#') {
+            kid
+        } else {
+            let auth = doc.doc.find_authentication(None);
+            lookup_owned = auth.first()?.to_string();
+            &lookup_owned
+        };
+
+        let vm = doc
+            .doc
+            .authentication
+            .iter()
+            .filter_map(|a| match a {
+                VerificationRelationship::VerificationMethod(vm)
+                    if vm.id.as_str() == lookup_kid =>
+                {
+                    Some(vm.as_ref())
+                }
+                _ => None,
+            })
+            .next()
+            .or_else(|| doc.doc.get_verification_method(lookup_kid))?;
+
+        let (codec, bytes) = vm.decode_public_key().ok()?;
+        if codec == affinidi_encoding::ED25519_PUB {
+            bytes.try_into().ok()
+        } else {
+            None
+        }
     }
 
     pub async fn unpack_forward(
@@ -894,6 +1003,158 @@ mod tests {
         assert_eq!(unpacked.id, "test-k256-anon-1");
         assert!(meta.encrypted);
         assert!(!meta.authenticated);
+    }
+
+    /// Generate a did:peer:2 with an Ed25519 signing key (V, #key-1) and
+    /// an X25519 key-agreement key (E, #key-2). Returns the DID, the
+    /// Ed25519 private key, the signer kid, and the X25519 secret.
+    fn generate_peer_did_signing_and_x25519() -> (String, [u8; 32], String, Secret) {
+        use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+        let x25519_secret = Secret::generate_x25519(Some("temp"), None).unwrap();
+        let x25519_multibase = x25519_secret.get_public_keymultibase().unwrap();
+
+        let keys = vec![
+            PeerCreateKey::new(PeerKeyPurpose::Verification, PeerKeyType::Ed25519),
+            PeerCreateKey::from_multibase(PeerKeyPurpose::Encryption, x25519_multibase),
+        ];
+        let (did, created) = DID::generate_peer(&keys, None).unwrap();
+        let did_string = did.to_string();
+
+        // V (Ed25519) is the first created key; `d` is its base64url private.
+        let v_priv: [u8; 32] = BASE64_URL_SAFE_NO_PAD
+            .decode(&created[0].d)
+            .unwrap()
+            .try_into()
+            .expect("Ed25519 private key is 32 bytes");
+        let signer_kid = format!("{did_string}#key-1");
+
+        let mut secret = x25519_secret;
+        secret.id = format!("{did_string}#key-2");
+
+        (did_string, v_priv, signer_kid, secret)
+    }
+
+    /// #323: a top-level signed (JWS) message must be cryptographically
+    /// verified — and the signer attributed — not parsed blindly. (The
+    /// prior behaviour returned the payload unverified with
+    /// `non_repudiation: true`.)
+    #[tokio::test]
+    async fn unpack_signed_jws_verifies_and_attributes() {
+        use affinidi_messaging_didcomm::message::pack;
+
+        let (did, v_priv, signer_kid, _x) = generate_peer_did_signing_and_x25519();
+        // No secrets needed to *verify* — the signer's key is resolved.
+        let atm = create_atm().await;
+
+        let msg = DcMessage::build(
+            "sig-1".to_string(),
+            "example/v1".to_string(),
+            json!({"signed": true}),
+        )
+        .from(did.clone())
+        .finalize();
+        let jws = pack::pack_signed(&msg, &signer_kid, &v_priv).unwrap();
+
+        let (unpacked, meta) = atm
+            .unpack(&jws)
+            .await
+            .expect("a validly-signed JWS should verify");
+        assert_eq!(unpacked.id, "sig-1");
+        assert!(!meta.encrypted);
+        assert!(
+            meta.non_repudiation,
+            "verified signature => non_repudiation"
+        );
+        assert_eq!(meta.sign_from.as_deref(), Some(signer_kid.as_str()));
+    }
+
+    /// #323 security: a JWS whose payload was tampered after signing must
+    /// be REJECTED, not accepted as non-repudiable.
+    #[tokio::test]
+    async fn unpack_signed_jws_tampered_payload_is_rejected() {
+        use affinidi_messaging_didcomm::message::pack;
+        use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+
+        let (did, v_priv, signer_kid, _x) = generate_peer_did_signing_and_x25519();
+        let atm = create_atm().await;
+
+        let msg = DcMessage::build("sig-ok".to_string(), "example/v1".to_string(), json!({}))
+            .from(did.clone())
+            .finalize();
+        let jws = pack::pack_signed(&msg, &signer_kid, &v_priv).unwrap();
+
+        // Swap the payload for a different message; the signature no
+        // longer covers it.
+        let mut v: serde_json::Value = serde_json::from_str(&jws).unwrap();
+        v["payload"] = json!(
+            BASE64_URL_SAFE_NO_PAD
+                .encode(br#"{"id":"evil","typ":"example/v1","type":"example/v1","body":{"x":1}}"#)
+        );
+        let tampered = serde_json::to_string(&v).unwrap();
+
+        assert!(
+            atm.unpack(&tampered).await.is_err(),
+            "a tampered JWS must fail verification, not be trusted"
+        );
+    }
+
+    /// #324: DIDComm v2.1 sign-then-encrypt through the SDK — the inner
+    /// JWS is verified after decryption, surfacing non-repudiation + the
+    /// signer.
+    #[tokio::test]
+    async fn unpack_sign_then_encrypt() {
+        use affinidi_messaging_didcomm::crypto::key_agreement::{
+            Curve, PrivateKeyAgreement, PublicKeyAgreement,
+        };
+        use affinidi_messaging_didcomm::jwe::encrypt;
+        use affinidi_messaging_didcomm::message::pack;
+
+        let (sender_did, v_priv, signer_kid, sender_x) = generate_peer_did_signing_and_x25519();
+        let (recipient_did, recipient_secret) = generate_peer_did_with_x25519();
+        let recipient_atm = create_atm_with_secrets(vec![recipient_secret.clone()]).await;
+
+        let msg = DcMessage::build(
+            "ste-1".to_string(),
+            "example/v1".to_string(),
+            json!({"v": 7}),
+        )
+        .from(sender_did.clone())
+        .to(recipient_did.clone())
+        .finalize();
+
+        // Sign first, then authcrypt the JWS bytes (sign-then-encrypt).
+        let jws = pack::pack_signed(&msg, &signer_kid, &v_priv).unwrap();
+
+        let sender_priv =
+            PrivateKeyAgreement::from_raw_bytes(Curve::X25519, sender_x.get_private_bytes())
+                .unwrap();
+        let (_, rpub) = affinidi_encoding::decode_multikey_with_codec(
+            &recipient_secret.get_public_keymultibase().unwrap(),
+        )
+        .unwrap();
+        let recipient_pub = PublicKeyAgreement::from_raw_bytes(Curve::X25519, &rpub).unwrap();
+
+        let jwe = encrypt::authcrypt(
+            jws.as_bytes(),
+            &format!("{sender_did}#key-2"),
+            &sender_priv,
+            &[(&format!("{recipient_did}#key-2"), &recipient_pub)],
+        )
+        .unwrap();
+
+        let (unpacked, meta) = recipient_atm
+            .unpack(&jwe)
+            .await
+            .expect("sign-then-encrypt should decrypt and verify");
+        assert_eq!(unpacked.id, "ste-1");
+        assert_eq!(unpacked.body, json!({"v": 7}));
+        assert!(meta.encrypted);
+        assert!(meta.authenticated, "authcrypt => authenticated");
+        assert!(
+            meta.non_repudiation,
+            "inner JWS verified => non_repudiation"
+        );
+        assert_eq!(meta.sign_from.as_deref(), Some(signer_kid.as_str()));
     }
 
     const FORWARD_TYPE: &str = "https://didcomm.org/routing/2.0/forward";

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.12.3] - 2026-05-31
+
+### Changed
+
+- Bump `affinidi-messaging-didcomm` to 0.14 (DIDComm v2.1 interop fixes:
+  ECDH-1PU authcrypt KDF #322, JWS unprotected `kid` #323,
+  sign-then-encrypt unpack #324). No text-client API change.
+
 ## [0.12.2] - 2026-05-24
 
 ### Security

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.2"
+version = "0.12.3"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ repository.workspace = true
 # Affinidi Crates
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.13" }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.14" }
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.7.2] - 2026-05-31
+
+### Changed
+
+- Bump `affinidi-messaging-didcomm` to 0.14 (DIDComm v2.1 interop fixes:
+  ECDH-1PU authcrypt KDF #322, JWS unprotected `kid` #323,
+  sign-then-encrypt unpack #324). No `affinidi-tdk` API change.
+
 ## [0.7.1] - 2026-05-02
 
 ### Deprecated

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.7.1"
+version = "0.7.2"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -23,7 +23,7 @@ data-integrity = ["dep:affinidi-data-integrity", "dep:serde"]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.3"
 affinidi-messaging-sdk = { version = "0.18", optional = true }
-affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.13" }
+affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.14" }
 affinidi-did-authentication = "0.3"
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"


### PR DESCRIPTION
Fixes #322, #323, #324 — DIDComm v2.1 interop bugs found via an interop matrix against [credo-ts](https://github.com/openwallet-foundation/credo-ts), verified against the code and the relevant specs. Also hardens the **SDK** consumer path and consolidates duplicated key parsing.

## didcomm crate (the three filed issues)

**#322 — ECDH-1PU Concat KDF missing length prefix on the tag (high).** `cc_tag` was fed to the KDF without the 32-bit big-endian length prefix every other OtherInfo field carries, so the derived KEK differed from every spec-following impl (credo-ts/Askar, didcomm-python) — breaking all `ECDH-1PU+A256KW` authcrypt interop. Confirmed against draft-madden-jose-ecdh-1pu-04 §2.3/App. B. Packing is now spec-correct (X25519/P-256/K-256; anoncrypt unaffected). A transitional **dual-KEK decrypt fallback** (try correct, then legacy on AES-KW failure) keeps upgraded recipients able to read not-yet-upgraded senders; reported via `legacy_kek_used`.

**#323 — unprotected JWS `kid` ignored.** `JwsSignature` gained the per-signature unprotected `header` (RFC 7515 §7.2.1); verify reads protected then unprotected `kid`, so `signer_kid` is populated.

**#324 — sign-then-encrypt not auto-unwrapped.** `unpack()` now detects a JWS inside a decrypted JWE, verifies the inner signature, and reports `non_repudiation` + inner `signer_kid`. `UnpackResult` is now `#[non_exhaustive]`.

## SDK hardening (the real consumer path)

The SDK's `unpack()` had a **parallel** implementation that didn't deliver #323/#324 to clients:
- **Security:** signed JWS were parsed **without verifying the signature**, yet returned with `non_repudiation: true` — a forged signature was accepted and labelled non-repudiable. `unpack()` now resolves the signer's Ed25519 key (via the DID resolver), verifies, and **errors** on an unresolvable signer or bad signature. Signer attributed in `UnpackMetadata.sign_from`.
- **Sign-then-encrypt** is now verified end-to-end through the SDK.

## Consolidation (reduce parallel paths)

Three copies of "DID verification-material → key" parsing collapsed into one: `affinidi-did-common`'s new `VerificationMethod::decode_public_key()` (handles `publicKeyMultibase` + `publicKeyJwk` via `affinidi-crypto`, returns `(multicodec, bytes)`). The SDK sender-key path and DID-authentication's key-agreement resolver both delegate to it. **didcomm stays pure** (no DID-resolution dep); resolution lives in the SDK/auth layers.

## Tests
- didcomm: length-prefix KAT, spec≠legacy KEK, dual-KEK fallback for X25519/P-256/K-256, JWS unprotected-kid + precedence, sign-then-encrypt + missing-key error (98 pass)
- did-common: `decode_public_key` multibase + JWK (Ed25519 / P-256 SEC1) + missing-material
- SDK: JWS verify+attribute, **tampered JWS rejected**, sign-then-encrypt round-trip, all existing authcrypt/anoncrypt round-trips (X25519/P-256/K-256) still green
- Full workspace build + `clippy --all-targets --all-features -D warnings` clean; `cargo deny` shows only pre-existing advisories

## Versions (major.minor pinning)
`affinidi-messaging-didcomm` 0.13.3 → **0.14.0** (interop-affecting). Dependent bumps + didcomm pin `0.13`→`0.14`: sdk 0.18.4, mediator 0.15.7, tdk 0.7.2, helpers 0.13.1, text-client 0.12.3, did-authentication 0.3.4, meeting-place 0.4.1, didcomm-service 0.3.2. Plus **affinidi-did-common 0.3.3 → 0.3.4** (new `decode_public_key` API; patched + `0.3`-pinned, so no further cascade).

## Migration / rollout
0.14 senders emit the spec-correct KEK, so they can't be decrypted by un-upgraded 0.13 recipients. **Upgrade recipients before senders** (the dual-KEK fallback makes upgraded nodes bilingual). No working external interop is lost. The SDK JWS change is stricter: flows that relied on unverified-JWS parsing now get an error.

## Known follow-ups
- **Centralize the crypto core in `affinidi-crypto`** (separate ADR): didcomm hand-rolls its JOSE crypto (ECDH/Concat-KDF/AEAD/key-wrap) — the parallel-crypto root cause of #322. affinidi-crypto today is signing/key-type/JWK/PQC only; growing it + rebasing didcomm is a multi-PR migration.
- **vta-sdk 0.7.0** (external) still pins didcomm `0.13` → pulls the published 0.13.3 (two didcomm versions coexist; `multiple-versions = "allow"`, deny passes). Republish vta-sdk against 0.14, then bump its pin.
- A sibling JS DIDComm lib (e.g. vta-didcomm-js), if it hand-rolls ECDH-1PU, needs the same length-prefix fix to interop with 0.14 senders.