### PR TITLE
docs+test: ADR + KAT harness for JOSE crypto centralization (#327 PR 5a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ environments.json
 Cargo.lock
 **/environments.json*
 
-docs
+docs/*
+# Architecture Decision Records are first-class, tracked docs.
+!docs/adr/
 
 # mediator-setup wizard generated artifacts (may land in any directory)
 **/conf/secrets.json

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-06-01
+
+Test-only; no shipped behaviour change (the published crate is
+byte-identical to 0.14.0). Patch-level so the workspace `[patch.crates-io]`
+keeps `vta-sdk` unified on one didcomm version.
+
+### Added
+
+- **Known-answer test harness for the JOSE crypto primitives**
+  (`src/crypto/kat.rs`). Pins the byte-level output of AES-256 Key Wrap
+  (a real RFC 3394 §4.6 vector), the ECDH-ES Concat KDF, the ECDH-1PU KEK
+  derivation (including the #322 length-prefixed `cc_tag`), A256CBC-HS512,
+  and EdDSA. This is the safety net for the #327 migration of this
+  crate's hand-rolled crypto into `affinidi-crypto`: the relocated
+  implementation must keep these vectors passing byte-for-byte. See
+  `docs/adr/0001-centralize-jose-crypto-in-affinidi-crypto.md`.
+
 ## [0.14.0] - 2026-05-31
 
 DIDComm v2.1 interop fixes found via an interop matrix against

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/kat.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/kat.rs
@@ -1,0 +1,213 @@
+//! Known-answer tests (KATs) for the DIDComm JOSE crypto primitives.
+//!
+//! # Why this module exists
+//!
+//! Issue #327 centralises this crate's hand-rolled JOSE crypto (ECDH-1PU,
+//! ECDH-ES, the Concat KDF, A256KW, A256CBC-HS512, EdDSA) into
+//! `affinidi-crypto`. That migration rewrites now-*fixed* crypto (the
+//! #322 ECDH-1PU KDF bug), so the entire risk is a silent change in the
+//! bytes on the wire. These tests are the safety net: they pin the
+//! exact output of each primitive **before** the migration so the moved
+//! implementation can be proven byte-identical **after**.
+//!
+//! Two kinds of vector live here:
+//!
+//! 1. **Spec known-answer vectors** — fixed inputs and outputs taken
+//!    verbatim from a published standard. These prove spec-correctness,
+//!    not just stability. Currently: AES-256 Key Wrap (RFC 3394 §4.6).
+//!
+//! 2. **Golden-master vectors** — deterministic inputs with outputs
+//!    captured from the current (post-#326, spec-correct) implementation.
+//!    They don't independently prove spec-correctness, but they lock the
+//!    byte-level behaviour so the #327 rewrite can't drift. Each is
+//!    annotated with how it was produced. When the primitive moves to
+//!    `affinidi-crypto`, port the *same* vector there and assert the same
+//!    expected bytes.
+//!
+//! If a change to any primitive is intended to alter output, that is a
+//! wire-breaking change and the vector (and a migration note) must be
+//! updated deliberately — never "to make the test pass".
+
+#![cfg(test)]
+
+use crate::crypto::ecdh_1pu::{derive_key_1pu, derive_key_1pu_recipient};
+use crate::crypto::ecdh_es::concat_kdf;
+use crate::crypto::key_agreement::{Curve, PrivateKeyAgreement};
+use crate::crypto::{aes_kw, content_encryption, signing};
+
+/// Lower-case hex of a byte slice, for comparison against vector literals.
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Decode an even-length lower/upper-case hex string to bytes.
+fn unhex(s: &str) -> Vec<u8> {
+    assert!(
+        s.len().is_multiple_of(2),
+        "hex string must have even length"
+    );
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+// Deterministic key seeds for the golden vectors. Arbitrary fixed bytes —
+// the point is reproducibility, not key quality.
+const SENDER_SEED: [u8; 32] = [0x11; 32];
+const RECIP_SEED: [u8; 32] = [0x22; 32];
+const EPH_SEED: [u8; 32] = [0x33; 32];
+const ED_SEED: [u8; 32] = [0x44; 32];
+
+// ─── Spec KAT: AES-256 Key Wrap (RFC 3394 §4.6) ─────────────────────────────
+
+/// RFC 3394 §4.6 — "Wrap 128 bits of Key Data with a 256-bit KEK".
+/// This is a published known-answer vector, so it proves the A256KW
+/// implementation is spec-correct (not merely self-consistent).
+#[test]
+fn aes256_kw_rfc3394_section_4_6() {
+    let kek: [u8; 32] = core::array::from_fn(|i| i as u8); // 00 01 .. 1f
+    let key_data = unhex("00112233445566778899aabbccddeeff"); // 128-bit CEK
+    const EXPECTED_WRAPPED: &str = "64e8c3f9ce0f5ba263e9777905818a2a93c8191e7d6e8ae7";
+
+    let wrapped = aes_kw::wrap(&kek, &key_data).expect("wrap");
+    assert_eq!(
+        hex(&wrapped),
+        EXPECTED_WRAPPED,
+        "A256KW must match RFC 3394 §4.6"
+    );
+
+    let unwrapped = aes_kw::unwrap(&kek, &wrapped).expect("unwrap");
+    assert_eq!(unwrapped, key_data, "unwrap must invert wrap");
+}
+
+// ─── Golden: Concat KDF for ECDH-ES (RFC 7518 §4.6) ─────────────────────────
+
+/// Golden master for the SHA-256 Concat KDF used by ECDH-ES.
+/// Captured from the current implementation with `Z = 00..1f`,
+/// `alg = "ECDH-ES+A256KW"`, `apu = "Alice"`, `apv = "Bob"`, 256-bit
+/// output. Locks the OtherInfo encoding (round || Z || len-prefixed
+/// alg/apu/apv || keydatalen).
+#[test]
+fn concat_kdf_es_golden() {
+    let z: [u8; 32] = core::array::from_fn(|i| i as u8);
+    const EXPECTED: &str = "5655555b3d044d53f6b50fd49674ff388654cb284a4f6d4e2112de7b876a59d6";
+
+    let dk = concat_kdf(&z, b"ECDH-ES+A256KW", b"Alice", b"Bob", 256).expect("concat_kdf");
+    assert_eq!(hex(&dk), EXPECTED, "ECDH-ES Concat KDF output changed");
+}
+
+// ─── Golden: ECDH-1PU KEK derivation (incl. the #322 length-prefixed tag) ───
+
+/// Golden master for the full ECDH-1PU + Concat-KDF-1PU KEK derivation
+/// over X25519, including the spec-correct length-prefixed `cc_tag` that
+/// #322 fixed. Captured from the current implementation with the fixed
+/// seeds below, `apu = "did:example:alice#key-1"`, `apv = "apv-bytes"`,
+/// `cc_tag = 0xAB×32`, 256-bit output. Also asserts the recipient side
+/// derives the identical KEK.
+#[test]
+fn ecdh_1pu_x25519_kek_golden() {
+    const EXPECTED_KEK: &str = "f3cc56f46a09991543b654ce36e0913bb8c9656ad53fa159f732c0edcf1a4f9c";
+
+    let sender = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &SENDER_SEED).unwrap();
+    let recip = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &RECIP_SEED).unwrap();
+    let eph = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &EPH_SEED).unwrap();
+    let cc_tag = [0xABu8; 32];
+
+    let kek = derive_key_1pu(
+        &eph,
+        &sender,
+        &recip.public_key(),
+        b"ECDH-1PU+A256KW",
+        b"did:example:alice#key-1",
+        b"apv-bytes",
+        &cc_tag,
+        256,
+    )
+    .expect("derive_key_1pu");
+    assert_eq!(hex(&kek), EXPECTED_KEK, "ECDH-1PU KEK changed");
+
+    let kek_recipient = derive_key_1pu_recipient(
+        &recip,
+        &sender.public_key(),
+        &eph.public_key(),
+        b"ECDH-1PU+A256KW",
+        b"did:example:alice#key-1",
+        b"apv-bytes",
+        &cc_tag,
+        256,
+    )
+    .expect("derive_key_1pu_recipient");
+    assert_eq!(
+        kek_recipient, kek,
+        "sender and recipient must derive the same KEK"
+    );
+}
+
+// ─── Golden: A256CBC-HS512 content encryption (RFC 7518 §5.2.6) ──────────────
+
+/// Golden master for A256CBC-HS512. Captured from the current
+/// implementation with `CEK = 00..3f` (64 bytes), `IV = f0..ff`,
+/// `AAD = "aad"`, plaintext `"DIDComm KAT plaintext"`. Locks the
+/// ciphertext and the 32-byte truncated HMAC-SHA-512 tag, then verifies
+/// decrypt round-trips and that a flipped tag is rejected.
+#[test]
+fn a256cbc_hs512_golden() {
+    const EXPECTED_CT: &str = "f74554842ded8fa32ff9b5185f9a7df88d3fd7539a5d8012abf5b82aeacd9ebd";
+    const EXPECTED_TAG: &str = "83dbed2db1a941c503ce5a28b0fdf14180a9869426366fae9dc2d8a81cfc4223";
+
+    let cek: [u8; 64] = core::array::from_fn(|i| i as u8);
+    let iv: [u8; 16] = core::array::from_fn(|i| (0xF0 + i) as u8);
+    let plaintext = b"DIDComm KAT plaintext";
+
+    let (ct, tag) = content_encryption::encrypt(plaintext, &cek, &iv, b"aad").expect("encrypt");
+    assert_eq!(hex(&ct), EXPECTED_CT, "A256CBC-HS512 ciphertext changed");
+    assert_eq!(hex(&tag), EXPECTED_TAG, "A256CBC-HS512 tag changed");
+
+    let recovered = content_encryption::decrypt(&ct, &cek, &iv, b"aad", &tag).expect("decrypt");
+    assert_eq!(recovered, plaintext, "decrypt must round-trip");
+
+    // A single-bit tag corruption must fail authentication.
+    let mut bad_tag = tag;
+    bad_tag[0] ^= 0x01;
+    assert!(
+        content_encryption::decrypt(&ct, &cek, &iv, b"aad", &bad_tag).is_err(),
+        "corrupted tag must be rejected"
+    );
+}
+
+// ─── Golden: Ed25519 (EdDSA) signing ────────────────────────────────────────
+
+/// Golden master for EdDSA. Captured from the current implementation
+/// with the 32-byte seed below over message `"DIDComm KAT message"`.
+/// Locks the derived public key and signature, verifies the signature,
+/// and checks that a tampered message is rejected.
+#[test]
+fn ed25519_eddsa_golden() {
+    const EXPECTED_PK: &str = "d759793bbc13a2819a827c76adb6fba8a49aee007f49f2d0992d99b825ad2c48";
+    const EXPECTED_SIG: &str = "86209dd05dd745917219c1cf7fded1726cc4b9a8063edb88554a6d5bb8f86adfa17de70c841ef7c0a727c819177ccbcac44611f23e5d646aa922373f3291e000";
+
+    let msg = b"DIDComm KAT message";
+    let pk = signing::public_key_from_private(&ED_SEED);
+    assert_eq!(
+        hex(&pk),
+        EXPECTED_PK,
+        "Ed25519 public key derivation changed"
+    );
+
+    let sig = signing::sign(msg, &ED_SEED).expect("sign");
+    assert_eq!(hex(&sig), EXPECTED_SIG, "Ed25519 signature changed");
+
+    assert!(
+        signing::verify(msg, &sig, &pk).is_ok(),
+        "signature must verify"
+    );
+    assert!(
+        signing::verify(b"tampered", &sig, &pk).is_err(),
+        "signature must not verify a different message"
+    );
+}

--- a/crates/messaging/affinidi-messaging-didcomm/src/crypto/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/crypto/mod.rs
@@ -12,3 +12,9 @@ pub mod ecdh_1pu;
 pub mod ecdh_es;
 pub mod key_agreement;
 pub mod signing;
+
+/// Known-answer / golden-master tests that pin the byte-level output of
+/// every JOSE primitive. The #327 migration to `affinidi-crypto` must
+/// keep these passing unchanged.
+#[cfg(test)]
+mod kat;

--- a/docs/adr/0001-centralize-jose-crypto-in-affinidi-crypto.md
+++ b/docs/adr/0001-centralize-jose-crypto-in-affinidi-crypto.md
@@ -1,0 +1,252 @@
+# ADR 0001 — Centralize JOSE crypto primitives in `affinidi-crypto`
+
+- **Status:** Proposed
+- **Date:** 2026-06-01
+- **Tracking issue:** #327 (follow-up to #326, which fixed #322/#323/#324)
+- **Supersedes / relates to:** the didcomm/vta-sdk patch interaction (#328), `vti-didcomm-js` wire-compat sibling
+
+## Context
+
+The workspace currently runs **two independent, overlapping crypto stacks**:
+
+- `affinidi-crypto` (core) provides key types, JWK/multikey parsing,
+  `did:key` conversions, ECDSA/EdDSA signing, X25519 helpers, and PQC
+  (ML-DSA / SLH-DSA). It exposes **no** JOSE key-agreement / KDF / AEAD /
+  key-wrap primitives.
+- `affinidi-messaging-didcomm` hand-rolls its **entire** JOSE crypto
+  stack in `src/crypto/`: ECDH-1PU (`ecdh_1pu.rs`), ECDH-ES
+  (`ecdh_es.rs`), the JOSE Concat KDF, AES-256 Key Wrap (`aes_kw.rs`,
+  RFC 3394), A256CBC-HS512 content encryption (`content_encryption.rs`),
+  and EdDSA (`signing.rs`) — plus its own key/curve representation
+  (`key_agreement.rs`: `Curve`, `PublicKeyAgreement`,
+  `PrivateKeyAgreement`), parallel to `affinidi-crypto`'s key types.
+
+This duplication is the **root cause of #322**: the ECDH-1PU Concat KDF
+shipped feeding `cc_tag` into the KDF without its 32-bit length prefix,
+deriving a non-spec KEK that broke all authcrypt interop with credo-ts /
+didcomm-python. A single shared, audited KDF would not have shipped that
+way. #326 fixed the bug, but the structural duplication remains — the bug
+class can recur in any of the parallel implementations.
+
+### Wider duplication (whole-workspace survey)
+
+A survey of crypto across the repo (core, identity, messaging,
+credentials, OID4VC, mDoc) found the JOSE duplication is the sharpest
+case of a broader pattern. Primitives re-implemented in ≥2 places:
+
+| Primitive | Occurrences (representative) |
+|---|---|
+| SHA-256/384/512 digest | `affinidi-sd-jwt/hasher.rs`, `affinidi-mdoc/issuer_signed_item.rs`, `affinidi-rdf-encoding/rdfc1/*`, `affinidi-data-integrity/lib.rs`, `affinidi-bbs/hash.rs` |
+| base64url (URL_SAFE_NO_PAD) | sd-jwt, oid4vc-core (`jwt.rs`, `es256.rs`), affinidi-crypto JWK exporters, didcomm JWE/JWS |
+| Compact JWS framing (encode/decode) | `oid4vc-core/jwt.rs`, `affinidi-sd-jwt/signer.rs` |
+| ES256 (P-256 ECDSA) sign/verify | `affinidi-mdoc/es256_cose.rs`, `oid4vc-core/es256.rs` (identical `p256` wrapping, different framing) |
+| JWK coordinate export | `affinidi-crypto/p256.rs`, `oid4vc-core/es256.rs` |
+| Random salt/nonce (32B) | sd-jwt `disclosure.rs`, mdoc `issuer_signed_item.rs` |
+
+The survey also confirmed a **healthy** baseline: the identity layer
+(`affinidi-did-common`, `affinidi-secrets-resolver`) already delegates
+key generation/signing to `affinidi-crypto`, and no crate pulls in the
+vulnerable `rsa` crate. So the target — "one audited crypto core, thin
+domain wrappers above it" — is already the house style; JOSE and the
+hotspots above are where it isn't yet followed.
+
+## Decision
+
+**1. `affinidi-crypto` becomes the single home for low-level crypto
+primitives.** Add a `jose` module providing:
+
+- ECDH key agreement over X25519 / P-256 / K-256
+- ECDH-1PU and ECDH-ES
+- the JOSE Concat KDF, with the **length-prefixed `cc_tag`** baked in
+- AES-256 Key Wrap (A256KW)
+- A256CBC-HS512 content encryption
+
+**2. Unify key types.** Reconcile didcomm's `Curve` /
+`PublicKeyAgreement` / `PrivateKeyAgreement` with `affinidi-crypto`'s key
+representation so there is **one** type for an agreement key, with
+`From`/`Into` conversions at the boundary during migration.
+
+**3. `affinidi-messaging-didcomm` keeps only the envelope layer.** After
+migration it owns DIDComm/JOSE envelope logic (`pack`/`unpack`,
+JWE/JWS framing, header construction, the legacy-KEK decrypt fallback)
+and calls `affinidi-crypto::jose` for all crypto. It contains **no
+bespoke crypto**.
+
+**4. Behaviour is gated by known-answer tests.** The KAT harness added in
+this PR (`src/crypto/kat.rs`) pins the byte-level output of every
+primitive. The migration is only allowed to land if these same vectors
+pass byte-identically against the relocated `affinidi-crypto::jose`
+implementation.
+
+### Target layering
+
+```
+            ┌─────────────────────────────────────────────┐
+  envelope  │ affinidi-messaging-didcomm                  │
+            │   pack / unpack, JWE & JWS framing,          │
+            │   header build, legacy-KEK fallback          │
+            └───────────────┬─────────────────────────────┘
+                            │ calls (no crypto of its own)
+            ┌───────────────▼─────────────────────────────┐
+  crypto    │ affinidi-crypto                             │
+  core      │   jose: ECDH(-1PU/-ES), Concat KDF,         │
+            │         A256KW, A256CBC-HS512                │
+            │   keys: Ed25519/X25519/P-256/P-384/K-256,    │
+            │         JWK, did:key, PQC                    │
+            └───────────────┬─────────────────────────────┘
+                            │ wraps
+            ┌───────────────▼─────────────────────────────┐
+  vendored  │ ed25519-dalek, x25519-dalek, p256, k256,    │
+            │ aes, cbc, hmac, sha2, subtle …              │
+            └─────────────────────────────────────────────┘
+```
+
+The same core is the natural home for the wider hotspots (a shared
+hasher, one base64url codec, one compact-JWS helper, one ES256, JWK
+export helpers). Those are **out of scope for #327's PRs** but recorded
+below as a follow-on roadmap so the consolidation is deliberate, not
+incidental.
+
+## Extensibility — adding new crypto types
+
+A central goal: the JOSE core must make it cheap and **safe** to add new
+algorithms (curves, KDFs, AEADs, key-wraps, signature schemes, and
+eventually PQC/hybrid) without re-touching every call site or weakening
+the security boundary. The current didcomm design fails this: `Curve` /
+`PublicKeyAgreement` / `PrivateKeyAgreement` are closed enums, so adding
+(say) P-521 means editing the enum plus every `match` in `key_agreement`,
+`ecdh_1pu`, `ecdh_es`, and the JWK glue. The new `affinidi-crypto::jose`
+module is designed around two ideas instead.
+
+### 1. One trait per JOSE role; algorithms are implementations
+
+Define a small trait per cryptographic role, each keyed by its JOSE
+identifier:
+
+- `KeyAgreement` — ECDH over a curve (X25519, P-256, K-256, …); produces
+  the raw `Z`.
+- `KeyDerivation` — Concat KDF (and room for HKDF-based JOSE KDFs).
+- `KeyWrap` — A256KW today; A128KW / AES-GCM-KW later.
+- `ContentEncryption` — A256CBC-HS512 today; A256GCM / XC20P later.
+- `JwsSigner` / `JwsVerifier` — EdDSA today; ES256/ES384/ES256K, and PQC
+  (ML-DSA via the existing `affinidi-crypto::ml_dsa`) later.
+
+Adding an algorithm is then a **localized, additive** change: implement
+the trait for the new type and register it. The envelope layer (didcomm)
+keeps calling the trait, not a concrete primitive, so `pack`/`unpack`
+don't change when a new `enc` or `alg` is added — only the registry does.
+This is the open/closed seam the closed enums lack.
+
+### 2. Typed wire identifiers stay the security boundary
+
+Extensibility must not become uncontrolled algorithm agility — that is
+how downgrade / `alg:none` bugs (cf. #321) creep in. So:
+
+- The JOSE `alg` (e.g. `ECDH-1PU+A256KW`) and `enc` (e.g.
+  `A256CBC-HS512`) identifiers remain **typed, exhaustively-matched
+  enums** at the parse boundary. An unrecognised identifier is a hard
+  error, never a silent fallthrough.
+- The set of algorithms a given DIDComm message is *permitted* to use is
+  an **allowlist in the envelope layer**, independent of what the crypto
+  core *can* do. Registering a new primitive in `affinidi-crypto` does
+  not auto-enable it on the wire; the envelope opts in.
+- Negotiation / capability discovery (which curve, which `enc`) lives in
+  the envelope layer, not the crypto core. The core just answers "do this
+  named operation".
+
+The net: the **registry** is open for extension (new impls), while the
+**wire-acceptance policy** stays closed and explicit.
+
+### 3. PQC / hybrid readiness
+
+The core already ships PQC signatures (ML-DSA, SLH-DSA). Structuring key
+agreement behind a `KeyAgreement` trait (rather than an X25519/P-256/K-256
+enum) is what lets a future **hybrid KEM** — e.g. X25519 + ML-KEM
+concatenated into `Z` before the KDF — slot in as just another
+implementation, which is the expected direction for DIDComm/JOSE PQC.
+Signature extensibility lands the same way via `JwsSigner`/`JwsVerifier`.
+
+### 4. KATs scale with the design
+
+Every new algorithm ships with its own KAT in the same harness this PR
+establishes (a spec vector where one exists, a golden master otherwise).
+The harness is structured per-primitive precisely so a new curve or `enc`
+adds a test without disturbing the others — extensibility includes the
+test surface, not just the code.
+
+This trait-plus-typed-registry shape is a **requirement on PR 5b** (where
+`affinidi-crypto::jose` is authored), called out here so the module is
+born extensible rather than retrofitted. PR 5c's key-type unification
+should land the `KeyAgreement` trait + curve registry rather than port
+the closed enum across.
+
+## Migration plan (KAT-gated, multi-PR)
+
+- **PR 5a (this PR):** ADR + KAT harness locking current behaviour. No
+  code moves.
+- **PR 5b:** add the additive `affinidi-crypto::jose` module with the
+  primitives + the *same* KATs ported across. No didcomm change yet.
+- **PR 5c:** unify the key types behind the `KeyAgreement` trait + curve
+  registry (see Extensibility), *not* a ported closed enum; add
+  `From`/`Into` so the swap is mechanical and reversible.
+- **PR 5d:** rebase didcomm `pack`/`unpack` onto `affinidi-crypto::jose`,
+  delete `src/crypto/{ecdh_1pu,ecdh_es,aes_kw,content_encryption,
+  key_agreement,signing}.rs`. KATs must still pass byte-for-byte.
+
+Each PR is one bump commit, rebased between merges.
+
+## Consequences
+
+### Positive
+- One audited KDF/AEAD/key-wrap path; the #322 bug class cannot recur in
+  a forgotten parallel copy.
+- `affinidi-crypto::jose` is reusable by the SDK, mediator, and future
+  protocol crates instead of being trapped inside didcomm.
+- A clear seam to later fold in the whole-workspace hotspots.
+
+### Risks / costs
+- **Wire compatibility is the whole ballgame.** The rewrite must produce
+  byte-identical JWE/JWS. The KAT harness (this PR) is the guard; PR 5d
+  may not merge unless every vector passes unchanged.
+- **didcomm version bump re-triggers #328.** A **minor** bump of
+  `affinidi-messaging-didcomm` (which PR 5d will need) un-unifies
+  `vta-sdk` from the `[patch.crates-io]` redirect until vta-sdk is
+  republished against the new didcomm. PR 5d must be paired with a
+  vta-sdk republish. (PR 5a/5b are test/additive and can stay patch-level
+  to avoid this.)
+- **`vti-didcomm-js` sibling.** The OpenVTC JS DIDComm library is kept
+  wire-compatible with this crate; any crypto/wire-affecting change must
+  be mirrored there. The migration is meant to be wire-neutral, so the
+  KATs double as the cross-language conformance contract.
+- **Legacy-KEK fallback** (`derive_key_1pu_recipient_legacy`, the #322
+  migration path) must move with the rest and keep its own KAT.
+
+## Alternatives considered
+
+- **Leave the stacks separate.** Rejected: keeps the duplication that
+  caused #322 and blocks reuse.
+- **New `affinidi-messaging-crypto` crate** instead of growing
+  `affinidi-crypto`. Rejected for the JOSE core: it would re-create a
+  parallel crypto crate, the exact smell we're removing. The primitives
+  are protocol-agnostic and belong in the existing core. (TSP's HPKE in
+  `affinidi-tsp/src/crypto/hpke.rs` is genuinely protocol-specific and
+  stays put.)
+- **Big-bang single PR.** Rejected: unreviewable and unsafe for
+  wire-affecting crypto. The KAT-gated staged plan above is the safe path.
+
+## Follow-on roadmap (out of scope for #327, recorded for deliberate sequencing)
+
+Once `affinidi-crypto::jose` exists, fold the surveyed hotspots in,
+prioritised by blast radius:
+
+1. **Shared hasher** (SHA-256/384/512) — collapses ~5 sites; touches
+   sd-jwt, mdoc, rdf-encoding, data-integrity.
+2. **One base64url codec** + **one compact-JWS helper** — collapses the
+   sd-jwt / oid4vc-core framing duplication.
+3. **One ES256** shared by `affinidi-mdoc` (COSE framing) and
+   `oid4vc-core` (JWS framing) over a common P-256 core.
+4. **JWK export helpers** in `affinidi-crypto::jwk`.
+5. **Shared random salt/nonce** helper.
+
+Each is independently shippable and should get the same before/after
+characterization-test treatment as the JOSE migration.


### PR DESCRIPTION
First piece of #327. **No crypto moves in this PR** — it establishes the design decision and the safety net that gate the rest of the migration. Test-only + docs; the published `affinidi-messaging-didcomm` crate is byte-identical to 0.14.0.

## ADR — `docs/adr/0001-centralize-jose-crypto-in-affinidi-crypto.md`

- **Target layering:** `affinidi-crypto` grows a `jose` module owning ECDH-1PU/-ES, the Concat KDF, A256KW, and A256CBC-HS512; `affinidi-messaging-didcomm` keeps only the envelope layer (`pack`/`unpack`, JWE/JWS framing, legacy-KEK fallback) and contains **no bespoke crypto**. This removes the structural duplication that was the root cause of #322.
- **Whole-workspace crypto survey** (answering "what else can be consolidated?"): documents duplication hotspots — SHA-256/384/512, base64url, compact-JWS framing, ES256 (mdoc vs oid4vc-core), JWK export, salt/nonce — as a prioritised **follow-on roadmap** (out of scope for #327's PRs, but recorded so the consolidation is deliberate). Also notes the healthy baseline: identity/secrets already delegate to `affinidi-crypto`, and nothing pulls in the vulnerable `rsa` crate.
- **Extensibility (per review feedback):** a dedicated section requires PR 5b to build `jose` around **one trait per JOSE role** (`KeyAgreement` / `KeyDerivation` / `KeyWrap` / `ContentEncryption` / `JwsSigner`/`JwsVerifier`) with algorithms as implementations, while keeping **typed, exhaustively-matched wire identifiers** (`alg`/`enc`) as the security boundary and an envelope-layer allowlist (no silent downgrade — cf. #321). This makes new curves (P-521), AEADs (A256GCM/XC20P), signature algs (ES256/384, PQC ML-DSA), and **hybrid PQC KEMs** (X25519+ML-KEM) additive rather than enum-edits across every call site. PR 5c lands the `KeyAgreement` trait + curve registry instead of porting the closed enum.
- **KAT-gated multi-PR plan** (5a→5d), with the #328 re-trigger (a didcomm *minor* bump un-unifies vta-sdk until republished) and the `vti-didcomm-js` wire-mirror duty called out explicitly.

## KAT harness — `src/crypto/kat.rs` (`#[cfg(test)]`)

Pins the byte-level output of every primitive so the relocated `affinidi-crypto::jose` can be proven byte-identical:

- **AES-256-KW** against the real **RFC 3394 §4.6** vector (proves spec-correctness, not just stability).
- **Golden masters** captured from the current spec-correct (post-#326) impl, each documented with how it was produced: ECDH-ES Concat KDF; the ECDH-1PU KEK including the **#322 length-prefixed `cc_tag`** (asserts sender==recipient); A256CBC-HS512 (+ decrypt round-trip + tag-tamper rejection); EdDSA (+ verify + tamper).

The harness is structured per-primitive so a new algorithm adds a vector without disturbing the others.

## `.gitignore`

`docs/` was ignore-by-default (select files force-added). Changed `docs` → `docs/*` + `!docs/adr/` so **ADRs are first-class tracked docs** going forward, without un-ignoring the rest of `docs/` (proposals etc. stay ignored; already-tracked files unaffected).

## Versioning

`affinidi-messaging-didcomm` `0.14.0 → 0.14.1` — **patch**, so `[patch.crates-io]` keeps `vta-sdk` unified on one didcomm version (verified: single `0.14.1` in `Cargo.lock`).

## Checks

- `cargo fmt --check` clean
- `cargo test -p affinidi-messaging-didcomm` → 97 passed (incl. 5 new KATs)
- `cargo clippy --all-targets` → clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok