### PR TITLE
chore(release): pin release pipeline to per-crate fix branch (publish crypto 0.2.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   rust-pipeline:
-    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@main
+    # TEMPORARY: pinned to the per-crate isolated-publish fix branch
+    # (affinidi/pipeline-rust#77) so the affinidi-crypto 0.2.0 release can
+    # publish each crate independently instead of failing on the full-workspace
+    # build (vta-sdk un-unification). Revert to `@main` once #77 merges.
+    # Tracking: affinidi/affinidi-tdk-rs#367
+    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@fix/per-crate-isolated-publish
     secrets: inherit
     with:
       toolchain: "1.95.0"


### PR DESCRIPTION
Temporarily points `release.yaml` at **affinidi/pipeline-rust#77** (`@fix/per-crate-isolated-publish`) so the `affinidi-crypto 0.2.0` release can go out.

## Why

The current pipeline does an unconditional full-workspace `cargo build --release` before publishing. That compiles `vta-sdk`, which un-unifies `affinidi-crypto` (it pins `0.1`) and fails the build → **nothing publishes**. The fix branch removes that global build and publishes each crate **in isolation, only when its local version is higher than crates.io**.

## Effect once merged to `main`

Merging this triggers the release workflow (push to `main`) using the fixed pipeline. It will:
- ✅ publish `affinidi-crypto 0.2.0` + the other bumped, healthy crates (secrets-resolver 0.5.7, did-common 0.3.5, did-authentication 0.3.6, messaging-didcomm 0.15.1, messaging-sdk 0.18.7, did-resolver-cache-sdk 0.8.7, affinidi-tdk 0.7.4);
- ⏭️ skip the ~29 unchanged crates;
- ❌ fail only on the **mediator family** (vta-sdk, #364) — without blocking the rest. A re-run after vta-sdk lands publishes those (everything else skipped as already-published).

The job will therefore finish **red** (mediator can't publish yet), but everything publishable will be published.

## Temporary — must be reverted

This pins a *branch* of pipeline-rust, not `@main`. **Revert to `@main` once #77 merges** — tracked in **#367**.

## Related
- affinidi/pipeline-rust#77 — release-job fix
- #367 — revert tracking
- #364 — vta-sdk re-unification (mediator unblock)