### PR TITLE
fix: extend operating-secret boot guard to network-published (VTA) DIDs

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Changelog history
 
+## 10th June 2026
+
+### 0.15.18 — Boot guard covers network-published (VTA) DIDs (#398)
+
+- The operating-secret coverage guard added in #394 only ran for self-hosted
+  DIDs (`did_web_self_hosted` set), so a VTA-managed / network-published
+  mediator booted without verifying that its loaded operating secrets can
+  actually decrypt its own inbound DIDComm. A VTA key-label/kid mismatch
+  (e.g. `vta-sdk` < 0.11.1's label-as-kid bug) therefore surfaced only at
+  runtime, failing every message — including the `/authenticate` handshake —
+  with `No local secret matches any JWE recipient`, while the mediator
+  otherwise booted clean.
+- The guard now also runs in the non-self-hosted path: it resolves the
+  mediator's own published DID document and verifies the loaded operating
+  secrets cover a `keyAgreement` verification-method id, aborting boot with an
+  actionable error on a confirmed gap. A resolver failure is logged and
+  skipped so a transient DID-host outage cannot block startup; only a
+  *confirmed* coverage gap is fatal. Logic extracted into
+  `assert_operating_secrets_cover_key_agreement` with regression tests.
+
 ## 9th June 2026
 
 ### 0.15.17 — Consolidate mediator self-DID resolver preload (#395)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.17"
+version = "0.15.18"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -11,9 +11,10 @@
 //!   `aws_parameter_store://`.
 //! - Hostname resolution and forwarding-loop protection.
 
-use affinidi_did_common::{Document, service::Endpoint};
+use affinidi_did_common::{Document, DocumentExt, service::Endpoint};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_secrets_resolver::SecretsResolver;
 #[cfg(feature = "aws")]
 use aws_config::SdkConfig;
 #[cfg(feature = "aws")]
@@ -575,6 +576,59 @@ pub(crate) async fn preload_self_did(
     info!("Preloaded mediator DID into resolver cache: {mediator_did}");
 }
 
+/// Boot guard: the loaded operating secrets must be able to decrypt this
+/// mediator's own inbound DIDComm.
+///
+/// A peer encrypts inbound DIDComm to the `keyAgreement` verification-method
+/// id(s) published in *our* DID document, and the unpack path
+/// ([`crate::didcomm_compat`]) does an exact-match lookup of that kid against
+/// the loaded operating secrets. If no loaded secret carries a matching id,
+/// every inbound message — including the `/authenticate` handshake — fails at
+/// runtime with `No local secret matches any JWE recipient`: the mediator boots
+/// clean but can never read a single message.
+///
+/// A common cause is a VTA context whose key *labels* don't equal the DID-doc VM
+/// ids — `vta-sdk` < 0.11.1 used a key's free-text/`did:key` label as its kid,
+/// so the bundle was keyed by the wrong ids instead of `…#key-N`. Catch that at
+/// boot with an actionable error rather than as a silent per-request outage.
+///
+/// Vacuously OK when the document publishes no `keyAgreement` key (nothing to
+/// match against).
+pub(crate) async fn assert_operating_secrets_cover_key_agreement(
+    mediator_doc: &Document,
+    mediator_secrets: &impl SecretsResolver,
+) -> Result<(), MediatorError> {
+    let ka_kids: Vec<String> = mediator_doc
+        .find_key_agreement(None)
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    if ka_kids.is_empty() {
+        return Ok(());
+    }
+    if !mediator_secrets.find_secrets(&ka_kids).await.is_empty() {
+        return Ok(());
+    }
+    let loaded = mediator_secrets.len().await;
+    error!(
+        "Operating secrets do not cover any published keyAgreement key. \
+         Loaded {loaded} secret(s); DID document keyAgreement id(s): {ka_kids:?}"
+    );
+    Err(MediatorError::ConfigError(
+        12,
+        "NA".into(),
+        format!(
+            "Mediator cannot decrypt inbound DIDComm: {loaded} operating secret(s) loaded, but \
+             none match this mediator's published keyAgreement key(s) {ka_kids:?}. Every inbound \
+             message (including /authenticate) would fail with \"No local secret matches any JWE \
+             recipient\". If this mediator is VTA-managed, ensure the VTA context's key labels \
+             equal the DID document verification-method ids and re-provision (vta-sdk >= 0.11.1 \
+             fixes the label-as-kid bug); for self-hosted setups re-run mediator-setup so the \
+             operating secrets match the published DID document."
+        ),
+    ))
+}
+
 /// Creates a set of URI's that can be used to detect if forwarding loopbacks to the mediator could occur
 pub(crate) async fn load_forwarding_protection_blocks(
     did_resolver: &DIDCacheClient,
@@ -741,5 +795,107 @@ mod tests {
         let cached = resolver.resolve(DID_KEY).await.unwrap();
         assert!(cached.cache_hit, "preloaded DID was not served from cache");
         assert_eq!(cached.doc, doc);
+    }
+
+    /// The boot guard passes when a loaded operating secret matches a published
+    /// `keyAgreement` verification-method id — the mediator can decrypt inbound
+    /// DIDComm.
+    #[tokio::test]
+    async fn coverage_guard_passes_when_secret_matches_key_agreement() {
+        use affinidi_did_common::DocumentExt;
+        use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+        use affinidi_secrets_resolver::{
+            SecretsResolver, ThreadedSecretsResolver, secrets::Secret,
+        };
+
+        const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+        let doc = resolver.resolve(DID_KEY).await.unwrap().doc;
+        let ka_kid = doc
+            .find_key_agreement(None)
+            .first()
+            .copied()
+            .expect("did:key publishes a keyAgreement key")
+            .to_string();
+
+        // A secret keyed under the *correct* published kid. `find_secrets`
+        // matches on id, which is exactly what the unpack path looks up.
+        let (secrets, _h) = ThreadedSecretsResolver::new(None).await;
+        secrets
+            .insert_vec(&[Secret::generate_ed25519(Some(&ka_kid), Some(&[7u8; 32]))])
+            .await;
+
+        super::assert_operating_secrets_cover_key_agreement(&doc, &secrets)
+            .await
+            .expect("guard must pass when a secret covers the keyAgreement kid");
+    }
+
+    /// Regression for the storm.ws label-as-kid outage: the document publishes a
+    /// `keyAgreement` kid, but the loaded secret is keyed under the *wrong* id (a
+    /// decorative `did:key` label, as `vta-sdk` < 0.11.1 produced). The guard
+    /// must abort boot rather than let the mediator fail every `/authenticate` at
+    /// runtime with "No local secret matches any JWE recipient".
+    #[tokio::test]
+    async fn coverage_guard_fails_when_no_secret_matches_key_agreement() {
+        use affinidi_did_common::DocumentExt;
+        use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+        use affinidi_secrets_resolver::{
+            SecretsResolver, ThreadedSecretsResolver, secrets::Secret,
+        };
+
+        const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+        let doc = resolver.resolve(DID_KEY).await.unwrap().doc;
+        let ka_kid = doc
+            .find_key_agreement(None)
+            .first()
+            .copied()
+            .expect("did:key publishes a keyAgreement key")
+            .to_string();
+
+        // Loaded under a decorative free-text label, NOT the published VM id.
+        let (secrets, _h) = ThreadedSecretsResolver::new(None).await;
+        secrets
+            .insert_vec(&[Secret::generate_ed25519(
+                Some("did:key:z6MkDecorative key-agreement key"),
+                Some(&[9u8; 32]),
+            )])
+            .await;
+
+        let err = super::assert_operating_secrets_cover_key_agreement(&doc, &secrets)
+            .await
+            .expect_err("guard must fail when no secret covers the keyAgreement kid");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("No local secret matches any JWE recipient"),
+            "error must name the runtime failure mode, got: {msg}"
+        );
+        assert!(
+            msg.contains(&ka_kid),
+            "error must name the uncovered kid, got: {msg}"
+        );
+    }
+
+    /// A document publishing no `keyAgreement` key has nothing to match, so the
+    /// guard is vacuously satisfied even with an empty secret set.
+    #[tokio::test]
+    async fn coverage_guard_vacuous_when_no_key_agreement() {
+        use affinidi_did_common::Document;
+        use affinidi_secrets_resolver::ThreadedSecretsResolver;
+
+        let doc: Document = serde_json::from_value(serde_json::json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:example:no-key-agreement",
+        }))
+        .expect("minimal DID document parses");
+
+        let (secrets, _h) = ThreadedSecretsResolver::new(None).await;
+        super::assert_operating_secrets_cover_key_agreement(&doc, &secrets)
+            .await
+            .expect("guard is vacuous when the doc publishes no keyAgreement key");
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -9,7 +9,7 @@ pub use limits::*;
 pub use processors::*;
 pub use security::*;
 
-use affinidi_did_common::{Document, DocumentExt};
+use affinidi_did_common::Document;
 use affinidi_did_resolver_cache_sdk::{
     DIDCacheClient,
     config::{DIDCacheConfig, DIDCacheConfigBuilder},
@@ -20,7 +20,7 @@ use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     secrets::open_store,
 };
-use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver};
+use affinidi_secrets_resolver::ThreadedSecretsResolver;
 use async_convert::{TryFrom, async_trait};
 #[cfg(feature = "aws")]
 use aws_config::{self, BehaviorVersion, Region};
@@ -44,8 +44,8 @@ use vta_sdk::integration::{
 };
 
 use helpers::{
-    get_hostname, load_forwarding_protection_blocks, preload_self_did, read_config_file,
-    read_did_config, read_document,
+    assert_operating_secrets_cover_key_agreement, get_hostname, load_forwarding_protection_blocks,
+    preload_self_did, read_config_file, read_did_config, read_document,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -877,57 +877,6 @@ impl TryFrom<ConfigRaw> for Config {
             config.streaming_uuid = get_hostname(&raw.streaming.uuid)?;
         }
 
-        // ── Guard: operating secrets must be able to decrypt our own traffic ──
-        //
-        // A peer encrypts inbound DIDComm to the keyAgreement verification-method
-        // id(s) published in *our* DID document, and the unpack path does an
-        // exact-match lookup of that kid against the loaded operating secrets
-        // (`didcomm_compat::unpack_jwe`). If no loaded secret carries a matching
-        // id, every inbound message fails at runtime with "No local secret
-        // matches any JWE recipient" — including the /authenticate handshake — so
-        // the mediator boots cleanly but can never read a single message.
-        //
-        // A common cause is a VTA context whose key *labels* don't equal the
-        // DID-document VM ids: `fetch_did_secrets_bundle` uses each key's label as
-        // its kid, so a context labelled `did:key:…`/free-text yields a bundle
-        // keyed by the wrong ids instead of `…#key-N`. Surface that at boot with
-        // an actionable error rather than as a silent per-request outage.
-        if let Some(mediator_doc) = did_document.as_ref() {
-            let ka_kids: Vec<String> = mediator_doc
-                .find_key_agreement(None)
-                .into_iter()
-                .map(str::to_string)
-                .collect();
-            if !ka_kids.is_empty() {
-                let matched = config
-                    .security
-                    .mediator_secrets
-                    .find_secrets(&ka_kids)
-                    .await;
-                if matched.is_empty() {
-                    let loaded = config.security.mediator_secrets.len().await;
-                    error!(
-                        "Operating secrets do not cover any published keyAgreement key. \
-                         Loaded {loaded} secret(s); DID document keyAgreement id(s): {ka_kids:?}"
-                    );
-                    return Err(MediatorError::ConfigError(
-                        12,
-                        "NA".into(),
-                        format!(
-                            "Mediator cannot decrypt inbound DIDComm: {loaded} operating secret(s) \
-                             loaded, but none match this mediator's published keyAgreement key(s) \
-                             {ka_kids:?}. Every inbound message (including /authenticate) would fail \
-                             with \"No local secret matches any JWE recipient\". If this mediator is \
-                             VTA-managed, ensure the VTA context's key labels exactly equal the DID \
-                             document verification-method ids and re-provision; for self-hosted setups \
-                             re-run mediator-setup so the operating secrets match the published DID \
-                             document."
-                        ),
-                    ));
-                }
-            }
-        }
-
         // Fill out the forwarding protection for DIDs and associated service endpoints
         // This protects against the mediator forwarding messages to itself.
         let mut did_resolver = DIDCacheClient::new(config.did_resolver_config.clone())
@@ -949,6 +898,45 @@ impl TryFrom<ConfigRaw> for Config {
         if let Some(mediator_doc) = did_document {
             preload_self_did(&mut did_resolver, &config.mediator_did, &mediator_doc).await;
             config.mediator_did_document = Some(mediator_doc);
+        }
+
+        // ── Guard: operating secrets must be able to decrypt our own traffic ──
+        //
+        // See `assert_operating_secrets_cover_key_agreement`. For a self-hosted
+        // DID we check against the local document we just loaded. For a
+        // VTA-managed / network-published DID (no `did_web_self_hosted`) we
+        // resolve our *own* published DID and check against that — that path was
+        // previously unguarded, so a VTA key-label/kid mismatch booted clean and
+        // failed every request at runtime. A resolver failure is logged and
+        // skipped (a transient DID-host blip must not block boot); only a
+        // *confirmed* coverage gap aborts startup.
+        match &config.mediator_did_document {
+            Some(doc) => {
+                assert_operating_secrets_cover_key_agreement(
+                    doc,
+                    config.security.mediator_secrets.as_ref(),
+                )
+                .await?;
+            }
+            None => match did_resolver.resolve(&config.mediator_did).await {
+                Ok(resolved) => {
+                    assert_operating_secrets_cover_key_agreement(
+                        &resolved.doc,
+                        config.security.mediator_secrets.as_ref(),
+                    )
+                    .await?;
+                }
+                Err(err) => {
+                    warn!(
+                        mediator_did = %config.mediator_did,
+                        error = %err,
+                        "Could not resolve our own published DID document at boot; skipping the \
+                         operating-secret coverage guard. Inbound DIDComm decryption is unverified \
+                         — a key/kid mismatch would surface at runtime as \"No local secret matches \
+                         any JWE recipient\"."
+                    );
+                }
+            },
         }
 
         load_forwarding_protection_blocks(


### PR DESCRIPTION
## What

Extends the operating-secret coverage guard (added in #394) to run for **network-published / VTA-managed** DIDs, not just self-hosted ones. Bumps the mediator `0.15.17 → 0.15.18`.

## Why

The #394 guard verifies, at boot, that the loaded operating secrets actually cover the mediator's published `keyAgreement` verification-method id — otherwise every inbound DIDComm (including `/authenticate`) fails at runtime with `No local secret matches any JWE recipient` while the mediator boots clean.

But it only ran when `did_web_self_hosted` was set:

```rust
if let Some(mediator_doc) = did_document.as_ref() { /* guard */ }
```

`did_document` is only populated for self-hosted DIDs, so a **VTA-managed mediator whose DID is resolved from the network was completely unguarded**. That's exactly how the recent storm.ws outage stayed silent: `vta-sdk` < 0.11.1 delivered operating secrets keyed by a decorative `did:key` **label** instead of the published `…#key-N` kid (fixed in vta-sdk #337 / 0.11.1), and the mediator booted fine then `403`-ed every authenticate.

## What changed

- Moved the check below the DID-resolver construction and extracted it into `helpers::assert_operating_secrets_cover_key_agreement`.
- It now runs in **both** paths:
  - **Self-hosted** → checks against the local document.
  - **Non-self-hosted (VTA / network)** → resolves the mediator's *own* published DID and checks against that.
- A resolver failure is **logged and skipped** (a transient DID-host blip must not block boot); only a *confirmed* coverage gap aborts startup.
- Error message updated to point at the `vta-sdk >= 0.11.1` fix.

## Tests

New regression tests in `config::helpers` (all green):
- `coverage_guard_passes_when_secret_matches_key_agreement`
- `coverage_guard_fails_when_no_secret_matches_key_agreement` — reproduces the label-as-kid outage (secret keyed under a decorative label → boot aborts)
- `coverage_guard_vacuous_when_no_key_agreement`

## Verification

- `cargo fmt`
- `cargo clippy -p affinidi-messaging-mediator --all-targets` — clean
- `cargo test -p affinidi-messaging-mediator --lib config::` — 30 passed (incl. 3 new)

Dependent `affinidi-messaging-test-mediator` pins `"0.15"`, satisfied by `0.15.18` — no pin change needed.