### PR TITLE
fix: status-list decoy collision — reserve indices so add_decoys sets N distinct bits (#329)

### DIFF
--- a/crates/credentials/affinidi-status-list/CHANGELOG.md
+++ b/crates/credentials/affinidi-status-list/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi Status List Changelog
 
+## 1st June 2026 Release 0.1.3
+
+### Fixed
+
+- **Decoy entries could collide, undercounting distinct set bits.**
+  `BitstringStatusList::add_decoys()` checked `!assigned[index]` before
+  placing a decoy but never marked the chosen index as assigned, and
+  `set()` likewise left `assigned` untouched. Two decoys (or a decoy and
+  a `set()` entry) could therefore land on the same index — each passing
+  the check, re-setting an already-set bit, and still counting toward the
+  total — so `add_decoys(N)` sometimes set fewer than `N` distinct bits.
+  This also made the `decoy_entries` test flaky (~6–7%, a birthday
+  collision) and surfaced as an unrelated CI failure. Both `add_decoys`
+  and `set` now reserve the index in `assigned`, making it the single
+  authority for which slots are free. Added a 500-round regression test.
+
 ## 28th May 2026 Release 0.1.2
 
 ### Security

--- a/crates/credentials/affinidi-status-list/Cargo.toml
+++ b/crates/credentials/affinidi-status-list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-status-list"
 description = "Credential status and revocation lists (Bitstring Status List, eIDAS ASL/ARL)."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-status-list/src/bitstring.rs
+++ b/crates/credentials/affinidi-status-list/src/bitstring.rs
@@ -145,6 +145,13 @@ impl BitstringStatusList {
             self.bits[byte_index] &= !(1 << bit_index);
         }
 
+        // Setting a status declares this index a real entry, so reserve it.
+        // `assigned` is the authority for which indices are free; keeping it in
+        // sync here stops `add_decoys` from later landing a decoy on top of a
+        // real entry (which would collide and undercount). Marked regardless of
+        // `revoked` — an un-revoked entry is still a real, allocated slot.
+        self.assigned[index] = true;
+
         Ok(())
     }
 
@@ -157,6 +164,12 @@ impl BitstringStatusList {
         while added < count {
             let index = rng.random_range(0..self.size);
             if !self.assigned[index] {
+                // Reserve the index before counting it. Without this, a later
+                // iteration could pick the same free index again — passing the
+                // `!assigned` check, re-setting an already-set bit (a no-op),
+                // and still incrementing `added`. That let `add_decoys(N)` set
+                // fewer than `N` distinct bits and made the count flaky.
+                self.assigned[index] = true;
                 let byte_index = index / 8;
                 let bit_index = 7 - (index % 8);
                 self.bits[byte_index] |= 1 << bit_index;
@@ -379,6 +392,22 @@ mod tests {
         assert_eq!(list.count_set(), 11);
         // Original revocation still present
         assert!(list.get(42).unwrap());
+    }
+
+    #[test]
+    fn decoys_are_always_distinct() {
+        // Regression for the decoy-collision flake: `add_decoys(N)` must set
+        // exactly N new distinct bits, never colliding with each other or with
+        // a real entry. Two decoys landing on the same free index (or on the
+        // `set()` entry below) used to leave `count_set() < 1 + N` a few percent
+        // of the time. Run many rounds so a reintroduced collision can't hide.
+        for _ in 0..500 {
+            let mut list = BitstringStatusList::new(1000, StatusPurpose::Revocation);
+            list.set(42, true).unwrap();
+            list.add_decoys(10);
+            assert_eq!(list.count_set(), 11);
+            assert!(list.get(42).unwrap());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #329.

## Root cause

`assigned` is meant to be the authority for which indices are free, but two writers mutated bits without updating it:

- `add_decoys` checked `!assigned[index]` before placing a decoy but **never marked the chosen index assigned**.
- `set()` left `assigned` untouched entirely.

So two decoys — or a decoy and a `set()` entry (exactly what `decoy_entries` does with `set(42, true)` on an un-allocated index) — could pick the same free index: each passes the `!assigned` check, re-sets an already-set bit (a no-op), and still increments the counter. `add_decoys(N)` therefore sometimes set **fewer than N distinct bits**, weakening the privacy padding and making `decoy_entries` flaky (~6–7%, a birthday collision for 11 items in 1000 slots). This surfaced as the unrelated `rust-pipeline / test` failure on #326.

## Fix

Make `assigned` the single authority for free slots:

- `add_decoys` now sets `assigned[index] = true` before placing each decoy.
- `set()` now reserves the index too — regardless of `revoked`, since an entry is a real allocated slot either way — so a decoy can never land on a `set()` entry.

Added `decoys_are_always_distinct`, a 500-round regression test asserting exactly `1 + count` distinct set bits, so the flake can't return.

## Versioning

- `affinidi-status-list` `0.1.2 → 0.1.3` (patch) + CHANGELOG entry.
- No other workspace crate depends on `affinidi-status-list`, so no cascade bumps.

## Checks

- `cargo fmt` applied
- `cargo test -p affinidi-status-list` → 21 passed
- `cargo clippy -p affinidi-status-list --all-targets` → clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok