### PR TITLE
fix: bbs-2023 safe-mode expansion — reject forged undefined attributes (#381)

### DIFF
--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi Data Integrity Changelog
 
+## 8th June 2026 Release 0.7.5
+
+### Fixed
+
+- **`bbs-2023` soundness — forged undisclosed/undefined attribute values
+  (issue #381).** A credential holder could change the value of an attribute
+  that the credential's `@context` does **not** define (e.g. `memberLevel`
+  under the bare `credentials/v2` context), re-derive a fresh disclosure proof,
+  and have `verify_derived_proof` accept it. Root cause: JSON-LD expansion
+  **silently dropped** unmapped terms, so such an attribute was never part of
+  the signed RDF dataset — neither covered by the issuer's signature nor checked
+  by the verifier — yet it remained in the JSON envelope that applications read.
+  The underlying `affinidi-bbs` primitive was sound; the defect was in the
+  document/cryptosuite layer. Fix: every sign / derive / verify path now
+  canonicalizes via JSON-LD **safe-mode** expansion
+  (`affinidi-rdf-encoding::jsonld::expand_and_to_rdf_safe`), which errors on any
+  term not defined by the active `@context`. Consequences:
+  - Issuers (`sign_base_document`) **refuse** to sign a credential with an
+    undefined claim instead of emitting one with an unprotected attribute.
+  - Verifiers (`verify_derived_proof` / `verify_pseudonym_derived_proof`)
+    **reject** a reveal document carrying an undefined term.
+
+  Applies to both the basic and pseudonym (`0xd95d08` / `0xd95d09`) suites.
+  Credentials whose claims are all defined by their context (e.g. via `@vocab`)
+  are unaffected — all W3C `vc-di-bbs` KAT vectors still pass byte-for-byte.
+
+### Changed
+
+- Bump `affinidi-rdf-encoding` to `0.1.5` (adds safe-mode expansion).
+
 ## 7th June 2026 Release 0.7.4
 
 ### Changed

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-data-integrity/src/bbs_2023_transform.rs
+++ b/crates/credentials/affinidi-data-integrity/src/bbs_2023_transform.rs
@@ -364,11 +364,14 @@ pub fn verify_derived_proof(
     let proof_hash = proof_hash(&proof_config)?;
 
     // Canonicalize the reveal document (minus proof), relabel via the label map.
+    // Safe mode: reject a reveal document carrying any term not defined by its
+    // @context — such a term would be dropped from the RDF and thus escape the
+    // BBS check while still appearing in the JSON (issue #381).
     let mut doc = reveal_document.clone();
     doc.as_object_mut()
         .ok_or_else(|| malformed("document must be an object"))?
         .remove("proof");
-    let dataset = jsonld::expand_and_to_rdf(&doc).map_err(canon_err)?;
+    let dataset = jsonld::expand_and_to_rdf_safe(&doc).map_err(canon_err)?;
     let (canonical_c14n, _) = rdfc1::canonicalize_with_label_map(&dataset).map_err(canon_err)?;
     let labeled = lines_with_newline(&relabel_and_sort(&canonical_c14n, &parsed.label_map));
 
@@ -1108,11 +1111,13 @@ pub fn verify_pseudonym_derived_proof(
     }
     let proof_hash = proof_hash(&proof_config)?;
 
+    // Safe mode (issue #381): see verify_derived_proof — an unmapped term in the
+    // reveal document must not slip past the BBS check.
     let mut doc = reveal_document.clone();
     doc.as_object_mut()
         .ok_or_else(|| malformed("document must be an object"))?
         .remove("proof");
-    let dataset = jsonld::expand_and_to_rdf(&doc).map_err(canon_err)?;
+    let dataset = jsonld::expand_and_to_rdf_safe(&doc).map_err(canon_err)?;
     let (canonical_c14n, _) = rdfc1::canonicalize_with_label_map(&dataset).map_err(canon_err)?;
     let labeled = lines_with_newline(&relabel_and_sort(&canonical_c14n, &parsed.label_map));
 
@@ -1192,7 +1197,8 @@ pub fn proof_hash(proof_config: &Value) -> Result<[u8; 32], DataIntegrityError> 
 ///    (`u…`), then assign `b0, b1, …` in that order.
 /// 4. Relabel the canonical N-Quads and re-sort the lines.
 pub fn hmac_canonicalize(document: &Value, hmac_key: &[u8]) -> Result<String, DataIntegrityError> {
-    let dataset = jsonld::expand_and_to_rdf(document).map_err(canon_err)?;
+    // Safe mode (issue #381): undefined terms must not be silently dropped.
+    let dataset = jsonld::expand_and_to_rdf_safe(document).map_err(canon_err)?;
     let canonical = rdfc1::canonicalize(&dataset).map_err(canon_err)?;
     let label_map = hmac_label_map(&canonical, hmac_key)?;
     Ok(relabel_and_sort(&canonical, &label_map))
@@ -1385,7 +1391,10 @@ fn skolemize_value(v: &mut Value, counter: &mut u64, ctx: &JsonLdContext) {
 /// RDF → serialize, then map `<urn:bnid:X>` back to blank nodes `_:X`. Each
 /// returned line is newline-terminated.
 fn to_deskolemized_nquads(document: &Value) -> Result<Vec<String>, DataIntegrityError> {
-    let dataset = jsonld::expand_and_to_rdf(document).map_err(canon_err)?;
+    // Safe mode (issue #381): this is the canonicalization used for both signing
+    // (issuer) and deriving (holder); reject documents whose claims are not all
+    // defined by the active @context, so no claim is signed/disclosed out-of-band.
+    let dataset = jsonld::expand_and_to_rdf_safe(document).map_err(canon_err)?;
     let mut lines: Vec<String> = dataset
         .quads()
         .iter()
@@ -2062,6 +2071,145 @@ mod tests {
         let mut bad = reveal.clone();
         bad["credentialSubject"]["sailNumber"] = Value::String("Mallory".into());
         assert!(!matches!(verify_derived_proof(&bad, &pk), Ok(true)));
+    }
+
+    // --- issue #381 soundness regression tests --------------------------------
+    //
+    // #381: a holder could change a credential attribute that was NOT defined by
+    // the document's @context, re-derive a fresh proof, and have it verify — the
+    // undefined term is dropped from the signed RDF yet remains readable in the
+    // JSON. The fix enforces JSON-LD safe-mode expansion on every sign/derive/
+    // verify path. These tests encode the threat model directly.
+
+    fn bbs_keys() -> (bbs::SecretKey, bbs::PublicKey) {
+        let km = json("BBSKeyMaterial.json");
+        let sk = bbs::SecretKey::from_bytes(
+            &hex_decode(km["privateKeyHex"].as_str().unwrap())
+                .try_into()
+                .unwrap(),
+        )
+        .unwrap();
+        let pk = bbs::PublicKey::from_bytes(
+            &hex_decode(km["publicKeyHex"].as_str().unwrap())
+                .try_into()
+                .unwrap(),
+        )
+        .unwrap();
+        (sk, pk)
+    }
+
+    /// (B) Coverage/completeness: the issuer must REFUSE to sign a credential
+    /// carrying a claim (`memberLevel`) that the bare `credentials/v2` context
+    /// does not define — otherwise the claim is signed by nobody yet travels in
+    /// the JSON. This is the exact document from issue #381.
+    #[test]
+    fn issue_381_unmapped_claim_rejected_at_issuance() {
+        let sk = bbs::keygen(b"key-material-at-least-32-bytes!!", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        let did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
+        let vc = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": did,
+            "credentialSubject": { "id": "did:key:zMember", "memberLevel": "gold" }
+        });
+        let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
+        let r = sign_base_document(
+            &vc,
+            &mandatory,
+            &format!("{did}#bbs-key-0"),
+            "2020-01-01T00:00:00Z",
+            &sk,
+            &pk,
+            b"32-byte-hmac-key-padding-xxxxxxx",
+        );
+        assert!(
+            r.is_err(),
+            "issuer must refuse to sign a VC with an undefined claim (memberLevel); got {r:?}"
+        );
+    }
+
+    /// (B) Verifier-side defense in depth: a reveal document carrying a term not
+    /// defined by its `@context` must be rejected, even before the BBS check —
+    /// the term would be dropped from the verified RDF while remaining in the
+    /// JSON. (The reference proof bytes are retained; safe-mode expansion trips
+    /// first, so this exercises the verifier's safe-mode guard specifically.)
+    #[test]
+    fn issue_381_verifier_rejects_unmapped_term_in_reveal() {
+        let (_sk, pk) = bbs_keys();
+        let mut reveal = json("derivedRevealDocument.json");
+        // A context with no catch-all @vocab — so the injected term is undefined.
+        reveal["@context"] = serde_json::json!(["https://www.w3.org/ns/credentials/v2"]);
+        reveal["credentialSubject"]["forgedAttribute"] = Value::String("anything".into());
+        let r = verify_derived_proof(&reveal, &pk);
+        assert!(
+            r.is_err(),
+            "verifier must reject a reveal document carrying an undefined term; got {r:?}"
+        );
+    }
+
+    /// (A) Adversarial re-derivation harness — encodes the actual threat model:
+    /// the holder owns the base credential and re-derives at will. For every leaf
+    /// claim, tampering it in the base and deriving a FRESH proof must never
+    /// verify. Uses `windDoc` (a `@vocab`-mapped document, so the claims ARE
+    /// signed) to exercise the BBS message↔statement binding under re-derivation,
+    /// not just the safe-mode guard.
+    #[test]
+    fn issue_381_adversarial_rederivation_rejects_single_field_tampers() {
+        let (sk, pk) = bbs_keys();
+        let hmac_key = [0x42u8; 32];
+        let doc = json("windDoc.json");
+        let mandatory = ["/issuer", "/credentialSubject/sailNumber"];
+        let base = sign_base_document(
+            &doc,
+            &mandatory,
+            "did:key:zHolder#bbs",
+            "2024-01-01T00:00:00Z",
+            &sk,
+            &pk,
+            &hmac_key,
+        )
+        .unwrap();
+
+        // Control: an HONEST re-derivation of an untampered claim must verify, so
+        // the harness is not vacuously passing because derivation always fails.
+        let honest =
+            create_derived_proof(&base, &["/credentialSubject/boards/0"], b"nonce", &pk).unwrap();
+        assert!(
+            verify_derived_proof(&honest, &pk).unwrap(),
+            "control: honest re-derivation must verify"
+        );
+
+        // (pointer to tamper and disclose, forged value). Covers a mandatory
+        // claim, non-mandatory strings, and a non-mandatory number.
+        let cases: [(&str, Value); 4] = [
+            ("/credentialSubject/sailNumber", serde_json::json!("FORGED")), // mandatory
+            (
+                "/credentialSubject/boards/0/boardName",
+                serde_json::json!("FORGED"),
+            ),
+            ("/credentialSubject/boards/0/year", serde_json::json!(1999)),
+            (
+                "/credentialSubject/sails/0/sailName",
+                serde_json::json!("FORGED"),
+            ),
+        ];
+        for (ptr, forged) in cases {
+            let mut tampered = base.clone();
+            *tampered
+                .pointer_mut(ptr)
+                .unwrap_or_else(|| panic!("pointer {ptr} not present in base")) = forged.clone();
+
+            // The holder re-derives a fresh proof disclosing the tampered claim.
+            // Derivation itself refusing the tamper is also a safe outcome; only
+            // a successful derive that then verifies is a soundness break.
+            if let Ok(reveal) = create_derived_proof(&tampered, &[ptr], b"nonce", &pk) {
+                assert!(
+                    !matches!(verify_derived_proof(&reveal, &pk), Ok(true)),
+                    "SOUNDNESS: forged {ptr} = {forged} re-derived and verified"
+                );
+            }
+        }
     }
 
     fn hex_lower(b: &[u8]) -> String {

--- a/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
+++ b/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
@@ -6,13 +6,20 @@
 
 - **JSON-LD safe-mode expansion** — `expand_document_safe` and
   `expand_and_to_rdf_safe`. These behave like the existing lenient functions
-  except that a property whose key is **not defined by the active `@context`**
-  (a term lenient expansion silently drops) now raises an error naming the
-  offending term. Required by the W3C Verifiable Credential Data Integrity
-  algorithms so that canonicalization cannot discard unmapped claims. The
-  default `expand_document` / `expand_and_to_rdf` behaviour is **unchanged**
-  (still lenient), so this release is backward-compatible. Supports the
-  soundness fix in `affinidi-data-integrity` 0.7.5 (issue #381).
+  except that anything lenient expansion would silently drop now raises an error
+  naming the offending input. Safe mode covers all three drop sites:
+  - a **property key** not defined by the active `@context`;
+  - a node **`@type`** that does not resolve to an absolute IRI (no term
+    definition and no `@vocab`) — rejected rather than passed through as a
+    relative IRI; non-string `@type` entries are likewise rejected;
+  - a free-standing **scalar** where a node is expected (document root or a
+    node array).
+
+  Required by the W3C Verifiable Credential Data Integrity algorithms so that
+  canonicalization cannot discard unmapped data. The default `expand_document` /
+  `expand_and_to_rdf` behaviour is **unchanged** (still lenient), so this
+  release is backward-compatible. Supports the soundness fix in
+  `affinidi-data-integrity` 0.7.5 (issue #381).
 
 ## 7th June 2026 Release 0.1.4
 

--- a/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
+++ b/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Affinidi RDF Encoding Changelog
 
+## 8th June 2026 Release 0.1.5
+
+### Added
+
+- **JSON-LD safe-mode expansion** — `expand_document_safe` and
+  `expand_and_to_rdf_safe`. These behave like the existing lenient functions
+  except that a property whose key is **not defined by the active `@context`**
+  (a term lenient expansion silently drops) now raises an error naming the
+  offending term. Required by the W3C Verifiable Credential Data Integrity
+  algorithms so that canonicalization cannot discard unmapped claims. The
+  default `expand_document` / `expand_and_to_rdf` behaviour is **unchanged**
+  (still lenient), so this release is backward-compatible. Supports the
+  soundness fix in `affinidi-data-integrity` 0.7.5 (issue #381).
+
 ## 7th June 2026 Release 0.1.4
 
 Full **63/63** W3C `rdf-canon` (RDFC-1.0) conformance — the last 4 skipped

--- a/crates/credentials/affinidi-rdf-encoding/Cargo.toml
+++ b/crates/credentials/affinidi-rdf-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-rdf-encoding"
 description = "RDF Dataset Canonicalization (RDFC-1.0) and JSON-LD expansion for W3C Verifiable Credentials"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-rdf-encoding/src/jsonld/expand.rs
+++ b/crates/credentials/affinidi-rdf-encoding/src/jsonld/expand.rs
@@ -65,8 +65,16 @@ fn expand_element(element: &Value, context: &Context, safe: bool) -> Result<Valu
             Ok(Value::Array(result))
         }
         Value::Object(_) => expand_object(element, context, safe),
+        Value::Null => Ok(Value::Null),
         _ => {
-            // Scalars at the top level are dropped per JSON-LD spec
+            // A free-standing scalar where a node is expected is dropped per the
+            // JSON-LD spec. In safe mode, refuse it rather than discard data
+            // (issue #381).
+            if safe {
+                return Err(RdfError::expansion(format!(
+                    "safe mode: scalar {element} cannot be expanded as a node and would be dropped"
+                )));
+            }
             Ok(Value::Null)
         }
     }
@@ -119,12 +127,12 @@ fn expand_object(obj: &Value, parent_context: &Context, safe: bool) -> Result<Va
         if key == "@type" || key == "type" {
             if let Some(type_def) = context.get_term(key) {
                 if type_def.iri == "@type" {
-                    let expanded_types = expand_type_value(value, &context)?;
+                    let expanded_types = expand_type_value(value, &context, safe)?;
                     result.insert("@type".to_string(), expanded_types);
                     continue;
                 }
             } else if key == "@type" {
-                let expanded_types = expand_type_value(value, &context)?;
+                let expanded_types = expand_type_value(value, &context, safe)?;
                 result.insert("@type".to_string(), expanded_types);
                 continue;
             }
@@ -244,18 +252,25 @@ fn build_type_scoped_context(
 }
 
 /// Expand @type values to full IRIs.
-fn expand_type_value(value: &Value, context: &Context) -> Result<Value> {
+fn expand_type_value(value: &Value, context: &Context, safe: bool) -> Result<Value> {
     match value {
         Value::String(s) => {
-            let expanded = expand_type_iri(s, context);
+            let expanded = expand_type_iri(s, context, safe)?;
             Ok(json!([expanded]))
         }
         Value::Array(arr) => {
-            let expanded: Vec<Value> = arr
-                .iter()
-                .filter_map(|v| v.as_str())
-                .map(|s| json!(expand_type_iri(s, context)))
-                .collect();
+            let mut expanded = Vec::with_capacity(arr.len());
+            for v in arr {
+                match v.as_str() {
+                    Some(s) => expanded.push(json!(expand_type_iri(s, context, safe)?)),
+                    None if safe => {
+                        return Err(RdfError::expansion(format!(
+                            "safe mode: non-string @type entry {v} would be dropped"
+                        )));
+                    }
+                    None => {} // lenient: skip non-string entries
+                }
+            }
             Ok(Value::Array(expanded))
         }
         _ => Err(RdfError::expansion(format!("invalid @type value: {value}"))),
@@ -263,25 +278,37 @@ fn expand_type_value(value: &Value, context: &Context) -> Result<Value> {
 }
 
 /// Expand a type name to a full IRI.
-fn expand_type_iri(type_name: &str, context: &Context) -> String {
+///
+/// In safe mode a type that does not resolve to an absolute IRI (via a term
+/// definition or `@vocab`) is an error rather than being passed through as a
+/// relative IRI — a relative type would otherwise enter the signed dataset
+/// ambiguously / be dropped by stricter processors (issue #381).
+fn expand_type_iri(type_name: &str, context: &Context, safe: bool) -> Result<String> {
     // If already an absolute IRI, return as-is
     if type_name.contains("://") || type_name.starts_with("urn:") {
-        return type_name.to_string();
+        return Ok(type_name.to_string());
     }
 
     // Look up in context — for types, we want the @id value
     if let Some(def) = context.get_term(type_name)
         && (def.iri.contains("://") || def.iri.starts_with("urn:"))
     {
-        return def.iri.clone();
+        return Ok(def.iri.clone());
     }
 
     // Try vocab expansion
     if let Some(ref vocab) = context.vocab {
-        return format!("{vocab}{type_name}");
+        return Ok(format!("{vocab}{type_name}"));
     }
 
-    type_name.to_string()
+    if safe {
+        return Err(RdfError::expansion(format!(
+            "safe mode: type '{type_name}' is not defined by the active @context \
+             and would not expand to an absolute IRI"
+        )));
+    }
+
+    Ok(type_name.to_string())
 }
 
 /// Expand a value object ({ "@value": ... }).
@@ -476,6 +503,65 @@ mod tests {
             "credentialSubject": { "id": "did:example:123" }
         });
         assert!(expand_document_safe(&doc).is_ok());
+    }
+
+    /// Safe mode must reject a node `@type` that does not resolve to an absolute
+    /// IRI (no term definition, no `@vocab`) — it would otherwise be passed
+    /// through as a relative IRI into the signed dataset.
+    #[test]
+    fn safe_mode_rejects_unmapped_type() {
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "credentialSubject": { "id": "did:example:1" }
+        });
+        let err = expand_document_safe(&doc).unwrap_err();
+        assert!(
+            err.to_string().contains("MembershipCredential"),
+            "error should name the unresolved type: {err}"
+        );
+    }
+
+    /// A custom type that DOES resolve (here via `@vocab`) is accepted.
+    #[test]
+    fn safe_mode_accepts_custom_type_via_vocab() {
+        let doc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                { "@vocab": "https://example.com/vocab#" }
+            ],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "credentialSubject": { "id": "did:example:1" }
+        });
+        assert!(expand_document_safe(&doc).is_ok());
+    }
+
+    /// Safe mode must reject a free-standing scalar at the document root, which
+    /// lenient expansion would silently drop.
+    #[test]
+    fn safe_mode_rejects_top_level_scalar() {
+        let err = expand_document_safe(&json!("not-a-node")).unwrap_err();
+        assert!(
+            err.to_string().contains("scalar"),
+            "error should flag the dropped scalar: {err}"
+        );
+    }
+
+    /// Safe mode must reject a stray scalar mixed into a top-level node array.
+    #[test]
+    fn safe_mode_rejects_scalar_in_node_array() {
+        let doc = json!([
+            {
+                "@context": ["https://www.w3.org/ns/credentials/v2"],
+                "type": ["VerifiableCredential"]
+            },
+            "stray-scalar"
+        ]);
+        let err = expand_document_safe(&doc).unwrap_err();
+        assert!(
+            err.to_string().contains("scalar"),
+            "error should flag the dropped scalar: {err}"
+        );
     }
 
     #[test]

--- a/crates/credentials/affinidi-rdf-encoding/src/jsonld/expand.rs
+++ b/crates/credentials/affinidi-rdf-encoding/src/jsonld/expand.rs
@@ -3,11 +3,35 @@ use serde_json::{Map, Value, json};
 use super::context::Context;
 use crate::error::{RdfError, Result};
 
-/// Expand a JSON-LD document to its expanded form.
+/// Expand a JSON-LD document to its expanded form (lenient mode).
 ///
 /// The expanded form has all terms replaced with full IRIs, all context
 /// processing resolved, and all values in a normalized array/object structure.
+///
+/// Terms not defined by the active `@context` are **silently dropped**. For
+/// security-sensitive canonicalization (e.g. Data Integrity proofs) use
+/// [`expand_document_safe`] instead, so undefined claims cannot ride along
+/// unsigned.
 pub fn expand_document(document: &Value) -> Result<Value> {
+    expand_document_inner(document, false)
+}
+
+/// Expand a JSON-LD document in **safe mode**.
+///
+/// Identical to [`expand_document`] except that a property whose key does not
+/// map to an absolute IRI or a JSON-LD keyword — i.e. a term that lenient
+/// expansion would silently drop — raises an error instead.
+///
+/// This is required by the W3C Verifiable Credential Data Integrity algorithms:
+/// canonicalization must not discard unmapped terms, otherwise a credential can
+/// carry attributes that are present in the JSON envelope yet absent from the
+/// signed RDF dataset (issue #381 — a holder could set an undefined attribute to
+/// any value and still pass verification).
+pub fn expand_document_safe(document: &Value) -> Result<Value> {
+    expand_document_inner(document, true)
+}
+
+fn expand_document_inner(document: &Value, safe: bool) -> Result<Value> {
     let mut context = Context::default();
 
     // Process top-level @context
@@ -15,7 +39,7 @@ pub fn expand_document(document: &Value) -> Result<Value> {
         context.process(ctx_val)?;
     }
 
-    let result = expand_element(document, &context)?;
+    let result = expand_element(document, &context, safe)?;
 
     // Wrap in array if not already
     match result {
@@ -26,12 +50,12 @@ pub fn expand_document(document: &Value) -> Result<Value> {
 }
 
 /// Expand a single JSON-LD element (object, array, or value).
-fn expand_element(element: &Value, context: &Context) -> Result<Value> {
+fn expand_element(element: &Value, context: &Context, safe: bool) -> Result<Value> {
     match element {
         Value::Array(arr) => {
             let mut result = Vec::new();
             for item in arr {
-                let expanded = expand_element(item, context)?;
+                let expanded = expand_element(item, context, safe)?;
                 match expanded {
                     Value::Array(inner) => result.extend(inner),
                     Value::Null => {} // skip nulls
@@ -40,7 +64,7 @@ fn expand_element(element: &Value, context: &Context) -> Result<Value> {
             }
             Ok(Value::Array(result))
         }
-        Value::Object(_) => expand_object(element, context),
+        Value::Object(_) => expand_object(element, context, safe),
         _ => {
             // Scalars at the top level are dropped per JSON-LD spec
             Ok(Value::Null)
@@ -49,7 +73,7 @@ fn expand_element(element: &Value, context: &Context) -> Result<Value> {
 }
 
 /// Expand a JSON-LD object node.
-fn expand_object(obj: &Value, parent_context: &Context) -> Result<Value> {
+fn expand_object(obj: &Value, parent_context: &Context, safe: bool) -> Result<Value> {
     let map = obj
         .as_object()
         .ok_or_else(|| RdfError::expansion("expected object"))?;
@@ -112,7 +136,18 @@ fn expand_object(obj: &Value, parent_context: &Context) -> Result<Value> {
                 continue; // Skip keyword aliases
             }
             Some(iri) if iri.contains("://") || iri.starts_with("urn:") => iri,
-            _ => continue, // Drop unmapped terms
+            _ => {
+                if safe {
+                    // Safe mode: an unmapped term would be dropped from the RDF
+                    // dataset while remaining in the JSON envelope. Refuse it so
+                    // it cannot be signed/verified out-of-band (issue #381).
+                    return Err(RdfError::expansion(format!(
+                        "safe mode: term '{key}' is not defined by the active @context \
+                         and would be dropped from the signed dataset"
+                    )));
+                }
+                continue; // Drop unmapped terms (lenient mode)
+            }
         };
 
         // Get term definition for type coercion and scoped context
@@ -131,7 +166,7 @@ fn expand_object(obj: &Value, parent_context: &Context) -> Result<Value> {
         };
 
         // Expand the value
-        let expanded_value = expand_property_value(value, type_mapping, &prop_context)?;
+        let expanded_value = expand_property_value(value, type_mapping, &prop_context, safe)?;
 
         if expanded_value != Value::Null {
             // Merge into result
@@ -278,6 +313,7 @@ fn expand_property_value(
     value: &Value,
     type_mapping: Option<&str>,
     context: &Context,
+    safe: bool,
 ) -> Result<Value> {
     // `@json`-typed values are kept verbatim as a JSON literal (the whole value,
     // including arrays/objects, is preserved and serialized canonically later).
@@ -289,7 +325,7 @@ fn expand_property_value(
         Value::Array(arr) => {
             let mut result = Vec::new();
             for item in arr {
-                let expanded = expand_property_value(item, type_mapping, context)?;
+                let expanded = expand_property_value(item, type_mapping, context, safe)?;
                 match expanded {
                     Value::Null => {}
                     Value::Array(items) => result.extend(items),
@@ -300,7 +336,7 @@ fn expand_property_value(
         }
         Value::Object(_) => {
             // Recursively expand nested objects
-            expand_object(value, context)
+            expand_object(value, context, safe)
         }
         Value::String(s) => {
             // Apply type coercion
@@ -359,6 +395,87 @@ mod tests {
         let node = &arr[0];
         assert_eq!(node.get("@id").unwrap(), "urn:uuid:test");
         assert!(node.get("@type").is_some());
+    }
+
+    // --- safe-mode expansion (issue #381) ------------------------------------
+
+    /// Lenient expansion silently drops a term the context does not define — the
+    /// behaviour that made the #381 soundness break possible. Pinned as a guard.
+    #[test]
+    fn lenient_mode_drops_unmapped_term() {
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "credentialSubject": { "id": "did:example:1", "memberLevel": "gold" }
+        });
+        let expanded = expand_document(&doc).unwrap();
+        let s = expanded.to_string();
+        assert!(
+            !s.contains("memberLevel") && !s.contains("gold"),
+            "lenient mode is expected to drop the undefined term"
+        );
+    }
+
+    /// Safe mode must REJECT a top-level property the active context does not map.
+    #[test]
+    fn safe_mode_rejects_unmapped_property() {
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "forgedProperty": "x"
+        });
+        let err = expand_document_safe(&doc).unwrap_err();
+        assert!(
+            err.to_string().contains("forgedProperty"),
+            "error should name the offending term: {err}"
+        );
+    }
+
+    /// Safe mode must reject an undefined term NESTED under a mapped parent
+    /// (`credentialSubject.memberLevel`) — the exact shape from issue #381.
+    #[test]
+    fn safe_mode_rejects_nested_unmapped_term() {
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "credentialSubject": { "id": "did:example:1", "memberLevel": "gold" }
+        });
+        let err = expand_document_safe(&doc).unwrap_err();
+        assert!(
+            err.to_string().contains("memberLevel"),
+            "error should name the nested undefined term: {err}"
+        );
+    }
+
+    /// Safe mode must ACCEPT a document whose terms are all defined — here via a
+    /// catch-all `@vocab`. The same custom term that fails above now maps.
+    #[test]
+    fn safe_mode_accepts_fully_mapped_document() {
+        let doc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                { "@vocab": "https://example.com/vocab#" }
+            ],
+            "type": ["VerifiableCredential"],
+            "credentialSubject": { "id": "did:example:1", "memberLevel": "gold" }
+        });
+        let expanded =
+            expand_document_safe(&doc).expect("fully-mapped document must expand in safe mode");
+        assert!(expanded.to_string().contains("memberLevel"));
+    }
+
+    /// Safe mode must not trip on the standard, fully-defined VC keywords/terms.
+    #[test]
+    fn safe_mode_accepts_standard_vc_terms() {
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "id": "urn:uuid:test",
+            "type": ["VerifiableCredential"],
+            "issuer": "https://example.com/issuer",
+            "validFrom": "2023-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:example:123" }
+        });
+        assert!(expand_document_safe(&doc).is_ok());
     }
 
     #[test]

--- a/crates/credentials/affinidi-rdf-encoding/src/jsonld/mod.rs
+++ b/crates/credentials/affinidi-rdf-encoding/src/jsonld/mod.rs
@@ -22,3 +22,16 @@ pub fn expand_and_to_rdf(document: &Value) -> Result<Dataset> {
     tracing::debug!(expanded = %expanded, "JSON-LD expanded form");
     to_rdf::to_rdf(&expanded)
 }
+
+/// Expand a JSON-LD document in **safe mode** and convert it to an RDF Dataset.
+///
+/// Identical to [`expand_and_to_rdf`] except that any term not defined by the
+/// active `@context` — which lenient expansion would silently drop — raises an
+/// error. Use this for Data Integrity canonicalization so that undefined claims
+/// cannot ride along in the JSON envelope without being part of the signed RDF
+/// dataset (issue #381).
+pub fn expand_and_to_rdf_safe(document: &Value) -> Result<Dataset> {
+    let expanded = expand::expand_document_safe(document)?;
+    tracing::debug!(expanded = %expanded, "JSON-LD expanded form (safe mode)");
+    to_rdf::to_rdf(&expanded)
+}


### PR DESCRIPTION
Closes #381.

## Summary

The `bbs-2023` selective-disclosure cryptosuite was **unsound**: a credential holder could change the value of an attribute that the credential's `@context` does **not** define (e.g. `memberLevel` under the bare `credentials/v2` context), re-derive a fresh disclosure proof, and have `verify_derived_proof` **accept** the forged value.

## Root cause

JSON-LD expansion **silently dropped unmapped terms** (`affinidi-rdf-encoding/src/jsonld/expand.rs` — `_ => continue`). An undefined attribute therefore produced **no RDF statement at all**: it was neither covered by the issuer's signature nor checked by the verifier, yet it remained in the JSON envelope that applications read. Instrumentation on the PoC showed `non_mandatory_indexes = []` — the BBS proof was over an empty message set, so it verified regardless of the JSON value.

The `affinidi-bbs` primitive is sound (it rejects the equivalent raw tamper), and the suspected `adj_selective` / index mapping was actually correct — the message set simply never contained the term. This is the W3C Data Integrity **"safe mode"** gap.

## Fix

Enforce JSON-LD safe mode on every sign / derive / verify path.

### `affinidi-rdf-encoding` 0.1.4 → 0.1.5

Add `expand_document_safe` / `expand_and_to_rdf_safe`, which error (naming the offending input) on **anything lenient expansion would silently drop**. All three drop sites are covered:

- a **property key** not defined by the active `@context`;
- a node **`@type`** that doesn't resolve to an absolute IRI (no term definition, no `@vocab`) — rejected rather than passed through as a relative IRI; non-string `@type` entries are rejected too;
- a free-standing **scalar** where a node is expected (document root or a node array).

The lenient `expand_document` / `expand_and_to_rdf` defaults are **unchanged** — backward-compatible, additive API.

### `affinidi-data-integrity` 0.7.4 → 0.7.5

`sign_base_document` (issuer), the derive path (`canonicalize_hmac` / `to_deskolemized_nquads`), and `verify_derived_proof` / `verify_pseudonym_derived_proof` (verifier) now canonicalize via the safe variant. (`proof_hash` stays lenient — it processes proof options, not claims.)

- Issuers **refuse** to sign a credential with an undefined claim.
- Verifiers **reject** a reveal document carrying an undefined term.
- Both the basic and pseudonym (`0xd95d08`/`0xd95d09`) suites are covered.

Credentials whose claims are all defined by their context (e.g. via `@vocab`) are unaffected — all W3C `vc-di-bbs` KAT vectors still pass byte-for-byte (13/13 transform + full suites green).

## Tests added

- **(A) Adversarial re-derivation harness** — encodes the threat model (holder owns the base credential and re-derives at will): for every leaf claim, tamper-in-base then re-derive must never verify, with an honest-derivation control so it can't pass vacuously.
- **(B) Coverage/completeness** — issuer rejects an undefined claim at issuance; verifier rejects an undefined term in a reveal document.
- **(C) `affinidi-rdf-encoding` safe-mode unit tests** — reject unmapped property, nested-unmapped term, unmapped `@type`, top-level scalar, and stray-scalar-in-array; accept fully-mapped (`@vocab`) docs, custom types via `@vocab`, and standard VC terms; plus a lenient-drop guard pinning the old behaviour.

## Why we missed it originally

All conformance fixtures (`windDoc` with `@vocab`, `license.json`) are fully mapped, so the drop could never trigger; the two existing negative tests mutate the reveal **after** derivation (keeping the frozen proof bytes) rather than re-deriving as an attacker would. The new tests close both gaps.

## Verification

- `cargo test` — both crates green (incl. all `vc-di-bbs` KATs)
- `cargo clippy --all-targets --all-features` — clean
- `cargo fmt --all -- --check` — clean
- `cargo deny check` — advisories/bans/licenses/sources ok
- downstream `cargo check -p affinidi-vc --all-features` — clean

## Commits

1. `fix: affinidi-data-integrity 0.7.5 — bbs-2023 safe-mode expansion rejects forged undefined attributes (#381)` — core soundness fix + safe-mode for unmapped property keys.
2. `fix: affinidi-rdf-encoding safe mode — also reject unmapped @type and dropped scalars (#381)` — extend safe mode to the remaining two drop sites.