### PR TITLE
fix: preload mediator DID into server resolver cache

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -473,7 +473,7 @@ pub async fn serve_internal(
         (None, None)
     };
 
-    let did_resolver = DIDCacheClient::new(config.did_resolver_config.clone())
+    let mut did_resolver = DIDCacheClient::new(config.did_resolver_config.clone())
         .await
         .map_err(|e| {
             error!("Failed to create DID resolver: {e}");
@@ -483,6 +483,21 @@ pub async fn serve_internal(
                 format!("Failed to create DID resolver: {e}"),
             )
         })?;
+
+    // Preload the mediator's own DID document so it can pack/unpack DIDComm
+    // messages without hitting the network (the did:web resolver requires HTTPS
+    // which may not be reachable from the mediator's own network).
+    if let Some(ref did_doc_json) = config.mediator_did_doc {
+        if let Ok(doc) = serde_json::from_str::<affinidi_did_common::Document>(did_doc_json) {
+            did_resolver
+                .add_did_document(&config.mediator_did, doc)
+                .await;
+            info!(
+                "Preloaded mediator DID into resolver cache: {}",
+                config.mediator_did
+            );
+        }
+    }
 
     #[cfg(feature = "didcomm")]
     let discover_features = Arc::new(DiscoverFeatures {


### PR DESCRIPTION
## Problem

The mediator's `server.rs` creates a fresh `DIDCacheClient` at startup (line 476) that does **not** contain the mediator's own DID document. A separate resolver instance in `Config::from_raw()` (line 884) does preload it, but that instance is discarded after config validation.

When the mediator packs a DIDComm response (e.g. to a message-pickup or live-delivery request), it needs to resolve its own DID as the sender. For `did:web` and `did:webvh`, this triggers an HTTPS request to `/.well-known/did.json(l)` — which may not be reachable from the mediator's own network:

```
ERROR: Failed to resolve sender DID: did:web HTTP request failed:
       GET https://mediator/.well-known/did.json: error sending request
```

## Fix

After creating the server's `DIDCacheClient`, preload `config.mediator_did_doc` (already parsed during config loading) into its cache. This ensures the mediator can resolve its own DID without network access.

## Impact

- **did:peer** mediators: unaffected (did:peer resolves locally without HTTP)
- **did:web / did:webvh** mediators: **cannot send DIDComm messages** without this fix
- Zero risk of regression — only adds a cache entry that would otherwise be fetched via HTTP

## Testing

Validated with local E2E tests for all three DID methods:
- `did:peer` ✅
- `did:web` ✅
- `did:webvh` ✅

Mediator logs confirm preload: `Preloaded mediator DID into resolver cache: did:web:mediator`