### PR TITLE
fix: surface VTA connection failure on the setup wizard recovery screen

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/diagnostics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/diagnostics.rs
@@ -169,7 +169,11 @@ fn build_status_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
     }
 }
 
-fn diag_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
+/// The per-check checklist lines. Shared with the recovery screen
+/// (`ui::recovery`) so a failed connection shows the *same* diagnostics that
+/// were on the Testing screen — instead of letting them flash past on the way
+/// to the recovery prompt.
+pub(crate) fn diag_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
     if state.diagnostics.is_empty() {
         return vec![Line::from(Span::styled(
             "  Waiting for diagnostics…",

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/recovery.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/recovery.rs
@@ -2,8 +2,11 @@
 //!
 //! Layout mirrors `render_diagnostics`: title/description header,
 //! an action box with the retry / offline / back options, and a
-//! bordered "Last attempt" panel beneath that lists each
-//! transport's failure reason in dim red.
+//! bordered "Why it failed" panel beneath. That panel surfaces the
+//! failure detail that previously only flashed past on the Testing
+//! screen before the transition to recovery: the overall error, the
+//! per-check diagnostics checklist (reused from `ui::diagnostics`),
+//! and the per-transport attempt summary (see [`recovery_detail_lines`]).
 //!
 //! Option building lives in `app::current_options()`; the renderer
 //! is purely presentational. Disabled options come from the
@@ -15,6 +18,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::ui::diagnostics::diag_lines;
 use crate::ui::selection::SelectionOption;
 use crate::ui::theme;
 use crate::vta::{AttemptResult, AttemptResultKind, VtaConnectState};
@@ -63,15 +67,57 @@ pub fn render_recovery_prompt(
         Vec::new(),
     );
 
-    let attempt_lines = build_attempt_lines(state);
+    let detail_lines = recovery_detail_lines(state);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(theme::border_style())
-        .title(Span::styled(" Last attempt ", theme::title_style()));
-    let para = Paragraph::new(attempt_lines)
+        .title(Span::styled(" Why it failed ", theme::title_style()));
+    let para = Paragraph::new(detail_lines)
         .block(block)
         .wrap(Wrap { trim: false });
     frame.render_widget(para, chunks[2]);
+}
+
+/// Compose the recovery screen's failure panel so the operator can actually
+/// *read* what went wrong instead of catching it as it flashes past on the
+/// Testing screen. Three sections, each shown only when it has content:
+///   1. the overall error (`last_error`),
+///   2. the per-check diagnostics checklist — the same lines the Testing screen
+///      rendered, now persisted (see [`diag_lines`]),
+///   3. the per-transport attempt summary.
+pub(crate) fn recovery_detail_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    if let Some(err) = state.last_error.as_ref() {
+        lines.push(Line::from(Span::styled(
+            format!("  Error: {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+
+    if !state.diagnostics.is_empty() {
+        if !lines.is_empty() {
+            lines.push(Line::from(""));
+        }
+        lines.extend(diag_lines(state));
+    }
+
+    let attempts = transport_attempt_lines(state);
+    if !attempts.is_empty() {
+        if !lines.is_empty() {
+            lines.push(Line::from(""));
+        }
+        lines.extend(attempts);
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No transport advertised by the VTA — switch to offline sealed-handoff.",
+            theme::muted_style(),
+        )));
+    }
+
+    lines
 }
 
 /// Render the per-transport failure reasons. Each transport gets
@@ -79,7 +125,7 @@ pub fn render_recovery_prompt(
 /// outcomes are skipped (they wouldn't be in the recovery prompt
 /// in normal flow). Empty state means the recovery prompt fired
 /// before any attempt landed (`Neither` advertised).
-fn build_attempt_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
+fn transport_attempt_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
     let mut lines = Vec::new();
 
     if let Some(result) = state.attempted.didcomm.as_ref()
@@ -91,13 +137,6 @@ fn build_attempt_lines(state: &VtaConnectState) -> Vec<Line<'_>> {
         && let Some(line) = format_attempt_line("REST", result)
     {
         lines.push(line);
-    }
-
-    if lines.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  No transport advertised by the VTA — switch to offline sealed-handoff.",
-            theme::muted_style(),
-        )));
     }
 
     lines
@@ -116,4 +155,64 @@ fn format_attempt_line(label: &str, result: &AttemptResult) -> Option<Line<'stat
         ),
         Span::styled(reason, theme::muted_style()),
     ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recovery_detail_lines;
+    use crate::vta::{AttemptResult, AttemptResultKind, VtaConnectState, VtaIntent};
+    use ratatui::prelude::Line;
+    use std::time::Instant;
+
+    /// Flatten rendered lines back to plain text for assertions.
+    fn text(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn surfaces_the_overall_error() {
+        let mut st = VtaConnectState::new(VtaIntent::FullSetup);
+        st.last_error = Some("VTA DID resolution failed: not found".into());
+        let rendered = text(&recovery_detail_lines(&st));
+        assert!(
+            rendered.contains("VTA DID resolution failed: not found"),
+            "recovery panel must show the captured error, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn surfaces_per_transport_attempt_reason() {
+        let mut st = VtaConnectState::new(VtaIntent::FullSetup);
+        st.attempted.rest = Some(AttemptResult {
+            outcome: AttemptResultKind::PreAuthFailure("REST 401 Unauthorized".into()),
+            at: Instant::now(),
+        });
+        let rendered = text(&recovery_detail_lines(&st));
+        assert!(rendered.contains("REST (pre-auth)"), "got: {rendered}");
+        assert!(
+            rendered.contains("REST 401 Unauthorized"),
+            "got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn falls_back_when_nothing_was_captured() {
+        // No error, no diagnostics, no attempts: still render an actionable line
+        // rather than an empty box.
+        let st = VtaConnectState::new(VtaIntent::FullSetup);
+        let rendered = text(&recovery_detail_lines(&st));
+        assert!(
+            rendered.contains("No transport advertised"),
+            "got: {rendered}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When `mediator-setup`'s online-VTA connection fails, the wizard jumps straight from the "Testing" screen to the **VTA Integration — Recover** screen. The Testing screen renders a rich per-check diagnostics checklist (the failed check's detail in red) plus the overall error — but that only **flashes past** on the way to recovery. The recovery screen showed only a terse per-transport "Last attempt" summary, omitting both the overall error and the per-check diagnostics, so operators couldn't read *why* the connection failed without dropping to the headless CLI.

(Reported: "the connection-attempt screen jumps straight to Recover; I can only see the error flash on the previous screen.")

## Fix

Surface the failure on the recovery screen instead of letting it flash. The detail was already captured in state (`last_error`, `diagnostics`, `attempted`) — it just wasn't rendered there.

- New `recovery_detail_lines` composes the panel from three sections, each shown only when populated:
  1. the overall error (`last_error`),
  2. the **per-check diagnostics checklist** — reused from `ui::diagnostics::diag_lines` (now `pub(crate)`); these persist from the Testing phase into recovery,
  3. the per-transport attempt summary.
- Panel retitled **"Last attempt" → "Why it failed"**.
- `build_attempt_lines` → `transport_attempt_lines`; the "no transport advertised" fallback moves to the composite so it only appears when nothing else does.

No state-machine change; purely what the recovery renderer shows.

## Before / after (recovery screen bottom panel)

```
Before:  Last attempt
           REST (pre-auth): <terse reason>      ← or just "No transport advertised…"

After:   Why it failed
           Error: <full last_error>
           ✔ Resolve VTA DID        ok
           ✘ Authenticate (REST)    ACL entry not found for did:key:… (401)
           REST (pre-auth): ACL entry not found…
```

## Tests
3 new unit tests in `ui::recovery` (`recovery_detail_lines`): surfaces the overall error, surfaces per-transport reason, empty-state fallback. `cargo test -p affinidi-messaging-mediator-setup` → 345 passed; `clippy --all-targets -- -D warnings` clean.