### PR TITLE
feat: robust key-agreement negotiation + P-384/P-521 curves (#357)

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Affinidi Crypto Changelog
 
+## 6th June 2026 (0.2.0)
+
+**Breaking release.** Adds P-384/P-521 key agreement and makes the
+key-agreement enums `#[non_exhaustive]` — the major-version bump is taken
+once, now, so that every *future* curve or key addition is a non-breaking
+patch.
+
+> **Coordination note (vta-sdk):** the `0.1 → 0.2` bump un-unifies any
+> external crate that pins `affinidi-crypto = "0.1"` from the workspace
+> `[patch.crates-io]` redirect. `vta-sdk` (used by the mediator and
+> mediator-setup) does this, so those two crates will not build until a
+> `vta-sdk` release that depends on `affinidi-crypto 0.2` is published and
+> their `vta-sdk` pin is bumped. All other crates are unaffected.
+
+- **Added P-384 and P-521 key agreement (#357).** `jose::key_agreement`
+  now supports ECDH on the NIST P-384 and P-521 curves alongside X25519,
+  P-256 and secp256k1: new `Curve::P384`/`Curve::P521` variants, matching
+  `PublicKeyAgreement`/`PrivateKeyAgreement` variants, and full
+  `generate`/`from_raw_bytes`/`from_jwk`/`to_jwk`/`diffie_hellman` support.
+  The ConcatKDF/key-wrap/content-encryption stack is curve-agnostic, so
+  ECDH-1PU (authcrypt) and ECDH-ES (anoncrypt) work on the new curves
+  unchanged (uniform `A256KW` + `A256CBC-HS512`); KAT roundtrips added for
+  both. New `p521` key-generation module (`affinidi_crypto::p521`) mirroring
+  `p384`, plus JWK `crv: "P-521"` parsing. New `p521` feature (on by
+  default); the `p384`/`p521` features now also enable the `ecdh`
+  capability, and the `jose` feature now pulls `p384` + `p521`. Added
+  `PublicKeyAgreement::to_public_bytes()` (raw/compressed-SEC1 bytes) so
+  callers no longer match on the curve enum themselves.
+- **BREAKING:** `Curve`, `PublicKeyAgreement` and `PrivateKeyAgreement` are
+  now `#[non_exhaustive]`. External code matching them must add a wildcard
+  arm; in return, future variant additions are non-breaking. (`KeyType` is
+  deliberately left exhaustive so the secrets-resolver encode/decode paths
+  still fail to compile if a new key type is unhandled.)
+
 ## 4th June 2026 (0.1.12)
 
 - **FIX (#348):** Tightened the `affinidi-encoding` dependency from the

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.1.12"
+version = "0.2.0"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -13,10 +13,11 @@ readme = "README.md"
 rust-version.workspace = true
 
 [features]
-default = ["p256", "k256", "p384", "ed25519"]
+default = ["p256", "k256", "p384", "p521", "ed25519"]
 p256 = ["dep:p256"]
 k256 = ["dep:k256"]
 p384 = ["dep:p384"]
+p521 = ["dep:p521"]
 ed25519 = ["dep:ed25519-dalek"]
 # Post-quantum cryptography (experimental — W3C di-quantum-safe v0.3).
 # `post-quantum` is the umbrella flag; `ml-dsa` and `slh-dsa` can be enabled
@@ -27,7 +28,7 @@ slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
 # JOSE primitives (#327): ECDH-ES / ECDH-1PU Concat KDF, A256KW key wrap,
 # A256CBC-HS512 content encryption, EdDSA signing. Pulls in EdDSA via the
 # `ed25519` feature. Key agreement (curves) lands separately in a later PR.
-jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519", "p256", "k256"]
+jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519", "p256", "k256", "p384", "p521"]
 
 [dependencies]
 # Requires >= 0.1.4: the `bls12381` module imports
@@ -53,6 +54,11 @@ p256 = { version = "0.13", features = [
 p384 = { version = "0.13", features = [
   "ecdsa-core",
   "arithmetic",
+  "ecdh",
+], optional = true }
+p521 = { version = "0.13", features = [
+  "arithmetic",
+  "ecdh",
 ], optional = true }
 # JOSE content-encryption / key-wrap primitives (`jose` feature).
 aes = { version = "0.8", optional = true }

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -164,7 +164,13 @@ fn ecdh_1pu_x25519_kek_golden() {
 
 #[test]
 fn ecdh_es_roundtrip_all_curves() {
-    for curve in [Curve::X25519, Curve::P256, Curve::K256] {
+    for curve in [
+        Curve::X25519,
+        Curve::P256,
+        Curve::K256,
+        Curve::P384,
+        Curve::P521,
+    ] {
         let recip = PrivateKeyAgreement::generate(curve);
         let eph = PrivateKeyAgreement::generate(curve);
         let s = derive_key_es(
@@ -191,8 +197,56 @@ fn ecdh_es_roundtrip_all_curves() {
 }
 
 #[test]
+fn ecdh_1pu_roundtrip_all_curves() {
+    // ECDH-1PU (authcrypt) sender/recipient KEK agreement across every
+    // supported key-agreement curve, including the newly-added P-384/P-521.
+    let cc_tag = [0xABu8; 32];
+    for curve in [
+        Curve::X25519,
+        Curve::P256,
+        Curve::K256,
+        Curve::P384,
+        Curve::P521,
+    ] {
+        let sender = PrivateKeyAgreement::generate(curve);
+        let recip = PrivateKeyAgreement::generate(curve);
+        let eph = PrivateKeyAgreement::generate(curve);
+        let s = derive_key_1pu(
+            &eph,
+            &sender,
+            &recip.public_key(),
+            b"ECDH-1PU+A256KW",
+            b"alice",
+            b"bob",
+            &cc_tag,
+            256,
+        )
+        .unwrap();
+        let r = derive_key_1pu_recipient(
+            &recip,
+            &sender.public_key(),
+            &eph.public_key(),
+            b"ECDH-1PU+A256KW",
+            b"alice",
+            b"bob",
+            &cc_tag,
+            256,
+        )
+        .unwrap();
+        assert_eq!(s, r, "ECDH-1PU KEK must agree for {curve:?}");
+        assert_eq!(s.len(), 32);
+    }
+}
+
+#[test]
 fn public_key_jwk_roundtrip_all_curves() {
-    for curve in [Curve::X25519, Curve::P256, Curve::K256] {
+    for curve in [
+        Curve::X25519,
+        Curve::P256,
+        Curve::K256,
+        Curve::P384,
+        Curve::P521,
+    ] {
         let pk = PrivateKeyAgreement::generate(curve).public_key();
         let jwk = pk.to_jwk();
         let parsed = PublicKeyAgreement::from_jwk(&jwk).unwrap();

--- a/crates/core/affinidi-crypto/src/jose/key_agreement.rs
+++ b/crates/core/affinidi-crypto/src/jose/key_agreement.rs
@@ -18,11 +18,18 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::error::CryptoError;
 
 /// Supported key-agreement curves (JOSE `crv` identifiers).
+// `#[non_exhaustive]`: adding a new key-agreement curve must be a
+// non-breaking change for downstream crates, so external matches always
+// carry a wildcard arm. The break for this attribute was taken once, in the
+// 0.2.0 release that introduced P-384/P-521.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Curve {
     X25519,
     P256,
     K256,
+    P384,
+    P521,
 }
 
 impl Curve {
@@ -32,16 +39,21 @@ impl Curve {
             Curve::X25519 => "X25519",
             Curve::P256 => "P-256",
             Curve::K256 => "secp256k1",
+            Curve::P384 => "P-384",
+            Curve::P521 => "P-521",
         }
     }
 }
 
 /// A public key for key agreement (any supported curve).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum PublicKeyAgreement {
     X25519([u8; 32]),
     P256(p256::PublicKey),
     K256(k256::PublicKey),
+    P384(p384::PublicKey),
+    P521(p521::PublicKey),
 }
 
 impl PublicKeyAgreement {
@@ -51,6 +63,8 @@ impl PublicKeyAgreement {
             PublicKeyAgreement::X25519(_) => Curve::X25519,
             PublicKeyAgreement::P256(_) => Curve::P256,
             PublicKeyAgreement::K256(_) => Curve::K256,
+            PublicKeyAgreement::P384(_) => Curve::P384,
+            PublicKeyAgreement::P521(_) => Curve::P521,
         }
     }
 
@@ -82,6 +96,52 @@ impl PublicKeyAgreement {
                     "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
                 })
             }
+            PublicKeyAgreement::P384(pk) => {
+                use p384::elliptic_curve::sec1::ToEncodedPoint;
+                let point = pk.to_encoded_point(false);
+                serde_json::json!({
+                    "kty": "EC",
+                    "crv": "P-384",
+                    "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+                })
+            }
+            PublicKeyAgreement::P521(pk) => {
+                use p521::elliptic_curve::sec1::ToEncodedPoint;
+                let point = pk.to_encoded_point(false);
+                serde_json::json!({
+                    "kty": "EC",
+                    "crv": "P-521",
+                    "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+                })
+            }
+        }
+    }
+
+    /// Raw public-key bytes for storage/transport: the 32-byte key for
+    /// X25519, or the **compressed** SEC1 point for the EC curves. Curve
+    /// dispatch lives here (alongside every other curve arm) so callers do
+    /// not match on the enum themselves.
+    pub fn to_public_bytes(&self) -> Vec<u8> {
+        match self {
+            PublicKeyAgreement::X25519(bytes) => bytes.to_vec(),
+            PublicKeyAgreement::P256(pk) => {
+                use p256::elliptic_curve::sec1::ToEncodedPoint;
+                pk.to_encoded_point(true).as_bytes().to_vec()
+            }
+            PublicKeyAgreement::K256(pk) => {
+                use k256::elliptic_curve::sec1::ToEncodedPoint;
+                pk.to_encoded_point(true).as_bytes().to_vec()
+            }
+            PublicKeyAgreement::P384(pk) => {
+                use p384::elliptic_curve::sec1::ToEncodedPoint;
+                pk.to_encoded_point(true).as_bytes().to_vec()
+            }
+            PublicKeyAgreement::P521(pk) => {
+                use p521::elliptic_curve::sec1::ToEncodedPoint;
+                pk.to_encoded_point(true).as_bytes().to_vec()
+            }
         }
     }
 
@@ -108,6 +168,18 @@ impl PublicKeyAgreement {
                     CryptoError::KeyAgreement(format!("invalid K-256 public key: {e}"))
                 })?;
                 Ok(PublicKeyAgreement::K256(pk))
+            }
+            Curve::P384 => {
+                let pk = p384::PublicKey::from_sec1_bytes(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-384 public key: {e}"))
+                })?;
+                Ok(PublicKeyAgreement::P384(pk))
+            }
+            Curve::P521 => {
+                let pk = p521::PublicKey::from_sec1_bytes(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-521 public key: {e}"))
+                })?;
+                Ok(PublicKeyAgreement::P521(pk))
             }
         }
     }
@@ -143,6 +215,18 @@ impl PublicKeyAgreement {
                     .map_err(|e| CryptoError::KeyAgreement(format!("invalid K-256 key: {e}")))?;
                 Ok(PublicKeyAgreement::K256(pk))
             }
+            "P-384" => {
+                let point = ec_point_from_jwk(jwk)?;
+                let pk = p384::PublicKey::from_sec1_bytes(&point)
+                    .map_err(|e| CryptoError::KeyAgreement(format!("invalid P-384 key: {e}")))?;
+                Ok(PublicKeyAgreement::P384(pk))
+            }
+            "P-521" => {
+                let point = ec_point_from_jwk(jwk)?;
+                let pk = p521::PublicKey::from_sec1_bytes(&point)
+                    .map_err(|e| CryptoError::KeyAgreement(format!("invalid P-521 key: {e}")))?;
+                Ok(PublicKeyAgreement::P521(pk))
+            }
             other => Err(CryptoError::UnsupportedKeyType(format!(
                 "unsupported key-agreement curve: {other}"
             ))),
@@ -173,10 +257,13 @@ fn ec_point_from_jwk(jwk: &Value) -> Result<Vec<u8>, CryptoError> {
 
 /// A private key for key agreement (any supported curve).
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub enum PrivateKeyAgreement {
     X25519(#[zeroize(skip)] x25519_dalek::StaticSecret),
     P256(#[zeroize(skip)] p256::SecretKey),
     K256(#[zeroize(skip)] k256::SecretKey),
+    P384(#[zeroize(skip)] p384::SecretKey),
+    P521(#[zeroize(skip)] p521::SecretKey),
 }
 
 impl std::fmt::Debug for PrivateKeyAgreement {
@@ -185,6 +272,8 @@ impl std::fmt::Debug for PrivateKeyAgreement {
             PrivateKeyAgreement::X25519(_) => write!(f, "PrivateKeyAgreement::X25519([REDACTED])"),
             PrivateKeyAgreement::P256(_) => write!(f, "PrivateKeyAgreement::P256([REDACTED])"),
             PrivateKeyAgreement::K256(_) => write!(f, "PrivateKeyAgreement::K256([REDACTED])"),
+            PrivateKeyAgreement::P384(_) => write!(f, "PrivateKeyAgreement::P384([REDACTED])"),
+            PrivateKeyAgreement::P521(_) => write!(f, "PrivateKeyAgreement::P521([REDACTED])"),
         }
     }
 }
@@ -216,6 +305,18 @@ impl PrivateKeyAgreement {
                 })?;
                 Ok(PrivateKeyAgreement::K256(sk))
             }
+            Curve::P384 => {
+                let sk = p384::SecretKey::from_slice(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-384 private key: {e}"))
+                })?;
+                Ok(PrivateKeyAgreement::P384(sk))
+            }
+            Curve::P521 => {
+                let sk = p521::SecretKey::from_slice(bytes).map_err(|e| {
+                    CryptoError::KeyAgreement(format!("invalid P-521 private key: {e}"))
+                })?;
+                Ok(PrivateKeyAgreement::P521(sk))
+            }
         }
     }
 
@@ -227,6 +328,8 @@ impl PrivateKeyAgreement {
             }
             Curve::P256 => PrivateKeyAgreement::P256(p256::SecretKey::random(&mut OsRng)),
             Curve::K256 => PrivateKeyAgreement::K256(k256::SecretKey::random(&mut OsRng)),
+            Curve::P384 => PrivateKeyAgreement::P384(p384::SecretKey::random(&mut OsRng)),
+            Curve::P521 => PrivateKeyAgreement::P521(p521::SecretKey::random(&mut OsRng)),
         }
     }
 
@@ -238,6 +341,8 @@ impl PrivateKeyAgreement {
             }
             PrivateKeyAgreement::P256(sk) => PublicKeyAgreement::P256(sk.public_key()),
             PrivateKeyAgreement::K256(sk) => PublicKeyAgreement::K256(sk.public_key()),
+            PrivateKeyAgreement::P384(sk) => PublicKeyAgreement::P384(sk.public_key()),
+            PrivateKeyAgreement::P521(sk) => PublicKeyAgreement::P521(sk.public_key()),
         }
     }
 
@@ -247,6 +352,8 @@ impl PrivateKeyAgreement {
             PrivateKeyAgreement::X25519(_) => Curve::X25519,
             PrivateKeyAgreement::P256(_) => Curve::P256,
             PrivateKeyAgreement::K256(_) => Curve::K256,
+            PrivateKeyAgreement::P384(_) => Curve::P384,
+            PrivateKeyAgreement::P521(_) => Curve::P521,
         }
     }
 
@@ -267,6 +374,16 @@ impl PrivateKeyAgreement {
             }
             (PrivateKeyAgreement::K256(sk), PublicKeyAgreement::K256(pk)) => {
                 use k256::ecdh::diffie_hellman;
+                let shared = diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+                Ok(shared.raw_secret_bytes().to_vec())
+            }
+            (PrivateKeyAgreement::P384(sk), PublicKeyAgreement::P384(pk)) => {
+                use p384::ecdh::diffie_hellman;
+                let shared = diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+                Ok(shared.raw_secret_bytes().to_vec())
+            }
+            (PrivateKeyAgreement::P521(sk), PublicKeyAgreement::P521(pk)) => {
+                use p521::ecdh::diffie_hellman;
                 let shared = diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
                 Ok(shared.raw_secret_bytes().to_vec())
             }

--- a/crates/core/affinidi-crypto/src/jwk.rs
+++ b/crates/core/affinidi-crypto/src/jwk.rs
@@ -1,6 +1,8 @@
 //! JWK (JSON Web Key) types per RFC 7517
 
-use affinidi_encoding::{ED25519_PUB, MultiEncoded, P256_PUB, P384_PUB, SECP256K1_PUB, X25519_PUB};
+use affinidi_encoding::{
+    ED25519_PUB, MultiEncoded, P256_PUB, P384_PUB, P521_PUB, SECP256K1_PUB, X25519_PUB,
+};
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -24,6 +26,7 @@ impl JWK {
                 "P-256" => KeyType::P256,
                 "secp256k1" => KeyType::Secp256k1,
                 "P-384" => KeyType::P384,
+                "P-521" => KeyType::P521,
                 _ => KeyType::Unknown,
             },
             Params::OKP(params) => match params.curve.as_str() {
@@ -48,6 +51,8 @@ impl JWK {
             P256_PUB => crate::p256::public_jwk(decoded.data()),
             #[cfg(feature = "p384")]
             P384_PUB => crate::p384::public_jwk(decoded.data()),
+            #[cfg(feature = "p521")]
+            P521_PUB => crate::p521::public_jwk(decoded.data()),
             #[cfg(feature = "k256")]
             SECP256K1_PUB => crate::secp256k1::public_jwk(decoded.data()),
             #[cfg(feature = "ed25519")]

--- a/crates/core/affinidi-crypto/src/lib.rs
+++ b/crates/core/affinidi-crypto/src/lib.rs
@@ -33,6 +33,9 @@ pub mod secp256k1;
 #[cfg(feature = "p384")]
 pub mod p384;
 
+#[cfg(feature = "p521")]
+pub mod p521;
+
 #[cfg(feature = "jose")]
 pub mod jose;
 

--- a/crates/core/affinidi-crypto/src/p521.rs
+++ b/crates/core/affinidi-crypto/src/p521.rs
@@ -1,0 +1,139 @@
+//! P-521 (secp521r1) key operations
+//!
+//! Mirrors the [`crate::p384`] module but is built on `SecretKey` rather than
+//! the ECDSA `SigningKey`, so it needs only the `arithmetic` feature of the
+//! `p521` crate (P-521 key agreement, not signing, is what this stack uses).
+
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use p521::{
+    AffinePoint, EncodedPoint, SecretKey,
+    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+};
+use rand_core::OsRng;
+
+use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
+
+/// Generated key pair with raw bytes and JWK representation
+#[derive(Debug, Clone)]
+pub struct KeyPair {
+    pub key_type: KeyType,
+    pub private_bytes: Vec<u8>,
+    pub public_bytes: Vec<u8>,
+    pub jwk: JWK,
+}
+
+/// Generates a random P-521 key pair using the OS RNG.
+///
+/// This is the infallible counterpart to [`generate`] when no seed is needed.
+pub fn generate_random() -> KeyPair {
+    generate(None).expect("generate(None) is infallible")
+}
+
+/// Generates a P-521 key pair
+pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
+    let secret_key = match secret {
+        Some(secret) => SecretKey::from_slice(secret).map_err(|e| {
+            CryptoError::KeyError(format!("P-521 secret material isn't valid: {e}"))
+        })?,
+        None => SecretKey::random(&mut OsRng),
+    };
+
+    let public_key = secret_key.public_key();
+    let private_bytes = secret_key.to_bytes().to_vec();
+    let ep = public_key.to_encoded_point(false);
+    let public_bytes = ep.as_bytes().to_vec();
+
+    Ok(KeyPair {
+        key_type: KeyType::P521,
+        private_bytes: private_bytes.clone(),
+        public_bytes,
+        jwk: JWK {
+            key_id: None,
+            params: Params::EC(ECParams {
+                curve: "P-521".to_string(),
+                x: BASE64_URL_SAFE_NO_PAD.encode(
+                    ep.x()
+                        .ok_or_else(|| CryptoError::KeyError("Couldn't get X coordinate".into()))?
+                        .as_slice(),
+                ),
+                y: BASE64_URL_SAFE_NO_PAD.encode(
+                    ep.y()
+                        .ok_or_else(|| CryptoError::KeyError("Couldn't get Y coordinate".into()))?
+                        .as_slice(),
+                ),
+                d: Some(BASE64_URL_SAFE_NO_PAD.encode(&private_bytes)),
+            }),
+        },
+    })
+}
+
+/// Generates a public JWK from P-521 raw bytes (compressed or uncompressed)
+pub fn public_jwk(data: &[u8]) -> Result<JWK> {
+    let ep = EncodedPoint::from_bytes(data)
+        .map_err(|e| CryptoError::KeyError(format!("P-521 public key isn't valid: {e}")))?;
+
+    // Convert to AffinePoint to validate the point is on the curve
+    let ap: AffinePoint = AffinePoint::from_encoded_point(&ep)
+        .into_option()
+        .ok_or_else(|| {
+            CryptoError::KeyError("Couldn't convert P-521 EncodedPoint to AffinePoint".into())
+        })?;
+
+    // Decompress to get x and y coordinates
+    let ep = ap.to_encoded_point(false);
+
+    Ok(JWK {
+        key_id: None,
+        params: Params::EC(ECParams {
+            curve: "P-521".to_string(),
+            x: BASE64_URL_SAFE_NO_PAD.encode(
+                ep.x()
+                    .ok_or_else(|| CryptoError::KeyError("Couldn't get X coordinate".into()))?
+                    .as_slice(),
+            ),
+            y: BASE64_URL_SAFE_NO_PAD.encode(
+                ep.y()
+                    .ok_or_else(|| CryptoError::KeyError("Couldn't get Y coordinate".into()))?
+                    .as_slice(),
+            ),
+            d: None,
+        }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_roundtrips_through_secret() {
+        // Generate, then reload from the private bytes — the derived public
+        // coordinates must match (proves load + public derivation agree).
+        let kp = generate_random();
+        let reloaded = generate(Some(&kp.private_bytes)).unwrap();
+        assert_eq!(reloaded.public_bytes, kp.public_bytes);
+        assert_eq!(reloaded.private_bytes, kp.private_bytes);
+        // P-521 uncompressed SEC1 point: 0x04 || x(66) || y(66) = 133 bytes.
+        assert_eq!(kp.public_bytes.len(), 133);
+        assert_eq!(kp.private_bytes.len(), 66);
+        match &kp.jwk.params {
+            Params::EC(p) => assert_eq!(p.curve, "P-521"),
+            _ => panic!("expected EC params"),
+        }
+    }
+
+    #[test]
+    fn public_jwk_from_uncompressed() {
+        let kp = generate_random();
+        let jwk = public_jwk(&kp.public_bytes).unwrap();
+        match (&jwk.params, &kp.jwk.params) {
+            (Params::EC(got), Params::EC(want)) => {
+                assert_eq!(got.curve, "P-521");
+                assert_eq!(got.x, want.x);
+                assert_eq!(got.y, want.y);
+                assert!(got.d.is_none());
+            }
+            _ => panic!("expected EC params"),
+        }
+    }
+}

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi Secrets Manager
 
+## 6th June 2026 (0.5.7)
+
+- **Full P-521 secret support (#357).** Added `Secret::generate_p521`
+  (load/generate P-521 key-agreement secrets) and wired P-521 into
+  `from_multibase` decoding (`P521_PRIV`) — previously a P-521 private key
+  could be *written* but not *loaded*. Also unblocked P-521 public-key
+  multibase encoding, which had been hard-erroring with "P-521 is not
+  supported". This lets a sender/recipient actually use a P-521
+  key-agreement key end-to-end. New `p521` feature (on by default).
+
 ## 28th May 2026 (0.5.6)
 
 - **SECURITY (HIGH):** Redact private key material in `Debug` output for

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,10 +13,11 @@ publish.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["p256", "k256", "p384", "ed25519"]
+default = ["p256", "k256", "p384", "p521", "ed25519"]
 p256 = ["affinidi-crypto/p256"]
 k256 = ["affinidi-crypto/k256"]
 p384 = ["affinidi-crypto/p384"]
+p521 = ["affinidi-crypto/p521"]
 ed25519 = ["affinidi-crypto/ed25519"]
 # Post-quantum cryptography (experimental). Off by default.
 post-quantum = ["ml-dsa", "slh-dsa"]
@@ -24,7 +25,7 @@ ml-dsa = ["affinidi-crypto/ml-dsa"]
 slh-dsa = ["affinidi-crypto/slh-dsa"]
 
 [dependencies]
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 affinidi-encoding = "0.1"
 ahash = "0.8"
 base58 = "0.2"

--- a/crates/core/affinidi-secrets-resolver/src/crypto/mod.rs
+++ b/crates/core/affinidi-secrets-resolver/src/crypto/mod.rs
@@ -15,6 +15,9 @@ pub mod secp256k1;
 #[cfg(feature = "p384")]
 pub mod p384;
 
+#[cfg(feature = "p521")]
+pub mod p521;
+
 #[cfg(feature = "ml-dsa")]
 pub mod ml_dsa;
 

--- a/crates/core/affinidi-secrets-resolver/src/crypto/p521.rs
+++ b/crates/core/affinidi-secrets-resolver/src/crypto/p521.rs
@@ -1,0 +1,66 @@
+use affinidi_crypto::KeyType;
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use rand::{TryRng, rngs::SysRng};
+
+use crate::{
+    errors::SecretsResolverError,
+    secrets::{Secret, SecretMaterial, SecretType},
+};
+
+impl Secret {
+    /// Creates a P-521 key pair
+    /// kid: Key ID, if none specified then a random value is assigned
+    /// secret: Generate from secret bytes if known, otherwise random key is generated
+    pub fn generate_p521(
+        kid: Option<&str>,
+        secret: Option<&[u8]>,
+    ) -> Result<Self, SecretsResolverError> {
+        let keypair = affinidi_crypto::p521::generate(secret)?;
+
+        let kid = kid.map(|k| k.to_string()).unwrap_or_else(|| {
+            BASE64_URL_SAFE_NO_PAD.encode(SysRng.try_next_u64().unwrap().to_ne_bytes())
+        });
+
+        Ok(Secret {
+            id: kid,
+            type_: SecretType::JsonWebKey2020,
+            secret_material: SecretMaterial::JWK(keypair.jwk.clone()),
+            private_bytes: keypair.private_bytes,
+            public_bytes: keypair.public_bytes,
+            key_type: KeyType::P521,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use affinidi_crypto::Params;
+
+    use crate::secrets::{Secret, SecretMaterial};
+
+    #[test]
+    fn check_p521_roundtrip() {
+        // Generate, reload from the private bytes, and confirm the JWK and raw
+        // bytes are stable (proves load + public-key derivation agree).
+        let first =
+            Secret::generate_p521(Some("did:web:example#p521"), None).expect("generate P-521");
+        let reloaded =
+            Secret::generate_p521(Some("did:web:example#p521"), Some(&first.private_bytes))
+                .expect("reload P-521");
+
+        assert_eq!(reloaded.private_bytes, first.private_bytes);
+        assert_eq!(reloaded.public_bytes, first.public_bytes);
+        // P-521 raw private scalar is 66 bytes; uncompressed point is 133.
+        assert_eq!(first.private_bytes.len(), 66);
+        assert_eq!(first.public_bytes.len(), 133);
+
+        if let SecretMaterial::JWK(jwk) = &reloaded.secret_material
+            && let Params::EC(params) = &jwk.params
+        {
+            assert_eq!(params.curve, "P-521");
+            assert!(params.d.is_some(), "private key material present");
+        } else {
+            panic!("expected EC JWK secret material");
+        }
+    }
+}

--- a/crates/core/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/core/affinidi-secrets-resolver/src/secrets.rs
@@ -14,7 +14,7 @@ use crate::{
     errors::{Result, SecretsResolverError},
     multicodec::{
         ED25519_PRIV, ED25519_PUB, MultiEncoded, MultiEncodedBuf, P256_PRIV, P256_PUB, P384_PRIV,
-        P384_PUB, P521_PRIV, SECP256K1_PRIV, SECP256K1_PUB, X25519_PRIV, X25519_PUB,
+        P384_PUB, P521_PRIV, P521_PUB, SECP256K1_PRIV, SECP256K1_PUB, X25519_PRIV, X25519_PUB,
     },
 };
 pub use affinidi_crypto::KeyType;
@@ -250,6 +250,7 @@ impl Secret {
                 Secret::generate_p256(kid, Some(private_bytes.data()))
             }
             P384_PRIV => Secret::generate_p384(kid, Some(private_bytes.data())),
+            P521_PRIV => Secret::generate_p521(kid, Some(private_bytes.data())),
             SECP256K1_PRIV => Secret::generate_secp256k1(kid, Some(private_bytes.data())),
             #[cfg(feature = "ml-dsa")]
             ML_DSA_44_PRIV_SEED => {
@@ -314,11 +315,7 @@ impl Secret {
             KeyType::X25519 => MultiEncodedBuf::encode_bytes(X25519_PUB, &self.public_bytes),
             KeyType::P256 => compress_ec_point(&self.public_bytes, 33, P256_PUB)?,
             KeyType::P384 => compress_ec_point(&self.public_bytes, 49, P384_PUB)?,
-            KeyType::P521 => {
-                return Err(SecretsResolverError::KeyError(
-                    "P-521 is not supported".to_string(),
-                ));
-            }
+            KeyType::P521 => compress_ec_point(&self.public_bytes, 67, P521_PUB)?,
             KeyType::Secp256k1 => compress_ec_point(&self.public_bytes, 33, SECP256K1_PUB)?,
             #[cfg(feature = "ml-dsa")]
             KeyType::MlDsa44 => MultiEncodedBuf::encode_bytes(ML_DSA_44_PUB, &self.public_bytes),

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -23,6 +23,9 @@ ADR 0002.
   signature/proof wire format is now IETF-compliant (`draft-irtf-cfrg-bbs-signatures`)
   and is **not** compatible with the previous, self-consistent format. No BBS
   credentials had been issued in production.
+- Bumped `affinidi-crypto` to `0.2` (P-384/P-521 key agreement +
+  `#[non_exhaustive]` key-agreement enums, #357). No API change in this crate
+  from that bump.
 
 ### Notes
 

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -22,7 +22,7 @@ ml-dsa = ["affinidi-crypto/ml-dsa", "affinidi-secrets-resolver/ml-dsa"]
 slh-dsa = ["affinidi-crypto/slh-dsa", "affinidi-secrets-resolver/slh-dsa"]
 
 [dependencies]
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 affinidi-rdf-encoding = { version = "0.1", path = "../affinidi-rdf-encoding" }
 affinidi-secrets-resolver = "0.5"
 affinidi-did-common = "0.3"

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Affinidi DID Authentication
 
+## 6th June 2026 (0.3.6)
+
+- Robust sender/recipient key-agreement negotiation (#357). The authcrypt
+  pack path now enumerates *all* of the sender's usable key-agreement keys
+  and negotiates the best shared curve with the recipient by a documented
+  preference order (`X25519 > P-256 > secp256k1`), instead of deriving the
+  curve from the sender's *first* key only. A sender whose first KA curve
+  has no recipient match but whose second does now packs successfully, and a
+  no-common-curve failure names the curve set each side offered. The
+  negotiation + key-resolution logic moved into `affinidi-did-common`'s new
+  `key_negotiation` module (enabled via its `key-agreement` feature),
+  removing the helpers that were duplicated between this crate and the
+  messaging SDK. The sender key-type → curve mapping now also covers the
+  newly-supported P-384 and P-521 key-agreement curves (#357).
+
 ## 1st June 2026 (0.3.5)
 
 - Release on `affinidi-messaging-didcomm` 0.15 (#327). The authcrypt

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,10 +13,10 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-affinidi-crypto = { version = "0.1", features = ["jose"] }
+affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-resolver-cache-sdk = "0.8"
-affinidi-did-common = "0.3"
+affinidi-did-common = { version = "0.3", features = ["key-agreement"] }
 affinidi-secrets-resolver = "0.5"
 affinidi-encoding = "0.1"
 

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -14,9 +14,11 @@
  * This needs to be refactored in the future when the services align on implementation
  */
 
-use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
+use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement};
 use affinidi_did_common::{
-    Document, document::DocumentExt, verification_method::VerificationRelationship,
+    Document,
+    document::DocumentExt,
+    key_negotiation::{DEFAULT_CURVE_PREFERENCE, negotiate_authcrypt},
 };
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_didcomm::message::{Message, pack};
@@ -702,101 +704,67 @@ async fn _pack_encrypted_for_did<S>(
 where
     S: SecretsResolver,
 {
-    // 1. Resolve sender DID and get their key agreement key + curve
+    // 1. Resolve the sender DID and enumerate its *usable* key-agreement
+    //    keys — those we hold a secret for, on a supported curve.
+    //    Bidirectional negotiation needs the whole set (sender curve order
+    //    is irrelevant; selection follows the documented curve preference),
+    //    not just `first()`.
     let sender_doc = did_resolver
         .resolve(sender_did)
         .await
         .map_err(|e| DIDAuthError::DIDResolver(format!("{e}")))?;
     let sender_ka_kids = sender_doc.doc.find_key_agreement(None);
-    let sender_kid = sender_ka_kids
-        .first()
-        .ok_or_else(|| DIDAuthError::DIDComm("sender has no key agreement key".into()))?;
 
-    let sender_secret = secrets_resolver
-        .get_secret(sender_kid.as_ref())
-        .await
-        .ok_or_else(|| DIDAuthError::Secrets(format!("no secret found for {sender_kid}")))?;
+    let mut sender_keys: Vec<(&str, PrivateKeyAgreement, Curve)> = Vec::new();
+    for &kid in &sender_ka_kids {
+        let Some(secret) = secrets_resolver.get_secret(kid).await else {
+            continue;
+        };
+        let Ok(curve) = _key_type_to_curve(secret.get_key_type()) else {
+            continue;
+        };
+        match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
+            Ok(private) => sender_keys.push((kid, private, curve)),
+            Err(e) => debug!("skipping unusable sender key {kid}: {e}"),
+        }
+    }
+    if sender_keys.is_empty() {
+        return Err(DIDAuthError::DIDComm(
+            "sender has no usable key agreement key".into(),
+        ));
+    }
+    let sender_curves: Vec<Curve> = sender_keys.iter().map(|(_, _, c)| *c).collect();
 
-    let sender_curve = _key_type_to_curve(sender_secret.get_key_type())?;
-    let sender_private =
-        PrivateKeyAgreement::from_raw_bytes(sender_curve, sender_secret.get_private_bytes())
-            .map_err(|e| DIDAuthError::DIDComm(format!("invalid sender private key: {e}")))?;
-
-    // 2. Resolve recipient DID and find a key agreement key on the same curve
+    // 2. Resolve the recipient DID and negotiate the best shared-curve pair.
     let recipient_doc = did_resolver
         .resolve(recipient_did)
         .await
         .map_err(|e| DIDAuthError::DIDResolver(format!("{e}")))?;
     let recipient_ka_kids = recipient_doc.doc.find_key_agreement(None);
 
-    let (recipient_kid, recipient_pub) =
-        _find_matching_recipient_key(&recipient_doc.doc, &recipient_ka_kids, sender_curve)?;
+    let pairing = negotiate_authcrypt(
+        &sender_curves,
+        &recipient_doc.doc,
+        &recipient_ka_kids,
+        &DEFAULT_CURVE_PREFERENCE,
+    )
+    .map_err(|e| DIDAuthError::DIDComm(e.to_string()))?;
 
-    // 3. Pack with authcrypt
+    // The negotiated curve was drawn from `sender_curves`, so a matching
+    // sender key is guaranteed present.
+    let (sender_kid, sender_private, _) = sender_keys
+        .iter()
+        .find(|(_, _, c)| *c == pairing.curve)
+        .expect("negotiated curve came from sender_curves");
+
+    // 3. Pack with authcrypt.
     pack::pack_encrypted_authcrypt(
         msg,
         sender_kid,
-        &sender_private,
-        &[(recipient_kid, &recipient_pub)],
+        sender_private,
+        &[(pairing.recipient_kid, &pairing.recipient_pub)],
     )
     .map_err(|e| DIDAuthError::DIDComm(format!("pack failed: {e}")))
-}
-
-/// Find the first recipient key agreement key whose curve matches the sender's.
-fn _find_matching_recipient_key<'a>(
-    doc: &Document,
-    ka_kids: &'a [&'a str],
-    sender_curve: affinidi_crypto::jose::key_agreement::Curve,
-) -> Result<(&'a str, PublicKeyAgreement)> {
-    for kid in ka_kids {
-        if let Ok(pub_key) = _resolve_public_key_agreement(doc, kid)
-            && pub_key.curve() == sender_curve
-        {
-            return Ok((kid, pub_key));
-        }
-    }
-    Err(DIDAuthError::DIDComm(format!(
-        "recipient has no key agreement key on curve {sender_curve:?}"
-    )))
-}
-
-/// Extract a PublicKeyAgreement from a DID Document's verification method.
-fn _resolve_public_key_agreement(doc: &Document, kid: &str) -> Result<PublicKeyAgreement> {
-    // Find the verification method — check embedded in key_agreement first, then top-level
-    let vm = doc
-        .key_agreement
-        .iter()
-        .filter_map(|ka| match ka {
-            VerificationRelationship::VerificationMethod(vm) if vm.id.as_str() == kid => {
-                Some(vm.as_ref())
-            }
-            _ => None,
-        })
-        .next()
-        .or_else(|| doc.get_verification_method(kid))
-        .ok_or_else(|| DIDAuthError::DIDComm(format!("verification method not found: {kid}")))?;
-
-    // Decode the verification material (publicKeyJwk or
-    // publicKeyMultibase) via the shared `affinidi-did-common` decoder —
-    // one parser for the whole stack — then map the multicodec onto a
-    // key-agreement curve.
-    let (codec, key_bytes) = vm
-        .decode_public_key()
-        .map_err(|e| DIDAuthError::DIDComm(format!("invalid verification material: {e}")))?;
-
-    let curve = match codec {
-        affinidi_encoding::X25519_PUB => Curve::X25519,
-        affinidi_encoding::P256_PUB => Curve::P256,
-        affinidi_encoding::SECP256K1_PUB => Curve::K256,
-        _ => {
-            return Err(DIDAuthError::DIDComm(format!(
-                "unsupported multicodec for key agreement: 0x{codec:x}"
-            )));
-        }
-    };
-
-    PublicKeyAgreement::from_raw_bytes(curve, &key_bytes)
-        .map_err(|e| DIDAuthError::DIDComm(format!("invalid key bytes: {e}")))
 }
 
 /// Map from secrets resolver KeyType to DIDComm Curve.
@@ -805,6 +773,8 @@ fn _key_type_to_curve(key_type: affinidi_secrets_resolver::secrets::KeyType) -> 
         affinidi_secrets_resolver::secrets::KeyType::X25519 => Ok(Curve::X25519),
         affinidi_secrets_resolver::secrets::KeyType::P256 => Ok(Curve::P256),
         affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Ok(Curve::K256),
+        affinidi_secrets_resolver::secrets::KeyType::P384 => Ok(Curve::P384),
+        affinidi_secrets_resolver::secrets::KeyType::P521 => Ok(Curve::P521),
         other => Err(DIDAuthError::DIDComm(format!(
             "unsupported key type for key agreement: {other:?}"
         ))),
@@ -904,60 +874,57 @@ mod tests {
         assert_eq!(refresh_check(&tokens), RefreshCheck::Expired);
     }
 
+    // Boundary smoke test: this crate now delegates curve negotiation to
+    // `affinidi-did-common::key_negotiation` (exhaustively tested there).
+    // Here we confirm the wiring compiles and behaves for the real
+    // curve-mismatch bug — recipient [Ed25519(undecodable), P-256, X25519],
+    // X25519 sender → skip the first two and pick X25519 — plus the
+    // both-sets-named failure message.
     #[test]
-    fn find_matching_recipient_key_selects_correct_curve() {
-        use affinidi_crypto::jose::key_agreement::Curve;
-        use affinidi_did_common::Document;
+    fn authcrypt_negotiation_at_call_site() {
+        use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement};
+        use affinidi_did_common::{
+            Document,
+            key_negotiation::{DEFAULT_CURVE_PREFERENCE, negotiate_authcrypt},
+        };
 
-        // 32 random bytes as X25519 public key
-        let x25519_pub_bytes = [7u8; 32];
-        let x25519_multibase =
-            affinidi_encoding::encode_multikey(affinidi_encoding::X25519_PUB, &x25519_pub_bytes);
-
-        // Use Ed25519 multibase for a non-X25519 key (will fail decode as
-        // key-agreement, simulating a curve the function can't use)
-        let ed_pub_bytes = [9u8; 32];
-        let ed_multibase =
-            affinidi_encoding::encode_multikey(affinidi_encoding::ED25519_PUB, &ed_pub_bytes);
-
-        let ed_kid = "did:web:example#key-2";
-        let x25519_kid = "did:web:example#key-5";
-
-        // Build doc: first keyAgreement is Ed25519 (unsupported for KA), second is X25519
-        let doc_json = serde_json::json!({
-            "id": "did:web:example",
-            "verificationMethod": [
-                {
-                    "id": ed_kid,
-                    "type": "Multikey",
-                    "controller": "did:web:example",
-                    "publicKeyMultibase": ed_multibase
-                },
-                {
-                    "id": x25519_kid,
-                    "type": "Multikey",
-                    "controller": "did:web:example",
-                    "publicKeyMultibase": x25519_multibase
-                }
-            ],
-            "keyAgreement": [ed_kid, x25519_kid]
+        let ka_jwk = |kid: &str, curve: Curve| {
+            serde_json::json!({
+                "id": kid,
+                "type": "JsonWebKey2020",
+                "controller": "did:web:example",
+                "publicKeyJwk": PrivateKeyAgreement::generate(curve).public_key().to_jwk(),
+            })
+        };
+        let ed_kid = "did:web:example#ed";
+        let p256_kid = "did:web:example#p256";
+        let x_kid = "did:web:example#x";
+        // Ed25519 signing key wrongly listed under keyAgreement (undecodable
+        // as a KA curve) — exercises the codec-skip path via multibase.
+        let ed_vm = serde_json::json!({
+            "id": ed_kid,
+            "type": "Multikey",
+            "controller": "did:web:example",
+            "publicKeyMultibase":
+                affinidi_encoding::encode_multikey(affinidi_encoding::ED25519_PUB, &[9u8; 32]),
         });
-        let doc: Document = serde_json::from_value(doc_json).unwrap();
+        let doc: Document = serde_json::from_value(serde_json::json!({
+            "id": "did:web:example",
+            "verificationMethod": [ed_vm, ka_jwk(p256_kid, Curve::P256), ka_jwk(x_kid, Curve::X25519)],
+            "keyAgreement": [ed_kid, p256_kid, x_kid],
+        }))
+        .unwrap();
+        let kids = [ed_kid, p256_kid, x_kid];
 
-        let ka_kids: Vec<&str> = vec![ed_kid, x25519_kid];
+        let m =
+            negotiate_authcrypt(&[Curve::X25519], &doc, &kids, &DEFAULT_CURVE_PREFERENCE).unwrap();
+        assert_eq!(m.recipient_kid, x_kid);
+        assert_eq!(m.curve, Curve::X25519);
 
-        // X25519 sender should skip #key-2 (Ed25519, unsupported codec for KA)
-        // and match #key-5
-        let (kid, pub_key) =
-            super::_find_matching_recipient_key(&doc, &ka_kids, Curve::X25519).unwrap();
-        assert_eq!(kid, x25519_kid);
-        assert_eq!(pub_key.curve(), Curve::X25519);
-
-        // P256 sender should fail (no P256 key in doc)
-        let result = super::_find_matching_recipient_key(&doc, &ka_kids, Curve::P256);
-        assert!(result.is_err());
-        assert!(
-            format!("{:?}", result.unwrap_err()).contains("no key agreement key on curve P256")
-        );
+        // No shared curve → error names both offered sets.
+        let err = negotiate_authcrypt(&[Curve::K256], &doc, &kids, &DEFAULT_CURVE_PREFERENCE)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("K256") && msg.contains("X25519"), "{msg}");
     }
 }

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-06-06
+
+### Added
+
+- `key_negotiation` module (behind the new opt-in `key-agreement` feature)
+  — the single home for sender/recipient key-agreement curve negotiation,
+  shared by the messaging SDK and the DID-authentication layer (#357). It
+  exposes `negotiate_authcrypt` (bidirectional best-curve match over the
+  cross-product of sender×recipient keys, by a documented preference order
+  `X25519 > P-256 > secp256k1`), `select_anoncrypt_key` (first recipient KA
+  key that resolves to a supported curve, skipping undecodable codecs),
+  `resolve_public_key_agreement`, the `DEFAULT_CURVE_PREFERENCE` constant,
+  and a neutral `KeyNegotiationError` (whose `NoCommonCurve` names the curve
+  set each side offered). The curve-preference policy is overridable at
+  runtime: both `negotiate_authcrypt` and `select_anoncrypt_key` take a
+  `preference: &[Curve]` argument (pass `DEFAULT_CURVE_PREFERENCE` for the
+  standard policy, or a custom order to force e.g. P-256 first). The default
+  policy and key resolution now span all five key-agreement curves —
+  `X25519 > P-256 > P-384 > P-521 > secp256k1` (#357) — including JWK
+  decoding of `crv: "P-521"`. Anoncrypt
+  uses the **same** preference-ordered selection as authcrypt — it picks the
+  recipient's most-preferred usable curve rather than the document-first
+  key — so signed and anonymous encryption never diverge. The feature gates
+  an `affinidi-crypto/jose` dependency, so the default build of this crate is
+  unchanged. This replaces the byte-for-byte-duplicated negotiation helpers
+  that previously lived in both call-site crates.
+
 ## [0.3.4] - 2026-05-31
 
 ### Added

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.4"
+version = "0.3.5"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true
@@ -18,9 +18,13 @@ ed25519 = ["affinidi-crypto/ed25519"]
 p256 = ["affinidi-crypto/p256"]
 p384 = ["affinidi-crypto/p384"]
 k256 = ["affinidi-crypto/k256"]
+# Sender/recipient key-agreement negotiation helpers (DIDComm encryption).
+# Pulls in affinidi-crypto's JOSE key-agreement types; opt-in so the default
+# build of this foundational crate stays lean.
+key-agreement = ["affinidi-crypto/jose"]
 
 [dependencies]
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 affinidi-encoding = "0.1"
 
 # External Crates

--- a/crates/identity/affinidi-did-common/src/key_negotiation.rs
+++ b/crates/identity/affinidi-did-common/src/key_negotiation.rs
@@ -1,0 +1,460 @@
+//! Sender/recipient key-agreement negotiation for DIDComm encryption.
+//!
+//! Packing an authcrypt (ECDH-1PU) message requires the sender and the
+//! recipient to share an elliptic curve. A DID document may advertise
+//! several `keyAgreement` keys on different curves, so picking a working
+//! pair is a small negotiation rather than a blind `first()`.
+//!
+//! This module is the single home for that logic — both the
+//! DID-authentication layer and the messaging SDK delegate here, mapping
+//! the neutral [`KeyNegotiationError`] into their own error type at the
+//! call site. It lives in `affinidi-did-common` because that crate already
+//! owns [`Document`] decoding and already depends on `affinidi-crypto`; no
+//! new dependency edge is introduced, and the crypto crate stays free of
+//! DID types.
+//!
+//! Sender *secret* resolution is deliberately **not** done here — it needs
+//! the async secrets resolver, which would drag another dependency into
+//! this crate. Call sites resolve their sender secrets, hand us the set of
+//! curves they can actually use, and we choose the best recipient pairing.
+
+use affinidi_crypto::jose::key_agreement::{Curve, PublicKeyAgreement};
+
+use crate::{Document, DocumentExt, verification_method::VerificationRelationship};
+
+/// Default curve preference, most-preferred first.
+///
+/// `X25519 > P-256 > P-384 > P-521 > secp256k1`: modern/safe curves first,
+/// then the NIST P-curves in ascending size, with secp256k1 last (least
+/// preferred for general DIDComm use). When several pairings are possible,
+/// the earliest curve in the *active* preference list that both sides offer
+/// wins. This is the policy used when a caller does not override it; pass a
+/// custom `&[Curve]` to [`negotiate_authcrypt`] / [`select_anoncrypt_key`] to
+/// force a different order at runtime (e.g. a FIPS deployment that wants
+/// P-256 first). Both the authcrypt and anoncrypt paths consult the same
+/// ordering, so signed and anonymous encryption never diverge in which curve
+/// they choose.
+pub const DEFAULT_CURVE_PREFERENCE: [Curve; 5] = [
+    Curve::X25519,
+    Curve::P256,
+    Curve::P384,
+    Curve::P521,
+    Curve::K256,
+];
+
+/// Errors from key-agreement resolution and negotiation.
+///
+/// Neutral by design: each call site maps these into its own error type so
+/// the message context (`DIDAuthError` / `ATMError`) stays at the boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum KeyNegotiationError {
+    /// No verification method matched the given key id.
+    #[error("verification method not found: {0}")]
+    NotFound(String),
+
+    /// The verification material decoded, but its multicodec is not a
+    /// supported key-agreement curve (e.g. an Ed25519 signing key listed
+    /// under `keyAgreement`).
+    #[error("unsupported multicodec for key agreement: 0x{0:x}")]
+    UnsupportedCodec(u64),
+
+    /// The verification material could not be decoded at all.
+    #[error("invalid verification material: {0}")]
+    InvalidMaterial(String),
+
+    /// The decoded bytes were not a valid public key for the curve.
+    #[error("invalid key bytes: {0}")]
+    InvalidKeyBytes(String),
+
+    /// Sender and recipient share no common key-agreement curve. Names the
+    /// curve set each side actually offered, to aid mediator interop
+    /// debugging.
+    #[error(
+        "no common key-agreement curve: sender offers {sender:?}, recipient offers {recipient:?}"
+    )]
+    NoCommonCurve {
+        /// Curves the sender can use (has a usable secret for).
+        sender: Vec<Curve>,
+        /// Curves the recipient advertises a usable key-agreement key on.
+        recipient: Vec<Curve>,
+    },
+
+    /// The recipient advertised key-agreement keys, but none resolved to a
+    /// supported curve (anoncrypt). Lists the key ids that were tried.
+    #[error("recipient has no usable key-agreement key (tried: {0:?})")]
+    NoUsableRecipientKey(Vec<String>),
+}
+
+/// A chosen authcrypt pairing on a shared curve.
+#[derive(Debug)]
+pub struct AuthcryptMatch<'a> {
+    /// The negotiated curve (the caller selects its sender key on this curve).
+    pub curve: Curve,
+    /// The recipient key-agreement key id to encrypt to.
+    pub recipient_kid: &'a str,
+    /// The recipient public key.
+    pub recipient_pub: PublicKeyAgreement,
+}
+
+/// Resolve a single `keyAgreement` verification method into a
+/// [`PublicKeyAgreement`].
+///
+/// Checks embedded verification methods first, then the document's
+/// top-level `verificationMethod` set, and decodes the material through the
+/// shared [`VerificationMethod::decode_public_key`] parser so JWK and
+/// multibase do not drift between call sites.
+///
+/// [`VerificationMethod::decode_public_key`]: crate::verification_method::VerificationMethod::decode_public_key
+pub fn resolve_public_key_agreement(
+    doc: &Document,
+    kid: &str,
+) -> Result<PublicKeyAgreement, KeyNegotiationError> {
+    let vm = doc
+        .key_agreement
+        .iter()
+        .filter_map(|ka| match ka {
+            VerificationRelationship::VerificationMethod(vm) if vm.id.as_str() == kid => {
+                Some(vm.as_ref())
+            }
+            _ => None,
+        })
+        .next()
+        .or_else(|| doc.get_verification_method(kid))
+        .ok_or_else(|| KeyNegotiationError::NotFound(kid.to_string()))?;
+
+    let (codec, key_bytes) = vm
+        .decode_public_key()
+        .map_err(|e| KeyNegotiationError::InvalidMaterial(e.to_string()))?;
+
+    let curve = match codec {
+        affinidi_encoding::X25519_PUB => Curve::X25519,
+        affinidi_encoding::P256_PUB => Curve::P256,
+        affinidi_encoding::SECP256K1_PUB => Curve::K256,
+        affinidi_encoding::P384_PUB => Curve::P384,
+        affinidi_encoding::P521_PUB => Curve::P521,
+        other => return Err(KeyNegotiationError::UnsupportedCodec(other)),
+    };
+
+    PublicKeyAgreement::from_raw_bytes(curve, &key_bytes)
+        .map_err(|e| KeyNegotiationError::InvalidKeyBytes(e.to_string()))
+}
+
+/// Resolve the recipient's advertised key-agreement keys, preserving
+/// document order and skipping entries that do not resolve to a supported
+/// curve (undecodable codecs, unsupported curves, bad key bytes).
+fn resolve_recipient_keys<'a>(
+    doc: &Document,
+    recipient_ka_kids: &[&'a str],
+) -> Vec<(&'a str, PublicKeyAgreement)> {
+    recipient_ka_kids
+        .iter()
+        .copied()
+        .filter_map(|kid| {
+            resolve_public_key_agreement(doc, kid)
+                .ok()
+                .map(|pk| (kid, pk))
+        })
+        .collect()
+}
+
+/// Negotiate the best authcrypt pairing from the cross-product of the
+/// sender's usable curves and the recipient's usable key-agreement keys.
+///
+/// `sender_curves` is the set of curves the sender has a usable secret for
+/// (order is irrelevant — selection follows `preference`). `preference` is
+/// the active curve-preference policy, most-preferred first; pass
+/// [`DEFAULT_CURVE_PREFERENCE`] for the standard policy or a custom slice to
+/// force a different order. The earliest curve in `preference` that both
+/// sides offer is chosen, and the first recipient key on that curve (in
+/// document order) is returned.
+///
+/// Returns [`KeyNegotiationError::NoCommonCurve`] (naming both offered sets)
+/// when no shared curve exists.
+pub fn negotiate_authcrypt<'a>(
+    sender_curves: &[Curve],
+    doc: &Document,
+    recipient_ka_kids: &[&'a str],
+    preference: &[Curve],
+) -> Result<AuthcryptMatch<'a>, KeyNegotiationError> {
+    let recipient = resolve_recipient_keys(doc, recipient_ka_kids);
+
+    for &curve in preference {
+        if sender_curves.contains(&curve)
+            && let Some((kid, pk)) = recipient.iter().find(|(_, pk)| pk.curve() == curve)
+        {
+            return Ok(AuthcryptMatch {
+                curve,
+                recipient_kid: kid,
+                recipient_pub: pk.clone(),
+            });
+        }
+    }
+
+    Err(KeyNegotiationError::NoCommonCurve {
+        sender: dedup_preserve_order(sender_curves.iter().copied()),
+        recipient: dedup_preserve_order(recipient.iter().map(|(_, pk)| pk.curve())),
+    })
+}
+
+/// Select an anoncrypt recipient key using the **same** curve-preference
+/// selection as [`negotiate_authcrypt`] — there is simply no sender side to
+/// intersect with. The recipient's most-preferred usable curve (per
+/// `preference`) wins, and the first key on it (document order) is returned.
+/// Keeping the two paths identical avoids a surprising divergence between
+/// signed and anonymous encryption over which curve gets used.
+pub fn select_anoncrypt_key<'a>(
+    doc: &Document,
+    recipient_ka_kids: &[&'a str],
+    preference: &[Curve],
+) -> Result<(&'a str, PublicKeyAgreement), KeyNegotiationError> {
+    let recipient = resolve_recipient_keys(doc, recipient_ka_kids);
+
+    for &curve in preference {
+        if let Some((kid, pk)) = recipient.iter().find(|(_, pk)| pk.curve() == curve) {
+            return Ok((kid, pk.clone()));
+        }
+    }
+    Err(KeyNegotiationError::NoUsableRecipientKey(
+        recipient_ka_kids.iter().map(|k| k.to_string()).collect(),
+    ))
+}
+
+/// Deduplicate curves preserving first-seen order, for stable, readable
+/// error messages. Unlike the preference filter, this names *every* offered
+/// curve (even ones outside the active preference) so a mismatch error shows
+/// the real picture.
+fn dedup_preserve_order(curves: impl IntoIterator<Item = Curve>) -> Vec<Curve> {
+    let mut out: Vec<Curve> = Vec::new();
+    for c in curves {
+        if !out.contains(&c) {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_crypto::jose::key_agreement::PrivateKeyAgreement;
+    use serde_json::{Value, json};
+
+    // A valid KA verification method, built from a freshly generated key of
+    // the given curve and serialised as a `publicKeyJwk` (the shared decoder
+    // accepts JWK, so this avoids re-implementing SEC1 encoding in the test).
+    fn ka_vm(kid: &str, curve: Curve) -> Value {
+        let pub_key = PrivateKeyAgreement::generate(curve).public_key();
+        json!({
+            "id": kid,
+            "type": "JsonWebKey2020",
+            "controller": "did:web:example",
+            "publicKeyJwk": pub_key.to_jwk(),
+        })
+    }
+
+    // An Ed25519 *signing* key erroneously listed under keyAgreement: it
+    // decodes fine but its multicodec is not a supported KA curve, so
+    // resolution rejects it at the codec step (no key parsing needed — 32
+    // arbitrary bytes suffice).
+    fn ed25519_vm(kid: &str) -> Value {
+        json!({
+            "id": kid,
+            "type": "Multikey",
+            "controller": "did:web:example",
+            "publicKeyMultibase":
+                affinidi_encoding::encode_multikey(affinidi_encoding::ED25519_PUB, &[9u8; 32]),
+        })
+    }
+
+    // Build a Document whose keyAgreement lists every supplied VM by id.
+    fn doc_with(vms: &[Value]) -> Document {
+        let kids: Vec<&str> = vms.iter().map(|vm| vm["id"].as_str().unwrap()).collect();
+        serde_json::from_value(json!({
+            "id": "did:web:example",
+            "verificationMethod": vms,
+            "keyAgreement": kids,
+        }))
+        .unwrap()
+    }
+
+    // The standard policy, used by most tests.
+    const PREF: &[Curve] = &DEFAULT_CURVE_PREFERENCE;
+
+    // Real bug from the PR description: a *valid* key on the wrong curve must
+    // be skipped, not just an undecodable codec. Recipient offers [P-256,
+    // X25519]; an X25519 sender must select the X25519 key.
+    #[test]
+    fn authcrypt_skips_valid_wrong_curve_key() {
+        let doc = doc_with(&[
+            ka_vm("did:web:example#p256", Curve::P256),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#p256", "did:web:example#x"];
+        let m = negotiate_authcrypt(&[Curve::X25519], &doc, &kids, PREF).unwrap();
+        assert_eq!(m.curve, Curve::X25519);
+        assert_eq!(m.recipient_kid, "did:web:example#x");
+        assert_eq!(m.recipient_pub.curve(), Curve::X25519);
+    }
+
+    // The original #355 test scenario: first keyAgreement entry is an
+    // Ed25519 signing key (undecodable as KA); the X25519 key after it wins.
+    #[test]
+    fn authcrypt_skips_undecodable_codec() {
+        let doc = doc_with(&[
+            ed25519_vm("did:web:example#ed"),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#ed", "did:web:example#x"];
+        let m = negotiate_authcrypt(&[Curve::X25519], &doc, &kids, PREF).unwrap();
+        assert_eq!(m.recipient_kid, "did:web:example#x");
+    }
+
+    // Bidirectional negotiation: sender's *first* curve (P-256) has no
+    // recipient match, but its second (X25519) does. Must still succeed.
+    #[test]
+    fn authcrypt_uses_sender_second_curve() {
+        let doc = doc_with(&[ka_vm("did:web:example#x", Curve::X25519)]);
+        let kids = ["did:web:example#x"];
+        // Sender curve list ordered P-256 first to prove order-independence.
+        let m = negotiate_authcrypt(&[Curve::P256, Curve::X25519], &doc, &kids, PREF).unwrap();
+        assert_eq!(m.curve, Curve::X25519);
+        assert_eq!(m.recipient_kid, "did:web:example#x");
+    }
+
+    // Multiple valid pairings: both sides offer P-256 and X25519. The default
+    // preference (X25519 > P-256) must win regardless of the order keys
+    // appear in the document or the sender list.
+    #[test]
+    fn authcrypt_follows_curve_preference() {
+        let doc = doc_with(&[
+            ka_vm("did:web:example#p256", Curve::P256),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#p256", "did:web:example#x"];
+        // P-256 listed first on the sender side; X25519 must still win.
+        let m = negotiate_authcrypt(&[Curve::P256, Curve::X25519], &doc, &kids, PREF).unwrap();
+        assert_eq!(m.curve, Curve::X25519);
+    }
+
+    // Runtime policy override (#2): same doc as above, but a caller forces
+    // P-256 first — the override must beat the default X25519-first policy.
+    #[test]
+    fn authcrypt_honours_custom_preference_override() {
+        let doc = doc_with(&[
+            ka_vm("did:web:example#p256", Curve::P256),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#p256", "did:web:example#x"];
+        let fips_first = [Curve::P256, Curve::X25519, Curve::K256];
+        let m =
+            negotiate_authcrypt(&[Curve::P256, Curve::X25519], &doc, &kids, &fips_first).unwrap();
+        assert_eq!(m.curve, Curve::P256);
+        assert_eq!(m.recipient_kid, "did:web:example#p256");
+    }
+
+    // No shared curve: sender P-256 only, recipient X25519 only. The error
+    // must name both offered curve sets.
+    #[test]
+    fn authcrypt_no_common_curve_names_both_sets() {
+        let doc = doc_with(&[ka_vm("did:web:example#x", Curve::X25519)]);
+        let kids = ["did:web:example#x"];
+        let err = negotiate_authcrypt(&[Curve::P256], &doc, &kids, PREF).unwrap_err();
+        match &err {
+            KeyNegotiationError::NoCommonCurve { sender, recipient } => {
+                assert_eq!(sender, &vec![Curve::P256]);
+                assert_eq!(recipient, &vec![Curve::X25519]);
+            }
+            other => panic!("expected NoCommonCurve, got {other:?}"),
+        }
+        let msg = err.to_string();
+        assert!(msg.contains("P256"), "msg names sender curve: {msg}");
+        assert!(msg.contains("X25519"), "msg names recipient curve: {msg}");
+    }
+
+    // Anoncrypt: first entry is an undecodable Ed25519 codec; selection must
+    // fall through to the usable X25519 key rather than failing on first().
+    #[test]
+    fn anoncrypt_skips_undecodable_first_key() {
+        let doc = doc_with(&[
+            ed25519_vm("did:web:example#ed"),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#ed", "did:web:example#x"];
+        let (kid, pk) = select_anoncrypt_key(&doc, &kids, PREF).unwrap();
+        assert_eq!(kid, "did:web:example#x");
+        assert_eq!(pk.curve(), Curve::X25519);
+    }
+
+    // Anoncrypt now follows the SAME curve preference as authcrypt (#4):
+    // recipient lists secp256k1 *first*, X25519 second — anoncrypt must still
+    // pick X25519 (most-preferred), not the document-first secp256k1.
+    #[test]
+    fn anoncrypt_follows_curve_preference() {
+        let doc = doc_with(&[
+            ka_vm("did:web:example#k", Curve::K256),
+            ka_vm("did:web:example#x", Curve::X25519),
+        ]);
+        let kids = ["did:web:example#k", "did:web:example#x"];
+        let (kid, pk) = select_anoncrypt_key(&doc, &kids, PREF).unwrap();
+        assert_eq!(kid, "did:web:example#x");
+        assert_eq!(pk.curve(), Curve::X25519);
+    }
+
+    #[test]
+    fn anoncrypt_no_usable_key_lists_tried() {
+        let doc = doc_with(&[ed25519_vm("did:web:example#ed")]);
+        let kids = ["did:web:example#ed"];
+        let err = select_anoncrypt_key(&doc, &kids, PREF).unwrap_err();
+        assert!(matches!(err, KeyNegotiationError::NoUsableRecipientKey(_)));
+        assert!(err.to_string().contains("did:web:example#ed"));
+    }
+
+    // secp256k1 is the least-preferred but still usable curve.
+    #[test]
+    fn authcrypt_matches_secp256k1() {
+        let doc = doc_with(&[ka_vm("did:web:example#k", Curve::K256)]);
+        let kids = ["did:web:example#k"];
+        let m = negotiate_authcrypt(&[Curve::K256], &doc, &kids, PREF).unwrap();
+        assert_eq!(m.curve, Curve::K256);
+    }
+
+    // The larger NIST curves negotiate end-to-end through the shared helper
+    // (full JWE/wire support lives in affinidi-crypto + the DIDComm layer).
+    #[test]
+    fn authcrypt_matches_p384_and_p521() {
+        for curve in [Curve::P384, Curve::P521] {
+            let doc = doc_with(&[ka_vm("did:web:example#ec", curve)]);
+            let kids = ["did:web:example#ec"];
+            let m = negotiate_authcrypt(&[curve], &doc, &kids, PREF).unwrap();
+            assert_eq!(m.curve, curve);
+            assert_eq!(m.recipient_pub.curve(), curve);
+        }
+    }
+
+    // With the default preference, P-256 outranks the larger NIST curves and
+    // secp256k1: a recipient offering all of them, to a sender that has all,
+    // selects P-256 (after X25519, which isn't offered here).
+    #[test]
+    fn authcrypt_default_preference_orders_nist_curves() {
+        let doc = doc_with(&[
+            ka_vm("did:web:example#k", Curve::K256),
+            ka_vm("did:web:example#p521", Curve::P521),
+            ka_vm("did:web:example#p384", Curve::P384),
+            ka_vm("did:web:example#p256", Curve::P256),
+        ]);
+        let kids = [
+            "did:web:example#k",
+            "did:web:example#p521",
+            "did:web:example#p384",
+            "did:web:example#p256",
+        ];
+        let m = negotiate_authcrypt(
+            &[Curve::K256, Curve::P521, Curve::P384, Curve::P256],
+            &doc,
+            &kids,
+            PREF,
+        )
+        .unwrap();
+        assert_eq!(m.curve, Curve::P256);
+    }
+}

--- a/crates/identity/affinidi-did-common/src/lib.rs
+++ b/crates/identity/affinidi-did-common/src/lib.rs
@@ -19,6 +19,8 @@ pub mod builder;
 pub mod did;
 pub mod did_method;
 pub mod document;
+#[cfg(feature = "key-agreement")]
+pub mod key_negotiation;
 pub mod one_or_many;
 pub mod service;
 pub mod verification_method;

--- a/crates/identity/affinidi-did-common/src/verification_method.rs
+++ b/crates/identity/affinidi-did-common/src/verification_method.rs
@@ -117,6 +117,9 @@ impl VerificationMethod {
             (Params::EC(p), KeyType::P384) => {
                 Ok((affinidi_encoding::P384_PUB, sec1(&b64(&p.x)?, &b64(&p.y)?)))
             }
+            (Params::EC(p), KeyType::P521) => {
+                Ok((affinidi_encoding::P521_PUB, sec1(&b64(&p.x)?, &b64(&p.y)?)))
+            }
             (Params::EC(p), KeyType::Secp256k1) => Ok((
                 affinidi_encoding::SECP256K1_PUB,
                 sec1(&b64(&p.x)?, &b64(&p.y)?),

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 6th June 2026
+
+### 0.8.7 — affinidi-crypto 0.2
+
+- Bump `affinidi-crypto` to `0.2` (P-384/P-521 key agreement +
+  `#[non_exhaustive]` key-agreement enums, #357). No API change in this
+  crate.
+
 ## 18th April 2026
 
 ### DID Resolver Cache SDK (0.8.6)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.6"
+version = "0.8.7"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -77,7 +77,7 @@ wasm-bindgen-futures = "0.4"
 web-socket = { version = "0.7", optional = true }
 
 [dev-dependencies]
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 affinidi-secrets-resolver = "0.5"
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-06-06
+
+### Added
+
+- **P-384 and P-521 authcrypt/anoncrypt (#357).** The JWE encrypt/decrypt
+  paths are curve-agnostic (the ephemeral key is generated on the
+  recipient's curve, and the `alg`/`enc`/KDF/key-wrap are uniform), so the
+  new `affinidi-crypto` P-384/P-521 key-agreement curves work on the wire
+  with no protocol changes. Added full ECDH-1PU and ECDH-ES JWE roundtrip
+  tests for both curves.
+
 ## [0.15.0] - 2026-06-01
 
 Completes #327: this crate now contains **no bespoke crypto** — only the

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -20,7 +20,7 @@ messaging-core = ["dep:affinidi-messaging-core", "dep:async-trait"]
 # JOSE crypto primitives (#327) — this crate owns only the DIDComm/JOSE
 # envelope layer; all key agreement, KDF, key-wrap, content-encryption,
 # and signing live in affinidi-crypto's `jose` module.
-affinidi-crypto = { version = "0.1", features = ["jose"] }
+affinidi-crypto = { version = "0.2", features = ["jose"] }
 
 # Curve crates — still used directly by the adapter for SEC1 point
 # encoding (`ToEncodedPoint`) on resolved public keys.

--- a/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/adapter.rs
@@ -318,18 +318,7 @@ fn extract_payload(body: &serde_json::Value) -> Vec<u8> {
 
 /// Get raw bytes from a PublicKeyAgreement for the ResolvedIdentity.
 fn public_key_bytes(key: &affinidi_crypto::jose::key_agreement::PublicKeyAgreement) -> Vec<u8> {
-    use affinidi_crypto::jose::key_agreement::PublicKeyAgreement;
-    match key {
-        PublicKeyAgreement::X25519(bytes) => bytes.to_vec(),
-        PublicKeyAgreement::P256(pk) => {
-            use p256::elliptic_curve::sec1::ToEncodedPoint;
-            pk.to_encoded_point(true).as_bytes().to_vec()
-        }
-        PublicKeyAgreement::K256(pk) => {
-            use k256::elliptic_curve::sec1::ToEncodedPoint;
-            pk.to_encoded_point(true).as_bytes().to_vec()
-        }
-    }
+    key.to_public_bytes()
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-messaging-didcomm/src/jwe/decrypt.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jwe/decrypt.rs
@@ -233,6 +233,54 @@ mod tests {
     }
 
     #[test]
+    fn authcrypt_roundtrip_p384_p521() {
+        // Full ECDH-1PU JWE roundtrip on the larger NIST curves: the wire
+        // layer is curve-agnostic (ephemeral is generated on the recipient's
+        // curve), so these must pack and unpack like the others.
+        for curve in [Curve::P384, Curve::P521] {
+            let sender = PrivateKeyAgreement::generate(curve);
+            let recipient = PrivateKeyAgreement::generate(curve);
+
+            let jwe_str = encrypt::authcrypt(
+                b"big-curve authcrypt",
+                "did:example:alice#ec",
+                &sender,
+                &[("did:example:bob#ec", &recipient.public_key())],
+            )
+            .unwrap();
+
+            let result = decrypt(
+                &jwe_str,
+                "did:example:bob#ec",
+                &recipient,
+                Some(&sender.public_key()),
+            )
+            .unwrap();
+
+            assert_eq!(result.plaintext, b"big-curve authcrypt", "curve {curve:?}");
+            assert!(result.authenticated, "curve {curve:?}");
+        }
+    }
+
+    #[test]
+    fn anoncrypt_roundtrip_p384_p521() {
+        for curve in [Curve::P384, Curve::P521] {
+            let recipient = PrivateKeyAgreement::generate(curve);
+
+            let jwe_str = encrypt::anoncrypt(
+                b"big-curve anoncrypt",
+                &[("did:example:bob#ec", &recipient.public_key())],
+            )
+            .unwrap();
+
+            let result = decrypt(&jwe_str, "did:example:bob#ec", &recipient, None).unwrap();
+
+            assert_eq!(result.plaintext, b"big-curve anoncrypt", "curve {curve:?}");
+            assert!(!result.authenticated, "curve {curve:?}");
+        }
+    }
+
+    #[test]
     fn authcrypt_roundtrip_p256() {
         let sender = PrivateKeyAgreement::generate(Curve::P256);
         let recipient = PrivateKeyAgreement::generate(Curve::P256);

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-helpers"
-version = "0.13.1"
+version = "0.13.2"
 description = "CLI tools for Affinidi Messaging (mediator administration)"
 edition.workspace = true
 authors.workspace = true
@@ -25,7 +25,7 @@ affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" 
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
 ## DIDComm message types — used by example binaries
-affinidi-crypto = { version = "0.1", features = ["jose"] }
+affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }
 ## Protocol-agnostic messaging-core traits — used by `unified_messaging` example
 affinidi-messaging-core = { path = "../affinidi-messaging-core" }

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Changelog history
 
+## 6th June 2026
+
+### 0.15.14 — P-384/P-521 key agreement (#357)
+
+- The DIDComm-compat pack/unpack paths now recognise P-384 and P-521
+  key-agreement keys (sender secret resolution, recipient verification-method
+  decoding, and the secret-key-type → curve mapping). Previously these curves
+  were silently skipped by a wildcard arm, so a mediator could not pack to or
+  unpack from a P-384/P-521 peer.
+- **Build note:** the bump to `affinidi-crypto 0.2` un-unifies `vta-sdk`
+  (which pins `affinidi-crypto 0.1`) from the workspace `[patch.crates-io]`
+  redirect. This crate will not build until a `vta-sdk` release against
+  `affinidi-crypto 0.2` is published and the `vta-sdk` dependency here is
+  bumped to it. Tracked as a cross-repo coordination follow-up.
+
 ## 5th June 2026
 
 ### 0.15.13 — coverage-build fix + redis 1.2

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.13"
+version = "0.15.14"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -64,7 +64,7 @@ affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" 
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
-affinidi-crypto = { version = "0.1", features = ["jose"], optional = true }
+affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Multibase/multicodec encoding helpers (needed by didcomm for key encoding)

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -219,6 +219,8 @@ impl MetaEnvelope {
                     affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
                     affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
                     affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
+                    affinidi_secrets_resolver::secrets::KeyType::P384 => Curve::P384,
+                    affinidi_secrets_resolver::secrets::KeyType::P521 => Curve::P521,
                     _ => continue,
                 };
                 match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
@@ -345,6 +347,8 @@ fn resolve_public_key(
             affinidi_encoding::X25519_PUB => Curve::X25519,
             affinidi_encoding::P256_PUB => Curve::P256,
             affinidi_encoding::SECP256K1_PUB => Curve::K256,
+            affinidi_encoding::P384_PUB => Curve::P384,
+            affinidi_encoding::P521_PUB => Curve::P521,
             _ => return None,
         };
         return PublicKeyAgreement::from_raw_bytes(curve, &key_bytes).ok();
@@ -395,6 +399,8 @@ pub async fn pack_encrypted<S: SecretsResolver>(
             affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
             affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
             affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
+            affinidi_secrets_resolver::secrets::KeyType::P384 => Curve::P384,
+            affinidi_secrets_resolver::secrets::KeyType::P521 => Curve::P521,
             _ => return Err("Unsupported key type for sender".to_string()),
         };
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 6th June 2026
 
+### 0.1.8 — affinidi-crypto 0.2
+
+- Bump `affinidi-crypto` to `0.2` (P-384/P-521 key agreement +
+  `#[non_exhaustive]` key-agreement enums, #357). **Note:** this tool also
+  depends on `vta-sdk`, which pins `affinidi-crypto 0.1`; it will not build
+  until a `vta-sdk` release against `affinidi-crypto 0.2` is published and
+  the `vta-sdk` pin here is bumped.
+
 ### 0.1.7 — stop clobbering the unified secret backend
 
 - **FIX (#354):** After provisioning the unified secret backend, the wizard

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.7"
+version = "0.1.8"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -62,7 +62,7 @@ affinidi-secrets-resolver = { path = "../../../../core/affinidi-secrets-resolver
 ## did:key helpers used by the sealed-handoff full-setup path to derive
 ## the `client_did` from the ephemeral Ed25519 pubkey when signing a
 ## VP-framed `provision_integration::BootstrapRequest`. Small, no cycles.
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 
 # ── Mediator unified secret backend ─────────────────────────────────────
 ## Shared secrets module (open_store, MediatorSecrets, well-known keys)

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.18.7] - 2026-06-06
+
+### Changed
+
+- **Robust key-agreement negotiation in `pack_encrypted` (#357).** The
+  authcrypt path now enumerates *all* of the sender's usable key-agreement
+  keys and negotiates the best shared curve with the recipient by a
+  documented preference order (`X25519 > P-256 > secp256k1`), rather than
+  deriving the curve from the sender's *first* key only — so a sender whose
+  first KA curve has no recipient match but whose second does now packs
+  successfully, and a no-common-curve failure names the curve set each side
+  offered. The anoncrypt path now selects the recipient's most-preferred
+  usable key-agreement curve using the **same** ordering as authcrypt
+  (skipping undecodable/unsupported entries) instead of blindly taking
+  `first()`, so the two paths never disagree on curve choice. The duplicated
+  negotiation/resolution helpers were removed in favour of
+  `affinidi-did-common`'s shared `key_negotiation` module (its new
+  `key-agreement` feature).
+- **P-384/P-521 key agreement + configurable curve preference (#357).**
+  `pack_encrypted` now supports the P-384 and P-521 key-agreement curves
+  (sender key-type → curve mapping), and `ATMConfigBuilder` gains
+  `with_curve_preference(Vec<Curve>)` to override the default curve ordering
+  (`X25519 > P-256 > P-384 > P-521 > secp256k1`) at runtime — e.g. P-256
+  first for a FIPS deployment. The override applies to both authcrypt and
+  anoncrypt.
+
 ## [0.18.6] - 2026-06-01
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.6"
+version = "0.18.7"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -15,14 +15,14 @@ repository.workspace = true
 [dependencies]
 # Affinidi Crates
 affinidi-tdk-common = "0.6"
-affinidi-crypto = { version = "0.1", features = ["jose"] }
+affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Source of truth for the mediator protocol vocabulary (ACLs, accounts,
 ## message types, problem reports). The SDK re-exports these so existing
 ## call sites continue to resolve their old paths.
 affinidi-messaging-mediator-common = { path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", version = "0.15", default-features = false }
 affinidi-did-authentication = "0.3"
-affinidi-did-common = "0.3"
+affinidi-did-common = { version = "0.3", features = ["key-agreement"] }
 affinidi-encoding = "0.1"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -2,6 +2,7 @@ use crate::{
     errors::ATMError, protocols::discover_features::DiscoverFeatures,
     transports::websockets::WebSocketResponses,
 };
+use affinidi_crypto::jose::key_agreement::Curve;
 use rustls::pki_types::CertificateDer;
 use std::{fs::File, io::BufReader, sync::Arc};
 use tokio::sync::{RwLock, broadcast::Sender};
@@ -29,9 +30,22 @@ pub struct ATMConfig {
 
     /// Can configure any protocol discoverable information here
     pub(crate) discover_features: Arc<RwLock<DiscoverFeatures>>,
+
+    /// Optional override for the key-agreement curve preference used when
+    /// packing encrypted messages. `None` uses
+    /// [`affinidi_did_common::key_negotiation::DEFAULT_CURVE_PREFERENCE`]
+    /// (`X25519 > P-256 > P-384 > P-521 > secp256k1`). Set a custom order to
+    /// force a specific policy, e.g. P-256 first for a FIPS deployment.
+    pub(crate) curve_preference: Option<Vec<Curve>>,
 }
 
 impl ATMConfig {
+    /// The configured key-agreement curve preference, if any. `None` means
+    /// the negotiator's built-in default order is used.
+    pub fn get_curve_preference(&self) -> Option<&[Curve]> {
+        self.curve_preference.as_deref()
+    }
+
     /// Returns a builder for `ATMConfig`
     /// Example:
     /// ```
@@ -63,6 +77,7 @@ pub struct ATMConfigBuilder {
     inbound_message_channel: Option<Sender<WebSocketResponses>>,
     unpack_forwards: bool,
     discover_features: DiscoverFeatures,
+    curve_preference: Option<Vec<Curve>>,
 }
 
 impl Default for ATMConfigBuilder {
@@ -74,6 +89,7 @@ impl Default for ATMConfigBuilder {
             inbound_message_channel: None,
             unpack_forwards: true,
             discover_features: DiscoverFeatures::default(),
+            curve_preference: None,
         }
     }
 }
@@ -132,6 +148,25 @@ impl ATMConfigBuilder {
         self
     }
 
+    /// Override the key-agreement curve preference used when packing
+    /// encrypted messages. Curves are tried most-preferred first; the first
+    /// curve both sender and recipient offer is chosen. Omit to use the
+    /// default order (`X25519 > P-256 > P-384 > P-521 > secp256k1`).
+    ///
+    /// Example — prefer the NIST P-256 curve first (FIPS-leaning):
+    /// ```no_run
+    /// use affinidi_messaging_sdk::config::ATMConfig;
+    /// use affinidi_crypto::jose::key_agreement::Curve;
+    ///
+    /// let config = ATMConfig::builder()
+    ///     .with_curve_preference(vec![Curve::P256, Curve::P384, Curve::P521, Curve::X25519, Curve::K256])
+    ///     .build();
+    /// ```
+    pub fn with_curve_preference(mut self, preference: Vec<Curve>) -> Self {
+        self.curve_preference = Some(preference);
+        self
+    }
+
     pub fn build(self) -> Result<ATMConfig, ATMError> {
         // Process any custom SSL certificates
         let mut certs = vec![];
@@ -167,6 +202,7 @@ impl ATMConfigBuilder {
             inbound_message_channel: self.inbound_message_channel,
             unpack_forwards: self.unpack_forwards,
             discover_features: Arc::new(RwLock::new(self.discover_features)),
+            curve_preference: self.curve_preference,
         })
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
@@ -1,10 +1,11 @@
-use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
+use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement};
 use affinidi_did_common::{
-    Document, document::DocumentExt, verification_method::VerificationRelationship,
+    document::DocumentExt,
+    key_negotiation::{DEFAULT_CURVE_PREFERENCE, negotiate_authcrypt, select_anoncrypt_key},
 };
 use affinidi_messaging_didcomm::message::{Message, pack};
 use affinidi_secrets_resolver::SecretsResolver;
-use tracing::{Instrument, Level, span};
+use tracing::{Instrument, Level, debug, span};
 
 use crate::{ATM, SharedState, errors::ATMError};
 
@@ -53,9 +54,21 @@ impl SharedState {
                 })?;
             let recipient_ka_kids = recipient_doc.doc.find_key_agreement(None);
 
+            // Curve-preference policy: a runtime override from config, else
+            // the negotiator's documented default order. Shared by both the
+            // authcrypt and anoncrypt paths so they never disagree.
+            let preference = self
+                .config
+                .get_curve_preference()
+                .unwrap_or(&DEFAULT_CURVE_PREFERENCE);
+
             if let Some(sender_did) = from {
-                // Authcrypt: resolve sender first to determine curve, then
-                // pick a recipient key on the same curve.
+                // Authcrypt: enumerate the sender's *usable* key-agreement
+                // keys (a secret we hold, on a supported curve), then
+                // negotiate the best shared curve with the recipient.
+                // Selection follows the documented curve preference, so the
+                // sender's list order is irrelevant — a later sender curve can
+                // still match when the first does not.
                 let sender_doc = self
                     .tdk_common
                     .did_resolver()
@@ -68,47 +81,49 @@ impl SharedState {
                         )
                     })?;
                 let sender_ka_kids = sender_doc.doc.find_key_agreement(None);
-                let sender_kid = sender_ka_kids.first().ok_or_else(|| {
-                    ATMError::DidcommError(
+
+                let mut sender_keys: Vec<(&str, PrivateKeyAgreement, Curve)> = Vec::new();
+                for &kid in &sender_ka_kids {
+                    let Some(secret) = self.tdk_common.secrets_resolver().get_secret(kid).await
+                    else {
+                        continue;
+                    };
+                    let Ok(curve) = key_type_to_curve(secret.get_key_type()) else {
+                        continue;
+                    };
+                    match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
+                        Ok(private) => sender_keys.push((kid, private, curve)),
+                        Err(e) => debug!("skipping unusable sender key {kid}: {e}"),
+                    }
+                }
+                if sender_keys.is_empty() {
+                    return Err(ATMError::DidcommError(
                         "pack_encrypted".into(),
-                        "sender has no key agreement key".into(),
-                    )
-                })?;
+                        "sender has no usable key agreement key".into(),
+                    ));
+                }
+                let sender_curves: Vec<Curve> = sender_keys.iter().map(|(_, _, c)| *c).collect();
 
-                // Get sender's private key from secrets resolver
-                let sender_secret = self
-                    .tdk_common
-                    .secrets_resolver()
-                    .get_secret(sender_kid.as_ref())
-                    .await
-                    .ok_or_else(|| {
-                        ATMError::SecretsError(format!("no secret found for {sender_kid}"))
-                    })?;
-
-                let sender_curve = key_type_to_curve(sender_secret.get_key_type())?;
-                let sender_private = PrivateKeyAgreement::from_raw_bytes(
-                    sender_curve,
-                    sender_secret.get_private_bytes(),
-                )
-                .map_err(|e| {
-                    ATMError::DidcommError(
-                        "pack_encrypted".into(),
-                        format!("invalid sender private key: {e}"),
-                    )
-                })?;
-
-                // Find a recipient key agreement key on the same curve
-                let (recipient_kid, recipient_pub) = find_matching_recipient_key(
+                let pairing = negotiate_authcrypt(
+                    &sender_curves,
                     &recipient_doc.doc,
                     &recipient_ka_kids,
-                    sender_curve,
-                )?;
+                    preference,
+                )
+                .map_err(|e| ATMError::DidcommError("pack_encrypted".into(), e.to_string()))?;
+
+                // The negotiated curve was drawn from `sender_curves`, so a
+                // matching sender key is guaranteed present.
+                let (sender_kid, sender_private, _) = sender_keys
+                    .iter()
+                    .find(|(_, _, c)| *c == pairing.curve)
+                    .expect("negotiated curve came from sender_curves");
 
                 let packed = pack::pack_encrypted_authcrypt(
                     message,
                     sender_kid,
-                    &sender_private,
-                    &[(recipient_kid, &recipient_pub)],
+                    sender_private,
+                    &[(pairing.recipient_kid, &pairing.recipient_pub)],
                 )
                 .map_err(|e| {
                     ATMError::DidcommError(
@@ -120,20 +135,19 @@ impl SharedState {
                 let metadata = PackEncryptedMetadata {
                     from_kid: Some(sender_kid.to_string()),
                     sign_by_kid: None,
-                    to_kids: vec![recipient_kid.to_string()],
+                    to_kids: vec![pairing.recipient_kid.to_string()],
                 };
 
                 Ok((packed, metadata))
             } else {
-                // Anoncrypt: pick the first available key agreement key
-                let recipient_kid = recipient_ka_kids.first().ok_or_else(|| {
-                    ATMError::DidcommError(
-                        "pack_encrypted".into(),
-                        "recipient has no key agreement key".into(),
-                    )
-                })?;
-                let recipient_pub =
-                    resolve_public_key_agreement(&recipient_doc.doc, recipient_kid)?;
+                // Anoncrypt: pick the first advertised key-agreement key that
+                // resolves to a supported curve (skipping undecodable codecs),
+                // rather than blindly taking `first()`.
+                let (recipient_kid, recipient_pub) =
+                    select_anoncrypt_key(&recipient_doc.doc, &recipient_ka_kids, preference)
+                        .map_err(|e| {
+                            ATMError::DidcommError("pack_encrypted".into(), e.to_string())
+                        })?;
 
                 let packed =
                     pack::pack_encrypted_anoncrypt(message, &[(recipient_kid, &recipient_pub)])
@@ -175,85 +189,6 @@ impl SharedState {
     }
 }
 
-/// Find the first recipient key agreement key whose curve matches the sender's.
-fn find_matching_recipient_key<'a>(
-    doc: &Document,
-    ka_kids: &'a [&'a str],
-    sender_curve: Curve,
-) -> Result<(&'a str, PublicKeyAgreement), ATMError> {
-    for kid in ka_kids {
-        if let Ok(pub_key) = resolve_public_key_agreement(doc, kid)
-            && pub_key.curve() == sender_curve
-        {
-            return Ok((kid, pub_key));
-        }
-    }
-    Err(ATMError::DidcommError(
-        "pack_encrypted".into(),
-        format!("recipient has no key agreement key on curve {sender_curve:?}"),
-    ))
-}
-
-/// Extract a PublicKeyAgreement from a DID Document's verification method.
-fn resolve_public_key_agreement(doc: &Document, kid: &str) -> Result<PublicKeyAgreement, ATMError> {
-    // Find the verification method
-    let vm = doc
-        .key_agreement
-        .iter()
-        .filter_map(|ka| match ka {
-            VerificationRelationship::VerificationMethod(vm) if vm.id.as_str() == kid => {
-                Some(vm.as_ref())
-            }
-            _ => None,
-        })
-        .next()
-        .or_else(|| doc.get_verification_method(kid))
-        .ok_or_else(|| {
-            ATMError::DidcommError(
-                "resolve_key".into(),
-                format!("verification method not found: {kid}"),
-            )
-        })?;
-
-    // Try publicKeyJwk first
-    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk") {
-        return PublicKeyAgreement::from_jwk(jwk_value).map_err(|e| {
-            ATMError::DidcommError("resolve_key".into(), format!("invalid JWK: {e}"))
-        });
-    }
-
-    // Try publicKeyMultibase (Multikey format)
-    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
-        && let Some(multibase_str) = multibase_value.as_str()
-    {
-        let (codec, key_bytes) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
-            .map_err(|e| {
-                ATMError::DidcommError("resolve_key".into(), format!("invalid multikey: {e}"))
-            })?;
-
-        let curve = match codec {
-            affinidi_encoding::X25519_PUB => Curve::X25519,
-            affinidi_encoding::P256_PUB => Curve::P256,
-            affinidi_encoding::SECP256K1_PUB => Curve::K256,
-            _ => {
-                return Err(ATMError::DidcommError(
-                    "resolve_key".into(),
-                    format!("unsupported multicodec for key agreement: 0x{codec:x}"),
-                ));
-            }
-        };
-
-        return PublicKeyAgreement::from_raw_bytes(curve, &key_bytes).map_err(|e| {
-            ATMError::DidcommError("resolve_key".into(), format!("invalid key bytes: {e}"))
-        });
-    }
-
-    Err(ATMError::DidcommError(
-        "resolve_key".into(),
-        format!("no supported key material in verification method: {kid}"),
-    ))
-}
-
 /// Map from secrets resolver KeyType to DIDComm Curve.
 fn key_type_to_curve(
     key_type: affinidi_secrets_resolver::secrets::KeyType,
@@ -262,6 +197,8 @@ fn key_type_to_curve(
         affinidi_secrets_resolver::secrets::KeyType::X25519 => Ok(Curve::X25519),
         affinidi_secrets_resolver::secrets::KeyType::P256 => Ok(Curve::P256),
         affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Ok(Curve::K256),
+        affinidi_secrets_resolver::secrets::KeyType::P384 => Ok(Curve::P384),
+        affinidi_secrets_resolver::secrets::KeyType::P521 => Ok(Curve::P521),
         other => Err(ATMError::DidcommError(
             "key_type_to_curve".into(),
             format!("unsupported key type for key agreement: {other:?}"),

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.7.4] - 2026-06-06
+
+### Changed
+
+- Bump `affinidi-crypto` to `0.2` (P-384/P-521 key agreement +
+  `#[non_exhaustive]` key-agreement enums, #357). No API change in this
+  crate.
+
 ## [0.7.3] - 2026-06-01
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.7.3"
+version = "0.7.4"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -27,7 +27,7 @@ affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcom
 affinidi-did-authentication = "0.3"
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.2"
 affinidi-meeting-place = { version = "0.4", optional = true }
 affinidi-data-integrity = { version = "0.7",  optional = true }
 


### PR DESCRIPTION
Closes #357. Follow-up tracked in #364.

## Summary

Robust sender/recipient key-agreement (KA) negotiation, extended to **all usable ECDH curves**, with a **runtime-configurable curve-preference policy** and a unified authcrypt/anoncrypt selection path.

PR #355 fixed the immediate ECDH-1PU curve-mismatch with a greedy "first recipient key on the sender's first curve" pick. This replaces that with a bidirectional best-match and adds the remaining NIST curves end-to-end.

## What changed

### Negotiation — new `affinidi-did-common::key_negotiation` (opt-in `key-agreement` feature)
- **Bidirectional best-curve match** over the sender×recipient cross-product, choosing the most-preferred curve **both** sides offer. Precise `NoCommonCurve` error naming each side's offered curve set.
- **Configurable policy**: default `X25519 > P-256 > P-384 > P-521 > secp256k1`, overridable at runtime (`negotiate_authcrypt`/`select_anoncrypt_key` take a preference slice; surfaced via `ATMConfigBuilder::with_curve_preference`).
- **Anoncrypt uses the identical preference-ordered selection** as authcrypt (no more document-order divergence).
- Single shared helper; **removes the byte-for-byte-duplicated helpers** previously in `did-authentication` and `messaging-sdk`.

### Curves — `affinidi-crypto 0.2.0` (breaking)
- Added **P-384 and P-521** ECDH key agreement (enum variants + `generate`/`from_raw_bytes`/`from_jwk`/`to_jwk`/`diffie_hellman`, new `p521` keygen module, JWK `crv: "P-521"`). KDF/key-wrap/content-encryption is curve-agnostic, so ECDH-1PU/ECDH-ES work unchanged — covered by new KAT + JWE roundtrip tests.
- **`#[non_exhaustive]`** on `Curve` / `PublicKeyAgreement` / `PrivateKeyAgreement` so future curve/key additions are non-breaking. `KeyType` left exhaustive on purpose (keeps secrets-resolver encode/decode compile-checked).
- `secrets-resolver`: full P-521 support (`generate_p521`, `P521_PRIV` load, unblocked P-521 public encoding).
- Mediator didcomm-compat + call-site `key_type_to_curve` gained P-384/P-521 arms. `mdoc` unchanged (separate COSE enum).

### Out of scope: PQC
The stack's PQC is **ML-DSA / SLH-DSA — signature-only**; there is no ML-KEM, so PQC key agreement isn't possible and is explicitly out of scope.

## Versioning
`affinidi-crypto 0.1→0.2` with the required pin cascade across 11 dependents (5 newly version-bumped). All CHANGELOGs updated; dependencies refreshed to latest compatible.

## ⚠️ Known-red until vta-sdk is updated (#364)
The `affinidi-crypto 0.1→0.2` bump **un-unifies the external `vta-sdk`** (pins `affinidi-crypto 0.1`) from the workspace `[patch.crates-io]` redirect, leaving two crypto copies. The **mediator family** (`mediator`, `mediator-setup`, `mediator-monitor`, `mediator-processors`, `test-mediator`) will not build until OpenVTC publishes a `vta-sdk` built against `affinidi-crypto 0.2` and its pin is bumped. **All other crates build, lint and test clean.** Steps tracked in #364.

## Testing
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets` ✓ (excluding the 5 vta-transitive mediator crates)
- `cargo test` ✓ across every touched crate + dependents (crypto incl. P-384/P-521 KATs, didcomm incl. P-384/P-521 JWE roundtrips, did-common negotiation suite, secrets-resolver P-521, sdk, did-auth, tdk, data-integrity, cache-sdk)
- `cargo deny check` ✓ (advisories/bans/licenses/sources ok)