### PR TITLE
feat: OpenID4VCI key-binding proof layer + Ed25519 JWT signer/verifier

### DIFF
--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Affinidi OID4VC Core Changelog
 
+## 3rd June 2026 Release 0.1.3
+
+### Added
+
+- **`eddsa` feature — Ed25519 `JwtSigner` / `JwtVerifier`.** New
+  `EdDsaSigner` / `EdDsaVerifier` (`eddsa` module) mirroring the existing
+  `es256` impls, for the `EdDSA` JWS algorithm (RFC 8037). Ed25519
+  `did:key` is the dominant holder-key shape in the stack, so consumers no
+  longer hand-roll `verify_strict` to check an Ed25519-signed compact JWS.
+  `from_bytes` / `generate` / `with_kid` / `public_key_bytes` /
+  `public_key_jwk` (OKP) / `from_jwk`, symmetric with `es256`. Enabled by
+  default alongside `es256`.
+- **`jwt::Audience` — string-or-array `aud` helper.** RFC 7519 §4.1.3
+  allows the `aud` claim to be a single string *or* an array. The new
+  untagged `Audience` type deserialises both and offers `.contains()` /
+  `.iter()`, so consumers stop re-implementing (and occasionally
+  mishandling) the array form.
+
 ## 28th May 2026 Release 0.1.2
 
 ### Security

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,13 +13,16 @@ publish.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["es256"]
+default = ["es256", "eddsa"]
 _test-utils = []
 es256 = ["dep:p256"]
+eddsa = ["dep:ed25519-dalek", "dep:rand_core"]
 
 [dependencies]
 base64 = "0.22"
+ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
+rand_core = { version = "0.6", features = ["getrandom"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
@@ -1,0 +1,237 @@
+/*!
+ * EdDSA (Ed25519) JWT signer and verifier.
+ *
+ * Provides production-ready Ed25519 implementations of the
+ * [`JwtSigner`](crate::jwt::JwtSigner) and
+ * [`JwtVerifier`](crate::jwt::JwtVerifier) traits for use in SIOPv2,
+ * OpenID4VCI, and OpenID4VP — the `EdDSA` JWS algorithm (RFC 8037).
+ *
+ * Ed25519 `did:key` is the dominant holder-key shape in the Affinidi stack,
+ * so this is the natural companion to [`es256`](crate::es256): consumers that
+ * sign or verify an OID4VCI key-binding proof (or any compact JWS) with an
+ * Ed25519 key plug these in instead of hand-rolling `verify_strict`.
+ *
+ * Enabled via the `eddsa` feature flag.
+ */
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+
+use crate::jwt::{JwtError, JwtSigner, JwtVerifier};
+
+/// The JWS `alg` value for Ed25519 (RFC 8037 §3.1).
+pub const ALG: &str = "EdDSA";
+
+/// Ed25519 JWT signer wrapping a signing (private) key.
+pub struct EdDsaSigner {
+    signing_key: SigningKey,
+    kid: Option<String>,
+}
+
+impl EdDsaSigner {
+    /// Create a signer from the 32-byte Ed25519 seed (private key).
+    pub fn from_bytes(private_key: &[u8]) -> Result<Self, JwtError> {
+        let seed: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| JwtError::Signing("Ed25519 private key must be 32 bytes".into()))?;
+        Ok(Self {
+            signing_key: SigningKey::from_bytes(&seed),
+            kid: None,
+        })
+    }
+
+    /// Generate a new random Ed25519 key pair using the OS RNG.
+    pub fn generate() -> Self {
+        Self::generate_with_rng(&mut rand_core::OsRng)
+    }
+
+    /// Generate a new Ed25519 key pair using a caller-supplied RNG.
+    ///
+    /// Useful for tests that need deterministic keys via a seeded RNG.
+    pub fn generate_with_rng<R>(rng: &mut R) -> Self
+    where
+        R: rand_core::CryptoRng + rand_core::RngCore,
+    {
+        Self {
+            signing_key: SigningKey::generate(rng),
+            kid: None,
+        }
+    }
+
+    /// Set the key ID for the JWT header `kid`.
+    pub fn with_kid(mut self, kid: impl Into<String>) -> Self {
+        self.kid = Some(kid.into());
+        self
+    }
+
+    /// The 32-byte Ed25519 public key.
+    pub fn public_key_bytes(&self) -> Vec<u8> {
+        self.signing_key.verifying_key().to_bytes().to_vec()
+    }
+
+    /// The public key as an RFC 8037 OKP JWK `Value`.
+    pub fn public_key_jwk(&self) -> serde_json::Value {
+        serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": URL_SAFE_NO_PAD.encode(self.signing_key.verifying_key().to_bytes()),
+        })
+    }
+}
+
+impl JwtSigner for EdDsaSigner {
+    fn algorithm(&self) -> &str {
+        ALG
+    }
+
+    fn key_id(&self) -> Option<&str> {
+        self.kid.as_deref()
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, JwtError> {
+        let signature: Signature = self.signing_key.sign(data);
+        Ok(signature.to_bytes().to_vec())
+    }
+}
+
+/// Ed25519 JWT verifier wrapping a verifying (public) key.
+pub struct EdDsaVerifier {
+    verifying_key: VerifyingKey,
+}
+
+impl EdDsaVerifier {
+    /// Create a verifier from the 32-byte Ed25519 public key.
+    pub fn from_bytes(public_key: &[u8]) -> Result<Self, JwtError> {
+        let bytes: [u8; 32] = public_key
+            .try_into()
+            .map_err(|_| JwtError::Verification("Ed25519 public key must be 32 bytes".into()))?;
+        let verifying_key = VerifyingKey::from_bytes(&bytes)
+            .map_err(|e| JwtError::Verification(format!("invalid Ed25519 public key: {e}")))?;
+        Ok(Self { verifying_key })
+    }
+
+    /// Create a verifier from an RFC 8037 OKP JWK `Value` (`crv: "Ed25519"`).
+    pub fn from_jwk(jwk: &serde_json::Value) -> Result<Self, JwtError> {
+        // RFC 8037: an Ed25519 JWK is `kty: "OKP"`, `crv: "Ed25519"`. Reject
+        // a mismatched/missing `kty` so a malformed key (e.g. `kty: "EC"`)
+        // can't slip through on the `crv` check alone.
+        match jwk.get("kty").and_then(|v| v.as_str()) {
+            Some("OKP") => {}
+            Some(other) => {
+                return Err(JwtError::Verification(format!(
+                    "expected JWK kty OKP, got {other}"
+                )));
+            }
+            None => return Err(JwtError::Verification("JWK missing kty".into())),
+        }
+        match jwk.get("crv").and_then(|v| v.as_str()) {
+            Some("Ed25519") => {}
+            Some(other) => {
+                return Err(JwtError::Verification(format!(
+                    "expected OKP crv Ed25519, got {other}"
+                )));
+            }
+            None => return Err(JwtError::Verification("JWK missing crv".into())),
+        }
+        let x = jwk
+            .get("x")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| JwtError::Verification("JWK missing x".into()))?;
+        let x_bytes = URL_SAFE_NO_PAD
+            .decode(x)
+            .map_err(|e| JwtError::Verification(format!("x decode: {e}")))?;
+        Self::from_bytes(&x_bytes)
+    }
+}
+
+impl JwtVerifier for EdDsaVerifier {
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), JwtError> {
+        let sig = Signature::from_slice(signature)
+            .map_err(|e| JwtError::Verification(format!("invalid signature: {e}")))?;
+        // `verify_strict` rejects malleable / small-order-component signatures
+        // (the stronger of dalek's two checks) — the right default for tokens.
+        self.verifying_key
+            .verify_strict(data, &sig)
+            .map_err(|_| JwtError::Verification("EdDSA signature verification failed".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jwt::{decode_compact_jws_verified, encode_compact_jws};
+    use serde_json::json;
+
+    #[test]
+    fn eddsa_sign_verify_jwt() {
+        let signer = EdDsaSigner::from_bytes(&[7u8; 32]).unwrap().with_kid("k1");
+        let verifier = EdDsaVerifier::from_bytes(&signer.public_key_bytes()).unwrap();
+
+        let header = json!({"alg": "EdDSA", "typ": "JWT", "kid": "k1"});
+        let payload = json!({"sub": "user123", "name": "Alice"});
+
+        let jws = encode_compact_jws(&header, &payload, &signer).unwrap();
+        let (decoded_header, decoded_payload) =
+            decode_compact_jws_verified(&jws, &verifier).unwrap();
+
+        assert_eq!(decoded_header["alg"], "EdDSA");
+        assert_eq!(decoded_payload["sub"], "user123");
+    }
+
+    #[test]
+    fn eddsa_wrong_key_fails() {
+        let signer = EdDsaSigner::from_bytes(&[1u8; 32]).unwrap();
+        let other = EdDsaSigner::from_bytes(&[2u8; 32]).unwrap();
+        let verifier = EdDsaVerifier::from_bytes(&other.public_key_bytes()).unwrap();
+
+        let jws = encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"x": 1}), &signer).unwrap();
+        assert!(decode_compact_jws_verified(&jws, &verifier).is_err());
+    }
+
+    #[test]
+    fn eddsa_from_jwk_roundtrip() {
+        let signer = EdDsaSigner::from_bytes(&[3u8; 32]).unwrap();
+        let jwk = signer.public_key_jwk();
+        assert_eq!(jwk["kty"], "OKP");
+        assert_eq!(jwk["crv"], "Ed25519");
+
+        let verifier = EdDsaVerifier::from_jwk(&jwk).unwrap();
+        let jws =
+            encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"test": true}), &signer).unwrap();
+        let (_, payload) = decode_compact_jws_verified(&jws, &verifier).unwrap();
+        assert_eq!(payload["test"], true);
+    }
+
+    #[test]
+    fn eddsa_from_jwk_rejects_wrong_curve() {
+        let jwk = json!({"kty": "OKP", "crv": "X25519", "x": "AAAA"});
+        assert!(EdDsaVerifier::from_jwk(&jwk).is_err());
+    }
+
+    #[test]
+    fn eddsa_from_jwk_rejects_wrong_kty() {
+        // `crv` claims Ed25519 but `kty` is EC — malformed, must be rejected.
+        let jwk = json!({"kty": "EC", "crv": "Ed25519", "x": "AAAA"});
+        assert!(EdDsaVerifier::from_jwk(&jwk).is_err());
+    }
+
+    #[test]
+    fn eddsa_signature_is_64_bytes() {
+        let signer = EdDsaSigner::from_bytes(&[5u8; 32]).unwrap();
+        assert_eq!(signer.sign(b"test data").unwrap().len(), 64);
+    }
+
+    #[test]
+    fn eddsa_generate_produces_working_keypair() {
+        let signer = EdDsaSigner::generate();
+        let verifier = EdDsaVerifier::from_bytes(&signer.public_key_bytes()).unwrap();
+        let jws = encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"ok": 1}), &signer).unwrap();
+        assert!(decode_compact_jws_verified(&jws, &verifier).is_ok());
+    }
+
+    #[test]
+    fn eddsa_from_bytes_rejects_wrong_length() {
+        assert!(EdDsaSigner::from_bytes(&[0u8; 16]).is_err());
+        assert!(EdDsaVerifier::from_bytes(&[0u8; 16]).is_err());
+    }
+}

--- a/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
@@ -6,7 +6,41 @@
  */
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+/// A JWT `aud` (audience) claim, which RFC 7519 §4.1.3 allows to be **either**
+/// a single string or an array of strings. Deserialising into this type accepts
+/// both wire shapes so consumers don't each re-implement the string-or-array
+/// dance (and don't silently mishandle the array form).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Audience {
+    /// A single audience value.
+    One(String),
+    /// Multiple audience values.
+    Many(Vec<String>),
+}
+
+impl Audience {
+    /// Whether `value` is one of the audiences.
+    pub fn contains(&self, value: &str) -> bool {
+        match self {
+            Self::One(a) => a == value,
+            Self::Many(a) => a.iter().any(|v| v == value),
+        }
+    }
+
+    /// Iterate the audience values.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        // Box to unify the two arm types behind one iterator.
+        let items: Box<dyn Iterator<Item = &str>> = match self {
+            Self::One(a) => Box::new(std::iter::once(a.as_str())),
+            Self::Many(a) => Box::new(a.iter().map(String::as_str)),
+        };
+        items
+    }
+}
 
 /// Error type for JWT operations.
 #[derive(Debug, thiserror::Error)]
@@ -293,6 +327,17 @@ mod tests {
     fn invalid_jwt_format() {
         assert!(decode_compact_jws_unverified("not.a.valid.jwt.too.many.parts").is_err());
         assert!(decode_compact_jws_unverified("only-one-part").is_err());
+    }
+
+    #[test]
+    fn audience_accepts_string_or_array() {
+        let one: Audience = serde_json::from_value(json!("a")).unwrap();
+        assert!(one.contains("a") && !one.contains("b"));
+        assert_eq!(one.iter().collect::<Vec<_>>(), vec!["a"]);
+
+        let many: Audience = serde_json::from_value(json!(["a", "b"])).unwrap();
+        assert!(many.contains("a") && many.contains("b") && !many.contains("c"));
+        assert_eq!(many.iter().collect::<Vec<_>>(), vec!["a", "b"]);
     }
 
     #[test]

--- a/crates/protocols/affinidi-oid4vc-core/src/lib.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/lib.rs
@@ -17,6 +17,10 @@ pub mod jwt;
 #[cfg(feature = "es256")]
 pub mod es256;
 
+/// EdDSA (Ed25519) signer and verifier for production JWT operations.
+#[cfg(feature = "eddsa")]
+pub mod eddsa;
+
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/protocols/affinidi-openid4vci/CHANGELOG.md
+++ b/crates/protocols/affinidi-openid4vci/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi OpenID4VCI Changelog
 
+## 3rd June 2026 Release 0.1.3
+
+### Added
+
+- **`proof` module — key-binding proof build + verify.** The credential
+  endpoint requires the wallet to prove possession of the key the credential
+  binds to (§8.2.1, `typ: "openid4vci-proof+jwt"`). Previously the proof was
+  an opaque `String` on both sides and every consumer hand-rolled the
+  security-critical JWT assembly / verification. Now:
+  - `build_key_proof_jwt(signer, aud, nonce, iat)` (wallet) assembles and
+    signs the proof over the `oid4vc-core` `JwtSigner` trait.
+  - `KeyProof::parse` → `verify` (issuer) does the structural decode
+    (`typ`/`alg`/key-id/claims), then signature + claim checks against a
+    `ProofPolicy { audience, nonce, now, max_age_secs }`. The policy is a
+    named-field struct on purpose — `nonce` (the `c_nonce` replay binding,
+    §8.2.1.1) is easy to forget as a positional arg, so it must be stated
+    explicitly. `aud`, `c_nonce`, and `iat` freshness are all enforced.
+    **DID resolution stays with the caller** — `parse` surfaces the claimed
+    `kid` / `jwk`; the consumer resolves it to a `JwtVerifier` (and must
+    confirm the key's algorithm matches `proof.algorithm()`). The module is
+    crypto-agnostic (depends only on `oid4vc-core`'s always-on `jwt`
+    module, `default-features = false`).
+
+### Changed
+
+- `validate_credential_request` docs now state explicitly that it is a
+  **structural check only** and does **not** verify the proof — issuers must
+  call `proof::KeyProof` before issuing. (Closing a footgun: the function
+  returned `Ok` for a request bearing a forged/expired proof.)
+
 ## 28th May 2026 Release 0.1.2
 
 ### Security

--- a/crates/protocols/affinidi-openid4vci/Cargo.toml
+++ b/crates/protocols/affinidi-openid4vci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-openid4vci"
 description = "OpenID for Verifiable Credential Issuance (OpenID4VCI) implementation."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -12,8 +12,11 @@ repository.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 
+# `proof` is crypto-agnostic — it only needs oid4vc-core's always-on `jwt`
+# module (signer/verifier traits + compact-JWS), not the concrete es256/eddsa
+# key impls. Consumers bring their own signer/verifier (and DID resolution).
 [dependencies]
-affinidi-oid4vc-core = { version = "0.1", path = "../affinidi-oid4vc-core" }
+affinidi-oid4vc-core = { version = "0.1", path = "../affinidi-oid4vc-core", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
@@ -21,4 +24,6 @@ tracing = "0.1"
 url = "2"
 
 [dev-dependencies]
+# The proof tests need a concrete signer/verifier; use the Ed25519 impl.
+affinidi-oid4vc-core = { version = "0.1", path = "../affinidi-oid4vc-core", features = ["eddsa"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/protocols/affinidi-openid4vci/src/issuer.rs
+++ b/crates/protocols/affinidi-openid4vci/src/issuer.rs
@@ -18,7 +18,13 @@ use crate::types::*;
 /// Checks:
 /// - The format is supported
 /// - Required fields are present
-/// - Proof of possession (if present) has the right structure
+/// - Proof of possession (if present) has the right *structure*
+///
+/// **This is a structural check only — it does NOT verify the proof.** A
+/// request whose proof JWT is forged, expired, or for the wrong audience still
+/// passes here. Before issuing, the credential endpoint MUST cryptographically
+/// verify the key-binding proof with [`crate::proof::KeyProof`] (parse → resolve
+/// the `kid`/`jwk` to a key → [`KeyProof::verify`](crate::proof::KeyProof::verify)).
 pub fn validate_credential_request(request: &CredentialRequest) -> Result<()> {
     if request.format.is_empty() {
         return Err(Oid4vciError::InvalidRequest("format is required".into()));

--- a/crates/protocols/affinidi-openid4vci/src/lib.rs
+++ b/crates/protocols/affinidi-openid4vci/src/lib.rs
@@ -33,8 +33,10 @@
 
 pub mod error;
 pub mod issuer;
+pub mod proof;
 pub mod types;
 pub mod wallet;
 
 pub use error::Oid4vciError;
+pub use proof::{KeyProof, KeyProofClaims, ProofPolicy, build_key_proof_jwt};
 pub use types::*;

--- a/crates/protocols/affinidi-openid4vci/src/proof.rs
+++ b/crates/protocols/affinidi-openid4vci/src/proof.rs
@@ -1,0 +1,465 @@
+/*!
+ * OpenID4VCI key-binding proof (proof-of-possession).
+ *
+ * The credential endpoint requires the wallet to prove control of the key the
+ * issued credential will be bound to (OpenID4VCI §8.2.1, `proof_type: "jwt"`,
+ * `typ: "openid4vci-proof+jwt"`). This module is the build + verify pair for
+ * that proof — the piece every issuer/wallet otherwise hand-rolls, and the
+ * security-critical one.
+ *
+ * It is deliberately **crypto-agnostic**: signing and signature verification go
+ * through the [`JwtSigner`] / [`JwtVerifier`] traits from `affinidi-oid4vc-core`
+ * (use [`affinidi_oid4vc_core::eddsa`] / [`affinidi_oid4vc_core::es256`], or
+ * your own impl). **DID resolution stays with the caller** — [`KeyProof::parse`]
+ * surfaces the claimed key identifier (`kid` / `jwk`) so the consumer resolves
+ * it to a verifying key with their own DID stack, then calls
+ * [`KeyProof::verify`].
+ *
+ * ```no_run
+ * # use affinidi_openid4vci::proof::{KeyProof, ProofPolicy};
+ * # use affinidi_oid4vc_core::jwt::JwtVerifier;
+ * # fn resolve(_kid: Option<&str>) -> Box<dyn JwtVerifier> { unimplemented!() }
+ * # fn demo(jwt: &str, issuer_id: &str, c_nonce: &str, now: i64) -> Result<(), Box<dyn std::error::Error>> {
+ * let proof = KeyProof::parse(jwt)?;                 // structural decode, no crypto
+ * let verifier = resolve(proof.kid());               // caller resolves kid -> key
+ * let claims = proof.verify(&*verifier, &ProofPolicy {
+ *     audience: issuer_id,
+ *     nonce: Some(c_nonce),                          // bind to the issued c_nonce
+ *     now,
+ *     max_age_secs: 300,
+ * })?;                                               // sig + aud + nonce + freshness
+ * // `proof.kid()` is now a cryptographically-proven holder identifier.
+ * # let _ = claims; Ok(())
+ * # }
+ * ```
+ */
+
+use affinidi_oid4vc_core::jwt::{
+    self, Audience, JwtError, JwtSigner, JwtVerifier, decode_compact_jws_unverified,
+};
+use serde_json::Value;
+
+use crate::error::{Oid4vciError, Result};
+
+/// The required `typ` header value of an OpenID4VCI key-binding proof JWT
+/// (OpenID4VCI §8.2.1.1).
+pub const KEY_PROOF_TYP: &str = "openid4vci-proof+jwt";
+
+/// Default tolerance, in seconds, for a proof `iat` slightly ahead of the
+/// verifier's clock (wallet clock drift).
+pub const IAT_FUTURE_LEEWAY_SECS: i64 = 60;
+
+/// The claims carried by a key-binding proof JWT (OpenID4VCI §8.2.1.1).
+#[derive(Debug, Clone)]
+pub struct KeyProofClaims {
+    /// `iss` — the client identifier. OPTIONAL, and omitted in the
+    /// pre-authorized-code flow.
+    pub iss: Option<String>,
+    /// `aud` — the Credential Issuer Identifier. REQUIRED.
+    pub aud: Audience,
+    /// `iat` — when the proof was created (seconds since the Unix epoch).
+    pub iat: i64,
+    /// `nonce` — the issuer-supplied `c_nonce` the proof commits to, binding it
+    /// to one issuance. Present whenever the issuer provided a nonce.
+    pub nonce: Option<String>,
+}
+
+/// A parsed, **not-yet-cryptographically-verified** key-binding proof.
+///
+/// [`KeyProof::parse`] does the structural work (decode, `typ`/`alg` checks,
+/// surface the claimed key id + typed claims) but performs **no** signature or
+/// freshness check — call [`KeyProof::verify`] (or
+/// [`verify_signature`](Self::verify_signature) + [`verify_claims`](Self::verify_claims))
+/// with a verifier resolved from [`kid`](Self::kid) / [`jwk`](Self::jwk).
+#[derive(Debug, Clone)]
+pub struct KeyProof {
+    jwt: String,
+    alg: String,
+    kid: Option<String>,
+    jwk: Option<Value>,
+    claims: KeyProofClaims,
+}
+
+impl KeyProof {
+    /// Parse and structurally validate a key-binding proof JWT.
+    ///
+    /// Checks the compact-JWS shape, that `typ` is [`KEY_PROOF_TYP`], that `alg`
+    /// is present and not `none`, that the header identifies the key (`kid` or
+    /// `jwk`), and that the required claims (`aud`, `iat`) are present and typed.
+    /// Does **not** verify the signature — see [`verify`](Self::verify).
+    pub fn parse(jwt: &str) -> Result<Self> {
+        let (header, payload) = decode_compact_jws_unverified(jwt).map_err(jwt_err)?;
+
+        match header.get("typ").and_then(Value::as_str) {
+            Some(t) if t == KEY_PROOF_TYP => {}
+            other => {
+                return Err(Oid4vciError::InvalidProof(format!(
+                    "proof `typ` must be `{KEY_PROOF_TYP}` (got {other:?})"
+                )));
+            }
+        }
+
+        let alg = header
+            .get("alg")
+            .and_then(Value::as_str)
+            .filter(|a| !a.eq_ignore_ascii_case("none"))
+            .ok_or_else(|| {
+                Oid4vciError::InvalidProof("proof header missing `alg` (or `alg=none`)".into())
+            })?
+            .to_string();
+
+        let kid = header
+            .get("kid")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let jwk = header.get("jwk").filter(|v| v.is_object()).cloned();
+        if kid.is_none() && jwk.is_none() {
+            return Err(Oid4vciError::InvalidProof(
+                "proof header must identify the holder key via `kid` or `jwk`".into(),
+            ));
+        }
+
+        let aud_value = payload
+            .get("aud")
+            .cloned()
+            .ok_or_else(|| Oid4vciError::InvalidProof("proof missing `aud`".into()))?;
+        let aud: Audience = serde_json::from_value(aud_value)
+            .map_err(|e| Oid4vciError::InvalidProof(format!("invalid `aud`: {e}")))?;
+        let iat = payload
+            .get("iat")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| Oid4vciError::InvalidProof("proof missing numeric `iat`".into()))?;
+        let iss = payload
+            .get("iss")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let nonce = payload
+            .get("nonce")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
+        Ok(Self {
+            jwt: jwt.to_string(),
+            alg,
+            kid,
+            jwk,
+            claims: KeyProofClaims {
+                iss,
+                aud,
+                iat,
+                nonce,
+            },
+        })
+    }
+
+    /// The JWS `alg` of the proof (e.g. `EdDSA`, `ES256`).
+    pub fn algorithm(&self) -> &str {
+        &self.alg
+    }
+
+    /// The `kid` header — the holder's key identifier (typically a DID URL).
+    /// The caller resolves this to a verifying key.
+    pub fn kid(&self) -> Option<&str> {
+        self.kid.as_deref()
+    }
+
+    /// The inline `jwk` header, if the proof identifies its key that way.
+    ///
+    /// **Security:** a `jwk`-identified proof only proves possession of *some*
+    /// key — the one in the header. It does **not** establish that the key is
+    /// the holder's. An issuer MUST independently bind this `jwk` to the
+    /// credential's intended subject (e.g. require it to match the subject's
+    /// DID / `kid`) before trusting it; otherwise an attacker proves possession
+    /// of a key they just minted. Prefer [`kid`](Self::kid) resolution.
+    pub fn jwk(&self) -> Option<&Value> {
+        self.jwk.as_ref()
+    }
+
+    /// The parsed claims (audience, issued-at, nonce, …).
+    pub fn claims(&self) -> &KeyProofClaims {
+        &self.claims
+    }
+
+    /// Verify the proof's signature with a caller-resolved verifier.
+    ///
+    /// **Caller contract (load-bearing):** the `verifier` MUST wrap the key
+    /// named by this proof's own [`kid`](Self::kid) / [`jwk`](Self::jwk) —
+    /// resolve that identifier (e.g. DID → key) and confirm the resolved key's
+    /// algorithm matches [`algorithm`](Self::algorithm). Resolving a verifier
+    /// from anywhere else, or picking one by `alg` rather than by key, defeats
+    /// the proof: this crate is crypto-agnostic by design and cannot police the
+    /// key↔proof binding for you. (`alg=none` and empty signatures are still
+    /// rejected here regardless.)
+    pub fn verify_signature(&self, verifier: &dyn JwtVerifier) -> Result<()> {
+        jwt::decode_compact_jws_verified(&self.jwt, verifier)
+            .map(|_| ())
+            .map_err(jwt_err)
+    }
+
+    /// Verify the bound claims against `policy`: `aud` names the expected
+    /// issuer, the `c_nonce` (if the issuer issued one) matches, and `iat` is
+    /// fresh (within `max_age_secs` in the past and [`IAT_FUTURE_LEEWAY_SECS`]
+    /// in the future).
+    pub fn verify_claims(&self, policy: &ProofPolicy<'_>) -> Result<()> {
+        if !self.claims.aud.contains(policy.audience) {
+            return Err(Oid4vciError::InvalidProof(format!(
+                "proof `aud` does not name this issuer ({})",
+                policy.audience
+            )));
+        }
+        // Nonce binding (OpenID4VCI §8.2.1.1): when the issuer issued a
+        // `c_nonce`, the proof must echo exactly it — this is what stops a
+        // captured proof being replayed within the freshness window. When the
+        // issuer issued no nonce, there is nothing to bind.
+        if let Some(expected) = policy.nonce
+            && self.claims.nonce.as_deref() != Some(expected)
+        {
+            return Err(Oid4vciError::InvalidProof(
+                "proof `nonce` does not match the issued c_nonce".into(),
+            ));
+        }
+        if self.claims.iat > policy.now + IAT_FUTURE_LEEWAY_SECS {
+            return Err(Oid4vciError::InvalidProof(
+                "proof `iat` is in the future".into(),
+            ));
+        }
+        if policy.now - self.claims.iat > policy.max_age_secs {
+            return Err(Oid4vciError::InvalidProof(format!(
+                "proof is stale (older than {}s)",
+                policy.max_age_secs
+            )));
+        }
+        Ok(())
+    }
+
+    /// Verify the signature **and** the bound claims, returning the proven
+    /// claims. The convenience composition of [`verify_signature`](Self::verify_signature)
+    /// then [`verify_claims`](Self::verify_claims) — see those for the caller
+    /// contract and the checks performed.
+    pub fn verify(
+        &self,
+        verifier: &dyn JwtVerifier,
+        policy: &ProofPolicy<'_>,
+    ) -> Result<&KeyProofClaims> {
+        self.verify_signature(verifier)?;
+        self.verify_claims(policy)?;
+        Ok(&self.claims)
+    }
+}
+
+/// What a verifier requires of a key-binding proof's claims.
+///
+/// A named-field struct (rather than positional args) on purpose: this is a
+/// security-sensitive call, and `nonce` in particular is easy to forget — here
+/// you must state it explicitly (`None` = the issuer issued no `c_nonce`).
+#[derive(Debug, Clone)]
+pub struct ProofPolicy<'a> {
+    /// The Credential Issuer Identifier the proof's `aud` must name.
+    pub audience: &'a str,
+    /// The `c_nonce` the issuer issued for this request, if any. `Some` →
+    /// the proof's `nonce` must equal it; `None` → no nonce binding required.
+    pub nonce: Option<&'a str>,
+    /// Current time, in seconds since the Unix epoch.
+    pub now: i64,
+    /// Maximum accepted proof age in seconds (`now - iat`).
+    pub max_age_secs: i64,
+}
+
+/// Build a key-binding proof JWT (wallet side).
+///
+/// Assembles the `openid4vci-proof+jwt` header (`typ` + the signer's `alg` and
+/// `kid`) and the claims (`aud`, `iat`, optional `nonce` / `iss`), then signs
+/// with `signer`. The signer **must** expose a [`key_id`](JwtSigner::key_id)
+/// (the holder's DID URL) — an OpenID4VCI proof must identify its key; build a
+/// `jwk`-identified proof with [`encode_compact_jws`](jwt::encode_compact_jws)
+/// directly if you need that form.
+pub fn build_key_proof_jwt(
+    signer: &dyn JwtSigner,
+    audience: &str,
+    nonce: Option<&str>,
+    iat: i64,
+) -> Result<String> {
+    let kid = signer.key_id().ok_or_else(|| {
+        Oid4vciError::InvalidProof(
+            "signer has no key_id; a key-binding proof must identify the holder key (kid)".into(),
+        )
+    })?;
+    let header = serde_json::json!({
+        "typ": KEY_PROOF_TYP,
+        "alg": signer.algorithm(),
+        "kid": kid,
+    });
+    let mut payload = serde_json::json!({ "aud": audience, "iat": iat });
+    if let Some(n) = nonce {
+        payload["nonce"] = Value::String(n.to_string());
+    }
+    jwt::encode_compact_jws(&header, &payload, signer).map_err(jwt_err)
+}
+
+/// Map a JWT-layer error onto the crate's `InvalidProof`.
+fn jwt_err(e: JwtError) -> Oid4vciError {
+    Oid4vciError::InvalidProof(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_oid4vc_core::eddsa::{EdDsaSigner, EdDsaVerifier};
+
+    const ISSUER: &str = "https://issuer.example";
+    const NOW: i64 = 1_700_000_000;
+
+    fn signer(seed: u8, kid: &str) -> EdDsaSigner {
+        EdDsaSigner::from_bytes(&[seed; 32]).unwrap().with_kid(kid)
+    }
+
+    /// A policy with no nonce requirement, anchored at `now`.
+    fn policy(audience: &str, now: i64) -> ProofPolicy<'_> {
+        ProofPolicy {
+            audience,
+            nonce: None,
+            now,
+            max_age_secs: 300,
+        }
+    }
+
+    #[test]
+    fn build_then_verify_roundtrip() {
+        let s = signer(7, "did:key:zHolder#0");
+        let v = EdDsaVerifier::from_bytes(&s.public_key_bytes()).unwrap();
+
+        let jwt = build_key_proof_jwt(&s, ISSUER, Some("c-nonce-1"), NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+
+        assert_eq!(proof.algorithm(), "EdDSA");
+        assert_eq!(proof.kid(), Some("did:key:zHolder#0"));
+        assert_eq!(proof.claims().nonce.as_deref(), Some("c-nonce-1"));
+
+        let claims = proof
+            .verify(
+                &v,
+                &ProofPolicy {
+                    audience: ISSUER,
+                    nonce: Some("c-nonce-1"),
+                    now: NOW + 5,
+                    max_age_secs: 300,
+                },
+            )
+            .unwrap();
+        assert!(claims.aud.contains(ISSUER));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_audience() {
+        let s = signer(8, "did:key:zH#0");
+        let v = EdDsaVerifier::from_bytes(&s.public_key_bytes()).unwrap();
+        let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+        let err = proof
+            .verify(&v, &policy("https://other.example", NOW))
+            .unwrap_err();
+        assert!(
+            matches!(&err, Oid4vciError::InvalidProof(m) if m.contains("aud")),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_mismatched_or_missing_nonce() {
+        let s = signer(20, "did:key:zH#0");
+        // Issuer expects "n-issued"; proof carries the wrong nonce.
+        let jwt = build_key_proof_jwt(&s, ISSUER, Some("n-wrong"), NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+        let pol = ProofPolicy {
+            audience: ISSUER,
+            nonce: Some("n-issued"),
+            now: NOW,
+            max_age_secs: 300,
+        };
+        let err = proof.verify_claims(&pol).unwrap_err();
+        assert!(
+            matches!(&err, Oid4vciError::InvalidProof(m) if m.contains("nonce")),
+            "{err:?}"
+        );
+
+        // A proof with no nonce at all is also rejected when one was issued.
+        let no_nonce =
+            KeyProof::parse(&build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap()).unwrap();
+        assert!(no_nonce.verify_claims(&pol).is_err());
+
+        // Matching nonce passes.
+        let ok = KeyProof::parse(&build_key_proof_jwt(&s, ISSUER, Some("n-issued"), NOW).unwrap())
+            .unwrap();
+        assert!(ok.verify_claims(&pol).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_stale_and_future() {
+        let s = signer(9, "did:key:zH#0");
+        let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+        // Stale: now is far past iat.
+        assert!(proof.verify_claims(&policy(ISSUER, NOW + 10_000)).is_err());
+        // Future: iat well ahead of now.
+        assert!(proof.verify_claims(&policy(ISSUER, NOW - 10_000)).is_err());
+        // Fresh.
+        assert!(proof.verify_claims(&policy(ISSUER, NOW + 10)).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let s = signer(10, "did:key:zH#0");
+        let other = signer(11, "did:key:zH#0");
+        let v = EdDsaVerifier::from_bytes(&other.public_key_bytes()).unwrap();
+        let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+        assert!(proof.verify_signature(&v).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_typ() {
+        // A plain JWT (typ=JWT), not an openid4vci proof.
+        let s = signer(12, "did:key:zH#0");
+        let header = serde_json::json!({ "typ": "JWT", "alg": "EdDSA", "kid": "did:key:zH#0" });
+        let payload = serde_json::json!({ "aud": ISSUER, "iat": NOW });
+        let jwt = jwt::encode_compact_jws(&header, &payload, &s).unwrap();
+        let err = KeyProof::parse(&jwt).unwrap_err();
+        assert!(
+            matches!(&err, Oid4vciError::InvalidProof(m) if m.contains("typ")),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_missing_key_id() {
+        let s = signer(13, "ignored");
+        // No kid, no jwk in the header.
+        let header = serde_json::json!({ "typ": KEY_PROOF_TYP, "alg": "EdDSA" });
+        let payload = serde_json::json!({ "aud": ISSUER, "iat": NOW });
+        let jwt = jwt::encode_compact_jws(&header, &payload, &s).unwrap();
+        let err = KeyProof::parse(&jwt).unwrap_err();
+        assert!(
+            matches!(&err, Oid4vciError::InvalidProof(m) if m.contains("kid")),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_array_audience() {
+        let s = signer(14, "did:key:zH#0");
+        let header =
+            serde_json::json!({ "typ": KEY_PROOF_TYP, "alg": "EdDSA", "kid": "did:key:zH#0" });
+        let payload = serde_json::json!({ "aud": [ISSUER, "https://b.example"], "iat": NOW });
+        let jwt = jwt::encode_compact_jws(&header, &payload, &s).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+        assert!(proof.claims().aud.contains(ISSUER));
+        assert!(proof.claims().aud.contains("https://b.example"));
+    }
+
+    #[test]
+    fn build_requires_a_key_id() {
+        // A signer with no kid cannot build a proof.
+        let s = EdDsaSigner::from_bytes(&[15u8; 32]).unwrap();
+        assert!(build_key_proof_jwt(&s, ISSUER, None, NOW).is_err());
+    }
+}


### PR DESCRIPTION
## OpenID4VCI key-binding proof layer + Ed25519 JWT signer/verifier

The OID4VCI key-binding **proof-of-possession** — the cryptographic proof that
gates credential issuance — was an opaque `String` on both the wallet and issuer
sides, so every consumer hand-rolled the security-critical JWT assembly and
verification (and diverged on the boring, easy-to-botch parts: `typ`/`alg`
checks, base64url, `aud`/`iat`/`nonce`). This adds the build/verify pair, plus
the **Ed25519** `JwtSigner`/`JwtVerifier` that was conspicuously missing next to
the existing P-256 one (the stack is Ed25519-`did:key`-first).

### `affinidi-oid4vc-core` (0.1.2 → 0.1.3)
- **`eddsa` feature** — `EdDsaSigner` / `EdDsaVerifier` (`EdDSA` / Ed25519,
  RFC 8037), mirroring `es256` exactly: `from_bytes` / `generate` / `with_kid` /
  `public_key_bytes` / `public_key_jwk` (OKP) / `from_jwk`. Uses `verify_strict`
  (rejects malleable / small-order-component signatures — the right default for
  tokens), and validates both `kty` and `crv` on JWK import. Default-on next to
  `es256`.
- **`jwt::Audience`** — untagged string-or-array `aud` helper (RFC 7519 §4.1.3)
  with `.contains()` / `.iter()`, so consumers stop re-implementing (and
  occasionally mishandling) the array form.

### `affinidi-openid4vci` (0.1.2 → 0.1.3)
- **`proof` module.**
  - Wallet: `build_key_proof_jwt(signer, aud, nonce, iat)`.
  - Issuer: `KeyProof::parse` → `verify` against a
    `ProofPolicy { audience, nonce, now, max_age_secs }`. Enforces signature,
    `aud`, **`c_nonce` replay binding** (§8.2.1.1), and `iat` freshness. The
    policy is a **named-field struct on purpose** — `nonce` is easy to forget as
    a positional arg on a security call, so it must be stated explicitly.
  - **Crypto-agnostic by design:** depends only on `oid4vc-core`'s always-on
    `jwt` module (`default-features = false`); **DID resolution stays with the
    caller** — `parse` surfaces the claimed `kid` / `jwk`, the consumer resolves
    it to a `JwtVerifier`. This keeps DID-method coupling out of the crate.
- **`validate_credential_request`** docs now state it is a **structural check
  only** and does **not** verify the proof — closing a footgun where it returned
  `Ok` for a request bearing a forged/expired proof.

### Versioning / compatibility
Changes are **additive**. `siopv2` and `openid4vp` pin `oid4vc-core` at
`version = "0.1"`, which still resolves to `0.1.3`, so there is **no dependent
fan-out** — both still build unchanged. `openid4vci` is the only consumer of the
new symbols.

### Review & verification
A full end-to-end security review traced the verify path against `alg=none`,
forged-signature, wrong-key, wrong-audience, alg-confusion, replay (time +
nonce), TOCTOU, and malformed-input panics — the signature path is sound. Review
findings folded in: `c_nonce` enforcement, the caller-contract docs (verifier
MUST be resolved from the proof's own `kid`/`jwk` and match `algorithm()`), the
bare-`jwk` warning, and the JWK `kty` check.

- `cargo clippy -D warnings` clean across feature permutations (default /
  `--no-default-features` / `--features eddsa` only / `es256` only).
- `cargo fmt --check`, **56 tests** (incl. doctest), and `cargo deny` clean.

### A note on dependency updates
The crates' deps are already at their latest workspace-consistent majors. The
one newer major available — `sha2 0.10 → 0.11` — was **deliberately not** taken:
sha2 0.10 is used by 12+ workspace crates and 0.11 pulls `digest 0.11`, a
workspace-wide RustCrypto migration most consumers can't satisfy yet. Bumping
one crate would split the tree into two `sha2` majors — a worse state than
staying consistent. The new deps (`ed25519-dalek 2`, `rand_core 0.6`) match the
versions `affinidi-crypto` already uses, so no new duplicates are introduced.
