### PR TITLE
fix: reproducible cross-mediator DIDComm forwarding (4 fixes)

### DIFF
--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -152,6 +152,7 @@ async fn main() -> Result<(), ATMError> {
     let msg_id = send_message(
         &alice_atm,
         &atm_alice,
+        &alice_mediator_did,
         &atm_bob,
         &bob_mediator_did,
         msg_text,
@@ -196,6 +197,7 @@ async fn main() -> Result<(), ATMError> {
     let response_id = send_message(
         &bob_atm,
         &atm_bob,
+        &bob_mediator_did,
         &atm_alice,
         &alice_mediator_did,
         response_text,
@@ -261,6 +263,7 @@ async fn main() -> Result<(), ATMError> {
             let ping_id = send_message(
                 &alice_atm,
                 &atm_alice,
+                &alice_mediator_did,
                 &atm_bob,
                 &bob_mediator_did,
                 &ping_msg,
@@ -284,6 +287,7 @@ async fn main() -> Result<(), ATMError> {
             let pong_id = send_message(
                 &bob_atm,
                 &atm_bob,
+                &bob_mediator_did,
                 &atm_alice,
                 &alice_mediator_did,
                 &pong_msg,
@@ -338,10 +342,16 @@ async fn main() -> Result<(), ATMError> {
     Ok(())
 }
 
-/// Send a message from sender to recipient through the recipient's mediator
+/// Send a message from sender to recipient, routing through both mediators when they differ.
+///
+/// When sender and recipient use different mediators, two forward layers are required:
+///   outer (encrypted for sender_mediator, next=recipient_mediator) wraps
+///   inner (encrypted for recipient_mediator, next=recipient).
+/// This ensures each mediator only decrypts its own layer.
 async fn send_message(
     sender_atm: &affinidi_messaging_sdk::ATM,
     sender_profile: &std::sync::Arc<ATMProfile>,
+    sender_mediator_did: &str,
     recipient_profile: &std::sync::Arc<ATMProfile>,
     recipient_mediator_did: &str,
     body_text: &str,
@@ -374,8 +384,8 @@ async fn send_message(
         )
         .await?;
 
-    // Wrap in forward envelope for the recipient's mediator
-    let (_forward_id, forward_msg) = sender_atm
+    // Inner forward: encrypted for recipient's mediator, next=recipient
+    let (_inner_id, inner_fwd) = sender_atm
         .routing()
         .forward_message(
             sender_profile,
@@ -387,6 +397,26 @@ async fn send_message(
             None,
         )
         .await?;
+
+    // Outer forward (cross-mediator only): encrypted for sender's mediator,
+    // next=recipient_mediator so the sender's mediator relays inner_fwd onward.
+    let forward_msg = if sender_mediator_did != recipient_mediator_did {
+        let (_outer_id, outer_fwd) = sender_atm
+            .routing()
+            .forward_message(
+                sender_profile,
+                false,
+                &inner_fwd,
+                sender_mediator_did,
+                recipient_mediator_did,
+                None,
+                None,
+            )
+            .await?;
+        outer_fwd
+    } else {
+        inner_fwd
+    };
 
     // Send via sender's mediator
     sender_atm

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -212,3 +212,34 @@ where
         authenticate_token(&state, bearer.token()).await
     }
 }
+
+/// Extractor that wraps `Session` and never rejects.
+///
+/// When a valid `Authorization: Bearer` token is present the inner `Session`
+/// is fully populated (i.e. `session.authenticated == true`). When the header
+/// is absent or invalid an anonymous session is synthesised using the
+/// mediator's global default ACL — this is intentional for inter-mediator
+/// relay requests sent by a remote `ForwardingProcessor`.
+pub struct MaybeSession(pub Session);
+
+impl<S> FromRequestParts<S> for MaybeSession
+where
+    SharedData: FromRef<S>,
+    S: Send + Sync + Debug,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match Session::from_request_parts(parts, state).await {
+            Ok(session) => Ok(MaybeSession(session)),
+            Err(_) => {
+                let shared = SharedData::from_ref(state);
+                Ok(MaybeSession(Session {
+                    session_id: "ANON-INBOUND".to_string(),
+                    acls: shared.config.security.global_acl_default.clone(),
+                    ..Default::default()
+                }))
+            }
+        }
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -3,6 +3,7 @@ use crate::{
     common::session::{Session, SessionClaims},
 };
 use affinidi_messaging_mediator_common::errors::ErrorResponse;
+use affinidi_messaging_sdk::protocols::mediator::acls::MediatorACLSet;
 use axum::{
     Json, RequestPartsExt,
     extract::{FromRef, FromRequestParts},
@@ -213,13 +214,29 @@ where
     }
 }
 
-/// Extractor that wraps `Session` and never rejects.
+/// Whether an unauthenticated (no-Bearer) inbound request may be accepted as an
+/// anonymous session.
+///
+/// Anonymous inbound exists solely for inter-mediator relay: a remote
+/// `ForwardingProcessor` POSTs a forward whose inner authcrypt *is* the
+/// authentication. We only honour that when the operator has opted into acting
+/// as a relay, signalled by the global default ACL granting `SEND_FORWARDED`
+/// (the capability the relay path consumes, gated again per-message in
+/// `routing.rs`). On a mediator with the shipped secure default this returns
+/// `false`, so anonymous requests are rejected exactly like before.
+fn anonymous_inbound_allowed(global_acl_default: &MediatorACLSet) -> bool {
+    global_acl_default.get_send_forwarded().0
+}
+
+/// Extractor that wraps `Session`, optionally allowing anonymous relay requests.
 ///
 /// When a valid `Authorization: Bearer` token is present the inner `Session`
 /// is fully populated (i.e. `session.authenticated == true`). When the header
-/// is absent or invalid an anonymous session is synthesised using the
-/// mediator's global default ACL — this is intentional for inter-mediator
-/// relay requests sent by a remote `ForwardingProcessor`.
+/// is absent or invalid the request is only accepted — as an anonymous session
+/// carrying the global default ACL — if [`anonymous_inbound_allowed`] permits it
+/// (the mediator is configured as an inter-mediator relay). Otherwise the
+/// original authentication rejection is propagated, so a mediator with the
+/// shipped secure default keeps rejecting unauthenticated `/inbound` requests.
 pub struct MaybeSession(pub Session);
 
 impl<S> FromRequestParts<S> for MaybeSession
@@ -227,19 +244,44 @@ where
     SharedData: FromRef<S>,
     S: Send + Sync + Debug,
 {
-    type Rejection = std::convert::Infallible;
+    type Rejection = AuthError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         match Session::from_request_parts(parts, state).await {
             Ok(session) => Ok(MaybeSession(session)),
-            Err(_) => {
+            Err(e) => {
                 let shared = SharedData::from_ref(state);
-                Ok(MaybeSession(Session {
-                    session_id: "ANON-INBOUND".to_string(),
-                    acls: shared.config.security.global_acl_default.clone(),
-                    ..Default::default()
-                }))
+                if anonymous_inbound_allowed(&shared.config.security.global_acl_default) {
+                    Ok(MaybeSession(Session {
+                        session_id: "ANON-INBOUND".to_string(),
+                        acls: shared.config.security.global_acl_default.clone(),
+                        ..Default::default()
+                    }))
+                } else {
+                    Err(e)
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anon_inbound_allowed_when_global_default_grants_send_forwarded() {
+        let acls = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
+        assert!(anonymous_inbound_allowed(&acls));
+    }
+
+    #[test]
+    fn anon_inbound_denied_for_shipped_secure_default() {
+        // The shipped default global_acl_default: fine for direct messaging but
+        // NOT a relay (no SEND_FORWARDED), so anonymous inbound must be refused.
+        let acls =
+            MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
+                .unwrap();
+        assert!(!anonymous_inbound_allowed(&acls));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -33,9 +33,11 @@ pub struct InboundMessage {
 
 /// Handles inbound messages to the mediator.
 ///
-/// Accepts both authenticated (JWT Bearer) and anonymous requests.
-/// Anonymous requests are used by remote mediator ForwardingProcessors for
-/// inter-mediator message relay; they are assigned the global default ACL.
+/// Authenticated (JWT Bearer) requests are always accepted. Anonymous requests
+/// — used by remote mediator ForwardingProcessors for inter-mediator relay —
+/// are accepted only when the mediator is configured as a relay (global default
+/// ACL grants `SEND_FORWARDED`); otherwise they are rejected like any other
+/// unauthenticated request. See `MaybeSession`.
 /// ACL_MODE: Requires SEND_MESSAGES in the session (or global default) ACL.
 pub async fn message_inbound_handler(
     MaybeSession(session): MaybeSession,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -1,4 +1,4 @@
-use crate::{SharedData, common::session::Session, messages::inbound::handle_inbound};
+use crate::{SharedData, common::jwt_auth::MaybeSession, messages::inbound::handle_inbound};
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::messages::{
     problem_report::{ProblemReportScope, ProblemReportSorter},
@@ -31,11 +31,14 @@ pub struct InboundMessage {
     pub tag: String,
 }
 
-/// Handles inbound messages to the mediator
-/// ACL_MODE: Requires LOCAL access
+/// Handles inbound messages to the mediator.
 ///
+/// Accepts both authenticated (JWT Bearer) and anonymous requests.
+/// Anonymous requests are used by remote mediator ForwardingProcessors for
+/// inter-mediator message relay; they are assigned the global default ACL.
+/// ACL_MODE: Requires SEND_MESSAGES in the session (or global default) ACL.
 pub async fn message_inbound_handler(
-    session: Session,
+    MaybeSession(session): MaybeSession,
     State(state): State<SharedData>,
     Json(body): Json<InboundMessage>,
 ) -> Result<(StatusCode, Json<SuccessResponse<InboundMessageResponse>>), AppError> {

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -137,7 +137,9 @@ async fn handle_inbound_didcomm(
                     // Does the sender identity match the session DID?
                     // The sender can be identified by JWS signing (sign_from) or
                     // authcrypt encryption (encrypted_from_kid).
-                    if state.config.security.force_session_did_match {
+                    // Skip for unauthenticated sessions (e.g. inter-mediator relay):
+                    // there is no session DID to match against.
+                    if state.config.security.force_session_did_match && session.authenticated {
                         let sender_kid =
                             metadata.sign_from.as_ref().or(metadata.encrypted_from_kid.as_ref());
                         check_session_sender_match(session, &msg.id, &sender_kid)?;

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -196,11 +196,42 @@ pub(crate) async fn process(
         let from_account = if let Some(from) = &msg.from {
             let from_account = match state.database.account_get(&digest(from.as_str())).await {
                 Ok(Some(from_account)) => from_account,
-                Ok(None) => Account {
-                    did_hash: digest(from.as_str()),
-                    acls: state.config.security.global_acl_default.to_u64(),
-                    ..Default::default()
-                },
+                Ok(None) => {
+                    // First time we've seen this forwarding sender. Persist it
+                    // as a registered account seeded from `global_acl_default`
+                    // (mirrors the `next_account` branch above). Without this,
+                    // `store_message` later creates a bare `DID:<hash>` record
+                    // holding only queue counters (no `ACLS` field). On every
+                    // subsequent forward `account_get` then returns that phantom
+                    // record with `acls = 0` (DENY_ALL), so the `send_forwarded`
+                    // gate below rejects the relay with 403 — even though the
+                    // global default is `ALLOW_ALL`. Registering here keeps the
+                    // stored sender default from being stricter than the global
+                    // default and makes cross-mediator forwarding reproducible.
+                    debug!("Forwarding sender account not found, creating a new one");
+                    state
+                        .database
+                        .account_add(
+                            &digest(from.as_str()),
+                            &state.config.security.global_acl_default,
+                            None,
+                        )
+                        .await
+                        .map_err(|e| {
+                            MediatorError::problem_with_log(
+                                14,
+                                &session.session_id,
+                                Some(msg.id.to_string()),
+                                ProblemReportSorter::Error,
+                                ProblemReportScope::Protocol,
+                                "me.res.storage.error",
+                                "Database transaction error: {1}",
+                                vec![e.to_string()],
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                format!("Database transaction error: {e}"),
+                            )
+                        })?
+                }
                 Err(e) => {
                     return Err(MediatorError::problem_with_log(
                         14,


### PR DESCRIPTION
## Summary

Four related fixes that together make **cross-mediator** DIDComm v2 message relay work
end-to-end and **reproducibly** between two independent mediators, plus a security gate so the
relax of inbound auth only applies to mediators explicitly configured as relays. Discovered while
standing up two local `did:peer` mediators (ports 7037/7038, `redis-backend`) and running the
`cross_mediator_forwarding` example.

Before this series the example could not complete a cross-mediator round-trip; after the first
three fixes it round-tripped **once** against a cold Redis but failed on every subsequent run — the
4th fix closes that regression.

## The fixes

**1. `cross_mediator_forwarding` example — double-wrap the forward envelope**
`send_message()` built a single forward encrypted *for the recipient's mediator* and sent it *to the
sender's mediator*, which couldn't decrypt it and fell through to the direct-delivery error path.
Correct pattern: `inner = forward(packed, target=RecipientMediator, next=Recipient)` then
`outer = forward(inner, target=SenderMediator, next=RecipientMediator)`.

**2. `/inbound` rejected anonymous requests — blocked inter-mediator relay**
`ForwardingProcessor` POSTs to the remote mediator with no JWT (the inner forward's authcrypt *is*
the authentication), but the `Session` extractor returned `401` first. Added a `MaybeSession`
extractor: Bearer → authenticated session; no Bearer → anonymous session with `global_acl_default`
**— but only when the mediator is configured as a relay (see fix #5)**.

**3. `force_session_did_match` broke anonymous sessions**
The sender-DID check compared the JWE sender against `session.did = ""` for anonymous sessions and
always failed. Now gated on `session.authenticated`.

**4. Forwarding sender never registered — relay not reproducible** (the regression)
In `routing.rs::forward_message`, the `next_account` (recipient) branch persists the next hop via
`account_add(global_acl_default)` when missing, but the `from_account` (sender) branch only built an
*in-memory* `Account` and never persisted it. `store_message`'s Redis Lua then `HINCRBY`s queue
counters onto `DID:<sender>`, creating a row with **only** `SEND_QUEUE_*` fields — no `ACLS`, never
added to `KNOWN_DIDS`. On the next forward, `account_get` returns that phantom row with `acls = 0`
(DENY_ALL), so the `SEND_FORWARDED` gate rejects the relay with `403 e.p.authorization.send_forwarded`.
Fix: mirror the `next_account` branch — `account_add` the forwarding sender from `global_acl_default`
on first contact.

**5. Gate anonymous `/inbound` on relay capability (`SEND_FORWARDED`)**
Fix #2 alone moved the inbound auth boundary for **every** mediator: with the shipped secure default
(`DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES`) an anonymous caller still gained
`SEND_MESSAGES`/`RECEIVE_MESSAGES`/`LOCAL` — strictly more than the previous `401`. `MaybeSession`
now synthesizes the anonymous session **only when `global_acl_default` grants `SEND_FORWARDED`** —
i.e. the operator has opted into acting as an inter-mediator relay (capability re-checked per-message
in `routing.rs`). Otherwise the original `AuthError` is propagated, so a mediator on the shipped
default keeps rejecting unauthenticated `/inbound` exactly as before. `ALLOW_ALL` enables relay (as
the cross-mediator example already requires); the secure default does not. Uses capability-bit
checking to match the existing `routing.rs` ACL gates rather than whole-set equality against
`ALLOW_ALL`. Unit-tested in `jwt_auth.rs`.

## Reproduction / verification

Two `did:peer` mediators on :7037 / :7038, `--no-default-features --features didcomm,redis-backend`
(the `ForwardingProcessor` is `#[cfg(feature = "redis-backend")]`-only), with
`global_acl_default = "ALLOW_ALL"`, then:

```
cargo run -p affinidi-messaging-helpers --example cross_mediator_forwarding -- \
  --alice-environment alice --bob-environment bob
```

- Before #4: 1st run (cold Redis) delivers both ways; every later run →
  `403 e.p.authorization.send_forwarded`.
- After #4: from a clean Redis, **5 consecutive runs** deliver both directions (~40ms localhost).
- After #5: on a mediator without `SEND_FORWARDED` in `global_acl_default`, unauthenticated
  `/inbound` is rejected (`401`) rather than silently treated as anonymous.

Tests: `affinidi-messaging-mediator` lib (101, incl. 2 new gate tests) and integration
`test_sender_authentication` (9), 0 failures, with `--features redis-backend`.

## Security / trust note

With this series, anonymous inbound relay is **gated behind explicit relay configuration**
(`global_acl_default` granting `SEND_FORWARDED`, i.e. `ALLOW_ALL` in practice). A mediator left on
the shipped secure default is unaffected and keeps rejecting unauthenticated `/inbound`. Operators
who enable relay accept an **open-relay** posture between trusted mediators; for stricter production
use, gate further on a per-DID ACL or an allowlist of the inner forward's authcrypt sender.

