### PR TITLE
fix: fail in-flight websocket requests on disconnect

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.3] - 2026-06-01
+
+### Changed
+
+- Offline sync no longer logs a misleading `Offline sync failed ... No
+  response from API` warning when a websocket reconnect (e.g. the mediator
+  closing the socket on access-token expiry) aborts an in-flight poll. The
+  reconnect race is now recognised via `ATMError::Disconnected` and logged
+  at `debug` ("Offline sync skipped: websocket reconnecting"); it self-heals
+  on the next 30s cycle. Genuine failures still warn. Bumps
+  `affinidi-messaging-sdk` to 0.18.5.
+
 ## [0.3.2] - 2026-05-31
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.2"
+version = "0.3.3"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use affinidi_messaging_sdk::errors::ATMError;
 use affinidi_messaging_sdk::protocols::mediator::acls::{AccessListModeType, MediatorACLSet};
 use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use sha256::digest;
@@ -59,7 +60,19 @@ impl Listener {
                 }
                 _ = tokio::time::sleep(Duration::from_secs(OFFLINE_SYNC_INTERVAL_SECS)) => {
                     if let Err(e) = Listener::sync_offline_messages(listener_id, atm, profile, handler).await {
-                        warn!(profile = %profile_alias, error = %e, "Offline sync failed");
+                        // A websocket reconnect (e.g. when the mediator closes the
+                        // socket on access-token expiry) can land mid-poll and
+                        // abort an in-flight request. That is expected and self-
+                        // heals on the next cycle, so log it at debug rather than
+                        // raising a misleading "sync failed" warning.
+                        if matches!(
+                            e.downcast_ref::<ATMError>(),
+                            Some(ATMError::Disconnected(_))
+                        ) {
+                            debug!(profile = %profile_alias, "Offline sync skipped: websocket reconnecting");
+                        } else {
+                            warn!(profile = %profile_alias, error = %e, "Offline sync failed");
+                        }
                     }
                 }
             }

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.18.5] - 2026-06-01
+
+### Changed
+
+- **In-flight websocket requests now fail fast on disconnect.** When the
+  connection to the mediator drops (server `Close`, reset, missed pong, or
+  any socket error), every pending `live_stream_get` / `live_stream_next`
+  waiter is notified immediately instead of blocking until its own timeout
+  elapses. Previously a request that was in flight when the socket dropped
+  (e.g. the mediator closing the socket on access-token expiry) sat idle for
+  up to the full wait window and then surfaced as a misleading
+  `MsgSendError("No response from API")`.
+  - New `WebSocketResponses::Disconnected` variant carries the signal to
+    waiters. `live_stream_next` / `live_stream_next_packed` map it to
+    `Ok(None)` (streaming callers quietly retry on reconnect);
+    `live_stream_get` maps it to the new `ATMError::Disconnected` so
+    request/response callers can distinguish a reconnect race from a genuine
+    no-response.
+
 ## [0.18.4] - 2026-05-31
 
 ### Security

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.4"
+version = "0.18.5"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/errors.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/errors.rs
@@ -21,6 +21,8 @@ pub enum ATMError {
     MsgSendError(String),
     #[error("Message receive error: {0}")]
     MsgReceiveError(String),
+    #[error("WebSocket disconnected: {0}")]
+    Disconnected(String),
     #[error("Config error: {0}")]
     ConfigError(String),
     #[error("Authentication error: {0}")]

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -273,6 +273,14 @@ impl MessagePickup {
                             }
                             Ok(Some((*msg, meta)))
                         }
+                        Ok(WebSocketResponses::Disconnected) => {
+                            // Connection dropped while waiting. Treat as "no
+                            // message right now" so streaming callers quietly
+                            // retry on the reconnected socket instead of logging
+                            // a spurious receive error.
+                            debug!("WebSocket disconnected while awaiting next message");
+                            Ok(None)
+                        }
                         Ok(WebSocketResponses::PackedMessageReceived(_)) => {
                             Err(ATMError::MsgReceiveError(
                                 "Received packed message when expecting unpacked message. Use live_stream_next_packed() for packed messages.".into()
@@ -358,6 +366,17 @@ impl MessagePickup {
                                 atm.delete_message_background(profile, &meta.sha256_hash).await?;
                             }
                             Ok(Some((*msg, meta)))
+                        }
+                        Ok(WebSocketResponses::Disconnected) => {
+                            // Connection dropped while waiting for this specific
+                            // response. The request was lost with the socket, so
+                            // fail fast with a typed error — this lets callers
+                            // tell a reconnect race apart from a genuine
+                            // no-response and avoid a misleading send-failure log.
+                            debug!("WebSocket disconnected while awaiting message {msg_id}");
+                            Err(ATMError::Disconnected(format!(
+                                "Connection reset while awaiting response for {msg_id}"
+                            )))
                         }
                         Ok(WebSocketResponses::PackedMessageReceived(_)) => {
                             Err(ATMError::MsgReceiveError(
@@ -662,6 +681,13 @@ impl MessagePickup {
                                 debug!("Deleted message in background with hash: {}", sha256_hash);
                             }
                             Ok(Some(*packed_msg))
+                        }
+                        Ok(WebSocketResponses::Disconnected) => {
+                            // Connection dropped while waiting. Treat as "no
+                            // message right now" so streaming callers quietly
+                            // retry on the reconnected socket.
+                            debug!("WebSocket disconnected while awaiting next packed message");
+                            Ok(None)
                         }
                         Ok(WebSocketResponses::MessageReceived(_, _)) => {
                             Err(ATMError::MsgReceiveError(

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/mod.rs
@@ -26,4 +26,10 @@ pub enum WebSocketResponses {
 
     /// PackedMessageReceived - sent to SDK when a message is received (still packed as string)
     PackedMessageReceived(Box<String>),
+
+    /// Disconnected - sent to any in-flight request waiter when the underlying
+    /// websocket connection is lost, so the caller fails fast instead of
+    /// blocking until its own timeout elapses. The request is gone; it will not
+    /// be answered on the (re)connected socket.
+    Disconnected,
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -210,6 +210,7 @@ impl WebSocketTransport {
                                 let _ = web_socket.close(None).await;
                             }
                             self.web_socket = None;
+                            self.fail_pending_requests();
                             self.backoff_delay();
                         } else if let Some(web_socket) = self.web_socket.as_mut() {
                             let _ = web_socket.send(Message::Ping(Bytes::new())).await;
@@ -351,6 +352,7 @@ impl WebSocketTransport {
                 Message::Close(_) => {
                     debug!("WebSocket connection closed by server");
                     self.web_socket = None;
+                    self.fail_pending_requests();
                     self.backoff_delay();
                 }
                 _ => {
@@ -363,11 +365,13 @@ impl WebSocketTransport {
                 // Connection Dropped
                 warn!("WebSocket connection dropped");
                 self.web_socket = None;
+                self.fail_pending_requests();
                 self.backoff_delay();
             }
             Err(e) => {
                 error!("Generic websocket error: {:?}", e);
                 self.web_socket = None;
+                self.fail_pending_requests();
                 self.backoff_delay();
             }
         }
@@ -441,6 +445,37 @@ impl WebSocketTransport {
             Err(e) => {
                 error!("Error unpacking message: {:?}", e);
             }
+        }
+    }
+
+    /// Notify every in-flight request waiter that the connection was lost.
+    ///
+    /// Called on each disconnect transition so callers (`live_stream_get` /
+    /// `live_stream_next`) return immediately instead of blocking until their
+    /// own timeout elapses. These requests are gone — the mediator never saw
+    /// them, or their response was lost with the socket — so they will not be
+    /// answered on the reconnected socket.
+    fn fail_pending_requests(&mut self) {
+        let mut notified = 0usize;
+
+        // Pending `Next` waiters
+        for (_, sender) in self.next_requests.drain() {
+            let _ = sender.send(WebSocketResponses::Disconnected);
+            notified += 1;
+        }
+        self.next_requests_list.clear();
+
+        // Pending `GetMessage` (wanted) waiters
+        for sender in self.inbound_cache.drain_wanted() {
+            let _ = sender.send(WebSocketResponses::Disconnected);
+            notified += 1;
+        }
+
+        if notified > 0 {
+            debug!(
+                count = notified,
+                "Failed in-flight requests after websocket disconnect"
+            );
         }
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/ws_cache.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/ws_cache.rs
@@ -180,4 +180,49 @@ impl MessageCache {
     pub(crate) fn is_full(&self) -> bool {
         self.cache_full
     }
+
+    /// Remove and return every pending "wanted" sender.
+    ///
+    /// Used when the websocket connection drops: each in-flight `GetMessage`
+    /// waiter is handed back so the caller can be told the request was lost
+    /// (rather than leaving it to time out). Cached messages are left intact.
+    pub(crate) fn drain_wanted(&mut self) -> Vec<oneshot::Sender<WebSocketResponses>> {
+        self.wanted_list.drain().map(|(_, sender)| sender).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn drain_wanted_returns_and_clears_pending_senders() {
+        let mut cache = MessageCache::default();
+
+        let (tx_a, rx_a) = oneshot::channel();
+        let (tx_b, rx_b) = oneshot::channel();
+        cache.wanted_list.insert("msg-a".to_string(), tx_a);
+        cache.wanted_list.insert("msg-b".to_string(), tx_b);
+
+        let drained = cache.drain_wanted();
+
+        // Both waiters are handed back and the wanted list is now empty.
+        assert_eq!(drained.len(), 2);
+        assert!(cache.wanted_list.is_empty());
+        assert!(cache.drain_wanted().is_empty());
+
+        // Each drained sender can still notify its waiter that the
+        // connection was lost (the senders are live, not dropped).
+        for sender in drained {
+            sender.send(WebSocketResponses::Disconnected).unwrap();
+        }
+        assert!(matches!(rx_a.await, Ok(WebSocketResponses::Disconnected)));
+        assert!(matches!(rx_b.await, Ok(WebSocketResponses::Disconnected)));
+    }
+
+    #[test]
+    fn drain_wanted_on_empty_cache_is_noop() {
+        let mut cache = MessageCache::default();
+        assert!(cache.drain_wanted().is_empty());
+    }
 }

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.12.4] - 2026-06-01
+
+### Changed
+
+- Handle the new `WebSocketResponses::Disconnected` variant on the inbound
+  stream (no-op). Bumps `affinidi-messaging-sdk` to 0.18.5.
+
 ## [0.12.3] - 2026-05-31
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.3"
+version = "0.12.4"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/state_store.rs
@@ -19,7 +19,7 @@ use tokio::sync::{
     broadcast,
     mpsc::{self, UnboundedReceiver, UnboundedSender},
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 pub struct StateStore {
     state_tx: UnboundedSender<State>,
@@ -114,6 +114,12 @@ impl StateStore {
                         Ok(WebSocketResponses::PackedMessageReceived(_)) => {
                             // Ignore packed messages
                             warn!("Packed message received but not handled");
+                        },
+                        Ok(WebSocketResponses::Disconnected) => {
+                            // In-flight request waiters are notified of a dropped
+                            // connection via dedicated channels; nothing to do on
+                            // the broadcast inbound stream.
+                            debug!("WebSocket disconnected notification");
                         },
                         Err(e) => {
                             warn!("Failed to receive message: {}", e);


### PR DESCRIPTION
## Problem

Clients occasionally see this warning in the offline-sync loop:

```
WARN affinidi_messaging_didcomm_service::service::mediator: Offline sync failed profile=VTC error=Message sending error: No response from API
```

**Root cause.** The mediator authorises the websocket at the HTTP upgrade with the client's access token and closes the socket when that token expires. The token is only sent at connect time — there is no client-side close on token refresh. When the socket drops **mid-request**, the in-flight `live_stream_get` waiter (used by the 30s offline-sync `status-request`) is left dangling: nothing fails it, so it blocks until its own 10s timeout, then `live_stream_get` returns `Ok(None)` → `send_message` reports `MsgSendError("No response from API")`. The label is misleading (it's a reply timeout during a reconnect, not a send failure) and the loop can't tell a reconnect race from a genuine failure. It self-heals on the next cycle, hence "rare".

## Fix (fail-fast on disconnect)

On **every** disconnect transition (server `Close`, `ResetWithoutClosingHandshake`, missed-pong watchdog, generic socket error) the websocket task now drains all pending `Next` and `GetMessage` waiters and notifies them via a new `WebSocketResponses::Disconnected` signal. Callers fail fast instead of waiting out their timeout:

- `live_stream_next` / `live_stream_next_packed` → `Ok(None)` (streaming callers quietly retry on the reconnected socket — including the always-online receive loop, which must not start logging errors).
- `live_stream_get` → new `ATMError::Disconnected`, so request/response callers distinguish a reconnect race from a genuine no-response.

The didcomm-service offline-sync loop recognises `ATMError::Disconnected` and logs it at `debug` (`"Offline sync skipped: websocket reconnecting"`) instead of `warn`. Genuine failures still warn.

## Scope / blast radius

- `WebSocketResponses` is matched exhaustively in `text-client`; added a benign no-op arm there (the variant only flows through the per-request oneshot channels, never the broadcast inbound stream).
- No dependency changes.

## Versions

- `affinidi-messaging-sdk` 0.18.4 → 0.18.5
- `affinidi-messaging-didcomm-service` 0.3.2 → 0.3.3
- `affinidi-messaging-text-client` 0.12.3 → 0.12.4

Patch bumps keep the internal `"0.18"` major.minor pins valid; nothing depends on the two app crates.

## Tests / CI

- New unit tests for `MessageCache::drain_wanted` (returns + clears pending senders; notifies waiters; empty-cache no-op).
- `cargo fmt`, `clippy -D warnings` (sdk/service/text-client), `cargo test -p affinidi-messaging-sdk` (60 passed), `cargo deny check` — all green.

Branch rebased onto `main` after #339.