### PR TITLE
feat: per-hop re-wrapping for inter-mediator relay (relay_mode=rewrap) (#385 item 3)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,41 @@
 
 ## 10th June 2026
 
+### 0.15.20 — Per-hop re-wrapping for inter-mediator relay (#385 item 3, #388)
+
+- Final piece of #385. Adds **per-hop re-wrapping** for the inter-mediator
+  relay path, behind the new `[processors.forwarding] relay_mode` config
+  (`blind` | `rewrap`, default `blind` — **no behaviour change** for
+  existing deployments).
+- **Why:** in the historical *blind* relay the relaying mediator forwards
+  the inner envelope byte-for-byte, so (a) the receiving mediator never
+  sees the relaying *peer's* identity — making a trusted-peer allowlist
+  impossible at the DIDComm layer — and (b) the inner authcrypt JWE carries
+  the original sender's key id (`skid`) in cleartext on the
+  mediator↔mediator hop. In `rewrap` mode each mediator re-encrypts the
+  inner forward in a fresh `forward` authcrypted *from itself* to the next
+  hop: the original sender and inner envelope are hidden from on-wire
+  observers, and the receiver gets an authenticated peer identity to
+  allowlist.
+- **Send** (`routing.rs::rewrap_for_relay`): wraps the inner attachment in a
+  new `forward` authcrypted from this mediator to the next hop (carrying the
+  running `hop_count`), enqueued instead of the verbatim bytes.
+- **Receive** (`inbound.rs::peel_relay_rewrap_layers`): a pre-pass (rewrap
+  mode only) that strips `forward`-to-self layers a peer produced,
+  authenticates the relaying peer against `relay_trusted_mediators`
+  (empty = any; non-empty = members only, anonymous rejected with
+  `authorization.relay.untrusted_peer`), and continues on the inner
+  envelope. Bounded by `max_hops`. Implemented as a pre-pass so
+  `handle_inbound_didcomm`'s body is unchanged — zero regression risk on the
+  direct-delivery and normal-message paths; cost is one extra unpack of the
+  outer layer for to-mediator messages on a rewrap mediator.
+- Both mediators in a relaying pair must use the same mode. Verified
+  end-to-end on the memory backend by `affinidi-messaging-test-mediator`'s
+  `cross_mediator_forwarding` suite (rewrap round trip + trusted-peer
+  admit/reject), now possible because #399 made the forwarding processor
+  run on non-Redis backends; the on-wire crypto is covered by
+  `tests/relay_rewrap.rs`. Closes #385.
+
 ### 0.15.19 — Forwarding runs on Fjall and in-memory backends (#399)
 
 - The forwarding processor now spawns for every storage backend, not just

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.19"
+version = "0.15.20"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 10th June 2026
 
+### 0.15.5 — `RelayMode` config for inter-mediator relay (#385 item 3)
+
+- Adds the `RelayMode` enum (`Blind` | `Rewrap`, default `Blind`) and two
+  fields on `ForwardingConfig`: `relay_mode` and `relay_trusted_mediators`
+  (a peer-mediator DID allowlist used only in `Rewrap`). Purely additive —
+  `Default` keeps the historical blind-relay behaviour, so existing
+  deployments are unchanged. Consumed by the mediator's routing/inbound
+  rewrap paths (see `affinidi-messaging-mediator` 0.15.20).
+
 ### 0.15.4 — `ForwardingProcessor` compiles for all storage backends
 
 - `tasks::forwarding::processor` is no longer gated on `redis-backend`.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.4"
+version = "0.15.5"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/config.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/config.rs
@@ -12,6 +12,30 @@
 use ahash::AHashSet as HashSet;
 use serde::{Deserialize, Serialize};
 
+/// How a mediator relays a forward whose next hop is a *remote* mediator.
+///
+/// See [`ForwardingConfig::relay_mode`]. Both mediators in a relaying pair must
+/// agree on the mode: a `Rewrap` sender produces envelopes only a `Rewrap`
+/// receiver knows how to peel.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelayMode {
+    /// Relay the inner forward attachment to the next mediator **unchanged**
+    /// (byte-for-byte). Simple, but the inner envelope — including the original
+    /// sender's key id in its JWE protected header — is visible on the wire,
+    /// and the receiving mediator cannot identify the relaying peer mediator.
+    /// This is the historical behaviour and the default.
+    #[default]
+    Blind,
+    /// **Re-encrypt** the inner forward for the next mediator: wrap it in a new
+    /// `forward` authcrypted *from this mediator* to the next hop. The inner
+    /// envelope (and the original sender's identity) is hidden from on-wire
+    /// observers, and the receiving mediator can authenticate and allowlist the
+    /// relaying peer mediator (see [`ForwardingConfig::relay_trusted_mediators`]).
+    /// Requires the receiving mediator to also run in `Rewrap` mode.
+    Rewrap,
+}
+
 /// DIDComm routing and forwarding configuration. Consumed by
 /// [`ForwardingProcessor`](crate::tasks::forwarding::ForwardingProcessor).
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -43,6 +67,14 @@ pub struct ForwardingConfig {
     /// Maximum number of hops a forwarded message can make before being dropped.
     /// Prevents forwarding loops between mediators.
     pub max_hops: u32,
+    /// How to relay a forward to a remote next-hop mediator. See [`RelayMode`].
+    /// Defaults to [`RelayMode::Blind`] (historical behaviour, no regression).
+    pub relay_mode: RelayMode,
+    /// In [`RelayMode::Rewrap`], the allowlist of peer-mediator DIDs whose
+    /// re-wrapped relays this mediator will accept on its inbound endpoint.
+    /// Empty = accept any peer (capability still gated by ACLs). Ignored in
+    /// [`RelayMode::Blind`], where the relaying peer's identity is not visible.
+    pub relay_trusted_mediators: HashSet<String>,
 }
 
 impl Default for ForwardingConfig {
@@ -63,6 +95,8 @@ impl Default for ForwardingConfig {
             consumer_group: "forwarding".to_string(),
             accept_invalid_certs: false,
             max_hops: 10,
+            relay_mode: RelayMode::Blind,
+            relay_trusted_mediators: HashSet::new(),
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
@@ -8,7 +8,7 @@
 //! the same [`ForwardingProcessor`] over `Arc<dyn MediatorStore>`.
 
 pub mod config;
-pub use config::ForwardingConfig;
+pub use config::{ForwardingConfig, RelayMode};
 
 // `ForwardingProcessor` is backend-agnostic: it consumes the
 // `forward_queue_*` methods on `Arc<dyn MediatorStore>`, which every

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -435,6 +435,23 @@ max_backoff_ms = "60000"
 ### in-memory backends it names the single in-process group.
 consumer_group = "forwarding"
 
+### Env: PROCESSOR_FORWARDING_RELAY_MODE
+### How to relay a forward whose next hop is a *remote* mediator:
+###   "blind"  (default) — relay the inner envelope unchanged. The inner
+###            envelope (incl. the original sender's key id) is visible on the
+###            wire and the receiving mediator cannot identify the relaying peer.
+###   "rewrap" — re-encrypt the inner envelope for the next mediator, authcrypted
+###            from THIS mediator. Hides the sender/inner envelope from the wire
+###            and lets the receiving mediator authenticate & allowlist the peer
+###            mediator. BOTH mediators in the pair must use "rewrap".
+relay_mode = "blind"
+
+### Env: PROCESSOR_FORWARDING_RELAY_TRUSTED_MEDIATORS
+### Comma-separated allowlist of peer-mediator DIDs whose re-wrapped relays this
+### mediator will accept (rewrap mode only). Empty = accept any peer (still ACL
+### gated). Ignored in blind mode.
+relay_trusted_mediators = ""
+
 [processors.message_expiry_cleanup]
 ### Env: PROCESSOR_MESSAGE_EXPIRY_CLEANUP_ENABLED
 ### Enable the message expiry cleanup processor

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
@@ -1,5 +1,6 @@
 use affinidi_messaging_mediator_common::errors::MediatorError;
 pub use affinidi_messaging_mediator_common::tasks::forwarding::ForwardingConfig;
+use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
 use ahash::AHashSet as HashSet;
 use serde::{Deserialize, Serialize};
 
@@ -121,6 +122,12 @@ pub(crate) struct ForwardingConfigRaw {
     pub accept_invalid_certs: String,
     #[serde(default = "default_10")]
     pub max_hops: String,
+    /// Relay mode for remote next-hop forwards: "blind" (default) or "rewrap".
+    #[serde(default = "default_blind")]
+    pub relay_mode: String,
+    /// Comma-separated allowlist of trusted peer-mediator DIDs (rewrap mode).
+    #[serde(default)]
+    pub relay_trusted_mediators: String,
 }
 
 fn default_300() -> String {
@@ -155,6 +162,9 @@ fn default_true() -> String {
 }
 fn default_10() -> String {
     "10".to_string()
+}
+fn default_blind() -> String {
+    "blind".to_string()
 }
 
 impl std::convert::TryFrom<ForwardingConfigRaw> for ForwardingConfig {
@@ -222,6 +232,21 @@ impl std::convert::TryFrom<ForwardingConfigRaw> for ForwardingConfig {
                 warn_default("max_hops", "10");
                 10
             }),
+            relay_mode: match raw.relay_mode.trim().to_ascii_lowercase().as_str() {
+                "rewrap" => RelayMode::Rewrap,
+                "blind" | "" => RelayMode::Blind,
+                other => {
+                    warn_default(&format!("relay_mode (unrecognised: {other:?})"), "blind");
+                    RelayMode::Blind
+                }
+            },
+            relay_trusted_mediators: raw
+                .relay_trusted_mediators
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
         })
     }
 }
@@ -268,6 +293,8 @@ mod tests {
             consumer_group: default_forwarding_group(),
             accept_invalid_certs: default_false(),
             max_hops: default_10(),
+            relay_mode: default_blind(),
+            relay_trusted_mediators: String::new(),
         };
         let config = ForwardingConfig::try_from(raw).unwrap();
         assert!(config.enabled);
@@ -306,6 +333,8 @@ mod tests {
             consumer_group: "custom_group".to_string(),
             accept_invalid_certs: "false".to_string(),
             max_hops: "5".to_string(),
+            relay_mode: "rewrap".to_string(),
+            relay_trusted_mediators: "did:peer:alice , did:peer:bob".to_string(),
         };
         let config = ForwardingConfig::try_from(raw).unwrap();
         assert!(!config.enabled);
@@ -322,6 +351,46 @@ mod tests {
         assert_eq!(config.initial_backoff_ms, 2000);
         assert_eq!(config.max_backoff_ms, 120000);
         assert_eq!(config.consumer_group, "custom_group");
+        // relay_mode parses case-insensitively; the trusted-mediator list is
+        // comma-split with surrounding whitespace trimmed and blanks dropped.
+        assert_eq!(config.relay_mode, RelayMode::Rewrap);
+        assert!(config.relay_trusted_mediators.contains("did:peer:alice"));
+        assert!(config.relay_trusted_mediators.contains("did:peer:bob"));
+        assert_eq!(config.relay_trusted_mediators.len(), 2);
+    }
+
+    #[test]
+    fn relay_mode_defaults_to_blind_with_empty_allowlist() {
+        // The first try_from fixture leaves relay_mode = "blind" and an empty
+        // trusted list — the historical, no-regression default.
+        let config = ForwardingConfig::default();
+        assert_eq!(config.relay_mode, RelayMode::Blind);
+        assert!(config.relay_trusted_mediators.is_empty());
+    }
+
+    #[test]
+    fn unrecognised_relay_mode_falls_back_to_blind() {
+        let raw = ForwardingConfigRaw {
+            enabled: "true".to_string(),
+            external_forwarding: "true".to_string(),
+            future_time_limit: "3600".to_string(),
+            report_errors: "true".to_string(),
+            blocked_forwarding_dids: String::new(),
+            rate_window_seconds: default_300(),
+            ws_threshold_msgs_per_10s: default_1(),
+            ws_idle_timeout_seconds: default_60(),
+            batch_size: default_50(),
+            max_retries: default_5(),
+            initial_backoff_ms: default_1000(),
+            max_backoff_ms: default_60000(),
+            consumer_group: default_forwarding_group(),
+            accept_invalid_certs: default_false(),
+            max_hops: default_10(),
+            relay_mode: "bogus".to_string(),
+            relay_trusted_mediators: String::new(),
+        };
+        let config = ForwardingConfig::try_from(raw).unwrap();
+        assert_eq!(config.relay_mode, RelayMode::Blind);
     }
 
     #[test]
@@ -342,10 +411,13 @@ mod tests {
             consumer_group: "forwarding".to_string(),
             accept_invalid_certs: "bad".to_string(),
             max_hops: "bad".to_string(),
+            relay_mode: "bad".to_string(),
+            relay_trusted_mediators: String::new(),
         };
         let config = ForwardingConfig::try_from(raw).unwrap();
         // All invalid values should fall back to unwrap_or defaults
         assert!(config.enabled); // default true
+        assert_eq!(config.relay_mode, RelayMode::Blind); // unrecognised → blind
         assert!(config.external_forwarding); // default true
         assert!(config.report_errors); // default true
         assert_eq!(config.future_time_limit, 86400);

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -4,8 +4,12 @@ use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat::MetaEnvelope;
 #[cfg(feature = "didcomm")]
 use crate::messages::MessageHandler;
+#[cfg(feature = "didcomm")]
+use crate::messages::protocols::routing::{relay_peer_trusted, rewrap_inner_attachment};
 use crate::{SharedData, common::session::Session, messages::store::store_message};
 use affinidi_messaging_mediator_common::errors::MediatorError;
+#[cfg(feature = "didcomm")]
+use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::{
@@ -60,6 +64,19 @@ async fn handle_inbound_didcomm(
     );
 
     async move {
+        // Re-wrap relay (RelayMode::Rewrap): a peer mediator may have wrapped the
+        // message in one or more `forward`-to-us layers (see `rewrap_for_relay`).
+        // Authenticate the relaying peer and strip those layers before the normal
+        // path runs on the innermost envelope. In the default `Blind` mode this is
+        // skipped entirely, so existing behaviour is unchanged.
+        let peeled;
+        let message: &str = if state.config.processors.forwarding.relay_mode == RelayMode::Rewrap {
+            peeled = peel_relay_rewrap_layers(state, session, message.to_string()).await?;
+            &peeled
+        } else {
+            message
+        };
+
         let envelope = match MetaEnvelope::new(message, &state.did_resolver).await {
             Ok(envelope) => envelope,
             Err(e) => {
@@ -291,6 +308,90 @@ async fn handle_inbound_didcomm(
     }
     .instrument(_span)
     .await
+}
+
+/// Strip peer-mediator re-wrap layers from an inbound message (RelayMode::Rewrap).
+///
+/// A re-wrap layer is a `forward` addressed to this mediator whose `next` hop is
+/// *also* this mediator — the envelope a peer produces in [`rewrap_for_relay`].
+/// For each such layer this authenticates the relaying peer (the authcrypt
+/// `from`) against the trusted-peer allowlist, then replaces the message with
+/// the inner attachment and repeats, returning the innermost envelope once it is
+/// no longer a re-wrap layer. Bounded by `max_hops` to stop relay loops.
+///
+/// Any decrypt/unpack failure here is *not* fatal: the message is handed back
+/// unchanged so the normal inbound path produces the canonical error. The cost
+/// is one extra unpack of the outer layer on a rewrap-mode mediator; acceptable
+/// for an opt-in relay posture.
+#[cfg(feature = "didcomm")]
+async fn peel_relay_rewrap_layers(
+    state: &SharedData,
+    session: &Session,
+    message: String,
+) -> Result<String, MediatorError> {
+    let mut current = message;
+    let mut depth: u32 = 0;
+    loop {
+        let envelope = match MetaEnvelope::new(&current, &state.did_resolver).await {
+            Ok(e) => e,
+            Err(_) => return Ok(current),
+        };
+        if envelope.to_did.as_deref() != Some(state.config.mediator_did.as_str()) {
+            return Ok(current);
+        }
+        let (msg, _meta) = match envelope
+            .unpack(
+                &state.did_resolver,
+                &*state.config.security.mediator_secrets,
+            )
+            .await
+        {
+            Ok(ok) => ok,
+            Err(_) => return Ok(current),
+        };
+        let Some(inner) = rewrap_inner_attachment(&state.config.mediator_did, &msg) else {
+            return Ok(current);
+        };
+
+        // Authenticate the relaying peer mediator before peeling its layer.
+        if !relay_peer_trusted(
+            &state.config.processors.forwarding.relay_trusted_mediators,
+            msg.from.as_deref(),
+        ) {
+            return Err(MediatorError::problem(
+                60,
+                &session.session_id,
+                Some(msg.id.clone()),
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "authorization.relay.untrusted_peer",
+                "Relaying mediator is not in the trusted relay allowlist",
+                vec![],
+                StatusCode::FORBIDDEN,
+            ));
+        }
+
+        depth += 1;
+        if depth > state.config.processors.forwarding.max_hops {
+            return Err(MediatorError::problem(
+                94,
+                &session.session_id,
+                Some(msg.id.clone()),
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "protocol.forwarding.loop_detected",
+                "Re-wrap relay exceeded maximum hop count, possible loop",
+                vec![],
+                StatusCode::LOOP_DETECTED,
+            ));
+        }
+
+        debug!(
+            peer = msg.from.as_deref().unwrap_or("anon"),
+            depth, "Peeled inter-mediator relay re-wrap layer"
+        );
+        current = inner;
+    }
 }
 
 /// Ensure the Session DID and the message sender DID match.

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -11,9 +11,10 @@ use crate::{
     },
 };
 use affinidi_did_common::Document;
-use affinidi_messaging_didcomm::message::Message;
+use affinidi_messaging_didcomm::message::{Attachment, Message};
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_mediator_common::store::types::ForwardQueueEntry;
+use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::{
     messages::problem_report::{ProblemReport, ProblemReportScope, ProblemReportSorter},
@@ -25,6 +26,7 @@ use serde::Deserialize;
 use sha256::digest;
 use tracing::{Instrument, debug, info, span, warn};
 use url::Url;
+use uuid::Uuid;
 
 // Reads the body of an incoming forward message
 #[derive(Default, Deserialize)]
@@ -51,6 +53,94 @@ fn relay_sender_acls(global_acl_default: &MediatorACLSet) -> MediatorACLSet {
         let _ = acls.set_send_forwarded(true, false, true);
     }
     acls
+}
+
+/// Re-wrap an inner forward envelope for relay to a remote peer mediator
+/// ([`RelayMode::Rewrap`]).
+///
+/// Produces a fresh `forward` whose single attachment is `inner`, authcrypted
+/// FROM this mediator TO `next` (the peer mediator) and carrying the running
+/// `hop_count`. The peer mediator authenticates *this* mediator as the sender
+/// (which is what makes its trusted-peer allowlist possible), sees that
+/// `next == its own DID`, and peels the attachment to continue routing. Because
+/// the inner envelope is now ciphertext inside this layer, on-wire observers
+/// between the two mediators no longer see the original sender's key id (which
+/// authcrypt otherwise carries, in the clear, in the inner JWE header).
+async fn rewrap_for_relay(
+    state: &SharedData,
+    session: &Session,
+    inner: &str,
+    next: &str,
+    hop_count: u32,
+) -> Result<String, MediatorError> {
+    let attachment = Attachment::base64(BASE64_URL_SAFE_NO_PAD.encode(inner)).finalize();
+    let mut forward = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/routing/2.0/forward".to_owned(),
+        serde_json::json!({ "next": next }),
+    )
+    .to(next.to_owned())
+    .from(state.config.mediator_did.clone())
+    .attachment(attachment)
+    .finalize();
+    // Carry the running hop count so the peer mediator continues loop detection
+    // across the re-wrap rather than resetting it.
+    forward
+        .extra
+        .insert("hop_count".to_string(), serde_json::json!(hop_count));
+
+    crate::didcomm_compat::pack_encrypted(
+        &forward,
+        next,
+        Some(&state.config.mediator_did),
+        &state.did_resolver,
+        &*state.config.security.mediator_secrets,
+    )
+    .await
+    .map(|(packed, _)| packed)
+    .map_err(|e| {
+        MediatorError::problem_with_log(
+            47,
+            &session.session_id,
+            None,
+            ProblemReportSorter::Error,
+            ProblemReportScope::Protocol,
+            "message.pack",
+            "Couldn't re-wrap forward for relay: {1}",
+            vec![e.clone()],
+            StatusCode::BAD_REQUEST,
+            format!("Couldn't re-wrap forward for relay: {e}"),
+        )
+    })
+}
+
+/// If `msg` is a relay re-wrap layer — a `forward` whose `next` hop is this
+/// mediator itself (the envelope produced by [`rewrap_for_relay`] on a peer) —
+/// decode and return its inner attachment (the envelope to continue processing).
+///
+/// Returns `None` for any other message, including an ordinary `forward` bound
+/// for a different next hop, so non-relay traffic is never altered.
+pub(crate) fn rewrap_inner_attachment(mediator_did: &str, msg: &Message) -> Option<String> {
+    if msg.typ != "https://didcomm.org/routing/2.0/forward" {
+        return None;
+    }
+    let next = serde_json::from_value::<ForwardRequest>(msg.body.clone())
+        .ok()?
+        .next?;
+    if next != mediator_did {
+        return None;
+    }
+    let b64 = msg.attachments.as_ref()?.first()?.data.base64.as_ref()?;
+    let bytes = BASE64_URL_SAFE_NO_PAD.decode(b64).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Whether `from` (the authcrypt sender of a re-wrap layer) is an allowed relay
+/// peer. An empty allowlist accepts any peer (the relay capability is still
+/// gated by ACLs); a non-empty list admits only its members, and rejects an
+/// anonymous (`None`) peer outright.
+pub(crate) fn relay_peer_trusted(allow: &ahash::AHashSet<String>, from: Option<&str>) -> bool {
+    allow.is_empty() || matches!(from, Some(did) if allow.contains(did))
 }
 
 /// Process a forward message, run checks and then if accepted place into FORWARD_TASKS stream
@@ -719,9 +809,19 @@ pub(crate) async fn process(
                 // Get the sender's full DID for problem reports
                 let from_did = msg.from.as_deref().unwrap_or("").to_string();
 
+                // Blind relay forwards the inner envelope verbatim; rewrap relay
+                // re-encrypts it from this mediator to the peer (see
+                // `rewrap_for_relay`). Default is blind — no behaviour change.
+                let relay_message = match state.config.processors.forwarding.relay_mode {
+                    RelayMode::Blind => data.clone(),
+                    RelayMode::Rewrap => {
+                        rewrap_for_relay(state, session, &data, &next, hop_count + 1).await?
+                    }
+                };
+
                 let entry = ForwardQueueEntry {
                     stream_id: String::new(), // Set by Redis on XADD
-                    message: data.clone(),
+                    message: relay_message,
                     to_did_hash: next_did_hash.clone(),
                     from_did_hash: from_account.did_hash.clone(),
                     from_did,
@@ -866,10 +966,70 @@ fn uri_points_at_self(
 
 #[cfg(test)]
 mod tests {
-    use super::{relay_sender_acls, uri_points_at_self};
+    use super::{
+        relay_peer_trusted, relay_sender_acls, rewrap_inner_attachment, uri_points_at_self,
+    };
     use crate::server::{compute_self_authorities_from, normalize_host};
+    use affinidi_messaging_didcomm::message::{Attachment, Message};
     use affinidi_messaging_sdk::protocols::mediator::acls::MediatorACLSet;
+    use base64::prelude::*;
     use std::collections::HashSet;
+
+    fn allowlist(entries: &[&str]) -> ahash::AHashSet<String> {
+        entries.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn relay_peer_trusted_empty_allowlist_accepts_any() {
+        let empty = ahash::AHashSet::new();
+        assert!(relay_peer_trusted(&empty, Some("did:peer:anyone")));
+        assert!(relay_peer_trusted(&empty, None));
+    }
+
+    #[test]
+    fn relay_peer_trusted_nonempty_allowlist_is_membership_only() {
+        let allow = allowlist(&["did:peer:alice_mediator", "did:peer:bob_mediator"]);
+        assert!(relay_peer_trusted(&allow, Some("did:peer:alice_mediator")));
+        assert!(!relay_peer_trusted(&allow, Some("did:peer:stranger")));
+        // A non-empty allowlist rejects an anonymous relaying peer.
+        assert!(!relay_peer_trusted(&allow, None));
+    }
+
+    fn forward_to(next: &str, attachment_bytes: &[u8]) -> Message {
+        let att = Attachment::base64(BASE64_URL_SAFE_NO_PAD.encode(attachment_bytes)).finalize();
+        Message::build(
+            "id-1".to_string(),
+            "https://didcomm.org/routing/2.0/forward".to_string(),
+            serde_json::json!({ "next": next }),
+        )
+        .attachment(att)
+        .finalize()
+    }
+
+    #[test]
+    fn rewrap_inner_attachment_peels_forward_to_self() {
+        let msg = forward_to("did:peer:this_mediator", b"INNER-ENVELOPE");
+        let inner = rewrap_inner_attachment("did:peer:this_mediator", &msg);
+        assert_eq!(inner.as_deref(), Some("INNER-ENVELOPE"));
+    }
+
+    #[test]
+    fn rewrap_inner_attachment_ignores_forward_to_other_next() {
+        // An ordinary forward bound for a different next hop must NOT be peeled.
+        let msg = forward_to("did:peer:some_recipient", b"INNER");
+        assert!(rewrap_inner_attachment("did:peer:this_mediator", &msg).is_none());
+    }
+
+    #[test]
+    fn rewrap_inner_attachment_ignores_non_forward() {
+        let msg = Message::build(
+            "id-2".to_string(),
+            "https://didcomm.org/basicmessage/2.0/message".to_string(),
+            serde_json::json!({ "content": "hi" }),
+        )
+        .finalize();
+        assert!(rewrap_inner_attachment("did:peer:this_mediator", &msg).is_none());
+    }
 
     #[test]
     fn relay_sender_acls_grant_only_send_forwarded_on_a_relay() {

--- a/crates/messaging/affinidi-messaging-mediator/tests/relay_rewrap.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/relay_rewrap.rs
@@ -1,0 +1,212 @@
+//! Integration test for inter-mediator relay re-wrapping (`RelayMode::Rewrap`).
+//!
+//! Exercises the cryptographic round-trip of the re-wrap layer that
+//! `routing::rewrap_for_relay` builds and `inbound::peel_relay_rewrap_layers`
+//! peels, using real authcrypt over the `did:peer` fixtures in `common.rs`.
+//! Here `ALICE_DID` plays the **relaying** mediator and `BOB_DID` the
+//! **receiving** mediator.
+//!
+//! It proves the three properties the feature exists for:
+//! 1. **Privacy** — the inner envelope (and anything in it, e.g. the original
+//!    sender's key id) is ciphertext inside the outer layer, not on the wire.
+//! 2. **Peer identity** — the receiving mediator authenticates the *relaying
+//!    mediator* as the authcrypt sender. This is what blind relay cannot do and
+//!    is what makes the trusted-peer allowlist (`relay_trusted_mediators`)
+//!    possible.
+//! 3. **Peel + loop continuity** — the inner envelope round-trips intact, the
+//!    `next == receiving mediator` re-wrap signal is present, and the running
+//!    `hop_count` survives the re-wrap.
+//!
+//! The HTTP + `FORWARD_Q` plumbing around this is unchanged from the (merged)
+//! blind-relay path and is not re-exercised here.
+
+mod common;
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_messaging_didcomm::message::{Attachment, Message};
+use affinidi_messaging_mediator::didcomm_compat;
+use affinidi_secrets_resolver::{SimpleSecretsResolver, secrets::Secret};
+use base64::prelude::*;
+use common::{ALICE_DID, ALICE_E1, ALICE_V1, BOB_DID, BOB_E1, BOB_V1};
+use serde_json::json;
+use uuid::Uuid;
+
+const FORWARD_TYPE: &str = "https://didcomm.org/routing/2.0/forward";
+
+async fn setup() -> (DIDCacheClient, SimpleSecretsResolver, SimpleSecretsResolver) {
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .unwrap();
+
+    // ALICE = relaying mediator, BOB = receiving mediator.
+    let relay_secrets = SimpleSecretsResolver::new(&[
+        Secret::from_str(&format!("{ALICE_DID}#key-1"), &ALICE_V1).expect("relay V1 key"),
+        Secret::from_str(&format!("{ALICE_DID}#key-2"), &ALICE_E1).expect("relay E1 key"),
+    ])
+    .await;
+    let receiver_secrets = SimpleSecretsResolver::new(&[
+        Secret::from_str(&format!("{BOB_DID}#key-1"), &BOB_V1).expect("receiver V1 key"),
+        Secret::from_str(&format!("{BOB_DID}#key-2"), &BOB_E1).expect("receiver E1 key"),
+    ])
+    .await;
+
+    (resolver, relay_secrets, receiver_secrets)
+}
+
+/// Build the re-wrap envelope exactly as `routing::rewrap_for_relay` does:
+/// a `forward` whose single base64 attachment is `inner`, `next` = the receiving
+/// mediator, `hop_count` in the header, authcrypted from the relaying mediator.
+async fn build_rewrap_envelope(
+    resolver: &DIDCacheClient,
+    relay_secrets: &SimpleSecretsResolver,
+    inner: &str,
+    hop_count: u64,
+) -> String {
+    let attachment = Attachment::base64(BASE64_URL_SAFE_NO_PAD.encode(inner)).finalize();
+    let mut forward = Message::build(
+        Uuid::new_v4().to_string(),
+        FORWARD_TYPE.to_owned(),
+        json!({ "next": BOB_DID }),
+    )
+    .to(BOB_DID.to_owned())
+    .from(ALICE_DID.to_owned())
+    .attachment(attachment)
+    .finalize();
+    forward
+        .extra
+        .insert("hop_count".to_string(), json!(hop_count));
+
+    let (packed, pack_meta) =
+        didcomm_compat::pack_encrypted(&forward, BOB_DID, Some(ALICE_DID), resolver, relay_secrets)
+            .await
+            .expect("re-wrap pack (authcrypt relay -> receiver) failed");
+    assert!(
+        pack_meta.from_kid.is_some(),
+        "re-wrap must be authcrypt so the peer mediator is authenticated"
+    );
+    packed
+}
+
+#[tokio::test]
+async fn rewrap_round_trip_hides_inner_authenticates_peer_and_peels() {
+    let (resolver, relay_secrets, receiver_secrets) = setup().await;
+
+    // Stand-in for the inner envelope a peer relays (e.g. the original sender's
+    // authcrypt envelope addressed to the receiving mediator). Opaque to the
+    // re-wrap layer; we only assert it round-trips and never leaks to the wire.
+    let inner = "SENTINEL-INNER-RELAY-ENVELOPE-7f3a91";
+    let hop_count = 4u64;
+
+    let packed = build_rewrap_envelope(&resolver, &relay_secrets, inner, hop_count).await;
+
+    // (1) Privacy: neither the inner envelope nor its base64 form appears in the
+    // outer JWE — it is encrypted to the receiving mediator.
+    assert!(
+        !packed.contains(inner),
+        "inner envelope must not appear in cleartext on the wire"
+    );
+    assert!(
+        !packed.contains(&BASE64_URL_SAFE_NO_PAD.encode(inner)),
+        "inner attachment must be ciphertext inside the outer layer, not visible on the wire"
+    );
+
+    // The receiving mediator opens the outer layer.
+    let (unpacked, metadata) = didcomm_compat::unpack(&packed, &resolver, &receiver_secrets)
+        .await
+        .expect("receiving mediator failed to unpack the re-wrap layer");
+
+    // (2) Peer identity: the relaying mediator is the authenticated authcrypt
+    // sender — the property blind relay cannot provide.
+    assert!(
+        metadata.authenticated,
+        "re-wrap layer must be authenticated (authcrypt)"
+    );
+    assert_eq!(
+        unpacked.from.as_deref(),
+        Some(ALICE_DID),
+        "the re-wrap layer's sender is the relaying mediator, not the original sender"
+    );
+    let from_kid = metadata
+        .encrypted_from_kid
+        .expect("authcrypt re-wrap must carry encrypted_from_kid");
+    assert!(
+        from_kid.starts_with(ALICE_DID),
+        "authcrypt sender ({from_kid}) must be the relaying mediator's key"
+    );
+
+    // (3a) Re-wrap signal: a forward whose next hop is the receiving mediator.
+    assert_eq!(unpacked.typ, FORWARD_TYPE);
+    assert_eq!(
+        unpacked.body.get("next").and_then(|v| v.as_str()),
+        Some(BOB_DID),
+        "next must be the receiving mediator itself (the peel signal)"
+    );
+
+    // (3b) Loop-detection continuity: hop_count survives the re-wrap.
+    assert_eq!(
+        unpacked.extra.get("hop_count").and_then(|v| v.as_u64()),
+        Some(hop_count),
+        "hop_count must be carried across the re-wrap"
+    );
+
+    // (3c) Peel: the inner envelope is recovered intact (mirrors
+    // routing::rewrap_inner_attachment's base64 attachment extraction).
+    let recovered_b64 = unpacked
+        .attachments
+        .as_ref()
+        .and_then(|a| a.first())
+        .and_then(|a| a.data.base64.as_ref())
+        .expect("re-wrap layer must carry the inner envelope as a base64 attachment");
+    let recovered = String::from_utf8(
+        BASE64_URL_SAFE_NO_PAD
+            .decode(recovered_b64)
+            .expect("inner attachment must be valid base64url"),
+    )
+    .expect("inner attachment must be valid UTF-8");
+    assert_eq!(
+        recovered, inner,
+        "peeled inner envelope must match what the relaying mediator wrapped"
+    );
+}
+
+/// A mediator that is NOT the named next hop must not treat the layer as a peel
+/// target — i.e. the re-wrap signal is specifically `next == this mediator`.
+#[tokio::test]
+async fn rewrap_signal_is_specifically_next_equals_self() {
+    // This mirrors the guard in routing::rewrap_inner_attachment: an ordinary
+    // forward bound for some other `next` is not a re-wrap layer. We assert it at
+    // the wire level: the receiving mediator can read `next` and see it is itself
+    // only when the relay addressed the layer to it.
+    let (resolver, relay_secrets, receiver_secrets) = setup().await;
+
+    // A forward whose `next` is a third party (not the receiving mediator).
+    let attachment = Attachment::base64(BASE64_URL_SAFE_NO_PAD.encode("X")).finalize();
+    let forward = Message::build(
+        Uuid::new_v4().to_string(),
+        FORWARD_TYPE.to_owned(),
+        json!({ "next": "did:peer:2.SomeoneElse" }),
+    )
+    .to(BOB_DID.to_owned())
+    .from(ALICE_DID.to_owned())
+    .attachment(attachment)
+    .finalize();
+
+    let (packed, _) = didcomm_compat::pack_encrypted(
+        &forward,
+        BOB_DID,
+        Some(ALICE_DID),
+        &resolver,
+        &relay_secrets,
+    )
+    .await
+    .expect("pack failed");
+    let (unpacked, _) = didcomm_compat::unpack(&packed, &resolver, &receiver_secrets)
+        .await
+        .expect("unpack failed");
+
+    assert_ne!(
+        unpacked.body.get("next").and_then(|v| v.as_str()),
+        Some(BOB_DID),
+        "an ordinary forward to another next hop must not look like a re-wrap layer"
+    );
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## 10th June 2026
 
+### 0.2.6 — relay rewrap builder knobs + end-to-end rewrap tests (#388)
+
+- **FEAT:** `TestMediatorBuilder::relay_mode(RelayMode)` and
+  `relay_trusted_mediators(...)` expose the inter-mediator relay posture so
+  tests can stand up `RelayMode::Rewrap` mediators (per-hop re-encryption)
+  with an optional trusted-peer allowlist. `RelayMode` is re-exported from
+  the crate root.
+- **TEST:** extends `cross_mediator_forwarding` with three rewrap
+  end-to-end cases on the memory backend — a bidirectional rewrap round
+  trip, a trusted-peer allowlist *admitting* the relaying mediator, and an
+  allowlist *rejecting* an unlisted peer (no delivery; the relay is refused
+  with `authorization.relay.untrusted_peer`). This is the automated pre-merge
+  verification `affinidi-messaging-mediator` #388 had been waiting on — the
+  full rewrap plumbing (routing rewrap → FORWARD_Q → processor → HTTP →
+  inbound peel), now exercisable without Redis thanks to #399.
+
 ### 0.2.5 — cross-mediator forwarding test + production-shaped mediator DID
 
 - **FIX:** the fixture's generated mediator `did:peer` advertised its

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.5"
+version = "0.2.6"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -85,6 +85,9 @@ pub use environment::{TestEnvironment, TestEnvironmentError, TestUser};
 pub use affinidi_messaging_mediator_common::types::acls::{
     ACLError, AccessListModeType, MediatorACLSet,
 };
+// Re-exported so cross-mediator-forwarding tests can select the relay
+// posture (`relay_mode(...)`) without a direct dep on mediator-common.
+pub use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
 
 use std::{
     net::{SocketAddr, TcpListener},
@@ -276,6 +279,14 @@ pub struct TestMediatorBuilder {
     listen_addr: Option<SocketAddr>,
     enable_forwarding: bool,
     enable_external_forwarding: bool,
+    /// Relay posture for forwards to a remote next-hop mediator. Defaults
+    /// to [`RelayMode::Blind`] (verbatim relay). Set to [`RelayMode::Rewrap`]
+    /// to exercise per-hop re-encryption (both mediators in a relaying pair
+    /// must agree on the mode).
+    relay_mode: RelayMode,
+    /// Trusted peer-mediator DID allowlist for [`RelayMode::Rewrap`]. Empty
+    /// accepts any relaying peer; non-empty admits only listed DIDs.
+    relay_trusted_mediators: Vec<String>,
     enable_message_expiry: bool,
     enable_streaming: bool,
     /// Additional DIDs to register as LOCAL accounts at startup. Tests
@@ -326,6 +337,8 @@ impl Default for TestMediatorBuilder {
             listen_addr: None,
             enable_forwarding: false,
             enable_external_forwarding: true,
+            relay_mode: RelayMode::Blind,
+            relay_trusted_mediators: Vec::new(),
             enable_message_expiry: false,
             enable_streaming: true,
             local_dids: Vec::new(),
@@ -390,6 +403,39 @@ impl TestMediatorBuilder {
     /// [`enable_forwarding`]: Self::enable_forwarding
     pub fn enable_external_forwarding(mut self, enabled: bool) -> Self {
         self.enable_external_forwarding = enabled;
+        self
+    }
+
+    /// Select the relay posture for forwards to a *remote* next-hop
+    /// mediator. Defaults to [`RelayMode::Blind`] (relay the inner
+    /// envelope verbatim). [`RelayMode::Rewrap`] re-encrypts each hop
+    /// from this mediator to the next, hiding the original sender on the
+    /// wire and exposing an authenticated peer identity the receiver can
+    /// allowlist (see [`relay_trusted_mediators`]).
+    ///
+    /// Both mediators in a relaying pair must use the same mode — a
+    /// `Rewrap` sender produces envelopes only a `Rewrap` receiver peels.
+    /// Has no effect unless [`enable_forwarding`] is `true`.
+    ///
+    /// [`relay_trusted_mediators`]: Self::relay_trusted_mediators
+    /// [`enable_forwarding`]: Self::enable_forwarding
+    pub fn relay_mode(mut self, mode: RelayMode) -> Self {
+        self.relay_mode = mode;
+        self
+    }
+
+    /// Restrict which peer mediators this mediator accepts re-wrapped
+    /// relays from (only meaningful in [`RelayMode::Rewrap`]). Empty (the
+    /// default) accepts any peer; a non-empty list admits only the listed
+    /// DIDs and rejects an anonymous or unlisted relaying peer with
+    /// `authorization.relay.untrusted_peer`. Repeated calls accumulate.
+    pub fn relay_trusted_mediators<I, S>(mut self, dids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.relay_trusted_mediators
+            .extend(dids.into_iter().map(Into::into));
         self
     }
 
@@ -635,6 +681,9 @@ impl TestMediatorBuilder {
             affinidi_messaging_mediator::common::config::ProcessorsConfig::default();
         processors.forwarding.enabled = self.enable_forwarding;
         processors.forwarding.external_forwarding = self.enable_external_forwarding;
+        processors.forwarding.relay_mode = self.relay_mode;
+        processors.forwarding.relay_trusted_mediators =
+            self.relay_trusted_mediators.into_iter().collect();
         processors.message_expiry_cleanup.enabled = self.enable_message_expiry;
 
         // Default to a fresh in-memory store. Tests that want a

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
@@ -26,7 +26,7 @@ mod common;
 use std::time::Duration;
 
 use affinidi_messaging_didcomm::Message;
-use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, TestUser, acl};
+use affinidi_messaging_test_mediator::{RelayMode, TestEnvironment, TestMediator, TestUser, acl};
 use common::init_tracing;
 use serde_json::json;
 use uuid::Uuid;
@@ -55,6 +55,34 @@ async fn spawn_relay_environment() -> TestEnvironment {
         .expect("wire SDK environment to forwarding mediator")
 }
 
+/// Spawn a forwarding mediator running in `RelayMode::Rewrap`, with an
+/// optional trusted-peer allowlist.
+///
+/// In rewrap mode each mediator re-encrypts the inner forward from itself
+/// to the next hop (hiding the original sender on the mediator↔mediator
+/// wire) and the receiver authenticates the relaying peer. `trusted_peers`
+/// is the receiver-side allowlist: empty accepts any relaying peer,
+/// non-empty admits only the listed mediator DIDs (an unlisted peer's
+/// relay is rejected with `authorization.relay.untrusted_peer`).
+///
+/// Otherwise identical to [`spawn_relay_environment`] — same relay
+/// deployment ACLs, so the cross-mediator sender is still auto-registered
+/// with `SEND_FORWARDED` once its layer is peeled.
+async fn spawn_rewrap_environment(trusted_peers: &[String]) -> TestEnvironment {
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .relay_mode(RelayMode::Rewrap)
+        .relay_trusted_mediators(trusted_peers.iter().cloned())
+        .spawn()
+        .await
+        .expect("spawn rewrap forwarding mediator");
+    TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment to rewrap mediator")
+}
+
 /// Add a user and bring up its WebSocket live-stream connection.
 ///
 /// Retrieval uses message-pickup `live_stream_get` (the supported
@@ -73,11 +101,12 @@ async fn add_live_user(env: &TestEnvironment, alias: &str) -> TestUser {
 }
 
 /// Drive one cross-mediator delivery: wrap `text` as the routing-2.0
-/// double forward, send it to the sender's own mediator, then poll the
-/// recipient's mediator until the decrypted message arrives.
+/// double forward, send it to the sender's own mediator, then wait up to
+/// `wait` for the recipient's live stream to surface the decrypted message.
 ///
 /// Returns the recipient's view of the `content` body field, or `None`
-/// if nothing arrived within the timeout.
+/// if nothing arrived within `wait` (used by the negative trust test,
+/// which expects no delivery, with a shorter `wait`).
 #[allow(clippy::too_many_arguments)]
 async fn forward_and_receive(
     sender_env: &TestEnvironment,
@@ -87,6 +116,7 @@ async fn forward_and_receive(
     recipient: &TestUser,
     recipient_mediator_did: &str,
     text: &str,
+    wait: Duration,
 ) -> Option<String> {
     let now = unix_secs();
 
@@ -160,7 +190,7 @@ async fn forward_and_receive(
     match recipient_env
         .atm
         .message_pickup()
-        .live_stream_get(&recipient.profile, &msg_id, Duration::from_secs(15), true)
+        .live_stream_get(&recipient.profile, &msg_id, wait, true)
         .await
     {
         Ok(Some((received, _meta))) => received
@@ -200,6 +230,7 @@ async fn cross_mediator_forward_delivers_over_memory_backend() {
         &bob,
         &mediator_b_did,
         text,
+        Duration::from_secs(15),
     )
     .await;
 
@@ -238,6 +269,7 @@ async fn cross_mediator_forward_round_trips() {
         &bob,
         &mediator_b_did,
         to_bob,
+        Duration::from_secs(15),
     )
     .await;
     assert_eq!(
@@ -255,12 +287,158 @@ async fn cross_mediator_forward_round_trips() {
         &alice,
         &mediator_a_did,
         to_alice,
+        Duration::from_secs(15),
     )
     .await;
     assert_eq!(
         got_by_alice.as_deref(),
         Some(to_alice),
         "Alice should receive Bob's pong (B → A)"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+// ─── RelayMode::Rewrap (per-hop re-encryption) ──────────────────────────────
+//
+// Same Alice → A → B → Bob double-forward construction as the blind tests
+// above — only the mediators' relay posture changes. In rewrap mode each
+// mediator re-encrypts the inner forward from itself to the next hop, so the
+// A → B wire envelope is authcrypted `from = mediator A` (not the original
+// sender) and B authenticates A before peeling. These exercise the full
+// rewrap plumbing end-to-end (routing rewrap → FORWARD_Q → processor → HTTP
+// → inbound peel pre-pass) on the memory backend; the on-wire crypto
+// properties themselves are covered by the mediator crate's
+// `tests/relay_rewrap.rs`.
+
+/// Rewrap relay round-trips end to end (empty allowlist = accept any peer).
+#[tokio::test]
+async fn rewrap_relay_round_trips_end_to_end() {
+    init_tracing();
+
+    let env_a = spawn_rewrap_environment(&[]).await;
+    let env_b = spawn_rewrap_environment(&[]).await;
+
+    let mediator_a_did = env_a.mediator.did().to_string();
+    let mediator_b_did = env_b.mediator.did().to_string();
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let to_bob = "Rewrapped ping from Alice.";
+    let got_by_bob = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        to_bob,
+        Duration::from_secs(15),
+    )
+    .await;
+    assert_eq!(
+        got_by_bob.as_deref(),
+        Some(to_bob),
+        "Bob should receive Alice's message relayed in rewrap mode (A → B)"
+    );
+
+    let to_alice = "Rewrapped pong from Bob.";
+    let got_by_alice = forward_and_receive(
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        to_alice,
+        Duration::from_secs(15),
+    )
+    .await;
+    assert_eq!(
+        got_by_alice.as_deref(),
+        Some(to_alice),
+        "Alice should receive Bob's rewrapped reply (B → A)"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+/// A populated allowlist that names the relaying peer admits the relay —
+/// the item-3 trust gate's positive case.
+#[tokio::test]
+async fn rewrap_relay_admits_trusted_peer() {
+    init_tracing();
+
+    // Spawn A first so its DID can be placed on B's trusted-peer allowlist.
+    let env_a = spawn_rewrap_environment(&[]).await;
+    let mediator_a_did = env_a.mediator.did().to_string();
+
+    let env_b = spawn_rewrap_environment(std::slice::from_ref(&mediator_a_did)).await;
+    let mediator_b_did = env_b.mediator.did().to_string();
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let text = "Hello from a trusted relay.";
+    let received = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        text,
+        Duration::from_secs(15),
+    )
+    .await;
+    assert_eq!(
+        received.as_deref(),
+        Some(text),
+        "Bob should receive the relay because mediator A is on B's trusted-peer allowlist"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+/// A populated allowlist that does NOT name the relaying peer rejects the
+/// relay (`authorization.relay.untrusted_peer`), so nothing reaches Bob —
+/// the item-3 trust gate's negative case.
+#[tokio::test]
+async fn rewrap_relay_rejects_untrusted_peer() {
+    init_tracing();
+
+    let env_a = spawn_rewrap_environment(&[]).await;
+    let mediator_a_did = env_a.mediator.did().to_string();
+
+    // B trusts only some *other* mediator — never A — so A's re-wrapped
+    // relay must be rejected at B's inbound peel pre-pass.
+    let stranger = "did:peer:2.NotTheRelayingMediator".to_string();
+    let env_b = spawn_rewrap_environment(std::slice::from_ref(&stranger)).await;
+    let mediator_b_did = env_b.mediator.did().to_string();
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let received = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        "This relay should be dropped.",
+        // Short wait: delivery is sub-second on success, so a few seconds of
+        // silence is conclusive that the untrusted relay was rejected.
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(
+        received, None,
+        "Bob must NOT receive a relay from a mediator absent from his trusted-peer allowlist"
     );
 
     env_a.shutdown().await.expect("shutdown mediator A");


### PR DESCRIPTION
## Summary

Final piece of #385. Adds **per-hop re-wrapping** for inter-mediator relay, behind a new `relay_mode` config (default `blind` — **no behaviour change** for existing deployments).

> **Draft / verification needed:** the unit surface is fully covered and all feature combos build clean, but I could **not** run the live two-mediator + Redis `cross_mediator_forwarding` round-trip in my environment. This needs a manual end-to-end pass before merge — see *Manual verification* below.

## Background — why this exists

During #385 we established (by reading the SDK + mediator) that with the current **blind** relay:
- `forward_message` authcrypts the inner forward `from = the original sender`, and the relaying mediator forwards that inner envelope **byte-for-byte** (`ForwardQueueEntry { message: data.clone() }`).
- So the receiving mediator never sees the relaying *peer mediator's* identity — only the original sender's. That made item #3's "trusted peer-mediator allowlist" impossible at the DIDComm layer.
- Worse, an authcrypt JWE carries the sender's key id (`skid`) **in cleartext** in its protected header, so an observer on the mediator↔mediator hop can link sender → recipient-mediator.

Per maintainer decision, the fix is **per-hop encapsulation**: each mediator re-encrypts the inner envelope for the next hop, authcrypted *from itself*. This hides the original sender (and the inner envelope) from the wire **and** gives the receiving mediator an authenticated peer identity to allowlist.

## What's implemented

**Config (`[processors.forwarding]`)**
- `relay_mode = "blind" | "rewrap"` (default `blind`).
- `relay_trusted_mediators` — comma-separated allowlist of peer-mediator DIDs (rewrap only).

**Send side — `routing.rs::rewrap_for_relay`**
Wraps the inner forward attachment in a fresh `forward` authcrypted **FROM this mediator TO the next hop**, carrying the running `hop_count`, and enqueues *that* instead of the verbatim inner envelope.

**Receive side — `inbound.rs::peel_relay_rewrap_layers`**
A pre-pass (only in rewrap mode) that strips `forward`-to-self layers a peer produced: authenticates the relaying peer against the allowlist, then continues on the inner envelope. Bounded by `max_hops`. Implemented as a **pre-pass so `handle_inbound_didcomm`'s body is unchanged** — the direct-delivery and normal-message paths carry zero regression risk. (Cost: one extra unpack of the outer layer for to-mediator messages on a rewrap mediator — acceptable for an opt-in posture.)

**Trust gate — `relay_peer_trusted`**
Empty allowlist → accept any peer (ACL still applies). Non-empty → members only; an anonymous peer is rejected. This is the item-3 payoff, possible only because the rewrap layer's authcrypt `from` is the peer mediator.

## Trust ⟷ privacy note
Rewrap uses **authcrypt-from-mediator** (the chosen tradeoff): it reveals "which mediator relayed" to the receiving mediator in exchange for an authenticated, allowlistable peer identity. It hides the original sender + inner envelope from on-wire observers. (Pure anonymity — anoncrypt per hop — would forgo the peer identity and thus the allowlist; not chosen.)

## Tests
113 mediator lib tests pass (`--features redis-backend`), incl. new unit tests:
- `relay_mode` parsing (case-insensitive, unknown→blind, trimmed allowlist split)
- `relay_peer_trusted` (empty=any, membership-only, anon rejected)
- `rewrap_inner_attachment` (peels forward-to-self, ignores other-next & non-forward)

`clippy --all-targets -- -D warnings` clean on `redis-backend` and `didcomm,memory-backend`; `cargo deny` ok.

## Manual verification (before un-drafting / merge)
Two `did:peer` mediators on :7037/:7038 with `relay_mode = "rewrap"` (and optionally each other's DID in `relay_trusted_mediators`), then:
```
cargo run -p affinidi-messaging-helpers --example cross_mediator_forwarding -- \
  --alice-environment alice --bob-environment bob
```
Expected: both directions still round-trip; on the wire the mediator↔mediator envelope is authcrypted `from = relaying mediator` (no original-sender `skid`); with a populated allowlist, a non-listed peer's relay is rejected (`authorization.relay.untrusted_peer`).

## Commits
1. `feat: add relay_mode (blind|rewrap) config …`
2. `feat: implement rewrap relay — per-hop re-encryption + peer-mediator trust`

(Builds on #386 and #387, both merged.)

Closes #385