### PR TITLE
refactor: extract store delete-authorization to store::ops (simplification T16, part 1)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 11th June 2026
 
+### 0.15.35 — Route store delete-authorization through `store::ops` (simplification T16)
+
+- `FjallStore` and `MemoryStore` now call `mediator-common`'s new
+  `store::ops::delete_message_permitted` for the message-delete authorization
+  check instead of each carrying their own identical copy. Pure refactor — the
+  decision (Admin bypasses; an Owner must be the message's recipient or
+  non-anonymous sender) is unchanged and now unit-tested in one place.
+- Requires `affinidi-messaging-mediator-common` 0.15.8.
+
 ### 0.15.34 — Supervise the WebSocket streaming task (T2 follow-up)
 
 - The WebSocket live-streaming task was the last background task still

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.34"
+version = "0.15.35"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 11th June 2026
+
+### 0.15.8 — Extract shared store decision logic to `store::ops` (simplification T16)
+
+- Adds `store::ops`, a home for backend-agnostic decision logic shared by the
+  in-process Rust backends so it can't drift between them. First extraction:
+  `ops::delete_message_permitted` (message-delete authorization — Admin
+  bypasses; an Owner must be the recipient or the non-anonymous sender), which
+  `FjallStore` and `MemoryStore` previously each implemented identically. Now
+  unit-tested directly; both backends call it. Additive, no behaviour change.
+  (The Redis backend performs the equivalent check in Lua and is unaffected.)
+
 ## 10th June 2026
 
 ### 0.15.7 — ACL bitfield round-trip safety net (simplification T5)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.7"
+version = "0.15.8"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -58,6 +58,10 @@ use tokio::sync::broadcast;
 
 pub mod types;
 
+/// Backend-agnostic decision logic (authorization checks shared by the
+/// in-process Rust backends), extracted so it can't drift between them.
+pub mod ops;
+
 #[cfg(feature = "redis-backend")]
 pub mod redis;
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/ops.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/ops.rs
@@ -1,0 +1,80 @@
+//! Backend-agnostic decision logic for the store layer.
+//!
+//! The storage backends reduce to persistence primitives; the *decisions*
+//! they share — authorization checks and the like — live here as pure,
+//! unit-tested functions so they cannot drift between backends. `FjallStore`
+//! and `MemoryStore` previously each carried their own copy of these checks.
+//!
+//! The Redis backend performs the equivalent checks server-side in Lua and is
+//! necessarily separate (Lua can't call Rust), so these functions cover the
+//! in-process Rust backends; the conformance suite (`store_conformance`) is
+//! what keeps Redis aligned with them.
+
+use crate::store::types::DeletionAuthority;
+
+/// Whether `authority` may delete a message addressed to `to_did_hash` and
+/// (optionally) from `from_did_hash`.
+///
+/// - [`DeletionAuthority::Admin`] always may — the message-expiry processor and
+///   account removal delete on the owner's behalf.
+/// - [`DeletionAuthority::Owner`] may only delete a message it is a party to:
+///   its DID hash must be the recipient or the (non-anonymous) sender.
+pub fn delete_message_permitted(
+    authority: &DeletionAuthority,
+    to_did_hash: &str,
+    from_did_hash: Option<&str>,
+) -> bool {
+    match authority {
+        DeletionAuthority::Admin { .. } => true,
+        DeletionAuthority::Owner { did_hash } => {
+            did_hash == to_did_hash || from_did_hash == Some(did_hash.as_str())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner(h: &str) -> DeletionAuthority {
+        DeletionAuthority::Owner {
+            did_hash: h.to_string(),
+        }
+    }
+    fn admin(h: &str) -> DeletionAuthority {
+        DeletionAuthority::Admin {
+            admin_did_hash: h.to_string(),
+        }
+    }
+
+    #[test]
+    fn admin_may_delete_anything() {
+        assert!(delete_message_permitted(
+            &admin("anyone"),
+            "to",
+            Some("from")
+        ));
+        assert!(delete_message_permitted(&admin("anyone"), "to", None));
+    }
+
+    #[test]
+    fn owner_must_be_a_party_to_the_message() {
+        // The recipient may delete.
+        assert!(delete_message_permitted(&owner("to"), "to", Some("from")));
+        // The sender may delete.
+        assert!(delete_message_permitted(&owner("from"), "to", Some("from")));
+        // An unrelated third party may not.
+        assert!(!delete_message_permitted(
+            &owner("other"),
+            "to",
+            Some("from")
+        ));
+    }
+
+    #[test]
+    fn anonymous_message_only_the_recipient_qualifies() {
+        // With no sender, only the recipient is a party.
+        assert!(delete_message_permitted(&owner("to"), "to", None));
+        assert!(!delete_message_permitted(&owner("from"), "to", None));
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -49,7 +49,7 @@ use affinidi_messaging_mediator_common::{
     store::{
         DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
         MessageMetaData, MetadataStats, PubSubRecord, Session, SessionState, SessionSweepReport,
-        StatCounter, StoreHealth, StreamingClientState,
+        StatCounter, StoreHealth, StreamingClientState, ops,
     },
 };
 use affinidi_messaging_sdk::{
@@ -701,17 +701,13 @@ impl MediatorStore for FjallStore {
             }
         };
 
-        let permitted = match &by {
-            DeletionAuthority::Admin { .. } => true,
-            DeletionAuthority::Owner { did_hash } => {
-                did_hash == &stored.to_did_hash
-                    || stored
-                        .from_did_hash
-                        .as_deref()
-                        .map(|f| f == did_hash)
-                        .unwrap_or(false)
-            }
-        };
+        // Authorisation. Owner must be TO or FROM. Admin bypasses. Shared with
+        // the memory backend via `store::ops` so the two can't drift.
+        let permitted = ops::delete_message_permitted(
+            &by,
+            &stored.to_did_hash,
+            stored.from_did_hash.as_deref(),
+        );
         if !permitted {
             return Err(MediatorError::InternalError(
                 403,

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -29,7 +29,7 @@ use affinidi_messaging_mediator_common::{
     store::{
         DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
         MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
-        StoreHealth, StreamingClientState,
+        StoreHealth, StreamingClientState, ops,
     },
 };
 use affinidi_messaging_sdk::{
@@ -465,18 +465,13 @@ impl MediatorStore for MemoryStore {
             )
         })?;
 
-        // Authorisation. Owner must be TO or FROM. Admin bypasses.
-        let permitted = match &by {
-            DeletionAuthority::Admin { .. } => true,
-            DeletionAuthority::Owner { did_hash } => {
-                did_hash == &record.to_did_hash
-                    || record
-                        .from_did_hash
-                        .as_deref()
-                        .map(|f| f == did_hash)
-                        .unwrap_or(false)
-            }
-        };
+        // Authorisation. Owner must be TO or FROM. Admin bypasses. Shared with
+        // the Fjall backend via `store::ops` so the two can't drift.
+        let permitted = ops::delete_message_permitted(
+            &by,
+            &record.to_did_hash,
+            record.from_did_hash.as_deref(),
+        );
         if !permitted {
             return Err(MediatorError::InternalError(
                 403,


### PR DESCRIPTION
## Summary

**T16 part 1** — begins shrinking the `MediatorStore` surface by moving pure decision logic out of the backends into a shared, unit-tested module, so the two in-process Rust backends can't drift.

- New **`mediator-common/src/store/ops.rs`** with `delete_message_permitted` — the message-delete authorization: `Admin` bypasses; an `Owner` must be the message's recipient or its non-anonymous sender. Direct unit tests included.
- `FjallStore` and `MemoryStore` each previously carried a **byte-identical** copy of this check inline; both now call `ops::delete_message_permitted`.

## Behaviour: byte-identical

Same `403 PERMISSION_DENIED` for a non-party `Owner`, same `Admin` bypass. Pure refactor. The Redis backend performs the equivalent check in Lua (can't share Rust) and is unaffected — the `store_conformance` suite is what keeps Redis aligned.

## Versions (semver-aware, per the T16 acceptance)

- `affinidi-messaging-mediator-common` 0.15.7 → **0.15.8** (additive `pub` module/fn).
- `affinidi-messaging-mediator` 0.15.34 → **0.15.35** (rewired to call it; the `"0.15"` common pin already covers 0.15.8).

## Remaining T16 (own PRs)

Consolidate the ACL/access-list method family and remove the legacy 1:1 aliases (toward the "≥20% method-count reduction" acceptance).

## Verification

`cargo test -p affinidi-messaging-mediator-common --lib` (138 + 3 new `ops` tests); `cargo test -p affinidi-messaging-mediator --lib` on `memory-backend,fjall-backend` → 192 passed; `store_conformance` → 20 passed; default (`redis-backend`) build compiles; clippy clean (common + mediator, both feature sets); `cargo fmt --check`; `cargo deny` ok.
