### PR TITLE
chore: release affinidi-tdk family on didcomm 0.15 to unblock vta-sdk (#327)

### DIFF
--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Meeting Place Changelog
 
+## 1st June 2026 (0.4.2)
+
+- Release on `affinidi-messaging-didcomm` 0.15 (#327). Dependency-only;
+  no Meeting Place API or behaviour change.
+
 ## 31st May 2026 (0.4.1)
 
 - Bump `affinidi-messaging-didcomm` to 0.14 (DIDComm v2.1 interop fixes:

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.4.1"
+version = "0.4.2"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi DID Authentication
 
+## 1st June 2026 (0.3.5)
+
+- Release on `affinidi-messaging-didcomm` 0.15 (#327). The authcrypt
+  challenge/response now uses the key-agreement types from
+  `affinidi-crypto`'s `jose` module (the `didcomm::crypto` module was
+  removed); added a direct `affinidi-crypto` dependency. No behaviour
+  change — the ECDH-1PU authcrypt path is byte-identical.
+
 ## 31st May 2026 (0.3.4)
 
 - Bump `affinidi-messaging-didcomm` to 0.14. This crate authcrypts the

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 1st June 2026
 
+### 0.15.12 — release on didcomm 0.15
+
+- Release on `affinidi-messaging-didcomm` 0.15 (#327). The
+  `didcomm_compat` layer now imports key-agreement types from
+  `affinidi-crypto`'s `jose` module (the `didcomm::crypto` module was
+  removed); `affinidi-crypto` is added as an optional dep under the
+  `didcomm` feature. No behaviour change.
+
 ### 0.15.11 — backend-parameterised auth-flow tests
 
 Completes #308 (items 5–6). Test-only + docs; no shipped behaviour change.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.11"
+version = "0.15.12"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 1st June 2026
+
+### 0.2.4 — rebuilt against the didcomm 0.15 mediator
+
+- Release rebuilt against `affinidi-messaging-mediator` 0.15.12 /
+  `affinidi-messaging-didcomm` 0.15 (#327). Test fixture only; no
+  behaviour change. Lets downstream test trees (e.g. `vta-sdk`) build on
+  a single didcomm 0.15.
+
 ## 21st May 2026
 
 ### 0.2.3 — WebSocket subprotocol auth integration tests

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.3"
+version = "0.2.4"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,18 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.7.3] - 2026-06-01
+
+### Changed
+
+- Release on `affinidi-messaging-didcomm` 0.15 (#327). This crate
+  re-exports didcomm as `affinidi_tdk::didcomm`, so consumers now get the
+  0.15 envelope crate (crypto centralized in `affinidi-crypto`; the
+  `crypto` submodule was removed — its key-agreement types now live at
+  `affinidi_crypto::jose::key_agreement`). Wire behaviour is unchanged.
+  This release is what unblocks downstream crates (e.g. `vta-sdk`) from
+  pulling two incompatible didcomm `Message` types.
+
 ## [0.7.2] - 2026-05-31
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.7.2"
+version = "0.7.3"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
The didcomm-0.15 ecosystem from #327 (PR #339) is on `main` but **unpublished**, so the latest published `affinidi-tdk` (0.7.2) still pins `didcomm ^0.14`. Since `affinidi-tdk` **re-exports didcomm** and `vta-sdk` feeds `affinidi_messaging_didcomm::Message` through tdk's APIs, vta-sdk drags in two incompatible `Message` types (the `E0308` it hit) and **cannot move to 0.15 until we publish the tdk family on 0.15**.

This PR does the release-version bumps PR #339 deferred, so the family can be published.

## Bumps (all patch — no requirement cascade)
| crate | bump | role |
|---|---|---|
| **affinidi-tdk** | 0.7.2 → **0.7.3** | re-exports didcomm 0.15 — the hard blocker |
| affinidi-messaging-sdk | 0.18.4 → 0.18.5 | pack/unpack use `affinidi-crypto::jose` types |
| affinidi-messaging-didcomm-service | 0.3.2 → 0.3.3 | dep-only |
| affinidi-messaging-mediator | 0.15.11 → 0.15.12 | `didcomm_compat` on 0.15 |
| affinidi-messaging-test-mediator | 0.2.3 → 0.2.4 | rebuilt against 0.15 mediator |
| affinidi-did-authentication | 0.3.4 → 0.3.5 | authcrypt on `affinidi-crypto` types |
| affinidi-meeting-place | 0.4.1 → 0.4.2 | dep-only |

Patch bumps keep every `major.minor` pin valid, so downstream `"0.7"`/`"0.18"`/`"0.3"` pins (incl. vta-sdk's) pick up the new releases automatically — matching the approach the vta-sdk team described. `publish = false` crates (`helpers`, `text-client`) are intentionally not bumped.

**No behaviour change** — all seven were already wire-identical on didcomm 0.15 (proven in #339). This PR only moves version numbers + changelogs.

## Publish order (maintainer, post-merge)
`affinidi-crypto 0.1.10` → `affinidi-messaging-didcomm 0.15.0` → (`mediator-common`/`tdk-common` unchanged) → the seven crates above. Once published, vta-sdk bumps its `affinidi-tdk` pin, moves to didcomm 0.15 (small `didcomm::crypto` → `affinidi_crypto::jose` migration on their side), and the split resolves.

## Follow-up (separate PR, gated on vta-sdk publishing)
Bump this workspace's `vta-sdk 0.9` dep to the new vta-sdk release and re-unify `Cargo.lock` to a single didcomm 0.15. Until then the tree intentionally carries two didcomm versions (allowed by `deny.toml`).

## Checks
- `cargo build --workspace` clean
- `cargo fmt --all --check` clean
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok