### PR TITLE
feat: boot-time config invariant validation (simplification T6)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 10th June 2026
 
+### 0.15.25 — Boot-time config invariant validation (simplification T6)
+
+- Adds a single `validate_config` pass at config load (`common/config/validate.rs`)
+  that fails fast on hard misconfigurations and warns on suspicious-but-legal
+  combinations, replacing the lone inline JWT-expiry check.
+- **Errors (abort startup):** `mediator_did` / `admin_did` not valid DID
+  syntax; `jwt_access_expiry >= jwt_refresh_expiry`; `use_ssl = true` with a
+  missing, empty, or unreadable certificate/key file (previously only caught
+  later, at the TLS handshake in the binary path).
+- **Warnings (logged, non-fatal):** `admin_did == mediator_did` (privilege
+  confusion); `mediator_acl_mode = ExplicitDeny` together with a
+  `global_acl_default` of `ALLOW_ALL` (every new DID accepts everything);
+  `block_remote_admin_msgs = false` (remote DIDs may send admin messages).
+- `admin_did == mediator_did` is a **warning, not an error** despite the plan
+  listing it as fatal: the shipped example config (and possibly live
+  deployments) use one DID for both, and the validation contract requires that
+  no currently-valid deployment starts failing to boot. The footgun is still
+  surfaced loudly. Each check is a pure helper with unit tests (valid config
+  passes; each bad input fails with the right message).
+
 ### 0.15.24 — Fail-closed session rename for the in-memory backend (simplification T4)
 
 - Picks up the fail-closed `update_session_authenticated` default from

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.24"
+version = "0.15.25"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -2,6 +2,7 @@ pub mod helpers;
 pub mod limits;
 pub mod processors;
 pub mod security;
+pub mod validate;
 pub(crate) mod vta_bootstrap;
 pub mod vta_cache;
 
@@ -859,18 +860,9 @@ impl TryFrom<ConfigRaw> for Config {
             did_document = Some(parsed_document);
         }
 
-        // Ensure that the security JWT expiry times are valid
-        if config.security.jwt_access_expiry >= config.security.jwt_refresh_expiry {
-            error!(
-                "JWT Access expiry ({}) must be less than JWT Refresh expiry ({})",
-                config.security.jwt_access_expiry, config.security.jwt_refresh_expiry
-            );
-            return Err(MediatorError::ConfigError(
-                12,
-                "NA".into(),
-                "JWT Access expiry must be less than JWT Refresh expiry".into(),
-            ));
-        }
+        // Cross-field config invariants (incl. JWT access < refresh) are
+        // validated as one pass once `config` is fully populated — see the
+        // `validate::validate_config` call before `Ok(config)` below.
 
         // Get Subscriber unique hostname
         if config.streaming_enabled {
@@ -946,6 +938,10 @@ impl TryFrom<ConfigRaw> for Config {
             &raw.processors.forwarding.blocked_forwarding_dids,
         )
         .await?;
+
+        // Boot-time invariant validation: hard conflicts abort startup with
+        // an actionable message; suspicious-but-legal combinations warn.
+        validate::validate_config(&config)?;
 
         Ok(config)
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/validate.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/validate.rs
@@ -1,0 +1,321 @@
+//! Boot-time configuration invariant validation.
+//!
+//! A single pass, run once when the file-based config is loaded, that
+//! rejects hard misconfigurations early (with an actionable message)
+//! and warns on legal-but-suspicious combinations. The goal is to fail
+//! at startup rather than at the first request — or, for the warnings,
+//! to flag a footgun the operator probably didn't intend.
+//!
+//! Each check is a small pure helper so it can be unit-tested in
+//! isolation without building a full [`Config`]; [`validate_config`]
+//! wires them together, mapping hard failures to
+//! [`MediatorError::ConfigError`] and logging warnings.
+
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::types::acls::{AccessListModeType, MediatorACLSet};
+use tracing::warn;
+
+use super::Config;
+use crate::common::error_codes;
+
+/// Run all config invariants. Hard conflicts return an error (aborting
+/// startup); suspicious-but-legal combinations are logged at WARN.
+pub fn validate_config(config: &Config) -> Result<(), MediatorError> {
+    let cfg_err =
+        |msg: String| MediatorError::ConfigError(error_codes::CONFIG_ERROR, "NA".into(), msg);
+
+    // ── Hard errors ──────────────────────────────────────────────────
+    check_did_syntax("mediator_did", &config.mediator_did).map_err(cfg_err)?;
+    check_did_syntax("admin_did", &config.admin_did).map_err(cfg_err)?;
+    check_jwt_expiry(
+        config.security.jwt_access_expiry,
+        config.security.jwt_refresh_expiry,
+    )
+    .map_err(cfg_err)?;
+    check_tls(
+        config.security.use_ssl,
+        config.security.ssl_certificate_file.as_deref(),
+        config.security.ssl_key_file.as_deref(),
+    )
+    .map_err(cfg_err)?;
+
+    // ── Warnings (legal, but usually a mistake) ──────────────────────
+    if let Some(msg) = warn_admin_is_mediator(&config.admin_did, &config.mediator_did) {
+        warn!("{msg}");
+    }
+    if let Some(msg) = warn_permissive_default_with_denylist_mode(
+        &config.security.mediator_acl_mode,
+        &config.security.global_acl_default,
+    ) {
+        warn!("{msg}");
+    }
+    if let Some(msg) = warn_remote_admin_allowed(config.security.block_remote_admin_msgs) {
+        warn!("{msg}");
+    }
+
+    Ok(())
+}
+
+/// Warn when `admin_did` equals `mediator_did`: sharing one identity lets
+/// the mediator's operating key authenticate as admin (privilege confusion)
+/// and conflates two distinct trust roles.
+///
+/// This is a *warning*, not a hard error: the shipped example config (and
+/// possibly real deployments) use a single DID for both, so rejecting it at
+/// boot would break a currently-valid deployment — which the validation
+/// contract forbids. The footgun is still surfaced loudly.
+pub(crate) fn warn_admin_is_mediator(admin_did: &str, mediator_did: &str) -> Option<String> {
+    if admin_did == mediator_did {
+        return Some(format!(
+            "admin_did equals mediator_did ('{admin_did}') — the admin role shares the mediator's \
+             operating DID/key (privilege confusion). Use a separate DID for admin unless this is \
+             intentional."
+        ));
+    }
+    None
+}
+
+/// Minimal DID syntax check: `did:<method>:<method-specific-id>`, with a
+/// non-empty lowercase-alphanumeric method and a non-empty id. Not a full
+/// DID-spec parser — just enough to catch a fat-fingered or empty value
+/// before it fails opaquely at resolve time.
+pub(crate) fn check_did_syntax(field: &str, did: &str) -> Result<(), String> {
+    let invalid = |why: &str| {
+        Err(format!(
+            "{field} is not a valid DID ('{did}'): {why}. Expected 'did:<method>:<id>'"
+        ))
+    };
+    let Some(rest) = did.strip_prefix("did:") else {
+        return invalid("must start with 'did:'");
+    };
+    let Some((method, id)) = rest.split_once(':') else {
+        return invalid("missing the method or method-specific id");
+    };
+    if method.is_empty()
+        || !method
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        return invalid("method must be non-empty lowercase alphanumeric");
+    }
+    if id.is_empty() {
+        return invalid("method-specific id is empty");
+    }
+    Ok(())
+}
+
+/// JWT access tokens must expire before refresh tokens, otherwise refresh
+/// is pointless and the access token outlives its refresh window.
+pub(crate) fn check_jwt_expiry(access: u64, refresh: u64) -> Result<(), String> {
+    if access >= refresh {
+        return Err(format!(
+            "jwt_access_expiry ({access}s) must be less than jwt_refresh_expiry ({refresh}s)"
+        ));
+    }
+    Ok(())
+}
+
+/// When `use_ssl` is set, both the certificate and key must be configured
+/// and readable. Catches the misconfiguration at load time rather than at
+/// the TLS handshake. A no-op when `use_ssl` is false.
+pub(crate) fn check_tls(
+    use_ssl: bool,
+    cert: Option<&str>,
+    key: Option<&str>,
+) -> Result<(), String> {
+    if !use_ssl {
+        return Ok(());
+    }
+    // Check both are configured before touching the filesystem, so a missing
+    // path is reported as "not set" rather than masked by a readability error
+    // on the other file.
+    let cert = require_path("ssl_certificate_file", cert)?;
+    let key = require_path("ssl_key_file", key)?;
+    for (label, path) in [("ssl_certificate_file", cert), ("ssl_key_file", key)] {
+        std::fs::File::open(path)
+            .map_err(|e| format!("use_ssl is true but {label} ('{path}') is not readable: {e}"))?;
+    }
+    Ok(())
+}
+
+/// A configured TLS path must be present and non-empty.
+fn require_path<'a>(label: &str, path: Option<&'a str>) -> Result<&'a str, String> {
+    match path {
+        None => Err(format!("use_ssl is true but {label} is not set")),
+        Some("") => Err(format!("use_ssl is true but {label} is empty")),
+        Some(p) => Ok(p),
+    }
+}
+
+/// Warn when the mediator runs a permissive denylist mode
+/// (`ExplicitDeny`) *and* hands new DIDs an `ALLOW_ALL` default — together
+/// these mean every new account accepts everything from everyone, which is
+/// rarely intended for a deployment that bothered to set a mode.
+pub(crate) fn warn_permissive_default_with_denylist_mode(
+    mode: &AccessListModeType,
+    global_acl_default: &MediatorACLSet,
+) -> Option<String> {
+    let allow_all = MediatorACLSet::from_string_ruleset("ALLOW_ALL").ok()?;
+    if *mode == AccessListModeType::ExplicitDeny
+        && global_acl_default.to_u64() == allow_all.to_u64()
+    {
+        return Some(
+            "mediator_acl_mode is ExplicitDeny (denylist) and global_acl_default grants ALLOW_ALL \
+             — every new DID will accept messages from anyone. Confirm this is intended."
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// Warn when remote (non-local) DIDs may send admin-protocol messages.
+/// The secure posture restricts admin messaging to locally-registered
+/// DIDs; disabling that widens the admin attack surface.
+pub(crate) fn warn_remote_admin_allowed(block_remote_admin_msgs: bool) -> Option<String> {
+    if !block_remote_admin_msgs {
+        return Some(
+            "block_remote_admin_msgs is false — remote DIDs may send admin-protocol messages. \
+             This widens the admin attack surface; enable it unless you specifically need remote \
+             administration."
+                .to_string(),
+        );
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warns_only_when_admin_equals_mediator() {
+        assert!(warn_admin_is_mediator("did:key:zAdmin", "did:peer:2.zMediator").is_none());
+        let msg = warn_admin_is_mediator("did:peer:2.same", "did:peer:2.same")
+            .expect("identical DIDs should warn");
+        assert!(msg.contains("privilege confusion"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn did_syntax_accepts_real_methods() {
+        for did in [
+            "did:key:z6MkABC",
+            "did:peer:2.Vz6Mk.Ez6LS.SeyJ",
+            "did:web:mediator.example.com",
+            "did:webvh:scid:mediator.example.com:path",
+        ] {
+            assert!(
+                check_did_syntax("mediator_did", did).is_ok(),
+                "{did} should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn did_syntax_rejects_garbage() {
+        for bad in [
+            "",
+            "notadid",
+            "did:",
+            "did:key",
+            "did::id",
+            "did:KEY:z6",
+            "did:key:",
+        ] {
+            assert!(
+                check_did_syntax("admin_did", bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn jwt_expiry_ordering() {
+        assert!(check_jwt_expiry(900, 86_400).is_ok());
+        assert!(check_jwt_expiry(86_400, 86_400).is_err(), "equal must fail");
+        assert!(
+            check_jwt_expiry(90_000, 86_400).is_err(),
+            "access > refresh must fail"
+        );
+    }
+
+    #[test]
+    fn tls_noop_when_disabled() {
+        assert!(check_tls(false, None, None).is_ok());
+    }
+
+    #[test]
+    fn tls_requires_both_files_when_enabled() {
+        assert!(
+            check_tls(true, None, Some("/x/key.pem"))
+                .unwrap_err()
+                .contains("ssl_certificate_file")
+        );
+        assert!(
+            check_tls(true, Some("/x/cert.pem"), None)
+                .unwrap_err()
+                .contains("ssl_key_file")
+        );
+        assert!(
+            check_tls(true, Some(""), Some("/x/key.pem"))
+                .unwrap_err()
+                .contains("empty")
+        );
+    }
+
+    #[test]
+    fn tls_checks_readability_when_enabled() {
+        let cert = tempfile::NamedTempFile::new().expect("cert temp");
+        let key = tempfile::NamedTempFile::new().expect("key temp");
+        // Both present + readable → ok.
+        assert!(
+            check_tls(
+                true,
+                Some(cert.path().to_str().unwrap()),
+                Some(key.path().to_str().unwrap()),
+            )
+            .is_ok()
+        );
+        // A non-existent path → unreadable error.
+        let err = check_tls(
+            true,
+            Some(cert.path().to_str().unwrap()),
+            Some("/definitely/not/here/key.pem"),
+        )
+        .unwrap_err();
+        assert!(err.contains("not readable"), "msg was: {err}");
+    }
+
+    #[test]
+    fn warns_only_on_denylist_mode_plus_allow_all_default() {
+        let allow_all = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
+        let default = MediatorACLSet::default();
+
+        // The flagged combination.
+        assert!(
+            warn_permissive_default_with_denylist_mode(
+                &AccessListModeType::ExplicitDeny,
+                &allow_all
+            )
+            .is_some()
+        );
+        // Allowlist mode with ALLOW_ALL default → not flagged.
+        assert!(
+            warn_permissive_default_with_denylist_mode(
+                &AccessListModeType::ExplicitAllow,
+                &allow_all
+            )
+            .is_none()
+        );
+        // Denylist mode but restrictive default → not flagged.
+        assert!(
+            warn_permissive_default_with_denylist_mode(&AccessListModeType::ExplicitDeny, &default)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn warns_only_when_remote_admin_unblocked() {
+        assert!(warn_remote_admin_allowed(false).is_some());
+        assert!(warn_remote_admin_allowed(true).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

**T6** of the mediator architectural-simplification plan — and the **last item of the Phase 1 sweep**. Adds a single `validate_config` pass at config load (`common/config/validate.rs`), run once `config` is fully populated, replacing the lone inline JWT-expiry check. Hard misconfigurations abort startup with an actionable message; suspicious-but-legal combinations log a warning.

## Errors (abort startup)
- `mediator_did` / `admin_did` not valid DID syntax (`did:<method>:<id>`)
- `jwt_access_expiry >= jwt_refresh_expiry` (folded in from the old inline check)
- `use_ssl = true` with a missing / empty / **unreadable** cert or key file — previously only caught later at the TLS handshake on the binary path

## Warnings (logged, non-fatal)
- `admin_did == mediator_did` (privilege confusion)
- `mediator_acl_mode = ExplicitDeny` **and** `global_acl_default = ALLOW_ALL` (every new DID accepts everything)
- `block_remote_admin_msgs = false` (remote DIDs may send admin-protocol messages)

## Deviation from the plan (documented)

The task description listed `admin_did == mediator_did` as a hard **error**. I made it a **warning** because the shipped example `conf/mediator.toml` (which the integration tests load) uses one DID for both, and acceptance criterion #2 requires that *no currently-valid deployment starts failing to boot*. A hard error would violate that contract and break the integration tests. The footgun is still surfaced loudly. (Easy to promote to an error in a follow-up if the example config is given a distinct admin DID.)

## Audit notes
- The `did://` config prefix is stripped by `read_did_config` before validation runs, so `config.mediator_did` is a clean `did:peer:…` and passes the syntax check (the shipped config loads fine).
- The secrets-backend scheme is already enforced at construction (an unknown scheme fails earlier in config load), so it isn't re-checked here.

## Tests

Each check is a small pure helper, unit-tested in isolation (valid input passes; each bad input fails with the right message; TLS readability tested with `tempfile`s). 9 new tests in `config::validate`.

## Versions

`affinidi-messaging-mediator` 0.15.24 → 0.15.25.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` and `didcomm,memory-backend`; `cargo test -p affinidi-messaging-mediator --lib` 134 passed (9 new); `cargo deny` ok.

---

**Phase 1 complete** 🎉 — T1 (mutex poison) ✅, T2 (task supervision + /livez) ✅, T3 (request-path storage timeouts) ✅, T4 (fail-closed session rename) ✅, T5 (ACL bitfield safety net) ✅, **T6 (config invariants) — this PR**.
