### PR TITLE
fix: guard against operating-secret/DID-document key mismatch (+ cross-mediator example)

### DIFF
--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -1,28 +1,60 @@
 //! Cross-Mediator Forwarding Example
 //!
-//! Demonstrates message forwarding between two different mediators.
-//! Alice uses one mediator, Bob uses a different mediator. Messages are
-//! routed through both mediators, showing timing information.
+//! Demonstrates DIDComm message forwarding between two *different* mediators.
+//! Alice is registered with mediator 1, Bob with mediator 2. Each message is
+//! routed Alice -> mediator-1 -> mediator-2 -> Bob (and the reverse), so it
+//! exercises mediator-to-mediator routing in both directions.
 //!
-//! Supports a ping-pong mode for measuring round-trip latency over time.
+//! The default mode renders the exchange as a side-by-side timeline — Alice on
+//! the left, Bob on the right — showing every wrap (plaintext -> authcrypt ->
+//! inner forward -> outer forward), the wire hop between the two mediators, and
+//! the unwrap on the far side. Every step is stamped with an absolute wall-clock
+//! time, the delta since the previous step, and the elapsed total.
 //!
-//! Usage:
+//! ## Random-DID mode (default — just point it at two mediators)
+//!
+//! Fresh `did:peer` identities are generated for Alice and Bob at runtime; you
+//! only supply the two mediator DIDs:
+//!
+//!   cargo run --example cross_mediator_forwarding -- \
+//!     --mediator1 did:web:mediator-a.example.com \
+//!     --mediator2 did:web:mediator-b.example.com
+//!
+//! `--mediator1`/`--mediator2` are mediator *DIDs* (e.g. `did:web:...`), not raw
+//! URLs — the DID is resolved to discover the mediator's HTTP/WebSocket endpoints.
+//!
+//! ## Environment mode (use pre-configured profiles)
+//!
+//! If `--mediator1`/`--mediator2` are omitted, the example falls back to loading
+//! `Alice` and `Bob` profiles from TDK environment files (the original behaviour):
+//!
 //!   cargo run --example cross_mediator_forwarding -- \
 //!     --alice-environment alice_env --bob-environment bob_env
 //!
-//! Both environments must be configured in the TDK environments file
-//! with their respective mediator endpoints.
+//! ## Ping-pong latency mode
+//!
+//! Add `--ping-pong [--rounds N]` (works in either mode) to follow the visual
+//! exchange with a compact round-trip latency measurement loop.
 
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_sdk::{
+    ATM,
     errors::ATMError,
     profiles::ATMProfile,
     protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
 };
-use affinidi_tdk::{TDK, common::config::TDKConfig};
+use affinidi_tdk::{
+    TDK,
+    common::{config::TDKConfig, profiles::TDKProfile},
+    dids::{DID, KeyType, PeerKeyRole},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
-use serde_json::json;
-use std::time::{Duration, Instant, SystemTime};
+use serde_json::{Value, json};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 use tracing::info;
 use tracing_subscriber::filter;
 use uuid::Uuid;
@@ -30,29 +62,62 @@ use uuid::Uuid;
 #[derive(Parser, Debug)]
 #[command(
     version,
-    about = "Cross-mediator forwarding example with latency measurement"
+    about = "Cross-mediator forwarding example with a visual timeline and latency measurement"
 )]
 struct Args {
-    /// Environment name for Alice (must have Alice profile and mediator configured)
+    /// Alice's mediator DID. When set together with --mediator2, the example
+    /// generates random did:peer identities (random-DID mode).
+    #[arg(long)]
+    mediator1: Option<String>,
+
+    /// Bob's mediator DID (must differ from --mediator1 for true cross-mediator routing).
+    #[arg(long)]
+    mediator2: Option<String>,
+
+    /// Environment name for Alice (environment mode; used when --mediator1/2 are absent).
     #[arg(long, default_value = "alice")]
     alice_environment: String,
 
-    /// Environment name for Bob (must have Bob profile and a DIFFERENT mediator configured)
+    /// Environment name for Bob (environment mode; must have a DIFFERENT mediator).
     #[arg(long, default_value = "bob")]
     bob_environment: String,
 
-    /// Path to the environments file (defaults to environments.json)
+    /// Path to the environments file (defaults to environments.json).
     #[arg(short, long)]
     path_environments: Option<String>,
 
-    /// Enable ping-pong mode: continuously send messages back and forth
-    /// measuring round-trip latency (max 1 message per second)
+    /// The message text Alice sends to Bob.
+    #[arg(
+        long,
+        default_value = "Hello Bob! This message is routed through two mediators."
+    )]
+    message: String,
+
+    /// After the visual exchange, run a ping-pong loop measuring round-trip latency
+    /// (max 1 message per second).
     #[arg(long)]
     ping_pong: bool,
 
-    /// Number of ping-pong rounds (0 = infinite)
+    /// Number of ping-pong rounds (0 = infinite).
     #[arg(long, default_value = "10")]
     rounds: u32,
+}
+
+/// One participant in the exchange: a DID + the mediator it is registered with,
+/// plus the ATM client and active profile used to send/receive on its behalf.
+struct Party {
+    label: &'static str,
+    side: Side,
+    did: String,
+    mediator_did: String,
+    atm: ATM,
+    profile: Arc<ATMProfile>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Side {
+    Left,
+    Right,
 }
 
 #[tokio::main]
@@ -65,11 +130,138 @@ async fn main() -> Result<(), ATMError> {
     tracing::subscriber::set_global_default(subscriber).expect("Logging failed, exiting...");
 
     println!("=== Cross-Mediator Forwarding Example ===");
-    println!("Alice environment: {}", args.alice_environment);
-    println!("Bob environment: {}", args.bob_environment);
-    println!();
 
-    // --- Setup Alice's TDK and mediator ---
+    // `_guards` keeps the TDK instance(s) alive for the duration of the run;
+    // the Party values hold cloned ATM handles + Arc profiles.
+    let env_mode = args.mediator1.is_none() || args.mediator2.is_none();
+    let (_guards, alice, bob) =
+        if let (Some(m1), Some(m2)) = (args.mediator1.clone(), args.mediator2.clone()) {
+            println!("Mode: random did:peer identities");
+            println!("  Alice mediator: {m1}");
+            println!("  Bob   mediator: {m2}");
+            setup_random(&m1, &m2).await?
+        } else {
+            println!("Mode: environment-loaded profiles");
+            println!("  Alice environment: {}", args.alice_environment);
+            println!("  Bob   environment: {}", args.bob_environment);
+            setup_env(&args).await?
+        };
+
+    print_header(&alice, &bob);
+
+    if alice.mediator_did == bob.mediator_did {
+        println!("WARNING: Alice and Bob are using the same mediator.");
+        println!("For true cross-mediator forwarding, point them at different mediators.\n");
+    }
+
+    // Ensure Alice and Bob are allowed to message each other.
+    setup_acls(&alice, &bob).await?;
+
+    let mut tl = Timeline::new();
+
+    println!("\n========================= Alice -> Bob =========================\n");
+    if !deliver(&mut tl, &alice, &bob, &args.message, true).await? {
+        eprintln!("ERROR: Bob did not receive the message within the timeout.");
+        return Ok(());
+    }
+
+    println!("\n========================= Bob -> Alice =========================\n");
+    if !deliver(
+        &mut tl,
+        &bob,
+        &alice,
+        "Hi Alice! Got your message — routing works both ways.",
+        true,
+    )
+    .await?
+    {
+        eprintln!("ERROR: Alice did not receive the reply within the timeout.");
+        return Ok(());
+    }
+
+    if args.ping_pong {
+        ping_pong(&mut tl, &alice, &bob, args.rounds).await?;
+    }
+
+    // Tidy up. In random-DID mode both parties share one ATM, so only shut it
+    // down once; in environment mode each party owns its own ATM.
+    alice.atm.graceful_shutdown().await;
+    if env_mode {
+        bob.atm.graceful_shutdown().await;
+    }
+
+    println!("\n=== Example complete ===");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+/// Random-DID mode: one headless TDK + ATM, two freshly generated did:peers.
+async fn setup_random(
+    mediator1: &str,
+    mediator2: &str,
+) -> Result<(Vec<TDK>, Party, Party), ATMError> {
+    let tdk = TDK::new(
+        TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(true)
+            .build()?,
+        None,
+    )
+    .await?;
+    let atm = tdk.atm.clone().expect("ATM should be enabled");
+
+    let alice = make_random_party(&tdk, &atm, "Alice", Side::Left, mediator1).await?;
+    let bob = make_random_party(&tdk, &atm, "Bob", Side::Right, mediator2).await?;
+
+    // The borrows of `tdk` end with the calls above, so it can now be moved
+    // into the guard vec to outlive the parties.
+    Ok((vec![tdk], alice, bob))
+}
+
+/// Generate a random did:peer whose DIDComm service endpoint is the mediator's
+/// DID, register its secrets + profile, and connect (live stream) to the mediator.
+async fn make_random_party(
+    tdk: &TDK,
+    atm: &ATM,
+    label: &'static str,
+    side: Side,
+    mediator_did: &str,
+) -> Result<Party, ATMError> {
+    // The recipient's DID delegates to its mediator: the did:peer's `dm`
+    // service endpoint is the mediator's DID (routing 2.0 shape).
+    let (did, secrets) = DID::generate_did_peer(
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ],
+        Some(mediator_did.to_string()),
+    )?;
+
+    let tdk_profile = TDKProfile::new(label, &did, Some(mediator_did), secrets);
+    tdk.add_profile(&tdk_profile).await;
+
+    let profile = atm
+        .profile_add(
+            &ATMProfile::from_tdk_profile(atm, &tdk_profile).await?,
+            true,
+        )
+        .await?;
+
+    Ok(Party {
+        label,
+        side,
+        did,
+        mediator_did: mediator_did.to_string(),
+        atm: atm.clone(),
+        profile,
+    })
+}
+
+/// Environment mode: load `Alice` and `Bob` from their respective TDK environments.
+async fn setup_env(args: &Args) -> Result<(Vec<TDK>, Party, Party), ATMError> {
     let alice_tdk = TDK::new(
         TDKConfig::builder()
             .with_environment_name(args.alice_environment.clone())
@@ -77,31 +269,8 @@ async fn main() -> Result<(), ATMError> {
         None,
     )
     .await?;
+    let alice = load_env_party(&alice_tdk, "Alice", Side::Left, &args.alice_environment).await?;
 
-    let _shared = alice_tdk.get_shared_state();
-    let alice_env = _shared.environment();
-    let alice_atm = alice_tdk.atm.clone().unwrap();
-
-    let tdk_alice = alice_env.profiles().get("Alice").ok_or_else(|| {
-        ATMError::ConfigError(format!(
-            "Alice profile not found in environment: {}",
-            args.alice_environment
-        ))
-    })?;
-
-    alice_tdk.add_profile(tdk_alice).await;
-    let atm_alice = alice_atm
-        .profile_add(
-            &ATMProfile::from_tdk_profile(&alice_atm, tdk_alice).await?,
-            true,
-        )
-        .await?;
-
-    let alice_mediator_did = tdk_alice.mediator.clone().unwrap_or_default();
-    println!("Alice DID: {}", atm_alice.inner.did);
-    println!("Alice mediator: {alice_mediator_did}");
-
-    // --- Setup Bob's TDK and mediator ---
     let bob_tdk = TDK::new(
         TDKConfig::builder()
             .with_environment_name(args.bob_environment.clone())
@@ -109,375 +278,562 @@ async fn main() -> Result<(), ATMError> {
         None,
     )
     .await?;
+    let bob = load_env_party(&bob_tdk, "Bob", Side::Right, &args.bob_environment).await?;
 
-    let _shared = bob_tdk.get_shared_state();
-    let bob_env = _shared.environment();
-    let bob_atm = bob_tdk.atm.clone().unwrap();
+    Ok((vec![alice_tdk, bob_tdk], alice, bob))
+}
 
-    let tdk_bob = bob_env.profiles().get("Bob").ok_or_else(|| {
+async fn load_env_party(
+    tdk: &TDK,
+    profile_name: &'static str,
+    side: Side,
+    env_name: &str,
+) -> Result<Party, ATMError> {
+    let atm = tdk.atm.clone().expect("ATM should be enabled");
+    let shared = tdk.get_shared_state();
+    let environment = shared.environment();
+
+    let tdk_profile = environment.profiles().get(profile_name).ok_or_else(|| {
         ATMError::ConfigError(format!(
-            "Bob profile not found in environment: {}",
-            args.bob_environment
+            "{profile_name} profile not found in environment: {env_name}"
         ))
     })?;
 
-    bob_tdk.add_profile(tdk_bob).await;
-    let atm_bob = bob_atm
+    tdk.add_profile(tdk_profile).await;
+    let mediator_did = tdk_profile.mediator.clone().unwrap_or_default();
+    let profile = atm
         .profile_add(
-            &ATMProfile::from_tdk_profile(&bob_atm, tdk_bob).await?,
+            &ATMProfile::from_tdk_profile(&atm, tdk_profile).await?,
             true,
         )
         .await?;
 
-    let bob_mediator_did = tdk_bob.mediator.clone().unwrap_or_default();
-    println!("Bob DID: {}", atm_bob.inner.did);
-    println!("Bob mediator: {bob_mediator_did}");
-    println!();
+    Ok(Party {
+        label: profile_name,
+        side,
+        did: profile.inner.did.clone(),
+        mediator_did,
+        atm,
+        profile,
+    })
+}
 
-    if alice_mediator_did == bob_mediator_did {
-        println!("WARNING: Alice and Bob are using the same mediator.");
-        println!("For cross-mediator forwarding, configure different mediators.");
-        println!();
-    }
+/// Make sure both DIDs have an account on their mediator and are allowed to
+/// message each other (resets any stale ACL state from previous runs).
+async fn setup_acls(alice: &Party, bob: &Party) -> Result<(), ATMError> {
+    let (alice_hash, alice_acls) = ensure_account(alice).await?;
+    let (bob_hash, bob_acls) = ensure_account(bob).await?;
 
-    // --- Setup ACLs ---
-    // Ensure Alice and Bob can communicate with each other
-    setup_acls(&alice_atm, &atm_alice, &atm_bob, &bob_atm).await?;
+    apply_access(alice, alice_acls, &bob_hash).await?;
+    apply_access(bob, bob_acls, &alice_hash).await?;
 
-    // --- Send message: Alice -> Bob ---
-    println!("=== Alice -> Bob (through two mediators) ===");
-    let alice_send_start = Instant::now();
-
-    let msg_text = "Hello Bob! This message is routed through two mediators.";
-    let msg_id = send_message(
-        &alice_atm,
-        &atm_alice,
-        &alice_mediator_did,
-        &atm_bob,
-        &bob_mediator_did,
-        msg_text,
-    )
-    .await?;
-
-    println!(
-        "  Alice sent message (id: {}) in {}ms",
-        msg_id,
-        alice_send_start.elapsed().as_millis()
-    );
-
-    // Bob receives
-    let bob_receive_start = Instant::now();
-    match bob_atm
-        .message_pickup()
-        .live_stream_get(&atm_bob, &msg_id, Duration::from_secs(15), true)
-        .await?
-    {
-        Some(received) => {
-            let receive_time = bob_receive_start.elapsed();
-            let total_time = alice_send_start.elapsed();
-            println!(
-                "  Bob received message in {}ms (total: {}ms)",
-                receive_time.as_millis(),
-                total_time.as_millis()
-            );
-            println!("  Message body: {:?}", received.0.body);
-        }
-        None => {
-            println!("  ERROR: Bob did not receive the message within timeout");
-            return Ok(());
-        }
-    }
-    println!();
-
-    // --- Send response: Bob -> Alice ---
-    println!("=== Bob -> Alice (return path through two mediators) ===");
-    let bob_send_start = Instant::now();
-
-    let response_text = "Hi Alice! Got your message. Routing works both ways!";
-    let response_id = send_message(
-        &bob_atm,
-        &atm_bob,
-        &bob_mediator_did,
-        &atm_alice,
-        &alice_mediator_did,
-        response_text,
-    )
-    .await?;
-
-    println!(
-        "  Bob sent response (id: {}) in {}ms",
-        response_id,
-        bob_send_start.elapsed().as_millis()
-    );
-
-    // Alice receives
-    let alice_receive_start = Instant::now();
-    match alice_atm
-        .message_pickup()
-        .live_stream_get(&atm_alice, &response_id, Duration::from_secs(15), true)
-        .await?
-    {
-        Some(received) => {
-            let receive_time = alice_receive_start.elapsed();
-            let total_time = bob_send_start.elapsed();
-            println!(
-                "  Alice received response in {}ms (total: {}ms)",
-                receive_time.as_millis(),
-                total_time.as_millis()
-            );
-            println!("  Message body: {:?}", received.0.body);
-        }
-        None => {
-            println!("  ERROR: Alice did not receive the response within timeout");
-            return Ok(());
-        }
-    }
-    println!();
-
-    // --- Ping-Pong Mode ---
-    if args.ping_pong {
-        println!("=== Ping-Pong Latency Measurement ===");
-        println!(
-            "Rounds: {} (0 = infinite, max 1 msg/sec)",
-            if args.rounds == 0 {
-                "infinite".to_string()
-            } else {
-                args.rounds.to_string()
-            }
-        );
-        println!();
-
-        let mut round = 0u32;
-        let mut total_rtt_ms = 0u128;
-
-        loop {
-            round += 1;
-            if args.rounds > 0 && round > args.rounds {
-                break;
-            }
-
-            let rtt_start = Instant::now();
-
-            // Alice -> Bob ping
-            let ping_msg = format!("Ping #{round}");
-            let ping_id = send_message(
-                &alice_atm,
-                &atm_alice,
-                &alice_mediator_did,
-                &atm_bob,
-                &bob_mediator_did,
-                &ping_msg,
-            )
-            .await?;
-
-            match bob_atm
-                .message_pickup()
-                .live_stream_get(&atm_bob, &ping_id, Duration::from_secs(15), true)
-                .await?
-            {
-                Some(_) => {}
-                None => {
-                    println!("  Round {round}: TIMEOUT waiting for ping");
-                    continue;
-                }
-            }
-
-            // Bob -> Alice pong
-            let pong_msg = format!("Pong #{round}");
-            let pong_id = send_message(
-                &bob_atm,
-                &atm_bob,
-                &bob_mediator_did,
-                &atm_alice,
-                &alice_mediator_did,
-                &pong_msg,
-            )
-            .await?;
-
-            match alice_atm
-                .message_pickup()
-                .live_stream_get(&atm_alice, &pong_id, Duration::from_secs(15), true)
-                .await?
-            {
-                Some(_) => {
-                    let rtt = rtt_start.elapsed();
-                    total_rtt_ms += rtt.as_millis();
-                    let avg_rtt = total_rtt_ms / round as u128;
-                    println!(
-                        "  Round {round}: RTT = {}ms (avg: {}ms)",
-                        rtt.as_millis(),
-                        avg_rtt
-                    );
-                }
-                None => {
-                    println!("  Round {round}: TIMEOUT waiting for pong");
-                    continue;
-                }
-            }
-
-            // Rate limit: max 1 message per second
-            let elapsed = rtt_start.elapsed();
-            if elapsed < Duration::from_secs(1) {
-                tokio::time::sleep(Duration::from_secs(1) - elapsed).await;
-            }
-        }
-
-        if round > 1 {
-            let completed = if args.rounds > 0 {
-                round.min(args.rounds)
-            } else {
-                round - 1
-            };
-            println!();
-            println!(
-                "Ping-Pong complete: {} rounds, avg RTT: {}ms",
-                completed,
-                total_rtt_ms / completed as u128
-            );
-        }
-    }
-
-    println!();
-    println!("=== Example complete ===");
+    info!("ACLs configured for cross-mediator communication");
     Ok(())
 }
 
-/// Send a message from sender to recipient, routing through both mediators when they differ.
-///
-/// When sender and recipient use different mediators, two forward layers are required:
-///   outer (encrypted for sender_mediator, next=recipient_mediator) wraps
-///   inner (encrypted for recipient_mediator, next=recipient).
-/// This ensures each mediator only decrypts its own layer.
-async fn send_message(
-    sender_atm: &affinidi_messaging_sdk::ATM,
-    sender_profile: &std::sync::Arc<ATMProfile>,
-    sender_mediator_did: &str,
-    recipient_profile: &std::sync::Arc<ATMProfile>,
-    recipient_mediator_did: &str,
-    body_text: &str,
-) -> Result<String, ATMError> {
-    let now = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+/// Fetch the party's mediator account (creating it if the mediator allows
+/// self-registration). Returns (did_hash, acls).
+async fn ensure_account(party: &Party) -> Result<(String, u64), ATMError> {
+    match party
+        .atm
+        .mediator()
+        .account_get(&party.profile, None)
+        .await?
+    {
+        Some(account) => Ok((account.did_hash, account.acls)),
+        None => {
+            let hash = sha256::digest(party.profile.inner.did.as_str());
+            let account = party
+                .atm
+                .mediator()
+                .account_add(&party.profile, &hash, None)
+                .await?;
+            Ok((account.did_hash, account.acls))
+        }
+    }
+}
 
+/// Allow `peer_hash` to reach `party` regardless of the mediator's ACL mode.
+async fn apply_access(party: &Party, acls: u64, peer_hash: &str) -> Result<(), ATMError> {
+    let mode = MediatorACLSet::from_u64(acls).get_access_list_mode().0;
+    if let AccessListModeType::ExplicitAllow = mode {
+        party
+            .atm
+            .mediator()
+            .access_list_add(&party.profile, None, &[peer_hash])
+            .await?;
+    } else {
+        party
+            .atm
+            .mediator()
+            .access_list_remove(&party.profile, None, &[peer_hash])
+            .await?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Delivery (the core: wrap -> forward -> forward -> send -> unwrap)
+// ---------------------------------------------------------------------------
+
+/// Send `text` from `sender` to `recipient`, routing through both mediators when
+/// they differ, then wait for the recipient to receive and unwrap it.
+///
+/// When sender and recipient use different mediators, two forward layers are
+/// required: the OUTER forward (encrypted for the sender's mediator,
+/// next = recipient's mediator) wraps the INNER forward (encrypted for the
+/// recipient's mediator, next = recipient). Each mediator only ever decrypts
+/// its own layer.
+///
+/// When `verbose` is true, every step is rendered to the side-by-side timeline.
+/// Returns `Ok(true)` if delivered, `Ok(false)` on receive timeout.
+async fn deliver(
+    tl: &mut Timeline,
+    sender: &Party,
+    recipient: &Party,
+    text: &str,
+    verbose: bool,
+) -> Result<bool, ATMError> {
+    let now = unix_secs();
+
+    // 1. Compose the plaintext message.
     let msg = Message::build(
         Uuid::new_v4().to_string(),
-        "cross-mediator-test".to_string(),
-        json!(body_text),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
     )
-    .to(recipient_profile.inner.did.clone())
-    .from(sender_profile.inner.did.clone())
+    .to(recipient.profile.inner.did.clone())
+    .from(sender.profile.inner.did.clone())
     .created_time(now)
     .expires_time(now + 60)
     .finalize();
-
     let msg_id = msg.id.clone();
 
-    // Pack for recipient
-    let packed_msg = sender_atm
+    if verbose {
+        tl.event(
+            sender.side,
+            &format!("{}: compose plaintext", sender.label),
+            &[
+                "type  basicmessage/2.0/message".to_string(),
+                format!("to    {}", short(&recipient.profile.inner.did)),
+                format!("body  \"{text}\""),
+            ],
+        );
+    }
+
+    // 2. Authcrypt (encrypt + sign) for the recipient.
+    let packed = sender
+        .atm
         .pack_encrypted(
             &msg,
-            &recipient_profile.inner.did,
-            Some(&sender_profile.inner.did),
-            Some(&sender_profile.inner.did),
+            &recipient.profile.inner.did,
+            Some(&sender.profile.inner.did),
+            Some(&sender.profile.inner.did),
         )
         .await?;
 
-    // Inner forward: encrypted for recipient's mediator, next=recipient
-    let (_inner_id, inner_fwd) = sender_atm
+    if verbose {
+        let w = summarize(&packed.0);
+        tl.event(
+            sender.side,
+            &format!("{}: authcrypt for {}", sender.label, recipient.label),
+            &[
+                format!("alg   {}", w.alg),
+                format!("enc   {}", w.enc),
+                format!("recip {}", w.recipients.join(", ")),
+                format!("size  {} bytes", w.size),
+            ],
+        );
+    }
+
+    // 3. INNER forward: encrypted for the recipient's mediator, next = recipient.
+    let (_inner_id, inner_fwd) = sender
+        .atm
         .routing()
         .forward_message(
-            sender_profile,
+            &sender.profile,
             false,
-            &packed_msg.0,
-            recipient_mediator_did,
-            &recipient_profile.inner.did,
+            &packed.0,
+            &recipient.mediator_did,
+            &recipient.profile.inner.did,
             None,
             None,
         )
         .await?;
 
-    // Outer forward (cross-mediator only): encrypted for sender's mediator,
-    // next=recipient_mediator so the sender's mediator relays inner_fwd onward.
-    let forward_msg = if sender_mediator_did != recipient_mediator_did {
-        let (_outer_id, outer_fwd) = sender_atm
+    if verbose {
+        let w = summarize(&inner_fwd);
+        tl.event(
+            sender.side,
+            &format!("{}: wrap INNER forward", sender.label),
+            &[
+                format!(
+                    "to    {}  (recipient mediator)",
+                    short(&recipient.mediator_did)
+                ),
+                format!("next  {}  (recipient)", short(&recipient.profile.inner.did)),
+                format!("size  {} bytes", w.size),
+            ],
+        );
+    }
+
+    // 4. OUTER forward (cross-mediator only): encrypted for the sender's
+    //    mediator, next = recipient's mediator so it relays the inner forward.
+    let forward_msg = if sender.mediator_did != recipient.mediator_did {
+        let (_outer_id, outer_fwd) = sender
+            .atm
             .routing()
             .forward_message(
-                sender_profile,
+                &sender.profile,
                 false,
                 &inner_fwd,
-                sender_mediator_did,
-                recipient_mediator_did,
+                &sender.mediator_did,
+                &recipient.mediator_did,
                 None,
                 None,
             )
             .await?;
+
+        if verbose {
+            let w = summarize(&outer_fwd);
+            tl.event(
+                sender.side,
+                &format!("{}: wrap OUTER forward", sender.label),
+                &[
+                    format!("to    {}  (own mediator)", short(&sender.mediator_did)),
+                    format!(
+                        "next  {}  (recipient mediator)",
+                        short(&recipient.mediator_did)
+                    ),
+                    format!("size  {} bytes", w.size),
+                ],
+            );
+        }
         outer_fwd
     } else {
         inner_fwd
     };
 
-    // Send via sender's mediator
-    sender_atm
-        .send_message(sender_profile, &forward_msg, &msg_id, false, false)
+    // 5. Send to the sender's own mediator.
+    sender
+        .atm
+        .send_message(&sender.profile, &forward_msg, &msg_id, false, false)
         .await?;
 
-    Ok(msg_id)
+    if verbose {
+        tl.event(
+            sender.side,
+            &format!("{}: send to own mediator", sender.label),
+            &[short(&sender.mediator_did)],
+        );
+        tl.wire(sender, recipient);
+    }
+
+    // 6. Recipient receives and unwraps via the live stream.
+    match recipient
+        .atm
+        .message_pickup()
+        .live_stream_get(&recipient.profile, &msg_id, Duration::from_secs(15), true)
+        .await?
+    {
+        Some((received, meta)) => {
+            if verbose {
+                let body = received
+                    .body
+                    .get("content")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or("<no content>");
+                tl.event(
+                    recipient.side,
+                    &format!("{}: unwrap + decrypt", recipient.label),
+                    &[
+                        format!(
+                            "from  {}",
+                            meta.encrypted_from_kid
+                                .as_deref()
+                                .map(short)
+                                .unwrap_or_else(|| "<anonymous>".to_string())
+                        ),
+                        format!(
+                            "encrypted={}  authenticated={}",
+                            meta.encrypted, meta.authenticated
+                        ),
+                        format!("re_wrapped_in_forward={}", meta.re_wrapped_in_forward),
+                        format!("body  \"{body}\""),
+                    ],
+                );
+            }
+            Ok(true)
+        }
+        None => {
+            if verbose {
+                tl.event(
+                    recipient.side,
+                    &format!("{}: TIMEOUT (no message)", recipient.label),
+                    &[],
+                );
+            }
+            Ok(false)
+        }
+    }
 }
 
-/// Setup ACLs to allow Alice and Bob to communicate
-async fn setup_acls(
-    alice_atm: &affinidi_messaging_sdk::ATM,
-    atm_alice: &std::sync::Arc<ATMProfile>,
-    atm_bob: &std::sync::Arc<ATMProfile>,
-    bob_atm: &affinidi_messaging_sdk::ATM,
+// ---------------------------------------------------------------------------
+// Ping-pong latency mode
+// ---------------------------------------------------------------------------
+
+async fn ping_pong(
+    tl: &mut Timeline,
+    alice: &Party,
+    bob: &Party,
+    rounds: u32,
 ) -> Result<(), ATMError> {
-    // Get account info
-    let alice_info = alice_atm
-        .mediator()
-        .account_get(atm_alice, None)
-        .await?
-        .expect("Alice account not found");
+    println!("\n========================= Ping-Pong Latency =========================");
+    println!(
+        "Rounds: {} (max 1 msg/sec)\n",
+        if rounds == 0 {
+            "infinite".to_string()
+        } else {
+            rounds.to_string()
+        }
+    );
 
-    let bob_info = bob_atm
-        .mediator()
-        .account_get(atm_bob, None)
-        .await?
-        .expect("Bob account not found");
+    let mut round = 0u32;
+    let mut total_rtt_ms = 0u128;
+    let mut completed = 0u32;
 
-    // Reset Alice ACLs
-    let alice_acl_mode = MediatorACLSet::from_u64(alice_info.acls)
-        .get_access_list_mode()
-        .0;
-    if let AccessListModeType::ExplicitAllow = alice_acl_mode {
-        alice_atm
-            .mediator()
-            .access_list_add(atm_alice, None, &[&bob_info.did_hash])
-            .await?;
-    } else {
-        alice_atm
-            .mediator()
-            .access_list_remove(atm_alice, None, &[&bob_info.did_hash])
-            .await?;
+    loop {
+        round += 1;
+        if rounds > 0 && round > rounds {
+            break;
+        }
+
+        let rtt_start = Instant::now();
+
+        if !deliver(tl, alice, bob, &format!("Ping #{round}"), false).await? {
+            println!("  Round {round}: TIMEOUT waiting for ping");
+            continue;
+        }
+        if !deliver(tl, bob, alice, &format!("Pong #{round}"), false).await? {
+            println!("  Round {round}: TIMEOUT waiting for pong");
+            continue;
+        }
+
+        let rtt = rtt_start.elapsed();
+        total_rtt_ms += rtt.as_millis();
+        completed += 1;
+        println!(
+            "  Round {round}: RTT = {}ms (avg: {}ms)",
+            rtt.as_millis(),
+            total_rtt_ms / completed as u128
+        );
+
+        // Rate limit: max 1 round per second.
+        let elapsed = rtt_start.elapsed();
+        if elapsed < Duration::from_secs(1) {
+            tokio::time::sleep(Duration::from_secs(1) - elapsed).await;
+        }
     }
 
-    // Reset Bob ACLs
-    let bob_acl_mode = MediatorACLSet::from_u64(bob_info.acls)
-        .get_access_list_mode()
-        .0;
-    if let AccessListModeType::ExplicitAllow = bob_acl_mode {
-        bob_atm
-            .mediator()
-            .access_list_add(atm_bob, None, &[&alice_info.did_hash])
-            .await?;
-    } else {
-        bob_atm
-            .mediator()
-            .access_list_remove(atm_bob, None, &[&alice_info.did_hash])
-            .await?;
+    if completed > 0 {
+        println!(
+            "\nPing-Pong complete: {} rounds, avg RTT: {}ms",
+            completed,
+            total_rtt_ms / completed as u128
+        );
     }
-
-    info!("ACLs configured for cross-mediator communication");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Visual timeline rendering
+// ---------------------------------------------------------------------------
+
+/// Column width for each side of the side-by-side layout.
+const COL_W: usize = 56;
+
+/// Tracks wall-clock + monotonic time and renders timestamped events into the
+/// Alice (left) / Bob (right) columns.
+struct Timeline {
+    start_inst: Instant,
+    start_sys: SystemTime,
+    last: Instant,
+}
+
+impl Timeline {
+    fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            start_inst: now,
+            start_sys: SystemTime::now(),
+            last: now,
+        }
+    }
+
+    /// Returns (absolute HH:MM:SS.mmm UTC, delta-ms-since-last, total-ms-since-start).
+    fn stamp(&mut self) -> (String, u128, u128) {
+        let now = Instant::now();
+        let delta = now.duration_since(self.last).as_millis();
+        let total = now.duration_since(self.start_inst).as_millis();
+        self.last = now;
+
+        let wall = self.start_sys + now.duration_since(self.start_inst);
+        let since_epoch = wall.duration_since(UNIX_EPOCH).unwrap_or_default();
+        let ms = since_epoch.as_millis() % 1000;
+        let secs = since_epoch.as_secs();
+        let abs = format!(
+            "{:02}:{:02}:{:02}.{:03}",
+            (secs / 3600) % 24,
+            (secs / 60) % 60,
+            secs % 60,
+            ms
+        );
+        (abs, delta, total)
+    }
+
+    fn timestamp_line(&mut self) {
+        let (abs, delta, total) = self.stamp();
+        println!("  {abs} UTC   Δ +{delta:>5} ms   T +{total:>6} ms");
+    }
+
+    /// Render an event (a title plus detail lines) into the appropriate column.
+    fn event(&mut self, side: Side, title: &str, lines: &[String]) {
+        self.timestamp_line();
+        let mut rows = vec![format!("> {title}")];
+        rows.extend(lines.iter().map(|l| format!("    {l}")));
+        for row in rows {
+            match side {
+                Side::Left => println!("{:<width$} |", clip(&row, COL_W), width = COL_W),
+                Side::Right => println!("{:<width$} | {}", "", clip(&row, COL_W), width = COL_W),
+            }
+        }
+        println!();
+    }
+
+    /// Render the wire hop between the two mediators, oriented by sender side.
+    fn wire(&mut self, sender: &Party, recipient: &Party) {
+        self.timestamp_line();
+        let line = if sender.side == Side::Left {
+            format!(
+                "[{}] --> [{}] --> {}",
+                short(&sender.mediator_did),
+                short(&recipient.mediator_did),
+                recipient.label
+            )
+        } else {
+            format!(
+                "{} <-- [{}] <-- [{}]",
+                recipient.label,
+                short(&recipient.mediator_did),
+                short(&sender.mediator_did)
+            )
+        };
+        println!(
+            "{:^width$}",
+            "~~ forward relayed over the wire ~~",
+            width = COL_W * 2 + 3
+        );
+        println!("{:^width$}", line, width = COL_W * 2 + 3);
+        println!();
+    }
+}
+
+fn print_header(alice: &Party, bob: &Party) {
+    println!();
+    println!("{:<width$} | BOB  (right)", "ALICE  (left)", width = COL_W);
+    println!(
+        "{:<width$} | {}",
+        clip(&format!("did:      {}", short(&alice.did)), COL_W),
+        clip(&format!("did:      {}", short(&bob.did)), COL_W),
+        width = COL_W
+    );
+    println!(
+        "{:<width$} | {}",
+        clip(&format!("mediator: {}", short(&alice.mediator_did)), COL_W),
+        clip(&format!("mediator: {}", short(&bob.mediator_did)), COL_W),
+        width = COL_W
+    );
+    println!("{}-+-{}", "-".repeat(COL_W), "-".repeat(COL_W));
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/// A parsed summary of a packed DIDComm JWE (general-JSON serialization), used
+/// to make each wrapping step legible.
+struct WrapInfo {
+    size: usize,
+    alg: String,
+    enc: String,
+    recipients: Vec<String>,
+}
+
+fn summarize(packed: &str) -> WrapInfo {
+    let size = packed.len();
+    let mut info = WrapInfo {
+        size,
+        alg: "?".to_string(),
+        enc: "?".to_string(),
+        recipients: Vec::new(),
+    };
+
+    let Ok(jwe) = serde_json::from_str::<Value>(packed) else {
+        return info; // compact form or non-JSON: size is still useful.
+    };
+
+    if let Some(protected_b64) = jwe.get("protected").and_then(|p| p.as_str())
+        && let Ok(bytes) = URL_SAFE_NO_PAD.decode(protected_b64)
+        && let Ok(header) = serde_json::from_slice::<Value>(&bytes)
+    {
+        if let Some(alg) = header.get("alg").and_then(|v| v.as_str()) {
+            info.alg = alg.to_string();
+        }
+        if let Some(enc) = header.get("enc").and_then(|v| v.as_str()) {
+            info.enc = enc.to_string();
+        }
+    }
+
+    if let Some(recipients) = jwe.get("recipients").and_then(|r| r.as_array()) {
+        info.recipients = recipients
+            .iter()
+            .filter_map(|r| {
+                r.get("header")
+                    .and_then(|h| h.get("kid"))
+                    .and_then(|k| k.as_str())
+                    .map(short)
+            })
+            .collect();
+    }
+
+    info
+}
+
+/// Abbreviate a long DID / key id for display.
+fn short(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= 24 {
+        return s.to_string();
+    }
+    let head: String = chars[..16].iter().collect();
+    let tail: String = chars[chars.len() - 6..].iter().collect();
+    format!("{head}...{tail}")
+}
+
+/// Truncate a string to `width` chars (so column padding stays aligned).
+fn clip(s: &str, width: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= width {
+        return s.to_string();
+    }
+    let mut out: String = chars[..width - 1].iter().collect();
+    out.push('~');
+    out
+}
+
+fn unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -9,7 +9,7 @@ pub use limits::*;
 pub use processors::*;
 pub use security::*;
 
-use affinidi_did_common::Document;
+use affinidi_did_common::{Document, DocumentExt};
 use affinidi_did_resolver_cache_sdk::{
     DIDCacheClient,
     config::{DIDCacheConfig, DIDCacheConfigBuilder},
@@ -20,7 +20,7 @@ use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     secrets::open_store,
 };
-use affinidi_secrets_resolver::ThreadedSecretsResolver;
+use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver};
 use async_convert::{TryFrom, async_trait};
 #[cfg(feature = "aws")]
 use aws_config::{self, BehaviorVersion, Region};
@@ -865,6 +865,57 @@ impl TryFrom<ConfigRaw> for Config {
         // Get Subscriber unique hostname
         if config.streaming_enabled {
             config.streaming_uuid = get_hostname(&raw.streaming.uuid)?;
+        }
+
+        // ── Guard: operating secrets must be able to decrypt our own traffic ──
+        //
+        // A peer encrypts inbound DIDComm to the keyAgreement verification-method
+        // id(s) published in *our* DID document, and the unpack path does an
+        // exact-match lookup of that kid against the loaded operating secrets
+        // (`didcomm_compat::unpack_jwe`). If no loaded secret carries a matching
+        // id, every inbound message fails at runtime with "No local secret
+        // matches any JWE recipient" — including the /authenticate handshake — so
+        // the mediator boots cleanly but can never read a single message.
+        //
+        // A common cause is a VTA context whose key *labels* don't equal the
+        // DID-document VM ids: `fetch_did_secrets_bundle` uses each key's label as
+        // its kid, so a context labelled `did:key:…`/free-text yields a bundle
+        // keyed by the wrong ids instead of `…#key-N`. Surface that at boot with
+        // an actionable error rather than as a silent per-request outage.
+        if let Some(mediator_doc) = did_document.as_ref() {
+            let ka_kids: Vec<String> = mediator_doc
+                .find_key_agreement(None)
+                .into_iter()
+                .map(str::to_string)
+                .collect();
+            if !ka_kids.is_empty() {
+                let matched = config
+                    .security
+                    .mediator_secrets
+                    .find_secrets(&ka_kids)
+                    .await;
+                if matched.is_empty() {
+                    let loaded = config.security.mediator_secrets.len().await;
+                    error!(
+                        "Operating secrets do not cover any published keyAgreement key. \
+                         Loaded {loaded} secret(s); DID document keyAgreement id(s): {ka_kids:?}"
+                    );
+                    return Err(MediatorError::ConfigError(
+                        12,
+                        "NA".into(),
+                        format!(
+                            "Mediator cannot decrypt inbound DIDComm: {loaded} operating secret(s) \
+                             loaded, but none match this mediator's published keyAgreement key(s) \
+                             {ka_kids:?}. Every inbound message (including /authenticate) would fail \
+                             with \"No local secret matches any JWE recipient\". If this mediator is \
+                             VTA-managed, ensure the VTA context's key labels exactly equal the DID \
+                             document verification-method ids and re-provision; for self-hosted setups \
+                             re-run mediator-setup so the operating secrets match the published DID \
+                             document."
+                        ),
+                    ));
+                }
+            }
         }
 
         // Fill out the forwarding protection for DIDs and associated service endpoints

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -1183,7 +1183,7 @@ async fn mint_did_material(
     Option<String>,
     Option<String>,
 )> {
-    Ok(match config.did_method.as_str() {
+    let (did, secrets, did_log, authorization_vc) = match config.did_method.as_str() {
         DID_PEER => {
             let service_uri = did_peer_service_url(&config.public_url, &config.api_prefix);
             let (did, secrets) = generators::did_peer::generate_did_peer(service_uri)?;
@@ -1286,7 +1286,57 @@ async fn mint_did_material(
             );
             ("PLACEHOLDER_DID".into(), vec![], None, None)
         }
-    })
+    };
+
+    // Provision-time guard — reject any keyset that the mediator could not use
+    // to decrypt its own inbound traffic before it ever reaches disk / the VTA.
+    let admin_did = vta_session.map(|s| s.admin_did().to_string());
+    validate_operating_secrets(&did, &secrets, admin_did.as_deref())?;
+
+    Ok((did, secrets, did_log, authorization_vc))
+}
+
+/// Provision-time invariant: every operating secret must be a verification
+/// method of the mediator's own DID (`{did}#…`), and the admin credential key
+/// must never be provisioned as an operating secret.
+///
+/// The runtime registers each operating secret under its id, and a peer
+/// encrypts inbound DIDComm to the keyAgreement verification-method id
+/// published in the mediator's DID document. If the ids diverge the mediator
+/// boots cleanly but fails to decrypt *every* inbound message ("No local secret
+/// matches any JWE recipient"). The classic cause is a VTA context whose key
+/// *labels* are `did:key:…`/free-text instead of the DID document's `#key-N`
+/// ids — `fetch_did_secrets_bundle` uses the label as the kid — so catch it
+/// here rather than as a silent per-request runtime outage.
+fn validate_operating_secrets(
+    did: &str,
+    secrets: &[affinidi_secrets_resolver::secrets::Secret],
+    admin_did: Option<&str>,
+) -> anyhow::Result<()> {
+    let vm_prefix = format!("{did}#");
+    for secret in secrets {
+        if let Some(admin) = admin_did
+            && secret.id.starts_with(admin)
+        {
+            anyhow::bail!(
+                "The admin DID key `{admin}` was returned as an operating secret. The admin \
+                 credential must not double as a mediator operating key — re-provision the VTA \
+                 context so operating secrets contain only the mediator DID's keys."
+            );
+        }
+        if !secret.id.starts_with(&vm_prefix) {
+            anyhow::bail!(
+                "Operating secret id `{}` is not a verification method of the mediator DID \
+                 `{did}` (expected `{did}#…`). The mediator would publish its keyAgreement key \
+                 under `{did}#…` but hold the secret under a different id, so every inbound \
+                 message would fail to decrypt. If this DID is VTA-managed, set the VTA \
+                 context's key labels to the DID document verification-method ids and \
+                 re-provision.",
+                secret.id
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Phase 2 — open the unified secret backend, probe it, push every
@@ -2161,6 +2211,61 @@ fn print_final_summary(config: &app::WizardConfig) {
     );
 
     println!();
+}
+
+#[cfg(test)]
+mod operating_secrets_guard_tests {
+    use super::validate_operating_secrets;
+    use affinidi_secrets_resolver::secrets::Secret;
+
+    const MED: &str =
+        "did:webvh:QmQjq4GHRH9fwSXCg4884kxpCMT5EUqHB9XY2U7aXisP8R:webvh.storm.ws:mediator-2";
+
+    fn secret_with_id(id: &str) -> Secret {
+        let mut s = Secret::generate_ed25519(None, None);
+        s.id = id.to_string();
+        s
+    }
+
+    #[test]
+    fn accepts_secrets_keyed_by_mediator_vm_ids() {
+        let secrets = vec![
+            secret_with_id(&format!("{MED}#key-0")),
+            secret_with_id(&format!("{MED}#key-1")),
+        ];
+        assert!(validate_operating_secrets(MED, &secrets, None).is_ok());
+    }
+
+    #[test]
+    fn empty_secrets_is_ok() {
+        assert!(validate_operating_secrets(MED, &[], None).is_ok());
+    }
+
+    #[test]
+    fn rejects_did_key_labelled_secret() {
+        // The exact shape that broke a live mediator: a VTA context whose key
+        // labels are `did:key:` + free text instead of the DID document's
+        // `#key-N` verification-method ids.
+        let secrets = vec![secret_with_id(
+            "did:key:z6Mkr4JCdsEVcQvYKxcyjf39tPmVriDfg3gALvqv4GQHc5BH key-agreement key",
+        )];
+        let err = validate_operating_secrets(MED, &secrets, None).unwrap_err();
+        assert!(
+            err.to_string().contains("not a verification method"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_admin_key_as_operating_secret() {
+        let admin = "did:key:z6Mkt6eNM38RhFfjSdmXBtT1SRL7sPgPZD1MkXZbwjYBhTLf";
+        let secrets = vec![secret_with_id(&format!(
+            "{admin}#{}",
+            &admin["did:key:".len()..]
+        ))];
+        let err = validate_operating_secrets(MED, &secrets, Some(admin)).unwrap_err();
+        assert!(err.to_string().contains("admin"), "unexpected error: {err}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two related changes, in two commits:

1. **`fix:` operating-secret/DID-document key-mismatch guards.** A VTA context whose key *labels* are `did:key:…`/free-text instead of the DID document's `#key-N` verification-method ids yields an operating-secret bundle keyed by the wrong kid (`vta-sdk fetch_did_secrets_bundle` uses the label as the kid). The mediator boots cleanly but fails to decrypt **every** inbound message — including the `/authenticate` handshake — with `No local secret matches any JWE recipient`, because unpack does an exact-match lookup of the recipient kid (the published keyAgreement VM id) against loaded secret ids.

2. **`feat:` cross-mediator forwarding example** reworked to generate random `did:peer` identities at runtime (caller supplies only the two mediator DIDs) and render the exchange as a side-by-side, timestamped timeline.

## The guards

- **Boot-time (mediator):** after loading operating secrets, verify they cover the mediator's own DID-document keyAgreement VM id(s); refuse to boot with an actionable error (expected kids, loaded count, VTA-label cause) instead of failing silently per request.
- **Provision-time (mediator-setup):** `validate_operating_secrets` rejects any operating secret whose id is not a `{did}#…` VM of the mediator's own DID, and rejects the admin credential key as an operating secret. Unit-tested, including the exact `did:key:… key-agreement key` and admin-key shapes from a live failure.

> Note: these guards prevent the misconfiguration and surface it loudly. Repairing an already-broken VTA context (fixing its key labels / dropping the admin key) is a VTA-side action.

## The example

- **Random-DID mode (default):** fresh `did:peer` for Alice & Bob; `--mediator1`/`--mediator2` are the only required inputs.
- Side-by-side timeline (Alice left, Bob right): plaintext → authcrypt → inner forward → outer forward → wire hop → unwrap, each with absolute time, delta, and elapsed total.
- Retains the original `--alice-environment`/`--bob-environment` mode and `--ping-pong` loop. Routing core unchanged.

## Testing

- `cargo fmt --check` clean on the touched crates.
- `cargo clippy` clean (mediator, mediator-setup, helpers).
- `cargo test -p affinidi-messaging-mediator-setup` — 349 passed (4 new guard tests).
- Example builds; `--help` verified.

Fast pre-PR checks only (per request); `cargo deny` and the Redis-backed mediator integration tests were not run locally.