### PR TITLE
feat: optional did:web export for self-hosted webvh DIDs (mediator-setup)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 ## 9th June 2026
 
+### 0.1.10 — optional did:web export for self-hosted webvh DIDs
+
+- New option to also export a `did:web` copy of the mediator's DID
+  document when generating a `did:webvh`. `did:webvh` and `did:web` are
+  wire-compatible — the same document resolves under either method once
+  the SCID is dropped — so the wizard rewrites the resolved DID document's
+  identifier from `did:webvh:<scid>:<domain>` to `did:web:<domain>` (and
+  every self-reference: `id`, `controller`, verification-method and
+  service ids) and writes it to `did-web.json` next to `did.jsonl`. The
+  operator can host that file at a plain web server's
+  `/.well-known/did.json`.
+  - Interactive: a Yes/No prompt after the mediator public-URL step. It
+    defaults to "No (recommended)" and is framed as advanced — most
+    deployments only need the did:webvh log; pick "Yes" only if you know
+    you need a did:web identifier (e.g. a counterparty that resolves
+    did:web but not did:webvh).
+  - Non-interactive / recipe: `--save-did-web` CLI flag and
+    `[identity] save_did_web = true` recipe key.
+  - Covers both the local generator and VTA-managed webvh logs (the
+    export triggers whenever the minted DID is a `did:webvh:` and the
+    option is set); non-webvh DIDs are skipped with a note.
+  - The file is a standalone operator artefact — the mediator runtime
+    still serves its own document from the webvh log
+    (`did_web_self_hosted` → `did.jsonl`) and never reads `did-web.json`,
+    so the distinct filename avoids colliding with the runtime-served
+    `/.well-known/did.json`.
+
 ### 0.1.9 — vta-sdk 0.11 (fix online provisioning against current VTAs)
 
 - Bump `vta-sdk` `0.9.11` → `0.11`. Online VTA setup failed at the

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.9"
+version = "0.1.10"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -254,6 +254,9 @@ pub enum DidPhase {
     SelectWebvhHost,
     /// Text input for a different self-host base URL.
     EnterCustomUrl,
+    /// Yes/No selection: after a local did:webvh is configured, offer to
+    /// also export a did:web (`did-web.json`) copy of the DID document.
+    SaveDidWebChoice,
 }
 
 /// Sub-phases of the `Security` step. The SSL portion (selection list +
@@ -354,6 +357,10 @@ pub struct WizardConfig {
     pub tsp_enabled: bool,
     pub did_method: String,
     pub public_url: String,
+    /// When `did_method` produces a did:webvh, also export a did:web copy
+    /// of the DID document to `did-web.json`. Collected via the
+    /// `DidPhase::SaveDidWebChoice` prompt or the `--save-did-web` flag.
+    pub save_did_web: bool,
     pub secret_storage: String,
     // Per-backend config fields. Only the set relevant to `secret_storage`
     // is meaningful; others stay at defaults. Storing them as flat strings
@@ -519,6 +526,7 @@ impl Default for WizardConfig {
             tsp_enabled: false,
             did_method: String::new(),
             public_url: String::new(),
+            save_did_web: false,
             secret_storage: String::new(),
             secret_file_path: DEFAULT_SECRET_FILE_PATH.into(),
             secret_keyring_service: DEFAULT_KEYRING_SERVICE.into(),
@@ -2257,6 +2265,20 @@ impl WizardApp {
                 ]
             }
             WizardStep::Did => {
+                // After a local did:webvh URL is captured, offer the
+                // did:web export as a Yes/No pick (index 0 = Yes).
+                if self.did_phase == Some(DidPhase::SaveDidWebChoice) {
+                    return vec![
+                        SelectionOption::new(
+                            "No (recommended)",
+                            "Generate the did:webvh log only. This is all most deployments need.",
+                        ),
+                        SelectionOption::new(
+                            "Yes — also export a did:web copy",
+                            "Advanced: only if you specifically need a did:web identifier. Writes did-web.json (id rewritten to did:web:<domain>) for you to host at a web server's /.well-known/did.json.",
+                        ),
+                    ];
+                }
                 // When the webvh-host sub-flow is active, render its
                 // options (self-host / each server / self-host
                 // elsewhere) instead of the DID-method picker.
@@ -2564,6 +2586,18 @@ impl WizardApp {
                 _ => String::new(),
             },
             WizardStep::Did => {
+                if self.did_phase == Some(DidPhase::SaveDidWebChoice) {
+                    return "Most deployments should pick \"No\" — the did:webvh log is \
+                            always written and is all you need. Only choose \"Yes\" if you \
+                            specifically know you need a did:web identifier as well (e.g. \
+                            a verifier or counterparty that resolves did:web but not \
+                            did:webvh). did:webvh and did:web are wire-compatible — the \
+                            same document resolves under either method once the SCID is \
+                            dropped — so \"Yes\" writes an extra did-web.json (id rewritten \
+                            to did:web:<domain>) you host at a plain web server's \
+                            /.well-known/did.json."
+                        .into();
+                }
                 if self.did_phase == Some(DidPhase::SelectWebvhHost) {
                     return "Pick where the VTA should publish this DID's did.jsonl log. \
                             Self-host = the mediator (or another server you operate) serves \
@@ -2841,6 +2875,15 @@ impl WizardApp {
                 self.advance();
             }
             WizardStep::Did => {
+                // The did:web export Yes/No pick rides on the same
+                // selection-list UI. Record the choice and advance.
+                if self.did_phase == Some(DidPhase::SaveDidWebChoice) {
+                    // Index 0 = "No (recommended)", index 1 = "Yes".
+                    self.config.save_did_web = self.selection_index == 1;
+                    self.did_phase = None;
+                    self.advance();
+                    return;
+                }
                 // The webvh-host selection rides on top of the Did
                 // step's selection list UI. Route Enter to the
                 // sub-flow handler when that phase is active.
@@ -3597,6 +3640,16 @@ impl WizardApp {
         self.current_step == WizardStep::Did && self.did_phase.is_some()
     }
 
+    /// Enter the did:web export Yes/No prompt (a sub-phase of the Did
+    /// step). Index 0 = "No (recommended)", index 1 = "Yes" — pre-selects
+    /// the operator's current choice, defaulting to the recommended "No"
+    /// so the export stays opt-in.
+    fn enter_save_did_web_choice(&mut self) {
+        self.did_phase = Some(DidPhase::SaveDidWebChoice);
+        self.mode = InputMode::Selecting;
+        self.selection_index = usize::from(self.config.save_did_web);
+    }
+
     /// Confirm the SelectWebvhHost selection. `selection_index` maps
     /// to 0 = self-host at mediator URL, 1..=servers.len() = VTA-hosted
     /// server, servers.len()+1 = self-host elsewhere.
@@ -3682,6 +3735,14 @@ impl WizardApp {
                 if self.config.did_method == DID_VTA && self.vta_session.is_some() {
                     self.mode = InputMode::Selecting;
                     self.advance();
+                    return;
+                }
+                // Locally-generated did:webvh: offer the did:web export
+                // before advancing. (VTA-managed webvh DIDs are minted in
+                // the Vta sub-flow above and never reach this prompt; pass
+                // --save-did-web for those.)
+                if self.config.did_method == DID_WEBVH {
+                    self.enter_save_did_web_choice();
                     return;
                 }
                 self.mode = InputMode::Selecting;
@@ -4060,6 +4121,12 @@ impl WizardApp {
                     self.selection_index = 0;
                 }
                 Some(DidPhase::SelectWebvhHost) => {
+                    self.did_phase = None;
+                    self.mode = InputMode::TextInput;
+                    self.text_input = Input::new(self.config.public_url.clone());
+                }
+                Some(DidPhase::SaveDidWebChoice) => {
+                    // Back from the did:web pick → re-edit the mediator URL.
                     self.did_phase = None;
                     self.mode = InputMode::TextInput;
                     self.text_input = Input::new(self.config.public_url.clone());
@@ -4812,6 +4879,86 @@ mod tests {
         assert_eq!(app.current_step, WizardStep::Protocol);
         app.go_back();
         assert_eq!(app.current_step, WizardStep::Vta);
+    }
+
+    #[test]
+    fn local_webvh_url_confirm_enters_did_web_choice() {
+        // Non-VTA did:webvh path: after the public URL is confirmed the
+        // wizard offers the did:web export as a Yes/No sub-phase instead
+        // of advancing straight on.
+        let mut app = WizardApp::new("test.toml".into());
+        app.config.use_vta = false;
+        app.current_step = WizardStep::Did;
+        app.mode = InputMode::Selecting;
+        app.selection_index = 0; // "Generate did:webvh"
+        app.select_current();
+        assert_eq!(app.config.did_method, DID_WEBVH);
+        assert_eq!(app.mode, InputMode::TextInput);
+
+        app.text_input = tui_input::Input::new("https://mediator.example.com".into());
+        app.confirm_text_input();
+
+        assert_eq!(app.did_phase, Some(DidPhase::SaveDidWebChoice));
+        assert_eq!(app.mode, InputMode::Selecting);
+        assert_eq!(app.current_options().len(), 2);
+        // Opt-in: the prompt defaults to the recommended "No" (index 0).
+        assert_eq!(app.selection_index, 0);
+        assert_eq!(app.config.public_url, "https://mediator.example.com");
+    }
+
+    #[test]
+    fn did_web_choice_yes_sets_flag_and_advances_past_did() {
+        let mut app = WizardApp::new("test.toml".into());
+        app.config.use_vta = false;
+        app.current_step = WizardStep::Did;
+        app.mode = InputMode::Selecting;
+        app.selection_index = 0;
+        app.select_current();
+        app.text_input = tui_input::Input::new("https://mediator.example.com".into());
+        app.confirm_text_input();
+
+        // Pick "Yes" (index 1; index 0 is the recommended "No").
+        app.selection_index = 1;
+        app.select_current();
+        assert!(app.config.save_did_web);
+        assert!(app.did_phase.is_none());
+        assert_ne!(app.current_step, WizardStep::Did);
+    }
+
+    #[test]
+    fn did_web_choice_no_leaves_flag_unset() {
+        let mut app = WizardApp::new("test.toml".into());
+        app.config.use_vta = false;
+        app.current_step = WizardStep::Did;
+        app.mode = InputMode::Selecting;
+        app.selection_index = 0;
+        app.select_current();
+        app.text_input = tui_input::Input::new("https://mediator.example.com".into());
+        app.confirm_text_input();
+
+        // Pick "No" (the default highlight).
+        app.select_current();
+        assert!(!app.config.save_did_web);
+        assert!(app.did_phase.is_none());
+    }
+
+    #[test]
+    fn did_web_choice_back_nav_returns_to_url_input() {
+        let mut app = WizardApp::new("test.toml".into());
+        app.config.use_vta = false;
+        app.current_step = WizardStep::Did;
+        app.mode = InputMode::Selecting;
+        app.selection_index = 0;
+        app.select_current();
+        app.text_input = tui_input::Input::new("https://mediator.example.com".into());
+        app.confirm_text_input();
+        assert_eq!(app.did_phase, Some(DidPhase::SaveDidWebChoice));
+
+        app.go_back();
+        assert!(app.did_phase.is_none());
+        assert_eq!(app.mode, InputMode::TextInput);
+        assert_eq!(app.current_step, WizardStep::Did);
+        assert_eq!(app.text_input.value(), "https://mediator.example.com");
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
@@ -28,6 +28,14 @@ pub struct Args {
     #[arg(long)]
     pub public_url: Option<String>,
 
+    /// Also write a did:web copy of the generated DID document to
+    /// `did-web.json` (next to `did.jsonl`), rewriting the identifier
+    /// from `did:webvh:<scid>:<domain>` to `did:web:<domain>`. Only
+    /// applies when the mediator DID is a did:webvh (local generator or
+    /// VTA-managed webvh log).
+    #[arg(long)]
+    pub save_did_web: bool,
+
     /// Secret storage backend
     #[arg(long, value_enum)]
     pub secret_storage: Option<SecretStorage>,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -140,6 +140,60 @@ pub async fn generate_did_webvh(
     })
 }
 
+/// Convert a did:webvh log entry into the equivalent did:web DID document.
+///
+/// `did:webvh` and `did:web` are wire-compatible by design: a
+/// `did:webvh:{scid}:{domain}` DID resolves to the same document as
+/// `did:web:{domain}` once the self-certifying identifier (SCID) is
+/// dropped and every self-reference in the document is rewritten. This
+/// takes the resolved DID document — the log entry's `state` — and
+/// rewrites every reference to the webvh DID into its did:web form,
+/// returning `(did:web identifier, pretty-printed did.json document)`.
+///
+/// The returned document is an operator artefact for hosting the DID
+/// under did:web (e.g. at a web server's `/.well-known/did.json`). It is
+/// **not** consumed by the mediator runtime, which serves its own DID
+/// document from the webvh log (`did_web_self_hosted` → `did.jsonl`).
+pub fn webvh_log_to_did_web(
+    log_entry_json: &str,
+    webvh_did: &str,
+) -> anyhow::Result<(String, String)> {
+    let web_did = webvh_did_to_web(webvh_did)?;
+
+    let entry: serde_json::Value = serde_json::from_str(log_entry_json)
+        .map_err(|e| anyhow::anyhow!("Failed to parse did:webvh log entry: {e}"))?;
+    let state = entry
+        .get("state")
+        .ok_or_else(|| anyhow::anyhow!("did:webvh log entry has no `state` (DID document)"))?;
+
+    // Rewrite every self-reference. In the resolved state the DID always
+    // appears in full (`id`, `controller`, `{did}#key-0`, service ids …),
+    // so a whole-string swap of the webvh DID for its did:web form
+    // rewrites them all without touching unrelated values. `web_did`
+    // never contains `webvh_did`, so the replacement can't recurse.
+    let rewritten = serde_json::to_string(state)?.replace(webvh_did, &web_did);
+    let doc: serde_json::Value = serde_json::from_str(&rewritten)?;
+    let pretty = serde_json::to_string_pretty(&doc)?;
+
+    Ok((web_did, pretty))
+}
+
+/// Map a `did:webvh:{scid}:{domain}[:path…]` identifier to its
+/// `did:web:{domain}[:path…]` equivalent by dropping the SCID segment.
+/// Path segments (`:`-separated, did:web style) are preserved verbatim.
+fn webvh_did_to_web(webvh_did: &str) -> anyhow::Result<String> {
+    let rest = webvh_did
+        .strip_prefix("did:webvh:")
+        .ok_or_else(|| anyhow::anyhow!("not a did:webvh DID: {webvh_did}"))?;
+    let (_scid, domain_and_path) = rest
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("malformed did:webvh DID (missing domain): {webvh_did}"))?;
+    if domain_and_path.is_empty() {
+        anyhow::bail!("did:webvh DID has an empty domain: {webvh_did}");
+    }
+    Ok(format!("did:web:{domain_and_path}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +270,67 @@ mod tests {
         }
         assert!(result.secrets[0].id.ends_with("#key-0"));
         assert!(result.secrets[1].id.ends_with("#key-1"));
+    }
+
+    #[test]
+    fn webvh_did_to_web_drops_scid() {
+        assert_eq!(
+            webvh_did_to_web("did:webvh:QmScId:mediator.example.com").unwrap(),
+            "did:web:mediator.example.com"
+        );
+    }
+
+    #[test]
+    fn webvh_did_to_web_preserves_path_segments() {
+        // did:web path style: `:`-separated segments after the domain.
+        assert_eq!(
+            webvh_did_to_web("did:webvh:QmScId:example.com:mediators:m1").unwrap(),
+            "did:web:example.com:mediators:m1"
+        );
+    }
+
+    #[test]
+    fn webvh_did_to_web_rejects_non_webvh_and_malformed() {
+        assert!(webvh_did_to_web("did:web:example.com").is_err());
+        assert!(webvh_did_to_web("did:webvh:QmScId").is_err()); // no domain
+        assert!(webvh_did_to_web("did:webvh:QmScId:").is_err()); // empty domain
+    }
+
+    #[tokio::test]
+    async fn did_web_export_rewrites_every_self_reference() {
+        let result = generate_did_webvh(
+            "https://mediator.example.com",
+            "https://mediator.example.com/mediator/v1",
+        )
+        .await
+        .unwrap();
+
+        let (web_did, doc_str) = webvh_log_to_did_web(&result.did_doc, &result.did).unwrap();
+
+        // The webvh DID is `did:webvh:{scid}:mediator.example.com`, so the
+        // did:web form drops the scid segment.
+        assert_eq!(web_did, "did:web:mediator.example.com");
+
+        // No trace of the webvh identifier (or the bare `did:webvh:`
+        // method prefix) should survive anywhere in the document.
+        assert!(!doc_str.contains("did:webvh:"));
+        assert!(!doc_str.contains(&result.did));
+
+        let doc: Value = serde_json::from_str(&doc_str).unwrap();
+        assert_eq!(doc["id"], web_did);
+        // Verification-method + service self-references were all rewritten.
+        for vm in doc["verificationMethod"].as_array().unwrap() {
+            assert!(vm["id"].as_str().unwrap().starts_with("did:web:"));
+        }
+        for svc in doc["service"].as_array().unwrap() {
+            assert!(svc["id"].as_str().unwrap().starts_with("did:web:"));
+        }
+    }
+
+    #[tokio::test]
+    async fn did_web_export_errors_on_log_without_state() {
+        let err = webvh_log_to_did_web(r#"{"versionId":"1-abc"}"#, "did:webvh:QmScId:example.com")
+            .unwrap_err();
+        assert!(err.to_string().contains("state"));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -234,6 +234,9 @@ fn apply_cli_args(args: &Args, config: &mut WizardConfig) {
     if let Some(ref public_url) = args.public_url {
         config.public_url = public_url.clone();
     }
+    if args.save_did_web {
+        config.save_did_web = true;
+    }
     if let Some(ref secret_storage) = args.secret_storage {
         config.secret_storage = secret_storage.to_string();
     }
@@ -941,6 +944,42 @@ fn write_did_jsonl(config_path: &str, log_content: &str) {
     }
 }
 
+/// Convert the mediator's did:webvh log entry to a did:web DID document
+/// and write it next to the config as `did-web.json`. Purely an operator
+/// artefact for hosting the DID under did:web — the mediator runtime
+/// serves its own document from the webvh log, never this file, so the
+/// filename deliberately differs from the runtime-served `did.json`.
+/// Failures are surfaced but non-fatal: a bad conversion shouldn't roll
+/// back an otherwise-good setup.
+fn write_did_web_json(config_path: &str, log_content: &str, webvh_did: &str) {
+    let (web_did, doc) = match generators::did_webvh::webvh_log_to_did_web(log_content, webvh_did) {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("  \x1b[33mWarning:\x1b[0m could not derive did:web document: {e}");
+            return;
+        }
+    };
+    let did_web_path = std::path::Path::new(config_path)
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("did-web.json");
+    // did:web documents are public by definition (the operator hosts
+    // them at `/.well-known/did.json`), but mirror the owner-only posture
+    // of did.jsonl for defence in depth until the operator copies it out.
+    let body = format!("{}\n", doc.trim_end_matches('\n'));
+    match crate::secure_fs::write_sensitive(&did_web_path, body) {
+        Ok(()) => println!(
+            "  \x1b[32m\u{2714}\x1b[0m Saved did:web document (\x1b[36m{web_did}\x1b[0m): \
+             \x1b[36m{}\x1b[0m",
+            did_web_path.display()
+        ),
+        Err(e) => eprintln!(
+            "  \x1b[33mWarning:\x1b[0m could not write {}: {e}",
+            did_web_path.display()
+        ),
+    }
+}
+
 /// Drop any HTTP path from a URL, returning `<scheme>://<host>[:<port>]`.
 /// Used to derive the did:webvh DID identifier from the operator's full
 /// public URL (the trailing `/mediator/v1` would otherwise get baked into
@@ -1542,6 +1581,25 @@ fn write_config_artefacts(
     // `write_did_jsonl` adds the trailing newline strict JSONL requires.
     if let Some(ref doc) = artefacts.did_doc {
         write_did_jsonl(&config.config_path, doc);
+
+        // Optional did:web export. When the operator asked for it and the
+        // minted DID is a did:webvh (local generator or VTA-managed webvh
+        // log), rewrite the resolved DID document to its did:web form and
+        // drop it next to the config as `did-web.json` for hosting under
+        // did:web. Non-webvh DIDs (did:peer, VTA-managed did:web/did:key)
+        // have no scid to drop, so we skip with a note rather than emit a
+        // misleading file.
+        if config.save_did_web {
+            if artefacts.mediator_did.starts_with("did:webvh:") {
+                write_did_web_json(&config.config_path, doc, &artefacts.mediator_did);
+            } else {
+                eprintln!(
+                    "  \x1b[33mNote:\x1b[0m --save-did-web requested but the mediator DID \
+                     is not a did:webvh ({}); skipping did:web export.",
+                    artefacts.mediator_did
+                );
+            }
+        }
     }
 
     // Authorization VC archive (DID_VTA Full path only). Pre-serialised

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -117,6 +117,11 @@ pub struct IdentitySection {
     pub did_method: String,
     /// Required when `did_method = "did:webvh"`
     pub public_url: Option<String>,
+    /// Also write a did:web copy of the generated DID document to
+    /// `did-web.json`. Only meaningful for did:webvh / VTA-managed webvh
+    /// DIDs; ignored otherwise.
+    #[serde(default)]
+    pub save_did_web: bool,
 }
 
 fn default_did_method() -> String {
@@ -128,6 +133,7 @@ impl Default for IdentitySection {
         Self {
             did_method: default_did_method(),
             public_url: None,
+            save_did_web: false,
         }
     }
 }
@@ -483,6 +489,7 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
     } else if let Some(ref url) = recipe.identity.public_url {
         config.public_url = url.clone();
     }
+    config.save_did_web = recipe.identity.save_did_web;
 
     // Secrets — accept either the bare scheme (backward compat with
     // pre-cloud-config recipes) or a fully-formed URL. A full URL gets

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/mod.rs
@@ -840,6 +840,9 @@ fn render_step_content(frame: &mut Frame, area: Rect, app: &WizardApp) {
                     DidPhase::SelectWebvhHost => {
                         unreachable!("SelectWebvhHost runs in Selecting mode, not TextInput")
                     }
+                    DidPhase::SaveDidWebChoice => {
+                        unreachable!("SaveDidWebChoice runs in Selecting mode, not TextInput")
+                    }
                 };
                 prompt::render_prompt(
                     frame,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/summary.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/ui/summary.rs
@@ -141,6 +141,17 @@ pub fn render_summary(
             value_style,
         );
     }
+    // did:web export — only surfaced when the operator opted in. The file
+    // (`did-web.json`) is written only if the minted DID is a did:webvh.
+    if config.save_did_web {
+        add_field(
+            &mut lines,
+            "  did:web export",
+            "Yes (did-web.json)",
+            label_style,
+            value_style,
+        );
+    }
     let key_storage_display = build_backend_url(config);
     add_field(
         &mut lines,


### PR DESCRIPTION
## What

When mediator-setup generates a `did:webvh`, it can now **also** export a `did:web` copy of the DID document. `did:webvh` and `did:web` are wire-compatible — the same document resolves under either method once the SCID is dropped — so the resolved document's identifier is rewritten from `did:webvh:<scid>:<domain>` → `did:web:<domain>` (along with every self-reference: `id`, `controller`, verification-method and service ids) and written to **`did-web.json`** next to `did.jsonl`. The operator hosts that file at a plain web server's `/.well-known/did.json`.

## Why

Some counterparties/verifiers resolve `did:web` but not `did:webvh`. Since the two are wire-compatible, the wizard can emit the `did:web` form as a no-cost extra artefact for those integrations.

## Surfaces

- **Interactive (TUI)**: a Yes/No prompt after the public-URL step. Defaults to **"No (recommended)"** and is framed as advanced — the detail pane explains it's only needed if you specifically know you need a `did:web` identifier.
- **CLI**: `--save-did-web`
- **Recipe**: `[identity] save_did_web = true`

## Scope

The export triggers whenever the minted DID is a `did:webvh:`, covering **both** the local generator and VTA-managed webvh logs (shared write path). Non-webvh DIDs are skipped with a note.

## Correctness

`did-web.json` is a **standalone operator artefact** — the mediator runtime serves its own document from the webvh log (`did_web_self_hosted` → `did.jsonl`) and never reads this file, so the distinct filename deliberately avoids colliding with the runtime-served `/.well-known/did.json`.

## Testing

- 354 unit tests pass, including 8 new ones: SCID-drop, path-segment preservation, malformed-DID rejection, full self-reference rewrite, no-`state` error, and 4 TUI-flow tests (enter prompt, Yes commits + advances, No leaves flag unset, back-nav returns to URL input).
- End-to-end smoke test of the real binary (non-interactive `--did-method webvh --save-did-web --secret-storage file`): produced `did-web.json` with `id: did:web:mediator.example.com`, all references rewritten, service endpoints intact, `did.jsonl` still written.
- `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo deny check` clean.

Bumps `affinidi-messaging-mediator-setup` `0.1.9` → `0.1.10` (+ CHANGELOG entry).