### PR TITLE
fix: harden BBS verifier against malformed input + audit-readiness (#363)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ Cargo.lock
 docs/*
 # Architecture Decision Records are first-class, tracked docs.
 !docs/adr/
+# Security audit-readiness / threat-model docs are tracked.
+!docs/security/
 
 # mediator-setup wizard generated artifacts (may land in any directory)
 **/conf/secrets.json

--- a/crates/core/affinidi-bbs/Cargo.toml
+++ b/crates/core/affinidi-bbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-bbs"
 description = "BBS Signatures (IETF draft-irtf-cfrg-bbs-signatures) implementation over BLS12-381."
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-bbs/src/generators.rs
+++ b/crates/core/affinidi-bbs/src/generators.rs
@@ -168,6 +168,11 @@ pub fn point_to_bytes(p: &G1Projective) -> [u8; 48] {
 }
 
 /// Deserialize a G1 point from compressed bytes.
+///
+/// SECURITY: must use `from_compressed` (full on-curve + prime-order subgroup
+/// `is_torsion_free` check), NOT `from_compressed_unchecked` — skipping the
+/// subgroup check would open small-subgroup / cofactor attacks on every
+/// attacker-supplied proof point (Abar/Bbar/D, pseudonym).
 pub fn point_from_bytes(bytes: &[u8; 48]) -> Option<G1Projective> {
     let affine = G1Affine::from_compressed(bytes);
     if affine.is_some().into() {

--- a/crates/core/affinidi-bbs/src/lib.rs
+++ b/crates/core/affinidi-bbs/src/lib.rs
@@ -403,4 +403,80 @@ mod tests {
             .unwrap()
         );
     }
+
+    // --- Verifier robustness against malformed presentations (must return Err,
+    // never panic). Regression tests for the audit hardening (#363). ---
+
+    fn three_msg_proof() -> (PublicKey, Proof) {
+        let sk = keygen(b"robustness-key-material-32-bytes", b"").unwrap();
+        let pk = sk_to_pk(&sk);
+        let messages = [b"a".as_ref(), b"b", b"c"];
+        let sig = sign(&sk, &pk, b"app", &messages).unwrap();
+        let proof = proof_gen(&pk, &sig, b"app", b"s", &messages, &[0]).unwrap();
+        (pk, proof)
+    }
+
+    #[test]
+    fn verify_rejects_out_of_bounds_disclosed_index() {
+        let (pk, proof) = three_msg_proof();
+        let r = proof_verify(&pk, &proof, b"app", b"s", &[b"a".as_ref()], &[999]);
+        assert!(
+            r.is_err(),
+            "out-of-bounds disclosed index must error, not panic"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_duplicate_disclosed_index() {
+        let (pk, proof) = three_msg_proof();
+        let r = proof_verify(&pk, &proof, b"app", b"s", &[b"a".as_ref(), b"a"], &[0, 0]);
+        assert!(
+            r.is_err(),
+            "duplicate disclosed index must error, not panic"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_non_canonical_proof_length() {
+        let (pk, proof) = three_msg_proof();
+        let mut bytes = proof.to_bytes().to_vec();
+        bytes.push(0); // trailing partial-scalar byte
+        let bad = Proof::from_bytes(&bytes);
+        let r = proof_verify(&pk, &bad, b"app", b"s", &[b"a".as_ref()], &[0]);
+        assert!(r.is_err(), "non-canonical proof length must error");
+    }
+
+    #[test]
+    fn pseudonym_verify_rejects_degenerate_proof() {
+        // A minimal valid-structure proof (3 points + 4 scalars, U=0) with an
+        // empty disclosure forces L=0 in the pseudonym branch — must Err, not
+        // underflow/panic.
+        use bls12_381_plus::{G1Affine, Scalar};
+        let g1 = G1Affine::generator().to_compressed();
+        let one = Scalar::ONE.to_be_bytes();
+        let mut bytes = Vec::new();
+        for _ in 0..3 {
+            bytes.extend_from_slice(&g1);
+        }
+        for _ in 0..4 {
+            bytes.extend_from_slice(&one);
+        }
+        let proof = Proof::from_bytes(&bytes);
+        let pseudonym = Pseudonym::from_bytes(&g1).unwrap();
+        let (pk, _sig, _msgs) = pseudonym_fixture();
+        let r = proof_verify_with_pseudonym(
+            &pk,
+            &proof,
+            b"hdr",
+            b"s",
+            &[],
+            &[],
+            b"verifier-a",
+            &pseudonym,
+        );
+        assert!(
+            r.is_err(),
+            "degenerate pseudonym proof must error, not panic"
+        );
+    }
 }

--- a/crates/core/affinidi-bbs/src/proof.rs
+++ b/crates/core/affinidi-bbs/src/proof.rs
@@ -458,12 +458,44 @@ pub(crate) fn proof_verify_core(
     if proof_bytes.len() < min_len {
         return Err(BbsError::InvalidProof("proof too short".into()));
     }
+    // Reject non-canonical proof lengths (trailing partial-scalar bytes) so a
+    // proof has exactly one byte encoding.
+    if !(proof_bytes.len() - min_len).is_multiple_of(scalar_len) {
+        return Err(BbsError::InvalidProof(
+            "proof length is not canonical".into(),
+        ));
+    }
     let u = (proof_bytes.len() - min_len) / scalar_len;
     let l = r + u;
     if h_generators.len() != l {
         return Err(BbsError::InvalidProof(
             "generator/message count mismatch".into(),
         ));
+    }
+
+    // Validate the verifier-supplied disclosed indexes BEFORE they index into
+    // `h_generators` / `disclosed_scalars`. `proof_gen_core` validates the
+    // generation side; mirroring it here prevents a malformed presentation from
+    // panicking the verifier (remotely-triggerable DoS).
+    if disclosed_scalars.len() != r {
+        return Err(BbsError::InvalidProof(
+            "disclosed scalar/index count mismatch".into(),
+        ));
+    }
+    {
+        let mut seen = HashSet::with_capacity(r);
+        for &idx in disclosed_indexes {
+            if idx >= l {
+                return Err(BbsError::InvalidIndex(format!(
+                    "disclosed index {idx} >= message count {l}"
+                )));
+            }
+            if !seen.insert(idx) {
+                return Err(BbsError::InvalidIndex(format!(
+                    "duplicate disclosed index: {idx}"
+                )));
+            }
+        }
     }
 
     // 1. Deserialize proof components
@@ -497,6 +529,9 @@ pub(crate) fn proof_verify_core(
     }
 
     let challenge = read_scalar(proof_bytes, &mut offset)?;
+    if bool::from(challenge.is_zero()) {
+        return Err(BbsError::InvalidProof("zero challenge".into()));
+    }
 
     // 5. Determine undisclosed indexes
     let undisclosed_indexes: Vec<usize> =
@@ -528,6 +563,15 @@ pub(crate) fn proof_verify_core(
     // PseudonymProofVerify: Uv = OP·m̂_nym − Pseudonym·c.
     let nym_terms: Option<(G1Projective, G1Projective, G1Projective)> = match nym {
         Some((op, pseudonym)) => {
+            // A pseudonym proof structurally requires the `nym_secret` as a
+            // present, undisclosed last message, so `l >= 1` and `u >= 1`.
+            // Enforce it rather than assuming it (else `l - 1` / `m_hats[u - 1]`
+            // underflow/panic on a crafted proof — verifier DoS).
+            if l == 0 || u == 0 {
+                return Err(BbsError::InvalidProof(
+                    "pseudonym proof requires an undisclosed nym_secret".into(),
+                ));
+            }
             let nym_index = l - 1;
             if disclosed_indexes.contains(&nym_index) {
                 return Err(BbsError::InvalidIndex(

--- a/crates/core/affinidi-bbs/src/types.rs
+++ b/crates/core/affinidi-bbs/src/types.rs
@@ -17,8 +17,10 @@ pub struct SecretKey(pub(crate) Scalar);
 
 impl Drop for SecretKey {
     fn drop(&mut self) {
-        // Overwrite the scalar's memory with zeros using volatile writes.
-        // This prevents the compiler from optimizing away the zeroing.
+        // Overwrite the scalar's memory with zeros using volatile writes (the
+        // volatile prevents the compiler from optimizing the zeroing away). Sound
+        // because `bls12_381_plus::Scalar` is a plain inline `[u64; 4]` with no
+        // heap indirection; `SecretKey: Clone` means each clone runs this Drop.
         let ptr = &mut self.0 as *mut Scalar as *mut u8;
         let size = std::mem::size_of::<Scalar>();
         unsafe {
@@ -26,6 +28,9 @@ impl Drop for SecretKey {
                 std::ptr::write_volatile(ptr.add(i), 0);
             }
         }
+        // Prevent the compiler/CPU from reordering subsequent operations before
+        // the zeroing (defense in depth, matching the `zeroize` crate's fence).
+        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
     }
 }
 

--- a/docs/security/bbs-audit-readiness.md
+++ b/docs/security/bbs-audit-readiness.md
@@ -1,0 +1,153 @@
+# BBS / vc-di-bbs — Security Audit Readiness
+
+Status: **pre-audit**. Tracking issue: #363.
+
+This document scopes the proof-bearing BBS cryptography in this workspace for an
+external security audit: what it is, the trust model, what already gives
+assurance, the findings of an internal self-review (and their resolution), and
+the open questions we want an auditor to focus on.
+
+> **Production gate.** None of this crypto should back real credentials until the
+> external audit completes. The implementation is conformance-tested but
+> un-audited.
+
+## 1. Scope
+
+In-house implementation of:
+
+- **BBS signatures** over BLS12-381 — `draft-irtf-cfrg-bbs-signatures`
+- **Blind BBS** — `draft-irtf-cfrg-bbs-blind-signatures`
+- **Per-verifier pseudonyms / holder binding** — `draft-irtf-cfrg-bbs-per-verifier-linkability`
+- The **W3C vc-di-bbs `bbs-2023`** document cryptosuite that wraps the above
+
+| Crate | Path | Role | Audit priority |
+|---|---|---|---|
+| `affinidi-bbs` | `crates/core/affinidi-bbs` | BBS primitives: keygen, sign/verify, ProofGen/Verify, blind, nym/pseudonym | **Highest** (proof-bearing) |
+| `affinidi-rdf-encoding` | `crates/credentials/affinidi-rdf-encoding` | RDF Dataset Canonicalization (RDFC-1.0), JSON-LD expansion → the bytes that get signed/hashed | High (canon correctness ⇒ what is signed) |
+| `affinidi-data-integrity` | `crates/credentials/affinidi-data-integrity` | vc-di-bbs `bbs-2023` framing: proofHash, HMAC label map, grouping, CBOR `proofValue` | Medium (composition / encoding) |
+
+Dependencies (crypto-relevant): `bls12_381_plus` (scalar/point arithmetic,
+`subtle` constant-time), `rand` (CSPRNG), `zeroize`, `sha2`, `ciborium`,
+`multibase`, `hmac`.
+
+The legacy `affinidi_data_integrity::bbs_2023` module is **deprecated** and
+out of scope (it is being removed; not interoperable, no production use).
+
+## 2. Trust model
+
+**Assets**
+- Issuer BBS **secret key** (`SecretKey`) — forges credentials if leaked.
+- Holder **`nym_secret`** / `prover_nym` / `secret_prover_blind` — durable holder
+  secrets; leak enables impersonation and cross-verifier linkage.
+- Per-proof **nonces / blindings** — reuse or predictability breaks
+  unforgeability / unlinkability.
+
+**Adversaries**
+- A malicious **holder** crafting a derived proof to (a) prove undisclosed
+  attributes, (b) forge without a valid signature, or (c) DoS the verifier with
+  malformed input.
+- A malicious **verifier** (or colluding verifiers) attempting to learn
+  undisclosed attributes or link a holder across presentations.
+- A network attacker submitting **arbitrary bytes** to any deserialization /
+  verify entry point.
+
+**Security goals**
+- Unforgeability (EUF-CMA) of signatures and derived proofs.
+- Selective-disclosure soundness (verifier learns nothing about undisclosed
+  messages) and proof unlinkability.
+- Per-verifier pseudonym: stable per `context_id`, unlinkable across, and bound
+  so a proof can't be replayed against a different verifier.
+- No panics / DoS on attacker-controlled input (verify must return `Result`).
+
+**Out of scope / assumed**
+- BLS12-381 field/group arithmetic and pairing in `bls12_381_plus` (assumed
+  correct + constant-time; we rely on its `from_compressed` subgroup checks).
+- The hardness assumptions of BBS (q-SDH / generalized) and the security of the
+  IETF drafts themselves.
+- Key management / storage outside the process; side channels below the Rust
+  abstraction (cache, speculative execution).
+
+## 3. What gives assurance today
+
+- **Byte-exact conformance.** Every primitive is KAT-gated against the official
+  IETF/DIF and W3C `vc-di-bbs` test vectors — signature reproduction, proof
+  reproduction, blind commit/sign, pseudonym commit/sign/proof, and the full
+  vc-di-bbs document flow (issuer/holder/verifier, plain + pseudonym). Our
+  verifier accepts the W3C reference derived proofs byte-for-byte and vice versa.
+- **Deserialization validation.** All G1/G2 points go through
+  `from_compressed` (on-curve **and** prime-order subgroup `is_torsion_free`
+  check, confirmed in `bls12_381_plus 0.8.18`); all scalars through
+  `from_be_bytes` (rejects `>= r`, constant-time). Identity points are rejected
+  for `PublicKey`, `Signature.A`, `Pseudonym`, and blind commitments.
+  `point_from_bytes` carries a comment forbidding `from_compressed_unchecked`.
+- **Issuer secret handling.** `SK` bytes hashed into `e` are zeroized; the
+  `SK + e` intermediate is zeroized before the invertibility branch; `SecretKey`
+  has a redacting `Debug` and a volatile-write `Drop` (now with a `compiler_fence`).
+- **CSPRNG.** `rand::rng()` (`ThreadRng`, ChaCha-based, OS-seeded) — not
+  seedable/predictable. Deterministic mocked scalars are strictly `#[cfg(test)]`.
+- **Domain separation + transcript binding.** Distinct `api_id`s for
+  core / blind / pseudonym / blind-generators. The Fiat-Shamir transcript binds
+  `R`, the disclosed `(index, message)` pairs, `Abar/Bbar/D/T1/T2`, the pseudonym
+  triple `(Pseudonym, OP, Ut)`, the `domain` (binding `PK`, generator count, all
+  generators, `api_id`, length-prefixed header), and the length-prefixed
+  presentation header. A test confirms a pseudonym proof does not verify as a
+  plain proof (binding terms are non-strippable).
+
+## 4. Internal self-review — findings & resolution
+
+A focused crypto review was performed over `affinidi-bbs`. Two **High**
+(remotely-triggerable verifier panics / DoS) were reproduced with live tests and
+**fixed** in this change; lower findings are fixed or tracked below.
+
+| # | Sev | Finding | Status |
+|---|---|---|---|
+| 1 | High | Verifier panic on out-of-bounds / duplicate disclosed index (`proof_verify_core` indexed `h_generators`/`disclosed_scalars` without validating the verifier-supplied indexes). | **Fixed** — bounds + duplicate + count validation mirrored into the verify path. Regression tests added. |
+| 2 | High | Pseudonym verifier integer-underflow + OOB on a degenerate `L=0/U=0` proof (`l - 1`, `m_hats[u-1]`). | **Fixed** — `l == 0 / u == 0` guarded in the nym branch. Regression test added. |
+| 5 | Med | Non-canonical proof length accepted (trailing partial-scalar bytes ignored) ⇒ encoding malleability. | **Fixed** — verify rejects lengths not `≡ min_len (mod scalar_len)`. Regression test added. |
+| 7 | Low | Proof parser did not reject a zero `challenge`. | **Fixed** — zero challenge rejected. |
+| 4 | Med | `SecretKey` Drop used a hand-rolled volatile loop without a fence. | **Hardened** — added `compiler_fence(SeqCst)`; invariants documented. (Full migration to the `zeroize` crate deferred — see §5.) |
+| 6 | Low | Subgroup check relies on `from_compressed` with no guard against an accidental `_unchecked` swap. | **Mitigated** — explicit SECURITY comment in `point_from_bytes`. (A non-subgroup-encoding regression vector is still wanted — see §5.) |
+| 3 | Med | Holder secrets (`nym_secret`, `prover_nym`, `secret_prover_blind`, `m~`/`m^` blindings) are not zeroized in the nym/blind paths. | **Deferred** — see §5 (needs API design; `Scalar` is `Copy` and re-exported). |
+| — | Info | `Ciphersuite::Bls12381Shake256` is selectable but the hash layer is SHA-256-only (silent wrong output if selected). | **Deferred** — see §5. |
+
+Things the review explicitly found **done well** are in §3.
+
+## 5. Known limitations / recommended hardening (for the auditor)
+
+1. **Holder-secret zeroization (Finding 3).** `bls12_381_plus::Scalar` is `Copy`
+   and does not implement `Zeroize`; we also re-export `Scalar`, so callers hold
+   their own copies. Fully zeroizing `nym_secret` / `secret_prover_blind` and the
+   per-proof blinding vectors needs a `Zeroizing<Scalar>` newtype and an API
+   decision about caller-owned copies. We want the auditor's view on the right
+   boundary before committing to an API change.
+2. **`SecretKey` Drop (Finding 4).** Current approach is volatile-write +
+   `compiler_fence`. Question: prefer migrating to the `zeroize` crate's
+   `Zeroize`/`Zeroizing` for the inner scalar?
+3. **Subgroup regression vector (Finding 6).** We assert validation rejects
+   malformed encodings but do not yet have a known *on-curve, non-subgroup* G1/G2
+   encoding to assert rejection of. A vendored test vector would harden against
+   an accidental `_unchecked` swap.
+4. **SHAKE-256 ciphersuite.** Either implement it properly or make selecting it a
+   hard error rather than silently emitting SHA-256 output with mismatched scalar
+   lengths.
+5. **RNG + `fork()`.** `ThreadRng` does not reseed on `fork()`. Do not fork after
+   first RNG use (or reseed in children) to avoid nonce/blinding reuse across
+   forked workers.
+6. **Canonicalization is what gets signed.** The RDFC-1.0 / JSON-LD layer in
+   `affinidi-rdf-encoding` determines the exact bytes signed and hashed; a
+   canonicalization bug is a signature-soundness bug. It is W3C-`rdf-canon`-suite
+   conformant (59/63; 4 documented poison/automorphism skips — #361) but is part
+   of the trusted surface and worth auditor attention.
+
+## 6. Reproducing the evidence
+
+```sh
+# Primitive + conformance KATs, incl. the verifier-robustness regression tests:
+cargo test -p affinidi-bbs
+# vc-di-bbs document layer + RDFC conformance (incl. official W3C rdf-canon suite):
+cargo test -p affinidi-data-integrity --all-features
+cargo test -p affinidi-rdf-encoding
+```
+
+The malformed-input regression tests live in `affinidi-bbs/src/lib.rs`
+(`verify_rejects_*`, `pseudonym_verify_rejects_degenerate_proof`).


### PR DESCRIPTION
## Summary

An internal **pre-audit security self-review** of the proof-bearing BBS crypto in `affinidi-bbs` (the highest-risk surface), with fixes for the real findings and an audit-readiness package. Refs #363.

The review was assisted by a focused security pass; the two High-severity findings were **reproduced with live tests** against the public API before fixing.

## Fixes

**[HIGH] Verifier panic (DoS) on out-of-bounds / duplicate disclosed index.** `proof_verify_core` indexed `h_generators` / `disclosed_scalars` by the verifier-supplied `disclosed_indexes` with no validation — a malformed presentation made the verifier panic (and violated the `Result`-returning contract). Now validated (bounds + duplicates + count) before any indexing, mirroring `proof_gen_core`.

**[HIGH] Pseudonym verifier integer-underflow + OOB** on a degenerate `L=0/U=0` proof (`l - 1`, `m_hats[u - 1]`). The nym branch now guards `l == 0 / u == 0`.

**Hardening:**
- Reject non-canonical proof lengths (trailing partial-scalar bytes) and a zero `challenge`.
- `SecretKey::drop`: add a `compiler_fence` after the volatile zeroing; document the soundness invariants.
- `point_from_bytes`: SECURITY comment forbidding `from_compressed_unchecked` (the subgroup-check reliance).

**Regression tests** for every fix (`verify_rejects_out_of_bounds_disclosed_index`, `..._duplicate_...`, `..._non_canonical_proof_length`, `pseudonym_verify_rejects_degenerate_proof`).

## Audit-readiness doc

`docs/security/bbs-audit-readiness.md` — scope + the 3-crate surface map, trust model (assets / adversaries / goals / out-of-scope), what already gives assurance (KAT conformance, subgroup/range validation, secret handling, CSPRNG, domain separation), the self-review findings table with resolution status, deferred hardening, and **open questions for the external auditor**:
- holder-secret zeroization in the nym/blind paths (needs an API decision — `Scalar` is `Copy` + re-exported)
- migrate `SecretKey` Drop to the `zeroize` crate?
- a non-subgroup encoding regression vector
- resolve the selectable-but-unimplemented SHAKE-256 ciphersuite

(`.gitignore` updated to track `docs/security/`, mirroring `docs/adr/`.)

## Verification

76 `affinidi-bbs` tests pass (incl. the new regression tests); clippy `-D warnings` clean. `affinidi-bbs` 0.2.3 → 0.2.4 (fixes are additive — malformed input that previously panicked now returns `Err`; existing pins stay valid).

> Production gate: this crypto still requires the external audit before backing real credentials. This PR makes it audit-ready and closes the reproducible DoS findings.

Refs #363