### PR TITLE
test: end-to-end cross-mediator forwarding on the memory backend

### DIFF
--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Changelog history
 
+## 10th June 2026
+
+### 0.2.5 — cross-mediator forwarding test + production-shaped mediator DID
+
+- **FIX:** the fixture's generated mediator `did:peer` advertised its
+  DIDComm (`dm`) HTTP service endpoint *with* a trailing slash
+  (`http://<host>/mediator/v1/`). The production mediator DID advertises
+  the bare base with no trailing slash (see mediator-setup's `did_peer`
+  generator), and the SDK builds request URLs by concatenation
+  (`{endpoint}/inbound`) — so the trailing slash produced `…/v1//inbound`,
+  which the mediator router 404s. Any SDK HTTP send against the fixture
+  hit this; it was masked until now because existing tests retrieve over
+  WebSocket. The `dm` endpoint is now trimmed to match production; the
+  `#auth` endpoint string is unchanged, so authentication/WS tests are
+  unaffected.
+- **TEST:** new `cross_mediator_forwarding` suite — two in-process
+  mediators (Alice on A, Bob on B), with Alice's message routed
+  A → mediator-A → mediator-B → Bob via the routing-2.0 double forward and
+  picked up on Bob's live stream. Covers both one-way delivery and a
+  round trip, exercising the relay-sender auto-registration on each
+  mediator. This is the end-to-end regression for
+  `affinidi-messaging-mediator` #399 (forwarding processor running on the
+  memory backend) and the first multi-mediator scenario built purely on
+  the published `TestMediator` / `TestEnvironment` fixtures — no Redis.
+- Adds an `affinidi-messaging-didcomm` dev-dependency for the `Message`
+  builder the test uses to hand-roll the double forward.
+
 ## 1st June 2026
 
 ### 0.2.4 — rebuilt against the didcomm 0.15 mediator

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.4"
+version = "0.2.5"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -81,6 +81,9 @@ tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 ## errors when it offers a subprotocol the server doesn't echo back).
 tokio = { workspace = true, features = ["io-util"] }
 serde_json = "1"
+## DIDComm `Message` builder for the cross-mediator forwarding test, which
+## hand-rolls the routing-2.0 double forward (the SDK doesn't re-export it).
+affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-didcomm" }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -916,25 +916,23 @@ async fn generate_mediator_identity(
     service_uri: &str,
 ) -> Result<(String, Vec<Secret>, Arc<ThreadedSecretsResolver>), TestMediatorError> {
     // `service_uri` is `http://<bound>/mediator/v1/` (trailing slash).
-    // The DIDComm service entry advertises both HTTP and WS endpoints
-    // (matching the canonical mediator-template shape) so SDK clients
-    // that prefer the streaming transport can find a `ws://` URI. The
-    // `#auth` endpoint is `<service_uri>authenticate` (no extra slash
-    // — `service_uri` already ends in `/`); the auth library appends
-    // `/challenge` itself, yielding `…/authenticate/challenge`.
-    let ws_uri = format!(
-        "ws://{}",
-        service_uri
-            .trim_start_matches("http://")
-            .trim_end_matches('/'),
-    ) + "/ws";
-    let auth_uri = format!("{service_uri}authenticate");
+    // The DIDComm `dm` service endpoint must NOT carry that trailing
+    // slash: the production mediator DID advertises the bare base
+    // (`http://<host>/mediator/v1` — see mediator-setup's `did_peer`
+    // generator), and the SDK builds request URLs by concatenating
+    // (`{endpoint}/inbound`). A trailing slash there yields `…/v1//inbound`,
+    // which the mediator router 404s — so we mirror production and trim it.
+    // The `#auth` endpoint is `<base>/authenticate`; the auth library
+    // appends `/challenge` itself, yielding `…/authenticate/challenge`.
+    let base_uri = service_uri.trim_end_matches('/');
+    let ws_uri = format!("ws://{}", base_uri.trim_start_matches("http://")) + "/ws";
+    let auth_uri = format!("{base_uri}/authenticate");
     let services = vec![
         PeerService {
             type_: "dm".into(),
             endpoint: PeerServiceEndpoint::Long(OneOrMany::Many(vec![
                 PeerServiceEndpointLong {
-                    uri: service_uri.to_string(),
+                    uri: base_uri.to_string(),
                     accept: vec!["didcomm/v2".into()],
                     routing_keys: vec![],
                 },

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
@@ -1,0 +1,275 @@
+//! Cross-mediator forwarding over the in-memory backend.
+//!
+//! Two independent in-process mediators (A and B) on `127.0.0.1`, with
+//! Alice homed on A and Bob on B. Alice sends a basic message that
+//! routes Alice → mediator-A → mediator-B → Bob via the routing-2.0
+//! double forward: an OUTER forward addressed to Alice's own mediator
+//! wraps an INNER forward addressed to Bob's mediator, which delivers
+//! locally to Bob. Each mediator only ever decrypts its own layer.
+//!
+//! This exercises the forwarding *processor* delivering across
+//! mediators — the path PR #399 unblocked on non-Redis backends. Before
+//! that change, mediator A's forwarding processor was compiled out on
+//! the memory backend, so the outer forward was enqueued to `FORWARD_Q`
+//! and never delivered; Bob would time out. Running this on the default
+//! memory backend (no Redis) is the end-to-end regression guard for that
+//! fix, and the first multi-mediator scenario built purely on the
+//! published `TestMediator` / `TestEnvironment` fixtures.
+//!
+//! All identities are `did:peer:2.*`, so every DID involved (both
+//! mediators, both users) resolves locally — no DNS or real network
+//! resolution. The only real socket traffic is the loopback HTTP hop the
+//! forwarding processor makes from mediator A to mediator B's `/inbound`.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, TestUser, acl};
+use common::init_tracing;
+use serde_json::json;
+use uuid::Uuid;
+
+/// Spawn a forwarding-enabled mediator wired to an SDK environment.
+///
+/// `global_acl_default = allow_all` makes this a *relay* deployment: when
+/// an inner forward arrives whose sender is homed on the *other* mediator
+/// (and therefore has no account here), the routing handler auto-registers
+/// that sender via `relay_sender_acls(global_default)`, which only seeds
+/// `SEND_FORWARDED` when the global default grants it. Without that, the
+/// inbound relayed forward is rejected with 403 and never reaches the
+/// recipient — so a mediator that accepts cross-mediator forwards must
+/// default-grant it. (Locally-registered users like Bob are added with an
+/// explicit `allow_all` ACL by `add_user`, independent of this default.)
+async fn spawn_relay_environment() -> TestEnvironment {
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .spawn()
+        .await
+        .expect("spawn forwarding mediator");
+    TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment to forwarding mediator")
+}
+
+/// Add a user and bring up its WebSocket live-stream connection.
+///
+/// Retrieval uses message-pickup `live_stream_get` (the supported
+/// real-time path); over plain HTTP the SDK's delivery-request returns a
+/// `RestAPI` response variant that `send_delivery_request` doesn't unwrap,
+/// so the connection must be live before the forward arrives. `add_user`
+/// registers the DID as LOCAL/allow_all, which is what lets the WS upgrade
+/// through.
+async fn add_live_user(env: &TestEnvironment, alias: &str) -> TestUser {
+    let user = env.add_user(alias).await.expect("add user");
+    env.atm
+        .profile_enable_websocket(&user.profile)
+        .await
+        .expect("enable WebSocket live streaming");
+    user
+}
+
+/// Drive one cross-mediator delivery: wrap `text` as the routing-2.0
+/// double forward, send it to the sender's own mediator, then poll the
+/// recipient's mediator until the decrypted message arrives.
+///
+/// Returns the recipient's view of the `content` body field, or `None`
+/// if nothing arrived within the timeout.
+#[allow(clippy::too_many_arguments)]
+async fn forward_and_receive(
+    sender_env: &TestEnvironment,
+    sender: &TestUser,
+    sender_mediator_did: &str,
+    recipient_env: &TestEnvironment,
+    recipient: &TestUser,
+    recipient_mediator_did: &str,
+    text: &str,
+) -> Option<String> {
+    let now = unix_secs();
+
+    // 1. Plaintext basic message, Alice → Bob.
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(recipient.did.clone())
+    .from(sender.did.clone())
+    .created_time(now)
+    .expires_time(now + 60)
+    .finalize();
+    let msg_id = msg.id.clone();
+
+    // 2. Authcrypt (encrypt + sign) for the recipient.
+    let (packed, _) = sender_env
+        .atm
+        .pack_encrypted(&msg, &recipient.did, Some(&sender.did), Some(&sender.did))
+        .await
+        .expect("authcrypt for recipient");
+
+    // 3. INNER forward: encrypted for the recipient's mediator, next = recipient.
+    let (_inner_id, inner_fwd) = sender_env
+        .atm
+        .routing()
+        .forward_message(
+            &sender.profile,
+            false,
+            &packed,
+            recipient_mediator_did,
+            &recipient.did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap inner forward");
+
+    // 4. OUTER forward: encrypted for the sender's own mediator, next =
+    //    recipient's mediator (so the sender's mediator relays the inner
+    //    forward over the wire to the recipient's mediator).
+    let (_outer_id, outer_fwd) = sender_env
+        .atm
+        .routing()
+        .forward_message(
+            &sender.profile,
+            false,
+            &inner_fwd,
+            sender_mediator_did,
+            recipient_mediator_did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap outer forward");
+
+    // 5. Send the outer forward to the sender's own mediator. From here the
+    //    forwarding processor (running on the memory backend thanks to #399)
+    //    relays the inner forward to the recipient's mediator's /inbound,
+    //    which stores it for the recipient and live-delivers it.
+    sender_env
+        .atm
+        .send_message(&sender.profile, &outer_fwd, &msg_id, false, false)
+        .await
+        .expect("send outer forward to own mediator");
+
+    // 6. Receive on the recipient's live stream. The unwrapped message id is
+    //    the original basic-message id (the mediator stores the innermost
+    //    authcrypt addressed to the recipient), so we wait on `msg_id`.
+    match recipient_env
+        .atm
+        .message_pickup()
+        .live_stream_get(&recipient.profile, &msg_id, Duration::from_secs(15), true)
+        .await
+    {
+        Ok(Some((received, _meta))) => received
+            .body
+            .get("content")
+            .and_then(|c| c.as_str())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Alice on mediator A sends to Bob on mediator B; the message must arrive
+/// having traversed both mediators. This is the core regression for #399.
+#[tokio::test]
+async fn cross_mediator_forward_delivers_over_memory_backend() {
+    init_tracing();
+
+    let env_a = spawn_relay_environment().await;
+    let env_b = spawn_relay_environment().await;
+
+    let mediator_a_did = env_a.mediator.did().to_string();
+    let mediator_b_did = env_b.mediator.did().to_string();
+    assert_ne!(
+        mediator_a_did, mediator_b_did,
+        "the two mediators must have distinct DIDs for a real cross-mediator hop"
+    );
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let text = "Hello Bob — routed across two mediators.";
+    let received = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        text,
+    )
+    .await;
+
+    assert_eq!(
+        received.as_deref(),
+        Some(text),
+        "Bob should receive Alice's message after it routes A → B"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+/// Both directions over the two mediators: Alice → Bob, then Bob → Alice.
+/// Exercises the relay-sender auto-registration on *both* mediators (each
+/// sees the other's user as an account-less forward sender).
+#[tokio::test]
+async fn cross_mediator_forward_round_trips() {
+    init_tracing();
+
+    let env_a = spawn_relay_environment().await;
+    let env_b = spawn_relay_environment().await;
+
+    let mediator_a_did = env_a.mediator.did().to_string();
+    let mediator_b_did = env_b.mediator.did().to_string();
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let to_bob = "Ping from Alice.";
+    let got_by_bob = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        to_bob,
+    )
+    .await;
+    assert_eq!(
+        got_by_bob.as_deref(),
+        Some(to_bob),
+        "Bob should receive Alice's ping (A → B)"
+    );
+
+    let to_alice = "Pong from Bob.";
+    let got_by_alice = forward_and_receive(
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        to_alice,
+    )
+    .await;
+    assert_eq!(
+        got_by_alice.as_deref(),
+        Some(to_alice),
+        "Alice should receive Bob's pong (B → A)"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+fn unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}


### PR DESCRIPTION
## Summary

The first **multi-mediator** scenario built purely on the published `TestMediator` / `TestEnvironment` fixtures — no Redis. It's the end-to-end follow-up to #399 (forwarding processor now runs on the memory backend) and the first concrete consumer of the testing-plan's multi-mediator topology axis (TI1).

Two in-process mediators spawn on `127.0.0.1` (Alice homed on A, Bob on B). Alice's basic message is routed **Alice → mediator-A → mediator-B → Bob** via the routing-2.0 double forward:

- **INNER** forward — authcrypted for Bob's mediator (B), `next = Bob`
- **OUTER** forward — authcrypted for Alice's own mediator (A), `next = mediator-B`

Alice sends the outer forward to A; A decrypts its layer and enqueues the inner forward; the forwarding processor relays it over loopback HTTP to B's `/inbound`; B decrypts its layer and delivers locally to Bob, who picks it up on his live stream. Two tests: one-way delivery and a round trip (which also exercises the relay-sender auto-registration on *both* mediators).

**Why this is the #399 regression:** before #399 the forwarding processor was compiled out on the memory backend, so the outer forward sat undelivered in `FORWARD_Q` and the recipient timed out. With the processor running, the A→B hop completes — verified here end-to-end.

All identities are `did:peer:2.*`, so every DID (both mediators, both users) resolves locally — no DNS. The only real socket traffic is the loopback HTTP forward hop.

## Latent fixture bug fixed along the way

Root-caused while getting the first send to work: the fixture's generated mediator `did:peer` advertised its DIDComm (`dm`) HTTP service endpoint **with a trailing slash** (`http://<host>/mediator/v1/`). The production mediator DID uses the bare base with **no** trailing slash (asserted in `mediator-setup`'s `did_peer` generator: `http://localhost:7037/mediator/v1`). The SDK builds request URLs by concatenation (`{endpoint}/inbound`), so the trailing slash produced `…/v1//inbound` → **404 on every SDK HTTP send** against the fixture.

It stayed hidden because existing fixture tests retrieve over WebSocket (where sends go through the WS channel, not HTTP `/inbound`). Trimmed the `dm` endpoint to match production. The `#auth` endpoint string is byte-identical to before, so authentication and WebSocket tests are unaffected — the full suite stays green.

## Changes

- `tests/cross_mediator_forwarding.rs` — new suite (one-way + round-trip).
- `src/lib.rs` — `generate_mediator_identity` now advertises the `dm` endpoint without a trailing slash (production parity).
- Dev-dependency on `affinidi-messaging-didcomm` for the `Message` builder used to hand-roll the double forward.
- Version bump `affinidi-messaging-test-mediator` 0.2.4 → 0.2.5 + changelog.

## Notes / scope

- Retrieval uses message-pickup `live_stream_get` (the supported real-time path), matching the `cross_mediator_forwarding` helper example. The HTTP delivery-request path returns a `RestAPI` response variant that `send_delivery_request` doesn't unwrap, so it's WebSocket-only by design — noted in the test.
- The receiving mediator is configured as a relay deployment (`global_acl_default = allow_all`) so the account-less cross-mediator sender is auto-registered with `SEND_FORWARDED` via `relay_sender_acls`; otherwise the inbound relayed forward is correctly rejected 403. This is the realistic relay shape and is documented inline.
- This does **not** add a `TestTopology` builder abstraction yet — the two tests share small inline helpers. Whether to extract the builder (testing-plan TI1) is best decided once a second consumer (e.g. the pending #388 relay-REWRAP e2e) is in hand; the wiring here is modest.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy -p affinidi-messaging-test-mediator --all-targets` clean
- `cargo test -p affinidi-messaging-test-mediator` — 44 passed (incl. 2 new), on the default memory backend and with `--features fjall-backend`
- `cargo deny check` ok
