### PR TITLE
feat: supervise background tasks + /livez health split (simplification T2)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 ## 10th June 2026
 
+### 0.15.22 — Supervised background tasks + `/livez` health split (simplification T2)
+
+- **Background tasks are now supervised.** Every long-lived background task
+  (statistics, forwarding processor, message- and session-expiry sweeps,
+  VTA secrets refresh) is spawned through a new `TaskSupervisor` instead of
+  a bare `tokio::spawn`. A task that returns an error or **panics** is
+  restarted with capped exponential backoff (1s → 60s); the supervisor
+  never gives up. Previously any of these tasks could die silently — e.g. a
+  panic in the forwarding processor would stop all forwarding with no
+  signal. This is the deliberate "restart-and-degrade, never fail-fast"
+  posture: the mediator keeps serving while the fault is logged at ERROR
+  with its restart history and corrective hint, and surfaced via `/readyz`.
+- **Health-probe contract.**
+  - New `GET …/livez` — process-liveness only, always 200 while the server
+    answers. An orchestrator should use this for liveness so it does not
+    kill a mediator that is still serving traffic while a background
+    component is degraded.
+  - `GET …/readyz` now folds in supervised-task health under a new
+    `components` array (name / state / load_bearing / restarts /
+    last_error). A **load-bearing** component that isn't running fails
+    readiness (503 `not_ready`); a non-load-bearing one only marks the
+    instance `degraded` (still 200, stays in rotation). Load-bearing:
+    `forwarding_processor`, `vta_refresh`. Non-load-bearing: `statistics`,
+    `message_expiry_sweep`, `session_expiry_sweep`.
+- The WebSocket streaming task (which owns its own task lifecycle via
+  `StreamingTask`) is not yet routed through the supervisor — a focused
+  follow-up.
+- Internal: `SharedData` gains a `component_health` registry (a
+  `dashmap::DashMap`); the supervisor owns task cancellation, so the
+  supervised loop bodies no longer carry their own shutdown `select!`.
+
 ### 0.15.21 — Streaming task: remove lock-poison hazard (simplification T1)
 
 - The WebSocket streaming task guarded its in-flight inbox-redelivery set

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.21"
+version = "0.15.22"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -178,6 +178,9 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 lazy_static = "1"
 ## `FjallStore` smoke tests open a temp directory.
 tempfile = "3"
+## `test-util` enables `tokio::time::pause/advance` so the task-supervisor
+## backoff tests run deterministically without real sleeps.
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -1,4 +1,4 @@
-use crate::{SharedData, common::session::Session};
+use crate::{SharedData, common::session::Session, tasks::supervisor::ComponentState};
 use affinidi_messaging_mediator_common::errors::AppError;
 use affinidi_messaging_sdk::messages::SuccessResponse;
 use axum::{
@@ -120,11 +120,31 @@ pub async fn health_checker_handler(State(state): State<SharedData>) -> impl Int
     Json(response_json)
 }
 
+/// Process-liveness probe. Returns 200 whenever the HTTP server can answer
+/// — deliberately decoupled from component readiness so an orchestrator
+/// does not kill a mediator that is still serving traffic while a
+/// background component is degraded or restarting. Use `/readyz` to decide
+/// whether an instance should *receive* traffic.
+pub async fn liveness_handler() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "status": "alive" })),
+    )
+}
+
 /// Deep readiness check that verifies the mediator can serve traffic.
-/// Checks Redis connectivity, queue health, and shutdown state.
+/// Checks Redis connectivity, queue health, shutdown state, and the health
+/// of supervised background tasks.
+///
+/// Returns 503 `not_ready` when a hard dependency or a **load-bearing**
+/// background task is down; 200 `degraded` when only non-load-bearing
+/// components are unhealthy; 200 `ready` otherwise.
 pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResponse {
     let mut checks: Vec<serde_json::Value> = Vec::new();
     let mut all_ok = true;
+    // Non-fatal degradation (non-load-bearing components down). Keeps the
+    // instance in rotation (200) but flags the condition for dashboards.
+    let mut degraded = false;
 
     // Check if shutdown has been initiated
     if state.shutdown_token.is_cancelled() {
@@ -265,17 +285,53 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
         }
     };
 
+    // ── Supervised background-task health ────────────────────────────
+    //
+    // A load-bearing component that isn't `Running` fails readiness (503);
+    // a non-load-bearing one only marks the instance `degraded` (still 200,
+    // stays in rotation). A component that is `Running` but has restarted is
+    // reported for visibility without affecting the verdict.
+    let mut components: Vec<serde_json::Value> = Vec::new();
+    for entry in state.component_health.iter() {
+        let h = entry.value();
+        let healthy = h.state == ComponentState::Running;
+        if !healthy {
+            if h.load_bearing {
+                all_ok = false;
+            } else {
+                degraded = true;
+            }
+        }
+        components.push(serde_json::json!({
+            "name": h.name,
+            "state": h.state,
+            "load_bearing": h.load_bearing,
+            "restarts": h.restarts,
+            "last_error": h.last_error,
+        }));
+    }
+    // Stable order so dashboards diffing the payload don't see churn.
+    components.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+
     let status_code = if all_ok {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
     };
+    let status = if !all_ok {
+        "not_ready"
+    } else if degraded {
+        "degraded"
+    } else {
+        "ready"
+    };
 
     let response = serde_json::json!({
-        "status": if all_ok { "ready" } else { "not_ready" },
+        "status": status,
         "version": env!("CARGO_PKG_VERSION"),
         "uptime_seconds": (chrono::Utc::now() - state.service_start_timestamp).num_seconds(),
         "checks": checks,
+        "components": components,
         // Top-level fields (alongside `checks`) so ops dashboards can
         // pluck them without parsing the variable-length checks list.
         // The secrets backend URL is intentionally NOT exposed here —

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -16,6 +16,7 @@ use chrono::{DateTime, Utc};
 use common::{config::Config, did_rate_limiter::DidRateLimiter, jwt_auth::AuthError};
 use http::request::Parts;
 use std::{collections::HashSet, fmt::Debug, sync::Arc, sync::atomic::AtomicUsize};
+use tasks::supervisor::HealthRegistry;
 use tasks::websocket_streaming::StreamingTask;
 use tokio_util::sync::CancellationToken;
 
@@ -60,6 +61,11 @@ pub struct SharedData {
     /// `config.listen_address` plus any operator-declared
     /// `config.local_endpoints` aliases.
     pub self_authorities: Arc<HashSet<(String, u16)>>,
+    /// Live health of supervised background tasks, published by the
+    /// [`TaskSupervisor`](tasks::supervisor::TaskSupervisor). The readiness
+    /// handler reads this to fail `/readyz` when a load-bearing component is
+    /// down and to report `degraded` for non-load-bearing ones.
+    pub component_health: HealthRegistry,
 }
 
 impl Debug for SharedData {

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -13,8 +13,13 @@ use crate::{
         rate_limiter::{RateLimitLayer, RateLimiterState},
         request_id::RequestIdLayer,
     },
-    handlers::{admin_status, application_routes, health_checker_handler, readiness_handler},
-    tasks::{statistics::statistics, websocket_streaming::StreamingTask},
+    handlers::{
+        admin_status, application_routes, health_checker_handler, liveness_handler,
+        readiness_handler,
+    },
+    tasks::{
+        statistics::statistics, supervisor::TaskSupervisor, websocket_streaming::StreamingTask,
+    },
 };
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 #[cfg(feature = "redis-backend")]
@@ -311,153 +316,142 @@ pub async fn serve_internal(
 
     let metrics_handle = metrics::init_metrics();
 
-    // Statistics task — runs against any backend via the trait.
-    let stats_store = store.clone();
-    let tags = config.tags.clone();
-    let stats_token = shutdown_token.clone();
-    tokio::spawn(async move {
-        tokio::select! {
-            result = statistics(stats_store, tags) => {
-                if let Err(e) = result {
-                    error!("Statistics thread error: {}", e);
-                }
-            }
-            _ = stats_token.cancelled() => {
-                info!("Statistics thread shutting down");
-            }
-        }
-    });
+    // All long-lived background tasks run under a supervisor: a task that
+    // errors or panics is restarted with capped backoff (never fail-fast —
+    // the mediator keeps serving and the fault is logged + surfaced via
+    // /readyz), and each task's health is published for the readiness probe.
+    // The supervisor owns cancellation, so the task bodies below are plain
+    // loops with no shutdown `select!` — it aborts them on shutdown.
+    let supervisor = TaskSupervisor::new(shutdown_token.clone());
 
-    // Forwarding processor — runs against any backend via the
-    // `forward_queue_*` trait methods (Redis: Streams consumer
-    // groups; Fjall/Memory: in-process pending-claim emulation).
-    // Note the durability difference: Fjall queues survive a restart
-    // (pending claims are recovered via autoclaim), Memory queues are
-    // lost with the process. Multi-process forwarding (the standalone
+    // Statistics task — non-load-bearing (metrics only). Runs against any
+    // backend via the trait.
+    {
+        let store = store.clone();
+        let tags = config.tags.clone();
+        supervisor.spawn("statistics", false, move || {
+            let store = store.clone();
+            let tags = tags.clone();
+            async move { statistics(store, tags).await.map_err(|e| e.to_string()) }
+        });
+    }
+
+    // Forwarding processor — load-bearing (the cross-mediator delivery
+    // path). Runs against any backend via the `forward_queue_*` trait
+    // methods (Redis: Streams consumer groups; Fjall/Memory: in-process
+    // pending-claim emulation). Fjall queues survive a restart (pending
+    // claims recovered via autoclaim), Memory queues are lost with the
+    // process. Multi-process forwarding (the standalone
     // `forwarding_processor` binary) remains Redis-only.
     if config.processors.forwarding.enabled && config.processors.forwarding.external_forwarding {
-        let _database = store.clone();
-        let _config = config.processors.forwarding.clone();
-        let fwd_token = shutdown_token.clone();
-        tokio::spawn(async move {
-            let processor = match ForwardingProcessor::new(_config, _database) {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("Failed to create forwarding processor: {}", e);
-                    return;
-                }
-            };
-            tokio::select! {
-                result = processor.start() => {
-                    if let Err(e) = result {
-                        error!("Forwarding processor error: {}", e);
-                    }
-                }
-                _ = fwd_token.cancelled() => {
-                    info!("Forwarding processor shutting down");
-                }
+        let store = store.clone();
+        let fwd_config = config.processors.forwarding.clone();
+        supervisor.spawn("forwarding_processor", true, move || {
+            let store = store.clone();
+            let fwd_config = fwd_config.clone();
+            async move {
+                let processor =
+                    ForwardingProcessor::new(fwd_config, store).map_err(|e| e.to_string())?;
+                processor.start().await.map_err(|e| e.to_string())
             }
         });
     }
 
-    // Message expiry sweep — runs against any backend via
-    // `MediatorStore::sweep_expired_messages`. The standalone
-    // `message_expiry_cleanup` binary in mediator-processors keeps
-    // its own direct-Redis loop for distributed deployments.
+    // Message expiry sweep — non-load-bearing housekeeping. Runs against
+    // any backend via `MediatorStore::sweep_expired_messages`. The
+    // standalone `message_expiry_cleanup` binary in mediator-processors
+    // keeps its own direct-Redis loop for distributed deployments. Sweep
+    // errors are logged and the next tick retries; the supervisor restarts
+    // the loop only if it panics.
     if config.processors.message_expiry_cleanup.enabled {
-        let expiry_store = store.clone();
+        let store = store.clone();
         let admin_did_hash = config.mediator_did_hash.clone();
-        let cleanup_token = shutdown_token.clone();
-        tokio::spawn(async move {
-            let mut tick = tokio::time::interval(Duration::from_secs(1));
-            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select! {
-                    _ = cleanup_token.cancelled() => {
-                        info!("Message expiry cleanup shutting down");
-                        return;
-                    }
-                    _ = tick.tick() => {}
-                }
-
-                let now_secs = chrono::Utc::now().timestamp().max(0) as u64;
-                match expiry_store
-                    .sweep_expired_messages(now_secs, &admin_did_hash)
-                    .await
-                {
-                    Ok(report) if report.expired > 0 || report.timeslots_swept > 0 => {
-                        info!(
-                            event_type = "ExpirySweep",
-                            timeslots_swept = report.timeslots_swept,
-                            expired = report.expired,
-                            already_deleted = report.already_deleted,
-                            "expiry sweep drained {} messages across {} timeslots",
-                            report.expired,
-                            report.timeslots_swept,
-                        );
-                    }
-                    Ok(_) => {} // nothing to sweep
-                    Err(err) => {
-                        warn!("Message expiry sweep error: {err}");
+        // `E` is pinned explicitly: the loop never returns `Err`, so the
+        // error type is otherwise unconstrained.
+        supervisor.spawn::<_, _, String>("message_expiry_sweep", false, move || {
+            let store = store.clone();
+            let admin_did_hash = admin_did_hash.clone();
+            async move {
+                let mut tick = tokio::time::interval(Duration::from_secs(1));
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tick.tick().await;
+                    let now_secs = chrono::Utc::now().timestamp().max(0) as u64;
+                    match store
+                        .sweep_expired_messages(now_secs, &admin_did_hash)
+                        .await
+                    {
+                        Ok(report) if report.expired > 0 || report.timeslots_swept > 0 => {
+                            info!(
+                                event_type = "ExpirySweep",
+                                timeslots_swept = report.timeslots_swept,
+                                expired = report.expired,
+                                already_deleted = report.already_deleted,
+                                "expiry sweep drained {} messages across {} timeslots",
+                                report.expired,
+                                report.timeslots_swept,
+                            );
+                        }
+                        Ok(_) => {} // nothing to sweep
+                        Err(err) => {
+                            warn!("Message expiry sweep error: {err}");
+                        }
                     }
                 }
             }
         });
     }
 
-    // Session expiry sweep — reclaims expired session records on
-    // backends without native TTL (Fjall, memory). On Redis the trait
-    // default is a no-op, so this loop just ticks and finds nothing.
-    // Sessions expire over 15-minute / 24-hour horizons, so a full
-    // partition scan every second (as the message sweep does) would be
-    // wasteful — a coarser cadence is plenty.
+    // Session expiry sweep — non-load-bearing housekeeping. Reclaims
+    // expired session records on backends without native TTL (Fjall,
+    // memory). On Redis the trait default is a no-op, so this loop just
+    // ticks and finds nothing. Sessions expire over 15-minute / 24-hour
+    // horizons, so a coarse cadence is plenty.
     if config.processors.session_expiry_cleanup.enabled {
-        let session_store = store.clone();
-        let cleanup_token = shutdown_token.clone();
-        tokio::spawn(async move {
-            const SESSION_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
-            let mut tick = tokio::time::interval(SESSION_SWEEP_INTERVAL);
-            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select! {
-                    _ = cleanup_token.cancelled() => {
-                        info!("Session expiry cleanup shutting down");
-                        return;
-                    }
-                    _ = tick.tick() => {}
-                }
-
-                let now_secs = chrono::Utc::now().timestamp().max(0) as u64;
-                match session_store.sweep_expired_sessions(now_secs).await {
-                    Ok(report) if report.expired > 0 => {
-                        info!(
-                            event_type = "SessionExpirySweep",
-                            scanned = report.scanned,
-                            expired = report.expired,
-                            "session expiry sweep reclaimed {} of {} sessions",
-                            report.expired,
-                            report.scanned,
-                        );
-                    }
-                    Ok(_) => {} // nothing expired
-                    Err(err) => {
-                        warn!("Session expiry sweep error: {err}");
+        let store = store.clone();
+        supervisor.spawn::<_, _, String>("session_expiry_sweep", false, move || {
+            let store = store.clone();
+            async move {
+                const SESSION_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+                let mut tick = tokio::time::interval(SESSION_SWEEP_INTERVAL);
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tick.tick().await;
+                    let now_secs = chrono::Utc::now().timestamp().max(0) as u64;
+                    match store.sweep_expired_sessions(now_secs).await {
+                        Ok(report) if report.expired > 0 => {
+                            info!(
+                                event_type = "SessionExpirySweep",
+                                scanned = report.scanned,
+                                expired = report.expired,
+                                "session expiry sweep reclaimed {} of {} sessions",
+                                report.expired,
+                                report.scanned,
+                            );
+                        }
+                        Ok(_) => {} // nothing expired
+                        Err(err) => {
+                            warn!("Session expiry sweep error: {err}");
+                        }
                     }
                 }
             }
         });
     }
 
-    // VTA secrets refresh — only present when this is a VTA-linked
-    // deployment. Spawns a fire-and-forget loop that refreshes the
-    // cached bundle and runtime resolver on a cadence derived from
-    // the configured `[secrets].cache_ttl`. Also the path that
-    // converges a circular-bootstrapped mediator to a fresh cache
-    // once the listener is live.
+    // VTA secrets refresh — load-bearing when present (a stale operating
+    // secret means the mediator silently fails to decrypt its own inbound
+    // DIDComm). Only spawned for VTA-linked deployments. `run` honours the
+    // shutdown token itself; the supervisor's abort is a backstop.
     if let Some(refresher) = config.vta_refresher.clone() {
         let refresh_token = shutdown_token.clone();
-        tokio::spawn(async move {
-            refresher.run(refresh_token).await;
+        supervisor.spawn("vta_refresh", true, move || {
+            let refresher = refresher.clone();
+            let refresh_token = refresh_token.clone();
+            async move {
+                refresher.run(refresh_token).await;
+                Ok::<(), String>(())
+            }
         });
     }
 
@@ -577,6 +571,7 @@ pub async fn serve_internal(
         did_rate_limiter,
         shutdown_token: shutdown_token.clone(),
         self_authorities: Arc::new(self_authorities),
+        component_health: supervisor.registry(),
     };
 
     let app: Router = application_routes(&api_prefix, &shared_state);
@@ -610,6 +605,10 @@ pub async fn serve_internal(
         .route(
             join_api_path(&api_prefix, "readyz").as_str(),
             get(readiness_handler).with_state(shared_state.clone()),
+        )
+        .route(
+            join_api_path(&api_prefix, "livez").as_str(),
+            get(liveness_handler),
         )
         .route(
             join_api_path(&api_prefix, "admin/status").as_str(),

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
@@ -6,5 +6,6 @@
 /// implementation; re-exported here for backward compatibility.
 pub use affinidi_messaging_mediator_common::tasks::forwarding as forwarding_processor;
 pub mod statistics;
+pub mod supervisor;
 pub mod vta_refresh;
 pub mod websocket_streaming;

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/supervisor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/supervisor.rs
@@ -1,0 +1,385 @@
+//! Background-task supervision.
+//!
+//! Every long-lived background task (statistics, forwarding processor,
+//! message- and session-expiry sweeps, VTA secrets refresh) is spawned
+//! through a [`TaskSupervisor`] instead of a bare `tokio::spawn`. The
+//! supervisor turns a silent task death into a *detected, recovered, and
+//! observable* event:
+//!
+//! - **Restart on failure.** A task that returns an error or panics is
+//!   restarted with capped exponential backoff (1s → 60s). The supervisor
+//!   never gives up — a mediator with a wedged sweep keeps serving traffic
+//!   while the fault is logged at ERROR with its restart history. This is
+//!   the deliberate "restart-and-degrade, never fail-fast" posture: an
+//!   orchestrator should not kill a mediator that is still answering
+//!   requests just because a housekeeping loop is flapping.
+//! - **Health registry.** Each task's state (`Running` / `Restarting` /
+//!   `Stopped`), restart count, last error, and last-transition time are
+//!   recorded in a [`HealthRegistry`] that the `/readyz` handler reads to
+//!   decide readiness (a down *load-bearing* component → 503; a down
+//!   non-load-bearing component → 200 + `degraded`).
+//! - **Clean shutdown.** When the shared [`CancellationToken`] fires, the
+//!   running task is aborted and marked `Stopped` with no restart.
+//!
+//! The supervisor owns cancellation, so supervised task bodies don't need
+//! their own shutdown `select!` — they can be a plain `loop { … }` and the
+//! supervisor aborts them on shutdown. The sweeps are idempotent, so an
+//! abort mid-iteration is safe.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+/// Backoff applied after the first failure; doubles each subsequent
+/// consecutive failure up to [`MAX_BACKOFF`].
+const BASE_BACKOFF: Duration = Duration::from_secs(1);
+/// Ceiling for the restart backoff, so a permanently-broken component
+/// retries at a steady, low rate rather than hot-looping.
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Lifecycle state of a supervised component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentState {
+    /// The task future is currently executing.
+    Running,
+    /// The task failed and the supervisor is backing off before its next
+    /// restart attempt.
+    Restarting,
+    /// The task was stopped by shutdown and will not restart.
+    Stopped,
+}
+
+/// A point-in-time health snapshot for one supervised component.
+#[derive(Clone, Debug, Serialize)]
+pub struct ComponentHealth {
+    /// Stable component name (e.g. `"forwarding_processor"`).
+    pub name: String,
+    /// Whether a non-`Running` state should fail readiness (`/readyz` 503)
+    /// rather than merely mark the mediator `degraded`.
+    pub load_bearing: bool,
+    /// Current lifecycle state.
+    pub state: ComponentState,
+    /// Number of times the task has been restarted since process start.
+    pub restarts: u64,
+    /// Display of the most recent failure, if any.
+    pub last_error: Option<String>,
+    /// When the component last changed state.
+    pub since: DateTime<Utc>,
+}
+
+/// Shared, concurrently-readable map of component name → health. Cloned
+/// into [`SharedData`](crate::SharedData) so the readiness handler can read
+/// it without locking out the supervisor's writes.
+pub type HealthRegistry = Arc<DashMap<String, ComponentHealth>>;
+
+/// Spawns and supervises background tasks against a shared shutdown token,
+/// publishing their health into a [`HealthRegistry`].
+#[derive(Clone)]
+pub struct TaskSupervisor {
+    registry: HealthRegistry,
+    shutdown: CancellationToken,
+}
+
+impl TaskSupervisor {
+    /// Create a supervisor bound to `shutdown` (the same token used for
+    /// graceful shutdown elsewhere in the server).
+    pub fn new(shutdown: CancellationToken) -> Self {
+        Self {
+            registry: Arc::new(DashMap::new()),
+            shutdown,
+        }
+    }
+
+    /// The shared health registry. Clone this into request state so health
+    /// endpoints can report component status.
+    pub fn registry(&self) -> HealthRegistry {
+        self.registry.clone()
+    }
+
+    /// Spawn a supervised task.
+    ///
+    /// `factory` is invoked once per (re)start to produce the task future;
+    /// constructing fresh state each attempt (e.g. a new
+    /// `ForwardingProcessor`) keeps restarts clean. The future returns
+    /// `Ok(())` on intentional completion or `Err(_)` to request a restart;
+    /// a panic is caught and likewise triggers a restart.
+    ///
+    /// `load_bearing` controls how the readiness handler treats a
+    /// non-`Running` state — see [`ComponentHealth::load_bearing`].
+    pub fn spawn<F, Fut, E>(&self, name: impl Into<String>, load_bearing: bool, factory: F)
+    where
+        F: Fn() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), E>> + Send + 'static,
+        E: std::fmt::Display + Send + 'static,
+    {
+        let name = name.into();
+        let registry = self.registry.clone();
+        let shutdown = self.shutdown.clone();
+
+        set_state(
+            &registry,
+            &name,
+            load_bearing,
+            ComponentState::Running,
+            0,
+            None,
+        );
+
+        tokio::spawn(async move {
+            let mut restarts: u64 = 0;
+            loop {
+                // Mark Running at the top of every iteration so a task that
+                // recovered after a restart is reported healthy again (the
+                // prior `last_error` is preserved — `None` here leaves it
+                // untouched — so operators can still see it flapped).
+                set_state(
+                    &registry,
+                    &name,
+                    load_bearing,
+                    ComponentState::Running,
+                    restarts,
+                    None,
+                );
+
+                // Spawn the task on its own handle so a panic surfaces as a
+                // `JoinError` rather than tearing down the supervisor.
+                let mut handle = tokio::spawn(factory());
+
+                let failure: String = tokio::select! {
+                    joined = &mut handle => match joined {
+                        Ok(Ok(())) => {
+                            // Completed without error. Under shutdown that's
+                            // expected; otherwise a long-lived task ending is
+                            // itself a fault, so restart it.
+                            if shutdown.is_cancelled() {
+                                stop(&registry, &name, restarts);
+                                return;
+                            }
+                            warn!(task = %name, "Supervised task completed unexpectedly; restarting");
+                            "task returned before shutdown".to_string()
+                        }
+                        Ok(Err(e)) => e.to_string(),
+                        Err(join_err) if join_err.is_panic() => format!("panicked: {join_err}"),
+                        Err(join_err) => {
+                            // Cancelled/aborted without us asking — treat as a
+                            // stop rather than spin.
+                            warn!(task = %name, error = %join_err, "Supervised task aborted");
+                            stop(&registry, &name, restarts);
+                            return;
+                        }
+                    },
+                    _ = shutdown.cancelled() => {
+                        handle.abort();
+                        stop(&registry, &name, restarts);
+                        info!(task = %name, "Supervised task stopped (shutdown)");
+                        return;
+                    }
+                };
+
+                restarts += 1;
+                let backoff = backoff_for(restarts);
+                error!(
+                    task = %name,
+                    restarts,
+                    load_bearing,
+                    last_error = %failure,
+                    backoff_secs = backoff.as_secs(),
+                    "Supervised background task failed; restarting after backoff. \
+                     If this persists, inspect the backend/connectivity for this \
+                     component — the mediator keeps serving but this function is degraded.",
+                );
+                set_state(
+                    &registry,
+                    &name,
+                    load_bearing,
+                    ComponentState::Restarting,
+                    restarts,
+                    Some(failure),
+                );
+
+                tokio::select! {
+                    _ = tokio::time::sleep(backoff) => {}
+                    _ = shutdown.cancelled() => {
+                        stop(&registry, &name, restarts);
+                        info!(task = %name, "Supervised task stopped during backoff (shutdown)");
+                        return;
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Exponential backoff: `BASE * 2^(restarts-1)`, capped at `MAX_BACKOFF`.
+fn backoff_for(restarts: u64) -> Duration {
+    // Cap the exponent so the shift can't overflow; `MAX_BACKOFF` clamps the
+    // result regardless.
+    let exp = restarts.saturating_sub(1).min(16) as u32;
+    BASE_BACKOFF.saturating_mul(1u32 << exp).min(MAX_BACKOFF)
+}
+
+fn set_state(
+    registry: &HealthRegistry,
+    name: &str,
+    load_bearing: bool,
+    state: ComponentState,
+    restarts: u64,
+    last_error: Option<String>,
+) {
+    registry
+        .entry(name.to_string())
+        .and_modify(|h| {
+            h.state = state;
+            h.restarts = restarts;
+            if last_error.is_some() {
+                h.last_error = last_error.clone();
+            }
+            h.since = Utc::now();
+        })
+        .or_insert_with(|| ComponentHealth {
+            name: name.to_string(),
+            load_bearing,
+            state,
+            restarts,
+            last_error,
+            since: Utc::now(),
+        });
+}
+
+fn stop(registry: &HealthRegistry, name: &str, restarts: u64) {
+    if let Some(mut h) = registry.get_mut(name) {
+        h.state = ComponentState::Stopped;
+        h.restarts = restarts;
+        h.since = Utc::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    fn state_of(reg: &HealthRegistry, name: &str) -> Option<ComponentState> {
+        reg.get(name).map(|h| h.state)
+    }
+
+    async fn wait_for<F: Fn() -> bool>(pred: F) {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if pred() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("condition not met within timeout");
+    }
+
+    #[tokio::test]
+    async fn backoff_is_exponential_and_capped() {
+        assert_eq!(backoff_for(1), Duration::from_secs(1));
+        assert_eq!(backoff_for(2), Duration::from_secs(2));
+        assert_eq!(backoff_for(3), Duration::from_secs(4));
+        assert_eq!(backoff_for(7), Duration::from_secs(60)); // 64 → capped
+        assert_eq!(backoff_for(99), Duration::from_secs(60));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn restarts_a_failing_task_with_backoff() {
+        let sup = TaskSupervisor::new(CancellationToken::new());
+        let reg = sup.registry();
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = attempts.clone();
+
+        sup.spawn("flaky", false, move || {
+            let a = a.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err::<(), String>("boom".to_string())
+            }
+        });
+
+        // First attempt runs immediately and fails; the registry should show
+        // Restarting with the error recorded.
+        wait_for(|| attempts.load(Ordering::SeqCst) >= 1).await;
+        wait_for(|| state_of(&reg, "flaky") == Some(ComponentState::Restarting)).await;
+        assert_eq!(
+            reg.get("flaky").unwrap().last_error.as_deref(),
+            Some("boom")
+        );
+
+        // Advancing past the 1s backoff drives the next attempt.
+        tokio::time::advance(Duration::from_secs(1)).await;
+        wait_for(|| attempts.load(Ordering::SeqCst) >= 2).await;
+        assert!(reg.get("flaky").unwrap().restarts >= 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restarts_after_a_panic() {
+        let sup = TaskSupervisor::new(CancellationToken::new());
+        let reg = sup.registry();
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = attempts.clone();
+
+        sup.spawn("panicky", true, move || {
+            let a = a.clone();
+            async move {
+                let n = a.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    panic!("first attempt panics");
+                }
+                // Second attempt: run forever so it stays Running.
+                std::future::pending::<()>().await;
+                Ok::<(), String>(())
+            }
+        });
+
+        // The panic must be caught and the task restarted into a Running
+        // state — the supervisor itself must survive.
+        wait_for(|| attempts.load(Ordering::SeqCst) >= 2).await;
+        wait_for(|| state_of(&reg, "panicky") == Some(ComponentState::Running)).await;
+        assert!(reg.get("panicky").unwrap().restarts >= 1);
+        assert!(reg.get("panicky").unwrap().load_bearing);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_shutdown_stops_without_restart() {
+        let token = CancellationToken::new();
+        let sup = TaskSupervisor::new(token.clone());
+        let reg = sup.registry();
+        let attempts = Arc::new(AtomicU32::new(0));
+        let a = attempts.clone();
+
+        sup.spawn("worker", true, move || {
+            let a = a.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<()>().await; // runs until aborted
+                Ok::<(), String>(())
+            }
+        });
+
+        wait_for(|| state_of(&reg, "worker") == Some(ComponentState::Running)).await;
+        token.cancel();
+        wait_for(|| state_of(&reg, "worker") == Some(ComponentState::Stopped)).await;
+
+        // No restart should occur after shutdown.
+        let count = attempts.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            count,
+            "task restarted after shutdown"
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 10th June 2026
 
+### 0.2.7 — health-endpoint integration tests (mediator T2)
+
+- **TEST:** new `health_endpoints` suite covering the task-supervision
+  health contract added in `affinidi-messaging-mediator` 0.15.22 — `/livez`
+  returns 200 (process-liveness only) and `/readyz` reports supervised
+  background tasks under `components` with the always-on `statistics` task
+  and the load-bearing `forwarding_processor` task both `running`. Runs on
+  the default in-memory backend; fixture API unchanged.
+
 ### 0.2.6 — relay rewrap builder knobs + end-to-end rewrap tests (#388)
 
 - **FEAT:** `TestMediatorBuilder::relay_mode(RelayMode)` and

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.6"
+version = "0.2.7"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/health_endpoints.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/health_endpoints.rs
@@ -1,0 +1,108 @@
+//! Health-endpoint wiring: `/livez` and `/readyz` component health.
+//!
+//! Validates the task-supervision contract end-to-end through a real
+//! spawned mediator (the same `serve_internal` path the binary uses):
+//! - `/livez` is process-liveness only and answers 200.
+//! - `/readyz` reports the supervised background tasks under `components`,
+//!   with the always-on `statistics` task running, and (when forwarding is
+//!   enabled) the load-bearing `forwarding_processor` task running.
+//!
+//! These run on the default in-memory backend — no Redis.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestMediator;
+use common::init_tracing;
+use serde_json::Value;
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("client")
+}
+
+#[tokio::test]
+async fn livez_is_liveness_only_and_returns_200() {
+    init_tracing();
+    let mediator = TestMediator::spawn().await.expect("spawn");
+    let client = http_client();
+
+    let resp = client
+        .get(format!("{}livez", mediator.endpoint()))
+        .send()
+        .await
+        .expect("livez request");
+    assert_eq!(resp.status().as_u16(), 200, "livez should be 200");
+
+    let body: Value = resp.json().await.expect("livez json");
+    assert_eq!(body["status"], "alive");
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+#[tokio::test]
+async fn readyz_reports_supervised_component_health() {
+    init_tracing();
+    // Forwarding on so the load-bearing `forwarding_processor` component is
+    // present alongside the always-on `statistics` task.
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .spawn()
+        .await
+        .expect("spawn");
+    let client = http_client();
+
+    // The supervisor populates the registry synchronously at spawn, but give
+    // the tasks a moment to reach Running before asserting.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // /readyz may be 200 or 503 depending on backend-probe specifics; the
+    // body carries the component health regardless of status code.
+    let resp = client
+        .get(format!("{}readyz", mediator.endpoint()))
+        .send()
+        .await
+        .expect("readyz request");
+    let body: Value = resp.json().await.expect("readyz json");
+
+    let components = body["components"]
+        .as_array()
+        .expect("readyz body has a components array");
+    assert!(
+        !components.is_empty(),
+        "expected supervised components to be reported, got {body}"
+    );
+
+    // Every reported component must carry the supervision fields.
+    for c in components {
+        assert!(c["name"].is_string(), "component missing name: {c}");
+        assert!(c["state"].is_string(), "component missing state: {c}");
+        assert!(
+            c["load_bearing"].is_boolean(),
+            "component missing load_bearing: {c}"
+        );
+    }
+
+    let find = |name: &str| components.iter().find(|c| c["name"] == name).cloned();
+
+    let stats = find("statistics").expect("statistics component present");
+    assert_eq!(stats["state"], "running", "statistics should be running");
+    assert_eq!(stats["load_bearing"], false);
+
+    let fwd = find("forwarding_processor").expect("forwarding_processor component present");
+    assert_eq!(
+        fwd["state"], "running",
+        "forwarding processor should be running"
+    );
+    assert_eq!(
+        fwd["load_bearing"], true,
+        "forwarding processor is load-bearing"
+    );
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}


### PR DESCRIPTION
## Summary

**T2** of the mediator architectural-simplification plan (Phase 1 — resilience). Replaces fire-and-forget `tokio::spawn` for every long-lived background task with a supervising wrapper, and splits the health probes into liveness vs. readiness with per-component detail.

Motivation: `server.rs` spawned ~5 background tasks (statistics, forwarding processor, message/session expiry sweeps, VTA refresh) with no supervision — each fire-and-forget with only a shutdown `select!`. A **panic** in any of them killed that function silently. The forwarding processor (which #399 made run on *every* backend) is the sharpest example: a panic there stops all cross-mediator forwarding with zero signal.

## What's implemented

**`TaskSupervisor`** (`src/tasks/supervisor.rs`)
- Runs each task; on **error-return or panic**, restarts it with capped exponential backoff (1s → 60s). Never gives up — the deliberate *restart-and-degrade, never fail-fast* posture: the mediator keeps serving while the fault is logged at ERROR with restart history + a corrective hint.
- Publishes per-component health (`state` ∈ {running, restarting, stopped}, `restarts`, `last_error`, `since`) into a `dashmap`-backed `HealthRegistry` (dashmap became a direct dep in T1).
- Owns cancellation: on shutdown it aborts the task and marks it `stopped` (no restart). The supervised loop bodies therefore dropped their own shutdown `select!` (sweeps are idempotent, so a mid-iteration abort is safe).

**Health-probe contract**
- New **`GET …/livez`** — process-liveness only, always 200 while the server answers. Orchestrators should use this for liveness so they don't kill a mediator that's still serving while a background component is degraded.
- **`GET …/readyz`** now folds supervised-task health into a new `components` array. A **load-bearing** component not running → 503 `not_ready`; a non-load-bearing one → 200 `degraded` (stays in rotation).

**Load-bearing classification** (a per-task boolean — easy to flip if you disagree):
| Task | Load-bearing? | Rationale |
|---|---|---|
| `forwarding_processor` | ✅ | core cross-mediator delivery path |
| `vta_refresh` | ✅ | stale operating secret → silent decrypt outage (cf. #394/#398) |
| `statistics` | ❌ | metrics only |
| `message_expiry_sweep` | ❌ | housekeeping |
| `session_expiry_sweep` | ❌ | housekeeping |

## Tests

- `supervisor.rs` — 4 unit tests: exponential/capped backoff; restart-on-error (paused clock, deterministic — adds tokio `test-util` to dev-deps); restart-on-panic (the supervisor survives a panicking task and drives it back to `running`); clean-shutdown-no-restart.
- `affinidi-messaging-test-mediator/tests/health_endpoints.rs` — `/livez` 200; `/readyz` reports `statistics` (running, non-load-bearing) and `forwarding_processor` (running, load-bearing), on the memory backend.

**Bug caught while testing:** the supervisor must re-mark a component `running` at the top of each loop iteration — otherwise a task that recovered after a restart stays `restarting` forever, which would make `/readyz` report a healthy-again load-bearing component as permanently down.

## Scope notes

- The WebSocket streaming task owns its own lifecycle (`StreamingTask::new`) and is **not** yet routed through the supervisor — a focused follow-up.
- Health-state semantics deliberately keep the existing deep `/readyz` checks (Redis/circuit-breaker/secrets/queue) unchanged; component health is additive.

## Versions

`affinidi-messaging-mediator` 0.15.21 → 0.15.22; `affinidi-messaging-test-mediator` 0.2.6 → 0.2.7.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend`, `didcomm,memory-backend`, and test-mediator; `cargo test -p affinidi-messaging-mediator --lib` 123 passed (incl. 4 supervisor); test-mediator full suite incl. 2 `health_endpoints` passed; `cargo deny` ok.

Next in the Phase 1 sweep: T3 (storage-call timeouts), T4 (session-rename atomicity), T5 (ACL bitfield tests), T6 (config invariants).
