### PR TITLE
feat: Fjall session-op consistency & atomicity (#308 items 2-4)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ## 1st June 2026
 
+### 0.15.10 — Fjall session-op consistency & atomicity
+
+Hardening for the Fjall backend's session path (items 2–4 of #308). No
+config or API change; behaviour-preserving except where noted.
+
+- **FIX (consistency):** `put_session` / `delete_session` now take the
+  cross-partition `write_lock` like every other write op in the backend,
+  so session writes stay sequenced against other partitions.
+- **FIX (atomicity):** `update_session_authenticated` is overridden to
+  promote-and-rename a session in a single `db.batch()`. The trait
+  default does `put_session(new)` then `delete_session(old)`, leaving a
+  window where both keys exist — and on a crash mid-rename the old
+  `ChallengeSent` key lingered until lazy expiry. The new + old keys now
+  appear/disappear together.
+- **FIX (robustness):** `update_refresh_token_hash` is overridden with a
+  targeted read-by-key/mutate/write-back. The trait default round-trips
+  through `get_session(session_id, "")` + `put_session`, which can
+  substitute a corrupt `Session::default()` (state `Unknown`) and resets
+  the TTL. The override rewrites only `refresh_token_hash`, preserving
+  every other field **including the existing expiry** (matching Redis'
+  `HSET`), and now **errors on a missing session** instead of fabricating
+  a record.
+
 ### 0.15.9 — Fjall/in-memory session expiry sweeper
 
 Closes the missing background session sweeper tracked in #308.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.9"
+version = "0.15.10"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -48,8 +48,8 @@ use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{
         DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
-        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
-        StoreHealth, StreamingClientState,
+        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionState, SessionSweepReport,
+        StatCounter, StoreHealth, StreamingClientState,
     },
 };
 use affinidi_messaging_sdk::{
@@ -1174,6 +1174,12 @@ impl MediatorStore for FjallStore {
     // ─── Sessions ───────────────────────────────────────────────────────────
 
     async fn put_session(&self, session: &Session, ttl: Duration) -> Result<(), MediatorError> {
+        // Take the cross-partition write lock like every other write op
+        // in this backend. Session writes are single-key today, but
+        // holding the lock keeps them sequenced against other partitions
+        // so a future composite op (e.g. "delete session + clear
+        // streaming registration") stays consistent.
+        let _guard = self.write_lock.lock().await;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -1240,9 +1246,126 @@ impl MediatorStore for FjallStore {
     }
 
     async fn delete_session(&self, session_id: &str) -> Result<(), MediatorError> {
+        // See `put_session` — session ops take the write lock for
+        // consistency with the rest of the backend.
+        let _guard = self.write_lock.lock().await;
         self.sessions
             .remove(session_id.as_bytes())
             .map_err(|e| Self::db_err("delete_session:remove", e))?;
+        Ok(())
+    }
+
+    /// Override the trait default's `get_session → mutate → put_session
+    /// → delete_session` sequence with a single atomic batch. The
+    /// default leaves a brief window where both the old
+    /// (`ChallengeSent`) and new (`Authenticated`) session keys exist —
+    /// and if the process crashes between the put and the delete, the
+    /// old key lingers until lazy expiry or the session sweeper reaps
+    /// it. Doing the promote-and-rename as one `db.batch()` removes that
+    /// window: the new key appears and the old one disappears together
+    /// or not at all.
+    async fn update_session_authenticated(
+        &self,
+        old_session_id: &str,
+        new_session_id: &str,
+        did: &str,
+        refresh_token_hash: &str,
+    ) -> Result<(), MediatorError> {
+        let did_hash = digest(did);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        {
+            let _guard = self.write_lock.lock().await;
+
+            // Read the old record directly; fall back to a fresh session
+            // if it's already gone, matching the trait default's
+            // defensive `unwrap_or_else`.
+            let mut stored: StoredSession = match self
+                .sessions
+                .get(old_session_id.as_bytes())
+                .map_err(|e| Self::db_err("update_session_authenticated:get", e))?
+            {
+                Some(raw) => Self::decode(&raw)?,
+                None => StoredSession {
+                    session: Session {
+                        did: did.to_string(),
+                        did_hash: did_hash.clone(),
+                        ..Default::default()
+                    },
+                    expires_at_unix: 0,
+                },
+            };
+
+            if stored.session.did.is_empty() {
+                stored.session.did = did.to_string();
+                stored.session.did_hash = did_hash;
+            }
+            stored.session.state = SessionState::Authenticated;
+            stored.session.authenticated = true;
+            stored.session.refresh_token_hash = Some(refresh_token_hash.to_string());
+            stored.expires_at_unix = now.saturating_add(86_400);
+
+            let mut batch = self.db.batch();
+            batch.insert(
+                &self.sessions,
+                new_session_id.as_bytes(),
+                Self::encode(&stored)?,
+            );
+            // Guard against old == new: removing the key we just wrote
+            // would undo the promotion. (Session IDs are freshly
+            // randomised, so this is defensive.)
+            if old_session_id != new_session_id {
+                batch.remove(&self.sessions, old_session_id.as_bytes());
+            }
+            batch
+                .commit()
+                .map_err(|e| Self::db_err("update_session_authenticated:commit", e))?;
+
+            // `bump_global` is the non-locking sync counter helper (the
+            // same one `store_message` uses inside its guard), so it
+            // won't deadlock on the non-reentrant `write_lock`.
+            let _ = self.bump_global("SESSIONS_SUCCESS", 1);
+        }
+
+        Ok(())
+    }
+
+    /// Override the trait default with a targeted in-place mutation.
+    /// The default round-trips through `get_session(session_id, "")` +
+    /// `put_session`, which (a) can substitute a corrupt
+    /// `Session::default()` (state `Unknown`, empty DID) if the
+    /// empty-DID account join misbehaves, and (b) resets the TTL to 24h.
+    /// Reading the record by key and rewriting only `refresh_token_hash`
+    /// preserves every other field — including the existing expiry —
+    /// exactly as Redis' targeted `HSET` does.
+    async fn update_refresh_token_hash(
+        &self,
+        session_id: &str,
+        refresh_token_hash: &str,
+    ) -> Result<(), MediatorError> {
+        let _guard = self.write_lock.lock().await;
+        let raw = self
+            .sessions
+            .get(session_id.as_bytes())
+            .map_err(|e| Self::db_err("update_refresh_token_hash:get", e))?
+            .ok_or_else(|| {
+                // A refresh on a session that no longer exists must fail
+                // rather than fabricate a record — the rotation has
+                // nothing to attach to.
+                MediatorError::SessionError(
+                    14,
+                    session_id.into(),
+                    format!("Session not found: {session_id}"),
+                )
+            })?;
+        let mut stored: StoredSession = Self::decode(&raw)?;
+        stored.session.refresh_token_hash = Some(refresh_token_hash.to_string());
+        self.sessions
+            .insert(session_id.as_bytes(), Self::encode(&stored)?)
+            .map_err(|e| Self::db_err("update_refresh_token_hash:insert", e))?;
         Ok(())
     }
 
@@ -2670,6 +2793,102 @@ mod tests {
         assert!(
             store.sessions.contains_key(b"sid-live").unwrap(),
             "live session retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_session_authenticated_renames_atomically() {
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+
+        let did = "did:peer:auth";
+        let old = Session {
+            session_id: "challenge-sid".into(),
+            challenge: "chal".into(),
+            state: SessionState::ChallengeSent,
+            did: did.into(),
+            did_hash: hash(did),
+            ..Default::default()
+        };
+        store
+            .put_session(&old, Duration::from_secs(900))
+            .await
+            .expect("put challenge");
+
+        store
+            .update_session_authenticated("challenge-sid", "auth-sid", did, "refresh-hash")
+            .await
+            .expect("promote");
+
+        // The rename is atomic: old key gone, new key present — no window
+        // where both linger.
+        assert!(
+            !store.sessions.contains_key(b"challenge-sid").unwrap(),
+            "old ChallengeSent key removed"
+        );
+        assert!(
+            store.sessions.contains_key(b"auth-sid").unwrap(),
+            "new Authenticated key written"
+        );
+
+        let got = store.get_session("auth-sid", did).await.expect("get new");
+        assert_eq!(got.state, SessionState::Authenticated);
+        assert!(got.authenticated);
+        assert_eq!(got.did, did, "did preserved through promotion");
+        assert_eq!(got.did_hash, hash(did));
+        assert_eq!(got.refresh_token_hash.as_deref(), Some("refresh-hash"));
+    }
+
+    #[tokio::test]
+    async fn update_refresh_token_hash_preserves_record() {
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+
+        let did = "did:peer:refresh";
+        let session = Session {
+            session_id: "auth-sid".into(),
+            state: SessionState::Authenticated,
+            did: did.into(),
+            did_hash: hash(did),
+            authenticated: true,
+            refresh_token_hash: Some("hash-1".into()),
+            ..Default::default()
+        };
+        store
+            .put_session(&session, Duration::from_secs(86_400))
+            .await
+            .expect("put");
+        let ttl_before: StoredSession =
+            FjallStore::decode(&store.sessions.get(b"auth-sid").unwrap().unwrap()).unwrap();
+
+        store
+            .update_refresh_token_hash("auth-sid", "hash-2")
+            .await
+            .expect("rotate");
+
+        // did/state survive (the corruption the trait default risks) and
+        // only the hash changed.
+        let got = store.get_session("auth-sid", did).await.expect("get");
+        assert_eq!(got.did, did);
+        assert_eq!(got.state, SessionState::Authenticated);
+        assert_eq!(got.refresh_token_hash.as_deref(), Some("hash-2"));
+
+        // TTL is preserved in place, not reset — matching Redis' HSET.
+        let ttl_after: StoredSession =
+            FjallStore::decode(&store.sessions.get(b"auth-sid").unwrap().unwrap()).unwrap();
+        assert_eq!(
+            ttl_after.expires_at_unix, ttl_before.expires_at_unix,
+            "expiry must not move on refresh-hash rotation"
+        );
+
+        // Rotating a non-existent session fails rather than fabricating a
+        // corrupt record.
+        assert!(
+            store
+                .update_refresh_token_hash("ghost-sid", "x")
+                .await
+                .is_err(),
+            "refresh on missing session must error"
         );
     }
 


### PR DESCRIPTION
Addresses **items 2–4** of #308. Follows #333 (item 1, merged). Remaining items 5–6 (auth-flow test parity + the `expires_at` doc gap) will be a final PR.

Mediator-only, behaviour-preserving except where noted.

## Item 2 — `put_session` / `delete_session` take the `write_lock`

Every other multi-key write op in `fjall_store.rs` takes `self.write_lock` first; session ops didn't. They're single-key today, but holding the lock keeps them sequenced against other partitions so a future composite op (e.g. "delete session + clear streaming registration") stays consistent. Verified no production caller invokes these while already holding the lock, so there's no re-entrant-mutex deadlock.

## Item 4 — atomic `update_session_authenticated`

The trait default promotes a session with `put_session(new)` then `delete_session(old)` — a window where **both** keys exist, and on a crash mid-rename the old `ChallengeSent` key lingers until lazy expiry (or the #333 sweeper). The Fjall override does the read → mutate → write-new → remove-old as a single `db.batch()`, so the two keys commit together or not at all (mirroring Redis' `RENAME`). The `SESSIONS_SUCCESS` counter bump uses the non-locking `bump_global` helper (same pattern as `store_message`) so it doesn't re-enter the non-reentrant `write_lock` via `stats_increment`. Guards against `old == new` so a same-id call can't delete the key it just wrote.

## Item 3 — robust `update_refresh_token_hash`

The trait default round-trips through `get_session(session_id, "")` + `put_session`. On an empty-DID account-join miss it can substitute a corrupt `Session::default()` (state `Unknown`) and it resets the TTL. The Fjall override reads the record by key and rewrites **only** `refresh_token_hash`, preserving every other field — **including the existing expiry**, matching Redis' targeted `HSET`. It now **errors on a missing session** rather than fabricating a record (the refresh handler validates the session before rotating, so this only rejects genuinely-absent sessions).

## Tests

- `update_session_authenticated_renames_atomically` — old key gone, new key present, state/`did`/`did_hash`/`refresh_token_hash` promoted.
- `update_refresh_token_hash_preserves_record` — `did`/state survive, hash updated, `expires_at_unix` unchanged (TTL preserved), and rotating a missing session errors.

## Versioning

`affinidi-messaging-mediator` `0.15.9 → 0.15.10`. Mediator-only; no `mediator-common` change.

## Checks

- `cargo fmt --check` clean
- `cargo test -p affinidi-messaging-mediator --features fjall-backend,memory-backend` → 142 passed
- `cargo clippy` (redis + fjall + memory, all targets) → clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok