### PR TITLE
refactor: consolidate mediator self-DID resolver preload (#395)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ## 9th June 2026
 
+### 0.15.17 — Consolidate mediator self-DID resolver preload (#395)
+
+- Follow-up to #392, which preloaded the mediator's own DID document into the
+  request-time server resolver so `did:web`/`did:webvh` mediators can pack
+  DIDComm responses without resolving their own DID over HTTPS. That fix
+  re-deserialised `mediator_did_doc` at server startup and silently swallowed a
+  parse failure. This change:
+  - carries the typed `Document` parsed during config load on the new
+    `Config::mediator_did_document` field, so the server resolver preloads it
+    without a second deserialisation (the file-config path now parses the
+    document once, not twice);
+  - routes both the config-validation resolver and the request-time server
+    resolver through a single `preload_self_did` helper, establishing the
+    "the resolver knows its own DID" invariant in one place;
+  - logs a `warn!` instead of silently dropping a parse failure on the
+    builder-constructed fallback path (which only sets the JSON string form).
+  - Adds a regression test that `preload_self_did` leaves the DID resolvable
+    straight from cache. No behavioural change for did:peer mediators.
+
 ### 0.15.16 — vta-sdk 0.11 (canonical provision-integration Trust Task URI)
 
 - Bump `vta-sdk` `0.9.11` → `0.11`. The legacy

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.16"
+version = "0.15.17"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -11,7 +11,7 @@
 //!   `aws_parameter_store://`.
 //! - Hostname resolution and forwarding-loop protection.
 
-use affinidi_did_common::service::Endpoint;
+use affinidi_did_common::{Document, service::Endpoint};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 #[cfg(feature = "aws")]
@@ -552,6 +552,29 @@ pub fn join_api_path(prefix: &str, suffix: &str) -> String {
     }
 }
 
+/// Preload the mediator's own DID document into `resolver` so it can pack
+/// and unpack DIDComm messages addressed to or from itself without
+/// resolving its own DID over the network.
+///
+/// `did:web`/`did:webvh` self-resolution issues an HTTPS request to the
+/// mediator's own `/.well-known/did.json{,l}`, which is frequently not
+/// reachable from inside the mediator's own container or network. Seeding
+/// the cache with the document the mediator already holds sidesteps that.
+/// `did:peer` resolves locally and never reaches this path, so preloading
+/// it is a harmless no-op from the caller's perspective.
+///
+/// This is the single seam both the config-validation resolver and the
+/// request-time server resolver use, so the invariant "the resolver knows
+/// its own DID" is established in exactly one place.
+pub(crate) async fn preload_self_did(
+    resolver: &mut DIDCacheClient,
+    mediator_did: &str,
+    doc: &Document,
+) {
+    resolver.add_did_document(mediator_did, doc.clone()).await;
+    info!("Preloaded mediator DID into resolver cache: {mediator_did}");
+}
+
 /// Creates a set of URI's that can be used to detect if forwarding loopbacks to the mediator could occur
 pub(crate) async fn load_forwarding_protection_blocks(
     did_resolver: &DIDCacheClient,
@@ -692,5 +715,31 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `preload_self_did` must leave the mediator's own DID resolvable
+    /// straight from the cache — the whole point is that the request-time
+    /// resolver answers self-resolution without a network round-trip.
+    #[tokio::test]
+    async fn preload_self_did_makes_doc_resolvable_from_cache() {
+        use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+
+        const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+
+        let mut resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+
+        // Obtain a real Document, then evict it so the cache is cold.
+        let doc = resolver.resolve(DID_KEY).await.unwrap().doc;
+        resolver.remove(DID_KEY).await;
+
+        super::preload_self_did(&mut resolver, DID_KEY, &doc).await;
+
+        // The next resolve must be served from cache (no network), proving
+        // the preload seeded the document the server resolver will use.
+        let cached = resolver.resolve(DID_KEY).await.unwrap();
+        assert!(cached.cache_hit, "preloaded DID was not served from cache");
+        assert_eq!(cached.doc, doc);
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -44,8 +44,8 @@ use vta_sdk::integration::{
 };
 
 use helpers::{
-    get_hostname, load_forwarding_protection_blocks, read_config_file, read_did_config,
-    read_document,
+    get_hostname, load_forwarding_protection_blocks, preload_self_did, read_config_file,
+    read_did_config, read_document,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -169,6 +169,15 @@ pub struct Config {
     /// loader extracts `state` from the latter so both routes serve
     /// canonical-shape content.
     pub mediator_did_doc: Option<String>,
+    /// Typed copy of the mediator's own DID document, parsed once during
+    /// config load (`from_raw`). Carried so the request-time server
+    /// resolver can preload it via [`preload_self_did`] without
+    /// re-deserialising `mediator_did_doc`. `Some` whenever this mediator
+    /// self-hosts a document; `None` for builder-constructed configs,
+    /// which set only the string form (the server then parses that as a
+    /// fallback).
+    #[serde(skip)]
+    pub mediator_did_document: Option<Document>,
     /// Raw webvh log entry stream served at `/.well-known/did.jsonl`.
     /// `Some` only when the on-disk source parsed as a `LogEntry`
     /// (did:webvh self-host); `None` for the did:web shape, where the
@@ -277,6 +286,7 @@ impl Config {
             mediator_did: "".into(),
             mediator_did_hash: "".into(),
             mediator_did_doc: None,
+            mediator_did_document: None,
             mediator_did_log: None,
             admin_did: "".into(),
             local_endpoints: Vec::new(),
@@ -931,11 +941,14 @@ impl TryFrom<ConfigRaw> for Config {
                 )
             })?;
 
-        // Load the Local DID Document if self hosted
+        // Load the Local DID Document if self hosted. Preload it into this
+        // (config-validation) resolver so forwarding-loop detection can
+        // resolve our own DID, and stash the typed document on the config so
+        // the request-time server resolver can preload the same document
+        // without parsing it a second time.
         if let Some(mediator_doc) = did_document {
-            did_resolver
-                .add_did_document(&config.mediator_did, mediator_doc)
-                .await;
+            preload_self_did(&mut did_resolver, &config.mediator_did, &mediator_doc).await;
+            config.mediator_did_document = Some(mediator_doc);
         }
 
         load_forwarding_protection_blocks(

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -2,7 +2,11 @@ use crate::{
     SharedData,
     builder::{MediatorHandle, StartOpts, TlsMode, TracingMode},
     common::{
-        config::{Config, helpers::join_api_path, init},
+        config::{
+            Config,
+            helpers::{join_api_path, preload_self_did},
+            init,
+        },
         did_rate_limiter::DidRateLimiter,
         error_codes,
         metrics::{self, metrics_handler},
@@ -485,17 +489,20 @@ pub async fn serve_internal(
         })?;
 
     // Preload the mediator's own DID document so it can pack/unpack DIDComm
-    // messages without hitting the network (the did:web resolver requires HTTPS
-    // which may not be reachable from the mediator's own network).
-    if let Some(ref did_doc_json) = config.mediator_did_doc {
-        if let Ok(doc) = serde_json::from_str::<affinidi_did_common::Document>(did_doc_json) {
-            did_resolver
-                .add_did_document(&config.mediator_did, doc)
-                .await;
-            info!(
-                "Preloaded mediator DID into resolver cache: {}",
-                config.mediator_did
-            );
+    // messages without hitting the network (did:web/did:webvh self-resolution
+    // needs HTTPS, which may be unreachable from the mediator's own network).
+    // `from_raw` already parsed the document and handed us the typed form;
+    // builder-constructed configs set only the served JSON, so fall back to
+    // parsing that — logging, rather than silently dropping, a parse failure.
+    if let Some(ref doc) = config.mediator_did_document {
+        preload_self_did(&mut did_resolver, &config.mediator_did, doc).await;
+    } else if let Some(ref did_doc_json) = config.mediator_did_doc {
+        match serde_json::from_str::<affinidi_did_common::Document>(did_doc_json) {
+            Ok(doc) => preload_self_did(&mut did_resolver, &config.mediator_did, &doc).await,
+            Err(e) => warn!(
+                "Mediator DID document failed to parse for resolver preload; \
+                 self-resolution will fall back to the network: {e}"
+            ),
         }
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #392, which fixed `did:web`/`did:webvh` mediators failing to pack DIDComm responses by preloading the mediator's own DID document into the request-time server resolver. While reviewing that fix (see #395) three structural smells surfaced:

1. **Double parse** — the typed `Document` produced during config validation was dropped, so `server.rs` re-deserialised `mediator_did_doc` from its string form at startup.
2. **Two divergent preload paths** — the config-validation resolver and the request-time server resolver each preloaded the self-DID via separate inline code, with no shared seam guaranteeing the invariant.
3. **Silent swallow** — the server preload used `if let Ok(doc) = …`, silently degrading to (broken) network self-resolution with no log if the parse ever failed.

## Fix

- Carry the typed `Document` parsed during config load on a new `Config::mediator_did_document` field, so the server resolver preloads it **without a second deserialisation**. The file-config (`from_raw`) path now parses the document **once**, not twice.
- Route both resolvers through a single `preload_self_did` helper in `config::helpers`, establishing the *"the resolver knows its own DID"* invariant in one documented place.
- Replace the silent `if let Ok` swallow with a `warn!` on the **builder-constructed fallback path** (which only sets the JSON string form), so a parse failure is visible instead of silently degrading.

The builder path (embedded mediators via `MediatorBuilder`, which sets only the `mediator_did_doc` string and never goes through `from_raw`) is preserved: the server prefers the typed field and falls back to parsing the string, logging on failure.

## Testing

- Adds a regression test that `preload_self_did` leaves the DID resolvable straight from cache (no network round-trip).
- `cargo build`, `cargo clippy --all-targets`, and `cargo test -p affinidi-messaging-mediator` all pass.

## Impact

- **did:peer** mediators: no behavioural change.
- **did:web / did:webvh** mediators: identical runtime behaviour to #392, minus the redundant startup parse, plus a visible warning if the document ever fails to parse.
- Bumps `affinidi-messaging-mediator` `0.15.16` → `0.15.17` with a CHANGELOG entry. The only internal dependent (`affinidi-messaging-test-mediator`) pins `0.15`, so no dependent bump is required.

Closes #395