### PR TITLE
refactor: deprecate legacy bbs_2023 encoding in favour of bbs_2023_transform (#362)

### DIFF
--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Affinidi Data Integrity Changelog
 
+## 7th June 2026 Release 0.7.3
+
+### Deprecated
+
+- The legacy `bbs_2023` module (an affinidi-internal `pointer`/JCS statement
+  encoding) is **deprecated** — it is **not** interoperable with other vc-di-bbs
+  implementations (no RDF Dataset Canonicalization). Its public functions now
+  carry `#[deprecated]` attributes. Use `bbs_2023_transform` — the
+  standards-track, RDF-canonical `bbs-2023` cryptosuite pinned byte-for-byte to
+  the official `w3c/vc-di-bbs` vectors (issuer / holder / verifier + per-verifier
+  pseudonym). No BBS credentials using the legacy encoding were issued in
+  production. The module is retained this release for migration and will be
+  removed in a future release.
+
 ## 7th June 2026 Release 0.7.2
 
 W3C vc-di-bbs **per-verifier pseudonym / holder binding** (`featureOption:

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-data-integrity/src/bbs_2023.rs
+++ b/crates/credentials/affinidi-data-integrity/src/bbs_2023.rs
@@ -23,7 +23,25 @@
  *
  * Addresses ARF ZKP requirements ZKP_01 through ZKP_06 for unlinkable
  * selective disclosure of PID and QEAA attributes.
+ *
+ * # ⚠️ Deprecated — not interoperable
+ *
+ * This module's statement encoding (an affinidi-internal `pointer`/JCS scheme)
+ * is **not** interoperable with other vc-di-bbs implementations: it does not use
+ * RDF Dataset Canonicalization, so its `proofValue`s do not match the W3C
+ * vectors and cannot be verified by a conforming verifier (or vice versa).
+ *
+ * Use [`crate::bbs_2023_transform`] instead — the standards-track,
+ * RDF-canonical `bbs-2023` implementation, pinned byte-for-byte to the official
+ * `w3c/vc-di-bbs` test vectors (issuer / holder / verifier, plus per-verifier
+ * pseudonym / holder binding). No BBS credentials using this legacy encoding
+ * were issued in production.
  */
+
+// This module is itself deprecated; allow its internal cross-calls and tests to
+// use the deprecated functions without warnings. External callers still get the
+// per-function deprecation warnings.
+#![allow(deprecated)]
 
 use affinidi_bbs::{self as bbs, PublicKey, SecretKey, Signature};
 use serde::{Deserialize, Serialize};
@@ -48,6 +66,10 @@ use crate::DataIntegrityError;
 /// # Returns
 ///
 /// A tuple of (BBS signature, message bytes used for signing).
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn sign_base(
     claims: &[(&str, &[u8])],
     header: &[u8],
@@ -86,6 +108,10 @@ pub fn sign_base(
 /// # Returns
 ///
 /// The BBS zero-knowledge proof bytes.
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn derive_proof(
     pk: &PublicKey,
     signature: &Signature,
@@ -121,6 +147,10 @@ pub fn derive_proof(
 /// # Returns
 ///
 /// `true` if the proof is valid.
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn verify_proof(
     pk: &PublicKey,
     proof: &bbs::Proof,
@@ -152,6 +182,10 @@ pub fn verify_proof(
 ///
 /// Each mandatory statement is length-prefixed (8-byte big-endian) before hashing
 /// to prevent ambiguity (e.g., `["ab","cd"]` vs `["abc","d"]`).
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn compute_bbs_header(proof_options: &[u8], mandatory_statements: &[&[u8]]) -> Vec<u8> {
     let mut header = Vec::with_capacity(64);
 
@@ -227,6 +261,10 @@ struct DerivedProofValue {
 /// disclosed (typically `/@context`, `/type`, `/issuer`,
 /// `/credentialSubject/id`, validity dates). The returned document carries a
 /// `proof` with `cryptosuite: bbs-2023`.
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn sign_vc_base(
     document: &Value,
     mandatory_pointers: &[&str],
@@ -279,6 +317,10 @@ pub fn sign_vc_base(
 /// disclosing only the claims under `selective_pointers` (plus the mandatory
 /// ones). `presentation_header` is the verifier's nonce/challenge. `pk` is the
 /// issuer's BBS public key.
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn derive_vc(
     base_document: &Value,
     selective_pointers: &[&str],
@@ -355,6 +397,10 @@ pub fn derive_vc(
 /// Verify a **derived proof** document (verifier side). `presentation_header`
 /// must match the one the holder derived with; `pk` is the issuer's BBS public
 /// key. Returns `Ok(true)` iff the proof is valid for the disclosed claims.
+#[deprecated(
+    since = "0.7.3",
+    note = "the affinidi-internal bbs_2023 statement encoding is NOT interoperable with other vc-di-bbs implementations; use the standards-track `bbs_2023_transform` (W3C vc-di-bbs, RDF-canonical) instead"
+)]
 pub fn verify_vc_derived(
     derived_document: &Value,
     presentation_header: &[u8],

--- a/crates/credentials/affinidi-data-integrity/src/lib.rs
+++ b/crates/credentials/affinidi-data-integrity/src/lib.rs
@@ -88,15 +88,18 @@ pub use conformance::verify_conformance;
 pub use did_vm::{DidKeyResolver, ResolvedKey, VerificationMethodResolver};
 pub use multi::{MultiVerifyResult, VerifyPolicy, verify_multi};
 
-/// BBS-2023 Data Integrity Cryptosuite for zero-knowledge selective disclosure.
-///
-/// Enabled via the `bbs-2023` feature flag.
+/// **Deprecated** — the legacy affinidi-internal `bbs-2023` encoding (not
+/// interoperable with other vc-di-bbs implementations). Use
+/// [`bbs_2023_transform`] instead. Enabled via the `bbs-2023` feature flag.
 #[cfg(feature = "bbs-2023")]
 pub mod bbs_2023;
 
-/// W3C vc-di-bbs `bbs-2023` transformation primitives (RDF-canonical, standards
-/// interoperable). The standards-track replacement for [`bbs_2023`]'s internal
-/// statement encoding; built incrementally and pinned to the official vectors.
+/// W3C vc-di-bbs `bbs-2023` cryptosuite (RDF-canonical, standards-interoperable)
+/// — **the** `bbs-2023` implementation. Pinned byte-for-byte to the official
+/// `w3c/vc-di-bbs` vectors: issuer ([`bbs_2023_transform::sign_base_document`]),
+/// holder ([`bbs_2023_transform::create_derived_proof`]), verifier
+/// ([`bbs_2023_transform::verify_derived_proof`]), plus per-verifier pseudonym /
+/// holder binding. Supersedes the legacy [`bbs_2023`] module.
 #[cfg(feature = "bbs-2023")]
 pub mod bbs_2023_transform;
 
@@ -425,7 +428,10 @@ where
         #[cfg(feature = "bbs-2023")]
         if matches!(proof_config.cryptosuite, CryptoSuite::Bbs2023) {
             return Err(DataIntegrityError::UnsupportedCryptoSuite {
-                name: "bbs-2023 proofs must be verified via bbs_2023::verify_proof".to_string(),
+                name: "bbs-2023 derived proofs are verified via \
+                       bbs_2023_transform::verify_derived_proof (or \
+                       verify_pseudonym_derived_proof), not the generic verify path"
+                    .to_string(),
             });
         }
         let jcs_doc = to_string(&signed_doc)

--- a/crates/credentials/affinidi-data-integrity/src/suite_ops.rs
+++ b/crates/credentials/affinidi-data-integrity/src/suite_ops.rs
@@ -147,7 +147,8 @@ impl CryptoSuiteOps for Bbs2023 {
     }
     fn verify(&self, _key: &[u8], _data: &[u8], _sig: &[u8]) -> Result<(), DataIntegrityError> {
         Err(DataIntegrityError::UnsupportedCryptoSuite {
-            name: "bbs-2023 verification uses bbs_2023::verify_proof, not CryptoSuiteOps::verify"
+            name: "bbs-2023 verification uses \
+                   bbs_2023_transform::verify_derived_proof, not CryptoSuiteOps::verify"
                 .to_string(),
         })
     }


### PR DESCRIPTION
## Summary

Deprecates the legacy `affinidi_data_integrity::bbs_2023` module in favour of the standards-track `bbs_2023_transform`. Closes #362.

The legacy `bbs_2023` module uses an **affinidi-internal `pointer`/JCS statement encoding** that is **not interoperable** with other vc-di-bbs implementations — it doesn't use RDF Dataset Canonicalization, so its `proofValue`s don't match the W3C vectors and can't round-trip with a conforming verifier. `bbs_2023_transform` (built across #358 → #366 → #369 → #373) is the **RDF-canonical, byte-for-byte W3C-vectors-pinned** implementation (issuer / holder / verifier + per-verifier pseudonym / holder binding), and is now the canonical `bbs-2023` path.

## Changes

- `#[deprecated]` on all 7 public functions of `bbs_2023` (`sign_base`, `derive_proof`, `verify_proof`, `compute_bbs_header`, `sign_vc_base`, `derive_vc`, `verify_vc_derived`), each pointing to `bbs_2023_transform`.
- Module doc marks it deprecated / non-interoperable; an inner `#![allow(deprecated)]` keeps the module's own cross-calls and tests warning-free, while **external callers still get the per-function deprecation warnings**.
- Updated the `lib.rs` module docs and the BBS verify guidance strings (`lib.rs`, `suite_ops.rs`) to point at `bbs_2023_transform::verify_derived_proof` / `verify_pseudonym_derived_proof`.

## Why deprecate (not remove) yet

There are **no internal callers** of the legacy module (only guidance strings referenced it), and no BBS credentials using this encoding were issued in production. But the **OpenVTC sibling** may still reference the old wire format externally, so this release keeps the module functional with deprecation warnings to give a migration window; removal follows in a later release.

## Verification

- 64 data-integrity tests pass; clippy \`-D warnings\` clean (the inner allow means no stray deprecation warnings).
- \`cargo build --workspace\` is clean — nothing downstream uses the now-deprecated functions.

\`affinidi-data-integrity\` 0.7.2 → 0.7.3 (deprecation only; additive — existing pins stay valid).

Closes #362