### PR TITLE
fix: tighten affinidi-crypto's affinidi-encoding pin to 0.1.4 (#348)

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Affinidi Crypto Changelog
 
+## 4th June 2026 (0.1.12)
+
+- **FIX (#348):** Tightened the `affinidi-encoding` dependency from the
+  loose `"0.1"` to `"0.1.4"`. The `bls12381` module (added in 0.1.11)
+  imports `affinidi_encoding::BLS12381_G2_PUB`, which only exists from
+  `affinidi-encoding 0.1.4`. The loose requirement let a fresh resolve
+  against an existing lock keep `affinidi-encoding` at a `0.1.x < 0.1.4`,
+  breaking the build with `unresolved import ...::BLS12381_G2_PUB` for
+  external consumers. The workspace `[patch.crates-io]` redirect masked
+  this in-tree. No API change.
+
+## 1st June 2026 (0.1.11)
+
+- **FEATURE (#346):** BLS12-381 G2 `did:key` support for BBS+ issuer
+  keys. Adds `KeyType::Bls12381G2` and a new `bls12381` module that
+  encodes a G2 public key as a `did:key` (multicodec `0xeb`). Requires
+  `affinidi-encoding >= 0.1.4` for the `BLS12381_G2_PUB` codec constant.
+
 ## 1st June 2026 (0.1.10)
 
 - **FEATURE (#327, `jose`):** Added

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.11"
+version = "0.1.12"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -30,7 +30,10 @@ slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
 jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519", "p256", "k256"]
 
 [dependencies]
-affinidi-encoding = "0.1"
+# Requires >= 0.1.4: the `bls12381` module imports
+# `affinidi_encoding::BLS12381_G2_PUB`, added in 0.1.4 (#346). A loose "0.1"
+# resolved against an older lock to a 0.1.x < 0.1.4 and failed to compile (#348).
+affinidi-encoding = "0.1.4"
 
 base58 = "0.2"
 base64 = "0.22"


### PR DESCRIPTION
## Summary

`affinidi-crypto 0.1.11`'s `bls12381` module imports `affinidi_encoding::BLS12381_G2_PUB`, a constant that only exists from `affinidi-encoding 0.1.4` (added in #346). The dependency was left at a loose `"0.1"`, so a fresh dependency resolution against an existing lock could keep `affinidi-encoding` at a `0.1.x < 0.1.4` and fail to compile for external consumers:

```
error[E0432]: unresolved import `affinidi_encoding::BLS12381_G2_PUB`
  --> affinidi-crypto-0.1.11/src/bls12381.rs:19:25
```

It only built in-tree because the workspace `[patch.crates-io]` redirects `affinidi-encoding` to the local `0.1.4` path.

## Root cause

#346 added the `bls12381` module + bumped `affinidi-encoding` to 0.1.4, but did not tighten `affinidi-crypto`'s requirement on it (and didn't add a 0.1.11 CHANGELOG entry).

## Fix

- `crates/core/affinidi-crypto/Cargo.toml`: `affinidi-encoding = "0.1"` → `"0.1.4"`, version `0.1.11` → `0.1.12`.
- `CHANGELOG.md`: 0.1.12 fix entry + backfilled the missing 0.1.11 G2 feature entry.

No dependent bumps needed — all in-workspace consumers pin `affinidi-crypto = "0.1"` (major.minor), satisfied by the patch bump.

## Verification

- `cargo check -p affinidi-crypto` → resolves `affinidi-encoding v0.1.4`, builds clean
- `cargo fmt --all --check` clean
- `cargo clippy -p affinidi-crypto --all-features` clean
- `cargo test -p affinidi-crypto --all-features` → 57 passed

Closes #348