### PR TITLE
refactor: migrate handler/direct-delivery ACL checks to authz (simplification T8)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 10th June 2026
 
+### 0.15.27 — Migrate handler/direct-delivery ACL checks to authz (simplification T8)
+
+- Adds `authz::check_access_list` (the single wrapper over the store's
+  `access_list_allowed`, returning a typed allow/deny) and routes the
+  message-path ACL gates through the authz module:
+  - `message_inbound` `SEND_MESSAGES` gate → `require_capability(SendMessages)`;
+  - direct-delivery sender `SEND_MESSAGES` gate (`inbound.rs`) →
+    `require_capability(SendMessages)`;
+  - direct-delivery recipient access-list check (`inbound.rs`) →
+    `check_access_list`.
+- No inline capability/access-list logic remains in those handlers.
+  Structure only — behaviour byte-identical (same `authorization.send` /
+  `authorization.access_list.denied` problem reports, same anonymous-sender
+  handling). Phase 2, building on T7.
+
 ### 0.15.26 — Central authz module: auth-time checks (simplification T7)
 
 - Introduces `common/authz.rs` as the single home for permission semantics:

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.26"
+version = "0.15.27"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
@@ -15,6 +15,7 @@
 //! below is intentionally complete ahead of every call site adopting it.
 
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::store::MediatorStore;
 use affinidi_messaging_sdk::protocols::mediator::acls::MediatorACLSet;
 use tracing::debug;
 
@@ -81,6 +82,28 @@ pub(crate) fn require_capability(
         Ok(())
     } else {
         Err(CapabilityDenied(capability))
+    }
+}
+
+/// Returned when a recipient's access list denies a sender.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AccessListDenied;
+
+/// Whether `sender_hash` may deliver to `recipient_hash` under the
+/// recipient's access list (interpreted as an allowlist or denylist per the
+/// recipient's ACL mode). The single wrapper over the store's
+/// `access_list_allowed`, so the allow/deny verdict and its error mapping
+/// live alongside the rest of the authz vocabulary. `sender_hash` is `None`
+/// for an anonymous sender.
+pub(crate) async fn check_access_list(
+    store: &dyn MediatorStore,
+    recipient_hash: &str,
+    sender_hash: Option<&str>,
+) -> Result<(), AccessListDenied> {
+    if store.access_list_allowed(recipient_hash, sender_hash).await {
+        Ok(())
+    } else {
+        Err(AccessListDenied)
     }
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -1,4 +1,9 @@
-use crate::{SharedData, common::jwt_auth::MaybeSession, messages::inbound::handle_inbound};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::jwt_auth::MaybeSession,
+    messages::inbound::handle_inbound,
+};
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::messages::{
     problem_report::{ProblemReportScope, ProblemReportSorter},
@@ -56,7 +61,7 @@ pub async fn message_inbound_handler(
     );
     async move {
         // ACL Check
-        if !session.acls.get_send_messages().0 {
+        if authz::require_capability(&session.acls, Capability::SendMessages).is_err() {
             metrics::counter!(names::ACL_DENIALS_TOTAL, "action" => "send").increment(1);
             return Err(MediatorError::problem(
                 44,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -6,7 +6,12 @@ use crate::didcomm_compat::MetaEnvelope;
 use crate::messages::MessageHandler;
 #[cfg(feature = "didcomm")]
 use crate::messages::protocols::routing::{relay_peer_trusted, rewrap_inner_attachment};
-use crate::{SharedData, common::session::Session, messages::store::store_message};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+    messages::store::store_message,
+};
 use affinidi_messaging_mediator_common::errors::MediatorError;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
@@ -231,7 +236,7 @@ async fn handle_inbound_didcomm(
                             state.config.security.global_acl_default.clone()
                         };
 
-                        if !from_acls.get_send_messages().0 {
+                        if authz::require_capability(&from_acls, Capability::SendMessages).is_err() {
                             return Err(MediatorError::problem(
                                 44,
                                 &session.session_id,
@@ -257,10 +262,13 @@ async fn handle_inbound_didcomm(
                             StatusCode::FORBIDDEN,
                         ));
                     }
-                    if !state
-                        .database
-                        .access_list_allowed(&digest(to_did), from_hash.as_deref())
-                        .await
+                    if authz::check_access_list(
+                        state.database.as_ref(),
+                        &digest(to_did),
+                        from_hash.as_deref(),
+                    )
+                    .await
+                    .is_err()
                     {
                         return Err(MediatorError::problem(
                             73,


### PR DESCRIPTION
## Summary

**T8** of Phase 2 (authz centralization). Routes the message-path capability and access-list gates through the central `authz` module instead of inline ACL calls.

## Changes

- Adds **`authz::check_access_list`** — the single wrapper over the store's `access_list_allowed`, returning a typed allow/deny. (This is its first call site, so it lands now rather than as dead code back in T7.)
- Migrated gates:
  - `message_inbound` `SEND_MESSAGES` gate → `require_capability(SendMessages)`
  - direct-delivery **sender** `SEND_MESSAGES` gate (`inbound.rs`) → `require_capability(SendMessages)`
  - direct-delivery **recipient** access-list check (`inbound.rs`) → `check_access_list`

`grep` confirms no inline `get_send_messages().0` / `access_list_allowed` remains in the handlers.

## Behaviour: byte-identical

Same `authorization.send` / `authorization.access_list.denied` problem reports, same anonymous-sender handling. Structure only.

The session-DID-match enforcement the plan mentions near these sites (`inbound.rs:142-203`) is left as-is — it's identity matching, not a capability/ACL gate, and is already factored into `check_session_sender_match`. Folding it into `authz` would conflate two concerns; noted for review.

## Versions

`affinidi-messaging-mediator` 0.15.26 → 0.15.27.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` and `didcomm,memory-backend`; `cargo test -p affinidi-messaging-mediator --lib` 138 passed; `cargo deny` ok. (Direct-delivery / anonymous-sender behaviour is covered by `tests/integration_test_messaging.rs`.)

Phase 2: T7 ✅ → **T8 (this)** → T9 (routing + mediator/acls protocol checks) → T10 (decompose `routing.rs::process()`).
