### PR TITLE
fix: mediator-setup file:// URL (#350) + coverage-build dead-code gate (#351)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 5th June 2026
+
+### 0.15.13 — coverage-build fix + redis 1.2
+
+- **FIX (#351):** Gated the `store::auth_flow_harness` module (added in
+  0.15.11) to `#[cfg(all(test, any(feature = "fjall-backend", feature =
+  "memory-backend")))]`. Its only callers live in the Fjall and memory
+  test modules, so under a `redis-backend`-only build (the coverage CI
+  job) the harness was dead code and tripped `-D warnings`, failing the
+  job. Test-only; no shipped behaviour change.
+- **DEPS:** Bumped `redis` `1.1` → `1.2` (compatible upgrade).
+
 ## 1st June 2026
 
 ### 0.15.12 — release on didcomm 0.15

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.12"
+version = "0.15.13"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -98,7 +98,7 @@ tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
 # ── Database (Redis) ─────────────────────────────────────────────────────
 ## Redis 7.1+ required. Uses multiplexed connection (not pool).
 ## TLS: use `rediss://` URL scheme. Auth: `redis://:password@host/`.
-redis = { version = "1.1", features = [
+redis = { version = "1.2", features = [
   "tokio-rustls-comp",       # TLS via rustls (for rediss:// URLs)
   "tls-rustls-insecure",     # Allow self-signed certs (dev only, controlled by config)
   "connection-manager",      # Auto-reconnecting multiplexed connection

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -72,7 +72,11 @@ pub fn encode_oob_invite(invite: &Message) -> Result<String, MediatorError> {
 /// whole sequence against any [`MediatorStore`] so every backend gets
 /// parity — each backend's test module constructs its store and calls
 /// [`run_auth_session_flow`](auth_flow_harness::run_auth_session_flow).
-#[cfg(test)]
+// Only the fjall and memory backends call this harness (the Redis path has
+// its own integration tests). Gating it to those features keeps it from being
+// dead code — and tripping `-D warnings` — under a redis-backend-only build
+// such as the coverage job (#351).
+#[cfg(all(test, any(feature = "fjall-backend", feature = "memory-backend")))]
 pub(crate) mod auth_flow_harness {
     use affinidi_messaging_mediator_common::store::{MediatorStore, Session, SessionState};
     use sha256::digest;

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Affinidi Messaging Mediator Setup
+
+## Changelog history
+
+## 5th June 2026
+
+### 0.1.6 — well-formed `file://` secret-backend URLs
+
+- **FIX (#350):** The wizard built the `file://` secret-backend URL by
+  formatting the operator's storage path directly
+  (`format!("file://{path}")`). For a *relative* path such as the default
+  `conf/secrets.json` this produced `file://conf/secrets.json`, which is
+  RFC 3986-malformed: `conf` parses as the URL *authority* and the path
+  becomes `/secrets.json`. The mediator then opened `/secrets.json` at the
+  filesystem root — silently writing outside the working directory as
+  root, or failing the backend probe with `permission denied` for any
+  other user.
+
+  `build_backend_url` now resolves the path to absolute against the
+  current working directory before formatting, emitting a correct
+  three-slash `file:///<abs>` URL (empty authority). It also tolerates an
+  operator pasting a full `file://` URL into the path prompt (no more
+  double-prefixed `file://file:///…`). Absolute paths are unchanged.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.5"
+version = "0.1.6"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -318,6 +318,51 @@ fn url_host(url: &str) -> Option<String> {
     parsed.host_str().map(|h| h.to_string())
 }
 
+/// Build a well-formed `file://` backend URL from the operator's storage
+/// path.
+///
+/// The mediator's `SecretStore` parser treats a `file://` URL per RFC 3986:
+/// the segment between `//` and the next `/` is the *authority*, not part of
+/// the path. So a relative `file://conf/secrets.json` parses to
+/// authority=`conf`, path=`/secrets.json` — the mediator opens `/secrets.json`
+/// at the filesystem root, silently writing outside the working directory as
+/// root and failing the backend probe with `permission denied` for everyone
+/// else (#350).
+///
+/// A correct local URL needs an empty authority and an absolute path:
+/// `file:///<abs>` (three slashes). We get there by resolving the path to
+/// absolute against the current working directory before formatting — an
+/// already-absolute path contributes its own leading `/`, yielding the third
+/// slash. We also tolerate an operator pasting a full `file://` URL into the
+/// path prompt by stripping a leading `file://` scheme first.
+fn file_backend_url(raw_path: &str, encrypted: bool) -> String {
+    // Tolerate a `file://`-prefixed value in the path field: `file:///abs`
+    // strips to `/abs` (absolute), `file://rel` strips to `rel` (relative).
+    let path_str = raw_path.trim();
+    let path_str = path_str.strip_prefix("file://").unwrap_or(path_str);
+    let path = std::path::Path::new(path_str);
+
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        // Resolve against the wizard's working directory so the secrets file
+        // lands where the operator expects. If `current_dir` is unavailable
+        // (e.g. the dir was deleted), fall back to the raw path — the probe
+        // will then surface a clear error rather than us guessing.
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(path),
+            Err(_) => path.to_path_buf(),
+        }
+    };
+
+    let absolute = absolute.to_string_lossy();
+    if encrypted {
+        format!("file://{absolute}?encrypt=1")
+    } else {
+        format!("file://{absolute}")
+    }
+}
+
 /// Construct the `[secrets].backend` URL from the wizard's per-backend
 /// config choices. Mirrors the URL shape the mediator's `SecretStore`
 /// parser accepts. `vta://` is no longer supported as a storage scheme —
@@ -330,18 +375,7 @@ fn url_host(url: &str) -> Option<String> {
 /// than only being discovered when the mediator next boots.
 pub fn build_backend_url(config: &WizardConfig) -> String {
     match config.secret_storage.as_str() {
-        STORAGE_FILE => {
-            // Template default is `conf/secrets.json`; callers in
-            // `generate_and_write` may extend this later via absolute
-            // paths. Append `?encrypt=1` when the operator opted into
-            // envelope encryption — the mediator's `open_store` parser
-            // routes that flag to the AEAD-backed file store.
-            if config.secret_file_encrypted {
-                format!("file://{}?encrypt=1", config.secret_file_path)
-            } else {
-                format!("file://{}", config.secret_file_path)
-            }
-        }
+        STORAGE_FILE => file_backend_url(&config.secret_file_path, config.secret_file_encrypted),
         STORAGE_KEYRING => format!("keyring://{}", config.secret_keyring_service),
         STORAGE_AWS => format!(
             "aws_secrets://{}/{}",
@@ -378,27 +412,70 @@ mod tests {
     // so a typo in any branch silently misroutes secret storage.
 
     #[test]
-    fn build_backend_url_file_plain() {
+    fn build_backend_url_file_relative_resolves_to_absolute_three_slash() {
+        // A relative path must be resolved against the CWD into a
+        // three-slash `file:///<abs>` URL — a bare `file://conf/secrets.json`
+        // is RFC-malformed (authority=`conf`) and opens `/secrets.json` (#350).
         let cfg = WizardConfig {
             secret_storage: STORAGE_FILE.into(),
             secret_file_path: "conf/secrets.json".into(),
             secret_file_encrypted: false,
             ..WizardConfig::default()
         };
-        assert_eq!(build_backend_url(&cfg), "file://conf/secrets.json");
+        let expected = format!(
+            "file://{}",
+            std::env::current_dir()
+                .unwrap()
+                .join("conf/secrets.json")
+                .display()
+        );
+        let url = build_backend_url(&cfg);
+        assert_eq!(url, expected);
+        // Empty authority: exactly three slashes, then an absolute path.
+        assert!(url.starts_with("file:///"), "must be three-slash: {url}");
+    }
+
+    #[test]
+    fn build_backend_url_file_absolute_passes_through() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_FILE.into(),
+            secret_file_path: "/var/lib/mediator/secrets.json".into(),
+            secret_file_encrypted: false,
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "file:///var/lib/mediator/secrets.json"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_file_tolerates_pasted_file_url() {
+        // An operator who pastes a full `file://` URL into the path prompt
+        // must not get a double-prefixed `file://file:///…`.
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_FILE.into(),
+            secret_file_path: "file:///var/lib/mediator/secrets.json".into(),
+            secret_file_encrypted: false,
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "file:///var/lib/mediator/secrets.json"
+        );
     }
 
     #[test]
     fn build_backend_url_file_encrypted_appends_query() {
         let cfg = WizardConfig {
             secret_storage: STORAGE_FILE.into(),
-            secret_file_path: "conf/secrets.json".into(),
+            secret_file_path: "/var/lib/mediator/secrets.json".into(),
             secret_file_encrypted: true,
             ..WizardConfig::default()
         };
         assert_eq!(
             build_backend_url(&cfg),
-            "file://conf/secrets.json?encrypt=1"
+            "file:///var/lib/mediator/secrets.json?encrypt=1"
         );
     }
 
@@ -984,8 +1061,18 @@ mod tests {
         // `[secrets].backend = "<url>"` in mediator.toml. `string://` and
         // `vta://` are no longer storage backends (string:// dropped;
         // vta:// is a key *source*, not a store).
+        // The file:// backend resolves its (default, relative) path against
+        // the CWD into a three-slash absolute URL (#350), so compute the
+        // expected value the same way rather than hard-coding it.
+        let file_backend = format!(
+            "file://{}",
+            std::env::current_dir()
+                .unwrap()
+                .join(crate::consts::DEFAULT_SECRET_FILE_PATH)
+                .display()
+        );
         let cases = [
-            (STORAGE_FILE, "file://conf/secrets.json"),
+            (STORAGE_FILE, file_backend.as_str()),
             (STORAGE_KEYRING, "keyring://affinidi-mediator"),
             (STORAGE_AWS, "aws_secrets://us-east-1/mediator/"),
         ];


### PR DESCRIPTION
Addresses two mediator issues in one PR.

## #350 — mediator-setup writes a malformed `file://` secret-backend URL

`build_backend_url` formatted the operator's storage path verbatim
(`format!("file://{path}")`). For a **relative** path such as the default
`conf/secrets.json` this yields `file://conf/secrets.json`, which is
RFC 3986-malformed — `conf` is parsed as the URL *authority*, so the path
becomes `/secrets.json`. The mediator then opens `/secrets.json` at the
filesystem root:

- **as root:** the secrets file is silently written to `/`, not the
  wizard's working dir — the setup looks successful but lands the file
  somewhere unexpected.
- **as any other user:** the backend probe fails with
  `Permission denied (os error 13)` on `/secrets.json`.

**Fix:** `build_backend_url` resolves the path to absolute against the
current working directory before formatting, emitting a correct
three-slash `file:///<abs>` URL (empty authority). It also tolerates an
operator pasting a full `file://` URL into the path prompt (no more
double-prefixed `file://file:///…`). Absolute paths are unchanged.

New/updated unit tests cover: relative→absolute resolution (asserts
three-slash form), absolute pass-through, pasted-`file://`-URL tolerance,
and the encrypted variant.

## #351 — coverage CI job fails on dead-code under `-D warnings`

`store::auth_flow_harness` (added in 0.15.11) is `#[cfg(test)]` with no
feature gate, but its only callers are in the Fjall and memory test
modules. The coverage job builds `default,didcomm,redis-backend` (neither
backend), so the harness is dead code → `-D warnings` fails the build:

```
error: function `run_auth_session_flow` is never used
  --> src/store/mod.rs:85:25
```

**Fix:** gate the module to
`#[cfg(all(test, any(feature = "fjall-backend", feature = "memory-backend")))]`.
Test-only; no shipped behaviour change.

Reproduced before/after with:
```
RUSTFLAGS="-D warnings" cargo test -p affinidi-messaging-mediator \
  --no-default-features --features didcomm,redis-backend --no-run
```

## Dependency / version updates

- `affinidi-messaging-mediator` `0.15.12` → `0.15.13`; bumped `redis`
  `1.1` → `1.2` (the only compatible external upgrade — remaining
  candidates are major bumps the manifest flags as needing coordination).
- `affinidi-messaging-mediator-setup` `0.1.5` → `0.1.6` (+ new CHANGELOG).
- `affinidi-messaging-test-mediator` pins the mediator at `"0.15"`, so the
  patch bump needs no cascade.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy -p affinidi-messaging-mediator -p affinidi-messaging-mediator-setup --all-targets` clean
- mediator-setup suite: 342 passed; mediator memory-backend store tests: 18 passed; memory auth-flow harness test passes
- redis-backend-only `-D warnings` build now compiles clean (was the #351 failure)
- `cargo deny check`: advisories/bans/licenses/sources ok

Closes #350
Closes #351