### PR TITLE
refactor: migrate routing + ACL-protocol checks to authz (simplification T9)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Changelog history
 
+## 11th June 2026
+
+### 0.15.28 — Migrate routing + ACL-protocol checks to authz (simplification T9)
+
+- Completes the authz migration so every runtime permission decision flows
+  through `common/authz.rs`:
+  - routing forward-path gates → `require_capability(ReceiveForwarded)` /
+    `require_capability(SendForwarded)` (sender account + anonymous-session
+    paths) and the next-hop access-list check → `check_access_list`;
+  - the `relay_sender_acls` seed condition and `jwt_auth`'s
+    `anonymous_inbound_allowed` → `authz::grants(SendForwarded)`;
+  - the refresh handler's blocked-DID gate → `require_capability(NotBlocked)`;
+  - the admin-protocol self-change validator `acl_change_ok` (a pure
+    authorization predicate) relocated from the mediator ACL handler into
+    `authz`.
+- After this, `get_send_forwarded` / `get_receive_forwarded` / `get_blocked`
+  appear only in `authz` and the `MediatorACLSet` type itself (outside of
+  tests). Structure only — behaviour byte-identical (same problem reports,
+  same allow/deny verdicts); the routing `relay_sender_acls` unit suite
+  passes unchanged. `check_permissions` (admin/self + signature) is left in
+  the admin handler — it makes no capability-bit decision, so it's outside
+  the authz capability surface.
+
 ## 10th June 2026
 
 ### 0.15.27 — Migrate handler/direct-delivery ACL checks to authz (simplification T8)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.27"
+version = "0.15.28"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
@@ -148,6 +148,98 @@ pub(crate) async fn authentication_check(
     Ok((grants(&acls, Capability::NotBlocked), known))
 }
 
+/// Validate a self-initiated ACL change: for each capability, a DID may
+/// only flip the value when its `self_change` flag is set, and may never
+/// flip the `self_change` flag itself (only an admin can). Returns `None`
+/// when the change is permitted, or `Some(errors)` describing each
+/// disallowed modification.
+///
+/// (Relocated from the mediator admin-protocol handler so every permission
+/// decision — capability gates and self-change authorization alike — lives
+/// in this module.)
+pub(crate) fn acl_change_ok(
+    current_acls: &MediatorACLSet,
+    new_acls: &MediatorACLSet,
+) -> Option<Vec<String>> {
+    let mut errors = Vec::new();
+
+    if (current_acls.get_access_list_mode().0 != new_acls.get_access_list_mode().0)
+        && !current_acls.get_access_list_mode().1
+    {
+        errors.push("access_list_mode not allowed to change".to_string());
+    }
+
+    if current_acls.get_access_list_mode().1 != new_acls.get_access_list_mode().1 {
+        errors.push("access_list_mode:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_send_messages().0 != new_acls.get_send_messages().0)
+        && !current_acls.get_send_messages().1
+    {
+        errors.push("send_messages not allowed to change".to_string());
+    }
+
+    if current_acls.get_send_messages().1 != new_acls.get_send_messages().1 {
+        errors.push("send_messages:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_receive_messages().0 != new_acls.get_receive_messages().0)
+        && !current_acls.get_receive_messages().1
+    {
+        errors.push("receive_messages not allowed to change".to_string());
+    }
+
+    if current_acls.get_receive_messages().1 != new_acls.get_receive_messages().1 {
+        errors.push("receive_messages:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_send_forwarded().0 != new_acls.get_send_forwarded().0)
+        && !current_acls.get_send_forwarded().1
+    {
+        errors.push("send_forwarded not allowed to change".to_string());
+    }
+
+    if current_acls.get_send_forwarded().1 != new_acls.get_send_forwarded().1 {
+        errors.push("send_forwarded:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_receive_forwarded().0 != new_acls.get_receive_forwarded().0)
+        && !current_acls.get_receive_forwarded().1
+    {
+        errors.push("get_receive_forwarded not allowed to change".to_string());
+    }
+
+    if current_acls.get_receive_forwarded().1 != new_acls.get_receive_forwarded().1 {
+        errors.push("get_receive_forwarded:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_create_invites().0 != new_acls.get_create_invites().0)
+        && !current_acls.get_create_invites().1
+    {
+        errors.push("create_invites not allowed to change".to_string());
+    }
+
+    if current_acls.get_create_invites().1 != new_acls.get_create_invites().1 {
+        errors.push("create_invites:self_change can't modify!".to_string());
+    }
+
+    if (current_acls.get_anon_receive().0 != new_acls.get_anon_receive().0)
+        && !current_acls.get_anon_receive().1
+    {
+        errors.push("anon_receive not allowed to change".to_string());
+    }
+
+    if current_acls.get_anon_receive().1 != new_acls.get_anon_receive().1 {
+        errors.push("anon_receive:self_change can't modify!".to_string());
+    }
+
+    if errors.is_empty() {
+        None
+    } else {
+        Some(errors)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -226,7 +226,7 @@ where
 /// `routing.rs`). On a mediator with the shipped secure default this returns
 /// `false`, so anonymous requests are rejected exactly like before.
 fn anonymous_inbound_allowed(global_acl_default: &MediatorACLSet) -> bool {
-    global_acl_default.get_send_forwarded().0
+    authz::grants(global_acl_default, Capability::SendForwarded)
 }
 
 /// The minimal ACL set granted to an anonymous inter-mediator relay session.

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
@@ -5,6 +5,7 @@ use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat::MetaEnvelope;
 use crate::{
     SharedData,
+    common::authz::{self, Capability},
     common::session::{Session, SessionClaims, SessionState},
 };
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
@@ -289,7 +290,7 @@ pub async fn authentication_refresh(
         }
 
         // Does the Global ACL still allow them to connect?
-        if session_check.acls.get_blocked() {
+        if authz::require_capability(&session_check.acls, Capability::NotBlocked).is_err() {
             info!("DID({}) is blocked from connecting", digest(&session_check.did));
             return Err(MediatorError::problem(
                 25,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
@@ -189,7 +189,9 @@ pub(crate) async fn process(
                         }
                     };
 
-                    if let Some(errors) = acl_change_ok(&current_acls, &MediatorACLSet::from_u64(acls)) {
+                    if let Some(errors) =
+                        crate::common::authz::acl_change_ok(&current_acls, &MediatorACLSet::from_u64(acls))
+                    {
                         warn!("Can't change ACLs. Reason: self_change not allowed");
 
                         // Creates a string placement for each error. E.g. {1}, {2}, {3}
@@ -638,90 +640,6 @@ fn _generate_response_message(
         data: crate::messages::WrapperType::Message(Box::new(response)),
         forward_message: false,
     })
-}
-
-/// Helper method that checks if the ACL change is valid for non-admin accounts
-/// checks if self_change would block any modification of the ACLs
-/// returns None if ok
-/// returns Some(vec) with errors if not ok
-fn acl_change_ok(current_acls: &MediatorACLSet, new_acls: &MediatorACLSet) -> Option<Vec<String>> {
-    let mut errors = Vec::new();
-
-    if (current_acls.get_access_list_mode().0 != new_acls.get_access_list_mode().0)
-        && !current_acls.get_access_list_mode().1
-    {
-        errors.push("access_list_mode not allowed to change".to_string());
-    }
-
-    if current_acls.get_access_list_mode().1 != new_acls.get_access_list_mode().1 {
-        errors.push("access_list_mode:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_send_messages().0 != new_acls.get_send_messages().0)
-        && !current_acls.get_send_messages().1
-    {
-        errors.push("send_messages not allowed to change".to_string());
-    }
-
-    if current_acls.get_send_messages().1 != new_acls.get_send_messages().1 {
-        errors.push("send_messages:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_receive_messages().0 != new_acls.get_receive_messages().0)
-        && !current_acls.get_receive_messages().1
-    {
-        errors.push("receive_messages not allowed to change".to_string());
-    }
-
-    if current_acls.get_receive_messages().1 != new_acls.get_receive_messages().1 {
-        errors.push("receive_messages:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_send_forwarded().0 != new_acls.get_send_forwarded().0)
-        && !current_acls.get_send_forwarded().1
-    {
-        errors.push("send_forwarded not allowed to change".to_string());
-    }
-
-    if current_acls.get_send_forwarded().1 != new_acls.get_send_forwarded().1 {
-        errors.push("send_forwarded:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_receive_forwarded().0 != new_acls.get_receive_forwarded().0)
-        && !current_acls.get_receive_forwarded().1
-    {
-        errors.push("get_receive_forwarded not allowed to change".to_string());
-    }
-
-    if current_acls.get_receive_forwarded().1 != new_acls.get_receive_forwarded().1 {
-        errors.push("get_receive_forwarded:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_create_invites().0 != new_acls.get_create_invites().0)
-        && !current_acls.get_create_invites().1
-    {
-        errors.push("create_invites not allowed to change".to_string());
-    }
-
-    if current_acls.get_create_invites().1 != new_acls.get_create_invites().1 {
-        errors.push("create_invites:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_anon_receive().0 != new_acls.get_anon_receive().0)
-        && !current_acls.get_anon_receive().1
-    {
-        errors.push("anon_receive not allowed to change".to_string());
-    }
-
-    if current_acls.get_anon_receive().1 != new_acls.get_anon_receive().1 {
-        errors.push("anon_receive:self_change can't modify!".to_string());
-    }
-
-    if errors.is_empty() {
-        None
-    } else {
-        Some(errors)
-    }
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -1,3 +1,4 @@
+use crate::common::authz::{self, Capability};
 use crate::common::storage_timeout::with_storage_timeout;
 use crate::common::time::{unix_timestamp_millis, unix_timestamp_secs};
 
@@ -48,7 +49,7 @@ struct ForwardRequest {
 /// relay capability.
 fn relay_sender_acls(global_acl_default: &MediatorACLSet) -> MediatorACLSet {
     let mut acls = MediatorACLSet::from_string_ruleset("DENY_ALL").unwrap_or_default();
-    if global_acl_default.get_send_forwarded().0 {
+    if authz::grants(global_acl_default, Capability::SendForwarded) {
         // admin = true so the bit can be set on a fresh deny-all set; the
         // self-change flag stays false (an operator/admin governs it later).
         let _ = acls.set_send_forwarded(true, false, true);
@@ -262,7 +263,7 @@ pub(crate) async fn process(
         // ****************************************************
         // Check if the next hop is allowed to receive forwarded messages
         let next_acls = MediatorACLSet::from_u64(next_account.acls);
-        if !next_acls.get_receive_forwarded().0 {
+        if authz::require_capability(&next_acls, Capability::ReceiveForwarded).is_err() {
             return Err(MediatorError::problem(
                 58,
                 &session.session_id,
@@ -363,7 +364,7 @@ pub(crate) async fn process(
             };
             let from_acls = MediatorACLSet::from_u64(from_account.acls);
 
-            if !from_acls.get_send_forwarded().0 {
+            if authz::require_capability(&from_acls, Capability::SendForwarded).is_err() {
                 return Err(MediatorError::problem(
                     60,
                     &session.session_id,
@@ -378,7 +379,7 @@ pub(crate) async fn process(
             }
 
             from_account
-        } else if !session.acls.get_send_forwarded().0 {
+        } else if authz::require_capability(&session.acls, Capability::SendForwarded).is_err() {
             return Err(MediatorError::problem(
                 60,
                 &session.session_id,
@@ -401,10 +402,13 @@ pub(crate) async fn process(
 
         // ****************************************************
         // Is the sending DID allowed by the next DID access_list and ACL?
-        if state
-            .database
-            .access_list_allowed(&next_did_hash, Some(&from_account.did_hash))
-            .await
+        if authz::check_access_list(
+            state.database.as_ref(),
+            &next_did_hash,
+            Some(&from_account.did_hash),
+        )
+        .await
+        .is_ok()
         {
             debug!(
                 "Sender DID ({}) is allowed to send to next DID ({})",


### PR DESCRIPTION
## Summary

**T9** of Phase 2 — completes the authz migration so **every runtime permission decision flows through `common/authz.rs`**.

## Migrated

- **Routing forward-path gates** (`routing.rs`): `receive_forwarded` → `require_capability(ReceiveForwarded)`; `send_forwarded` (both the sender-account and anonymous-session paths) → `require_capability(SendForwarded)`; the next-hop access-list check → `check_access_list`.
- **Relay/anon helpers**: the `relay_sender_acls` seed condition and `jwt_auth`'s `anonymous_inbound_allowed` → `authz::grants(SendForwarded)`.
- **Refresh handler**: blocked-DID gate → `require_capability(NotBlocked)`.
- **`acl_change_ok`** (the pure ACL self-change validator) relocated from the mediator admin-protocol handler into `authz` (one caller updated).

## Acceptance: getters centralized

After this, `get_send_forwarded` / `get_receive_forwarded` / `get_blocked` appear only in `authz` and the `MediatorACLSet` type itself — outside of test code (the `relay_sender_acls` unit suite and a jwt_auth test legitimately assert on the getters). Behaviour is **byte-identical**: same `authorization.*` problem reports and allow/deny verdicts; the routing `relay_sender_acls` suite passes unchanged.

## Scope note

`check_permissions` (admin/self + signature verification) is left in the admin-protocol handler. It makes no capability-bit decision — it gates on `account_type` + signature — so it's outside the authz capability surface (and the acceptance grep). Folding it in would drag signature-verification plumbing into `authz` for no centralization gain. Flagged for review.

## Versions

`affinidi-messaging-mediator` 0.15.27 → 0.15.28.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` and `didcomm,memory-backend`; `cargo test -p affinidi-messaging-mediator --lib` 138 passed (incl. the relay_sender_acls suite, unchanged); `grep` confirms the three getters are authz/type-only in production; `cargo deny` ok.

Phase 2: T7 ✅ → T8 ✅ → **T9 (this)** → T10 (decompose `routing.rs::process()`).
