### PR TITLE
ci: revert release workflow to pipeline-rust@main (#367)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,12 +7,7 @@ on:
 
 jobs:
   rust-pipeline:
-    # TEMPORARY: pinned to the per-crate isolated-publish fix branch
-    # (affinidi/pipeline-rust#77) so the affinidi-crypto 0.2.0 release can
-    # publish each crate independently instead of failing on the full-workspace
-    # build (vta-sdk un-unification). Revert to `@main` once #77 merges.
-    # Tracking: affinidi/affinidi-tdk-rs#367
-    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@fix/per-crate-isolated-publish
+    uses: affinidi/pipeline-rust/.github/workflows/release.yaml@main
     secrets: inherit
     with:
       toolchain: "1.95.0"


### PR DESCRIPTION
## Summary

pipeline-rust#77 (per-crate isolated publish) has merged to `main`, so the temporary pin in `.github/workflows/release.yaml` to `@fix/per-crate-isolated-publish` is no longer needed.

- Revert the workflow `uses:` ref back to `@main`, matching the sibling `checks.yaml`
- Drop the temporary branch-pin comment block

This is the exact revert called for in #367.

## Notes

`workspace_publish: false` is left as-is. The current per-crate path already gives the skip-already-published behaviour we want for partial/security releases; flipping it would only affect all-crates-bump releases and warrants confirming #77's semantics first.

Closes #367