### PR TITLE
feat: explicit inter-mediator relay enablement flag (simplification T12)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ## 11th June 2026
 
+### 0.15.31 — Explicit inter-mediator relay flag (simplification T12)
+
+- Adds `security.enable_inter_mediator_relay` (env `ENABLE_INTER_MEDIATOR_RELAY`,
+  default `false`) — an explicit switch for acting as an inter-mediator relay
+  (accepting anonymous `/inbound` forwards). The anonymous-relay synthesis path
+  (`jwt_auth`) now gates on `flag || global_acl_default grants SEND_FORWARDED`.
+- **Deprecation (non-breaking this release):** existing mediators that relay
+  *implicitly* — `global_acl_default` grants `SEND_FORWARDED` without the flag —
+  keep working, but now log a deprecation **warning** at boot
+  (`validate_config`). A future release will require the explicit flag
+  (`flag && ACL`).
+- **Migration:** if your mediator relays inter-mediator forwards, set
+  `security.enable_inter_mediator_relay = "true"`. If it should not relay, drop
+  `SEND_FORWARDED` from `global_acl_default`. Documented in `conf/mediator.toml`.
+- Verified: new unit tests for the gate (`anonymous_session_for` with/without
+  the flag) and the boot warning (`warn_implicit_relay`); new
+  `affinidi-messaging-test-mediator` e2e
+  (`non_relay_mediator_rejects_cross_mediator_forward`) confirms a non-relay
+  mediator drops the anonymous cross-mediator hop, while the existing relay e2e
+  suite still delivers.
+
 ### 0.15.30 — Dedupe authenticate unpack/verify boilerplate (simplification T11)
 
 - The `authenticate` response and refresh handlers carried byte-identical

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.30"
+version = "0.15.31"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -237,6 +237,14 @@ block_remote_admin_msgs = "true"
 ### TTL in seconds for admin messages (minimizes replay attack risk)
 admin_messages_expiry = "3"
 
+### Env: ENABLE_INTER_MEDIATOR_RELAY
+### Explicitly act as an inter-mediator relay (accept anonymous /inbound
+### forwards from other mediators). Defaults to "false".
+### NOTE: today relay is also permitted when global_acl_default grants
+### SEND_FORWARDED even without this flag (you'll see a deprecation warning at
+### boot). A future release will require this flag to be "true" for relay.
+enable_inter_mediator_relay = "false"
+
 ### ****************************************************************************************************************************
 ### Live streaming setup
 ### ****************************************************************************************************************************

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -134,6 +134,10 @@ pub(crate) fn apply_env_overrides(config: &mut super::ConfigRaw) {
         "BLOCK_REMOTE_ADMIN_MSGS"
     );
     env_override!(
+        config.security.enable_inter_mediator_relay,
+        "ENABLE_INTER_MEDIATOR_RELAY"
+    );
+    env_override!(
         config.security.admin_messages_expiry,
         "ADMIN_MESSAGES_EXPIRY"
     );

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -219,6 +219,10 @@ pub struct SecurityConfigRaw {
     pub block_remote_admin_msgs: String,
     pub force_session_did_match: String,
     pub admin_messages_expiry: String,
+    /// Explicit inter-mediator relay switch. `#[serde(default)]` so configs
+    /// that predate the flag deserialize without it (empty → `false`).
+    #[serde(default)]
+    pub enable_inter_mediator_relay: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -249,6 +253,12 @@ pub struct SecurityConfig {
     pub force_session_did_match: bool,
     pub block_remote_admin_msgs: bool,
     pub admin_messages_expiry: u64,
+    /// When `true`, this mediator explicitly acts as an inter-mediator relay
+    /// (accepts anonymous `/inbound` forwards). Defaults to `false`. Today
+    /// relay is still permitted when `global_acl_default` grants
+    /// `SEND_FORWARDED` even without this flag (with a deprecation warning at
+    /// boot); a future release will require the flag.
+    pub enable_inter_mediator_relay: bool,
 }
 
 impl Debug for SecurityConfig {
@@ -280,6 +290,10 @@ impl Debug for SecurityConfig {
             .field("force_session_did_match", &self.force_session_did_match)
             .field("block_remote_admin_msgs", &self.block_remote_admin_msgs)
             .field("admin_messages_expiry", &self.admin_messages_expiry)
+            .field(
+                "enable_inter_mediator_relay",
+                &self.enable_inter_mediator_relay,
+            )
             .finish()
     }
 }
@@ -316,6 +330,7 @@ impl SecurityConfig {
             force_session_did_match: true,
             block_remote_admin_msgs: true,
             admin_messages_expiry: 3,
+            enable_inter_mediator_relay: false,
         }
     }
 }
@@ -531,6 +546,22 @@ impl SecurityConfigRaw {
                 warn_default("admin_messages_expiry", &self.admin_messages_expiry, "3");
                 3
             }),
+            // Absent (legacy configs) → false silently; a non-empty but
+            // unparseable value is a typo worth warning about.
+            enable_inter_mediator_relay: if self.enable_inter_mediator_relay.is_empty() {
+                false
+            } else {
+                self.enable_inter_mediator_relay
+                    .parse()
+                    .unwrap_or_else(|_| {
+                        warn_default(
+                            "enable_inter_mediator_relay",
+                            &self.enable_inter_mediator_relay,
+                            "false",
+                        );
+                        false
+                    })
+            },
             ..SecurityConfig::default(secrets_resolver)
         };
 

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/validate.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/validate.rs
@@ -16,6 +16,7 @@ use affinidi_messaging_mediator_common::types::acls::{AccessListModeType, Mediat
 use tracing::warn;
 
 use super::Config;
+use crate::common::authz::{Capability, grants};
 use crate::common::error_codes;
 
 /// Run all config invariants. Hard conflicts return an error (aborting
@@ -52,8 +53,40 @@ pub fn validate_config(config: &Config) -> Result<(), MediatorError> {
     if let Some(msg) = warn_remote_admin_allowed(config.security.block_remote_admin_msgs) {
         warn!("{msg}");
     }
+    if let Some(msg) = warn_implicit_relay(
+        config.security.enable_inter_mediator_relay,
+        &config.security.global_acl_default,
+    ) {
+        warn!("{msg}");
+    }
 
     Ok(())
+}
+
+/// Warn when this mediator relays inter-mediator forwards *implicitly* — i.e.
+/// `global_acl_default` grants `SEND_FORWARDED` (so anonymous `/inbound`
+/// forwards are accepted) but the operator hasn't set the explicit
+/// `security.enable_inter_mediator_relay` flag.
+///
+/// This is the deprecation half of the explicit-relay rollout: today the
+/// implicit configuration still works, but a future release will require the
+/// flag, so we surface it loudly now. Setting the flag (or removing
+/// `SEND_FORWARDED` from the global default) silences the warning.
+pub(crate) fn warn_implicit_relay(
+    enable_relay_flag: bool,
+    global_acl_default: &MediatorACLSet,
+) -> Option<String> {
+    if !enable_relay_flag && grants(global_acl_default, Capability::SendForwarded) {
+        return Some(
+            "inter-mediator relay is enabled implicitly: global_acl_default grants SEND_FORWARDED \
+             but security.enable_inter_mediator_relay is not set. This still works today, but a \
+             future release will require the explicit flag — set \
+             security.enable_inter_mediator_relay = \"true\" to opt in (or drop SEND_FORWARDED from \
+             the global default if this mediator should not relay)."
+                .to_string(),
+        );
+    }
+    None
 }
 
 /// Warn when `admin_did` equals `mediator_did`: sharing one identity lets
@@ -193,6 +226,27 @@ mod tests {
         let msg = warn_admin_is_mediator("did:peer:2.same", "did:peer:2.same")
             .expect("identical DIDs should warn");
         assert!(msg.contains("privilege confusion"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn implicit_relay_warning_fires_only_for_acl_without_flag() {
+        let relay = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
+        let no_relay =
+            MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
+                .unwrap();
+
+        // ACL grants SEND_FORWARDED but flag off → deprecation warning.
+        let msg = warn_implicit_relay(false, &relay).expect("implicit relay should warn");
+        assert!(
+            msg.contains("enable_inter_mediator_relay"),
+            "msg was: {msg}"
+        );
+
+        // Flag explicitly set → no warning (operator opted in).
+        assert!(warn_implicit_relay(true, &relay).is_none());
+        // ACL doesn't grant SEND_FORWARDED → not relaying, no warning.
+        assert!(warn_implicit_relay(false, &no_relay).is_none());
+        assert!(warn_implicit_relay(true, &no_relay).is_none());
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -262,9 +262,18 @@ fn relay_anonymous_acls() -> MediatorACLSet {
 /// expired, or blocked token must be rejected, never silently demoted to
 /// anonymous, and a backend error must surface as `500` rather than proceed as
 /// an unauthenticated relay.
-fn anonymous_session_for(err: &AuthError, global_acl_default: &MediatorACLSet) -> Option<Session> {
-    if matches!(err, AuthError::MissingCredentials) && anonymous_inbound_allowed(global_acl_default)
-    {
+///
+/// Relay is enabled when the explicit `enable_inter_mediator_relay` flag is set
+/// OR, for backward compatibility, when `global_acl_default` grants
+/// `SEND_FORWARDED` (the legacy implicit-relay behaviour, which boot-time
+/// validation now warns about). A future release will require the explicit flag.
+fn anonymous_session_for(
+    err: &AuthError,
+    enable_relay_flag: bool,
+    global_acl_default: &MediatorACLSet,
+) -> Option<Session> {
+    let relay_enabled = enable_relay_flag || anonymous_inbound_allowed(global_acl_default);
+    if matches!(err, AuthError::MissingCredentials) && relay_enabled {
         Some(Session {
             session_id: "ANON-INBOUND".to_string(),
             acls: relay_anonymous_acls(),
@@ -299,7 +308,12 @@ where
             Ok(session) => Ok(MaybeSession(session)),
             Err(e) => {
                 let shared = SharedData::from_ref(state);
-                match anonymous_session_for(&e, &shared.config.security.global_acl_default) {
+                let security = &shared.config.security;
+                match anonymous_session_for(
+                    &e,
+                    security.enable_inter_mediator_relay,
+                    &security.global_acl_default,
+                ) {
                     Some(session) => Ok(MaybeSession(session)),
                     None => Err(e),
                 }
@@ -358,7 +372,8 @@ mod tests {
     #[test]
     fn missing_credentials_downgrades_to_relay_session_only_when_relay_enabled() {
         let relay = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
-        let session = anonymous_session_for(&AuthError::MissingCredentials, &relay)
+        // Legacy implicit relay: ACL grants SEND_FORWARDED, flag off.
+        let session = anonymous_session_for(&AuthError::MissingCredentials, false, &relay)
             .expect("relay-enabled mediator accepts anonymous inbound");
         // Not authenticated, no DID, and scoped to the minimal relay ACL — never
         // the full global default.
@@ -371,7 +386,22 @@ mod tests {
         let secure =
             MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
                 .unwrap();
-        assert!(anonymous_session_for(&AuthError::MissingCredentials, &secure).is_none());
+        assert!(anonymous_session_for(&AuthError::MissingCredentials, false, &secure).is_none());
+    }
+
+    #[test]
+    fn explicit_relay_flag_enables_anonymous_inbound_without_the_acl_bit() {
+        // The explicit flag enables anonymous relay even when the global default
+        // ACL does NOT grant SEND_FORWARDED (the forward-compatible path).
+        let secure =
+            MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
+                .unwrap();
+        assert!(
+            anonymous_session_for(&AuthError::MissingCredentials, true, &secure).is_some(),
+            "explicit enable_inter_mediator_relay must accept anonymous inbound"
+        );
+        // ...and with neither the flag nor the ACL bit, it stays rejected.
+        assert!(anonymous_session_for(&AuthError::MissingCredentials, false, &secure).is_none());
     }
 
     #[test]
@@ -388,7 +418,7 @@ mod tests {
             AuthError::InternalServerError("backend down".into()),
         ] {
             assert!(
-                anonymous_session_for(&err, &relay).is_none(),
+                anonymous_session_for(&err, false, &relay).is_none(),
                 "{err:?} must not be downgraded to an anonymous session"
             );
         }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 11th June 2026
+
+### 0.2.8 — builder support for the explicit relay flag (mediator T12)
+
+- Adds `TestMediatorBuilder::enable_inter_mediator_relay(bool)` to override
+  `SecurityConfig.enable_inter_mediator_relay`, and a new e2e
+  (`non_relay_mediator_rejects_cross_mediator_forward`) verifying a non-relay
+  mediator drops the anonymous cross-mediator hop.
+
 ## 10th June 2026
 
 ### 0.2.7 — health-endpoint integration tests (mediator T2)

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.7"
+version = "0.2.8"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -315,6 +315,8 @@ pub struct TestMediatorBuilder {
     force_session_did_match: Option<bool>,
     /// Override for `SecurityConfig.block_remote_admin_msgs`.
     block_remote_admin_msgs: Option<bool>,
+    /// Override for `SecurityConfig.enable_inter_mediator_relay`.
+    enable_inter_mediator_relay: Option<bool>,
     /// Override for `SecurityConfig.jwt_access_expiry` (seconds).
     jwt_access_expiry_secs: Option<u64>,
     /// Override for `SecurityConfig.jwt_refresh_expiry` (seconds).
@@ -350,6 +352,7 @@ impl Default for TestMediatorBuilder {
             block_anonymous_outer_envelope: None,
             force_session_did_match: None,
             block_remote_admin_msgs: None,
+            enable_inter_mediator_relay: None,
             jwt_access_expiry_secs: None,
             jwt_refresh_expiry_secs: None,
             admin_identity: None,
@@ -504,6 +507,14 @@ impl TestMediatorBuilder {
     /// control. Defaults to `MediatorACLSet::default()`.
     pub fn global_acl_default(mut self, acls: MediatorACLSet) -> Self {
         self.global_acl_default = Some(acls);
+        self
+    }
+
+    /// Override `SecurityConfig.enable_inter_mediator_relay` — the explicit
+    /// switch for accepting anonymous inter-mediator `/inbound` forwards.
+    /// Defaults to the production default (`false`).
+    pub fn enable_inter_mediator_relay(mut self, enabled: bool) -> Self {
+        self.enable_inter_mediator_relay = Some(enabled);
         self
     }
 
@@ -668,6 +679,9 @@ impl TestMediatorBuilder {
         }
         if let Some(b) = self.block_remote_admin_msgs {
             security.block_remote_admin_msgs = b;
+        }
+        if let Some(b) = self.enable_inter_mediator_relay {
+            security.enable_inter_mediator_relay = b;
         }
         if let Some(secs) = self.jwt_access_expiry_secs {
             security.jwt_access_expiry = secs;

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
@@ -83,6 +83,25 @@ async fn spawn_rewrap_environment(trusted_peers: &[String]) -> TestEnvironment {
         .expect("wire SDK environment to rewrap mediator")
 }
 
+/// Spawn a mediator that is explicitly NOT a relay: its global default ACL
+/// does not grant `SEND_FORWARDED` and `enable_inter_mediator_relay` is off,
+/// so it must refuse the anonymous inter-mediator `/inbound` hop. Locally
+/// registered users (added via `add_user` with an explicit allow-all ACL) can
+/// still authenticate and receive their own direct messages.
+async fn spawn_non_relay_environment() -> TestEnvironment {
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::deny_all())
+        .enable_inter_mediator_relay(false)
+        .spawn()
+        .await
+        .expect("spawn non-relay mediator");
+    TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment to non-relay mediator")
+}
+
 /// Add a user and bring up its WebSocket live-stream connection.
 ///
 /// Retrieval uses message-pickup `live_stream_get` (the supported
@@ -238,6 +257,46 @@ async fn cross_mediator_forward_delivers_over_memory_backend() {
         received.as_deref(),
         Some(text),
         "Bob should receive Alice's message after it routes A → B"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+/// Negative counterpart of the above + the end-to-end half of T12: a mediator
+/// that is NOT configured as a relay must drop the anonymous inter-mediator
+/// hop, so a cross-mediator forward never reaches the recipient. (The flag's
+/// gate logic in isolation is unit-tested in `jwt_auth`; here we confirm the
+/// observable end-to-end behaviour with relay off.)
+#[tokio::test]
+async fn non_relay_mediator_rejects_cross_mediator_forward() {
+    init_tracing();
+
+    let env_a = spawn_relay_environment().await;
+    let env_b = spawn_non_relay_environment().await;
+
+    let mediator_a_did = env_a.mediator.did().to_string();
+    let mediator_b_did = env_b.mediator.did().to_string();
+    assert_ne!(mediator_a_did, mediator_b_did);
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let received = forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        &mediator_b_did,
+        "This must not arrive — mediator B is not a relay.",
+        Duration::from_secs(4),
+    )
+    .await;
+
+    assert_eq!(
+        received, None,
+        "a non-relay mediator must drop the anonymous cross-mediator hop"
     );
 
     env_a.shutdown().await.expect("shutdown mediator A");


### PR DESCRIPTION
## Summary

**T12** — makes inter-mediator relay an **explicit** choice instead of an implicit side effect of `global_acl_default` granting `SEND_FORWARDED`.

- Adds `security.enable_inter_mediator_relay` (env `ENABLE_INTER_MEDIATOR_RELAY`, default `false`).
- The anonymous-relay synthesis path (`jwt_auth::anonymous_session_for`) now gates on `flag || global_acl_default grants SEND_FORWARDED`.

## Deprecation cycle (non-breaking this release)

Mediators that relay **implicitly** (ACL grants `SEND_FORWARDED`, flag unset) keep working, but now log a **deprecation warning** at boot (`validate_config::warn_implicit_relay`). A future release will require the explicit flag (`flag && ACL`).

**Migration:** set `security.enable_inter_mediator_relay = "true"` if this mediator relays; otherwise drop `SEND_FORWARDED` from `global_acl_default`. Documented in `conf/mediator.toml`.

## A note on verification (raised before implementing)

In this release the gate is `flag || ACL` (so existing configs don't break), and end-to-end delivery *also* needs the downstream `SEND_FORWARDED` ACL for relay-sender auto-registration. So the flag's effect **can't be isolated via end-to-end delivery yet** — that's inherent to the deprecation step. Coverage is therefore split:
- **Gate logic** — unit-tested directly (`anonymous_session_for` with/without flag and ACL bit, incl. flag-enables-without-ACL).
- **Boot warning** — unit-tested (`warn_implicit_relay`).
- **Disabled behaviour** — new e2e `non_relay_mediator_rejects_cross_mediator_forward` (non-relay B drops the anonymous hop → no delivery).
- **Enabled behaviour** — the existing relay e2e suite (5 tests) still delivers.

## Config plumbing

`SecurityConfigRaw` gains a `#[serde(default)]` String field (legacy configs without it → `false`); `SecurityConfig` gains the bool; env override + TOML docs added. test-mediator gains `TestMediatorBuilder::enable_inter_mediator_relay(bool)`.

## Versions

`affinidi-messaging-mediator` 0.15.30 → 0.15.31; `affinidi-messaging-test-mediator` 0.2.7 → 0.2.8 (additive builder API).

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` + `didcomm,memory-backend` + test-mediator; `cargo test -p affinidi-messaging-mediator --lib` 143 passed; `cross_mediator_forwarding` 6 passed (incl. the new disabled case); `cargo deny` ok.

Phase 2 remaining: **T13** (per-DID WebSocket connection cap + always-on admin-message TTL).
