### PR TITLE
refactor: supervise the WebSocket streaming task (T2 follow-up)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 11th June 2026
 
+### 0.15.34 — Supervise the WebSocket streaming task (T2 follow-up)
+
+- The WebSocket live-streaming task was the last background task still
+  spawned detached, with its `JoinHandle` dropped — a panic killed live
+  delivery silently with no restart and no health signal. It now runs under
+  the `TaskSupervisor` (`StreamingTask::spawn_supervised`), so a panic or a
+  transient startup error (`streaming_clean_start` / `streaming_subscribe`)
+  restarts it with capped backoff and surfaces it as a component in `/readyz`.
+- Registered **not load-bearing**: if streaming is down, clients fall back to
+  message-pickup polling, so it degrades `/readyz` rather than failing it
+  (consistent with the statistics/sweep tasks).
+- The command channel survives restarts: the `tx` (held in `SharedData` and
+  every WebSocket handler) is unchanged, and the `rx` is wrapped in an
+  `Arc<Mutex<_>>` that each restart re-locks, so queued commands and live
+  socket registrations aren't lost. Side effect: a streaming backend hiccup
+  at startup no longer aborts mediator boot — it degrades and retries.
+
 ### 0.15.33 — Finish routing `process()` decomposition (T10 follow-up)
 
 - Completes the conservative `process()` decomposition started in 0.15.29 by

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.33"
+version = "0.15.34"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -457,17 +457,18 @@ pub async fn serve_internal(
 
     // Streaming task: subscribes via the trait, so it runs on any
     // backend. RedisStore bridges Redis pub/sub into a tokio
-    // broadcast; Memory and Fjall feed the broadcast directly.
-    let (streaming_task, _) = if config.streaming_enabled {
-        let _database = store.clone();
-        let uuid = config.streaming_uuid.clone();
-        let (_task, _handle) = StreamingTask::new(_database, &uuid).await.map_err(|e| {
-            error!("Error starting streaming task: {e}");
-            e
-        })?;
-        (Some(_task), Some(_handle))
+    // broadcast; Memory and Fjall feed the broadcast directly. Supervised
+    // (restart-and-degrade) rather than spawned detached, so a panic or a
+    // transient startup error restarts it instead of silently killing live
+    // delivery. Not load-bearing — clients fall back to message-pickup polling.
+    let streaming_task = if config.streaming_enabled {
+        Some(StreamingTask::spawn_supervised(
+            &supervisor,
+            store.clone(),
+            &config.streaming_uuid,
+        ))
     } else {
-        (None, None)
+        None
     };
 
     let mut did_resolver = DIDCacheClient::new(config.did_resolver_config.clone())

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -24,6 +24,7 @@ use crate::common::metrics::names::{
     WEBSOCKET_DUPLICATE_CHURN_TOTAL, WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL,
     WEBSOCKET_REDELIVERED_MESSAGES_TOTAL,
 };
+use crate::tasks::supervisor::TaskSupervisor;
 use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{MediatorStore, types::PubSubRecord},
@@ -37,8 +38,7 @@ use std::{
 };
 use tokio::{
     select,
-    sync::{broadcast, mpsc},
-    task::JoinHandle,
+    sync::{Mutex, broadcast, mpsc},
     time::sleep,
 };
 use tracing::{Instrument, Level, debug, error, info, span, warn};
@@ -105,39 +105,46 @@ pub struct StreamingTask {
 }
 
 impl StreamingTask {
-    /// Creates the streaming task handler
-    pub async fn new(
+    /// Create the streaming task's command channel and register the task with
+    /// the [`TaskSupervisor`], so a panic or startup error restarts it with
+    /// backoff (and surfaces as a `degraded` component in `/readyz`) instead of
+    /// dying silently with a dropped `JoinHandle`.
+    ///
+    /// The returned [`StreamingTask`] holds the `tx` side of the command
+    /// channel (cloned into `SharedData` and every WebSocket handler). The `rx`
+    /// side is wrapped in an `Arc<Mutex<_>>` so it survives restarts: the
+    /// supervisor builds a fresh future each restart, but it re-locks the
+    /// *same* receiver, so queued commands and the live `tx` clones stay valid.
+    /// `tokio`'s `Mutex` doesn't poison, so a panicking run releases the guard
+    /// cleanly for the next restart.
+    ///
+    /// Not load-bearing: if streaming is down, clients fall back to
+    /// message-pickup polling, so it degrades `/readyz` rather than failing it.
+    pub fn spawn_supervised(
+        supervisor: &TaskSupervisor,
         database: Arc<dyn MediatorStore>,
         mediator_uuid: &str,
-    ) -> Result<(Self, JoinHandle<()>), MediatorError> {
-        let _span = span!(Level::INFO, "StreamingTask::new");
+    ) -> Self {
+        // Create the inter-task channel - allows up to 10 queued messages
+        let (tx, rx) = mpsc::channel(10);
+        let task = StreamingTask {
+            channel: tx,
+            uuid: mediator_uuid.to_string(),
+        };
+        let rx = Arc::new(Mutex::new(rx));
 
-        async move {
-            // Create the inter-task channel - allows up to 10 queued messages
-            let (tx, mut rx) = mpsc::channel(10);
-            let task = StreamingTask {
-                channel: tx.clone(),
-                uuid: mediator_uuid.to_string(),
-            };
+        let supervised = task.clone();
+        supervisor.spawn("websocket_streaming", false, move || {
+            let task = supervised.clone();
+            let database = database.clone();
+            let rx = rx.clone();
+            async move {
+                let mut rx = rx.lock().await;
+                task.ws_streaming_task(database, &mut rx).await
+            }
+        });
 
-            // Start the streaming task
-            // With it's own clone of required data
-            let handle = {
-                let _task = task.clone();
-                tokio::spawn(async move {
-                    _task
-                        .ws_streaming_task(database, &mut rx)
-                        .await
-                        .unwrap_or_else(|e| {
-                            error!("websocket_streaming thread failed: {e}");
-                        });
-                })
-            };
-
-            Ok((task, handle))
-        }
-        .instrument(_span)
-        .await
+        task
     }
 
     /// Streams messages to subscribed clients over websocket.


### PR DESCRIPTION
## Summary

**Deferral 1** (the T2 follow-up). The WebSocket live-streaming task was the last background task still spawned **detached** — `StreamingTask::new` did `tokio::spawn(...)` and dropped the `JoinHandle`, so a panic killed live delivery silently with no restart and no health signal.

It now runs under the `TaskSupervisor` via `StreamingTask::spawn_supervised`:
- A panic or a transient startup error (`streaming_clean_start` / `streaming_subscribe`) **restarts it with capped backoff** and surfaces it as a `websocket_streaming` component in `/readyz`.
- Registered **not load-bearing** — if streaming is down, clients fall back to message-pickup polling, so it degrades `/readyz` rather than failing it (consistent with the statistics/sweep tasks).

## How the channel survives restarts

The supervisor builds a fresh future per restart, but the command channel must persist (its `tx` lives in `SharedData` and every WebSocket handler):
- `tx` — unchanged, still cloned into `SharedData`.
- `rx` — wrapped in `Arc<Mutex<_>>`; each restart re-locks the *same* receiver, so queued commands and live socket registrations aren't lost. `tokio`'s `Mutex` doesn't poison, so a panicking run releases the guard cleanly.

## Side effect (improvement)

A streaming-backend hiccup at startup no longer aborts mediator boot — it degrades and retries, matching T2's "restart-and-degrade, never fail-fast" posture (previously `StreamingTask::new` returned `Err` and `?`-aborted startup).

## Versions

`affinidi-messaging-mediator` 0.15.33 → 0.15.34.

## Verification

`cargo fmt --check`; `cargo clippy --all-targets` clean on `redis-backend` + `didcomm,memory-backend`; `cargo test --lib` 144 passed; WS-dependent e2e all green (`cross_mediator_forwarding` 6, `streaming_forwarding_acl` 6, `local_did_websocket` 2, `websocket_per_did_cap` 1, `lifecycle` 22, `health_endpoints` 2 — the supervised task is exercised end-to-end via `live_stream_get`); `cargo deny` ok.
