### PR TITLE
fix: clear cargo-deny advisories — drop serde_cbor from affinidi-mdoc 0.2.1, tidy deny.toml

### DIFF
--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi mdoc Changelog
 
+## 1st June 2026 Release 0.2.1
+
+### Security
+
+- **Drops the unmaintained `serde_cbor` dependency (RUSTSEC-2021-0127).**
+  `serde_cbor` was declared in `[dependencies]` but referenced nowhere
+  in the crate — all CBOR encoding/decoding already goes through
+  `ciborium`. Removing the unused dependency clears the advisory with
+  no code or behaviour change.
+
 ## 28th May 2026 Release 0.2.0
 
 ### Security

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -37,7 +37,6 @@ coset = "0.3"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
-serde_cbor = "0.11"
 serde_json = "1"
 p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
 p384 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,7 @@
 version = 2
 ignore = [
   { id = "RUSTSEC-2022-0092", reason = "askalono always provides valid utf-8 files from a cache, this is not relevant" },
+  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error (unmaintained) is a build-time-only transitive dep of the ssi-json-ld stack (ssi-dids-core -> linked-data-derive); no runtime exposure. Drops out once upstream ssi-* releases migrate off it." },
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 version = 2
 ignore = [
-  { id = "RUSTSEC-2022-0092", reason = "askalono always provides valid utf-8 files from a cache, this is not relevant" },
   { id = "RUSTSEC-2024-0370", reason = "proc-macro-error (unmaintained) is a build-time-only transitive dep of the ssi-json-ld stack (ssi-dids-core -> linked-data-derive); no runtime exposure. Drops out once upstream ssi-* releases migrate off it." },
 ]
 


### PR DESCRIPTION
## What

Gets `cargo deny check` fully green again. Three changes:

1. **Drop the unmaintained `serde_cbor` dependency from `affinidi-mdoc`** (bump `0.2.0` → `0.2.1`) — clears **RUSTSEC-2021-0127**.
2. **Ignore `proc-macro-error` (RUSTSEC-2024-0370)** in `deny.toml` — a separate, pre-existing advisory that was masked behind serde_cbor.
3. **Drop the stale `RUSTSEC-2022-0092` (askalono) ignore** — no crate in the tree matches it anymore.

## Why

### 1. serde_cbor (RUSTSEC-2021-0127) — real fix

`serde_cbor` (repo archived, unmaintained) was declared in `affinidi-mdoc`'s `[dependencies]` but **referenced nowhere** in the crate — `src/`, tests, benches, and examples are all clean. All CBOR encoding/decoding already goes through `ciborium` (used across 15 source files).

So it was a stale, unused dependency. Removing the line clears the advisory with **no code or behaviour change**. `affinidi-mdoc` was the sole path to `serde_cbor` in the workspace (`cargo tree -i serde_cbor`), so the advisory is fully resolved. The crate does **not** use the `ssi-*` / `json-ld` stack at all — its tree is a self-contained CBOR/COSE crypto set.

### 2. proc-macro-error (RUSTSEC-2024-0370) — ignore with justification

Clearing serde_cbor unmasked a second pre-existing advisory. `proc-macro-error` (unmaintained) is a **build-time-only** transitive dependency of the SSI/JSON-LD stack (`ssi-dids-core` → … → `linked-data-derive`), reachable via the identity/messaging crates — **not** via mdoc. No runtime exposure and no in-workspace crate depends on it directly. Ignored with a reason that notes it should drop out once upstream `ssi-*` releases migrate off it.

### 3. Stale askalono ignore — cleanup

`cargo deny` warned `no crate matched advisory criteria` for the existing `RUSTSEC-2022-0092` ignore — askalono is no longer in the tree. Removed the dead entry.

## Scope

- mdoc change is a dependency removal + patch bump only; no source changes. `affinidi-mdoc` is a leaf crate (no in-workspace dependents), so no cascade bumps.
- `deny.toml` changes are workspace-level policy, unrelated to mdoc.

## Verification

- `cargo deny check` — **advisories / bans / licenses / sources all ok** (no stale-ignore warnings)
- `cargo clippy -p affinidi-mdoc --all-targets --all-features` — clean
- `cargo test -p affinidi-mdoc --all-features` — **128 passed, 0 failed**
- `cargo tree -i serde_cbor` — no longer present in the graph
- `cargo fmt --all -- --check` — clean

## Commits

- `8279776` fix: affinidi-mdoc 0.2.1 — drop unmaintained serde_cbor (RUSTSEC-2021-0127)
- `650b9e4` chore: ignore RUSTSEC-2024-0370 (proc-macro-error) in cargo-deny
- `9400162` chore: drop stale RUSTSEC-2022-0092 ignore from cargo-deny