### PR TITLE
test: backend-parameterised auth-flow tests + expires_at doc — completes #308

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## 1st June 2026
 
+### 0.15.11 — backend-parameterised auth-flow tests
+
+Completes #308 (items 5–6). Test-only + docs; no shipped behaviour change.
+
+- **TEST:** Added a backend-agnostic auth-flow harness
+  (`store::auth_flow_harness::run_auth_session_flow`) that drives the full
+  `create_session → update_session_authenticated → get_session(new, did)
+  → refresh-hash rotation → delete_session` sequence the auth handlers
+  run, and call it from both the Fjall and in-memory test modules. Fjall
+  and memory now have parity with the Redis path's auth integration
+  coverage.
+- Pairs with the `Session::expires_at` doc clarification in
+  `affinidi-messaging-mediator-common` 0.15.3 (#308 item 6).
+
 ### 0.15.10 — Fjall session-op consistency & atomicity
 
 Hardening for the Fjall backend's session path (items 2–4 of #308). No

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.10"
+version = "0.15.11"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 1st June 2026
 
+### 0.15.3 — clarify `Session::expires_at` semantics (docs)
+
+- **DOCS:** Corrected the `Session::expires_at` doc comment (#308 item 6).
+  It previously claimed Redis "honours this directly" and that Fjall/
+  memory "sweep expired sessions" based on it — both wrong. The field is
+  the issued **access-token** expiry, stamped by the auth handler for the
+  authorization response; it is *not* the storage TTL. Session storage
+  lifetime is driven solely by the `ttl` argument to `put_session` (Redis
+  `EXPIRE`, which doesn't even persist this field; Fjall/memory store
+  their own derived expiry). No code change.
+
 ### 0.15.2 — session expiry sweep trait method
 
 - Added `MediatorStore::sweep_expired_sessions(now_secs)` returning a new

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.2"
+version = "0.15.3"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
@@ -79,9 +79,20 @@ pub struct Session {
     pub authenticated: bool,
     pub acls: MediatorACLSet,
     pub account_type: AccountType,
-    /// Unix timestamp (seconds) when this session expires. Backends with
-    /// native TTL (Redis EXPIRE) honour this directly; backends without
-    /// (Fjall, memory) sweep expired sessions in a background task.
+    /// Unix timestamp (seconds) at which the **access token** issued for
+    /// this session expires. The auth handler stamps it from the JWT's
+    /// `exp` so the authorization-response builder has the value to hand.
+    /// It is *not* the session's storage TTL and is informational on the
+    /// record.
+    ///
+    /// Session **storage** lifetime is controlled solely by the `ttl`
+    /// argument to `MediatorStore::put_session`: Redis applies it via
+    /// `EXPIRE` (and doesn't even persist this field), while Fjall and
+    /// memory store their own expiry derived from that `ttl` and reclaim
+    /// lapsed records via lazy reads plus the background
+    /// `sweep_expired_sessions` task. No backend consults `expires_at`
+    /// to decide when a stored session expires, so mutating it will not
+    /// extend or shorten a session.
     pub expires_at: u64,
     /// Hash of the most recently issued refresh token. Used to enforce
     /// one-time-use semantics on refresh — the handler reads the session,

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -2797,6 +2797,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_session_flow_end_to_end() {
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+        crate::store::auth_flow_harness::run_auth_session_flow(&store).await;
+    }
+
+    #[tokio::test]
     async fn update_session_authenticated_renames_atomically() {
         let dir = TempDir::new().expect("tempdir");
         let store = FjallStore::open(dir.path()).expect("open");

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -1809,6 +1809,12 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_session_flow_end_to_end() {
+        let store = MemoryStore::new();
+        crate::store::auth_flow_harness::run_auth_session_flow(&store).await;
+    }
+
+    #[tokio::test]
     async fn session_auth_rename_preserves_did() {
         // Full challenge → authenticated rename flow. Catches the bug
         // where `update_session_authenticated` rewrites the session

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -63,3 +63,99 @@ pub fn encode_oob_invite(invite: &Message) -> Result<String, MediatorError> {
     })?;
     Ok(BASE64_URL_SAFE_NO_PAD.encode(json))
 }
+
+/// Backend-agnostic auth-flow test harness.
+///
+/// The Redis path has integration tests covering the full session
+/// lifecycle the auth handlers run; Fjall and memory previously only
+/// tested session ops in isolation. This generic helper exercises the
+/// whole sequence against any [`MediatorStore`] so every backend gets
+/// parity — each backend's test module constructs its store and calls
+/// [`run_auth_session_flow`](auth_flow_harness::run_auth_session_flow).
+#[cfg(test)]
+pub(crate) mod auth_flow_harness {
+    use affinidi_messaging_mediator_common::store::{MediatorStore, Session, SessionState};
+    use sha256::digest;
+
+    /// Drive `create_session` → `update_session_authenticated` →
+    /// `get_session(new, did)` → refresh-hash rotation → `delete_session`,
+    /// mirroring `handlers::authenticate`. Asserts the session's identity
+    /// and state survive each transition and that stale session IDs stop
+    /// resolving.
+    pub(crate) async fn run_auth_session_flow<S: MediatorStore>(store: &S) {
+        let did = "did:peer:2.authflow";
+        let did_hash = digest(did);
+        let old_sid = "challenge-sid-0";
+        let new_sid = "auth-sid-0";
+
+        // 1. Challenge issued — a `ChallengeSent` session is created.
+        let challenge = Session {
+            session_id: old_sid.to_string(),
+            challenge: "challenge-nonce".to_string(),
+            state: SessionState::ChallengeSent,
+            did: did.to_string(),
+            did_hash: did_hash.clone(),
+            ..Default::default()
+        };
+        store
+            .create_session(&challenge)
+            .await
+            .expect("create_session");
+
+        let got = store
+            .get_session(old_sid, did)
+            .await
+            .expect("get challenge");
+        assert_eq!(got.state, SessionState::ChallengeSent);
+        assert_eq!(got.did, did, "did round-trips on the challenge read");
+
+        // 2. Authentication succeeds — promote and rename under a new ID.
+        store
+            .update_session_authenticated(old_sid, new_sid, did, "refresh-hash-1")
+            .await
+            .expect("update_session_authenticated");
+
+        let auth = store
+            .get_session(new_sid, did)
+            .await
+            .expect("get authenticated");
+        assert_eq!(auth.state, SessionState::Authenticated);
+        assert!(auth.authenticated, "authenticated flag set");
+        assert_eq!(auth.did, did, "did survives promotion");
+        assert_eq!(auth.did_hash, did_hash, "did_hash survives promotion");
+        assert_eq!(auth.refresh_token_hash.as_deref(), Some("refresh-hash-1"));
+
+        // The old challenge ID must no longer resolve after the rename.
+        assert!(
+            store.get_session(old_sid, did).await.is_err(),
+            "old challenge session ID gone after rename"
+        );
+
+        // 3. Refresh — rotate the refresh-token hash in place.
+        store
+            .update_refresh_token_hash(new_sid, "refresh-hash-2")
+            .await
+            .expect("update_refresh_token_hash");
+        let rotated = store
+            .get_session(new_sid, did)
+            .await
+            .expect("get after refresh");
+        assert_eq!(
+            rotated.state,
+            SessionState::Authenticated,
+            "state survives refresh-hash rotation"
+        );
+        assert_eq!(rotated.did, did, "did survives refresh-hash rotation");
+        assert_eq!(
+            rotated.refresh_token_hash.as_deref(),
+            Some("refresh-hash-2")
+        );
+
+        // 4. Logout — delete the session; it must stop resolving.
+        store.delete_session(new_sid).await.expect("delete_session");
+        assert!(
+            store.get_session(new_sid, did).await.is_err(),
+            "session gone after logout"
+        );
+    }
+}


### PR DESCRIPTION
**Closes #308.** Final piece — items 5 and 6. Follows #333 (item 1) and #334 (items 2–4). Test-only + docs; no shipped behaviour change.

## Item 5 — backend-parameterised auth-flow tests

The Redis path already had integration coverage of the full session lifecycle the auth handlers run; Fjall and memory only tested session ops in isolation (`session_lifecycle`).

Added a backend-agnostic harness `store::auth_flow_harness::run_auth_session_flow<S: MediatorStore>(store)` that drives the real handler sequence:

`create_session` (ChallengeSent) → `get_session(old, did)` → `update_session_authenticated(old, new, did, hash)` → `get_session(new, did)` (asserts Authenticated, `did`/`did_hash`/`refresh_token_hash` survive, old ID stops resolving) → `update_refresh_token_hash` (asserts state/did survive, hash rotates) → `delete_session` (asserts the session is gone).

Both the Fjall and in-memory test modules call it (`auth_session_flow_end_to_end`), so they reach parity with Redis. This exercises the trait-default `create_session` plus the Fjall overrides from #334 end-to-end, the way the handlers actually invoke them.

## Item 6 — `Session::expires_at` doc fix

The doc comment claimed Redis "honours this directly" and Fjall/memory "sweep expired sessions" based on it. Both are wrong:
- The field is the issued **access-token** expiry, stamped by the auth handler (`response.rs:401`) for the authorization response.
- Storage TTL is driven **solely** by the `ttl` argument to `put_session`. Verified against Redis `put_session`: its `HSET` doesn't persist `expires_at` at all, and `EXPIRE` uses `ttl.as_secs()`. Fjall/memory store their own `expires_at_unix` derived from `ttl`.

Rewrote the comment to say the field is informational and never consulted for storage expiry.

## Versioning

- `affinidi-messaging-mediator-common` `0.15.2 → 0.15.3` (doc)
- `affinidi-messaging-mediator` `0.15.10 → 0.15.11` (tests)
- Dependents pin `"0.15"`, so no cascade.

## Checks

- `cargo fmt --check` clean
- `cargo test -p affinidi-messaging-mediator --features fjall-backend,memory-backend` → 144 passed
- `cargo clippy` (redis + fjall + memory, all targets) → clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok