### PR TITLE
chore: update vta-sdk 0.9.11 + didwebvh-rs 0.5.4 — crypto 0.2 unification

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -11,11 +11,12 @@
   decoding, and the secret-key-type → curve mapping). Previously these curves
   were silently skipped by a wildcard arm, so a mediator could not pack to or
   unpack from a P-384/P-521 peer.
-- **Build note:** the bump to `affinidi-crypto 0.2` un-unifies `vta-sdk`
-  (which pins `affinidi-crypto 0.1`) from the workspace `[patch.crates-io]`
-  redirect. This crate will not build until a `vta-sdk` release against
-  `affinidi-crypto 0.2` is published and the `vta-sdk` dependency here is
-  bumped to it. Tracked as a cross-repo coordination follow-up.
+- Updated `vta-sdk` to `0.9.11` and `didwebvh-rs` to `0.5.4`, both of which
+  now build on `affinidi-crypto 0.2` / `affinidi-data-integrity 0.7`. This
+  resolves the earlier un-unification where the older `vta-sdk 0.9.x`
+  (`crypto 0.1`) and `didwebvh-rs 0.5.3` (`data-integrity 0.6 → crypto 0.1`)
+  dragged a second `affinidi-crypto` into the tree. The whole crate now
+  resolves to a single `affinidi-crypto 0.2.0`.
 
 ## 5th June 2026
 

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.9", features = ["integration"] }
+vta-sdk = { version = "0.9.11", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }
@@ -113,7 +113,7 @@ redis = { version = "1.2", features = [
 fjall = { version = "3.1", optional = true }
 
 # ── DID Infrastructure ───────────────────────────────────────────────────
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.5.4"
 
 # ── AWS Integration (optional, behind `aws` feature) ────────────────────
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -7,10 +7,10 @@
 ### 0.1.8 — affinidi-crypto 0.2
 
 - Bump `affinidi-crypto` to `0.2` (P-384/P-521 key agreement +
-  `#[non_exhaustive]` key-agreement enums, #357). **Note:** this tool also
-  depends on `vta-sdk`, which pins `affinidi-crypto 0.1`; it will not build
-  until a `vta-sdk` release against `affinidi-crypto 0.2` is published and
-  the `vta-sdk` pin here is bumped.
+  `#[non_exhaustive]` key-agreement enums, #357). Updated `vta-sdk` to
+  `0.9.11` and `didwebvh-rs` to `0.5.4` (both now on `affinidi-crypto 0.2` /
+  `affinidi-data-integrity 0.7`), so the tool resolves to a single
+  `affinidi-crypto 0.2.0`.
 
 ### 0.1.7 — stop clobbering the unified secret backend
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -76,7 +76,7 @@ affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator
 ] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.5.4"
 
 # ── VTA Integration ──────────────────────────────────────────────────────
 ## provision-client: orchestration layer that drives setup-key minting,
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.9", features = ["provision-client"] }
+vta-sdk = { version = "0.9.11", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.9", features = ["test-support"] }
+vta-sdk = { version = "0.9.11", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
Both external crates that were dragging a second `affinidi-crypto 0.1.12` into the tree now build on crypto 0.2:

- **`vta-sdk 0.9.11`** → `affinidi-crypto ^0.2`, `affinidi-data-integrity ^0.7`
- **`didwebvh-rs 0.5.4`** → `affinidi-data-integrity ^0.7` (→ crypto 0.2)

## Change

Pin `mediator` + `mediator-setup` to these minimum versions (`vta-sdk = "0.9.11"`, `didwebvh-rs = "0.5.4"`) so the workspace can never resolve the old crypto-0.1 builds again (`vta-sdk 0.9.9`, `didwebvh-rs 0.5.3 → data-integrity 0.6.1 → crypto 0.1`).

After `cargo update`, the lock **drops `affinidi-crypto 0.1.12` and `affinidi-data-integrity 0.6.1` entirely** — the whole workspace resolves to a single `affinidi-crypto 0.2.0`, and `mediator` + `mediator-setup` now build clean (verified locally).

No version bump: both crates were already bumped (`0.15.14` / `0.1.8`) and are unpublished.

## Effect

- ✅ Resolves the `vta-sdk` un-unification (**#364**) — the mediator family compiles on crypto 0.2.
- ✅ Eliminates the `didwebvh-rs → data-integrity 0.6 → crypto 0.1` transitive split.

## Ordering note (publish)

The mediator **publish** verify resolves from crates.io (no `[patch]`), where `vta-sdk 0.9.11` / `didwebvh-rs 0.5.4` both require `data-integrity ^0.7`. So **#371 (`affinidi-data-integrity 0.7.1`, crypto 0.2) must be published first** — otherwise `data-integrity ^0.7` resolves to the stale `0.7.0` (crypto 0.1). The per-crate release pipeline publishes `data-integrity` before the mediator (topological order), so merging #371 and this PR lets the mediator family finally publish on crypto 0.2.

## Related
- #364 — vta-sdk re-unification (this resolves it)
- #371 — data-integrity 0.7.1 (prerequisite for the mediator publish)
- #367 — revert release.yaml pin once pipeline-rust#77 merges