### PR TITLE
fix: unbreak ws_cache unit test compilation (follow-up to #340)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.6] - 2026-06-01
+
+### Fixed
+
+- Fix `cargo test` compilation in the `ws_cache` unit tests: a `oneshot`
+  send was `.unwrap()`-ed, which requires `WebSocketResponses: Debug` (not
+  derived). Assert on `.is_ok()` instead. Test-only; no runtime change.
+
 ## [0.18.5] - 2026-06-01
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.5"
+version = "0.18.6"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/ws_cache.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/ws_cache.rs
@@ -214,7 +214,7 @@ mod tests {
         // Each drained sender can still notify its waiter that the
         // connection was lost (the senders are live, not dropped).
         for sender in drained {
-            sender.send(WebSocketResponses::Disconnected).unwrap();
+            assert!(sender.send(WebSocketResponses::Disconnected).is_ok());
         }
         assert!(matches!(rx_a.await, Ok(WebSocketResponses::Disconnected)));
         assert!(matches!(rx_b.await, Ok(WebSocketResponses::Disconnected)));


### PR DESCRIPTION
## What

Follow-up hotfix to #340. The `ws_cache` unit test `drain_wanted_returns_and_clears_pending_senders` `.unwrap()`-ed a `oneshot::Sender::send(...)`. The `Result` error path returns the unsent value, so `.unwrap()` requires `WebSocketResponses: Debug` — which is **not** derived. As a result `cargo test -p affinidi-messaging-sdk` fails to compile on `main` after #340 merged.

Fix: assert on `.is_ok()` instead of `.unwrap()`.

## Why it slipped through #340

The fix was applied to the working tree and validated locally, but the commit was pushed without it — local clippy/test ran against the (fixed) working tree while the committed/merged code still had `.unwrap()`. Owning that miss.

## Impact

Test-only (`#[cfg(test)]`); no runtime or public-API change. Consumer-facing compiled artifact is unchanged.

## Verification

`cargo test -p affinidi-messaging-sdk --lib ws_cache` → 2 passed (compiles cleanly). `cargo fmt` clean.

Bumps `affinidi-messaging-sdk` 0.18.5 → 0.18.6.