### PR TITLE
fix: close concrete BBS audit-readiness hardening items (#363)

### DIFF
--- a/crates/core/affinidi-bbs/Cargo.toml
+++ b/crates/core/affinidi-bbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-bbs"
 description = "BBS Signatures (IETF draft-irtf-cfrg-bbs-signatures) implementation over BLS12-381."
-version = "0.2.4"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-bbs/src/ciphersuite.rs
+++ b/crates/core/affinidi-bbs/src/ciphersuite.rs
@@ -20,6 +20,27 @@ pub enum Ciphersuite {
 }
 
 impl Ciphersuite {
+    /// Reject ciphersuites that are *defined* by this enum but **not implemented**
+    /// by the hash layer.
+    ///
+    /// `Bls12381Shake256` carries the SHAKE-256 id strings and a 64-byte scalar
+    /// length, but every hashing path (`hash::hash_to_scalar`,
+    /// `generators::create_generators*`, `hash::expand_msg_xmd`) is
+    /// SHA-256/XMD-only. Running it would silently emit SHA-256 output under a
+    /// SHAKE domain-separation tag, truncated to 32-byte scalars — a result that
+    /// is neither correct nor interoperable. Fail loudly instead of producing
+    /// wrong cryptographic output. See `docs/security/bbs-audit-readiness.md` §5(4).
+    pub fn ensure_supported(&self) -> crate::error::Result<()> {
+        match self {
+            Self::Bls12381Sha256 => Ok(()),
+            Self::Bls12381Shake256 => Err(crate::error::BbsError::Unsupported(
+                "BLS12-381-SHAKE-256 ciphersuite is not implemented (the hash \
+                 layer is SHA-256/XMD only); use Ciphersuite::Bls12381Sha256"
+                    .into(),
+            )),
+        }
+    }
+
     /// The ciphersuite identifier string.
     pub fn id(&self) -> &'static str {
         match self {
@@ -111,5 +132,16 @@ mod tests {
         let cs = Ciphersuite::Bls12381Sha256;
         let api_id = cs.api_id();
         assert!(api_id.ends_with(b"H2G_HM2S_"));
+    }
+
+    #[test]
+    fn sha256_is_supported_shake256_is_not() {
+        assert!(Ciphersuite::Bls12381Sha256.ensure_supported().is_ok());
+        // SHAKE-256 is defined but unimplemented — must fail loudly rather than
+        // silently emit SHA-256 output (audit Finding §5(4)).
+        assert!(matches!(
+            Ciphersuite::Bls12381Shake256.ensure_supported(),
+            Err(crate::error::BbsError::Unsupported(_))
+        ));
     }
 }

--- a/crates/core/affinidi-bbs/src/error.rs
+++ b/crates/core/affinidi-bbs/src/error.rs
@@ -5,7 +5,11 @@
 use thiserror::Error;
 
 /// Errors that can occur during BBS operations.
+///
+/// `#[non_exhaustive]`: future variants may be added without a breaking change,
+/// so downstream `match` arms should include a wildcard.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum BbsError {
     /// Key material is invalid or too short.
     /// Check that key_material is >= 32 bytes and key_info <= 65535 bytes.
@@ -36,6 +40,11 @@ pub enum BbsError {
     /// This may indicate invalid parameters or an internal error.
     #[error("Crypto error: {0}")]
     Crypto(String),
+
+    /// A selected ciphersuite or option is defined but not implemented.
+    /// Proceeding would silently emit non-conforming output, so it is rejected.
+    #[error("Unsupported: {0}")]
+    Unsupported(String),
 }
 
 pub type Result<T> = std::result::Result<T, BbsError>;

--- a/crates/core/affinidi-bbs/src/generators.rs
+++ b/crates/core/affinidi-bbs/src/generators.rs
@@ -72,6 +72,9 @@ pub fn create_generators_with_api_id(
     api_id: &[u8],
     cs: Ciphersuite,
 ) -> Result<Vec<G1Projective>> {
+    // Reject not-yet-implemented ciphersuites (SHAKE-256) at the generator
+    // chokepoint: the hash-to-curve below is hard-wired to ExpandMsgXmd<Sha256>.
+    cs.ensure_supported()?;
     let seed_dst = [api_id, b"SIG_GENERATOR_SEED_"].concat();
     let generator_dst = [api_id, b"SIG_GENERATOR_DST_"].concat();
     let generator_seed = [api_id, b"MESSAGE_GENERATOR_SEED"].concat();
@@ -227,6 +230,48 @@ mod tests {
         let bytes = point_to_bytes(&p);
         let recovered = point_from_bytes(&bytes).unwrap();
         assert_eq!(point_to_bytes(&recovered), bytes);
+    }
+
+    /// Regression vector for the subgroup check (audit Finding 6).
+    ///
+    /// A compressed G1 encoding (x-coordinate = 4) that decodes to a point which
+    /// is **on the curve** but **not in the prime-order subgroup** (cofactor
+    /// torsion). `point_from_bytes` MUST reject it: accepting torsion points —
+    /// e.g. via an accidental `from_compressed_unchecked` swap — would open
+    /// small-subgroup / cofactor attacks on every attacker-supplied proof point
+    /// (Abar/Bbar/D, pseudonym). The `_unchecked` assertions below prove the
+    /// vector is a genuine subgroup-evasion case rather than mere garbage.
+    #[test]
+    fn point_from_bytes_rejects_on_curve_non_subgroup() {
+        let vector: [u8; 48] = hex::decode(
+            "800000000000000000000000000000000000000000000000\
+             000000000000000000000000000000000000000000000004",
+        )
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+        // The hardened path rejects it.
+        assert!(
+            point_from_bytes(&vector).is_none(),
+            "subgroup check must reject an on-curve torsion point"
+        );
+        assert!(bool::from(G1Affine::from_compressed(&vector).is_none()));
+
+        // Prove the vector really is on-curve-but-not-subgroup (so the test is
+        // meaningful): the unchecked decode succeeds, the point is on the curve,
+        // but it fails the prime-order subgroup membership test.
+        let unchecked = G1Affine::from_compressed_unchecked(&vector);
+        assert!(
+            bool::from(unchecked.is_some()),
+            "vector must decode unchecked"
+        );
+        let p = unchecked.unwrap();
+        assert!(bool::from(p.is_on_curve()), "vector must be on the curve");
+        assert!(
+            !bool::from(p.is_torsion_free()),
+            "vector must be outside the prime-order subgroup"
+        );
     }
 
     #[test]

--- a/crates/core/affinidi-bbs/src/hash.rs
+++ b/crates/core/affinidi-bbs/src/hash.rs
@@ -22,7 +22,10 @@ use crate::error::{BbsError, Result};
 /// Per IETF draft §4.3.3:
 /// 1. `uniform_bytes = expand_message(msg_octets, dst, expand_len)`
 /// 2. Return `OS2IP(uniform_bytes) mod r`
-pub fn hash_to_scalar(data: &[u8], dst: &[u8], _cs: Ciphersuite) -> Result<Scalar> {
+pub fn hash_to_scalar(data: &[u8], dst: &[u8], cs: Ciphersuite) -> Result<Scalar> {
+    // Reject not-yet-implemented ciphersuites (SHAKE-256) at the universal
+    // scalar-derivation chokepoint rather than silently hashing with SHA-256.
+    cs.ensure_supported()?;
     let expand_len = 48; // ceil((255 + 128) / 8)
     let uniform_bytes = expand_msg_xmd(data, dst, expand_len)?;
     Ok(scalar_from_wide_bytes(&uniform_bytes))
@@ -122,6 +125,13 @@ mod tests {
     fn hash_to_scalar_produces_nonzero() {
         let s = hash_to_scalar(b"test message", b"test-dst", Ciphersuite::Bls12381Sha256).unwrap();
         assert_ne!(s, Scalar::ZERO);
+    }
+
+    #[test]
+    fn hash_to_scalar_rejects_unimplemented_shake256() {
+        // Must error rather than silently hash with SHA-256 under a SHAKE DST.
+        let err = hash_to_scalar(b"msg", b"dst", Ciphersuite::Bls12381Shake256);
+        assert!(matches!(err, Err(BbsError::Unsupported(_))));
     }
 
     #[test]

--- a/crates/core/affinidi-bbs/src/keys.rs
+++ b/crates/core/affinidi-bbs/src/keys.rs
@@ -113,6 +113,18 @@ mod tests {
     }
 
     #[test]
+    fn keygen_rejects_unimplemented_shake256() {
+        // End-to-end: selecting the unimplemented SHAKE-256 suite must fail at
+        // the public API rather than derive a key with the wrong hash.
+        let result = keygen(
+            b"this-is-at-least-32-bytes-of-key-material!",
+            b"",
+            Ciphersuite::Bls12381Shake256,
+        );
+        assert!(matches!(result, Err(BbsError::Unsupported(_))));
+    }
+
+    #[test]
     fn sk_to_pk_deterministic() {
         let sk = keygen(
             b"test-key-material-at-least-32-by",

--- a/crates/core/affinidi-bbs/src/types.rs
+++ b/crates/core/affinidi-bbs/src/types.rs
@@ -4,33 +4,35 @@
 
 use bls12_381_plus::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 use ff::Field;
+use zeroize::Zeroize;
 
 use crate::error::{BbsError, Result};
 
 /// A BBS secret key (scalar in the BLS12-381 group).
 ///
 /// 32 bytes, must be nonzero and less than the group order.
-/// The key is zeroized in memory when dropped using volatile writes
-/// to prevent compiler optimization of the zeroing.
+/// The key is zeroized in memory when dropped via the vetted `zeroize` crate
+/// (guaranteed non-elided volatile writes followed by a memory fence).
 #[derive(Clone)]
 pub struct SecretKey(pub(crate) Scalar);
 
 impl Drop for SecretKey {
     fn drop(&mut self) {
-        // Overwrite the scalar's memory with zeros using volatile writes (the
-        // volatile prevents the compiler from optimizing the zeroing away). Sound
-        // because `bls12_381_plus::Scalar` is a plain inline `[u64; 4]` with no
-        // heap indirection; `SecretKey: Clone` means each clone runs this Drop.
-        let ptr = &mut self.0 as *mut Scalar as *mut u8;
-        let size = std::mem::size_of::<Scalar>();
-        unsafe {
-            for i in 0..size {
-                std::ptr::write_volatile(ptr.add(i), 0);
-            }
-        }
-        // Prevent the compiler/CPU from reordering subsequent operations before
-        // the zeroing (defense in depth, matching the `zeroize` crate's fence).
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+        // `bls12_381_plus::Scalar` does not implement `Zeroize` and exposes no
+        // mutable byte view, so we zeroize its backing storage directly. This is
+        // sound because `Scalar` is a plain inline `[u64; 4]` (Montgomery form,
+        // no heap indirection): an all-zero byte pattern is a valid `Scalar`, and
+        // the value is never read after this. Delegating to `zeroize` replaces the
+        // previous hand-rolled volatile loop with the crate's audited primitive
+        // (volatile writes + `atomic::compiler_fence(SeqCst)`); `SecretKey: Clone`
+        // means each clone runs this `Drop`.
+        let bytes = unsafe {
+            std::slice::from_raw_parts_mut(
+                std::ptr::from_mut(&mut self.0).cast::<u8>(),
+                std::mem::size_of::<Scalar>(),
+            )
+        };
+        bytes.zeroize();
     }
 }
 

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi Data Integrity Changelog
 
+## 7th June 2026 Release 0.7.4
+
+### Changed
+
+- Bump `affinidi-bbs` to `0.3` (BBS audit hardening: `SecretKey` zeroize-crate
+  migration, on-curve non-subgroup G1 regression vector, and a hard error when
+  the unimplemented SHAKE-256 ciphersuite is selected). No API change here; the
+  `bbs-2023` cryptosuite output is unchanged (all KAT vectors still pass).
+
 ## 7th June 2026 Release 0.7.3
 
 ### Deprecated

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -26,7 +26,7 @@ affinidi-crypto = "0.2"
 affinidi-rdf-encoding = { version = "0.1", path = "../affinidi-rdf-encoding" }
 affinidi-secrets-resolver = "0.5"
 affinidi-did-common = "0.3"
-affinidi-bbs = { version = "0.2", path = "../../core/affinidi-bbs", optional = true }
+affinidi-bbs = { version = "0.3", path = "../../core/affinidi-bbs", optional = true }
 hmac = { version = "0.12", optional = true }
 ciborium = { version = "0.2", optional = true }
 

--- a/docs/security/bbs-audit-readiness.md
+++ b/docs/security/bbs-audit-readiness.md
@@ -82,7 +82,8 @@ out of scope (it is being removed; not interoperable, no production use).
   `point_from_bytes` carries a comment forbidding `from_compressed_unchecked`.
 - **Issuer secret handling.** `SK` bytes hashed into `e` are zeroized; the
   `SK + e` intermediate is zeroized before the invertibility branch; `SecretKey`
-  has a redacting `Debug` and a volatile-write `Drop` (now with a `compiler_fence`).
+  has a redacting `Debug` and a `Drop` that clears its backing bytes via the
+  `zeroize` crate (non-elided volatile writes + memory fence).
 - **CSPRNG.** `rand::rng()` (`ThreadRng`, ChaCha-based, OS-seeded) — not
   seedable/predictable. Deterministic mocked scalars are strictly `#[cfg(test)]`.
 - **Domain separation + transcript binding.** Distinct `api_id`s for
@@ -105,10 +106,10 @@ A focused crypto review was performed over `affinidi-bbs`. Two **High**
 | 2 | High | Pseudonym verifier integer-underflow + OOB on a degenerate `L=0/U=0` proof (`l - 1`, `m_hats[u-1]`). | **Fixed** — `l == 0 / u == 0` guarded in the nym branch. Regression test added. |
 | 5 | Med | Non-canonical proof length accepted (trailing partial-scalar bytes ignored) ⇒ encoding malleability. | **Fixed** — verify rejects lengths not `≡ min_len (mod scalar_len)`. Regression test added. |
 | 7 | Low | Proof parser did not reject a zero `challenge`. | **Fixed** — zero challenge rejected. |
-| 4 | Med | `SecretKey` Drop used a hand-rolled volatile loop without a fence. | **Hardened** — added `compiler_fence(SeqCst)`; invariants documented. (Full migration to the `zeroize` crate deferred — see §5.) |
-| 6 | Low | Subgroup check relies on `from_compressed` with no guard against an accidental `_unchecked` swap. | **Mitigated** — explicit SECURITY comment in `point_from_bytes`. (A non-subgroup-encoding regression vector is still wanted — see §5.) |
+| 4 | Med | `SecretKey` Drop used a hand-rolled volatile loop without a fence. | **Resolved** — migrated to the `zeroize` crate's audited primitive (`<[u8]>::zeroize()`: non-elided volatile writes + `compiler_fence(SeqCst)`); soundness invariants documented. |
+| 6 | Low | Subgroup check relies on `from_compressed` with no guard against an accidental `_unchecked` swap. | **Resolved** — explicit SECURITY comment in `point_from_bytes` **plus** a vendored on-curve, non-prime-order-subgroup G1 regression vector asserting rejection (`point_from_bytes_rejects_on_curve_non_subgroup`). |
+| — | Info | `Ciphersuite::Bls12381Shake256` is selectable but the hash layer is SHA-256-only (silent wrong output if selected). | **Resolved** — selecting SHAKE-256 is now a hard error (`BbsError::Unsupported`) at both hashing chokepoints (`hash_to_scalar`, `create_generators*`); end-to-end + unit regression tests added. |
 | 3 | Med | Holder secrets (`nym_secret`, `prover_nym`, `secret_prover_blind`, `m~`/`m^` blindings) are not zeroized in the nym/blind paths. | **Deferred** — see §5 (needs API design; `Scalar` is `Copy` and re-exported). |
-| — | Info | `Ciphersuite::Bls12381Shake256` is selectable but the hash layer is SHA-256-only (silent wrong output if selected). | **Deferred** — see §5. |
 
 Things the review explicitly found **done well** are in §3.
 
@@ -119,25 +120,22 @@ Things the review explicitly found **done well** are in §3.
    their own copies. Fully zeroizing `nym_secret` / `secret_prover_blind` and the
    per-proof blinding vectors needs a `Zeroizing<Scalar>` newtype and an API
    decision about caller-owned copies. We want the auditor's view on the right
-   boundary before committing to an API change.
-2. **`SecretKey` Drop (Finding 4).** Current approach is volatile-write +
-   `compiler_fence`. Question: prefer migrating to the `zeroize` crate's
-   `Zeroize`/`Zeroizing` for the inner scalar?
-3. **Subgroup regression vector (Finding 6).** We assert validation rejects
-   malformed encodings but do not yet have a known *on-curve, non-subgroup* G1/G2
-   encoding to assert rejection of. A vendored test vector would harden against
-   an accidental `_unchecked` swap.
-4. **SHAKE-256 ciphersuite.** Either implement it properly or make selecting it a
-   hard error rather than silently emitting SHA-256 output with mismatched scalar
-   lengths.
-5. **RNG + `fork()`.** `ThreadRng` does not reseed on `fork()`. Do not fork after
+   boundary before committing to an API change. **This is the one remaining
+   deferred hardening item.**
+2. **RNG + `fork()`.** `ThreadRng` does not reseed on `fork()`. Do not fork after
    first RNG use (or reseed in children) to avoid nonce/blinding reuse across
    forked workers.
-6. **Canonicalization is what gets signed.** The RDFC-1.0 / JSON-LD layer in
+3. **Canonicalization is what gets signed.** The RDFC-1.0 / JSON-LD layer in
    `affinidi-rdf-encoding` determines the exact bytes signed and hashed; a
-   canonicalization bug is a signature-soundness bug. It is W3C-`rdf-canon`-suite
-   conformant (59/63; 4 documented poison/automorphism skips — #361) but is part
-   of the trusted surface and worth auditor attention.
+   canonicalization bug is a signature-soundness bug. It is fully W3C-`rdf-canon`-suite
+   conformant (63/63, no skips — #361) but is part of the trusted surface and
+   worth auditor attention.
+
+> Resolved since the initial readiness draft (were items 2–4 here; see §4 for
+> detail): the `SecretKey` Drop migration to the `zeroize` crate (Finding 4),
+> the on-curve non-subgroup G1 regression vector (Finding 6), and making the
+> unimplemented SHAKE-256 ciphersuite a hard error instead of silent wrong
+> output (Info).
 
 ## 6. Reproducing the evidence
 


### PR DESCRIPTION
Part of #363. Closes the three **self-contained** deferred hardening items from the BBS audit-readiness review (`docs/security/bbs-audit-readiness.md` §4/§5). The one remaining deferred item — holder-secret zeroization in the nym/blind paths — is left open because it needs an auditor API-boundary decision (`Scalar` is `Copy` and re-exported), exactly as the doc records.

## Changes

**1. `SecretKey` Drop → `zeroize` crate (Finding 4, Med).**
Replaces the hand-rolled volatile-write loop with the vetted `zeroize` crate primitive (`<[u8]>::zeroize()` — guaranteed non-elided volatile writes + memory fence). Soundness invariants (inline `[u64;4]`, no heap, all-zero is a valid `Scalar`) documented.

**2. On-curve, non-subgroup G1 regression vector (Finding 6, Low).**
Adds a vendored compressed G1 encoding (x-coordinate = 4) that is on the curve but **outside the prime-order subgroup** (cofactor torsion), and asserts `point_from_bytes` rejects it. Guards against an accidental `from_compressed_unchecked` swap re-opening small-subgroup / cofactor attacks on attacker-supplied proof points (Abar/Bbar/D, pseudonym). The `_unchecked` assertions in the test prove the vector is a genuine subgroup-evasion case rather than garbage.

**3. SHAKE-256 hard error (Info).**
`Ciphersuite::Bls12381Shake256` is defined (id strings, 64-byte scalar length) but every hashing path is SHA-256/XMD-only — selecting it previously produced **silent wrong output** (SHA-256 bytes under a SHAKE DST, truncated scalars). It is now a hard error (`BbsError::Unsupported`) enforced at both hashing chokepoints (`hash_to_scalar`, `create_generators*`), which covers keygen / sign / verify / proof / blind / nym. End-to-end (`keygen`) + unit regression tests added.

## Versioning

- `BbsError` marked `#[non_exhaustive]` (future-proofs variant additions) + new `Unsupported` variant ⇒ **affinidi-bbs 0.2.4 → 0.3.0** (breaking per 0.x semver).
- **affinidi-data-integrity** pin `0.2 → 0.3`; no public-API change and `bbs-2023` KAT output is unchanged ⇒ **0.7.3 → 0.7.4** (patch).
- TDK crates pin data-integrity at `"0.7"`, so the cascade stops here — no TDK changes.

## Verification

- `cargo test -p affinidi-bbs -p affinidi-data-integrity --all-features` — green (affinidi-bbs **80** tests, +4 new; all KAT vectors unchanged)
- `cargo check --workspace --all-features` — green (version cascade resolves)
- `cargo clippy … --all-targets --all-features` — clean
- `cargo fmt --all --check` — clean
- `cargo deny check` — advisories/bans/licenses/sources ok

## Doc

`docs/security/bbs-audit-readiness.md` updated: Findings 4/6 + the SHAKE Info item moved to **Resolved** (§4); §5 now lists holder-secret zeroization as the single remaining deferred item; the stale "59/63" RDFC conformance note corrected to "63/63" (#361 merged).