### PR TITLE
chore: bump mediator 0.15.8 + mediator-setup 0.1.5 — vta-sdk 0.9 unifies didcomm on 0.14

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 1st June 2026
+
+### 0.15.8 — vta-sdk 0.9 (didcomm 0.14 unification)
+
+Dependency-only release; no mediator config or API change.
+
+- **CHORE:** Bumps `vta-sdk` from `0.7` to `0.9` (both the mediator's
+  `integration` dependency and the `mediator-setup` wizard's
+  `provision-client` / `test-support` dependencies). vta-sdk 0.7 pinned
+  `affinidi-messaging-didcomm` at `0.13`, which the workspace
+  `[patch.crates-io]` redirect (now at `0.14`) no longer satisfied — so
+  the build dragged in an unpatched `affinidi-messaging-didcomm 0.13.3`
+  from crates.io alongside the in-tree `0.14.0`. vta-sdk 0.9 pins
+  `0.14`, so the patch re-applies and the whole tree unifies on the
+  in-tree `0.14.0` (carrying the DIDComm v2.1 interop/security fixes
+  from 0.15.7). The duplicate `0.13.3` copy is gone.
+- `mediator-setup` bumped to `0.1.5` for the coordinated vta-sdk pin.
+
 ## 31st May 2026
 
 ### 0.15.7 — DIDComm v2.1 interop fixes (via affinidi-messaging-didcomm 0.14)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.7"
+version = "0.15.8"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -82,7 +82,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.7", features = ["integration"] }
+vta-sdk = { version = "0.9", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.4"
+version = "0.1.5"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.7", features = ["provision-client"] }
+vta-sdk = { version = "0.9", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.7", features = ["test-support"] }
+vta-sdk = { version = "0.9", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
## What

Bumps `vta-sdk` from `0.7` to `0.9` across the mediator and its setup wizard, and bumps the two crates accordingly:

- `affinidi-messaging-mediator` `0.15.7` → `0.15.8`
- `affinidi-messaging-mediator-setup` `0.1.4` → `0.1.5`

## Why

vta-sdk `0.7` pinned `affinidi-messaging-didcomm` at `0.13`. The workspace `[patch.crates-io]` redirect now points didcomm at the in-tree `0.14`, which a `0.13` requirement no longer satisfies — so the build **un-unified** and dragged in an unpatched `affinidi-messaging-didcomm 0.13.3` from crates.io *alongside* the in-tree `0.14.0`. That stale copy missed the DIDComm v2.1 interop/security fixes shipped in `0.14.0` (ECDH-1PU KDF #322, JWS `kid` #323, sign-then-encrypt #324 — landed in mediator 0.15.7).

vta-sdk `0.9` pins `0.14`, so the patch re-applies and the whole dependency tree unifies on the in-tree `0.14.0`. The duplicate `0.13.3` is gone (`cargo update` reports `Removing affinidi-messaging-didcomm v0.13.3`).

The pin is bumped in three places: the mediator's `integration` dependency, and the setup wizard's `provision-client` and `test-support` dependencies. The `integration` / `provision-client` / `test-support` features all still exist in vta-sdk 0.9.

## Scope

- No mediator config or API change — dependency-only.
- `test-mediator` pins the mediator at `"0.15"`, so the patch bump cascades via workspace path resolution with no manifest edit (per the repo's major.minor pinning convention).
- `Cargo.lock` is gitignored in this workspace, so no lockfile is committed; CI regenerates it fresh.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy` clean on mediator / mediator-setup / test-mediator (all targets, all features)
- Tests pass — **44** across the three crates, including the `lifecycle.rs` end-to-end DIDComm flow
- `cargo deny`: bans / licenses / sources OK

> Note: `cargo deny` flags one **pre-existing, unrelated** advisory — `serde_cbor` (RUSTSEC-2021-0127, unmaintained) via `affinidi-mdoc 0.2.0` in the credentials layer. Not in the mediator tree and not introduced by this change; tracked separately.