### PR TITLE
chore: bump vta-sdk to 0.11 (fix VTA provisioning) + refresh mediator-setup deps

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 9th June 2026
+
+### 0.15.16 — vta-sdk 0.11 (canonical provision-integration Trust Task URI)
+
+- Bump `vta-sdk` `0.9.11` → `0.11`. The legacy
+  `https://firstperson.network/protocols/provision-integration/1.0` message
+  type that `0.9.11` sent was retired upstream and is rejected by current VTAs
+  with `validation error: unsupported message type`. `0.11` emits the canonical
+  Trust Task URI (`https://trusttasks.org/spec/provision/integration/0.1`) the
+  VTA now expects. No mediator source changes; the `affinidi-messaging-didcomm`
+  `[patch.crates-io]` still unifies (a single `affinidi-messaging-didcomm` in
+  the lockfile), and the `integration` API surface is unchanged.
+
 ## 7th June 2026
 
 ### 0.15.15 — Redeliver in-flight messages on duplicate-WebSocket replacement (#374)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.15"
+version = "0.15.16"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -84,7 +84,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 affinidi-did-common = "0.3"
 affinidi-secrets-resolver = "0.5"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.9.11", features = ["integration"] }
+vta-sdk = { version = "0.11", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Changelog history
 
+## 9th June 2026
+
+### 0.1.9 — vta-sdk 0.11 (fix online provisioning against current VTAs)
+
+- Bump `vta-sdk` `0.9.11` → `0.11`. Online VTA setup failed at the
+  `provision-integration` step against current VTAs with
+  `validation error: unsupported message type:
+  https://firstperson.network/protocols/provision-integration/1.0/provision-integration`
+  — that legacy FirstPerson-Network URI was retired upstream. `0.11`'s
+  provision-client emits the canonical Trust Task URI
+  (`https://trusttasks.org/spec/provision/integration/0.1`) the VTA accepts.
+  No source changes in the tool; it builds and tests clean against `0.11`.
+- Bump `toml_edit` `0.22` → `0.25` (the only other direct dependency behind a
+  newer release the caret couldn't reach; `config_writer` uses the stable
+  `DocumentMut` / `value` / `Table` API, unchanged across the bump). All other
+  direct dependencies were already at their latest compatible release.
+
 ## 6th June 2026
 
 ### 0.1.8 — affinidi-crypto 0.2

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.8"
+version = "0.1.9"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ tokio-stream = "0.1"
 
 # ── Config / Serialization ──────────────────────────────────────────────
 toml = "1"
-toml_edit = "0.22"
+toml_edit = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5.4"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.9.11", features = ["provision-client"] }
+vta-sdk = { version = "0.11", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.9.11", features = ["test-support"] }
+vta-sdk = { version = "0.11", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
## Summary

Fixes online VTA provisioning failing at the `provision-integration` step, and brings `mediator-setup` onto latest dependencies.

## Root cause

`mediator-setup` (and the mediator's `integration` feature) pinned **vta-sdk 0.9.11**, which sends the **retired** legacy provision-integration message type:

```
https://firstperson.network/protocols/provision-integration/1.0/provision-integration
```

Current VTAs reject it **post-auth** (auth succeeds, the request body is refused):

```
Provisioning failed. Details: provision-integration call failed:
validation error: unsupported message type: https://firstperson.network/protocols/provision-integration/1.0/provision-integration
```

The legacy FirstPerson-Network URI was retired upstream once consumers moved to the canonical Trust Task registry. **vta-sdk 0.11** sends the canonical URI the VTA now expects:

| | `provision_integration/didcomm.rs` sends |
|---|---|
| 0.9.11 | `PROVISION_INTEGRATION` = `firstperson.network/…/provision-integration/1.0/…` ❌ |
| 0.11.0 | `CANONICAL_PROVISION_INTEGRATION` = `trusttasks.org/spec/provision/integration/0.1` ✅ |

## Changes

- **Bump `vta-sdk` `0.9.11` → `0.11`** in `affinidi-messaging-mediator` (`integration`) and `mediator-setup` (`provision-client` + `test-support` dev-dep). Resolution stays unified — only vta-sdk changes; the `affinidi-messaging-didcomm` `[patch.crates-io]` still applies (single `affinidi-messaging-didcomm` in the lockfile); **no source changes** in either crate.
- **Refresh mediator-setup to latest deps**: `toml_edit` `0.22` → `0.25` (the only direct dep behind a release the caret couldn't reach — `config_writer` uses the stable `DocumentMut`/`value`/`Table` API; resolves to a single `toml_edit`). `cargo outdated` reports everything else already at its latest compatible release.
- Version + CHANGELOG bumps: mediator `0.15.15 → 0.15.16`, mediator-setup `0.1.8 → 0.1.9`.

> `Cargo.lock` is gitignored in this workspace, so caret-pinned deps already float to latest-compatible on every build; the only meaningful manifest lags were the two cross-minor bumps above.

## Verification
- `affinidi-messaging-mediator`: 106 lib tests, clippy `-D warnings` clean (redis-backend).
- `affinidi-messaging-mediator-setup`: 342 tests, clippy `-D warnings` clean.
- `cargo deny check`: advisories / bans / licenses / sources ok.
- ⚠️ The live two-mediator VTA provisioning round-trip wasn't run in this environment — this fixes the message type the VTA flagged, but please re-run `mediator-setup` against the VTA to confirm end-to-end. (The recovery-screen error surfacing from #390 will show any remaining issue clearly.)