### PR TITLE
feat: bound request-validation storage calls with an explicit timeout (simplification T3)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 10th June 2026
 
+### 0.15.23 — Explicit timeout on request-validation storage calls (simplification T3)
+
+- Adds an explicit, configurable, backend-agnostic timeout
+  (`common::storage_timeout::with_storage_timeout`) around the storage
+  calls made while *admitting/validating* a request — the routing
+  forward-queue-depth admission check and the `/readyz` Redis-metadata and
+  forward-queue-length probes. On expiry these now return a clean
+  `DatabaseError` (HTTP 503 "Service temporarily unavailable") instead of
+  hanging the request (which would amplify load via client retries).
+- The bound reuses the existing `[database] database_timeout` (default 2s)
+  via a new `SharedData::storage_timeout()` accessor — no new config knob.
+- **Context:** the production Redis backend already caps every command at
+  `database_timeout` (the request path only uses the response-timeout
+  connection; the un-timed connection is reserved for background blocking
+  reads), so this is primarily defense-in-depth — it makes the admission/
+  probe bound explicit and testable, and extends it to in-process backends
+  (Fjall/Memory) and any future backend lacking its own command timeout.
+  Verified with a unit test that drives a never-resolving store through the
+  timeout.
+
 ### 0.15.22 — Supervised background tasks + `/livez` health split (simplification T2)
 
 - **Background tasks are now supervised.** Every long-lived background task

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.22"
+version = "0.15.23"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/mod.rs
@@ -8,4 +8,5 @@ pub mod metrics;
 pub mod rate_limiter;
 pub mod request_id;
 pub mod session;
+pub mod storage_timeout;
 pub mod time;

--- a/crates/messaging/affinidi-messaging-mediator/src/common/storage_timeout.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/storage_timeout.rs
@@ -1,0 +1,103 @@
+//! Bounded request-path storage calls.
+//!
+//! A storage call made while *admitting* or *validating* an inbound request
+//! (e.g. the forward-queue-depth admission check, or the `/readyz` probe)
+//! must not hang: a stalled backend would tie up the request, and client
+//! retries would amplify the load.
+//!
+//! The production Redis backend already caps every command at
+//! `[database] database_timeout` (the request path only ever uses the
+//! response-timeout connection; the un-timed connection is reserved for
+//! background blocking reads). This helper makes that bound **explicit,
+//! configurable, and backend-agnostic** for the request-validation path —
+//! it also covers in-process backends (Fjall/Memory) and any future
+//! backend without its own command timeout. On expiry it returns a clean
+//! `DatabaseError` (HTTP 503 / `me.res.storage.timeout`) instead of
+//! hanging.
+
+use std::future::Future;
+use std::time::Duration;
+
+use affinidi_messaging_mediator_common::errors::MediatorError;
+
+use crate::common::error_codes;
+
+/// Run a request-path storage future under `timeout`, returning a
+/// `DatabaseError` if it does not complete in time.
+///
+/// `op` names the operation (for the log line); `session_id` threads the
+/// caller's session through to the error so it is traceable (`"NA"` where
+/// there is no session, e.g. the readiness probe).
+pub async fn with_storage_timeout<T, F>(
+    timeout: Duration,
+    op: &str,
+    session_id: &str,
+    fut: F,
+) -> Result<T, MediatorError>
+where
+    F: Future<Output = Result<T, MediatorError>>,
+{
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(result) => result,
+        Err(_) => Err(MediatorError::DatabaseError(
+            error_codes::DB_OPERATION_ERROR,
+            session_id.to_string(),
+            format!(
+                "storage operation '{op}' timed out after {}s",
+                timeout.as_secs()
+            ),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test(start_paused = true)]
+    async fn returns_value_when_inner_completes_in_time() {
+        let out: Result<u8, MediatorError> =
+            with_storage_timeout(Duration::from_secs(5), "noop", "NA", async { Ok(7u8) }).await;
+        assert_eq!(out.unwrap(), 7);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn maps_a_hung_call_to_a_database_error() {
+        // A future that never resolves stands in for a wedged backend.
+        let never = std::future::pending::<Result<(), MediatorError>>();
+        let fut = with_storage_timeout(
+            Duration::from_secs(5),
+            "get_forward_tasks_len",
+            "sess-1",
+            never,
+        );
+        tokio::pin!(fut);
+
+        // Before the timeout elapses the call is still pending.
+        assert!(
+            futures_poll_pending(&mut fut).await,
+            "should not resolve before the timeout"
+        );
+
+        // Advancing past the timeout yields a 503 DatabaseError, not a hang.
+        tokio::time::advance(Duration::from_secs(6)).await;
+        match fut.await {
+            Err(MediatorError::DatabaseError(_, session, msg)) => {
+                assert_eq!(session, "sess-1");
+                assert!(msg.contains("get_forward_tasks_len"), "msg was: {msg}");
+                assert!(msg.contains("timed out"), "msg was: {msg}");
+            }
+            other => panic!("expected DatabaseError, got {other:?}"),
+        }
+    }
+
+    /// Poll a pinned future once; return `true` if it is still pending.
+    async fn futures_poll_pending<F: Future>(fut: &mut std::pin::Pin<&mut F>) -> bool {
+        std::future::poll_fn(|cx| {
+            let pending = fut.as_mut().poll(cx).is_pending();
+            std::task::Poll::Ready(pending)
+        })
+        .await
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -1,4 +1,7 @@
-use crate::{SharedData, common::session::Session, tasks::supervisor::ComponentState};
+use crate::{
+    SharedData, common::session::Session, common::storage_timeout::with_storage_timeout,
+    tasks::supervisor::ComponentState,
+};
 use affinidi_messaging_mediator_common::errors::AppError;
 use affinidi_messaging_sdk::messages::SuccessResponse;
 use axum::{
@@ -179,8 +182,16 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
         }));
     }
 
-    // Check Redis connectivity
-    match state.database.get_db_metadata().await {
+    // Check Redis connectivity. Bounded so a wedged backend fails the probe
+    // promptly rather than hanging the load-balancer health check.
+    match with_storage_timeout(
+        state.storage_timeout(),
+        "get_db_metadata",
+        "NA",
+        state.database.get_db_metadata(),
+    )
+    .await
+    {
         Ok(_) => {
             checks.push(serde_json::json!({
                 "name": "redis",
@@ -197,8 +208,15 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
         }
     }
 
-    // Check FORWARD_Q length
-    match state.database.get_forward_tasks_len().await {
+    // Check FORWARD_Q length (bounded — see above).
+    match with_storage_timeout(
+        state.storage_timeout(),
+        "get_forward_tasks_len",
+        "NA",
+        state.database.get_forward_tasks_len(),
+    )
+    .await
+    {
         Ok(len) => {
             let queue_status = if len >= state.config.limits.forward_task_queue {
                 all_ok = false;

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -68,6 +68,16 @@ pub struct SharedData {
     pub component_health: HealthRegistry,
 }
 
+impl SharedData {
+    /// Bound for request-path storage calls made during admission/validation
+    /// (see [`common::storage_timeout`]). Sourced from the existing
+    /// `[database] database_timeout` (the same knob that caps Redis
+    /// commands), so it is operator-configurable and backend-agnostic.
+    pub fn storage_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.config.database.database_timeout as u64)
+    }
+}
+
 impl Debug for SharedData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SharedData")

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -1,3 +1,4 @@
+use crate::common::storage_timeout::with_storage_timeout;
 use crate::common::time::{unix_timestamp_millis, unix_timestamp_secs};
 
 use crate::didcomm_compat::MetaEnvelope;
@@ -504,7 +505,13 @@ pub(crate) async fn process(
         }
 
         if !ephemeral
-            && state.database.get_forward_tasks_len().await?
+            && with_storage_timeout(
+                state.storage_timeout(),
+                "get_forward_tasks_len",
+                &session.session_id,
+                state.database.get_forward_tasks_len(),
+            )
+            .await?
                 >= state.config.limits.forward_task_queue
         {
             warn!(


### PR DESCRIPTION
## Summary

**T3** of the mediator architectural-simplification plan (Phase 1). Bounds the storage calls made while *admitting/validating* an inbound request so a stalled backend returns a clean error instead of hanging the handler (which would amplify load via client retries).

Wrapped, via a new `common::storage_timeout::with_storage_timeout` helper:
- the routing **forward-queue-depth admission check** (`get_forward_tasks_len`), and
- the **`/readyz`** Redis-metadata (`get_db_metadata`) and forward-queue-length probes.

On expiry these return a clean `DatabaseError` → **HTTP 503** "Service temporarily unavailable" instead of hanging.

The bound reuses the existing **`[database] database_timeout`** (default 2s) via a new `SharedData::storage_timeout()` accessor — no new config knob, so no churn in the dual config parser.

## Scope rationale (the premise was partly already handled)

While scoping this I confirmed the production **Redis backend already caps every command** at `database_timeout`: the request path only ever uses the response-timeout connection, while the un-timed connection (`set_response_timeout(None)`) is reserved for **background** blocking reads (`forward_queue_read`, streaming subscribe). Non-Redis backends are in-process (no network hang). So request-path hangs are already largely mitigated.

This PR therefore lands the **light, defense-in-depth** version: it makes the admission/probe bound **explicit, testable, and backend-agnostic** (covering Fjall/Memory and any future backend without its own command timeout), rather than a full 71-method `TimeoutStore` decorator that would be largely redundant with the existing Redis timeout. (Scope was confirmed before implementing.)

## Tests

`common::storage_timeout` unit tests (paused clock, deterministic):
- pass-through returns the inner value on success;
- a **never-resolving** store is mapped to a 503 `DatabaseError` with the op name and session threaded through — proving the call returns instead of hanging.

## Versions

`affinidi-messaging-mediator` 0.15.22 → 0.15.23.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` and `didcomm,memory-backend`; `cargo test -p affinidi-messaging-mediator --lib` 125 passed (incl. 2 new); `cargo deny` ok.

Sweep status: T1 ✅, T2 ✅, **T3 in review**. Next: T4 (session-rename atomicity), T5 (ACL bitfield tests), T6 (config invariants).
