### PR TITLE
feat: affinidi-crypto jose key agreement + ECDH derivation (#327 PR 5c)

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Affinidi Crypto Changelog
 
+## 1st June 2026 (0.1.9)
+
+- **FEATURE — `jose` key agreement + ECDH derivation (#327, off by
+  default).** Builds on 0.1.8, completing the curve-bearing half of the
+  JOSE port from `affinidi-messaging-didcomm`.
+  - `jose::key_agreement` — `Curve` (X25519 / P-256 / secp256k1) plus
+    `PublicKeyAgreement` / `PrivateKeyAgreement` / `EphemeralKeyPair`,
+    with `from_raw_bytes`, `public_key`, `diffie_hellman`, and JWK
+    `to_jwk` / `from_jwk`. Curves are runtime-dispatched (a message picks
+    its curve at runtime); adding one is a localized change here — all
+    derivation/KDF/wrap/AEAD code stays curve-agnostic over the raw
+    shared secret.
+  - `jose::ecdh` — `derive_key_es` / `derive_key_1pu` (+ recipient and
+    `_legacy` variants and the `derive_sender_key*` helpers) combining
+    key agreement with the Concat KDF from 0.1.8.
+  - KATs now include the ECDH-1PU KEK over X25519, asserting the **same**
+    golden as the didcomm harness (PR #336) — proving key agreement +
+    Concat-KDF-1PU port byte-identically end to end — plus ECDH-ES and
+    JWK round-trips across all three curves.
+  - New `CryptoError::KeyAgreement` variant. The `jose` feature now also
+    enables the `p256` / `k256` features, and those crates gain the
+    `ecdh` cargo feature. Still **off by default**.
+
 ## 1st June 2026 (0.1.8)
 
 - **FEATURE — `jose` module (#327, off by default).** Adds the JOSE

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.8"
+version = "0.1.9"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -27,7 +27,7 @@ slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
 # JOSE primitives (#327): ECDH-ES / ECDH-1PU Concat KDF, A256KW key wrap,
 # A256CBC-HS512 content encryption, EdDSA signing. Pulls in EdDSA via the
 # `ed25519` feature. Key agreement (curves) lands separately in a later PR.
-jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519"]
+jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519", "p256", "k256"]
 
 [dependencies]
 affinidi-encoding = "0.1"
@@ -39,11 +39,13 @@ ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 k256 = { version = "0.13", features = [
   "ecdsa-core",
   "arithmetic",
+  "ecdh",
 ], optional = true }
 p256 = { version = "0.13", features = [
   "ecdsa-core",
   "ecdsa",
   "arithmetic",
+  "ecdh",
 ], optional = true }
 p384 = { version = "0.13", features = [
   "ecdsa-core",

--- a/crates/core/affinidi-crypto/src/error.rs
+++ b/crates/core/affinidi-crypto/src/error.rs
@@ -17,6 +17,9 @@ pub enum CryptoError {
     Encoding(#[from] affinidi_encoding::EncodingError),
 
     // ─── JOSE primitives (`jose` feature) ───────────────────────────────────
+    #[error("Key agreement error: {0}")]
+    KeyAgreement(String),
+
     #[error("Key derivation error: {0}")]
     KeyDerivation(String),
 

--- a/crates/core/affinidi-crypto/src/jose/ecdh.rs
+++ b/crates/core/affinidi-crypto/src/jose/ecdh.rs
@@ -1,0 +1,150 @@
+//! ECDH key derivation: ECDH-ES (anoncrypt) and ECDH-1PU (authcrypt).
+//!
+//! Combines the [key agreement](super::key_agreement) step with the
+//! [Concat KDF](super::concat_kdf) to produce a key-wrapping key (KEK).
+//! Ported from `affinidi-messaging-didcomm` for #327; byte-level output is
+//! locked by [`super::kat`] (the ECDH-1PU KEK golden matches PR #336).
+
+use crate::error::CryptoError;
+
+use super::concat_kdf::{concat_kdf, concat_kdf_1pu, concat_kdf_1pu_legacy};
+use super::key_agreement::{EphemeralKeyPair, PrivateKeyAgreement, PublicKeyAgreement};
+
+// ─── ECDH-ES (anonymous encryption) ─────────────────────────────────────────
+
+/// Derive a KEK with ECDH-ES + Concat KDF (sender side).
+pub fn derive_key_es(
+    ephemeral: &PrivateKeyAgreement,
+    recipient_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let z = ephemeral.diffie_hellman(recipient_public)?;
+    concat_kdf(&z, alg, apu, apv, key_len)
+}
+
+/// Derive a KEK with ECDH-ES + Concat KDF (recipient side).
+pub fn derive_key_es_recipient(
+    recipient_private: &PrivateKeyAgreement,
+    ephemeral_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let z = recipient_private.diffie_hellman(ephemeral_public)?;
+    concat_kdf(&z, alg, apu, apv, key_len)
+}
+
+/// Sender-side `ECDH-ES+A256KW` wrapping key (256-bit) for one recipient.
+pub fn derive_sender_key(
+    ephemeral: &EphemeralKeyPair,
+    recipient_public: &PublicKeyAgreement,
+    apu: &[u8],
+    apv: &[u8],
+) -> Result<[u8; 32], CryptoError> {
+    let kek = derive_key_es(
+        &ephemeral.private,
+        recipient_public,
+        b"ECDH-ES+A256KW",
+        apu,
+        apv,
+        256,
+    )?;
+    kek.try_into()
+        .map_err(|_| CryptoError::KeyAgreement("derived key wrong size".into()))
+}
+
+// ─── ECDH-1PU (authenticated encryption) ────────────────────────────────────
+
+/// Derive a KEK with ECDH-1PU + Concat KDF (sender side).
+///
+/// `Z = Ze || Zs` where `Ze = ECDH(ephemeral, recipient)` and
+/// `Zs = ECDH(sender, recipient)`. The content-encryption tag `cc_tag` is
+/// fed length-prefixed into the KDF (the #322-correct encoding).
+#[allow(clippy::too_many_arguments)]
+pub fn derive_key_1pu(
+    ephemeral: &PrivateKeyAgreement,
+    sender_private: &PrivateKeyAgreement,
+    recipient_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let ze = ephemeral.diffie_hellman(recipient_public)?;
+    let zs = sender_private.diffie_hellman(recipient_public)?;
+    let mut z = Vec::with_capacity(ze.len() + zs.len());
+    z.extend_from_slice(&ze);
+    z.extend_from_slice(&zs);
+    concat_kdf_1pu(&z, alg, apu, apv, key_len, cc_tag)
+}
+
+/// Derive a KEK with ECDH-1PU + Concat KDF (recipient side).
+#[allow(clippy::too_many_arguments)]
+pub fn derive_key_1pu_recipient(
+    recipient_private: &PrivateKeyAgreement,
+    sender_public: &PublicKeyAgreement,
+    ephemeral_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let ze = recipient_private.diffie_hellman(ephemeral_public)?;
+    let zs = recipient_private.diffie_hellman(sender_public)?;
+    let mut z = Vec::with_capacity(ze.len() + zs.len());
+    z.extend_from_slice(&ze);
+    z.extend_from_slice(&zs);
+    concat_kdf_1pu(&z, alg, apu, apv, key_len, cc_tag)
+}
+
+/// Recipient-side ECDH-1PU derivation using the **legacy** (pre-#322)
+/// Concat KDF that fed `cc_tag` without a length prefix. Transitional —
+/// used only by the decrypt fallback so a fixed node can still receive
+/// authcrypt from an unpatched peer during rollout.
+#[allow(clippy::too_many_arguments)]
+pub fn derive_key_1pu_recipient_legacy(
+    recipient_private: &PrivateKeyAgreement,
+    sender_public: &PublicKeyAgreement,
+    ephemeral_public: &PublicKeyAgreement,
+    alg: &[u8],
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+    key_len: u32,
+) -> Result<Vec<u8>, CryptoError> {
+    let ze = recipient_private.diffie_hellman(ephemeral_public)?;
+    let zs = recipient_private.diffie_hellman(sender_public)?;
+    let mut z = Vec::with_capacity(ze.len() + zs.len());
+    z.extend_from_slice(&ze);
+    z.extend_from_slice(&zs);
+    concat_kdf_1pu_legacy(&z, alg, apu, apv, key_len, cc_tag)
+}
+
+/// Sender-side `ECDH-1PU+A256KW` wrapping key (256-bit) for one recipient.
+pub fn derive_sender_key_1pu(
+    ephemeral: &EphemeralKeyPair,
+    sender_private: &PrivateKeyAgreement,
+    recipient_public: &PublicKeyAgreement,
+    apu: &[u8],
+    apv: &[u8],
+    cc_tag: &[u8],
+) -> Result<[u8; 32], CryptoError> {
+    let kek = derive_key_1pu(
+        &ephemeral.private,
+        sender_private,
+        recipient_public,
+        b"ECDH-1PU+A256KW",
+        apu,
+        apv,
+        cc_tag,
+        256,
+    )?;
+    kek.try_into()
+        .map_err(|_| CryptoError::KeyAgreement("derived key wrong size".into()))
+}

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -10,12 +10,17 @@
 //! - `aes256_kw_rfc3394_section_4_6` — real spec vector (RFC 3394 §4.6).
 //! - `concat_kdf_es_golden`, `a256cbc_hs512_golden`, `ed25519_eddsa_golden`
 //!   — same golden masters as #336; portable because the code is identical.
-//! - `concat_kdf_1pu_*` — structural lock of the #322 length-prefixed tag
-//!   (the full ECDH-1PU-with-key-agreement KEK golden from #336 needs the
-//!   curve types, which land in PR 5c).
+//! - `concat_kdf_1pu_*` — structural lock of the #322 length-prefixed tag.
+//! - `ecdh_1pu_x25519_kek_golden` — the full ECDH-1PU + Concat-KDF KEK,
+//!   asserting the **same** `f3cc56…` golden as didcomm #336 (closes the
+//!   vector 5b deferred until key agreement landed).
 
 #![cfg(test)]
 
+use super::ecdh::{
+    derive_key_1pu, derive_key_1pu_recipient, derive_key_es, derive_key_es_recipient,
+};
+use super::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
 use super::{A256CbcHs512, A256Kw, ContentEncryption, Ed25519, JwsSigner, JwsVerifier, KeyWrap};
 use super::{aes_kw, concat_kdf, content_encryption, signing};
 
@@ -114,6 +119,91 @@ fn concat_kdf_1pu_length_prefixes_tag() {
     let no_tag = concat_kdf::concat_kdf_1pu(z, alg, apu, apv, 256, b"").unwrap();
     let es = concat_kdf::concat_kdf(z, alg, apu, apv, 256).unwrap();
     assert_eq!(no_tag, es, "empty cc_tag must match ECDH-ES Concat KDF");
+}
+
+// ─── ECDH-1PU KEK over X25519 — same golden as didcomm #336 ─────────────────
+
+#[test]
+fn ecdh_1pu_x25519_kek_golden() {
+    // Identical fixed seeds, params, and expected KEK to didcomm
+    // src/crypto/kat.rs (#336) — proves key agreement + Concat-KDF-1PU
+    // port byte-identically end to end.
+    const EXPECTED_KEK: &str = "f3cc56f46a09991543b654ce36e0913bb8c9656ad53fa159f732c0edcf1a4f9c";
+
+    let sender = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &[0x11; 32]).unwrap();
+    let recip = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &[0x22; 32]).unwrap();
+    let eph = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, &[0x33; 32]).unwrap();
+    let cc_tag = [0xABu8; 32];
+
+    let kek = derive_key_1pu(
+        &eph,
+        &sender,
+        &recip.public_key(),
+        b"ECDH-1PU+A256KW",
+        b"did:example:alice#key-1",
+        b"apv-bytes",
+        &cc_tag,
+        256,
+    )
+    .unwrap();
+    assert_eq!(hex(&kek), EXPECTED_KEK, "ECDH-1PU KEK drifted from didcomm");
+
+    let kek_r = derive_key_1pu_recipient(
+        &recip,
+        &sender.public_key(),
+        &eph.public_key(),
+        b"ECDH-1PU+A256KW",
+        b"did:example:alice#key-1",
+        b"apv-bytes",
+        &cc_tag,
+        256,
+    )
+    .unwrap();
+    assert_eq!(kek_r, kek, "sender and recipient must derive the same KEK");
+}
+
+#[test]
+fn ecdh_es_roundtrip_all_curves() {
+    for curve in [Curve::X25519, Curve::P256, Curve::K256] {
+        let recip = PrivateKeyAgreement::generate(curve);
+        let eph = PrivateKeyAgreement::generate(curve);
+        let s = derive_key_es(
+            &eph,
+            &recip.public_key(),
+            b"ECDH-ES+A256KW",
+            b"",
+            b"apv",
+            256,
+        )
+        .unwrap();
+        let r = derive_key_es_recipient(
+            &recip,
+            &eph.public_key(),
+            b"ECDH-ES+A256KW",
+            b"",
+            b"apv",
+            256,
+        )
+        .unwrap();
+        assert_eq!(s, r, "ECDH-ES KEK must agree for {curve:?}");
+        assert_eq!(s.len(), 32);
+    }
+}
+
+#[test]
+fn public_key_jwk_roundtrip_all_curves() {
+    for curve in [Curve::X25519, Curve::P256, Curve::K256] {
+        let pk = PrivateKeyAgreement::generate(curve).public_key();
+        let jwk = pk.to_jwk();
+        let parsed = PublicKeyAgreement::from_jwk(&jwk).unwrap();
+        // Re-encoding the parsed key must reproduce the same JWK.
+        assert_eq!(
+            parsed.to_jwk(),
+            jwk,
+            "JWK round-trip mismatch for {curve:?}"
+        );
+        assert_eq!(parsed.curve(), curve);
+    }
 }
 
 // ─── A256CBC-HS512 — same golden as didcomm #336 ────────────────────────────

--- a/crates/core/affinidi-crypto/src/jose/key_agreement.rs
+++ b/crates/core/affinidi-crypto/src/jose/key_agreement.rs
@@ -1,0 +1,293 @@
+//! Key-agreement curves and keys for JOSE ECDH (X25519, P-256, K-256).
+//!
+//! Ported from `affinidi-messaging-didcomm` for the #327 centralization.
+//! Curve-polymorphic key material is necessarily runtime-dispatched (a
+//! DIDComm message selects its curve at runtime), so the public/private
+//! keys are enums. Extensibility is preserved by locality: adding a curve
+//! is a new variant plus its arms **here only** — every derivation, KDF,
+//! key-wrap, and content-encryption path is curve-agnostic (it operates on
+//! the raw shared-secret bytes `diffie_hellman` returns), so none of them
+//! change. The `Curve` enum doubles as the typed JOSE `crv` wire boundary.
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::error::CryptoError;
+
+/// Supported key-agreement curves (JOSE `crv` identifiers).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Curve {
+    X25519,
+    P256,
+    K256,
+}
+
+impl Curve {
+    /// JWK `crv` value for this curve.
+    pub fn jwk_crv(&self) -> &'static str {
+        match self {
+            Curve::X25519 => "X25519",
+            Curve::P256 => "P-256",
+            Curve::K256 => "secp256k1",
+        }
+    }
+}
+
+/// A public key for key agreement (any supported curve).
+#[derive(Debug, Clone)]
+pub enum PublicKeyAgreement {
+    X25519([u8; 32]),
+    P256(p256::PublicKey),
+    K256(k256::PublicKey),
+}
+
+impl PublicKeyAgreement {
+    /// The curve of this key.
+    pub fn curve(&self) -> Curve {
+        match self {
+            PublicKeyAgreement::X25519(_) => Curve::X25519,
+            PublicKeyAgreement::P256(_) => Curve::P256,
+            PublicKeyAgreement::K256(_) => Curve::K256,
+        }
+    }
+
+    /// Encode as a JWK JSON value.
+    pub fn to_jwk(&self) -> Value {
+        match self {
+            PublicKeyAgreement::X25519(bytes) => serde_json::json!({
+                "kty": "OKP",
+                "crv": "X25519",
+                "x": URL_SAFE_NO_PAD.encode(bytes),
+            }),
+            PublicKeyAgreement::P256(pk) => {
+                use p256::elliptic_curve::sec1::ToEncodedPoint;
+                let point = pk.to_encoded_point(false);
+                serde_json::json!({
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+                })
+            }
+            PublicKeyAgreement::K256(pk) => {
+                use k256::elliptic_curve::sec1::ToEncodedPoint;
+                let point = pk.to_encoded_point(false);
+                serde_json::json!({
+                    "kty": "EC",
+                    "crv": "secp256k1",
+                    "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+                })
+            }
+        }
+    }
+
+    /// Construct from raw bytes and a known curve.
+    ///
+    /// For X25519: expects 32 bytes. For P-256/K-256: expects a SEC1
+    /// encoded point (compressed or uncompressed).
+    pub fn from_raw_bytes(curve: Curve, bytes: &[u8]) -> Result<Self, CryptoError> {
+        match curve {
+            Curve::X25519 => {
+                let arr: [u8; 32] = bytes.try_into().map_err(|_| {
+                    CryptoError::KeyAgreement("X25519 public key must be 32 bytes".into())
+                })?;
+                Ok(PublicKeyAgreement::X25519(arr))
+            }
+            Curve::P256 => {
+                let pk = p256::PublicKey::from_sec1_bytes(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-256 public key: {e}"))
+                })?;
+                Ok(PublicKeyAgreement::P256(pk))
+            }
+            Curve::K256 => {
+                let pk = k256::PublicKey::from_sec1_bytes(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid K-256 public key: {e}"))
+                })?;
+                Ok(PublicKeyAgreement::K256(pk))
+            }
+        }
+    }
+
+    /// Parse from a JWK JSON value.
+    pub fn from_jwk(jwk: &Value) -> Result<Self, CryptoError> {
+        let crv = jwk["crv"]
+            .as_str()
+            .ok_or_else(|| CryptoError::KeyAgreement("missing crv in JWK".into()))?;
+
+        match crv {
+            "X25519" => {
+                let x = jwk["x"]
+                    .as_str()
+                    .ok_or_else(|| CryptoError::KeyAgreement("missing x in X25519 JWK".into()))?;
+                let bytes = URL_SAFE_NO_PAD
+                    .decode(x)
+                    .map_err(|e| CryptoError::KeyAgreement(format!("invalid x: {e}")))?;
+                let arr: [u8; 32] = bytes
+                    .try_into()
+                    .map_err(|_| CryptoError::KeyAgreement("X25519 key must be 32 bytes".into()))?;
+                Ok(PublicKeyAgreement::X25519(arr))
+            }
+            "P-256" => {
+                let point = ec_point_from_jwk(jwk)?;
+                let pk = p256::PublicKey::from_sec1_bytes(&point)
+                    .map_err(|e| CryptoError::KeyAgreement(format!("invalid P-256 key: {e}")))?;
+                Ok(PublicKeyAgreement::P256(pk))
+            }
+            "secp256k1" => {
+                let point = ec_point_from_jwk(jwk)?;
+                let pk = k256::PublicKey::from_sec1_bytes(&point)
+                    .map_err(|e| CryptoError::KeyAgreement(format!("invalid K-256 key: {e}")))?;
+                Ok(PublicKeyAgreement::K256(pk))
+            }
+            other => Err(CryptoError::UnsupportedKeyType(format!(
+                "unsupported key-agreement curve: {other}"
+            ))),
+        }
+    }
+}
+
+/// Build an uncompressed SEC1 point (`0x04 || x || y`) from a JWK's `x`/`y`.
+fn ec_point_from_jwk(jwk: &Value) -> Result<Vec<u8>, CryptoError> {
+    let x = jwk["x"]
+        .as_str()
+        .ok_or_else(|| CryptoError::KeyAgreement("missing x in EC JWK".into()))?;
+    let y = jwk["y"]
+        .as_str()
+        .ok_or_else(|| CryptoError::KeyAgreement("missing y in EC JWK".into()))?;
+    let x_bytes = URL_SAFE_NO_PAD
+        .decode(x)
+        .map_err(|e| CryptoError::KeyAgreement(format!("invalid x: {e}")))?;
+    let y_bytes = URL_SAFE_NO_PAD
+        .decode(y)
+        .map_err(|e| CryptoError::KeyAgreement(format!("invalid y: {e}")))?;
+    let mut point = Vec::with_capacity(1 + x_bytes.len() + y_bytes.len());
+    point.push(0x04);
+    point.extend_from_slice(&x_bytes);
+    point.extend_from_slice(&y_bytes);
+    Ok(point)
+}
+
+/// A private key for key agreement (any supported curve).
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub enum PrivateKeyAgreement {
+    X25519(#[zeroize(skip)] x25519_dalek::StaticSecret),
+    P256(#[zeroize(skip)] p256::SecretKey),
+    K256(#[zeroize(skip)] k256::SecretKey),
+}
+
+impl std::fmt::Debug for PrivateKeyAgreement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrivateKeyAgreement::X25519(_) => write!(f, "PrivateKeyAgreement::X25519([REDACTED])"),
+            PrivateKeyAgreement::P256(_) => write!(f, "PrivateKeyAgreement::P256([REDACTED])"),
+            PrivateKeyAgreement::K256(_) => write!(f, "PrivateKeyAgreement::K256([REDACTED])"),
+        }
+    }
+}
+
+impl PrivateKeyAgreement {
+    /// Construct from raw private key bytes and a known curve.
+    ///
+    /// For X25519: expects 32 bytes (clamped scalar). For P-256/K-256:
+    /// expects the scalar bytes.
+    pub fn from_raw_bytes(curve: Curve, bytes: &[u8]) -> Result<Self, CryptoError> {
+        match curve {
+            Curve::X25519 => {
+                let arr: [u8; 32] = bytes.try_into().map_err(|_| {
+                    CryptoError::KeyAgreement("X25519 private key must be 32 bytes".into())
+                })?;
+                Ok(PrivateKeyAgreement::X25519(
+                    x25519_dalek::StaticSecret::from(arr),
+                ))
+            }
+            Curve::P256 => {
+                let sk = p256::SecretKey::from_slice(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-256 private key: {e}"))
+                })?;
+                Ok(PrivateKeyAgreement::P256(sk))
+            }
+            Curve::K256 => {
+                let sk = k256::SecretKey::from_slice(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid K-256 private key: {e}"))
+                })?;
+                Ok(PrivateKeyAgreement::K256(sk))
+            }
+        }
+    }
+
+    /// Generate a new random private key on the given curve.
+    pub fn generate(curve: Curve) -> Self {
+        match curve {
+            Curve::X25519 => {
+                PrivateKeyAgreement::X25519(x25519_dalek::StaticSecret::random_from_rng(OsRng))
+            }
+            Curve::P256 => PrivateKeyAgreement::P256(p256::SecretKey::random(&mut OsRng)),
+            Curve::K256 => PrivateKeyAgreement::K256(k256::SecretKey::random(&mut OsRng)),
+        }
+    }
+
+    /// Derive the public key.
+    pub fn public_key(&self) -> PublicKeyAgreement {
+        match self {
+            PrivateKeyAgreement::X25519(sk) => {
+                PublicKeyAgreement::X25519(x25519_dalek::PublicKey::from(sk).to_bytes())
+            }
+            PrivateKeyAgreement::P256(sk) => PublicKeyAgreement::P256(sk.public_key()),
+            PrivateKeyAgreement::K256(sk) => PublicKeyAgreement::K256(sk.public_key()),
+        }
+    }
+
+    /// The curve of this key.
+    pub fn curve(&self) -> Curve {
+        match self {
+            PrivateKeyAgreement::X25519(_) => Curve::X25519,
+            PrivateKeyAgreement::P256(_) => Curve::P256,
+            PrivateKeyAgreement::K256(_) => Curve::K256,
+        }
+    }
+
+    /// Perform ECDH with a public key, returning the raw shared-secret bytes.
+    pub fn diffie_hellman(
+        &self,
+        their_public: &PublicKeyAgreement,
+    ) -> Result<Vec<u8>, CryptoError> {
+        match (self, their_public) {
+            (PrivateKeyAgreement::X25519(sk), PublicKeyAgreement::X25519(pk)) => {
+                let pk = x25519_dalek::PublicKey::from(*pk);
+                Ok(sk.diffie_hellman(&pk).as_bytes().to_vec())
+            }
+            (PrivateKeyAgreement::P256(sk), PublicKeyAgreement::P256(pk)) => {
+                use p256::ecdh::diffie_hellman;
+                let shared = diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+                Ok(shared.raw_secret_bytes().to_vec())
+            }
+            (PrivateKeyAgreement::K256(sk), PublicKeyAgreement::K256(pk)) => {
+                use k256::ecdh::diffie_hellman;
+                let shared = diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+                Ok(shared.raw_secret_bytes().to_vec())
+            }
+            _ => Err(CryptoError::KeyAgreement(
+                "curve mismatch between private and public keys".into(),
+            )),
+        }
+    }
+}
+
+/// An ephemeral key pair for ECDH (generated per-message).
+pub struct EphemeralKeyPair {
+    pub private: PrivateKeyAgreement,
+    pub public: PublicKeyAgreement,
+}
+
+impl EphemeralKeyPair {
+    /// Generate a new ephemeral key pair on the given curve.
+    pub fn generate(curve: Curve) -> Self {
+        let private = PrivateKeyAgreement::generate(curve);
+        let public = private.public_key();
+        Self { private, public }
+    }
+}

--- a/crates/core/affinidi-crypto/src/jose/mod.rs
+++ b/crates/core/affinidi-crypto/src/jose/mod.rs
@@ -1,29 +1,33 @@
 //! JOSE cryptographic primitives (`jose` feature).
 //!
 //! Centralizes the JOSE crypto previously hand-rolled in
-//! `affinidi-messaging-didcomm` (#327). This PR (5b) lands the **stateless
-//! primitives** — the Concat KDF, AES-256 Key Wrap, A256CBC-HS512 content
-//! encryption, and EdDSA — plus the algorithm traits that make them
-//! extensible (see [`traits`]). ECDH key agreement / curve types land in a
-//! later PR; until then `concat_kdf*` take the raw shared secret `z`
-//! directly.
+//! `affinidi-messaging-didcomm` (#327): the Concat KDF, AES-256 Key Wrap,
+//! A256CBC-HS512 content encryption, EdDSA, ECDH key agreement (X25519 /
+//! P-256 / K-256), and the ECDH-ES / ECDH-1PU derivations that combine
+//! them — plus the algorithm traits that make them extensible.
 //!
 //! Two ways to call:
 //!
 //! - **Free functions** ([`aes_kw`], [`content_encryption`],
-//!   [`concat_kdf`], [`signing`]) — the workhorses, ported verbatim from
-//!   didcomm. Their byte-level output is pinned by [`kat`].
+//!   [`concat_kdf`], [`signing`], [`key_agreement`], [`ecdh`]) — the
+//!   workhorses, ported verbatim from didcomm. Their byte-level output is
+//!   pinned by [`kat`].
 //! - **Traits** ([`traits`]) — `KeyWrap`, `ContentEncryption`,
 //!   `KeyDerivation`, `JwsSigner`/`JwsVerifier` with concrete impls
 //!   (`A256Kw`, `A256CbcHs512`, `ConcatKdf`, `Ed25519`). The
-//!   open-for-extension seam for adding new algorithms.
+//!   open-for-extension seam for adding new algorithms. Curves are
+//!   runtime-dispatched via [`key_agreement::Curve`]; adding one is a
+//!   localized change (see that module).
 
 pub mod aes_kw;
 pub mod concat_kdf;
 pub mod content_encryption;
+pub mod ecdh;
+pub mod key_agreement;
 pub mod signing;
 pub mod traits;
 
+pub use key_agreement::{Curve, EphemeralKeyPair, PrivateKeyAgreement, PublicKeyAgreement};
 pub use traits::{
     A256CbcHs512, A256Kw, ConcatKdf, ContentEncryption, Ed25519, JwsSigner, JwsVerifier,
     KeyDerivation, KeyWrap,


### PR DESCRIPTION
Third step of #327, after #336 (ADR+KATs) and #337 (stateless primitives). Adds the **curve-bearing half** of the JOSE port to `affinidi-crypto::jose`. Still **additive and off-default** (`jose` feature) — no wire change. The rewire of didcomm + deletion of its bespoke crypto is PR 5d.

## `jose::key_agreement`
`Curve` (X25519 / P-256 / secp256k1) + `PublicKeyAgreement` / `PrivateKeyAgreement` / `EphemeralKeyPair`, ported from didcomm, with `from_raw_bytes`, `public_key`, `diffie_hellman`, and JWK `to_jwk` / `from_jwk`.

**On the ADR's "trait + registry, not a closed enum":** curve-polymorphic key material *must* be runtime-dispatched — a DIDComm message picks its curve at runtime — so the key containers are enums; that's the form runtime dispatch requires, and it's what every Rust JOSE lib does. The extensibility the ADR actually wants is delivered by **locality**: adding a curve is a new variant plus its arms in this one module, because every derivation / KDF / key-wrap / AEAD path is curve-agnostic (it operates on the raw shared-secret bytes `diffie_hellman` returns) and the algorithm *roles* are already traits (from #337). I documented this reasoning in the module header rather than force a trait abstraction that fights the type system for no real gain.

## `jose::ecdh`
`derive_key_es` / `derive_key_1pu` (+ recipient, `_legacy`, and `derive_sender_key*` helpers) combining key agreement with the Concat KDF from #337.

## Byte-identical proof — closes the deferred vector
`ecdh_1pu_x25519_kek_golden` asserts the **same `f3cc56…` KEK** as the didcomm harness (#336), with identical fixed seeds/params — proving key agreement + Concat-KDF-1PU port byte-identically *end to end*. This is the vector #337 had to defer until the curve types existed. Plus ECDH-ES and JWK round-trips across all three curves.

## Other
- New `CryptoError::KeyAgreement` variant.
- `jose` feature now also enables `p256`/`k256`; those crates gain the `ecdh` cargo feature (additive).

## Versioning
`affinidi-crypto` `0.1.8 → 0.1.9`. Dependents pin `"0.1"` and `jose` is off by default → no cascade.

## Checks
- `cargo fmt --check` clean
- `cargo test -p affinidi-crypto --features jose` → 38 passed (8 jose KATs)
- builds clean with default features (no `jose`) and `--no-default-features --features jose`
- `cargo clippy` clean on both feature sets
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok

## Next (PR 5d)
Rewire didcomm `pack`/`unpack` onto `affinidi-crypto::jose`, delete the bespoke `src/crypto/*`, add `From`/`Into` for any boundary types, and run didcomm's existing KATs to confirm byte-identical wire output. That's the wire-affecting (didcomm minor bump → vta-sdk republish) step.