### PR TITLE
feat: additive affinidi-crypto jose module — JOSE primitives + trait seam (#327 PR 5b)

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Affinidi Crypto Changelog
 
+## 1st June 2026 (0.1.8)
+
+- **FEATURE — `jose` module (#327, off by default).** Adds the JOSE
+  crypto primitives previously hand-rolled in
+  `affinidi-messaging-didcomm`, as the first code-bearing step of the
+  centralization in `docs/adr/0001`. This release lands the **stateless**
+  primitives plus an extensible trait layer; ECDH key agreement / curve
+  types follow in a later PR.
+  - `jose::aes_kw` — AES-256 Key Wrap (RFC 3394).
+  - `jose::content_encryption` — A256CBC-HS512.
+  - `jose::concat_kdf` — JOSE Concat KDF for ECDH-ES and ECDH-1PU
+    (including the #322-correct length-prefixed `cc_tag`, plus a
+    `_legacy` variant for the decrypt-fallback migration path).
+  - `jose::signing` — Ed25519 (EdDSA).
+  - `jose::traits` — one trait per JOSE role (`KeyWrap`,
+    `ContentEncryption`, `KeyDerivation`, `JwsSigner`/`JwsVerifier`) with
+    concrete impls (`A256Kw`, `A256CbcHs512`, `ConcatKdf`, `Ed25519`)
+    carrying their JOSE `alg`/`enc` identifiers — the open-for-extension
+    seam for new curves/AEADs/sig-algs and future PQC.
+  - Known-answer tests assert the **same** vectors as the didcomm harness
+    (PR #336) plus the RFC 3394 §4.6 spec vector, proving the port is
+    byte-identical.
+  - New `CryptoError` variants: `KeyDerivation`, `KeyWrap`,
+    `ContentEncryption`, `Signing`, `Verification`.
+  - Gated behind the new `jose` feature (pulls `aes` / `cbc` / `hmac` /
+    `subtle` and enables `ed25519`); **off by default**, so existing
+    dependents are unaffected.
+
 ## 28th May 2026 (0.1.7)
 
 - **SECURITY (HIGH):** Redact the private `d` scalar in `Debug` output for

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.7"
+version = "0.1.8"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -24,6 +24,10 @@ ed25519 = ["dep:ed25519-dalek"]
 post-quantum = ["ml-dsa", "slh-dsa"]
 ml-dsa = ["dep:ml-dsa", "dep:rand_10"]
 slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
+# JOSE primitives (#327): ECDH-ES / ECDH-1PU Concat KDF, A256KW key wrap,
+# A256CBC-HS512 content encryption, EdDSA signing. Pulls in EdDSA via the
+# `ed25519` feature. Key agreement (curves) lands separately in a later PR.
+jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519"]
 
 [dependencies]
 affinidi-encoding = "0.1"
@@ -45,6 +49,11 @@ p384 = { version = "0.13", features = [
   "ecdsa-core",
   "arithmetic",
 ], optional = true }
+# JOSE content-encryption / key-wrap primitives (`jose` feature).
+aes = { version = "0.8", optional = true }
+cbc = { version = "0.1", features = ["alloc"], optional = true }
+hmac = { version = "0.12", optional = true }
+subtle = { version = "2", optional = true }
 ml-dsa = { version = "0.1.0", features = ["rand_core", "zeroize"], optional = true }
 slh-dsa = { version = "=0.2.0-rc.5", features = ["zeroize"], optional = true }
 # PQC crates (ml-dsa, slh-dsa) pull rand_core 0.10 transitively via

--- a/crates/core/affinidi-crypto/src/error.rs
+++ b/crates/core/affinidi-crypto/src/error.rs
@@ -15,6 +15,22 @@ pub enum CryptoError {
 
     #[error("Encoding error: {0}")]
     Encoding(#[from] affinidi_encoding::EncodingError),
+
+    // ─── JOSE primitives (`jose` feature) ───────────────────────────────────
+    #[error("Key derivation error: {0}")]
+    KeyDerivation(String),
+
+    #[error("Key wrap error: {0}")]
+    KeyWrap(String),
+
+    #[error("Content encryption error: {0}")]
+    ContentEncryption(String),
+
+    #[error("Signing error: {0}")]
+    Signing(String),
+
+    #[error("Verification error: {0}")]
+    Verification(String),
 }
 
 pub type Result<T> = std::result::Result<T, CryptoError>;

--- a/crates/core/affinidi-crypto/src/jose/aes_kw.rs
+++ b/crates/core/affinidi-crypto/src/jose/aes_kw.rs
@@ -1,0 +1,117 @@
+//! AES-256 Key Wrap (RFC 3394).
+//!
+//! Wraps and unwraps a content encryption key (CEK) using a key wrapping
+//! key (KEK). Ported verbatim from `affinidi-messaging-didcomm` as part of
+//! the #327 JOSE crypto centralization — the byte-level behaviour is locked
+//! by the known-answer tests in [`super::kat`].
+
+use aes::Aes256;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+
+use crate::error::CryptoError;
+
+const IV: u64 = 0xA6A6A6A6A6A6A6A6;
+
+/// Wrap a key using AES-256 Key Wrap (RFC 3394).
+///
+/// Input key must be a multiple of 8 bytes and at least 16 bytes. Output
+/// is `input_len + 8` bytes.
+pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let n = plaintext_key.len();
+    if !n.is_multiple_of(8) || n < 16 {
+        return Err(CryptoError::KeyWrap(
+            "key to wrap must be >= 16 bytes and multiple of 8".into(),
+        ));
+    }
+
+    let cipher = Aes256::new(kek.into());
+    let n_blocks = n / 8;
+
+    // Initialize: A = IV, R[1..n] = plaintext blocks
+    let mut a = IV;
+    let mut r: Vec<u64> = plaintext_key
+        .chunks_exact(8)
+        .map(|chunk| u64::from_be_bytes(chunk.try_into().unwrap()))
+        .collect();
+
+    // 6 * n rounds
+    for j in 0..6u64 {
+        for (i, ri) in r.iter_mut().enumerate().take(n_blocks) {
+            // B = AES(K, A || R[i])
+            let mut block = [0u8; 16];
+            block[..8].copy_from_slice(&a.to_be_bytes());
+            block[8..].copy_from_slice(&ri.to_be_bytes());
+
+            let b = aes::Block::from_mut_slice(&mut block);
+            cipher.encrypt_block(b);
+
+            // A = MSB(64, B) XOR t where t = (n*j)+i+1
+            let t = (n_blocks as u64) * j + (i as u64) + 1;
+            a = u64::from_be_bytes(block[..8].try_into().unwrap()) ^ t;
+            *ri = u64::from_be_bytes(block[8..].try_into().unwrap());
+        }
+    }
+
+    // Output: A || R[1] || ... || R[n]
+    let mut output = Vec::with_capacity(8 + n);
+    output.extend_from_slice(&a.to_be_bytes());
+    for block in &r {
+        output.extend_from_slice(&block.to_be_bytes());
+    }
+
+    Ok(output)
+}
+
+/// Unwrap a key using AES-256 Key Wrap (RFC 3394).
+///
+/// Input must be `plaintext_len + 8` bytes. Returns the unwrapped key, or
+/// an error if the integrity check fails.
+pub fn unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let total = ciphertext.len();
+    if !total.is_multiple_of(8) || total < 24 {
+        return Err(CryptoError::KeyWrap(
+            "wrapped key must be >= 24 bytes and multiple of 8".into(),
+        ));
+    }
+
+    let cipher = Aes256::new(kek.into());
+    let n_blocks = (total / 8) - 1;
+
+    // Initialize: A = C[0], R[i] = C[i]
+    let mut a = u64::from_be_bytes(ciphertext[..8].try_into().unwrap());
+    let mut r: Vec<u64> = ciphertext[8..]
+        .chunks_exact(8)
+        .map(|chunk| u64::from_be_bytes(chunk.try_into().unwrap()))
+        .collect();
+
+    // Unwrap: 6 * n rounds in reverse
+    for j in (0..6u64).rev() {
+        for i in (0..n_blocks).rev() {
+            let t = (n_blocks as u64) * j + (i as u64) + 1;
+
+            let mut block = [0u8; 16];
+            block[..8].copy_from_slice(&(a ^ t).to_be_bytes());
+            block[8..].copy_from_slice(&r[i].to_be_bytes());
+
+            let b = aes::Block::from_mut_slice(&mut block);
+            cipher.decrypt_block(b);
+
+            a = u64::from_be_bytes(block[..8].try_into().unwrap());
+            r[i] = u64::from_be_bytes(block[8..].try_into().unwrap());
+        }
+    }
+
+    // Verify IV
+    if a != IV {
+        return Err(CryptoError::KeyWrap(
+            "key unwrap integrity check failed".into(),
+        ));
+    }
+
+    let mut output = Vec::with_capacity(n_blocks * 8);
+    for block in &r {
+        output.extend_from_slice(&block.to_be_bytes());
+    }
+
+    Ok(output)
+}

--- a/crates/core/affinidi-crypto/src/jose/concat_kdf.rs
+++ b/crates/core/affinidi-crypto/src/jose/concat_kdf.rs
@@ -1,0 +1,144 @@
+//! JOSE Concat KDF (NIST SP 800-56A single-pass, SHA-256).
+//!
+//! Two flavours, both stateless over the raw shared secret `z` (the
+//! ECDH key-agreement step that produces `z` lands in a later #327 PR):
+//!
+//! - [`concat_kdf`] — ECDH-ES (RFC 7518 §4.6).
+//! - [`concat_kdf_1pu`] — ECDH-1PU (draft-madden-jose-ecdh-1pu-04 §2.3),
+//!   which appends the content-encryption authentication tag (`cc_tag`)
+//!   as the final, **length-prefixed** OtherInfo field. The missing
+//!   length prefix was bug #322; [`concat_kdf_1pu_legacy`] preserves the
+//!   pre-fix behaviour for the decrypt-fallback migration path only.
+//!
+//! Ported verbatim from `affinidi-messaging-didcomm`; byte-level output is
+//! locked by [`super::kat`].
+
+use sha2::{Digest, Sha256};
+
+use crate::error::CryptoError;
+
+/// JOSE Concat KDF for ECDH-ES (RFC 7518 §4.6).
+///
+/// `otherinfo = round(1) || Z || len‖AlgorithmID || len‖PartyUInfo ||
+/// len‖PartyVInfo || keydatalen`, hashed once with SHA-256 and truncated
+/// to `key_len_bits`.
+pub fn concat_kdf(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let key_len_bytes = (key_len_bits / 8) as usize;
+
+    // For 256-bit keys, one round of SHA-256 is sufficient.
+    let mut hasher = Sha256::new();
+
+    // round = 1 (big-endian u32)
+    hasher.update(1u32.to_be_bytes());
+
+    // Z (shared secret)
+    hasher.update(z);
+
+    // AlgorithmID: len(4) || value
+    hasher.update((alg.len() as u32).to_be_bytes());
+    hasher.update(alg);
+
+    // PartyUInfo: len(4) || value
+    hasher.update((apu.len() as u32).to_be_bytes());
+    hasher.update(apu);
+
+    // PartyVInfo: len(4) || value
+    hasher.update((apv.len() as u32).to_be_bytes());
+    hasher.update(apv);
+
+    // SuppPubInfo: key length in bits (big-endian u32)
+    hasher.update(key_len_bits.to_be_bytes());
+
+    let hash = hasher.finalize();
+    Ok(hash[..key_len_bytes].to_vec())
+}
+
+/// JOSE Concat KDF for ECDH-1PU. The content-encryption authentication
+/// tag is fed as the final OtherInfo entry, **length-prefixed** with a
+/// 32-bit big-endian length exactly like every other variable-length
+/// field (draft-madden-jose-ecdh-1pu-04 §2.3 / Appendix B.9; matches
+/// askar / didcomm-python). An empty `cc_tag` is identical to
+/// [`concat_kdf`].
+pub fn concat_kdf_1pu(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+    cc_tag: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    concat_kdf_1pu_inner(z, alg, apu, apv, key_len_bits, cc_tag, false)
+}
+
+/// Pre-fix ECDH-1PU Concat KDF that fed `cc_tag` **without** a length
+/// prefix — non-conformant, see #322. Retained only for the decrypt
+/// fallback during migration; never use it for packing.
+pub fn concat_kdf_1pu_legacy(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+    cc_tag: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    concat_kdf_1pu_inner(z, alg, apu, apv, key_len_bits, cc_tag, true)
+}
+
+fn concat_kdf_1pu_inner(
+    z: &[u8],
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len_bits: u32,
+    cc_tag: &[u8],
+    legacy_tag_encoding: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    if cc_tag.is_empty() {
+        // No tag — identical to standard Concat KDF (matches ECDH-ES). The
+        // legacy/spec distinction only concerns the tag encoding, so an
+        // empty tag is identical either way.
+        return concat_kdf(z, alg, apu, apv, key_len_bits);
+    }
+
+    let key_len_bytes = (key_len_bits / 8) as usize;
+
+    let mut hasher = Sha256::new();
+
+    // round = 1
+    hasher.update(1u32.to_be_bytes());
+
+    // Z
+    hasher.update(z);
+
+    // AlgorithmID
+    hasher.update((alg.len() as u32).to_be_bytes());
+    hasher.update(alg);
+
+    // PartyUInfo
+    hasher.update((apu.len() as u32).to_be_bytes());
+    hasher.update(apu);
+
+    // PartyVInfo
+    hasher.update((apv.len() as u32).to_be_bytes());
+    hasher.update(apv);
+
+    // SuppPubInfo: key length in bits
+    hasher.update(key_len_bits.to_be_bytes());
+
+    // SuppPrivInfo: cc_tag, length-prefixed per the ECDH-1PU draft. The
+    // legacy path omits the prefix (#322) and exists only for the decrypt
+    // fallback.
+    if !legacy_tag_encoding {
+        hasher.update((cc_tag.len() as u32).to_be_bytes());
+    }
+    hasher.update(cc_tag);
+
+    let hash = hasher.finalize();
+    Ok(hash[..key_len_bytes].to_vec())
+}

--- a/crates/core/affinidi-crypto/src/jose/content_encryption.rs
+++ b/crates/core/affinidi-crypto/src/jose/content_encryption.rs
@@ -1,0 +1,142 @@
+//! A256CBC-HS512 content encryption (RFC 7516 / 7518).
+//!
+//! Composite AEAD: AES-256-CBC + HMAC-SHA-512 (truncated to 256 bits).
+//! The 64-byte CEK is split: first 32 bytes = HMAC key, last 32 bytes =
+//! AES key. Ported verbatim from `affinidi-messaging-didcomm` for the #327
+//! centralization; byte-level behaviour is locked by [`super::kat`].
+
+use aes::Aes256;
+use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use hmac::{Hmac, Mac};
+use rand_core::RngCore;
+use sha2::Sha512;
+use subtle::ConstantTimeEq;
+
+use crate::error::CryptoError;
+
+type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+type Aes256CbcDec = cbc::Decryptor<Aes256>;
+
+/// CEK size for A256CBC-HS512 (32 bytes MAC key + 32 bytes AES key).
+pub const CEK_SIZE: usize = 64;
+
+/// IV size for AES-CBC.
+pub const IV_SIZE: usize = 16;
+
+/// Authentication tag size (HMAC-SHA-512 truncated to 256 bits).
+pub const TAG_SIZE: usize = 32;
+
+/// Generate a random 64-byte CEK.
+pub fn generate_cek() -> [u8; CEK_SIZE] {
+    let mut cek = [0u8; CEK_SIZE];
+    rand_core::OsRng.fill_bytes(&mut cek);
+    cek
+}
+
+/// Generate a random 16-byte IV.
+pub fn generate_iv() -> [u8; IV_SIZE] {
+    let mut iv = [0u8; IV_SIZE];
+    rand_core::OsRng.fill_bytes(&mut iv);
+    iv
+}
+
+/// Encrypt with A256CBC-HS512. Returns `(ciphertext, tag)`.
+pub fn encrypt(
+    plaintext: &[u8],
+    cek: &[u8; CEK_SIZE],
+    iv: &[u8; IV_SIZE],
+    aad: &[u8],
+) -> Result<(Vec<u8>, [u8; TAG_SIZE]), CryptoError> {
+    let mac_key = &cek[..32];
+    let enc_key = &cek[32..];
+
+    // PKCS7 padding: pad to AES block size (16 bytes)
+    let pad_len = 16 - (plaintext.len() % 16);
+    let mut padded = Vec::with_capacity(plaintext.len() + pad_len);
+    padded.extend_from_slice(plaintext);
+    padded.resize(plaintext.len() + pad_len, pad_len as u8);
+
+    // AES-256-CBC encrypt
+    let enc_key_arr: [u8; 32] = enc_key.try_into().unwrap();
+    let encryptor = Aes256CbcEnc::new(&enc_key_arr.into(), iv.into());
+    let ciphertext =
+        encryptor.encrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&padded);
+
+    // HMAC-SHA-512 over: AAD || IV || ciphertext || AAD_len_bits (big-endian u64)
+    let aad_len_bits = (aad.len() as u64) * 8;
+    let mut hmac = <Hmac<Sha512>>::new_from_slice(mac_key)
+        .map_err(|e| CryptoError::ContentEncryption(format!("HMAC init failed: {e}")))?;
+    hmac.update(aad);
+    hmac.update(iv);
+    hmac.update(&ciphertext);
+    hmac.update(&aad_len_bits.to_be_bytes());
+    let full_tag = hmac.finalize().into_bytes();
+
+    // Truncate to first 32 bytes
+    let mut tag = [0u8; TAG_SIZE];
+    tag.copy_from_slice(&full_tag[..TAG_SIZE]);
+
+    Ok((ciphertext, tag))
+}
+
+/// Decrypt with A256CBC-HS512. Verifies the tag in constant time before
+/// decrypting.
+pub fn decrypt(
+    ciphertext: &[u8],
+    cek: &[u8; CEK_SIZE],
+    iv: &[u8; IV_SIZE],
+    aad: &[u8],
+    tag: &[u8; TAG_SIZE],
+) -> Result<Vec<u8>, CryptoError> {
+    let mac_key = &cek[..32];
+    let enc_key = &cek[32..];
+
+    // Verify HMAC first
+    let aad_len_bits = (aad.len() as u64) * 8;
+    let mut hmac = <Hmac<Sha512>>::new_from_slice(mac_key)
+        .map_err(|e| CryptoError::ContentEncryption(format!("HMAC init failed: {e}")))?;
+    hmac.update(aad);
+    hmac.update(iv);
+    hmac.update(ciphertext);
+    hmac.update(&aad_len_bits.to_be_bytes());
+    let full_tag = hmac.finalize().into_bytes();
+
+    // Constant-time tag comparison to prevent timing attacks
+    if full_tag[..TAG_SIZE].ct_eq(tag).unwrap_u8() != 1 {
+        return Err(CryptoError::ContentEncryption(
+            "authentication tag mismatch".into(),
+        ));
+    }
+
+    // AES-256-CBC decrypt
+    let enc_key_arr: [u8; 32] = enc_key.try_into().unwrap();
+    let decryptor = Aes256CbcDec::new(&enc_key_arr.into(), iv.into());
+    let buf = ciphertext.to_vec();
+    let decrypted = decryptor
+        .decrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&buf)
+        .map_err(|e| CryptoError::ContentEncryption(format!("AES-CBC decrypt failed: {e}")))?;
+
+    // Remove PKCS7 padding
+    if decrypted.is_empty() {
+        return Err(CryptoError::ContentEncryption(
+            "decrypted data is empty".into(),
+        ));
+    }
+    let pad_len = *decrypted.last().unwrap() as usize;
+    if pad_len == 0 || pad_len > 16 || pad_len > decrypted.len() {
+        return Err(CryptoError::ContentEncryption(
+            "invalid PKCS7 padding".into(),
+        ));
+    }
+    // Verify all padding bytes
+    for &b in &decrypted[decrypted.len() - pad_len..] {
+        if b as usize != pad_len {
+            return Err(CryptoError::ContentEncryption(
+                "invalid PKCS7 padding".into(),
+            ));
+        }
+    }
+    let plaintext = &decrypted[..decrypted.len() - pad_len];
+
+    Ok(plaintext.to_vec())
+}

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -1,0 +1,188 @@
+//! Known-answer tests for `affinidi-crypto::jose`.
+//!
+//! These mirror the harness in `affinidi-messaging-didcomm`
+//! (`src/crypto/kat.rs`, PR #336). The expected bytes are **identical**:
+//! since this module is a verbatim port, matching the same vectors proves
+//! the #327 move changed nothing on the wire. When PR 5d deletes the
+//! didcomm copies and rewires onto this module, these vectors are the
+//! contract that nothing drifted.
+//!
+//! - `aes256_kw_rfc3394_section_4_6` — real spec vector (RFC 3394 §4.6).
+//! - `concat_kdf_es_golden`, `a256cbc_hs512_golden`, `ed25519_eddsa_golden`
+//!   — same golden masters as #336; portable because the code is identical.
+//! - `concat_kdf_1pu_*` — structural lock of the #322 length-prefixed tag
+//!   (the full ECDH-1PU-with-key-agreement KEK golden from #336 needs the
+//!   curve types, which land in PR 5c).
+
+#![cfg(test)]
+
+use super::{A256CbcHs512, A256Kw, ContentEncryption, Ed25519, JwsSigner, JwsVerifier, KeyWrap};
+use super::{aes_kw, concat_kdf, content_encryption, signing};
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn unhex(s: &str) -> Vec<u8> {
+    assert!(s.len().is_multiple_of(2), "hex must be even length");
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+// ─── AES-256-KW: RFC 3394 §4.6 (spec vector) ────────────────────────────────
+
+#[test]
+fn aes256_kw_rfc3394_section_4_6() {
+    let kek: [u8; 32] = core::array::from_fn(|i| i as u8);
+    let key_data = unhex("00112233445566778899aabbccddeeff");
+    const EXPECTED_WRAPPED: &str = "64e8c3f9ce0f5ba263e9777905818a2a93c8191e7d6e8ae7";
+
+    let wrapped = aes_kw::wrap(&kek, &key_data).expect("wrap");
+    assert_eq!(
+        hex(&wrapped),
+        EXPECTED_WRAPPED,
+        "A256KW must match RFC 3394 §4.6"
+    );
+    assert_eq!(aes_kw::unwrap(&kek, &wrapped).expect("unwrap"), key_data);
+
+    // Same vector through the trait surface.
+    let via_trait = A256Kw.wrap(&kek, &key_data).expect("trait wrap");
+    assert_eq!(hex(&via_trait), EXPECTED_WRAPPED);
+    assert_eq!(A256Kw.algorithm(), "A256KW");
+}
+
+// ─── Concat KDF (ECDH-ES) — same golden as didcomm #336 ─────────────────────
+
+#[test]
+fn concat_kdf_es_golden() {
+    let z: [u8; 32] = core::array::from_fn(|i| i as u8);
+    // Identical expected bytes to didcomm src/crypto/kat.rs (#336).
+    const EXPECTED: &str = "5655555b3d044d53f6b50fd49674ff388654cb284a4f6d4e2112de7b876a59d6";
+
+    let dk = concat_kdf::concat_kdf(&z, b"ECDH-ES+A256KW", b"Alice", b"Bob", 256).unwrap();
+    assert_eq!(
+        hex(&dk),
+        EXPECTED,
+        "ECDH-ES Concat KDF output drifted from didcomm"
+    );
+}
+
+// ─── Concat KDF (ECDH-1PU) — #322 length-prefixed tag, structural lock ──────
+
+#[test]
+fn concat_kdf_1pu_length_prefixes_tag() {
+    use sha2::{Digest, Sha256};
+
+    let z = b"0123456789abcdef0123456789abcdef";
+    let alg = b"ECDH-1PU+A256KW".as_slice();
+    let apu = b"did:example:alice#key-1".as_slice();
+    let apv = b"apv-bytes".as_slice();
+    let tag = [0xABu8; 32];
+
+    // Independently rebuild the spec-correct OtherInfo with the tag
+    // length-prefixed (the bytes under test: 00 00 00 20).
+    let mut h = Sha256::new();
+    h.update(1u32.to_be_bytes());
+    h.update(z);
+    h.update((alg.len() as u32).to_be_bytes());
+    h.update(alg);
+    h.update((apu.len() as u32).to_be_bytes());
+    h.update(apu);
+    h.update((apv.len() as u32).to_be_bytes());
+    h.update(apv);
+    h.update(256u32.to_be_bytes());
+    h.update((tag.len() as u32).to_be_bytes());
+    h.update(tag);
+    let expected = h.finalize()[..32].to_vec();
+
+    let got = concat_kdf::concat_kdf_1pu(z, alg, apu, apv, 256, &tag).unwrap();
+    assert_eq!(got, expected, "1PU KDF must length-prefix the cc_tag");
+
+    let legacy = concat_kdf::concat_kdf_1pu_legacy(z, alg, apu, apv, 256, &tag).unwrap();
+    assert_ne!(
+        got, legacy,
+        "the 4-byte length prefix must change the key (#322)"
+    );
+
+    // Empty tag must equal the plain ECDH-ES Concat KDF.
+    let no_tag = concat_kdf::concat_kdf_1pu(z, alg, apu, apv, 256, b"").unwrap();
+    let es = concat_kdf::concat_kdf(z, alg, apu, apv, 256).unwrap();
+    assert_eq!(no_tag, es, "empty cc_tag must match ECDH-ES Concat KDF");
+}
+
+// ─── A256CBC-HS512 — same golden as didcomm #336 ────────────────────────────
+
+#[test]
+fn a256cbc_hs512_golden() {
+    const EXPECTED_CT: &str = "f74554842ded8fa32ff9b5185f9a7df88d3fd7539a5d8012abf5b82aeacd9ebd";
+    const EXPECTED_TAG: &str = "83dbed2db1a941c503ce5a28b0fdf14180a9869426366fae9dc2d8a81cfc4223";
+
+    let cek: [u8; 64] = core::array::from_fn(|i| i as u8);
+    let iv: [u8; 16] = core::array::from_fn(|i| (0xF0 + i) as u8);
+    let plaintext = b"DIDComm KAT plaintext";
+
+    let (ct, tag) = content_encryption::encrypt(plaintext, &cek, &iv, b"aad").unwrap();
+    assert_eq!(
+        hex(&ct),
+        EXPECTED_CT,
+        "A256CBC-HS512 ciphertext drifted from didcomm"
+    );
+    assert_eq!(
+        hex(&tag),
+        EXPECTED_TAG,
+        "A256CBC-HS512 tag drifted from didcomm"
+    );
+
+    let recovered = content_encryption::decrypt(&ct, &cek, &iv, b"aad", &tag).unwrap();
+    assert_eq!(recovered, plaintext);
+
+    // Same vector through the trait surface, incl. tag-tamper rejection.
+    let (ct2, tag2) = A256CbcHs512.encrypt(plaintext, &cek, &iv, b"aad").unwrap();
+    assert_eq!(hex(&ct2), EXPECTED_CT);
+    assert_eq!(hex(&tag2), EXPECTED_TAG);
+    let mut bad = tag2.clone();
+    bad[0] ^= 0x01;
+    assert!(
+        A256CbcHs512.decrypt(&ct2, &cek, &iv, b"aad", &bad).is_err(),
+        "corrupted tag must be rejected"
+    );
+}
+
+// ─── EdDSA — same golden as didcomm #336 ────────────────────────────────────
+
+#[test]
+fn ed25519_eddsa_golden() {
+    const EXPECTED_PK: &str = "d759793bbc13a2819a827c76adb6fba8a49aee007f49f2d0992d99b825ad2c48";
+    const EXPECTED_SIG: &str = "86209dd05dd745917219c1cf7fded1726cc4b9a8063edb88554a6d5bb8f86adfa17de70c841ef7c0a727c819177ccbcac44611f23e5d646aa922373f3291e000";
+
+    let seed = [0x44u8; 32];
+    let msg = b"DIDComm KAT message";
+
+    let pk = signing::public_key_from_private(&seed);
+    assert_eq!(
+        hex(&pk),
+        EXPECTED_PK,
+        "Ed25519 public key drifted from didcomm"
+    );
+
+    let sig = signing::sign(msg, &seed).unwrap();
+    assert_eq!(
+        hex(&sig),
+        EXPECTED_SIG,
+        "Ed25519 signature drifted from didcomm"
+    );
+
+    assert!(signing::verify(msg, &sig, &pk).is_ok());
+    assert!(signing::verify(b"tampered", &sig, &pk).is_err());
+
+    // Same vector through the trait surface.
+    let sig_t = Ed25519.sign(msg, &seed).unwrap();
+    assert_eq!(hex(&sig_t), EXPECTED_SIG);
+    assert!(Ed25519.verify(msg, &sig_t, &pk).is_ok());
+}

--- a/crates/core/affinidi-crypto/src/jose/mod.rs
+++ b/crates/core/affinidi-crypto/src/jose/mod.rs
@@ -1,0 +1,38 @@
+//! JOSE cryptographic primitives (`jose` feature).
+//!
+//! Centralizes the JOSE crypto previously hand-rolled in
+//! `affinidi-messaging-didcomm` (#327). This PR (5b) lands the **stateless
+//! primitives** — the Concat KDF, AES-256 Key Wrap, A256CBC-HS512 content
+//! encryption, and EdDSA — plus the algorithm traits that make them
+//! extensible (see [`traits`]). ECDH key agreement / curve types land in a
+//! later PR; until then `concat_kdf*` take the raw shared secret `z`
+//! directly.
+//!
+//! Two ways to call:
+//!
+//! - **Free functions** ([`aes_kw`], [`content_encryption`],
+//!   [`concat_kdf`], [`signing`]) — the workhorses, ported verbatim from
+//!   didcomm. Their byte-level output is pinned by [`kat`].
+//! - **Traits** ([`traits`]) — `KeyWrap`, `ContentEncryption`,
+//!   `KeyDerivation`, `JwsSigner`/`JwsVerifier` with concrete impls
+//!   (`A256Kw`, `A256CbcHs512`, `ConcatKdf`, `Ed25519`). The
+//!   open-for-extension seam for adding new algorithms.
+
+pub mod aes_kw;
+pub mod concat_kdf;
+pub mod content_encryption;
+pub mod signing;
+pub mod traits;
+
+pub use traits::{
+    A256CbcHs512, A256Kw, ConcatKdf, ContentEncryption, Ed25519, JwsSigner, JwsVerifier,
+    KeyDerivation, KeyWrap,
+};
+
+/// Known-answer / golden-master tests. These assert the **same** expected
+/// bytes as the harness in `affinidi-messaging-didcomm` (PR #336): because
+/// the implementations here are a verbatim port, matching those vectors
+/// proves the move is byte-identical. PR 5d removes the didcomm copies and
+/// rewires it onto this module; these vectors are the contract.
+#[cfg(test)]
+mod kat;

--- a/crates/core/affinidi-crypto/src/jose/signing.rs
+++ b/crates/core/affinidi-crypto/src/jose/signing.rs
@@ -1,0 +1,31 @@
+//! Ed25519 signing and verification (EdDSA / JWS `alg: EdDSA`).
+//!
+//! Ported verbatim from `affinidi-messaging-didcomm` for the #327
+//! centralization; byte-level output is locked by [`super::kat`].
+
+use ed25519_dalek::{Signer, Verifier};
+
+use crate::error::CryptoError;
+
+/// Sign data with an Ed25519 private key (32-byte seed → 64-byte sig).
+pub fn sign(data: &[u8], private_key: &[u8; 32]) -> Result<[u8; 64], CryptoError> {
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(private_key);
+    let signature = signing_key.sign(data);
+    Ok(signature.to_bytes())
+}
+
+/// Verify an Ed25519 signature.
+pub fn verify(data: &[u8], signature: &[u8; 64], public_key: &[u8; 32]) -> Result<(), CryptoError> {
+    let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(public_key)
+        .map_err(|e| CryptoError::Verification(format!("invalid public key: {e}")))?;
+    let sig = ed25519_dalek::Signature::from_bytes(signature);
+    verifying_key
+        .verify(data, &sig)
+        .map_err(|e| CryptoError::Verification(format!("signature verification failed: {e}")))
+}
+
+/// Derive the Ed25519 public key from a private key.
+pub fn public_key_from_private(private_key: &[u8; 32]) -> [u8; 32] {
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(private_key);
+    signing_key.verifying_key().to_bytes()
+}

--- a/crates/core/affinidi-crypto/src/jose/traits.rs
+++ b/crates/core/affinidi-crypto/src/jose/traits.rs
@@ -1,0 +1,226 @@
+//! Algorithm traits — the open-for-extension seam for JOSE crypto.
+//!
+//! Per ADR 0001, each JOSE role is a trait; concrete algorithms are
+//! implementations keyed by their JOSE `alg`/`enc` identifier. Adding a
+//! new curve, AEAD, key-wrap, or signature scheme is then an additive
+//! `impl`, not an edit to a closed `match` across the codebase.
+//!
+//! Security boundary: these traits are *capability*. Deciding which
+//! identifiers a given protocol message is *allowed* to use stays an
+//! explicit allowlist in the envelope layer (e.g. didcomm) — registering
+//! an implementation here never auto-enables it on the wire. The traits
+//! take `&[u8]` keys (not fixed-size arrays) so differently-sized
+//! algorithms share one interface; each impl length-checks its inputs.
+
+use crate::error::CryptoError;
+
+use super::{aes_kw, concat_kdf, content_encryption, signing};
+
+/// Key-wrapping algorithms (JWE `alg` of the `…+AxxxKW` form).
+pub trait KeyWrap {
+    /// JOSE key-management algorithm identifier, e.g. `"A256KW"`.
+    fn algorithm(&self) -> &'static str;
+    /// Wrap `key` (the CEK) under `kek`.
+    fn wrap(&self, kek: &[u8], key: &[u8]) -> Result<Vec<u8>, CryptoError>;
+    /// Unwrap a wrapped key under `kek`.
+    fn unwrap(&self, kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, CryptoError>;
+}
+
+/// Authenticated content-encryption algorithms (JWE `enc`).
+pub trait ContentEncryption {
+    /// JOSE content-encryption identifier, e.g. `"A256CBC-HS512"`.
+    fn enc(&self) -> &'static str;
+    /// Required content-encryption key length in bytes.
+    fn cek_len(&self) -> usize;
+    /// Required IV length in bytes.
+    fn iv_len(&self) -> usize;
+    /// Authentication tag length in bytes.
+    fn tag_len(&self) -> usize;
+    /// Encrypt, returning `(ciphertext, tag)`.
+    fn encrypt(
+        &self,
+        plaintext: &[u8],
+        cek: &[u8],
+        iv: &[u8],
+        aad: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), CryptoError>;
+    /// Verify the tag and decrypt.
+    fn decrypt(
+        &self,
+        ciphertext: &[u8],
+        cek: &[u8],
+        iv: &[u8],
+        aad: &[u8],
+        tag: &[u8],
+    ) -> Result<Vec<u8>, CryptoError>;
+}
+
+/// JOSE key-derivation (Concat KDF and future KDFs). `cc_tag` is the
+/// ECDH-1PU content-encryption tag; pass an empty slice for ECDH-ES.
+pub trait KeyDerivation {
+    /// Derive `key_len_bits` of key-encryption key from the raw ECDH
+    /// shared secret `z` and the OtherInfo parameters.
+    fn derive(
+        &self,
+        z: &[u8],
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        key_len_bits: u32,
+        cc_tag: &[u8],
+    ) -> Result<Vec<u8>, CryptoError>;
+}
+
+/// JWS signing algorithms (`alg`).
+pub trait JwsSigner {
+    /// JOSE signature algorithm identifier, e.g. `"EdDSA"`.
+    fn algorithm(&self) -> &'static str;
+    /// Sign `data` with `private_key`.
+    fn sign(&self, data: &[u8], private_key: &[u8]) -> Result<Vec<u8>, CryptoError>;
+}
+
+/// JWS verification algorithms (`alg`).
+pub trait JwsVerifier {
+    /// JOSE signature algorithm identifier, e.g. `"EdDSA"`.
+    fn algorithm(&self) -> &'static str;
+    /// Verify `signature` over `data` with `public_key`.
+    fn verify(&self, data: &[u8], signature: &[u8], public_key: &[u8]) -> Result<(), CryptoError>;
+}
+
+// ─── Concrete algorithms ────────────────────────────────────────────────────
+
+/// AES-256 Key Wrap (RFC 3394).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct A256Kw;
+
+impl KeyWrap for A256Kw {
+    fn algorithm(&self) -> &'static str {
+        "A256KW"
+    }
+
+    fn wrap(&self, kek: &[u8], key: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let kek: &[u8; 32] = kek
+            .try_into()
+            .map_err(|_| CryptoError::KeyWrap("A256KW KEK must be 32 bytes".into()))?;
+        aes_kw::wrap(kek, key)
+    }
+
+    fn unwrap(&self, kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let kek: &[u8; 32] = kek
+            .try_into()
+            .map_err(|_| CryptoError::KeyWrap("A256KW KEK must be 32 bytes".into()))?;
+        aes_kw::unwrap(kek, wrapped)
+    }
+}
+
+/// A256CBC-HS512 (AES-256-CBC + HMAC-SHA-512/256).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct A256CbcHs512;
+
+impl ContentEncryption for A256CbcHs512 {
+    fn enc(&self) -> &'static str {
+        "A256CBC-HS512"
+    }
+    fn cek_len(&self) -> usize {
+        content_encryption::CEK_SIZE
+    }
+    fn iv_len(&self) -> usize {
+        content_encryption::IV_SIZE
+    }
+    fn tag_len(&self) -> usize {
+        content_encryption::TAG_SIZE
+    }
+
+    fn encrypt(
+        &self,
+        plaintext: &[u8],
+        cek: &[u8],
+        iv: &[u8],
+        aad: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+        let cek: &[u8; content_encryption::CEK_SIZE] = cek
+            .try_into()
+            .map_err(|_| CryptoError::ContentEncryption("CEK must be 64 bytes".into()))?;
+        let iv: &[u8; content_encryption::IV_SIZE] = iv
+            .try_into()
+            .map_err(|_| CryptoError::ContentEncryption("IV must be 16 bytes".into()))?;
+        let (ct, tag) = content_encryption::encrypt(plaintext, cek, iv, aad)?;
+        Ok((ct, tag.to_vec()))
+    }
+
+    fn decrypt(
+        &self,
+        ciphertext: &[u8],
+        cek: &[u8],
+        iv: &[u8],
+        aad: &[u8],
+        tag: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let cek: &[u8; content_encryption::CEK_SIZE] = cek
+            .try_into()
+            .map_err(|_| CryptoError::ContentEncryption("CEK must be 64 bytes".into()))?;
+        let iv: &[u8; content_encryption::IV_SIZE] = iv
+            .try_into()
+            .map_err(|_| CryptoError::ContentEncryption("IV must be 16 bytes".into()))?;
+        let tag: &[u8; content_encryption::TAG_SIZE] = tag
+            .try_into()
+            .map_err(|_| CryptoError::ContentEncryption("tag must be 32 bytes".into()))?;
+        content_encryption::decrypt(ciphertext, cek, iv, aad, tag)
+    }
+}
+
+/// JOSE Concat KDF (SHA-256), covering both ECDH-ES (empty `cc_tag`) and
+/// ECDH-1PU (length-prefixed `cc_tag`, the #322-correct encoding).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConcatKdf;
+
+impl KeyDerivation for ConcatKdf {
+    fn derive(
+        &self,
+        z: &[u8],
+        alg: &[u8],
+        apu: &[u8],
+        apv: &[u8],
+        key_len_bits: u32,
+        cc_tag: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        if cc_tag.is_empty() {
+            concat_kdf::concat_kdf(z, alg, apu, apv, key_len_bits)
+        } else {
+            concat_kdf::concat_kdf_1pu(z, alg, apu, apv, key_len_bits, cc_tag)
+        }
+    }
+}
+
+/// Ed25519 (EdDSA).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Ed25519;
+
+impl JwsSigner for Ed25519 {
+    fn algorithm(&self) -> &'static str {
+        "EdDSA"
+    }
+
+    fn sign(&self, data: &[u8], private_key: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let sk: &[u8; 32] = private_key
+            .try_into()
+            .map_err(|_| CryptoError::Signing("Ed25519 private key must be 32 bytes".into()))?;
+        Ok(signing::sign(data, sk)?.to_vec())
+    }
+}
+
+impl JwsVerifier for Ed25519 {
+    fn algorithm(&self) -> &'static str {
+        "EdDSA"
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8], public_key: &[u8]) -> Result<(), CryptoError> {
+        let sig: &[u8; 64] = signature
+            .try_into()
+            .map_err(|_| CryptoError::Verification("Ed25519 signature must be 64 bytes".into()))?;
+        let pk: &[u8; 32] = public_key
+            .try_into()
+            .map_err(|_| CryptoError::Verification("Ed25519 public key must be 32 bytes".into()))?;
+        signing::verify(data, sig, pk)
+    }
+}

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -29,6 +29,9 @@ pub mod secp256k1;
 #[cfg(feature = "p384")]
 pub mod p384;
 
+#[cfg(feature = "jose")]
+pub mod jose;
+
 #[cfg(feature = "ml-dsa")]
 pub mod ml_dsa;
 


### PR DESCRIPTION
Second step of #327, after #336 (ADR + KAT harness). Adds the JOSE crypto to `affinidi-crypto`, ported verbatim from `affinidi-messaging-didcomm`. **Purely additive** behind a new `jose` feature that is **off by default** — no existing dependent compiles differently and no wire behaviour changes. didcomm is untouched here; the rewire + deletion is PR 5d.

## Scope (per the plan agreed on #336)
Stateless primitives + the extensibility seam. ECDH key agreement / curve types are deferred to PR 5c, so `concat_kdf*` take the raw shared secret `z` directly for now.

## Primitives — `jose::{aes_kw, content_encryption, concat_kdf, signing}`
Verbatim ports (errors mapped to `CryptoError`):
- **AES-256 Key Wrap** (RFC 3394)
- **A256CBC-HS512** content encryption
- **Concat KDF** for ECDH-ES and ECDH-1PU — including the **#322 length-prefixed `cc_tag`**, plus a `_legacy` variant for the decrypt-fallback migration path
- **Ed25519** (EdDSA)

## Extensibility — `jose::traits` (ADR 0001 requirement)
One trait per JOSE role — `KeyWrap`, `ContentEncryption`, `KeyDerivation`, `JwsSigner`/`JwsVerifier` — each exposing its JOSE `alg`/`enc` identifier, with concrete impls `A256Kw`, `A256CbcHs512`, `ConcatKdf`, `Ed25519`. A new curve/AEAD/sig-alg (or future PQC/hybrid KEM) is an additive `impl`, not an edit to a closed `match`. The typed wire-identifier allowlist stays the envelope layer's responsibility — registering a primitive here never auto-enables it on the wire (no downgrade surface).

## Byte-identical guarantee — `jose::kat`
The KATs assert the **same expected bytes** as the didcomm harness from #336 for Concat-KDF-ES, A256CBC-HS512, and EdDSA — since this is a verbatim port, matching those vectors proves the move is byte-identical. Plus the real **RFC 3394 §4.6** A256KW spec vector and a structural lock on the 1PU length-prefixed tag. PR 5d's end-to-end KATs close the loop through key agreement.

## Other
- New `CryptoError` variants: `KeyDerivation`, `KeyWrap`, `ContentEncryption`, `Signing`, `Verification`.
- New optional deps `aes`/`cbc`/`hmac`/`subtle` — already in the workspace tree via didcomm.

## Versioning
`affinidi-crypto` `0.1.7 → 0.1.8`. Dependents pin `"0.1"` and `jose` is off by default → no cascade.

## Checks
- `cargo fmt --check` clean
- `cargo test -p affinidi-crypto --features jose` → 35 passed (5 new KATs)
- builds clean with default features (no `jose`) **and** `--no-default-features --features jose`
- `cargo clippy` clean on both feature sets
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok