### PR TITLE
fix: affinidi-tdk-common 0.6.3 — republish with data-integrity 0.7

### DIFF
--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,18 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.3 — 2026-06-07
+
+### Fixed
+
+- Republish to pick up the `affinidi-data-integrity` `0.6 → 0.7` bump. The
+  dependency requirement was updated to `0.7` in #358 but this crate's
+  version was not bumped, so the published `0.6.2` still required
+  `data-integrity ^0.6`. That left two `data-integrity` versions (0.6.x +
+  0.7.0) in any downstream graph that also used 0.7 — notably blocking
+  `affinidi-tdk` from publishing with `expected DataIntegrityError, found a
+  different DataIntegrityError`. No code or API change in this crate.
+
 ## 0.6.2 — 2026-05-28
 
 ### Security

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.2"
+version = "0.6.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"


### PR DESCRIPTION
## Problem

The `affinidi-crypto 0.2.0` release (per-crate pipeline) published 7 crates successfully, but **`affinidi-tdk` failed to publish**:

```
error[E0308]: expected `DataIntegrityError`, found a different `DataIntegrityError`
  affinidi-data-integrity-0.6.1  (via affinidi-tdk-common 0.6.2 from crates.io)
  affinidi-data-integrity-0.7.0  (what affinidi-tdk 0.7.4 pulls)
```

Root cause: PR #358 bumped `affinidi-data-integrity` `0.6 → 0.7` and updated `affinidi-tdk-common`'s requirement to `0.7`, **but did not bump `affinidi-tdk-common`'s own version**. So:

- crates.io `affinidi-tdk-common 0.6.2` still requires `data-integrity ^0.6`;
- the release version-gate correctly skips it (local `0.6.2` == published `0.6.2`), so the corrected crate never republishes;
- `affinidi-tdk 0.7.4` then resolves both `data-integrity 0.6.1` (via the stale tdk-common) and `0.7.0` → two incompatible `DataIntegrityError` types.

## Fix

Bump `affinidi-tdk-common` `0.6.2 → 0.6.3` so it republishes with the correct `data-integrity 0.7` requirement. Patch bump; `affinidi-tdk` pins `affinidi-tdk-common = "0.6"` so it picks it up automatically. No code/API change.

## Effect once merged

Triggers the (per-crate) release: publishes `affinidi-tdk-common 0.6.3` then `affinidi-tdk 0.7.4`; all already-published crates are skipped. The only remaining unpublished crate is the **mediator family** (blocked on vta-sdk, #364).

## Related
- #358 — introduced the data-integrity 0.7 bump (the skew).
- #364 — vta-sdk re-unification (mediator family; separate).
- affinidi/pipeline-rust#77 / #368 — the per-crate release pipeline that surfaced this cleanly instead of failing the whole release.