### PR TITLE
feat: Fjall/in-memory session expiry sweeper (#308 item 1)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 1st June 2026
 
+### 0.15.9 — Fjall/in-memory session expiry sweeper
+
+Closes the missing background session sweeper tracked in #308.
+
+- **FIX:** Backends without native TTL (Fjall, in-memory) expire
+  sessions only lazily on `get_session`, so a session that is created
+  but never read again — e.g. a one-off DID running
+  `/authenticate/challenge` and disappearing — accumulated on disk / in
+  the map unbounded. A new background task now calls
+  `MediatorStore::sweep_expired_sessions` on a 300s cadence to reclaim
+  them. On Redis the sweep is a no-op (native `EXPIRE` already handles
+  it), so the loop just ticks and finds nothing.
+- **CONFIG:** New `[processors.session_expiry_cleanup]` block with a
+  single `enabled` flag (default `true`), overridable via
+  `PROCESSOR_SESSION_EXPIRY_CLEANUP_ENABLED`. The block is optional —
+  configs written before this release parse unchanged and default to
+  enabled.
+- Requires `affinidi-messaging-mediator-common` 0.15.2 (new
+  `sweep_expired_sessions` trait method + `SessionSweepReport`).
+
 ### 0.15.8 — vta-sdk 0.9 (didcomm 0.14 unification)
 
 Dependency-only release; no mediator config or API change.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.8"
+version = "0.15.9"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 1st June 2026
+
+### 0.15.2 — session expiry sweep trait method
+
+- Added `MediatorStore::sweep_expired_sessions(now_secs)` returning a new
+  `SessionSweepReport { scanned, expired }`. The trait method has a
+  **default no-op** so native-TTL backends (Redis) and any external
+  implementations compile and behave unchanged. Backends without native
+  TTL (Fjall, in-memory) override it to reclaim session records that have
+  expired but were never read again — closing the doc-promised-but-missing
+  session sweeper noted in #308. Purely additive; no breaking change.
+
 ## 9th May 2026
 
 ### 0.15.1 — `MediatorStore` access-list signatures take `&[String]`

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.1"
+version = "0.15.2"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -63,8 +63,8 @@ pub mod redis;
 
 pub use types::{
     DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MessageMetaData,
-    MetadataStats, PubSubRecord, Session, SessionClaims, SessionState, StatCounter, StoreHealth,
-    StreamingClientState,
+    MetadataStats, PubSubRecord, Session, SessionClaims, SessionState, SessionSweepReport,
+    StatCounter, StoreHealth, StreamingClientState,
 };
 
 // ─── Trait ───────────────────────────────────────────────────────────────────
@@ -564,6 +564,25 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
         now_secs: u64,
         admin_did_hash: &str,
     ) -> Result<ExpiryReport, MediatorError>;
+
+    /// Run one pass of the session expiry sweep, removing session
+    /// records whose TTL has elapsed (`expires_at <= now_secs`).
+    ///
+    /// Backends with native TTL (Redis `EXPIRE`) reclaim expired
+    /// sessions themselves, so the default is a no-op. Backends without
+    /// (Fjall, memory) expire sessions lazily on [`get_session`], which
+    /// means a session that is created but never read again — e.g. a
+    /// one-off DID that runs `/authenticate/challenge` and disappears —
+    /// lingers on disk/in the map indefinitely. The session processor
+    /// calls this on a fixed cadence so those orphaned records are
+    /// reclaimed regardless of whether they're ever read.
+    async fn sweep_expired_sessions(
+        &self,
+        now_secs: u64,
+    ) -> Result<SessionSweepReport, MediatorError> {
+        let _ = now_secs;
+        Ok(SessionSweepReport::default())
+    }
 
     // ─── Legacy aliases ─────────────────────────────────────────────────────
     //

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
@@ -342,6 +342,20 @@ pub struct ExpiryReport {
     pub already_deleted: u32,
 }
 
+/// Outcome of one full pass of the session expiry sweep.
+///
+/// Only meaningful for backends without native TTL (Fjall, memory),
+/// which expire sessions lazily on read and so accumulate untouched
+/// expired records until swept. Native-TTL backends (Redis) report
+/// zero — their default sweep is a no-op.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SessionSweepReport {
+    /// Number of session records inspected.
+    pub scanned: u32,
+    /// Number of expired sessions removed this pass.
+    pub expired: u32,
+}
+
 // ─── Health ──────────────────────────────────────────────────────────────────
 
 /// Reported health of the storage backend, surfaced via `/readyz`.

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -430,3 +430,9 @@ consumer_group = "forwarding"
 ### Env: PROCESSOR_MESSAGE_EXPIRY_CLEANUP_ENABLED
 ### Enable the message expiry cleanup processor
 enabled = "true"
+
+[processors.session_expiry_cleanup]
+### Env: PROCESSOR_SESSION_EXPIRY_CLEANUP_ENABLED
+### Reclaim expired session records on backends without native TTL
+### (Fjall, in-memory). No-op on Redis, which expires sessions itself.
+enabled = "true"

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -267,6 +267,11 @@ pub(crate) fn apply_env_overrides(config: &mut super::ConfigRaw) {
         "PROCESSOR_MESSAGE_EXPIRY_CLEANUP_ENABLED"
     );
 
+    env_override!(
+        config.processors.session_expiry_cleanup.enabled,
+        "PROCESSOR_SESSION_EXPIRY_CLEANUP_ENABLED"
+    );
+
     env_override!(config.secrets.backend, "MEDIATOR_SECRETS_BACKEND");
     env_override_opt!(config.secrets.cache_ttl, "MEDIATOR_SECRETS_CACHE_TTL");
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -301,6 +301,7 @@ impl Config {
             processors: ProcessorsConfig {
                 forwarding: ForwardingConfig::default(),
                 message_expiry_cleanup: MessageExpiryCleanupConfig::default(),
+                session_expiry_cleanup: SessionExpiryCleanupConfig::default(),
             },
             limits: LimitsConfig::default(),
             tags: HashMap::from([("app".to_string(), "mediator".to_string())]),
@@ -737,6 +738,7 @@ impl TryFrom<ConfigRaw> for Config {
             processors: ProcessorsConfig {
                 forwarding: raw.processors.forwarding.clone().try_into()?,
                 message_expiry_cleanup: raw.processors.message_expiry_cleanup.clone().try_into()?,
+                session_expiry_cleanup: raw.processors.session_expiry_cleanup.clone().try_into()?,
             },
             limits: raw.limits.try_into()?,
             tags,

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
@@ -8,12 +8,17 @@ use serde::{Deserialize, Serialize};
 pub struct ProcessorsConfig {
     pub forwarding: ForwardingConfig,
     pub message_expiry_cleanup: MessageExpiryCleanupConfig,
+    pub session_expiry_cleanup: SessionExpiryCleanupConfig,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ProcessorsConfigRaw {
     pub forwarding: ForwardingConfigRaw,
     pub message_expiry_cleanup: MessageExpiryCleanupConfigRaw,
+    // Added after the first release of this struct; default so configs
+    // written before the session sweeper existed still parse.
+    #[serde(default)]
+    pub session_expiry_cleanup: SessionExpiryCleanupConfigRaw,
 }
 
 /// Configuration for the in-process message expiry sweep. The standalone
@@ -41,6 +46,44 @@ impl std::convert::TryFrom<MessageExpiryCleanupConfigRaw> for MessageExpiryClean
 
     fn try_from(raw: MessageExpiryCleanupConfigRaw) -> Result<Self, Self::Error> {
         Ok(MessageExpiryCleanupConfig {
+            enabled: raw.enabled.parse().unwrap_or(true),
+        })
+    }
+}
+
+/// Configuration for the in-process session expiry sweep. Only does work
+/// on backends without native TTL (Fjall, memory); on Redis the sweep is
+/// a no-op, so leaving it enabled there is harmless.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionExpiryCleanupConfig {
+    pub enabled: bool,
+}
+
+impl Default for SessionExpiryCleanupConfig {
+    fn default() -> Self {
+        SessionExpiryCleanupConfig { enabled: true }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct SessionExpiryCleanupConfigRaw {
+    #[serde(default = "default_true")]
+    pub enabled: String,
+}
+
+impl Default for SessionExpiryCleanupConfigRaw {
+    fn default() -> Self {
+        SessionExpiryCleanupConfigRaw {
+            enabled: default_true(),
+        }
+    }
+}
+
+impl std::convert::TryFrom<SessionExpiryCleanupConfigRaw> for SessionExpiryCleanupConfig {
+    type Error = MediatorError;
+
+    fn try_from(raw: SessionExpiryCleanupConfigRaw) -> Result<Self, Self::Error> {
+        Ok(SessionExpiryCleanupConfig {
             enabled: raw.enabled.parse().unwrap_or(true),
         })
     }
@@ -106,6 +149,9 @@ fn default_forwarding_group() -> String {
 }
 fn default_false() -> String {
     "false".to_string()
+}
+fn default_true() -> String {
+    "true".to_string()
 }
 fn default_10() -> String {
     "10".to_string()

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -402,6 +402,49 @@ pub async fn serve_internal(
         });
     }
 
+    // Session expiry sweep — reclaims expired session records on
+    // backends without native TTL (Fjall, memory). On Redis the trait
+    // default is a no-op, so this loop just ticks and finds nothing.
+    // Sessions expire over 15-minute / 24-hour horizons, so a full
+    // partition scan every second (as the message sweep does) would be
+    // wasteful — a coarser cadence is plenty.
+    if config.processors.session_expiry_cleanup.enabled {
+        let session_store = store.clone();
+        let cleanup_token = shutdown_token.clone();
+        tokio::spawn(async move {
+            const SESSION_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+            let mut tick = tokio::time::interval(SESSION_SWEEP_INTERVAL);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    _ = cleanup_token.cancelled() => {
+                        info!("Session expiry cleanup shutting down");
+                        return;
+                    }
+                    _ = tick.tick() => {}
+                }
+
+                let now_secs = chrono::Utc::now().timestamp().max(0) as u64;
+                match session_store.sweep_expired_sessions(now_secs).await {
+                    Ok(report) if report.expired > 0 => {
+                        info!(
+                            event_type = "SessionExpirySweep",
+                            scanned = report.scanned,
+                            expired = report.expired,
+                            "session expiry sweep reclaimed {} of {} sessions",
+                            report.expired,
+                            report.scanned,
+                        );
+                    }
+                    Ok(_) => {} // nothing expired
+                    Err(err) => {
+                        warn!("Session expiry sweep error: {err}");
+                    }
+                }
+            }
+        });
+    }
+
     // VTA secrets refresh — only present when this is a VTA-linked
     // deployment. Spawns a fire-and-forget loop that refreshes the
     // cached bundle and runtime resolver on a cadence derived from

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -48,8 +48,8 @@ use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{
         DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
-        MessageMetaData, MetadataStats, PubSubRecord, Session, StatCounter, StoreHealth,
-        StreamingClientState,
+        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
+        StoreHealth, StreamingClientState,
     },
 };
 use affinidi_messaging_sdk::{
@@ -304,8 +304,10 @@ impl StoredAccount {
 
 /// Persisted session record. The `expires_at_unix` is checked
 /// lazily on read — Fjall has no native TTL, so expired sessions
-/// linger on disk until they're either touched or swept by an
-/// external janitor.
+/// linger on disk until they're either touched (lazy expiry in
+/// `get_session`) or reclaimed by the background
+/// [`sweep_expired_sessions`](MediatorStore::sweep_expired_sessions)
+/// pass.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct StoredSession {
     session: Session,
@@ -2249,6 +2251,40 @@ impl MediatorStore for FjallStore {
         }
         Ok(report)
     }
+
+    async fn sweep_expired_sessions(
+        &self,
+        now_secs: u64,
+    ) -> Result<SessionSweepReport, MediatorError> {
+        // Full scan of the sessions partition: collect the keys whose
+        // TTL has elapsed first, then remove them. Collecting before
+        // removing avoids mutating the partition mid-iteration, and
+        // keeps the (potentially large) scan off the cross-partition
+        // `write_lock` — the removes below are single-key and
+        // self-consistent. `expires_at_unix == 0` means "no expiry"
+        // and is never swept, matching the lazy-expiry guard in
+        // `get_session`.
+        let mut report = SessionSweepReport::default();
+        let mut to_remove: Vec<Vec<u8>> = Vec::new();
+        for guard in self.sessions.iter() {
+            let (key, value) = guard
+                .into_inner()
+                .map_err(|e| Self::db_err("sweep_expired_sessions:iter", e))?;
+            report.scanned += 1;
+            let stored: StoredSession = Self::decode(&value)?;
+            if stored.expires_at_unix > 0 && stored.expires_at_unix <= now_secs {
+                to_remove.push(key.as_ref().to_vec());
+            }
+        }
+
+        for key in to_remove {
+            self.sessions
+                .remove(&key)
+                .map_err(|e| Self::db_err("sweep_expired_sessions:remove", e))?;
+            report.expired += 1;
+        }
+        Ok(report)
+    }
 }
 
 // ─── Smoke tests ────────────────────────────────────────────────────────────
@@ -2587,6 +2623,54 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1100)).await;
         let result = store.get_session("sid-2", "").await;
         assert!(result.is_err(), "expired session must not return");
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_sessions_reclaims_orphans() {
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+
+        // One already-expired session (0s TTL) and one still-live one.
+        // Neither is ever read back, so only the sweep can remove them —
+        // this is the orphan case lazy expiry never reaches.
+        let expired = Session {
+            session_id: "sid-expired".into(),
+            ..Default::default()
+        };
+        let live = Session {
+            session_id: "sid-live".into(),
+            ..Default::default()
+        };
+        store
+            .put_session(&expired, Duration::from_secs(0))
+            .await
+            .expect("put expired");
+        store
+            .put_session(&live, Duration::from_secs(3600))
+            .await
+            .expect("put live");
+
+        // Sweep at a wall-clock one second past the 0s-TTL entry; the
+        // live entry's expiry is ~an hour out, so it must survive.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 1;
+        let report = store.sweep_expired_sessions(now).await.expect("sweep");
+
+        assert_eq!(report.scanned, 2, "both sessions inspected");
+        assert_eq!(report.expired, 1, "only the expired session removed");
+        // Removed from the partition by the sweep itself, not a lazy
+        // read on `get_session`.
+        assert!(
+            !store.sessions.contains_key(b"sid-expired").unwrap(),
+            "expired session swept from partition"
+        );
+        assert!(
+            store.sessions.contains_key(b"sid-live").unwrap(),
+            "live session retained"
+        );
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -28,8 +28,8 @@ use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{
         DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
-        MessageMetaData, MetadataStats, PubSubRecord, Session, StatCounter, StoreHealth,
-        StreamingClientState,
+        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
+        StoreHealth, StreamingClientState,
     },
 };
 use affinidi_messaging_sdk::{
@@ -1577,6 +1577,24 @@ impl MediatorStore for MemoryStore {
         }
         Ok(report)
     }
+
+    async fn sweep_expired_sessions(
+        &self,
+        _now_secs: u64,
+    ) -> Result<SessionSweepReport, MediatorError> {
+        // Session TTLs are tracked as `Instant`s here, so the wall-clock
+        // `now_secs` argument is ignored in favour of `Instant::now()`,
+        // exactly matching the lazy-expiry check in `get_session_record`.
+        let now = Instant::now();
+        let mut state = self.state.lock().await;
+        let before = state.sessions.len();
+        state.sessions.retain(|_, record| record.expires_at > now);
+        let expired = (before - state.sessions.len()) as u32;
+        Ok(SessionSweepReport {
+            scanned: before as u32,
+            expired,
+        })
+    }
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -1592,6 +1610,46 @@ mod tests {
         store.initialize().await.expect("initialize");
         assert!(matches!(store.health().await, StoreHealth::Healthy));
         store.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_sessions_reclaims_orphans() {
+        let store = MemoryStore::new();
+
+        let expired = Session {
+            session_id: "sid-expired".into(),
+            ..Default::default()
+        };
+        let live = Session {
+            session_id: "sid-live".into(),
+            ..Default::default()
+        };
+        store
+            .put_session(&expired, Duration::from_secs(0))
+            .await
+            .expect("put expired");
+        store
+            .put_session(&live, Duration::from_secs(3600))
+            .await
+            .expect("put live");
+
+        // Let the monotonic clock advance past the 0s-TTL entry.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        // `now_secs` is ignored by the in-memory backend (it expires on
+        // `Instant`), so any value is fine here.
+        let report = store.sweep_expired_sessions(0).await.expect("sweep");
+        assert_eq!(report.scanned, 2, "both sessions inspected");
+        assert_eq!(report.expired, 1, "only the expired session removed");
+
+        assert!(
+            store.get_session("sid-expired", "").await.is_err(),
+            "expired session gone"
+        );
+        assert!(
+            store.get_session("sid-live", "").await.is_ok(),
+            "live session retained"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses **item 1** of #308 (the background session sweeper). The other checklist items (write-lock consistency, `update_refresh_token_hash`/`update_session_authenticated` overrides, auth-flow test parity, the `expires_at` doc gap) will follow in separate PRs.

## Problem

Backends without native TTL (Fjall, in-memory) expire sessions only *lazily* on `get_session` (`fjall_store.rs` lazy-expiry guard). The `Session` doc comment promises a background sweeper for these backends, but only `sweep_expired_messages` existed. A session that is created but never read again — e.g. a one-off DID that runs `/authenticate/challenge` and disappears — therefore lingers on disk / in the map indefinitely. For a mediator bouncing many one-off DIDs through the challenge endpoint, the sessions partition grows unbounded.

## Change

- **New trait method** `MediatorStore::sweep_expired_sessions(now_secs) -> SessionSweepReport { scanned, expired }` with a **default no-op**. Redis (native `EXPIRE`) and any external trait impls compile and behave unchanged — purely additive.
- **Fjall** overrides it: full scan of the sessions partition, collect keys with `expires_at_unix <= now`, then remove (collect-before-remove avoids mutating mid-iteration; `expires_at_unix == 0` = no-expiry, never swept — matching the lazy guard).
- **Memory** overrides it: `retain` on the sessions map against `Instant::now()`, matching its lazy-expiry check.
- **Background task** in `server.rs` mirroring the message-expiry loop, on a **300s** cadence (coarser than the 1s message sweep — sessions live on 15-min / 24-h horizons, so a per-second full scan would be wasteful).
- **Config:** new optional `[processors.session_expiry_cleanup]` block (`enabled`, default `true`; env `PROCESSOR_SESSION_EXPIRY_CLEANUP_ENABLED`). The raw field is `#[serde(default)]`, so configs predating this release parse unchanged.

## Backwards compatibility

- Trait method has a default → no existing impl breaks.
- Config block is optional with a default → existing `mediator.toml` / env setups are unaffected.
- On Redis the loop just ticks and the no-op finds nothing.

## Tests

`sweep_expired_sessions_reclaims_orphans` on both backends: an expired session that is **never read** is removed by the sweep itself (Fjall asserts directly against the partition via `contains_key`; Memory asserts via `get_session`), while a live session is retained, and the report counts are exact.

## Versioning

- `affinidi-messaging-mediator-common` `0.15.1 → 0.15.2` (additive trait method + `SessionSweepReport`)
- `affinidi-messaging-mediator` `0.15.8 → 0.15.9`
- Dependents pin `"0.15"` (major.minor), so no cascade bumps.

## Checks

- `cargo fmt --check` clean
- `cargo test -p affinidi-messaging-mediator --features fjall-backend,memory-backend` → 140 passed
- `cargo clippy` (redis + fjall + memory backends, all targets) → clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok