### PR TITLE
fix: stop didcomm-service websocket on terminal listener exit

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.5] - 2026-06-10
+
+### Fixed
+
+- Listener now tears down its websocket transport (`stop_websocket`) on
+  terminal exit — shutdown, `RestartPolicy::Never`, or exhausted
+  `OnFailure` retries — not only on the reconnect path. The SDK websocket
+  runs as an independent, self-reconnecting spawned task with no `Drop`
+  hook, so dropping the listener's `ATM`/profile previously left it alive.
+  In an in-process service teardown (e.g. a host's *soft restart*, where
+  the process keeps running) the orphaned socket kept reconnecting to the
+  mediator while the newly-started service opened a second channel for the
+  same DID, producing an endless `w.websocket.duplicate-channel` flood.
+
 ## [0.3.3] - 2026-06-01
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.4"
+version = "0.3.5"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -32,6 +32,11 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 affinidi-did-common = "0.3"
+# Embedded mediator fixture + DID generation for the soft-restart websocket
+# regression test. Sister-crate path deps carry an explicit `version =` so the
+# package stays publishable while using the in-tree path for dev-builds.
+affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator" }
+affinidi-tdk = { version = "0.7", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 
 
 [[example]]

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/restart.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/restart.rs
@@ -131,6 +131,21 @@ impl Listener {
                 }
             }
         }
+
+        // The websocket transport runs as an independent spawned task with its
+        // own auto-reconnect loop, and there is no `Drop` that stops it —
+        // dropping this listener's `ATM`/profile leaves that task alive. On the
+        // reconnect path `connect()` already tears the old socket down before
+        // opening a new one; the terminal-exit path (shutdown, `Never`, or
+        // exhausted `OnFailure` retries) must do the same. Without this, an
+        // in-process service teardown (e.g. a soft restart, where the process
+        // keeps running) orphans the websocket: it keeps reconnecting to the
+        // mediator while the freshly-started service opens a second channel
+        // for the same DID, triggering an endless `w.websocket.duplicate-channel`
+        // flood. `stop_websocket` is a no-op if the socket is already stopped.
+        if let Ok(profile) = self.profile() {
+            let _ = profile.stop_websocket().await;
+        }
     }
 }
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/tests/soft_restart_websocket.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/tests/soft_restart_websocket.rs
@@ -1,0 +1,168 @@
+//! Regression test for the in-process service-teardown websocket leak.
+//!
+//! The SDK websocket transport runs as an independent, self-reconnecting
+//! spawned task that is *not* stopped by dropping the listener's `ATM` /
+//! profile — only an explicit `stop_websocket()` (a `WebSocketCommands::Stop`)
+//! ends it. `connect()` already tears the old socket down on the reconnect
+//! path; before the fix, the terminal-exit path (shutdown / `Never` /
+//! exhausted retries) did not.
+//!
+//! On a process that exits (hard restart) the leak is invisible — the OS
+//! reaps every task. But a *soft restart* keeps the process alive and builds
+//! a fresh `DIDCommService` for the same DID. The orphaned socket from the
+//! previous service keeps reconnecting to the mediator while the new service
+//! opens a second channel for the same DID, and the mediator answers with an
+//! endless `w.websocket.duplicate-channel` flood.
+//!
+//! This test reproduces that exact shape: start a service, shut it down, then
+//! start a second service for the same DID (as a soft restart does) and assert
+//! the second service never receives a duplicate-channel problem report.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_didcomm_service::{
+    DIDCommResponse, DIDCommService, DIDCommServiceConfig, DIDCommServiceError, Extension,
+    HandlerContext, ListenerConfig, MESSAGE_PICKUP_STATUS_TYPE, RestartPolicy, RetryConfig, Router,
+    TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
+};
+use affinidi_messaging_test_mediator::TestMediator;
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use affinidi_tdk_common::profiles::TDKProfile;
+use tokio_util::sync::CancellationToken;
+
+const REPORT_PROBLEM_TYPE: &str = "https://didcomm.org/report-problem/2.0/problem-report";
+const LISTENER_ID: &str = "vta-main";
+
+/// Counts `w.websocket.duplicate-channel` problem reports delivered to the
+/// listener. A healthy, singly-connected listener never receives one.
+async fn count_duplicate_channel(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(counter): Extension<Arc<AtomicUsize>>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    if serde_json::to_string(&message.body)
+        .unwrap_or_default()
+        .contains("duplicate-channel")
+    {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }
+    Ok(None)
+}
+
+fn build_router(counter: Arc<AtomicUsize>) -> Router {
+    Router::new()
+        .extension(counter)
+        .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))
+        .expect("route trust-ping")
+        .route(MESSAGE_PICKUP_STATUS_TYPE, handler_fn(ignore_handler))
+        .expect("route pickup-status")
+        .route(REPORT_PROBLEM_TYPE, handler_fn(count_duplicate_channel))
+        .expect("route problem-report")
+        .fallback(handler_fn(ignore_handler))
+}
+
+fn service_config(profile: TDKProfile) -> DIDCommServiceConfig {
+    DIDCommServiceConfig {
+        listeners: vec![ListenerConfig {
+            id: LISTENER_ID.into(),
+            profile,
+            restart_policy: RestartPolicy::Always {
+                backoff: RetryConfig {
+                    initial_delay_secs: 1,
+                    max_delay_secs: 2,
+                },
+            },
+            ..Default::default()
+        }],
+    }
+}
+
+#[tokio::test]
+async fn soft_restart_does_not_leak_a_dueling_websocket() {
+    // A single DID plays the role of the VTA across the restart.
+    let (vta_did, vta_secrets) = DID::generate_did_peer(
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ],
+        None,
+    )
+    .expect("generate VTA DID");
+
+    // Pre-register the DID as a LOCAL account so the websocket upgrade is
+    // allowed (the fixture's default ACL denies the LOCAL bit otherwise).
+    let mediator = TestMediator::builder()
+        .local_did(vta_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+    let mediator_did = mediator.did().to_string();
+
+    let profile = || {
+        TDKProfile::new(
+            "vta",
+            &vta_did,
+            Some(mediator_did.as_str()),
+            vta_secrets.clone(),
+        )
+    };
+
+    // ── First service generation ──────────────────────────────────────
+    let counter1 = Arc::new(AtomicUsize::new(0));
+    let shutdown1 = CancellationToken::new();
+    let service1 = DIDCommService::start(
+        service_config(profile()),
+        build_router(counter1.clone()),
+        shutdown1.clone(),
+    )
+    .await
+    .expect("start service generation 1");
+    service1
+        .wait_connected(LISTENER_ID, Duration::from_secs(15))
+        .await
+        .expect("service 1 connects to mediator");
+
+    // Soft restart: tear the first service down. With the fix this stops the
+    // websocket; without it, the socket is orphaned and keeps reconnecting.
+    service1.shutdown().await;
+
+    // ── Second service generation (the "restarted" VTA) ──────────────
+    let counter2 = Arc::new(AtomicUsize::new(0));
+    let shutdown2 = CancellationToken::new();
+    let service2 = DIDCommService::start(
+        service_config(profile()),
+        build_router(counter2.clone()),
+        shutdown2.clone(),
+    )
+    .await
+    .expect("start service generation 2");
+    service2
+        .wait_connected(LISTENER_ID, Duration::from_secs(15))
+        .await
+        .expect("service 2 connects to mediator");
+
+    // Give any orphaned socket several reconnect cycles (initial backoff is
+    // 1s, capped at 2s) to start a duplicate-channel war. Poll so the test
+    // fails fast on the buggy path instead of always sleeping the full window.
+    for _ in 0..16 {
+        if counter2.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    let dup_count = counter2.load(Ordering::SeqCst);
+
+    shutdown2.cancel();
+    service2.shutdown().await;
+    mediator.shutdown();
+
+    assert_eq!(
+        dup_count, 0,
+        "restarted service received {dup_count} duplicate-channel problem report(s) — \
+         the previous generation's websocket was orphaned and kept reconnecting"
+    );
+}


### PR DESCRIPTION
## Problem

On an in-process **soft restart** of a DIDComm host (e.g. the VTA), the mediator floods the host with `w.websocket.duplicate-channel` problem-reports in an endless ~2s loop:

```
WARN ...messaging::handlers: received problem-report code="w.websocket.duplicate-channel"
     comment="A new duplicate websocket connection for this DID has caused this websocket to terminate"
```

## Root cause

The SDK websocket transport (`affinidi-messaging-sdk`) runs as an **independent, self-reconnecting spawned task** with **no `Drop` hook** — the only thing that ends it is an explicit `profile.stop_websocket()` (`WebSocketCommands::Stop`).

`Listener::connect()` already tears the old socket down on the **reconnect** path, but `run_with_restart` left it running on every **terminal exit** (shutdown, `RestartPolicy::Never`, or exhausted `OnFailure` retries). It just `break`s the loop and drops the `ATM`/profile.

- **Hard restart** (process exit): invisible — the OS reaps the task.
- **Soft restart** (process stays alive): the websocket is **orphaned**. It keeps auto-reconnecting to the mediator while the freshly-started service opens a *second* channel for the same DID. The mediator sees two channels, terminates one, the loser reconnects, and the two connections war forever.

## Fix

Tear the socket down once after the run loop exits, covering all terminal paths — symmetric with what `connect()` already does on reconnect. `stop_websocket()` is a no-op if the socket is already stopped.

```rust
if let Ok(profile) = self.profile() {
    let _ = profile.stop_websocket().await;
}
```

## Test

Adds an integration regression test (`tests/soft_restart_websocket.rs`) against the embedded `TestMediator` that reproduces the exact soft-restart shape — start a service → `shutdown()` → start a second service for the **same DID** — and asserts the restarted service receives **zero** duplicate-channel reports.

- **Without** the fix: fails (`received 1 duplicate-channel problem report(s)`).
- **With** the fix: passes.

## Verification

- `cargo test -p affinidi-messaging-didcomm-service` → 73 existing + 1 new, all green
- `cargo clippy -p affinidi-messaging-didcomm-service --all-targets` → clean
- `cargo fmt` applied

Bumps `affinidi-messaging-didcomm-service` 0.3.4 → 0.3.5.