### PR TITLE
feat: blind BBS signatures (Commit/BlindSign/BlindVerify) in affinidi-bbs (#359)

### DIFF
--- a/crates/core/affinidi-bbs/Cargo.toml
+++ b/crates/core/affinidi-bbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-bbs"
 description = "BBS Signatures (IETF draft-irtf-cfrg-bbs-signatures) implementation over BLS12-381."
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-bbs/src/blind.rs
+++ b/crates/core/affinidi-bbs/src/blind.rs
@@ -1,0 +1,743 @@
+/*!
+ * Blind BBS signatures (`draft-irtf-cfrg-bbs-blind-signatures`).
+ *
+ * Blind issuance lets a holder commit to *hidden* messages that the issuer
+ * never learns, while the issuer signs over that commitment together with its
+ * own (cleartext) messages. The resulting signature is an ordinary BBS
+ * signature over the combined message set, so it verifies and proves exactly
+ * like a plain BBS signature.
+ *
+ * This is the foundation for holder binding / per-verifier pseudonyms
+ * (`#353` / `#360`): the holder's `nym_secret` is a committed message.
+ *
+ * # Flow
+ *
+ * 1. **Holder** runs [`commit`] over its committed messages →
+ *    `(commitment_with_proof, secret_prover_blind)`. The `commitment_with_proof`
+ *    is sent to the issuer; `secret_prover_blind` is kept secret.
+ * 2. **Issuer** runs [`blind_sign`] over the `commitment_with_proof` and its own
+ *    messages → a blind [`Signature`]. The commitment proof is verified first so
+ *    a malformed commitment is rejected.
+ * 3. **Holder** runs [`blind_verify`] (with the committed messages and
+ *    `secret_prover_blind`) to confirm the signature is valid over the full
+ *    message set.
+ *
+ * # Ciphersuite namespacing
+ *
+ * Blind BBS uses [`Ciphersuite::blind_api_id`] (`…_BLIND_H2G_HM2S_`) for its
+ * signer generators and hashing, and `"BLIND_" || blind_api_id` for the blind
+ * (committed-message) generators. These are distinct from the core api_id, so a
+ * blind signature uses a different generator set than a plain one.
+ *
+ * Construction matches the reference `@digitalbazaar/bbs-signatures`; all
+ * primitives are KAT-gated byte-for-byte against the official IETF
+ * blind-signatures draft test vectors.
+ */
+
+use bls12_381_plus::{G1Projective, Scalar};
+use ff::Field;
+use rand::Rng;
+use zeroize::Zeroize;
+
+use crate::ciphersuite::Ciphersuite;
+use crate::error::{BbsError, Result};
+use crate::generators::{
+    calculate_domain_with_api_id, create_generators_with_api_id, p1_generator, point_from_bytes,
+    point_to_bytes,
+};
+use crate::hash::{
+    hash_to_scalar, messages_to_scalars_with_api_id, scalar_from_bytes, scalar_to_bytes,
+};
+use crate::types::{PublicKey, SecretKey, Signature};
+
+/// The api_id used for the blind (committed-message) generators:
+/// `"BLIND_" || blind_api_id`.
+fn blind_generators_api_id(cs: Ciphersuite) -> Vec<u8> {
+    [b"BLIND_".as_slice(), cs.blind_api_id().as_slice()].concat()
+}
+
+/// Commit to a set of hidden (committed) messages.
+///
+/// Returns `(commitment_with_proof, secret_prover_blind)`. The
+/// `commitment_with_proof` octets are handed to the issuer (see [`blind_sign`]);
+/// `secret_prover_blind` is retained by the holder and is required to verify
+/// (and later prove over) the resulting blind signature.
+///
+/// Random scalars are sampled fresh; the commitment is therefore not
+/// reproducible (each call yields a different, equally valid commitment).
+pub fn commit(committed_messages: &[&[u8]], cs: Ciphersuite) -> Result<(Vec<u8>, Scalar)> {
+    let m = committed_messages.len();
+    let random_scalars = random_scalars(m + 2);
+    commit_with_random_scalars(committed_messages, &random_scalars, cs)
+}
+
+/// [`commit`] with the random scalars injected — used to reproduce the
+/// deterministic IETF test vectors exactly. `random_scalars` must have length
+/// `committed_messages.len() + 2`: `(secret_prover_blind, s~, m~_1, …, m~_M)`.
+pub(crate) fn commit_with_random_scalars(
+    committed_messages: &[&[u8]],
+    random_scalars: &[Scalar],
+    cs: Ciphersuite,
+) -> Result<(Vec<u8>, Scalar)> {
+    let m = committed_messages.len();
+    if random_scalars.len() != m + 2 {
+        return Err(BbsError::Crypto(format!(
+            "blind commit needs {} random scalars, got {}",
+            m + 2,
+            random_scalars.len()
+        )));
+    }
+
+    let api_id = cs.blind_api_id();
+    let committed_scalars = messages_to_scalars_with_api_id(committed_messages, &api_id, cs)?;
+    // blind_generators = (Q_2, J_1, …, J_M), length M + 1
+    let blind_generators = create_generators_with_api_id(m + 1, &blind_generators_api_id(cs), cs)?;
+
+    core_commit(
+        &committed_scalars,
+        &blind_generators,
+        &api_id,
+        random_scalars,
+        cs,
+    )
+}
+
+/// `CoreCommit`: build the commitment `C` to the committed message scalars and a
+/// zero-knowledge proof of its correct construction.
+fn core_commit(
+    committed_scalars: &[Scalar],
+    blind_generators: &[G1Projective],
+    api_id: &[u8],
+    random_scalars: &[Scalar],
+    cs: Ciphersuite,
+) -> Result<(Vec<u8>, Scalar)> {
+    let m = committed_scalars.len();
+    if blind_generators.len() != m + 1 {
+        return Err(BbsError::Crypto(
+            "blind_generators length must be committed message count + 1".into(),
+        ));
+    }
+    let q2 = &blind_generators[0];
+    let j = &blind_generators[1..];
+
+    let secret_prover_blind = random_scalars[0];
+    let s_tilde = random_scalars[1];
+    let m_tildes = &random_scalars[2..];
+
+    // C = Q_2 * secret_prover_blind + sum_i J_i * msg_i
+    let mut c = q2 * secret_prover_blind;
+    for (i, msg) in committed_scalars.iter().enumerate() {
+        c += j[i] * msg;
+    }
+
+    // Cbar = Q_2 * s~ + sum_i J_i * m~_i
+    let mut cbar = q2 * s_tilde;
+    for (i, mt) in m_tildes.iter().enumerate() {
+        cbar += j[i] * mt;
+    }
+
+    // challenge = calculate_blind_challenge(C, Cbar, blind_generators, api_id)
+    let challenge = calculate_blind_challenge(&c, &cbar, blind_generators, api_id, cs)?;
+
+    // s^ = s~ + secret_prover_blind * challenge
+    let s_hat = s_tilde + secret_prover_blind * challenge;
+    // m^_i = m~_i + msg_i * challenge
+    let m_hats: Vec<Scalar> = m_tildes
+        .iter()
+        .zip(committed_scalars.iter())
+        .map(|(mt, msg)| mt + msg * challenge)
+        .collect();
+
+    // proof = (s^, m^_1, …, m^_M, challenge)
+    let mut proof = Vec::with_capacity(m + 2);
+    proof.push(s_hat);
+    proof.extend_from_slice(&m_hats);
+    proof.push(challenge);
+
+    let octets = commitment_with_proof_to_octets(&c, &proof);
+    Ok((octets, secret_prover_blind))
+}
+
+/// `calculate_blind_challenge`: Fiat–Shamir challenge over the blind generators
+/// and the commitment points. Serializes `(M, Q_2, J_1…J_M, C, Cbar)` and hashes
+/// to a scalar under `api_id || "H2S_"`.
+fn calculate_blind_challenge(
+    c: &G1Projective,
+    cbar: &G1Projective,
+    blind_generators: &[G1Projective],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<Scalar> {
+    let dst = [api_id, b"H2S_"].concat();
+    let m = blind_generators.len() - 1;
+
+    let mut data = Vec::new();
+    data.extend_from_slice(&(m as u64).to_be_bytes()); // I2OSP(M, 8)
+    for g in blind_generators {
+        data.extend_from_slice(&point_to_bytes(g));
+    }
+    data.extend_from_slice(&point_to_bytes(c));
+    data.extend_from_slice(&point_to_bytes(cbar));
+
+    hash_to_scalar(&data, &dst, cs)
+}
+
+/// Serialize `commitment_with_proof = serialize(C) || serialize(proof scalars)`.
+fn commitment_with_proof_to_octets(commitment: &G1Projective, proof: &[Scalar]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(48 + proof.len() * 32);
+    out.extend_from_slice(&point_to_bytes(commitment));
+    for s in proof {
+        out.extend_from_slice(&scalar_to_bytes(s));
+    }
+    out
+}
+
+/// Parse `commitment_with_proof` octets back into `(C, proof scalars)`.
+///
+/// Rejects an identity commitment, zero/out-of-range scalars, a trailing partial
+/// scalar, and proofs with fewer than two scalars (per the draft).
+fn octets_to_commitment_with_proof(
+    bytes: &[u8],
+    cs: Ciphersuite,
+) -> Result<(G1Projective, Vec<Scalar>)> {
+    let point_len = cs.octet_point_length();
+    let scalar_len = cs.octet_scalar_length();
+    let floor = point_len + 2 * scalar_len;
+    if bytes.len() < floor {
+        return Err(BbsError::Deserialization(format!(
+            "commitment_with_proof too short: {} < {floor}",
+            bytes.len()
+        )));
+    }
+
+    let mut c_bytes = [0u8; 48];
+    c_bytes.copy_from_slice(&bytes[..point_len]);
+    let commitment = point_from_bytes(&c_bytes)
+        .ok_or_else(|| BbsError::Deserialization("invalid commitment point".into()))?;
+    if bool::from(commitment.is_identity()) {
+        return Err(BbsError::Deserialization("commitment is identity".into()));
+    }
+
+    let mut proof = Vec::new();
+    let mut idx = point_len;
+    while idx + scalar_len <= bytes.len() {
+        let mut s_bytes = [0u8; 32];
+        s_bytes.copy_from_slice(&bytes[idx..idx + scalar_len]);
+        let s = scalar_from_bytes(&s_bytes).ok_or_else(|| {
+            BbsError::Deserialization("invalid scalar in commitment proof".into())
+        })?;
+        if bool::from(s.is_zero()) {
+            return Err(BbsError::Deserialization(
+                "zero scalar in commitment proof".into(),
+            ));
+        }
+        proof.push(s);
+        idx += scalar_len;
+    }
+    if idx != bytes.len() {
+        return Err(BbsError::Deserialization(
+            "trailing bytes in commitment proof".into(),
+        ));
+    }
+    if proof.len() < 2 {
+        return Err(BbsError::Deserialization(
+            "commitment proof must have at least two scalars".into(),
+        ));
+    }
+
+    Ok((commitment, proof))
+}
+
+/// `CoreCommitVerify`: check the commitment proof. `commitment_proof` is
+/// `(s^, m^_1, …, m^_M, cp)`; recomputes `Cbar` and confirms the challenge.
+fn core_commit_verify(
+    commitment: &G1Projective,
+    commitment_proof: &[Scalar],
+    blind_generators: &[G1Projective],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<bool> {
+    // (s^, m^_1..m^_M, cp)
+    let s_hat = commitment_proof[0];
+    let cp = commitment_proof[commitment_proof.len() - 1];
+    let m_hats = &commitment_proof[1..commitment_proof.len() - 1];
+
+    let m = m_hats.len();
+    if blind_generators.len() != m + 1 {
+        return Err(BbsError::Crypto(
+            "blind_generators length must equal commitment message count + 1".into(),
+        ));
+    }
+    let q2 = &blind_generators[0];
+    let j = &blind_generators[1..];
+
+    // Cbar = Q_2 * s^ + sum_i J_i * m^_i - commitment * cp
+    let mut cbar = q2 * s_hat;
+    for (i, mh) in m_hats.iter().enumerate() {
+        cbar += j[i] * mh;
+    }
+    cbar -= commitment * cp;
+
+    let cv = calculate_blind_challenge(commitment, &cbar, blind_generators, api_id, cs)?;
+    Ok(cv == cp)
+}
+
+/// Parse and verify a `commitment_with_proof` from the holder, returning the
+/// commitment point `C`. An empty input means "no committed messages" and yields
+/// the identity element. A failed proof or generator-count mismatch is rejected.
+fn deserialize_and_validate_commit(
+    commitment_with_proof: &[u8],
+    blind_generators: &[G1Projective],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<G1Projective> {
+    if commitment_with_proof.is_empty() {
+        return Ok(G1Projective::IDENTITY);
+    }
+
+    let (commitment, proof) = octets_to_commitment_with_proof(commitment_with_proof, cs)?;
+
+    // (number of message commitments) + 1 must equal the blind generator count.
+    let msg_commitments = proof.len() - 2;
+    if msg_commitments + 1 != blind_generators.len() {
+        return Err(BbsError::Deserialization(format!(
+            "commitment message count ({msg_commitments}) + 1 != blind generators ({})",
+            blind_generators.len()
+        )));
+    }
+
+    if !core_commit_verify(&commitment, &proof, blind_generators, api_id, cs)? {
+        return Err(BbsError::InvalidProof("commitment proof failed".into()));
+    }
+    Ok(commitment)
+}
+
+/// `B_calculate` for blind signing: `B = P1 + sum_i H_i * msg_i + commitment`.
+///
+/// Note `Q_1 * domain` is folded in later by [`finalize_blind_sign`].
+fn blind_b_calculate(
+    generators: &[G1Projective],
+    commitment: G1Projective,
+    message_scalars: &[Scalar],
+    cs: Ciphersuite,
+) -> Result<G1Projective> {
+    let l = message_scalars.len();
+    if generators.len() != l + 1 {
+        return Err(BbsError::Crypto(
+            "generators length must equal signer message count + 1".into(),
+        ));
+    }
+    let h = &generators[1..]; // H_1..H_L (Q_1 = generators[0] used for domain)
+
+    let mut b = p1_generator();
+    for (i, msg) in message_scalars.iter().enumerate() {
+        b += h[i] * msg;
+    }
+    b += commitment;
+
+    let _ = cs;
+    if bool::from(b.is_identity()) {
+        return Err(BbsError::InvalidSignature("blind B is identity".into()));
+    }
+    Ok(b)
+}
+
+/// `FinalizeBlindSign`: turn `B` into a BBS signature `(A, e)` over the combined
+/// signer + blind generators. Per the draft fix, `Q_1 * domain` is mixed into
+/// `B` here and `e = hash_to_scalar(serialize(SK, B), api_id || "H2S_")`.
+#[allow(clippy::too_many_arguments)]
+fn finalize_blind_sign(
+    sk: &SecretKey,
+    pk: &PublicKey,
+    b: G1Projective,
+    generators: &[G1Projective],
+    blind_generators: &[G1Projective],
+    header: &[u8],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<Signature> {
+    let q1 = &generators[0];
+
+    // domain over (H_1..H_L, Q_2, J_1..J_M) with Q_1 as the domain generator.
+    let mut h_list: Vec<G1Projective> = generators[1..].to_vec();
+    h_list.extend_from_slice(blind_generators);
+    let domain = calculate_domain_with_api_id(pk, q1, &h_list, header, api_id, cs)?;
+
+    // B += Q_1 * domain
+    let b = b + q1 * domain;
+
+    // e = hash_to_scalar(serialize(SK, B), api_id || "H2S_")
+    let e_dst = [api_id, b"H2S_"].concat();
+    let mut e_input = Vec::with_capacity(32 + 48);
+    e_input.extend_from_slice(&sk.scalar().to_be_bytes());
+    e_input.extend_from_slice(&point_to_bytes(&b));
+    let e = hash_to_scalar(&e_input, &e_dst, cs)?;
+    e_input.zeroize();
+
+    // A = B * (1 / (SK + e))
+    let mut sk_plus_e = sk.scalar() + e;
+    let inv = sk_plus_e.invert();
+    sk_plus_e.zeroize();
+    if inv.is_none().into() {
+        return Err(BbsError::Crypto("SK + e has no inverse".into()));
+    }
+    let a = b * inv.unwrap();
+    if bool::from(a.is_identity()) {
+        return Err(BbsError::InvalidSignature(
+            "blind signature A is identity".into(),
+        ));
+    }
+    Ok(Signature { a, e })
+}
+
+/// Blind-sign a holder commitment together with the issuer's own messages.
+///
+/// `commitment_with_proof` is the holder's output from [`commit`] (empty for no
+/// committed messages); `messages` are the issuer's cleartext messages. The
+/// commitment proof is verified before signing. Returns a BBS [`Signature`] over
+/// the combined message set, which the holder checks with [`blind_verify`].
+pub fn blind_sign(
+    sk: &SecretKey,
+    pk: &PublicKey,
+    commitment_with_proof: &[u8],
+    header: &[u8],
+    messages: &[&[u8]],
+    cs: Ciphersuite,
+) -> Result<Signature> {
+    let api_id = cs.blind_api_id();
+    let l = messages.len();
+    let m = blind_message_count(commitment_with_proof.len(), cs)?;
+
+    // generators = (Q_1, H_1..H_L); blind_generators = (Q_2, J_1..J_M)
+    let generators = create_generators_with_api_id(l + 1, &api_id, cs)?;
+    let blind_generators = create_generators_with_api_id(m + 1, &blind_generators_api_id(cs), cs)?;
+
+    let commitment =
+        deserialize_and_validate_commit(commitment_with_proof, &blind_generators, &api_id, cs)?;
+    let message_scalars = messages_to_scalars_with_api_id(messages, &api_id, cs)?;
+    let b = blind_b_calculate(&generators, commitment, &message_scalars, cs)?;
+
+    finalize_blind_sign(
+        sk,
+        pk,
+        b,
+        &generators,
+        &blind_generators,
+        header,
+        &api_id,
+        cs,
+    )
+}
+
+/// Verify a blind signature over the full message set.
+///
+/// The holder supplies the issuer's `messages`, its own `committed_messages`,
+/// and the `secret_prover_blind` from [`commit`]. The signature is checked over
+/// the combined generators `(Q_1, H_1…H_L, Q_2, J_1…J_M)` and the message vector
+/// `(m_1…m_L, secret_prover_blind, cm_1…cm_M)`.
+pub fn blind_verify(
+    pk: &PublicKey,
+    signature: &Signature,
+    header: &[u8],
+    messages: &[&[u8]],
+    committed_messages: &[&[u8]],
+    secret_prover_blind: Scalar,
+    cs: Ciphersuite,
+) -> Result<bool> {
+    pk.validate()?;
+    if bool::from(signature.a.is_identity()) {
+        return Err(BbsError::InvalidSignature("A is identity".into()));
+    }
+
+    let api_id = cs.blind_api_id();
+
+    // message_scalars (signer) and committed_message_scalars = (spb, cm_1…cm_M)
+    let mut msg_scalars = messages_to_scalars_with_api_id(messages, &api_id, cs)?;
+    let l = msg_scalars.len();
+    let mut committed_scalars = Vec::with_capacity(committed_messages.len() + 1);
+    committed_scalars.push(secret_prover_blind);
+    committed_scalars.extend(messages_to_scalars_with_api_id(
+        committed_messages,
+        &api_id,
+        cs,
+    )?);
+
+    // generators (Q_1, H_1…H_L) and blind_generators (Q_2, J_1…J_M)
+    let generators = create_generators_with_api_id(l + 1, &api_id, cs)?;
+    let blind_generators =
+        create_generators_with_api_id(committed_scalars.len(), &blind_generators_api_id(cs), cs)?;
+
+    // Combined generator list and combined message-scalar vector.
+    let mut all_gens = generators;
+    all_gens.extend_from_slice(&blind_generators);
+    let q1 = &all_gens[0];
+    let h_generators = &all_gens[1..];
+
+    msg_scalars.extend_from_slice(&committed_scalars);
+
+    let domain = calculate_domain_with_api_id(pk, q1, h_generators, header, &api_id, cs)?;
+    let b = crate::signature::compute_b(q1, &domain, h_generators, &msg_scalars);
+
+    Ok(crate::signature::verify_signature_pairing(
+        pk, signature, &b,
+    ))
+}
+
+/// Recover the committed-message count `M` from the length of a
+/// `commitment_with_proof` (length `0` ⇒ no committed messages, `M = 0`).
+fn blind_message_count(cwp_len: usize, cs: Ciphersuite) -> Result<usize> {
+    if cwp_len == 0 {
+        return Ok(0);
+    }
+    let point_len = cs.octet_point_length();
+    let scalar_len = cs.octet_scalar_length();
+    let floor = point_len + 2 * scalar_len;
+    if cwp_len < floor || !(cwp_len - floor).is_multiple_of(scalar_len) {
+        return Err(BbsError::Deserialization(format!(
+            "invalid commitment_with_proof length {cwp_len}"
+        )));
+    }
+    Ok((cwp_len - floor) / scalar_len)
+}
+
+/// Sample `count` non-zero random scalars (production path for [`commit`]).
+fn random_scalars(count: usize) -> Vec<Scalar> {
+    let mut rng = rand::rng();
+    (0..count)
+        .map(|_| {
+            loop {
+                let bytes: [u8; 48] = rng.random();
+                let s = Scalar::from_okm(&bytes);
+                if !bool::from(s.is_zero()) {
+                    return s;
+                }
+            }
+        })
+        .collect()
+}
+
+/// Deterministic mocked random scalars per the IETF draft (`expand_message` over
+/// a fixed seed), used only to reproduce the published test vectors.
+#[cfg(test)]
+pub(crate) fn mocked_calculate_random_scalars(
+    count: usize,
+    seed: &[u8],
+    dst: &[u8],
+    cs: Ciphersuite,
+) -> Result<Vec<Scalar>> {
+    let expand_len = cs.expand_len();
+    let v = crate::hash::expand_msg_xmd(seed, dst, expand_len * count)?;
+    Ok((0..count)
+        .map(|i| crate::hash::os2ip_mod_r(&v[i * expand_len..(i + 1) * expand_len]))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn hexd(s: &str) -> Vec<u8> {
+        hex::decode(s).expect("fixture hex")
+    }
+
+    fn fixture() -> Value {
+        let path = format!(
+            "{}/tests/fixtures/blind/bls12-381-sha-256.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        serde_json::from_str(&text).expect("fixture json")
+    }
+
+    /// Resolve a fixture message list that is either an explicit array or the
+    /// sentinel `"ALL"` (the full `committed_messages` / `messages` set).
+    fn resolve<'a>(v: &Value, all: &'a [Vec<u8>]) -> Vec<&'a [u8]> {
+        match v {
+            Value::String(s) if s == "ALL" => all.iter().map(|m| m.as_slice()).collect(),
+            Value::Array(_) => {
+                assert!(
+                    v.as_array().unwrap().is_empty(),
+                    "non-ALL arrays are empty in fixture"
+                );
+                vec![]
+            }
+            _ => panic!("unexpected message field"),
+        }
+    }
+
+    fn list_all(fx: &Value, key: &str) -> Vec<Vec<u8>> {
+        fx[key]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| hexd(m.as_str().unwrap()))
+            .collect()
+    }
+
+    fn committed_all(fx: &Value) -> Vec<Vec<u8>> {
+        list_all(fx, "committed_messages")
+    }
+
+    fn keys(fx: &Value) -> (SecretKey, PublicKey) {
+        let sk_bytes: [u8; 32] = hexd(fx["SK"].as_str().unwrap()).try_into().unwrap();
+        let pk_bytes: [u8; 96] = hexd(fx["PK"].as_str().unwrap()).try_into().unwrap();
+        (
+            SecretKey::from_bytes(&sk_bytes).unwrap(),
+            PublicKey::from_bytes(&pk_bytes).unwrap(),
+        )
+    }
+
+    #[test]
+    fn commit_matches_ietf_vectors() {
+        let fx = fixture();
+        let cs = Ciphersuite::Bls12381Sha256;
+        let seed = hexd(fx["mocked_random_scalars"]["seed"].as_str().unwrap());
+        let commit_dst = fx["mocked_random_scalars"]["commit_dst"]
+            .as_str()
+            .unwrap()
+            .as_bytes();
+        let all = committed_all(&fx);
+
+        for case in fx["commit_cases"].as_array().unwrap() {
+            let name = case["name"].as_str().unwrap();
+            let committed = resolve(&case["committed_messages"], &all);
+            let m = committed.len();
+
+            let randoms = mocked_calculate_random_scalars(m + 2, &seed, commit_dst, cs).unwrap();
+            let (cwp, spb) = commit_with_random_scalars(&committed, &randoms, cs).unwrap();
+
+            assert_eq!(
+                hex::encode(&cwp),
+                case["commitment_with_proof"].as_str().unwrap(),
+                "commitment_with_proof mismatch ({name})"
+            );
+            assert_eq!(
+                hex::encode(scalar_to_bytes(&spb)),
+                case["secret_prover_blind"].as_str().unwrap(),
+                "secret_prover_blind mismatch ({name})"
+            );
+
+            // The freshly serialized commitment must round-trip back to a valid
+            // commitment + proof of the right arity.
+            let (_c, proof) = octets_to_commitment_with_proof(&cwp, cs).unwrap();
+            assert_eq!(proof.len(), m + 2, "proof arity ({name})");
+        }
+    }
+
+    #[test]
+    fn blind_sign_matches_ietf_vectors() {
+        let fx = fixture();
+        let cs = Ciphersuite::Bls12381Sha256;
+        let (sk, pk) = keys(&fx);
+        let header = hexd(fx["header"].as_str().unwrap());
+        let messages_all = list_all(&fx, "messages");
+
+        for case in fx["blind_sign_cases"].as_array().unwrap() {
+            let name = case["name"].as_str().unwrap();
+            let cwp = hexd(case["commitment_with_proof"].as_str().unwrap());
+            let messages = resolve(&case["messages"], &messages_all);
+
+            let sig = blind_sign(&sk, &pk, &cwp, &header, &messages, cs).unwrap();
+
+            assert_eq!(
+                hex::encode(sig.to_bytes()),
+                case["signature"].as_str().unwrap(),
+                "blind signature mismatch ({name})"
+            );
+        }
+    }
+
+    #[test]
+    fn blind_verify_accepts_ietf_signatures() {
+        let fx = fixture();
+        let cs = Ciphersuite::Bls12381Sha256;
+        let (_sk, pk) = keys(&fx);
+        let header = hexd(fx["header"].as_str().unwrap());
+        let messages_all = list_all(&fx, "messages");
+        let committed_all = committed_all(&fx);
+
+        for case in fx["blind_sign_cases"].as_array().unwrap() {
+            let name = case["name"].as_str().unwrap();
+            let messages = resolve(&case["messages"], &messages_all);
+            let committed = resolve(&case["committed_messages"], &committed_all);
+            let spb = {
+                let b: [u8; 32] = hexd(case["secret_prover_blind"].as_str().unwrap())
+                    .try_into()
+                    .unwrap();
+                scalar_from_bytes(&b).unwrap()
+            };
+            let sig = Signature::from_bytes(&hexd(case["signature"].as_str().unwrap())).unwrap();
+
+            assert!(
+                blind_verify(&pk, &sig, &header, &messages, &committed, spb, cs).unwrap(),
+                "blind_verify rejected a valid IETF signature ({name})"
+            );
+        }
+    }
+
+    #[test]
+    fn blind_roundtrip_and_tamper_rejection() {
+        let cs = Ciphersuite::Bls12381Sha256;
+        let fx = fixture();
+        let (sk, pk) = keys(&fx);
+        let header = b"app-header";
+
+        let committed_owned = committed_all(&fx);
+        let committed: Vec<&[u8]> = committed_owned.iter().map(|m| m.as_slice()).collect();
+        let signer: Vec<&[u8]> = vec![b"role:issuer".as_ref(), b"level:gold"];
+
+        // Holder commits (fresh random scalars), issuer blind-signs, holder verifies.
+        let (cwp, spb) = commit(&committed, cs).unwrap();
+        let sig = blind_sign(&sk, &pk, &cwp, header, &signer, cs).unwrap();
+        assert!(blind_verify(&pk, &sig, header, &signer, &committed, spb, cs).unwrap());
+
+        // Wrong secret_prover_blind is rejected.
+        assert!(
+            !blind_verify(
+                &pk,
+                &sig,
+                header,
+                &signer,
+                &committed,
+                spb + Scalar::ONE,
+                cs
+            )
+            .unwrap()
+        );
+
+        // Tampered signer message is rejected.
+        let bad_signer: Vec<&[u8]> = vec![b"role:issuer".as_ref(), b"level:platinum"];
+        assert!(!blind_verify(&pk, &sig, header, &bad_signer, &committed, spb, cs).unwrap());
+
+        // Tampered committed message is rejected.
+        let mut bad_committed = committed.clone();
+        bad_committed[0] = b"forged";
+        assert!(!blind_verify(&pk, &sig, header, &signer, &bad_committed, spb, cs).unwrap());
+
+        // A different holder commitment yields a different (still valid) signature.
+        let (cwp2, spb2) = commit(&committed, cs).unwrap();
+        assert_ne!(cwp, cwp2, "commitments must be randomized");
+        let sig2 = blind_sign(&sk, &pk, &cwp2, header, &signer, cs).unwrap();
+        assert!(blind_verify(&pk, &sig2, header, &signer, &committed, spb2, cs).unwrap());
+    }
+
+    #[test]
+    fn blind_sign_rejects_malformed_commitment() {
+        let cs = Ciphersuite::Bls12381Sha256;
+        let fx = fixture();
+        let (sk, pk) = keys(&fx);
+        // Valid-length commitment_with_proof but corrupted proof scalar → the
+        // commitment proof must fail to verify.
+        let mut cwp = hexd(
+            fx["commit_cases"][1]["commitment_with_proof"]
+                .as_str()
+                .unwrap(),
+        );
+        let n = cwp.len();
+        cwp[n - 1] ^= 0x01;
+        let committed = committed_all(&fx);
+        let signer: Vec<&[u8]> = committed.iter().map(|m| m.as_slice()).collect();
+        assert!(blind_sign(&sk, &pk, &cwp, b"h", &signer, cs).is_err());
+    }
+}

--- a/crates/core/affinidi-bbs/src/ciphersuite.rs
+++ b/crates/core/affinidi-bbs/src/ciphersuite.rs
@@ -35,6 +35,18 @@ impl Ciphersuite {
         id
     }
 
+    /// The blind-BBS API identifier (ciphersuite_id || "BLIND_H2G_HM2S_").
+    ///
+    /// Per `draft-irtf-cfrg-bbs-blind-signatures`, blind issuance namespaces its
+    /// generators and hashing under this api_id (distinct from the core
+    /// [`api_id`](Self::api_id)); the blind generators prepend a further
+    /// `"BLIND_"` to it.
+    pub fn blind_api_id(&self) -> Vec<u8> {
+        let mut id = self.id().as_bytes().to_vec();
+        id.extend_from_slice(b"BLIND_H2G_HM2S_");
+        id
+    }
+
     /// The octet length of a scalar in the output.
     pub fn octet_scalar_length(&self) -> usize {
         match self {

--- a/crates/core/affinidi-bbs/src/generators.rs
+++ b/crates/core/affinidi-bbs/src/generators.rs
@@ -58,11 +58,23 @@ pub fn p1_generator() -> G1Projective {
 ///     generator_i = hash_to_curve_g1(v, generator_dst)
 /// ```
 pub fn create_generators(count: usize, cs: Ciphersuite) -> Result<Vec<G1Projective>> {
-    let api_id = cs.api_id();
+    create_generators_with_api_id(count, &cs.api_id(), cs)
+}
 
-    let seed_dst = [api_id.as_slice(), b"SIG_GENERATOR_SEED_"].concat();
-    let generator_dst = [api_id.as_slice(), b"SIG_GENERATOR_DST_"].concat();
-    let generator_seed = [api_id.as_slice(), b"MESSAGE_GENERATOR_SEED"].concat();
+/// Create `count` deterministic generators under an explicit `api_id`.
+///
+/// Identical to [`create_generators`] but lets the caller namespace the
+/// generators (the core suite uses [`Ciphersuite::api_id`]; blind BBS uses
+/// [`Ciphersuite::blind_api_id`] and `"BLIND_" || blind_api_id` for its blind
+/// generators).
+pub fn create_generators_with_api_id(
+    count: usize,
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<Vec<G1Projective>> {
+    let seed_dst = [api_id, b"SIG_GENERATOR_SEED_"].concat();
+    let generator_dst = [api_id, b"SIG_GENERATOR_DST_"].concat();
+    let generator_seed = [api_id, b"MESSAGE_GENERATOR_SEED"].concat();
 
     let expand_len = cs.expand_len();
     let mut generators = Vec::with_capacity(count);
@@ -110,7 +122,22 @@ pub fn calculate_domain(
     header: &[u8],
     cs: Ciphersuite,
 ) -> Result<Scalar> {
-    let domain_dst = [cs.api_id().as_slice(), b"H2S_"].concat();
+    calculate_domain_with_api_id(pk, q1, generators, header, &cs.api_id(), cs)
+}
+
+/// Calculate the domain under an explicit `api_id` (see [`calculate_domain`]).
+///
+/// Blind BBS computes the domain over the combined message + blind generators
+/// under [`Ciphersuite::blind_api_id`].
+pub fn calculate_domain_with_api_id(
+    pk: &PublicKey,
+    q1: &G1Projective,
+    generators: &[G1Projective],
+    header: &[u8],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<Scalar> {
+    let domain_dst = [api_id, b"H2S_"].concat();
 
     let pk_bytes = pk.to_bytes();
     let count = (generators.len() as u64).to_be_bytes();
@@ -128,7 +155,7 @@ pub fn calculate_domain(
     for g in generators {
         data.extend_from_slice(&point_to_bytes(g));
     }
-    data.extend_from_slice(&cs.api_id());
+    data.extend_from_slice(api_id);
     data.extend_from_slice(&(header.len() as u64).to_be_bytes());
     data.extend_from_slice(header);
 

--- a/crates/core/affinidi-bbs/src/hash.rs
+++ b/crates/core/affinidi-bbs/src/hash.rs
@@ -33,7 +33,18 @@ pub fn hash_to_scalar(data: &[u8], dst: &[u8], _cs: Ciphersuite) -> Result<Scala
 /// Per IETF draft §4.3.1:
 /// For each message: `hash_to_scalar(message, api_id || "MAP_MSG_TO_SCALAR_AS_HASH_")`
 pub fn messages_to_scalars(messages: &[&[u8]], cs: Ciphersuite) -> Result<Vec<Scalar>> {
-    let dst = [cs.api_id().as_slice(), b"MAP_MSG_TO_SCALAR_AS_HASH_"].concat();
+    messages_to_scalars_with_api_id(messages, &cs.api_id(), cs)
+}
+
+/// Convert messages to scalars under an explicit `api_id` (see
+/// [`messages_to_scalars`]). Blind BBS maps both committed and signer messages
+/// under [`Ciphersuite::blind_api_id`].
+pub fn messages_to_scalars_with_api_id(
+    messages: &[&[u8]],
+    api_id: &[u8],
+    cs: Ciphersuite,
+) -> Result<Vec<Scalar>> {
+    let dst = [api_id, b"MAP_MSG_TO_SCALAR_AS_HASH_"].concat();
 
     messages
         .iter()
@@ -56,6 +67,15 @@ pub fn expand_msg_xmd(msg: &[u8], dst: &[u8], len_in_bytes: usize) -> Result<Vec
         })?
         .fill_bytes(&mut output);
     Ok(output)
+}
+
+/// Convert a wide byte array (up to 48 bytes) to a scalar via OS2IP mod r.
+///
+/// Used by the blind-BBS mocked random-scalar routine to reproduce the IETF
+/// test vectors (the production path samples scalars directly).
+#[cfg(test)]
+pub(crate) fn os2ip_mod_r(bytes: &[u8]) -> Scalar {
+    scalar_from_wide_bytes(bytes)
 }
 
 /// Convert a wide byte array (48 bytes) to a scalar via OS2IP mod r.

--- a/crates/core/affinidi-bbs/src/lib.rs
+++ b/crates/core/affinidi-bbs/src/lib.rs
@@ -47,6 +47,7 @@
 
 #![allow(deprecated)] // G1/G2Projective::generator() deprecated in favor of GENERATOR constant
 
+pub mod blind;
 pub mod ciphersuite;
 pub mod error;
 pub mod generators;
@@ -57,6 +58,7 @@ pub mod pseudonym;
 pub mod signature;
 pub mod types;
 
+pub use blind::{blind_sign, blind_verify, commit};
 pub use ciphersuite::Ciphersuite;
 pub use error::BbsError;
 pub use keys::{keygen as keygen_with_cs, sk_to_pk};

--- a/crates/core/affinidi-bbs/src/signature.rs
+++ b/crates/core/affinidi-bbs/src/signature.rs
@@ -140,7 +140,20 @@ pub fn core_verify(
     // 4. Compute B
     let b = compute_b(q1, &domain, h_generators, &msg_scalars);
 
-    // 5. Pairing check: e(A, W + BP2*e) * e(-B, BP2) == 1_GT
+    // 5. Pairing check
+    Ok(verify_signature_pairing(pk, signature, &b))
+}
+
+/// The BBS verification pairing check given a precomputed `B`:
+/// `e(A, W + BP2*e) * e(-B, BP2) == 1_GT`.
+///
+/// Shared by [`core_verify`] and blind verification (which builds `B` over the
+/// combined signer + blind generators).
+pub(crate) fn verify_signature_pairing(
+    pk: &PublicKey,
+    signature: &Signature,
+    b: &G1Projective,
+) -> bool {
     let bp2 = G2Projective::generator();
     let w_plus_bp2_e = pk.0 + bp2 * signature.e;
 
@@ -155,7 +168,7 @@ pub fn core_verify(
     ])
     .final_exponentiation();
 
-    Ok(bool::from(result.is_identity()))
+    bool::from(result.is_identity())
 }
 
 #[cfg(test)]

--- a/crates/core/affinidi-bbs/tests/fixtures/blind/bls12-381-sha-256.json
+++ b/crates/core/affinidi-bbs/tests/fixtures/blind/bls12-381-sha-256.json
@@ -1,0 +1,80 @@
+{
+  "_source": "Official IETF draft-irtf-cfrg-bbs-blind-signatures test vectors (BLS12-381-SHA-256), as vendored by @digitalbazaar/bbs-signatures test/fixtures/blind-sha256.js. Used for byte-exact KAT gating of affinidi-bbs blind BBS.",
+  "ciphersuite": "BLS12381_SHA256",
+  "key_material": "746869732d49532d6a7573742d616e2d546573742d494b4d2d746f2d67656e65726174652d246528724074232d6b6579",
+  "key_info": "746869732d49532d736f6d652d6b65792d6d657461646174612d746f2d62652d757365642d696e2d746573742d6b65792d67656e",
+  "SK": "60e55110f76883a13d030b2f6bd11883422d5abde717569fc0731f51237169fc",
+  "PK": "a820f230f6ae38503b86c70dc50b61c58a77e45c39ab25c0652bbaa8fa136f2851bd4781c9dcde39fc9d1d52c9e60268061e7d7632171d91aa8d460acee0e96f1e7c4cfb12d3ff9ab5d5dc91c277db75c845d649ef3c4f63aebc364cd55ded0c",
+  "header": "11223344556677889900aabbccddeeff",
+  "messages": [
+    "9872ad089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
+    "c344136d9ab02da4dd5908bbba913ae6f58c2cc844b802a6f811f5fb075f9b80",
+    "7372e9daa5ed31e6cd5c825eac1b855e84476a1d94932aa348e07b73",
+    "77fe97eb97a1ebe2e81e4e3597a3ee740a66e9ef2412472c",
+    "496694774c5604ab1b2544eababcf0f53278ff50",
+    "515ae153e22aae04ad16f759e07237b4",
+    "d183ddc6e2665aa4e2f088af",
+    "ac55fb33a75909ed",
+    "96012096",
+    ""
+  ],
+  "committed_messages": [
+    "5982967821da3c5983496214df36aa5e58de6fa25314af4cf4c00400779f08c3",
+    "a75d8b634891af92282cc81a675972d1929d3149863c1fc0",
+    "835889a40744813a892eff9deb1edaeb",
+    "e1ca9729410dc6ba",
+    ""
+  ],
+  "mocked_random_scalars": {
+    "seed": "332e313431353932363533353839373933323338343632363433333833323739",
+    "commit_dst": "BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_COMMIT_MOCK_RANDOM_SCALARS_DST_"
+  },
+  "commit_cases": [
+    {
+      "name": "No Committed Messages",
+      "committed_messages": [],
+      "commitment_with_proof": "849d3cc626720202cbc1610fc01ab41ce32099af602def0c579f37dd18b485ef60719275a036bdd8120e7e938c8e1a3d4d0322587441ccc5caf186001b45dd09ee159713c3e3ea0f411f94a5d6665546562d09c093b687a129e464a57e18cdbf5306bcabf3e7cc95f5ba98cdd9bf3768",
+      "secret_prover_blind": "1b6f406b17aaf92dc7deb911c7cae49756a6623b5c385b5ae6214d7e3d9597f7"
+    },
+    {
+      "name": "Multiple Committed Messages",
+      "committed_messages": "ALL",
+      "commitment_with_proof": "a2a3e178bcc77f98a3c07f8532134021ab5847326b5b3bfc3089ca73f1bc51cfe2c99163f4919525dd6bedc8a14ee39e30374643902017ca2e6fb8b5647c736e82d1d3c5b05de5c3021fa6f40d9f36dd22fa06e522411aa20377088ca9a15885d7a5044175f0168e927149ee71e2d257079e0100d6d96a7ddf5392dbc64267af8df7b4711cb5eeccb5e8901d0580b9e837f38337cb7260cffcf4f962154fafe5c98beaed7e4d2fc0f8e7eb1ba4eb04086f170aa4924894e2ab63054049c9ef5dfff4f90b48ef0dcf1f50699907301073270e4782d4d7628cfbe1444cea930928bb45004e41e0ad86a874ea03473845ce42f78ceb6f855ba8326a4d47732c5aed3968b396a07f079b22b5bf2139e51a03",
+      "secret_prover_blind": "4fba5396baa36b2fde81d46a9b9ee89c425dbc5e1ffd65c20249afb4abd37589"
+    }
+  ],
+  "blind_sign_cases": [
+    {
+      "name": "No Committed Messages, No Signer Messages",
+      "commitment_with_proof": "849d3cc626720202cbc1610fc01ab41ce32099af602def0c579f37dd18b485ef60719275a036bdd8120e7e938c8e1a3d4d0322587441ccc5caf186001b45dd09ee159713c3e3ea0f411f94a5d6665546562d09c093b687a129e464a57e18cdbf5306bcabf3e7cc95f5ba98cdd9bf3768",
+      "messages": [],
+      "committed_messages": [],
+      "secret_prover_blind": "1b6f406b17aaf92dc7deb911c7cae49756a6623b5c385b5ae6214d7e3d9597f7",
+      "signature": "ab54c35fb2af5c75d6368bc5772547e126d60a92205d011bb9ee5d1149432e91611fd376fe5b79d6ed7c2ba00a19b7434744945fd77bf02cd4628a6e5deeae50768116d55510251bb6a716a38340e184"
+    },
+    {
+      "name": "Multiple Prover Committed Messages, No Signer Messages",
+      "commitment_with_proof": "a2a3e178bcc77f98a3c07f8532134021ab5847326b5b3bfc3089ca73f1bc51cfe2c99163f4919525dd6bedc8a14ee39e30374643902017ca2e6fb8b5647c736e82d1d3c5b05de5c3021fa6f40d9f36dd22fa06e522411aa20377088ca9a15885d7a5044175f0168e927149ee71e2d257079e0100d6d96a7ddf5392dbc64267af8df7b4711cb5eeccb5e8901d0580b9e837f38337cb7260cffcf4f962154fafe5c98beaed7e4d2fc0f8e7eb1ba4eb04086f170aa4924894e2ab63054049c9ef5dfff4f90b48ef0dcf1f50699907301073270e4782d4d7628cfbe1444cea930928bb45004e41e0ad86a874ea03473845ce42f78ceb6f855ba8326a4d47732c5aed3968b396a07f079b22b5bf2139e51a03",
+      "messages": [],
+      "committed_messages": "ALL",
+      "secret_prover_blind": "4fba5396baa36b2fde81d46a9b9ee89c425dbc5e1ffd65c20249afb4abd37589",
+      "signature": "b7446e6ae4e8b5707ac0108f3b1049e9ea01bd6b2b4a7dcf06e5ad1c62a9c0b1585829f0e30fba6c9761469ed908deca52ba5499cef2827b99527b4adf1f30522ce32366385ba87594b8d0e44d156eec"
+    },
+    {
+      "name": "No Prover Committed Messages, Multiple Signer Messages",
+      "commitment_with_proof": "849d3cc626720202cbc1610fc01ab41ce32099af602def0c579f37dd18b485ef60719275a036bdd8120e7e938c8e1a3d4d0322587441ccc5caf186001b45dd09ee159713c3e3ea0f411f94a5d6665546562d09c093b687a129e464a57e18cdbf5306bcabf3e7cc95f5ba98cdd9bf3768",
+      "messages": "ALL",
+      "committed_messages": [],
+      "secret_prover_blind": "1b6f406b17aaf92dc7deb911c7cae49756a6623b5c385b5ae6214d7e3d9597f7",
+      "signature": "b869cccbe84dce890949db3393c963ead72d044863b2c75bc26c0adfbe08b5bb01db9e4db3313fc660ebb3283634772809d177d191bffde6fe7fbd8ca95d7b842e434ae973b7e458325b9eb23b6cf076"
+    },
+    {
+      "name": "Multiple Prover Committed and Signer Messages",
+      "commitment_with_proof": "a2a3e178bcc77f98a3c07f8532134021ab5847326b5b3bfc3089ca73f1bc51cfe2c99163f4919525dd6bedc8a14ee39e30374643902017ca2e6fb8b5647c736e82d1d3c5b05de5c3021fa6f40d9f36dd22fa06e522411aa20377088ca9a15885d7a5044175f0168e927149ee71e2d257079e0100d6d96a7ddf5392dbc64267af8df7b4711cb5eeccb5e8901d0580b9e837f38337cb7260cffcf4f962154fafe5c98beaed7e4d2fc0f8e7eb1ba4eb04086f170aa4924894e2ab63054049c9ef5dfff4f90b48ef0dcf1f50699907301073270e4782d4d7628cfbe1444cea930928bb45004e41e0ad86a874ea03473845ce42f78ceb6f855ba8326a4d47732c5aed3968b396a07f079b22b5bf2139e51a03",
+      "messages": "ALL",
+      "committed_messages": "ALL",
+      "secret_prover_blind": "4fba5396baa36b2fde81d46a9b9ee89c425dbc5e1ffd65c20249afb4abd37589",
+      "signature": "862eb2fedd0a2b76fb978035cb33952004bdd6136e107bb343cb2c5ea566eb0c3b0ba31b1d022ebf03d0abf050ab293c0afd9c96003331aa13f18a7a47e2e1ccaa8feb7f3a236e92b2da38462358c48a"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **`draft-irtf-cfrg-bbs-blind-signatures`** in a new `affinidi-bbs::blind` module, **byte-exact KAT-gated against the official IETF blind-signatures test vectors** (BLS12-381-SHA-256). Closes #359.

Blind issuance lets a **holder commit to hidden messages the issuer never learns**; the issuer signs over that commitment together with its own cleartext messages, yielding an ordinary BBS signature over the combined set (so it verifies/proves like a plain BBS signature). This is the foundation for holder binding / per-verifier pseudonyms — the `nym_secret` is a committed message — and directly unblocks #360.

## Public API

- `commit(committed_messages) -> (commitment_with_proof, secret_prover_blind)` — holder commits hidden messages; sends `commitment_with_proof` to the issuer, keeps `secret_prover_blind`
- `blind_sign(sk, pk, commitment_with_proof, header, messages) -> Signature` — issuer verifies the commitment proof, then signs over the commitment + its own messages
- `blind_verify(pk, sig, header, messages, committed_messages, secret_prover_blind)` — holder confirms the signature over the full message set

Internals: `CoreCommit`/`CoreCommitVerify`, `calculate_blind_challenge`, the `commitment_with_proof` serialization, `blind_B_calculate`, and `FinalizeBlindSign`. Blind BBS namespaces its generators/hashing under the new `Ciphersuite::blind_api_id` (`…_BLIND_H2G_HM2S_`), with the blind (committed-message) generators prepending a further `"BLIND_"` — a distinct generator set from plain BBS.

## Verification

- **Commit + BlindSign + BlindVerify KATs** pass byte-for-byte across every committed/signer message combination (the official IETF vectors, vendored to `tests/fixtures/blind/`)
- Commit → blind-sign → blind-verify **round-trip** with tamper rejection (wrong `secret_prover_blind`, tampered signer/committed message) and malformed-commitment rejection
- Full crate: **73 tests pass**, `clippy -D warnings` clean, `fmt` clean

## Refactors (additive, no behaviour change)

- `create_generators_with_api_id` / `calculate_domain_with_api_id` / `messages_to_scalars_with_api_id` — explicit-`api_id` variants so the blind namespace can be used; the existing functions delegate to them, so all prior KATs are unaffected
- `verify_signature_pairing` extracted from `core_verify` and shared with `blind_verify`

## Versioning

`affinidi-bbs` **0.2.0 → 0.2.1** (patch). The change is purely additive, so the patch bump keeps the existing `major.minor` pin valid (`affinidi-data-integrity` depends on `affinidi-bbs = "0.2"`) — **no dependent cascade**.

## Notes

- Proof-bearing crypto over BLS12-381 — covered by the pending BBS security audit (#363) before backing real credentials.
- Next: #360 (vc-di-bbs pseudonym document layer) composes this blind issuance with the per-verifier pseudonym proof primitive already added in #358.

Closes #359