### PR TITLE
fix: axum 0.8.8 websocket upgrade + mediator-setup did:peer generation

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -27,7 +27,7 @@ use axum_extra::{
     TypedHeader,
     headers::{Authorization, authorization::Bearer},
 };
-use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN};
+use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN, header::SEC_WEBSOCKET_PROTOCOL};
 use serde_json::json;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -71,11 +71,15 @@ where
     I: IntoIterator<Item = &'a HeaderValue>,
 {
     protocols.into_iter().find_map(|p| {
-        p.to_str()
-            .ok()
-            .and_then(|s| s.strip_prefix(WS_BEARER_SUBPROTOCOL_PREFIX))
-            .filter(|token| !token.is_empty())
-            .map(str::to_string)
+        p.to_str().ok().and_then(|header_val| {
+            // RFC 6455: subprotocols may be comma-separated in a single header value
+            header_val.split(',').find_map(|s| {
+                s.trim()
+                    .strip_prefix(WS_BEARER_SUBPROTOCOL_PREFIX)
+                    .filter(|token| !token.is_empty())
+                    .map(str::to_string)
+            })
+        })
     })
 }
 
@@ -89,10 +93,13 @@ fn app_subprotocols<'a, I>(protocols: I) -> Vec<String>
 where
     I: IntoIterator<Item = &'a HeaderValue>,
 {
+    // RFC 6455: subprotocols may be comma-separated in a single header value
     protocols
         .into_iter()
         .filter_map(|p| p.to_str().ok())
-        .filter(|s| !s.starts_with(WS_BEARER_SUBPROTOCOL_PREFIX))
+        .flat_map(|header_val| header_val.split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !s.starts_with(WS_BEARER_SUBPROTOCOL_PREFIX))
         .map(str::to_string)
         .collect()
 }
@@ -165,7 +172,7 @@ pub async fn websocket_handler(
     let token = if let Some(TypedHeader(Authorization(bearer))) = &auth_header {
         Some(bearer.token().to_string())
     } else {
-        extract_bearer_subprotocol(ws.requested_protocols())
+        extract_bearer_subprotocol(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter())
     };
 
     let Some(token) = token else {
@@ -211,7 +218,7 @@ pub async fn websocket_handler(
     //    bearer entry, no subprotocol is selected and the response
     //    carries no `Sec-WebSocket-Protocol` header (RFC 6455 permits
     //    this; browsers accept it).
-    let app_protocols = app_subprotocols(ws.requested_protocols());
+    let app_protocols = app_subprotocols(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter());
     let ws = if app_protocols.is_empty() {
         ws
     } else {
@@ -566,6 +573,24 @@ mod tests {
         // selected in the 101 response.
         let protos = [hv("bearer.secret.jwt.here")];
         assert!(app_subprotocols(protos.iter()).is_empty());
+    }
+
+    #[test]
+    fn extract_bearer_from_comma_separated_header() {
+        // RFC 6455: clients MAY send subprotocols as comma-separated in
+        // a single Sec-WebSocket-Protocol header value.
+        let protos = [hv("didcomm/v2, bearer.tok.en.value")];
+        assert_eq!(
+            extract_bearer_subprotocol(protos.iter()),
+            Some("tok.en.value".to_string())
+        );
+    }
+
+    #[test]
+    fn app_subprotocols_from_comma_separated_header() {
+        // Comma-separated bearer entry must be excluded, app protocols kept.
+        let protos = [hv("didcomm/v2, bearer.secret.jwt.here")];
+        assert_eq!(app_subprotocols(protos.iter()), vec!["didcomm/v2"]);
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
@@ -1,5 +1,7 @@
 use affinidi_secrets_resolver::secrets::Secret;
-use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use affinidi_tdk::dids::{
+    DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
+};
 
 /// Generate a did:peer for the mediator with Ed25519 (signing) + X25519 (encryption) keys,
 /// plus an optional DIDComm service endpoint.
@@ -9,15 +11,83 @@ pub fn generate_did_peer(service_uri: Option<String>) -> anyhow::Result<(String,
         (PeerKeyRole::Encryption, KeyType::X25519),
     ];
 
-    let (did, secrets) = DID::generate_did_peer(keys, service_uri)
+    let services = service_uri.as_deref().map(mediator_services).transpose()?;
+
+    let (did, secrets) = DID::generate_did_peer_with_services(keys, services)
         .map_err(|e| anyhow::anyhow!("Failed to generate did:peer: {e}"))?;
 
     Ok((did, secrets))
 }
 
+fn mediator_services(service_uri: &str) -> anyhow::Result<Vec<PeerService>> {
+    let service_uri = service_uri.trim_end_matches('/').to_string();
+    let ws_uri = websocket_service_uri(&service_uri)?;
+    let auth_uri = format!("{service_uri}/authenticate");
+
+    Ok(vec![
+        PeerService {
+            type_: "dm".into(),
+            endpoint: PeerServiceEndpoint::Long(OneOrMany::Many(vec![
+                PeerServiceEndpointLong {
+                    uri: service_uri,
+                    accept: vec!["didcomm/v2".into()],
+                    routing_keys: vec![],
+                },
+                PeerServiceEndpointLong {
+                    uri: ws_uri,
+                    accept: vec!["didcomm/v2".into()],
+                    routing_keys: vec![],
+                },
+            ])),
+            id: None,
+        },
+        PeerService {
+            type_: "Authentication".into(),
+            endpoint: PeerServiceEndpoint::Uri(auth_uri),
+            id: Some("#auth".into()),
+        },
+    ])
+}
+
+fn websocket_service_uri(service_uri: &str) -> anyhow::Result<String> {
+    let mut url = url::Url::parse(service_uri)
+        .map_err(|e| anyhow::anyhow!("Invalid mediator service URL '{service_uri}': {e}"))?;
+
+    match url.scheme() {
+        "http" => url
+            .set_scheme("ws")
+            .map_err(|_| anyhow::anyhow!("Failed to convert '{service_uri}' to ws://"))?,
+        "https" => url
+            .set_scheme("wss")
+            .map_err(|_| anyhow::anyhow!("Failed to convert '{service_uri}' to wss://"))?,
+        other => {
+            return Err(anyhow::anyhow!(
+                "Mediator service URL must use http:// or https:// (got {other}://)"
+            ));
+        }
+    }
+
+    let path = url.path().trim_end_matches('/');
+    url.set_path(&format!("{path}/ws"));
+
+    Ok(url.to_string().trim_end_matches('/').to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use serde_json::Value;
+
+    fn decode_service_segments(did: &str) -> Vec<Value> {
+        did.split('.')
+            .filter_map(|segment| segment.strip_prefix('S'))
+            .map(|segment| {
+                let bytes = URL_SAFE_NO_PAD.decode(segment).unwrap();
+                serde_json::from_slice(&bytes).unwrap()
+            })
+            .collect()
+    }
 
     #[test]
     fn test_generate_did_peer() {
@@ -31,9 +101,25 @@ mod tests {
     #[test]
     fn test_generate_did_peer_with_service() {
         let (did, secrets) =
-            generate_did_peer(Some("https://mediator.example.com/mediator/v1".into())).unwrap();
+            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into())).unwrap();
         assert!(did.starts_with("did:peer:2.V"));
-        assert!(did.contains(".S")); // service section
+        assert_eq!(did.matches(".S").count(), 2);
         assert_eq!(secrets.len(), 2);
+
+        let services = decode_service_segments(&did);
+        assert_eq!(services.len(), 2);
+
+        let endpoints = services[0]["s"].as_array().unwrap();
+        assert_eq!(services[0]["t"], "dm");
+        assert_eq!(endpoints[0]["uri"], "http://localhost:7037/mediator/v1");
+        assert_eq!(endpoints[1]["uri"], "ws://localhost:7037/mediator/v1/ws");
+        assert_eq!(endpoints[0]["accept"][0], "didcomm/v2");
+
+        assert_eq!(services[1]["t"], "Authentication");
+        assert!(services[1]["id"].as_str().unwrap().ends_with("#auth"));
+        assert_eq!(
+            services[1]["s"],
+            "http://localhost:7037/mediator/v1/authenticate"
+        );
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -973,6 +973,59 @@ fn combine_url_prefix(base: &str, prefix: &str) -> String {
     }
 }
 
+/// Build the DIDComm base URL advertised inside a generated did:peer.
+///
+/// `public_url` may be either the host root (`https://m.example.com`) or
+/// an already-prefixed URL (`https://m.example.com/mediator/v1`). To stay
+/// backward compatible with existing operator habits, append `api_prefix`
+/// only when the URL path does not already end with it.
+fn did_peer_service_url(public_url: &str, api_prefix: &str) -> Option<String> {
+    let public_url = public_url.trim().trim_end_matches('/');
+    if public_url.is_empty() {
+        return None;
+    }
+
+    let prefix = api_prefix.trim_matches('/');
+    if prefix.is_empty() {
+        return Some(public_url.to_string());
+    }
+
+    let already_prefixed = url::Url::parse(public_url)
+        .ok()
+        .map(|url| {
+            let path = url.path().trim_matches('/');
+            path == prefix || path.ends_with(&format!("/{prefix}"))
+        })
+        .unwrap_or(false);
+
+    Some(if already_prefixed {
+        public_url.to_string()
+    } else {
+        combine_url_prefix(public_url, api_prefix)
+    })
+}
+
+#[cfg(test)]
+mod did_peer_service_url_tests {
+    use super::did_peer_service_url;
+
+    #[test]
+    fn appends_default_api_prefix_for_host_root_public_url() {
+        assert_eq!(
+            did_peer_service_url("https://mediator.example.com", "/mediator/v1/"),
+            Some("https://mediator.example.com/mediator/v1".into())
+        );
+    }
+
+    #[test]
+    fn does_not_double_append_existing_api_prefix() {
+        assert_eq!(
+            did_peer_service_url("https://mediator.example.com/mediator/v1/", "/mediator/v1/"),
+            Some("https://mediator.example.com/mediator/v1".into())
+        );
+    }
+}
+
 /// Bag of artefacts the mint phase produces and the later phases
 /// consume. Keeps the four `generate_and_write` phases coupled by an
 /// explicit value type rather than the prior soup of mutable locals.
@@ -1132,11 +1185,7 @@ async fn mint_did_material(
 )> {
     Ok(match config.did_method.as_str() {
         DID_PEER => {
-            let service_uri = if config.public_url.is_empty() {
-                None
-            } else {
-                Some(config.public_url.clone())
-            };
+            let service_uri = did_peer_service_url(&config.public_url, &config.api_prefix);
             let (did, secrets) = generators::did_peer::generate_did_peer(service_uri)?;
             (did, secrets, None, None)
         }
@@ -2232,6 +2281,17 @@ mod cache_bundle_tests {
 #[cfg(test)]
 mod generate_and_write_tests {
     use super::*;
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    fn decode_service_segments(did: &str) -> Vec<serde_json::Value> {
+        did.split('.')
+            .filter_map(|segment| segment.strip_prefix('S'))
+            .map(|segment| {
+                let bytes = URL_SAFE_NO_PAD.decode(segment).unwrap();
+                serde_json::from_slice(&bytes).unwrap()
+            })
+            .collect()
+    }
 
     /// Tempdir + CWD swap, restored on drop. Mirrors the
     /// `bootstrap_headless::tests::CwdGuard` pattern (kept private to
@@ -2290,6 +2350,7 @@ mod generate_and_write_tests {
             ssl_mode: SSL_NONE.into(),
             jwt_mode: JWT_MODE_GENERATE.into(),
             admin_did_mode: ADMIN_GENERATE.into(),
+            public_url: "http://localhost:7037".into(),
             ..app::WizardConfig::default()
         }
     }
@@ -2328,6 +2389,27 @@ mod generate_and_write_tests {
         assert!(
             mediator_did.starts_with("did://did:peer:"),
             "mediator_did must be a did:peer (got: {mediator_did})"
+        );
+        let mediator_did = mediator_did.trim_start_matches("did://");
+        assert_eq!(
+            mediator_did.matches(".S").count(),
+            2,
+            "did:peer should advertise DIDComm + #auth services"
+        );
+        let services = decode_service_segments(mediator_did);
+        assert_eq!(services.len(), 2);
+        assert_eq!(
+            services[0]["s"][0]["uri"],
+            "http://localhost:7037/mediator/v1"
+        );
+        assert_eq!(
+            services[0]["s"][1]["uri"],
+            "ws://localhost:7037/mediator/v1/ws"
+        );
+        assert!(services[1]["id"].as_str().unwrap().ends_with("#auth"));
+        assert_eq!(
+            services[1]["s"],
+            "http://localhost:7037/mediator/v1/authenticate"
         );
         let server = parsed.get("server").expect("[server] section");
         let admin_did = server


### PR DESCRIPTION
## Changes

### 1. Fix axum 0.8.8 breaking change (websocket.rs)
`WebSocketUpgrade::requested_protocols()` was removed in axum 0.8.8. Replaced with `headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter()` which is compatible with existing helper functions.

### 2. Fix mediator-setup did:peer generation
Previously `mediator-setup` generated incomplete did:peer:2 without WebSocket endpoint and #auth service. Now generates correct DIDComm-compliant did:peer with both HTTP and WS endpoints plus authentication service.

## Testing
- All mediator-setup tests pass (344)
- All mediator lib tests pass (101)  
- All websocket tests pass (11)
- E2E verified with local docker-compose harness