### PR TITLE
refactor: dedupe authenticate unpack/verify boilerplate (simplification T11)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 11th June 2026
 
+### 0.15.30 — Dedupe authenticate unpack/verify boilerplate (simplification T11)
+
+- The `authenticate` response and refresh handlers carried byte-identical
+  copies of the "unpack the DIDComm message, then require it be signed AND
+  encrypted" block. Extracted it into `helpers::unpack_auth_message`, so the
+  encrypted-AND-authenticated invariant for the unpacked message lives in
+  exactly one place. Behaviour unchanged (same `message.unpack` /
+  `authentication.message.not_signed_or_encrypted` problem reports).
+- The helper takes the already-built `MetaEnvelope` (the two handlers use
+  different envelope-parse error codes, so that step stays handler-local) and
+  borrows it, so the response handler can still run its post-unpack
+  inner/outer `from`-match check. The response handler also keeps its
+  separate pre-unpack outer-envelope check (a distinct earlier gate) so error
+  precedence is preserved.
+
 ### 0.15.29 — Decompose routing `process()` (simplification T10)
 
 - Extracts the deepest, longest blocks of `routing::process()` (~745 lines,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.29"
+version = "0.15.30"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/helpers.rs
@@ -1,11 +1,80 @@
+use crate::SharedData;
 use crate::common::session::SessionClaims;
 use crate::common::time::unix_timestamp_secs;
+use crate::didcomm_compat::MetaEnvelope;
+use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use http::StatusCode;
 use jsonwebtoken::{EncodingKey, Header, encode};
 use rand::{RngExt, distr::Alphanumeric};
 use sha256::digest;
+use tracing::debug;
+
+/// Unpack an authentication envelope and enforce the signed-AND-encrypted
+/// invariant in a single place, shared by the `authenticate` response and
+/// refresh handlers (the two previously carried byte-identical copies of
+/// this block).
+///
+/// The caller builds the [`MetaEnvelope`] first (the two handlers use
+/// different parse-error codes there, so that step stays handler-local) and
+/// retains it for any post-unpack checks; this borrows it, so it remains
+/// usable afterwards.
+pub(crate) async fn unpack_auth_message(
+    envelope: &MetaEnvelope,
+    state: &SharedData,
+) -> Result<(Message, UnpackMetadata), MediatorError> {
+    let (msg, unpack_metadata) = match envelope
+        .unpack(
+            &state.did_resolver,
+            &*state.config.security.mediator_secrets,
+        )
+        .await
+    {
+        Ok(ok) => ok,
+        Err(e) => {
+            return Err(MediatorError::problem_with_log(
+                32,
+                "",
+                None,
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "message.unpack",
+                "Failed to unpack message. Reason: {1}",
+                vec![e.to_string()],
+                StatusCode::FORBIDDEN,
+                format!("Failed to unpack message. Reason: {e}"),
+            ));
+        }
+    };
+
+    // Authentication messages MUST be signed and authenticated!
+    if unpack_metadata.authenticated && unpack_metadata.encrypted {
+        debug!("Auth message verified: signed and encrypted")
+    } else {
+        return Err(MediatorError::problem_with_log(
+            86,
+            "",
+            None,
+            ProblemReportSorter::Error,
+            ProblemReportScope::Protocol,
+            "authentication.message.not_signed_or_encrypted",
+            "DIDComm message MUST be signed ({1}) and encrypted ({2}) for this transaction",
+            vec![
+                unpack_metadata.authenticated.to_string(),
+                unpack_metadata.encrypted.to_string(),
+            ],
+            StatusCode::BAD_REQUEST,
+            format!(
+                "DIDComm message MUST be signed ({}) and encrypted ({}) for this transaction",
+                unpack_metadata.authenticated, unpack_metadata.encrypted
+            ),
+        ));
+    }
+
+    Ok((msg, unpack_metadata))
+}
 
 /// creates a random string of up to length characters
 pub fn create_random_string(length: usize) -> String {

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
@@ -18,7 +18,7 @@ use http::StatusCode;
 use jsonwebtoken::Validation;
 use sha256::digest;
 use subtle::ConstantTimeEq;
-use tracing::{Instrument, Level, debug, info, span};
+use tracing::{Instrument, Level, info, span};
 
 /// POST /authenticate/refresh
 /// Refresh existing JWT tokens.
@@ -60,50 +60,9 @@ pub async fn authentication_refresh(
             }
         };
 
-        // Unpack the message
-        let (msg, unpack_metadata) = match envelope
-            .unpack(
-                &state.did_resolver,
-                &*state.config.security.mediator_secrets,
-            )
-            .await
-        {
-            Ok(ok) => ok,
-            Err(e) => {
-                return Err(MediatorError::problem_with_log(
-                    32,
-                    "",
-                    None,
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "message.unpack",
-                    "Failed to unpack message. Reason: {1}",
-                    vec![e.to_string()],
-                    StatusCode::FORBIDDEN,
-                    format!("Failed to unpack message. Reason: {e}"),
-                )
-                .into());
-            }
-        };
-
-        // Authentication messages MUST be signed and authenticated!
-        if unpack_metadata.authenticated && unpack_metadata.encrypted {
-            debug!("Auth message verified: signed and encrypted")
-        } else {
-                return Err(MediatorError::problem_with_log(
-                    86,
-                    "",
-                    None,
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "authentication.message.not_signed_or_encrypted",
-                    "DIDComm message MUST be signed ({1}) and encrypted ({2}) for this transaction",
-                    vec![unpack_metadata.authenticated.to_string(), unpack_metadata.encrypted.to_string()],
-                    StatusCode::BAD_REQUEST,
-                    format!("DIDComm message MUST be signed ({}) and encrypted ({}) for this transaction", unpack_metadata.authenticated, unpack_metadata.encrypted),
-                )
-                .into());
-        }
+        // Unpack the message + enforce the signed/encrypted invariant.
+        let (msg, _unpack_metadata) =
+            super::helpers::unpack_auth_message(&envelope, &state).await?;
 
         // Only accepts AffinidiAuthenticateRefresh messages
         match msg.typ.as_str().parse::<MessageType>().map_err(|err| {

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
@@ -145,56 +145,9 @@ pub async fn authentication_response(
             }
         };
 
-        // Unpack the message
-        let (msg, unpack_metadata) = match envelope
-            .unpack(
-                &state.did_resolver,
-                &*state.config.security.mediator_secrets,
-            )
-            .await
-        {
-            Ok(ok) => ok,
-            Err(e) => {
-                return Err(MediatorError::problem_with_log(
-                    32,
-                    "",
-                    None,
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "message.unpack",
-                    "Failed to unpack message. Reason: {1}",
-                    vec![e.to_string()],
-                    StatusCode::FORBIDDEN,
-                    format!("Failed to unpack message. Reason: {e}"),
-                )
-                .into());
-            }
-        };
-
-        // Authentication messages MUST be signed and authenticated!
-        if unpack_metadata.authenticated && unpack_metadata.encrypted {
-            debug!("Auth message verified: signed and encrypted")
-        } else {
-            return Err(MediatorError::problem_with_log(
-                86,
-                "",
-                None,
-                ProblemReportSorter::Error,
-                ProblemReportScope::Protocol,
-                "authentication.message.not_signed_or_encrypted",
-                "DIDComm message MUST be signed ({1}) and encrypted ({2}) for this transaction",
-                vec![
-                    unpack_metadata.authenticated.to_string(),
-                    unpack_metadata.encrypted.to_string(),
-                ],
-                StatusCode::BAD_REQUEST,
-                format!(
-                    "DIDComm message MUST be signed ({}) and encrypted ({}) for this transaction",
-                    unpack_metadata.authenticated, unpack_metadata.encrypted
-                ),
-            )
-            .into());
-        }
+        // Unpack the message + enforce the signed/encrypted invariant.
+        let (msg, _unpack_metadata) =
+            super::helpers::unpack_auth_message(&envelope, &state).await?;
 
         // Check that the inner plaintext from matches the envelope skid
         if let Some(msg_from) = &msg.from {


### PR DESCRIPTION
## Summary

**T11** (independent Phase 2 cleanup). The `authenticate` **response** and **refresh** handlers carried byte-identical copies of the "unpack the DIDComm message, then require it be signed AND encrypted" block. Extracted into `helpers::unpack_auth_message` so the encrypted-AND-authenticated invariant for the unpacked message lives in **exactly one place**.

## Design notes

- The helper takes the already-built **`MetaEnvelope`** (not the raw body): the two handlers use *different* envelope-parse error codes (response `28`/`authentication.response.parse`; refresh `37`/`message.envelope.read`), so the envelope-creation step stays handler-local. It **borrows** the envelope (`unpack` is `&self`), so the response handler can still run its post-unpack `from`-match check against `envelope.from_did`.
- The response handler keeps its separate **pre-unpack outer-envelope** signed/encrypted check (a distinct earlier gate on `envelope.metadata`). Removing it would change error precedence for the blocked-DID + unsigned edge case, so it's preserved. The *cross-handler duplication* (the identical post-unpack block) is what's deduped.

## Behaviour: byte-identical

Same `message.unpack` (32) and `authentication.message.not_signed_or_encrypted` (86) problem reports.

## Versions

`affinidi-messaging-mediator` 0.15.29 → 0.15.30.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` and `didcomm,memory-backend`; `cargo test -p affinidi-messaging-mediator --lib` 141 passed; test-mediator auth suites (`websocket_subprotocol_auth` 5, `lifecycle` 22) passed; `cargo deny` ok.

Phase 2 remaining (independent): T12 (explicit `enable_inter_mediator_relay` flag), T13 (per-DID WS cap + always-on admin TTL).
