### PR TITLE
fix: replace poisonable streaming-task mutex with a DashSet (simplification T1)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 10th June 2026
 
+### 0.15.21 — Streaming task: remove lock-poison hazard (simplification T1)
+
+- The WebSocket streaming task guarded its in-flight inbox-redelivery set
+  with a `std::sync::Mutex<HashSet<String>>` accessed via `.lock().unwrap()`.
+  If any holder panicked, the mutex would be poisoned and every subsequent
+  `.unwrap()` would panic in turn — turning one fault into a cascading
+  failure of the streaming task. Replaced with a `dashmap::DashSet`, which
+  has no poisoning and no `.unwrap()`; `DashSet::insert` returns the same
+  "newly inserted" boolean the duplicate-drain guard relies on, so behaviour
+  is unchanged. `dashmap` was already compiled in the tree (via `governor`),
+  so this adds no new dependency to the build graph. First task of the
+  mediator architectural-simplification plan (Phase 1).
+
 ### 0.15.20 — Per-hop re-wrapping for inter-mediator relay (#385 item 3, #388)
 
 - Final piece of #385. Adds **per-hop re-wrapping** for the inter-mediator

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.20"
+version = "0.15.21"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -161,6 +161,10 @@ tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 
 # ── Utilities ────────────────────────────────────────────────────────────
 ahash = { version = "0.8", features = ["serde"] }
+## Lock-free concurrent set for the streaming task's in-flight redelivery
+## guard (no poison-on-panic, unlike std::sync::Mutex). Already compiled in
+## the tree via `governor`.
+dashmap = "6.2"
 chrono = "0.4"
 hostname = "0.4"
 itertools = "0.14"

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -30,9 +30,9 @@ use affinidi_messaging_mediator_common::{
     types::messages::FetchOptions,
 };
 use ahash::AHashMap as HashMap;
+use dashmap::DashSet;
 use std::{
-    collections::HashSet,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 use tokio::{
@@ -163,8 +163,7 @@ impl StreamingTask {
             // every couple of seconds must not re-dump the whole inbox on each
             // replacement. A replay already running for a DID covers the current
             // inbox state, so concurrent replacements skip spawning another.
-            let replay_in_progress: Arc<Mutex<HashSet<String>>> =
-                Arc::new(Mutex::new(HashSet::new()));
+            let replay_in_progress: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
             // Subscribe to delivery notifications via the trait. Backends
             // are responsible for the wire-level transport (Redis pub/sub,
@@ -318,7 +317,7 @@ impl StreamingTask {
         &self,
         database: &Arc<dyn MediatorStore>,
         clients: &mut HashMap<String, ClientEntry>,
-        replay_in_progress: &Arc<Mutex<HashSet<String>>>,
+        replay_in_progress: &Arc<DashSet<String>>,
         value: &StreamingUpdate,
     ) {
         let StreamingUpdateState::Register {
@@ -410,10 +409,11 @@ impl StreamingTask {
         // DID is already running, so a flip-flop duel can't amplify into a
         // repeated whole-inbox dump.
         if replacing {
-            let spawn = {
-                let mut guard = replay_in_progress.lock().unwrap();
-                guard.insert(value.did_hash.clone())
-            };
+            // `DashSet::insert` returns `true` only when the hash was newly
+            // added, so a concurrent redelivery for the same DID still sees
+            // `false` and skips the duplicate drain — same guard semantics as
+            // the previous `HashSet`, without the lock-poison hazard.
+            let spawn = replay_in_progress.insert(value.did_hash.clone());
             if spawn {
                 spawn_inbox_redelivery(
                     Arc::clone(database),
@@ -447,7 +447,7 @@ fn spawn_inbox_redelivery(
     client_tx: mpsc::Sender<WebSocketCommands>,
     did_hash: String,
     session_id: String,
-    replay_in_progress: Arc<Mutex<HashSet<String>>>,
+    replay_in_progress: Arc<DashSet<String>>,
 ) {
     tokio::spawn(async move {
         let mut start_id: Option<String> = None;
@@ -521,7 +521,7 @@ fn spawn_inbox_redelivery(
         if total > 0 {
             debug!(did_hash = %did_hash, total, "Inbox redelivery complete");
         }
-        replay_in_progress.lock().unwrap().remove(&did_hash);
+        replay_in_progress.remove(&did_hash);
     });
 }
 
@@ -563,7 +563,7 @@ mod tests {
             .expect("store message");
 
         let task = streaming_task();
-        let replay_in_progress: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let replay_in_progress: Arc<DashSet<String>> = Arc::new(DashSet::new());
         let mut clients: HashMap<String, ClientEntry> = HashMap::new();
 
         // Client A is the existing live session.
@@ -631,7 +631,7 @@ mod tests {
             .expect("store message");
 
         let task = streaming_task();
-        let replay_in_progress: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let replay_in_progress: Arc<DashSet<String>> = Arc::new(DashSet::new());
         let mut clients: HashMap<String, ClientEntry> = HashMap::new();
 
         let (b_tx, mut b_rx) = mpsc::channel(5);


### PR DESCRIPTION
## Summary

First task (**T1**) of the mediator architectural-simplification plan (Phase 1 — resilience & safety quick wins).

The WebSocket streaming task tracked its in-flight inbox-redelivery set in a `std::sync::Mutex<HashSet<String>>` accessed via `.lock().unwrap()` at both the insert (client registration) and remove (drain completion) sites. **Lock poisoning is the hazard:** if any holder panics, the mutex is poisoned and every subsequent `.lock().unwrap()` panics in turn — escalating a single fault into a cascading failure of the streaming task, which services *every* connected DID.

## Change

Replace the mutex-guarded set with a `dashmap::DashSet<String>`:
- No poisoning, no `.unwrap()`.
- `DashSet::insert` returns the same "newly inserted" boolean the duplicate-drain guard relies on, so behaviour is **unchanged** — a concurrent redelivery for the same DID still observes `false` and skips the duplicate whole-inbox drain (the #374 guard).
- `dashmap` (6.2) was already compiled in the tree via `governor`, so this adds **no crate to the build graph** — only a direct dependency line.

The lock was only ever held for a trivial insert/remove (never across `.await`), so there's no behavioural or ordering change beyond removing the panic-poison vector.

## Tests / verification

- `cargo test -p affinidi-messaging-mediator --lib` — 119 passed, incl. the 2 `websocket_streaming` registration tests (which exercise the redelivery-guard path).
- `cargo clippy --all-targets` clean on `redis-backend` (default) and `didcomm,memory-backend`.
- `cargo fmt --check` clean; `cargo deny check` ok (dashmap already vetted in the lock).

Bumps `affinidi-messaging-mediator` 0.15.20 → 0.15.21.

## Plan context

Phase 1 is a series of independent quick wins; this is the first. Next up in the sweep: **T2** (supervise background tasks via `JoinSet` + `/readyz` health — the higher-value resilience item that hardens the forwarding processor and other unsupervised spawns), then T3–T6.
