### PR TITLE
feat: per-DID WebSocket cap + always-on admin TTL hardening (simplification T13)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ## 11th June 2026
 
+### 0.15.32 — Per-DID WebSocket cap + always-on admin TTL (hardening T13)
+
+- **(a) Per-DID WebSocket connection cap.** Adds
+  `limits.max_websocket_connections_per_did` (env
+  `LIMIT_MAX_WEBSOCKET_CONNECTIONS_PER_DID`, default `100`, `0` = unlimited),
+  enforced at WebSocket upgrade so a single DID can't exhaust the global
+  `max_websocket_connections` budget. The reserved slot is released by an RAII
+  guard, so it's decremented on every connection-teardown path (including the
+  early returns the global counter misses). Over-cap connections complete the
+  101 handshake and are then closed by the server.
+- **(b) Admin-message TTL hardening.** The `created_time` / TTL check that
+  bounds admin-message replay was duplicated inline across the three admin
+  protocol handlers (`acls`, `administration`, `accounts`). Consolidated into
+  one unit-tested helper, `authz::admin_message_ttl_status`, which all three
+  now call (byte-identical problem reports). Audit note: the check was already
+  enforced **unconditionally** — it never depended on `block_remote_admin_msgs`
+  (that flag only gates the admin *signature* check), so the replay window the
+  plan flagged was already closed; the helper + tests pin that invariant so it
+  can't regress.
+- Tests: new `affinidi-messaging-test-mediator` e2e
+  (`second_connection_for_one_did_over_the_cap_is_closed`) and unit tests for
+  `admin_message_ttl_status` (fresh / stale / future / missing / `expiry == 0`).
+
 ### 0.15.31 — Explicit inter-mediator relay flag (simplification T12)
 
 - Adds `security.enable_inter_mediator_relay` (env `ENABLE_INTER_MEDIATOR_RELAY`,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.31"
+version = "0.15.32"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -369,6 +369,11 @@ oob_invite_ttl = "86400"
 ### Maximum concurrent WebSocket connections (0 = unlimited)
 # max_websocket_connections = "10000"
 
+### Env: LIMIT_MAX_WEBSOCKET_CONNECTIONS_PER_DID
+### Maximum concurrent WebSocket connections for a single DID, so one DID
+### can't exhaust the global max_websocket_connections budget (0 = unlimited)
+# max_websocket_connections_per_did = "100"
+
 ### Env: LIMIT_DID_RATE_LIMIT_PER_SECOND
 ### Requests per second per authenticated DID (0 = disabled)
 # did_rate_limit_per_second = "0"

--- a/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
@@ -240,9 +240,87 @@ pub(crate) fn acl_change_ok(
     }
 }
 
+/// Outcome of checking an admin message's `created_time` against the
+/// admin-message TTL.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AdminTtlStatus {
+    /// Within the allowed window — accept.
+    Ok,
+    /// `created_time` is too old (or in the future) — reject as expired; the
+    /// value is carried for the problem report.
+    Expired(u64),
+    /// No `created_time` header — reject as missing.
+    Missing,
+}
+
+/// Validate an admin message's `created_time` against `admin_messages_expiry`,
+/// bounding replay of captured admin messages.
+///
+/// This is deliberately independent of `block_remote_admin_msgs`: admin
+/// messages are *always* subject to the replay-bounding TTL, whether or not
+/// the mediator also requires a signature on remote admin messages. A
+/// `created_time` in the future is rejected too (clock skew / forgery).
+pub(crate) fn admin_message_ttl_status(
+    created_time: Option<u64>,
+    expiry: u64,
+    now: u64,
+) -> AdminTtlStatus {
+    match created_time {
+        Some(ct) if ct.saturating_add(expiry) <= now || ct > now => AdminTtlStatus::Expired(ct),
+        Some(_) => AdminTtlStatus::Ok,
+        None => AdminTtlStatus::Missing,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn admin_ttl_accepts_fresh_and_rejects_stale_future_and_missing() {
+        let now = 1_000_000;
+        let expiry = 3;
+
+        // Fresh: created within the window.
+        assert_eq!(
+            admin_message_ttl_status(Some(now), expiry, now),
+            AdminTtlStatus::Ok
+        );
+        assert_eq!(
+            admin_message_ttl_status(Some(now - 2), expiry, now),
+            AdminTtlStatus::Ok
+        );
+
+        // Stale: created_time + expiry <= now (the boundary is inclusive).
+        assert_eq!(
+            admin_message_ttl_status(Some(now - 3), expiry, now),
+            AdminTtlStatus::Expired(now - 3)
+        );
+        assert_eq!(
+            admin_message_ttl_status(Some(now - 100), expiry, now),
+            AdminTtlStatus::Expired(now - 100)
+        );
+
+        // Future created_time is rejected (clock skew / forgery).
+        assert_eq!(
+            admin_message_ttl_status(Some(now + 1), expiry, now),
+            AdminTtlStatus::Expired(now + 1)
+        );
+
+        // Missing header.
+        assert_eq!(
+            admin_message_ttl_status(None, expiry, now),
+            AdminTtlStatus::Missing
+        );
+
+        // The verdict never depends on `block_remote_admin_msgs` — it isn't an
+        // input here, so admin replay is bounded regardless of that flag. With
+        // `expiry == 0` every admin message (created_time == now) is expired.
+        assert_eq!(
+            admin_message_ttl_status(Some(now), 0, now),
+            AdminTtlStatus::Expired(now)
+        );
+    }
 
     /// Build an ACL set granting everything (ALLOW_ALL), then we revoke
     /// individual capabilities to test the gate.

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -206,6 +206,10 @@ pub(crate) fn apply_env_overrides(config: &mut super::ConfigRaw) {
         "LIMIT_MAX_WEBSOCKET_CONNECTIONS"
     );
     env_override!(
+        config.limits.max_websocket_connections_per_did,
+        "LIMIT_MAX_WEBSOCKET_CONNECTIONS_PER_DID"
+    );
+    env_override!(
         config.limits.did_rate_limit_per_second,
         "LIMIT_DID_RATE_LIMIT_PER_SECOND"
     );

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
@@ -28,6 +28,10 @@ pub struct LimitsConfig {
     pub rate_limit_burst: u32,
     /// Maximum number of concurrent WebSocket connections. 0 = unlimited.
     pub max_websocket_connections: usize,
+    /// Maximum concurrent WebSocket connections for a single DID, so one DID
+    /// can't exhaust the global `max_websocket_connections` budget.
+    /// 0 = unlimited (only the global cap applies).
+    pub max_websocket_connections_per_did: usize,
     /// Maximum requests per second per authenticated DID. 0 = unlimited (disabled).
     pub did_rate_limit_per_second: u32,
     /// Burst size for per-DID rate limiting (additional requests allowed in a burst).
@@ -58,6 +62,7 @@ impl Default for LimitsConfig {
             rate_limit_per_ip: 100,
             rate_limit_burst: 50,
             max_websocket_connections: 10000,
+            max_websocket_connections_per_did: 100,
             did_rate_limit_per_second: 0,
             did_rate_limit_burst: 10,
         }
@@ -90,6 +95,8 @@ pub(crate) struct LimitsConfigRaw {
     pub rate_limit_burst: String,
     #[serde(default = "default_max_websocket_connections")]
     pub max_websocket_connections: String,
+    #[serde(default = "default_max_websocket_connections_per_did")]
+    pub max_websocket_connections_per_did: String,
     #[serde(default = "default_did_rate_limit_per_second")]
     pub did_rate_limit_per_second: String,
     #[serde(default = "default_did_rate_limit_burst")]
@@ -104,6 +111,9 @@ fn default_rate_limit_burst() -> String {
 }
 fn default_max_websocket_connections() -> String {
     "10000".to_string()
+}
+fn default_max_websocket_connections_per_did() -> String {
+    "100".to_string()
 }
 fn default_did_rate_limit_per_second() -> String {
     "0".to_string()
@@ -214,6 +224,13 @@ impl std::convert::TryFrom<LimitsConfigRaw> for LimitsConfig {
                 warn_default("max_websocket_connections", "10000");
                 10000
             }),
+            max_websocket_connections_per_did: raw
+                .max_websocket_connections_per_did
+                .parse()
+                .unwrap_or_else(|_| {
+                    warn_default("max_websocket_connections_per_did", "100");
+                    100
+                }),
             did_rate_limit_per_second: raw.did_rate_limit_per_second.parse().unwrap_or_else(|_| {
                 warn_default("did_rate_limit_per_second", "0");
                 0
@@ -282,6 +299,7 @@ mod tests {
             rate_limit_per_ip: "200".to_string(),
             rate_limit_burst: "100".to_string(),
             max_websocket_connections: "5000".to_string(),
+            max_websocket_connections_per_did: "250".to_string(),
             did_rate_limit_per_second: "50".to_string(),
             did_rate_limit_burst: "20".to_string(),
         };
@@ -336,6 +354,7 @@ mod tests {
             rate_limit_per_ip: default_rate_limit_per_ip(),
             rate_limit_burst: default_rate_limit_burst(),
             max_websocket_connections: default_max_websocket_connections(),
+            max_websocket_connections_per_did: default_max_websocket_connections_per_did(),
             did_rate_limit_per_second: default_did_rate_limit_per_second(),
             did_rate_limit_burst: default_did_rate_limit_burst(),
         };

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -27,8 +27,10 @@ use axum_extra::{
     TypedHeader,
     headers::{Authorization, authorization::Bearer},
 };
+use dashmap::DashMap;
 use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN, header::SEC_WEBSOCKET_PROTOCOL};
 use serde_json::json;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::{
@@ -236,6 +238,25 @@ pub async fn websocket_handler(
         .await
 }
 
+/// Releases a DID's reserved per-DID WebSocket slot on drop, so the count is
+/// decremented on *every* `handle_socket` return path (including the early
+/// returns before the main loop). The entry is removed once it reaches zero
+/// so the registry doesn't accumulate idle DIDs.
+struct PerDidConnectionGuard {
+    registry: Arc<DashMap<String, u32>>,
+    did_hash: String,
+}
+
+impl Drop for PerDidConnectionGuard {
+    fn drop(&mut self) {
+        if let Some(mut count) = self.registry.get_mut(&self.did_hash) {
+            *count = count.saturating_sub(1);
+        }
+        self.registry
+            .remove_if(&self.did_hash, |_, &count| count == 0);
+    }
+}
+
 /// WebSocket state machine. This is spawned per connection.
 async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Session) {
     let _span = span!(
@@ -244,11 +265,38 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
         session = session.session_id
     );
     async move {
-        // Enforce connection limit
+        // Enforce the global connection limit.
         let current = state.active_websocket_count.fetch_add(1, Ordering::Relaxed);
         if current >= state.config.limits.max_websocket_connections {
             state.active_websocket_count.fetch_sub(1, Ordering::Relaxed);
             warn!("WebSocket connection limit reached ({}/{})", current, state.config.limits.max_websocket_connections);
+            let _ = socket.send(Message::Close(None)).await;
+            return;
+        }
+
+        // Enforce the per-DID connection cap (0 = unlimited). Reserve the slot
+        // immediately and bind a guard so it's released on every return path;
+        // then reject if this DID is over its cap (the global slot reserved
+        // above is backed out explicitly, the per-DID slot by the guard).
+        let per_did_count = {
+            let mut entry = state
+                .ws_connections_per_did
+                .entry(session.did_hash.clone())
+                .or_insert(0);
+            *entry += 1;
+            *entry
+        };
+        let _per_did_guard = PerDidConnectionGuard {
+            registry: state.ws_connections_per_did.clone(),
+            did_hash: session.did_hash.clone(),
+        };
+        let per_did_cap = state.config.limits.max_websocket_connections_per_did;
+        if per_did_cap != 0 && per_did_count as usize > per_did_cap {
+            state.active_websocket_count.fetch_sub(1, Ordering::Relaxed);
+            warn!(
+                "Per-DID WebSocket connection limit reached for {} ({}/{})",
+                session.did_hash, per_did_count, per_did_cap
+            );
             let _ = socket.send(Message::Close(None)).await;
             return;
         }

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -14,6 +14,7 @@ use affinidi_messaging_sdk::protocols::discover_features::DiscoverFeatures;
 use axum::extract::{FromRef, FromRequestParts};
 use chrono::{DateTime, Utc};
 use common::{config::Config, did_rate_limiter::DidRateLimiter, jwt_auth::AuthError};
+use dashmap::DashMap;
 use http::request::Parts;
 use std::{collections::HashSet, fmt::Debug, sync::Arc, sync::atomic::AtomicUsize};
 use tasks::supervisor::HealthRegistry;
@@ -51,6 +52,11 @@ pub struct SharedData {
     pub discover_features: Arc<DiscoverFeatures>,
     /// Counter for active WebSocket connections (used for connection limiting).
     pub active_websocket_count: Arc<AtomicUsize>,
+    /// Live WebSocket connection count per DID hash, enforcing
+    /// `limits.max_websocket_connections_per_did` so a single DID can't
+    /// exhaust the global connection budget. Entries are removed when a DID's
+    /// count returns to zero.
+    pub ws_connections_per_did: Arc<DashMap<String, u32>>,
     /// Per-DID rate limiter for authenticated endpoints.
     pub did_rate_limiter: DidRateLimiter,
     /// Cancellation token for coordinated graceful shutdown of all background tasks.

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
@@ -1,5 +1,6 @@
 use std::slice;
 
+use crate::common::authz;
 use crate::common::time::unix_timestamp_secs;
 
 use super::acls::check_permissions;
@@ -30,15 +31,20 @@ pub(crate) async fn process(
     let _span = span!(tracing::Level::DEBUG, "mediator_accounts");
 
     async move {
-        // Check if message is valid from an expiry perspective (for any admin accounts)
+        // Check if message is valid from an expiry perspective (for any admin
+        // accounts). Always enforced — independent of `block_remote_admin_msgs`
+        // — to bound replay of captured admin messages.
         if session.account_type == AccountType::Admin
         || session.account_type == AccountType::RootAdmin
         {
             let now = unix_timestamp_secs();
-            if let Some(created_time) = msg.created_time {
-                if (created_time + state.config.security.admin_messages_expiry) <= now
-                    || created_time > now
-                {
+            match authz::admin_message_ttl_status(
+                msg.created_time,
+                state.config.security.admin_messages_expiry,
+                now,
+            ) {
+                authz::AdminTtlStatus::Ok => {}
+                authz::AdminTtlStatus::Expired(created_time) => {
                     warn!("ADMIN related message has an invalid created_time header.");
                     return Err(MediatorError::problem_with_log(
                         31,
@@ -53,19 +59,20 @@ pub(crate) async fn process(
                         "Message was created too long ago for admin requests",
                     ));
                 }
-            } else {
-                warn!("ADMIN related message has no created_time header. Required.");
-                return Err(MediatorError::problem(
-                    91,
-                    &session.session_id,
-                    Some(msg.id.to_string()),
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "message.created_time.missing",
-                    "Admin messages must include a created_time header",
-                    vec![],
-                    StatusCode::BAD_REQUEST,
-                ));
+                authz::AdminTtlStatus::Missing => {
+                    warn!("ADMIN related message has no created_time header. Required.");
+                    return Err(MediatorError::problem(
+                        91,
+                        &session.session_id,
+                        Some(msg.id.to_string()),
+                        ProblemReportSorter::Error,
+                        ProblemReportScope::Protocol,
+                        "message.created_time.missing",
+                        "Admin messages must include a created_time header",
+                        vec![],
+                        StatusCode::BAD_REQUEST,
+                    ));
+                }
             }
         }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
@@ -1,5 +1,6 @@
 use std::slice;
 
+use crate::common::authz;
 use crate::common::time::unix_timestamp_secs;
 
 use crate::{SharedData, common::session::Session, messages::ProcessMessageResponse};
@@ -27,15 +28,20 @@ pub(crate) async fn process(
     let _span = span!(tracing::Level::DEBUG, "mediator_acls");
 
     async move {
-        // Check if message is valid from an expiry perspective (for any admin accounts)
+        // Check if message is valid from an expiry perspective (for any admin
+        // accounts). Always enforced for admin accounts — independent of
+        // `block_remote_admin_msgs` — to bound replay of captured admin messages.
         if session.account_type == AccountType::Admin
             || session.account_type == AccountType::RootAdmin
         {
             let now = unix_timestamp_secs();
-            if let Some(created_time) = msg.created_time {
-                if (created_time + state.config.security.admin_messages_expiry) <= now
-                    || created_time > now
-                {
+            match authz::admin_message_ttl_status(
+                msg.created_time,
+                state.config.security.admin_messages_expiry,
+                now,
+            ) {
+                authz::AdminTtlStatus::Ok => {}
+                authz::AdminTtlStatus::Expired(created_time) => {
                     warn!("ADMIN related message has an invalid created_time header.");
                     return Err(MediatorError::problem_with_log(
                         31,
@@ -50,19 +56,20 @@ pub(crate) async fn process(
                         "Message was created too long ago for admin requests",
                     ));
                 }
-            } else {
-                warn!("ADMIN related message has no created_time header. Required.");
-                return Err(MediatorError::problem(
-                    91,
-                    &session.session_id,
-                    Some(msg.id.to_string()),
-                    ProblemReportSorter::Error,
-                    ProblemReportScope::Protocol,
-                    "message.created_time.missing",
-                    "Admin messages must include a created_time header",
-                    vec![],
-                    StatusCode::BAD_REQUEST,
-                ));
+                authz::AdminTtlStatus::Missing => {
+                    warn!("ADMIN related message has no created_time header. Required.");
+                    return Err(MediatorError::problem(
+                        91,
+                        &session.session_id,
+                        Some(msg.id.to_string()),
+                        ProblemReportSorter::Error,
+                        ProblemReportScope::Protocol,
+                        "message.created_time.missing",
+                        "Admin messages must include a created_time header",
+                        vec![],
+                        StatusCode::BAD_REQUEST,
+                    ));
+                }
             }
         }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
@@ -1,5 +1,6 @@
 //! Adds and removed administration accounts from the mediator
 //! Must be a administrator to use this protocol
+use crate::common::authz;
 use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
@@ -29,13 +30,17 @@ pub(crate) async fn process(
     let _span = span!(tracing::Level::DEBUG, "mediator_administration");
 
     async move {
-        // Check if message is valid from an expiry perspective
+        // Check if message is valid from an expiry perspective. Always enforced
+        // (independent of `block_remote_admin_msgs`) to bound replay of captured
+        // admin messages.
         let now = unix_timestamp_secs();
-
-        if let Some(created_time) = msg.created_time {
-            if (created_time + state.config.security.admin_messages_expiry) <= now
-                || created_time > now
-            {
+        match authz::admin_message_ttl_status(
+            msg.created_time,
+            state.config.security.admin_messages_expiry,
+            now,
+        ) {
+            authz::AdminTtlStatus::Ok => {}
+            authz::AdminTtlStatus::Expired(created_time) => {
                 warn!("ADMIN related message has an invalid created_time header.");
                 return Err(MediatorError::problem_with_log(
                     31,
@@ -50,19 +55,20 @@ pub(crate) async fn process(
                     "Message was created too long ago for admin requests",
                 ));
             }
-        } else {
-            warn!("ADMIN related message has no created_time header. Required.");
-            return Err(MediatorError::problem(
-                91,
-                &session.session_id,
-                Some(msg.id.to_string()),
-                ProblemReportSorter::Error,
-                ProblemReportScope::Protocol,
-                "message.created_time.missing",
-                "Admin messages must include a created_time header",
-                vec![],
-                StatusCode::BAD_REQUEST,
-            ));
+            authz::AdminTtlStatus::Missing => {
+                warn!("ADMIN related message has no created_time header. Required.");
+                return Err(MediatorError::problem(
+                    91,
+                    &session.session_id,
+                    Some(msg.id.to_string()),
+                    ProblemReportSorter::Error,
+                    ProblemReportScope::Protocol,
+                    "message.created_time.missing",
+                    "Admin messages must include a created_time header",
+                    vec![],
+                    StatusCode::BAD_REQUEST,
+                ));
+            }
         }
 
         // Sender identity: prefer JWS signature, fall back to authcrypt sender

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -568,6 +568,7 @@ pub async fn serve_internal(
         #[cfg(feature = "didcomm")]
         discover_features,
         active_websocket_count: Arc::new(AtomicUsize::new(0)),
+        ws_connections_per_did: Arc::new(dashmap::DashMap::new()),
         did_rate_limiter,
         shutdown_token: shutdown_token.clone(),
         self_authorities: Arc::new(self_authorities),

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 11th June 2026
 
+### 0.2.9 — builder support for the per-DID WebSocket cap (mediator T13)
+
+- Adds `TestMediatorBuilder::max_websocket_connections_per_did(usize)` (passing
+  a custom `LimitsConfig` through to the mediator) and a new e2e
+  (`second_connection_for_one_did_over_the_cap_is_closed`) verifying the
+  over-cap WebSocket connection is closed by the server.
+
 ### 0.2.8 — builder support for the explicit relay flag (mediator T12)
 
 - Adds `TestMediatorBuilder::enable_inter_mediator_relay(bool)` to override

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.8"
+version = "0.2.9"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -76,6 +76,9 @@ reqwest = { version = "0.13", features = ["rustls", "json"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+## `StreamExt::next` to read frames from a `tokio-tungstenite` WebSocket
+## stream (per-DID connection-cap test reads the server's Close frame).
+futures-util = "0.3"
 ## `io-util` for the raw-socket WebSocket handshake test (the bearer-only
 ## browser scenario can't go through tokio-tungstenite's client, which
 ## errors when it offers a subprotocol the server doesn't echo back).

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -321,6 +321,8 @@ pub struct TestMediatorBuilder {
     jwt_access_expiry_secs: Option<u64>,
     /// Override for `SecurityConfig.jwt_refresh_expiry` (seconds).
     jwt_refresh_expiry_secs: Option<u64>,
+    /// Override for `LimitsConfig.max_websocket_connections_per_did`.
+    max_websocket_connections_per_did: Option<usize>,
     /// Stable admin identity for the mediator. `None` mints the
     /// historical opaque `did:key:z6Mk{uuid}` shape with no usable
     /// secrets — suitable for tests that don't authenticate as admin.
@@ -355,6 +357,7 @@ impl Default for TestMediatorBuilder {
             enable_inter_mediator_relay: None,
             jwt_access_expiry_secs: None,
             jwt_refresh_expiry_secs: None,
+            max_websocket_connections_per_did: None,
             admin_identity: None,
             #[cfg(feature = "fjall-backend")]
             fjall_dir: None,
@@ -515,6 +518,14 @@ impl TestMediatorBuilder {
     /// Defaults to the production default (`false`).
     pub fn enable_inter_mediator_relay(mut self, enabled: bool) -> Self {
         self.enable_inter_mediator_relay = Some(enabled);
+        self
+    }
+
+    /// Override `LimitsConfig.max_websocket_connections_per_did` — the cap on
+    /// concurrent WebSocket connections a single DID may hold. Defaults to the
+    /// production default (100). Set small to exercise the cap in tests.
+    pub fn max_websocket_connections_per_did(mut self, max: usize) -> Self {
+        self.max_websocket_connections_per_did = Some(max);
         self
     }
 
@@ -690,6 +701,12 @@ impl TestMediatorBuilder {
             security.jwt_refresh_expiry = secs;
         }
 
+        // Limits: production defaults, with any test overrides applied.
+        let mut limits = affinidi_messaging_mediator::common::config::LimitsConfig::default();
+        if let Some(max) = self.max_websocket_connections_per_did {
+            limits.max_websocket_connections_per_did = max;
+        }
+
         // Disable processors that aren't useful in most tests.
         let mut processors =
             affinidi_messaging_mediator::common::config::ProcessorsConfig::default();
@@ -718,6 +735,7 @@ impl TestMediatorBuilder {
             .listen_addr(bound_addr)
             .api_prefix(api_prefix)
             .security(security)
+            .limits(limits)
             .processors(processors)
             .streaming_enabled(self.enable_streaming)
             .local_endpoints(self.local_endpoints.clone())

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/websocket_per_did_cap.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/websocket_per_did_cap.rs
@@ -1,0 +1,109 @@
+//! Per-DID WebSocket connection cap (mediator T13a).
+//!
+//! `limits.max_websocket_connections_per_did` bounds how many concurrent
+//! WebSocket connections a single DID may hold, so one DID can't exhaust the
+//! global `max_websocket_connections` budget. The cap is enforced inside
+//! `handle_socket` — i.e. *after* the HTTP→WS upgrade returns `101` — so a
+//! rejected connection completes the handshake and then immediately receives
+//! a server `Close` frame.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, TestUser};
+use common::init_tracing;
+use futures_util::StreamExt;
+use tokio::time::timeout;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{ClientRequestBuilder, Message, http::Uri},
+};
+
+/// Authenticate `user` against the mediator and return a fresh access token
+/// plus the `ws://…/ws` upgrade URI (the same shape a browser would use).
+async fn token_and_ws_uri(env: &TestEnvironment, user: &TestUser) -> (String, Uri) {
+    let mediator_did = env.mediator.did().to_string();
+    let tokens = env
+        .tdk
+        .authentication()
+        .authenticate(user.did.clone(), mediator_did, 3, None)
+        .await
+        .expect("authenticate user");
+    let ws_uri: Uri = env
+        .mediator
+        .ws_endpoint()
+        .as_str()
+        .parse()
+        .expect("parse ws endpoint");
+    (tokens.access_token, ws_uri)
+}
+
+/// Open a WebSocket for `user` via the `bearer.<jwt>` subprotocol (each call
+/// mints a fresh session token but the same DID, so both count against that
+/// DID's cap).
+async fn open_ws(
+    env: &TestEnvironment,
+    user: &TestUser,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let (access_token, ws_uri) = token_and_ws_uri(env, user).await;
+    // Offer a benign app subprotocol alongside the bearer entry so the server
+    // selects (echoes) it — tokio-tungstenite's strict client refuses a
+    // handshake where the server selects no subprotocol at all.
+    let request = ClientRequestBuilder::new(ws_uri)
+        .with_sub_protocol("affinidi.test")
+        .with_sub_protocol(format!("bearer.{access_token}"));
+    let (stream, response) = connect_async(request)
+        .await
+        .expect("bearer subprotocol upgrade must reach 101");
+    assert_eq!(response.status().as_u16(), 101, "expected 101 upgrade");
+    stream
+}
+
+#[tokio::test]
+async fn second_connection_for_one_did_over_the_cap_is_closed() {
+    init_tracing();
+
+    // Cap a single DID at one concurrent WebSocket connection.
+    let mediator = TestMediator::builder()
+        .max_websocket_connections_per_did(1)
+        .spawn()
+        .await
+        .expect("spawn mediator with per-DID WS cap = 1");
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment");
+    let alice = env.add_user("Alice").await.expect("add user");
+
+    // First connection consumes Alice's single slot. Hold it open and give
+    // `handle_socket` a moment to reserve the per-DID slot (the cap check runs
+    // after the 101 upgrade the client already observed).
+    let mut conn1 = open_ws(&env, &alice).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Second connection for the SAME DID is over the cap: it completes the
+    // handshake but must then be closed by the server.
+    let mut conn2 = open_ws(&env, &alice).await;
+
+    let frame = timeout(Duration::from_secs(5), conn2.next())
+        .await
+        .expect("the over-cap connection should be closed promptly, not hang");
+    match frame {
+        Some(Ok(Message::Close(_))) | None => { /* rejected as expected */ }
+        other => panic!("expected a Close frame on the over-cap connection, got: {other:?}"),
+    }
+
+    // The first connection keeps its slot — closing conn2 frees nothing it
+    // was using, so conn1 remains usable. A fresh read should not surface a
+    // Close within a short window (it may see a keepalive ping, which is
+    // fine — anything other than Close/None means still-open).
+    if let Ok(Some(Ok(msg))) = timeout(Duration::from_secs(1), conn1.next()).await {
+        assert!(
+            !matches!(msg, Message::Close(_)),
+            "the first (in-cap) connection must stay open, not be closed"
+        );
+    }
+
+    drop(conn1);
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
## Summary

**T13** — the final Phase 2 task. Two independent hardening items.

### (a) Per-DID WebSocket connection cap

Adds `limits.max_websocket_connections_per_did` (env `LIMIT_MAX_WEBSOCKET_CONNECTIONS_PER_DID`, default `100`, `0` = unlimited), enforced at the WebSocket upgrade so a single DID can't exhaust the global `max_websocket_connections` budget (previously one DID could consume the whole 10k).

- Tracked in a per-DID `DashMap` on `SharedData`.
- The reserved slot is released by an **RAII Drop guard**, so it's decremented on *every* connection-teardown path — including the early returns the global counter currently misses.
- The cap runs inside `handle_socket` (after the 101 upgrade), so an over-cap connection completes the handshake and is then closed by the server.

### (b) Admin-message TTL hardening / dedup

The `created_time`/TTL check that bounds admin-message replay was duplicated inline across all three admin handlers (`acls`, `administration`, `accounts`). Consolidated into one unit-tested helper, `authz::admin_message_ttl_status`; all three now call it (byte-identical problem reports `31`/`91`).

**Audit note (agreed scoping):** the plan said the TTL was "skipped when `block_remote_admin_msgs` is false" — but the audit found it was already enforced **unconditionally**. `block_remote_admin_msgs` only gates the admin *signature* check, never the TTL. So the replay window was already closed; the helper + unit tests **pin that invariant** (including that the verdict doesn't take `block_remote_admin_msgs` as input) so it can't regress. **No behaviour change in (b).**

## Tests

- New e2e `second_connection_for_one_did_over_the_cap_is_closed` (memory backend).
- Unit tests for `admin_message_ttl_status` (fresh / stale / future / missing / `expiry == 0`).

## Versions

`affinidi-messaging-mediator` 0.15.31 → 0.15.32; `affinidi-messaging-test-mediator` 0.2.8 → 0.2.9 (additive builder method).

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` + `didcomm,memory-backend` + test-mediator; `cargo test -p affinidi-messaging-mediator --lib` 144 passed; test-mediator `websocket_per_did_cap` 1, `lifecycle` 22, `streaming_forwarding_acl` 6, `cross_mediator_forwarding` 6 passed; `cargo deny` ok.

---

**Phase 2 complete** (T7–T13). The only remaining plan item is the deferred `process()` account-resolution extraction noted as a T10 follow-up.
