### PR TITLE
feat: BLS12-381 G2 did:key support for BBS+ issuer keys

### DIFF
--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.10"
+version = "0.1.11"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/src/bls12381.rs
+++ b/crates/core/affinidi-crypto/src/bls12381.rs
@@ -1,0 +1,156 @@
+//! `did:key` framing for BLS12-381 G2 public keys (BBS+ issuer verification
+//! keys).
+//!
+//! A BBS+ issuer (`bbs-2023` Data-Integrity cryptosuite) signs with a
+//! BLS12-381 key pair whose **public** key is a point in G2 — 96 bytes
+//! compressed, multicodec `0xeb`. These helpers go between that raw 96-byte key
+//! and a `did:key:zUC7…` identifier so a BBS issuer DID (or a `#bbs-key-0`
+//! verification method) can be expressed with the same `did:key` machinery the
+//! rest of the workspace uses for Ed25519.
+//!
+//! ## Framing only — no curve arithmetic
+//!
+//! Like [`crate::did_key`] for Ed25519, these helpers are **byte framing**: they
+//! validate the multicodec and length but do **not** parse or validate the bytes
+//! as a well-formed G2 point. That keeps the BLS12-381 curve dependency out of
+//! this base crate entirely — point validation lives in `affinidi-bbs`, which
+//! interprets the bytes when the key is actually used to verify a signature.
+
+use affinidi_encoding::{BLS12381_G2_PUB, MultiEncoded, MultiEncodedBuf};
+use base58::{FromBase58, ToBase58};
+
+use crate::{CryptoError, error::Result};
+
+const DID_KEY_PREFIX: &str = "did:key:";
+
+/// The compressed byte length of a BLS12-381 G2 public key.
+pub const BLS12381_G2_PUB_LEN: usize = 96;
+
+/// Encode a 96-byte BLS12-381 G2 public key as a `did:key:zUC7…` identifier.
+pub fn g2_pub_to_did_key(pubkey: &[u8; BLS12381_G2_PUB_LEN]) -> String {
+    let multikey = MultiEncodedBuf::encode_bytes(BLS12381_G2_PUB, pubkey)
+        .into_bytes()
+        .to_base58();
+    format!("{DID_KEY_PREFIX}z{multikey}")
+}
+
+/// Decode a `did:key:zUC7…` string to its raw 96-byte BLS12-381 G2 public key.
+///
+/// Errors on a missing `did:key:` prefix, missing multibase `z` prefix, a
+/// multicodec other than BLS12-381-G2-pub (`0xeb`), or a payload that isn't 96
+/// bytes. The returned bytes are **not** validated as a well-formed G2 point —
+/// `affinidi-bbs` performs that check when it parses the key for verification.
+pub fn did_key_to_g2_pub(did: &str) -> Result<[u8; BLS12381_G2_PUB_LEN]> {
+    let multibase = did
+        .strip_prefix(DID_KEY_PREFIX)
+        .ok_or_else(|| CryptoError::Decoding(format!("Expected '{DID_KEY_PREFIX}' prefix")))?;
+    let base58 = multibase.strip_prefix('z').ok_or_else(|| {
+        CryptoError::Decoding("Expected multibase 'z' prefix after 'did:key:'".into())
+    })?;
+    let decoded = base58
+        .from_base58()
+        .map_err(|_| CryptoError::Decoding("Couldn't decode base58".into()))?;
+
+    let multicodec = MultiEncoded::new(decoded.as_slice())?;
+    if multicodec.codec() != BLS12381_G2_PUB {
+        return Err(CryptoError::KeyError(format!(
+            "Expected BLS12-381 G2 public key, instead received codec 0x{:x}",
+            multicodec.codec()
+        )));
+    }
+    let data = multicodec.data();
+    if data.len() != BLS12381_G2_PUB_LEN {
+        return Err(CryptoError::KeyError(format!(
+            "Invalid public key byte length: expected {BLS12381_G2_PUB_LEN}, got {}",
+            data.len()
+        )));
+    }
+
+    let mut out = [0u8; BLS12381_G2_PUB_LEN];
+    out.copy_from_slice(data);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_encoding::ED25519_PUB;
+
+    /// A fixed 96-byte stand-in for a compressed G2 point. The helpers do byte
+    /// framing only, so any 96 bytes round-trips (curve validity is checked in
+    /// `affinidi-bbs`, not here).
+    fn sample_g2() -> [u8; BLS12381_G2_PUB_LEN] {
+        let mut k = [0u8; BLS12381_G2_PUB_LEN];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(7).wrapping_add(1);
+        }
+        k
+    }
+
+    #[test]
+    fn g2_pub_to_did_key_roundtrip() {
+        let key = sample_g2();
+        let did = g2_pub_to_did_key(&key);
+        // multibase `z` (base58btc). (Real G2 points, whose leading byte carries
+        // the compression bits, canonically render `zUC7…`; a synthetic key
+        // need not, so we assert the framing + the round-trip, not the prefix.)
+        assert!(
+            did.starts_with("did:key:z"),
+            "expected did:key:z prefix, got {did}"
+        );
+        let back = did_key_to_g2_pub(&did).unwrap();
+        assert_eq!(back, key);
+    }
+
+    #[test]
+    fn g2_pub_to_did_key_is_deterministic() {
+        let key = sample_g2();
+        assert_eq!(g2_pub_to_did_key(&key), g2_pub_to_did_key(&key));
+    }
+
+    #[test]
+    fn did_key_to_g2_pub_missing_did_key_prefix() {
+        let err = did_key_to_g2_pub("zUC7abc").unwrap_err();
+        assert!(
+            matches!(err, CryptoError::Decoding(ref m) if m.contains("did:key:")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_g2_pub_missing_multibase_prefix() {
+        let err = did_key_to_g2_pub("did:key:UC7abc").unwrap_err();
+        assert!(
+            matches!(err, CryptoError::Decoding(ref m) if m.contains('z')),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_g2_pub_wrong_multicodec() {
+        // A valid did:key carrying an Ed25519 key (codec 0xed) — wrong algorithm.
+        let payload = MultiEncodedBuf::encode_bytes(ED25519_PUB, &[0u8; 32])
+            .into_bytes()
+            .to_base58();
+        let did = format!("did:key:z{payload}");
+        let err = did_key_to_g2_pub(&did).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("codec")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn did_key_to_g2_pub_wrong_length() {
+        // Correct G2 multicodec but a 48-byte payload (a G1-sized key).
+        let payload = MultiEncodedBuf::encode_bytes(BLS12381_G2_PUB, &[0u8; 48])
+            .into_bytes()
+            .to_base58();
+        let did = format!("did:key:z{payload}");
+        let err = did_key_to_g2_pub(&did).unwrap_err();
+        assert!(
+            matches!(err, CryptoError::KeyError(ref m) if m.contains("length") || m.contains("96")),
+            "unexpected error: {err:?}"
+        );
+    }
+}

--- a/crates/core/affinidi-crypto/src/key_type.rs
+++ b/crates/core/affinidi-crypto/src/key_type.rs
@@ -26,6 +26,10 @@ pub enum KeyType {
     P384,
     P521,
     Secp256k1,
+    /// BLS12-381 G2 public key — the verification key of a BBS+ issuer
+    /// (`bbs-2023` Data-Integrity cryptosuite). A 96-byte compressed G2 point,
+    /// multicodec `0xeb`.
+    Bls12381G2,
     /// ML-DSA-44 (FIPS 204) — post-quantum signature scheme.
     #[cfg(feature = "ml-dsa")]
     MlDsa44,
@@ -54,6 +58,7 @@ impl TryFrom<&str> for KeyType {
             "P-384" => Ok(KeyType::P384),
             "P-521" => Ok(KeyType::P521),
             "secp256k1" => Ok(KeyType::Secp256k1),
+            "Bls12381G2" => Ok(KeyType::Bls12381G2),
             #[cfg(feature = "ml-dsa")]
             "ML-DSA-44" => Ok(KeyType::MlDsa44),
             #[cfg(feature = "ml-dsa")]
@@ -76,6 +81,7 @@ impl fmt::Display for KeyType {
             KeyType::P384 => write!(f, "P-384"),
             KeyType::P521 => write!(f, "P-521"),
             KeyType::Secp256k1 => write!(f, "secp256k1"),
+            KeyType::Bls12381G2 => write!(f, "Bls12381G2"),
             #[cfg(feature = "ml-dsa")]
             KeyType::MlDsa44 => write!(f, "ML-DSA-44"),
             #[cfg(feature = "ml-dsa")]

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -14,6 +14,10 @@ mod error;
 mod jwk;
 mod key_type;
 
+/// BLS12-381 G2 `did:key` framing (BBS+ issuer keys). Curve-free, so it needs
+/// no feature gate.
+pub mod bls12381;
+
 #[cfg(feature = "ed25519")]
 pub mod did_key;
 

--- a/crates/core/affinidi-encoding/Cargo.toml
+++ b/crates/core/affinidi-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-encoding"
 description = "Multibase and multicodec encoding utilities for Affinidi TDK"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-encoding/src/lib.rs
+++ b/crates/core/affinidi-encoding/src/lib.rs
@@ -13,9 +13,9 @@ pub use multibase::{
     encode_base58btc, encode_multikey, validate_base58btc,
 };
 pub use multicodec::{
-    Codec, ED25519_PRIV, ED25519_PUB, MultiEncoded, MultiEncodedBuf, P256_PRIV, P256_PUB,
-    P384_PRIV, P384_PUB, P521_PRIV, P521_PUB, SECP256K1_PRIV, SECP256K1_PUB, X25519_PRIV,
-    X25519_PUB,
+    BLS12381_G1_PUB, BLS12381_G2_PUB, Codec, ED25519_PRIV, ED25519_PUB, MultiEncoded,
+    MultiEncodedBuf, P256_PRIV, P256_PUB, P384_PRIV, P384_PUB, P521_PRIV, P521_PUB, SECP256K1_PRIV,
+    SECP256K1_PUB, X25519_PRIV, X25519_PUB,
 };
 
 mod error;

--- a/crates/core/affinidi-encoding/src/multicodec.rs
+++ b/crates/core/affinidi-encoding/src/multicodec.rs
@@ -25,6 +25,10 @@ pub const P384_PUB: u64 = 0x1201;
 pub const P384_PRIV: u64 = 0x1307;
 pub const P521_PUB: u64 = 0x1202;
 pub const P521_PRIV: u64 = 0x1308;
+// BLS12-381 public keys (used by BBS+ issuers). Compressed group elements:
+// G1 = 48 bytes, G2 = 96 bytes. A BBS issuer's verification key is a G2 point.
+pub const BLS12381_G1_PUB: u64 = 0xea;
+pub const BLS12381_G2_PUB: u64 = 0xeb;
 
 // Post-quantum codecs — draft entries from the official multicodec table.
 // We store ML-DSA private keys as the 32-byte seed, so we use the
@@ -56,6 +60,8 @@ pub enum Codec {
     P384Priv,
     P521Pub,
     P521Priv,
+    Bls12381G1Pub,
+    Bls12381G2Pub,
     MlDsa44Pub,
     MlDsa44PrivSeed,
     MlDsa65Pub,
@@ -82,6 +88,8 @@ impl Codec {
             P384_PRIV => Codec::P384Priv,
             P521_PUB => Codec::P521Pub,
             P521_PRIV => Codec::P521Priv,
+            BLS12381_G1_PUB => Codec::Bls12381G1Pub,
+            BLS12381_G2_PUB => Codec::Bls12381G2Pub,
             ML_DSA_44_PUB => Codec::MlDsa44Pub,
             ML_DSA_44_PRIV_SEED => Codec::MlDsa44PrivSeed,
             ML_DSA_65_PUB => Codec::MlDsa65Pub,
@@ -108,6 +116,8 @@ impl Codec {
             Codec::P384Priv => P384_PRIV,
             Codec::P521Pub => P521_PUB,
             Codec::P521Priv => P521_PRIV,
+            Codec::Bls12381G1Pub => BLS12381_G1_PUB,
+            Codec::Bls12381G2Pub => BLS12381_G2_PUB,
             Codec::MlDsa44Pub => ML_DSA_44_PUB,
             Codec::MlDsa44PrivSeed => ML_DSA_44_PRIV_SEED,
             Codec::MlDsa65Pub => ML_DSA_65_PUB,
@@ -129,6 +139,8 @@ impl Codec {
                 | Codec::P256Pub
                 | Codec::P384Pub
                 | Codec::P521Pub
+                | Codec::Bls12381G1Pub
+                | Codec::Bls12381G2Pub
                 | Codec::MlDsa44Pub
                 | Codec::MlDsa65Pub
                 | Codec::MlDsa87Pub
@@ -145,6 +157,9 @@ impl Codec {
             Codec::P256Pub => Some(33),      // compressed
             Codec::P384Pub => Some(49),      // compressed
             Codec::P521Pub => Some(67),      // compressed
+            // BLS12-381 compressed group elements.
+            Codec::Bls12381G1Pub => Some(48),
+            Codec::Bls12381G2Pub => Some(96),
             // ML-DSA public keys: FIPS 204 fixed sizes
             Codec::MlDsa44Pub => Some(1312),
             Codec::MlDsa65Pub => Some(1952),


### PR DESCRIPTION
## What

BBS+ issuers (the `bbs-2023` W3C Data-Integrity cryptosuite) verify with a **BLS12-381 G2** public key — 96 bytes compressed, multicodec `0xeb`. Nothing in `affinidi-crypto` could express such a key as a `did:key`, which blocks representing a BBS issuer DID or a `#bbs-key-0` verification method. This is the prerequisite for wiring BBS+ into the downstream `verifiable-trust-infrastructure` workspace.

## Changes

**`affinidi-encoding`**
- Add the BLS12-381 G1 (`0xea`) and G2 (`0xeb`) public-key multicodec constants.
- Add their `Codec` enum variants + `expected_key_length` (48 / 96 bytes).

**`affinidi-crypto`**
- Add `KeyType::Bls12381G2`.
- New `bls12381` module: `g2_pub_to_did_key` / `did_key_to_g2_pub`.

## Design: framing only, curve stays out of the base crate

Like the existing Ed25519 `did:key` helpers, these are **byte framing** — they validate the multicodec and length but do **not** parse the bytes as a G2 point. That keeps the `bls12_381_plus` curve dependency entirely out of `affinidi-crypto`; point validation lives in `affinidi-bbs`, which interprets the key at verification time. The `bls12381` module is therefore curve-free and needs no feature gate.

## Tests

Round-trip plus wrong-multicodec, wrong-length, and missing-prefix rejection. `affinidi-encoding` + `affinidi-crypto` suites pass; `affinidi-did-common` (the downstream `Codec` consumer) builds clean; clippy clean.

Version bumps (`affinidi-encoding` 0.1.3→0.1.4, `affinidi-crypto` 0.1.10→0.1.11) so the support publishes for downstream consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
