### PR TITLE
fix: affinidi-data-integrity 0.7.1 — republish on affinidi-crypto 0.2

### DIFF
--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi Data Integrity Changelog
 
+## 7th June 2026 Release 0.7.1
+
+### Fixed
+
+- Republish requiring `affinidi-crypto 0.2`. 0.7.0 shipped (in #358) before
+  `affinidi-crypto 0.2.0` and so pinned `crypto ^0.1`; its requirement was
+  later moved to `0.2` without a version bump, leaving the published 0.7.0
+  stale. Any downstream on `crypto 0.2` (e.g. `affinidi-tdk`) then resolved
+  two `affinidi-crypto` copies (0.1.x + 0.2.0) and failed to build. Patch
+  bump to republish with the correct requirement. No code/API change.
+
 ## 6th June 2026 Release 0.7.0
 
 Standards-interoperable **W3C vc-di-bbs `bbs-2023`** selective disclosure

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"


### PR DESCRIPTION
## Problem

Published **`affinidi-data-integrity 0.7.0`** (shipped in #358, before `affinidi-crypto 0.2.0`) requires **`affinidi-crypto ^0.1`**. Its requirement was later moved to `0.2` without a version bump, so the release version-gate skips it (local `0.7.0` == published `0.7.0`) and the stale crate is never republished.

Effect: any dependency graph that also uses `crypto 0.2` resolves **two `affinidi-crypto` copies** (0.1.x + 0.2.0). This is the same class of skew that blocked `affinidi-tdk` (fixed for the `data-integrity` *version* mismatch in #370), but on the **crypto** axis.

Confirmed on crates.io:
```
affinidi-data-integrity 0.7.0 -> affinidi-crypto ^0.1   (stale)
```

## Fix

Bump `affinidi-data-integrity` `0.7.0 → 0.7.1` so it republishes requiring **`affinidi-crypto 0.2`**.

Downstreams pin `data-integrity` by **major.minor** (`"0.7"`), so this one republish converges the whole tree onto a single `crypto 0.2.0` — **no version bump needed** on the dependents you flagged:

- `affinidi-tdk-common 0.6.3` → `data-integrity ^0.7` → `0.7.1` → crypto 0.2
- `affinidi-tdk 0.7.4` → `data-integrity ^0.7` → `0.7.1` → crypto 0.2
- `affinidi-meeting-place 0.4.2` → (via `tdk-common`) → crypto 0.2

Patch bump, no code/API change.

## After merge

Triggers the per-crate release: publishes `affinidi-data-integrity 0.7.1`; everything else is skipped (already published / unchanged). Only the **mediator family** remains, blocked on vta-sdk (#364).

## Related
- #358 — introduced data-integrity 0.7 / the crypto-pin skew.
- #370 — sibling fix (tdk-common version skew on data-integrity).
- #364 — vta-sdk re-unification (mediator family).