### PR TITLE
fix: RDFC-1.0 Hash N-Degree Quads missing `_:` path delimiter — full 63/63 W3C rdf-canon conformance (#361)

### DIFF
--- a/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
+++ b/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Affinidi RDF Encoding Changelog
 
+## 7th June 2026 Release 0.1.4
+
+Full **63/63** W3C `rdf-canon` (RDFC-1.0) conformance — the last 4 skipped
+cases now pass byte-for-byte, so the suite has no quarantined cases.
+
+### Fixed
+
+- **RDFC-1.0 Hash N-Degree Quads — missing `_:` path delimiter** (root cause):
+  steps 5.4.4.1, 5.4.4.2.2, and 5.4.5.2 require each identifier to be appended
+  to the hash path in blank-node form (`_:` prefix). The `_:` is not cosmetic —
+  it delimits consecutive identifiers, so the lexicographic "smallest path"
+  tie-break matches the reference. Omitting it ran ids together
+  (`c14n1`+`c14n2` → `c14n1c14n2`) and selected a *valid-but-non-canonical*
+  labeling on highly-symmetric graphs. This unblocks the previously skipped
+  `test044`–`046` ("poison – evil" automorphism graphs) and `test054`
+  (deep `t-graph`). Real Verifiable Credentials were unaffected (their graphs
+  are not symmetric), and all vc-di-bbs / data-integrity KAT vectors are
+  unchanged.
+
 ## 7th June 2026 Release 0.1.3
 
 JSON-LD 1.1 expansion conformance for the W3C VC Data Model 1.0

--- a/crates/credentials/affinidi-rdf-encoding/Cargo.toml
+++ b/crates/credentials/affinidi-rdf-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-rdf-encoding"
 description = "RDF Dataset Canonicalization (RDFC-1.0) and JSON-LD expansion for W3C Verifiable Credentials"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-rdf-encoding/README.md
+++ b/crates/credentials/affinidi-rdf-encoding/README.md
@@ -14,6 +14,7 @@ Verifiable Credentials. A minimal-dependency implementation.
 - **RDF data model** — `NamedNode`, `BlankNode`, `Literal`, `Quad`, `Dataset`
 - **N-Quads parser/serializer** — W3C spec-compliant with proper escaping
 - **RDFC-1.0 canonicalization** — Full W3C RDF Dataset Canonicalization algorithm
+  (passes all 63 cases of the official `w3c/rdf-canon` `rdfc10` test suite)
 - **JSON-LD expansion + to-RDF** — Focused on VC/DID contexts with bundled W3C context documents
 
 ## Installation

--- a/crates/credentials/affinidi-rdf-encoding/src/rdfc1/hash_ndegree.rs
+++ b/crates/credentials/affinidi-rdf-encoding/src/rdfc1/hash_ndegree.rs
@@ -82,14 +82,22 @@ pub fn hash_ndegree_quads(
             // list. Issuing before recursing is what makes cyclic graphs
             // (e.g. a circle of blank nodes) terminate instead of recursing
             // forever.
+            // RDFC-1.0 step 5.4.4: each identifier is appended in blank-node
+            // form (`_:` prefix). The `_:` is not cosmetic — it delimits
+            // consecutive identifiers in the path string, so the lexicographic
+            // "smallest path" tie-break matches the reference byte-for-byte.
+            // Omitting it runs ids together (`c14n1`+`c14n2`) and silently
+            // selects a valid-but-non-canonical permutation on symmetric graphs.
             for &idx in &perm_indices {
                 let related = &blank_node_list[idx];
                 if canonical_issuer.is_issued(related) {
+                    path.push_str("_:");
                     path.push_str(canonical_issuer.get(related).unwrap());
                 } else {
                     if !issuer_copy.is_issued(related) {
                         recursion_list.push(related.clone());
                     }
+                    path.push_str("_:");
                     path.push_str(&issuer_copy.issue(related));
                 }
                 if !chosen_path.is_empty() && path > chosen_path {
@@ -109,6 +117,9 @@ pub fn hash_ndegree_quads(
                         blank_node_to_hash,
                     )?;
                     issuer_copy = result_issuer;
+                    // RDFC-1.0 step 5.4.5.2: `_:` + identifier (same delimiter
+                    // rationale as step 5.4.4 above).
+                    path.push_str("_:");
                     path.push_str(issuer_copy.get(related).unwrap_or(""));
                     path.push('<');
                     path.push_str(&result_hash);

--- a/crates/credentials/affinidi-rdf-encoding/tests/rdfc10_w3c_suite.rs
+++ b/crates/credentials/affinidi-rdf-encoding/tests/rdfc10_w3c_suite.rs
@@ -9,14 +9,11 @@
 
 use affinidi_rdf_encoding::{nquads, rdfc1};
 
-/// Known-failing cases: highly-symmetric graphs where a remaining RDFC-1.0
-/// N-degree tie-break subtlety picks a valid-but-non-canonical labeling.
-/// `test044`-`046` are the suite's "poison – evil" graphs (complexity 39);
-/// `test054` is a deep asymmetric tree. None of these structures occur in real
-/// Verifiable Credentials (the vc-di-bbs vectors canonicalize byte-exact), so
-/// they are tracked as a follow-up rather than blocking. **Skips are logged, not
-/// silent** — see the eprintln summary below.
-const KNOWN_FAILING: &[&str] = &["test044", "test045", "test046", "test054"];
+/// Known-failing cases. Empty — the full 63-case `rdfc10` suite passes
+/// byte-for-byte, including the "poison – evil" symmetric graphs
+/// (`test044`-`046`) and the deep `t-graph` (`test054`). Kept as a hook so a
+/// future regression can be quarantined explicitly rather than silently.
+const KNOWN_FAILING: &[&str] = &[];
 
 #[test]
 fn rdfc10_official_w3c_suite() {


### PR DESCRIPTION
Closes #361.

## Root cause

The RDFC-1.0 **Hash N-Degree Quads** algorithm builds a per-permutation *hash path* string and selects the lexicographically smallest path as the canonical tie-break. Per the spec, steps **5.4.4.1**, **5.4.4.2.2**, and **5.4.5.2** each append an identifier to the path *in blank-node form* — i.e. prefixed with `_:`.

Our implementation appended the bare identifier. The `_:` is not cosmetic: it **delimits consecutive identifiers** in the concatenated path. Without it, ids run together (`c14n1` + `c14n2` → `c14n1c14n2`), so the lexicographic comparison of competing permutations diverges from the reference implementation and selects a **valid-but-non-canonical** labeling on highly-symmetric graphs.

Diagnosed by running the 4 quarantined cases in isolation: all 4 returned a correct *isomorphism* but the wrong *labeling* in ~37 ms (no hang / stack overflow / permutation-limit blowup), which pointed at the tie-break path string rather than complexity handling.

## Fix

Add the `_:` prefix in the three path-construction sites in `hash_ndegree.rs` (phase-1 canonical id, phase-1 temporary id, phase-2 recursion id).

## Result

- Official `w3c/rdf-canon` `rdfc10` suite: **63/63** (was 59/63). The previously-skipped `test044`–`046` ("poison – evil" automorphism graphs) and `test054` (deep `t-graph`) now pass byte-for-byte; `KNOWN_FAILING` is now empty.
- Real Verifiable Credentials were unaffected (their graphs are not symmetric); **all vc-di-bbs / data-integrity KAT vectors are unchanged** (`affinidi-data-integrity` + `affinidi-bbs` suites green).
- `affinidi-rdf-encoding` **0.1.3 → 0.1.4** (patch; dependent pin `"0.1"` unchanged).

## Verification

- `cargo test -p affinidi-rdf-encoding` — green; `rdfc10 W3C suite: 63 passed, 0 skipped`
- `cargo test -p affinidi-data-integrity -p affinidi-bbs` — green (no KAT regressions)
- `cargo clippy -p affinidi-rdf-encoding --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo deny check` — advisories/bans/licenses/sources ok