### PR TITLE
fix: drain DIDComm offline backlog on connect, not after 30s

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.3"
+version = "0.3.4"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -13,6 +13,10 @@ use crate::error::{DIDCommServiceError, StartupError};
 use crate::handler::DIDCommHandler;
 
 const OFFLINE_SYNC_INTERVAL_SECS: u64 = 30;
+/// Short retry used only when the very first drains can't run yet because the
+/// websocket is still coming up right after connect — so the initial backlog is
+/// fetched within a second or two instead of waiting a full interval.
+const OFFLINE_SYNC_RETRY_SECS: u64 = 2;
 
 impl Listener {
     pub(crate) async fn set_acl_mode(
@@ -53,28 +57,48 @@ impl Listener {
     ) {
         let profile_alias = profile.inner.alias.clone();
         loop {
+            // Drain the offline/queued backlog at the TOP of the loop, so it runs
+            // immediately on connect rather than only after the first interval.
+            // Previously this slept `OFFLINE_SYNC_INTERVAL_SECS` *before* the
+            // first sync, so a message delivered while this listener was offline
+            // (e.g. a membership credential issued before the listener connected)
+            // wasn't picked up for ~30s. Now it arrives in ~1s.
+            let next_delay_secs = match Listener::sync_offline_messages(
+                listener_id,
+                atm,
+                profile,
+                handler,
+            )
+            .await
+            {
+                Ok(()) => OFFLINE_SYNC_INTERVAL_SECS,
+                Err(e) => {
+                    // A websocket reconnect (e.g. when the mediator closes the
+                    // socket on access-token expiry) can land mid-poll and abort
+                    // an in-flight request. That is expected and self-heals, so
+                    // log it at debug rather than raising a misleading "sync
+                    // failed" warning. Right after connect the socket may still be
+                    // coming up — retry soon so the initial drain isn't delayed a
+                    // whole interval; back off normally on any other error.
+                    if matches!(
+                        e.downcast_ref::<ATMError>(),
+                        Some(ATMError::Disconnected(_))
+                    ) {
+                        debug!(profile = %profile_alias, "Offline sync skipped: websocket reconnecting");
+                        OFFLINE_SYNC_RETRY_SECS
+                    } else {
+                        warn!(profile = %profile_alias, error = %e, "Offline sync failed");
+                        OFFLINE_SYNC_INTERVAL_SECS
+                    }
+                }
+            };
+
             tokio::select! {
                 _ = shutdown.cancelled() => {
                     debug!(profile = %profile_alias, "Offline sync task shutting down");
                     break;
                 }
-                _ = tokio::time::sleep(Duration::from_secs(OFFLINE_SYNC_INTERVAL_SECS)) => {
-                    if let Err(e) = Listener::sync_offline_messages(listener_id, atm, profile, handler).await {
-                        // A websocket reconnect (e.g. when the mediator closes the
-                        // socket on access-token expiry) can land mid-poll and
-                        // abort an in-flight request. That is expected and self-
-                        // heals on the next cycle, so log it at debug rather than
-                        // raising a misleading "sync failed" warning.
-                        if matches!(
-                            e.downcast_ref::<ATMError>(),
-                            Some(ATMError::Disconnected(_))
-                        ) {
-                            debug!(profile = %profile_alias, "Offline sync skipped: websocket reconnecting");
-                        } else {
-                            warn!(profile = %profile_alias, error = %e, "Offline sync failed");
-                        }
-                    }
-                }
+                _ = tokio::time::sleep(Duration::from_secs(next_delay_secs)) => {}
             }
         }
     }


### PR DESCRIPTION
## Problem

`DIDCommService`'s periodic offline-sync loop (`run_periodic_offline_sync`) slept the full `OFFLINE_SYNC_INTERVAL_SECS` (30s) **before** performing its first `sync_offline_messages`. Any messages already queued at the mediator when a listener connects — e.g. a credential pushed to a holder while it was offline — therefore sat undelivered for up to 30 seconds after connect, even though the live-stream was up. Consumers saw a consistent ~30s latency on the first message after (re)connect.

## Fix

Drain at the **top** of the loop, so the first `sync_offline_messages` runs immediately on connect, then compute the next delay based on the result:

- `Ok` → wait the normal `OFFLINE_SYNC_INTERVAL_SECS` (30s).
- `Disconnected` (WebSocket still coming up) → short `OFFLINE_SYNC_RETRY_SECS` (2s) retry.
- other errors → fall back to the normal interval.

The `tokio::select!` on shutdown vs. `sleep(next_delay)` is unchanged; `sync_offline_messages` itself (status-request → delivery-request → dispatch → messages-received ack) is unchanged.

## Impact

Queued messages are delivered as soon as the listener connects instead of after a fixed 30s delay. No API or behavioural change beyond the latency fix.

## Versioning

Bumps `affinidi-messaging-didcomm-service` 0.3.3 → 0.3.4 (patch).

## Notes

Surfaced while debugging a ~30s delay receiving join-approval credentials in a downstream DIDComm consumer (OpenVTC), which currently carries this fix via a local `[patch.crates-io]` pending this merge + publish.