### PR TITLE
refactor: remove legacy 1:1 aliases from MediatorStore trait (simplification T16, part 2)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## 11th June 2026
 
+### 0.15.36 — Migrate off the removed `MediatorStore` legacy aliases (simplification T16, part 2)
+
+- Updates the ~15 call sites that used the ten rename-only `MediatorStore`
+  aliases removed in `mediator-common` 0.15.9 to call the canonical methods
+  directly: stats/forward-queue reads (`get_global_stats`, `forward_queue_len`,
+  `forward_queue_enqueue`), the account role change (`account_set_role`), the
+  WebSocket streaming state transitions (`streaming_set_state(...)`), and the
+  websocket-open/close counters (`stats_increment(...)`). No behaviour change —
+  the aliases were thin delegates; verified against the store-conformance suite
+  and the cross-mediator / WebSocket e2e suites.
+- Requires `affinidi-messaging-mediator-common` 0.15.9.
+
 ### 0.15.35 — Route store delete-authorization through `store::ops` (simplification T16)
 
 - `FjallStore` and `MemoryStore` now call `mediator-common`'s new

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.35"
+version = "0.15.36"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 11th June 2026
 
+### 0.15.9 — Remove legacy 1:1 aliases from `MediatorStore` (simplification T16, part 2)
+
+- Removes ten pure rename-only default methods from the `MediatorStore` trait,
+  each of which delegated 1:1 to its canonical counterpart: `get_db_metadata`
+  (→ `get_global_stats`), `get_forward_tasks_len` (→ `forward_queue_len`),
+  `forward_queue_enqueue_with_limit` (→ `forward_queue_enqueue`),
+  `account_change_type` (→ `account_set_role`), the four streaming aliases
+  `streaming_register_client` / `streaming_start_live` / `streaming_stop_live`
+  / `streaming_deregister_client` (→ `streaming_set_state(state)`), and
+  `global_stats_increment_websocket_open` / `_close`
+  (→ `stats_increment(WebsocketOpen|WebsocketClose, 1)`). Call sites now invoke
+  the canonical method directly. No behaviour change — each alias was a thin
+  delegate. The multi-step legacy helpers (`create_session`,
+  `update_send_stats`, `add_admin_accounts`, `strip_admin_accounts`, the
+  session-rename helpers) are retained. The Redis backend's inherent methods of
+  the same names are unaffected (they are storage-level, not trait methods).
+
 ### 0.15.8 — Extract shared store decision logic to `store::ops` (simplification T16)
 
 - Adds `store::ops`, a home for backend-agnostic decision logic shared by the

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.8"
+version = "0.15.9"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -638,34 +638,6 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
     // delegates to its canonical counterpart. New code should call the
     // canonical method directly.
 
-    /// Legacy alias for [`get_global_stats`](Self::get_global_stats).
-    async fn get_db_metadata(&self) -> Result<MetadataStats, MediatorError> {
-        self.get_global_stats().await
-    }
-
-    /// Legacy alias for [`forward_queue_len`](Self::forward_queue_len).
-    async fn get_forward_tasks_len(&self) -> Result<usize, MediatorError> {
-        self.forward_queue_len().await
-    }
-
-    /// Legacy alias for [`forward_queue_enqueue`](Self::forward_queue_enqueue).
-    async fn forward_queue_enqueue_with_limit(
-        &self,
-        entry: &ForwardQueueEntry,
-        max_len: usize,
-    ) -> Result<String, MediatorError> {
-        self.forward_queue_enqueue(entry, max_len).await
-    }
-
-    /// Legacy alias for [`account_set_role`](Self::account_set_role).
-    async fn account_change_type(
-        &self,
-        did_hash: &str,
-        account_type: &AccountType,
-    ) -> Result<(), MediatorError> {
-        self.account_set_role(did_hash, account_type).await
-    }
-
     /// Legacy: synchronous health summary. Default impl calls the async
     /// [`health`](Self::health) and stringifies, but the cost of an
     /// async call from a sync context is real — backends with cheap
@@ -674,61 +646,6 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
     /// admin status handler already shows in operator dashboards.
     fn circuit_breaker_state(&self) -> &'static str {
         "closed"
-    }
-
-    /// Legacy alias for [`streaming_set_state`](Self::streaming_set_state)
-    /// with [`StreamingClientState::Registered`].
-    async fn streaming_register_client(
-        &self,
-        did_hash: &str,
-        mediator_uuid: &str,
-    ) -> Result<(), MediatorError> {
-        self.streaming_set_state(did_hash, mediator_uuid, StreamingClientState::Registered)
-            .await
-    }
-
-    /// Legacy alias for [`streaming_set_state`](Self::streaming_set_state)
-    /// with [`StreamingClientState::Live`].
-    async fn streaming_start_live(
-        &self,
-        did_hash: &str,
-        mediator_uuid: &str,
-    ) -> Result<(), MediatorError> {
-        self.streaming_set_state(did_hash, mediator_uuid, StreamingClientState::Live)
-            .await
-    }
-
-    /// Legacy: stop active live delivery. Conceptually a transition
-    /// back to `Registered` (still subscribed, queueing rather than
-    /// pushing).
-    async fn streaming_stop_live(
-        &self,
-        did_hash: &str,
-        mediator_uuid: &str,
-    ) -> Result<(), MediatorError> {
-        self.streaming_set_state(did_hash, mediator_uuid, StreamingClientState::Registered)
-            .await
-    }
-
-    /// Legacy alias for [`streaming_set_state`](Self::streaming_set_state)
-    /// with [`StreamingClientState::Deregistered`].
-    async fn streaming_deregister_client(
-        &self,
-        did_hash: &str,
-        mediator_uuid: &str,
-    ) -> Result<(), MediatorError> {
-        self.streaming_set_state(did_hash, mediator_uuid, StreamingClientState::Deregistered)
-            .await
-    }
-
-    /// Legacy alias — increments the websocket-open counter by 1.
-    async fn global_stats_increment_websocket_open(&self) -> Result<(), MediatorError> {
-        self.stats_increment(StatCounter::WebsocketOpen, 1).await
-    }
-
-    /// Legacy alias — increments the websocket-close counter by 1.
-    async fn global_stats_increment_websocket_close(&self) -> Result<(), MediatorError> {
-        self.stats_increment(StatCounter::WebsocketClose, 1).await
     }
 
     /// Legacy: increment the GLOBAL "sent" counters in one call.

--- a/crates/messaging/affinidi-messaging-mediator/src/common/storage_timeout.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/storage_timeout.rs
@@ -66,12 +66,8 @@ mod tests {
     async fn maps_a_hung_call_to_a_database_error() {
         // A future that never resolves stands in for a wedged backend.
         let never = std::future::pending::<Result<(), MediatorError>>();
-        let fut = with_storage_timeout(
-            Duration::from_secs(5),
-            "get_forward_tasks_len",
-            "sess-1",
-            never,
-        );
+        let fut =
+            with_storage_timeout(Duration::from_secs(5), "forward_queue_len", "sess-1", never);
         tokio::pin!(fut);
 
         // Before the timeout elapses the call is still pending.
@@ -85,7 +81,7 @@ mod tests {
         match fut.await {
             Err(MediatorError::DatabaseError(_, session, msg)) => {
                 assert_eq!(session, "sess-1");
-                assert!(msg.contains("get_forward_tasks_len"), "msg was: {msg}");
+                assert!(msg.contains("forward_queue_len"), "msg was: {msg}");
                 assert!(msg.contains("timed out"), "msg was: {msg}");
             }
             other => panic!("expected DatabaseError, got {other:?}"),

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/admin_status.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/admin_status.rs
@@ -115,7 +115,7 @@ pub async fn admin_status_handler(
 
     // Get message stats from Redis GLOBAL hash
     let (received_count, received_bytes, sent_count, sent_bytes, deleted_count) =
-        match state.database.get_db_metadata().await {
+        match state.database.get_global_stats().await {
             Ok(stats) => (
                 stats.received_count,
                 stats.received_bytes,
@@ -127,7 +127,7 @@ pub async fn admin_status_handler(
         };
 
     // Get forward queue length
-    let queue_length = state.database.get_forward_tasks_len().await.unwrap_or(0);
+    let queue_length = state.database.forward_queue_len().await.unwrap_or(0);
 
     let status = AdminStatus {
         version: env!("CARGO_PKG_VERSION"),

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -186,9 +186,9 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
     // promptly rather than hanging the load-balancer health check.
     match with_storage_timeout(
         state.storage_timeout(),
-        "get_db_metadata",
+        "get_global_stats",
         "NA",
-        state.database.get_db_metadata(),
+        state.database.get_global_stats(),
     )
     .await
     {
@@ -211,9 +211,9 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
     // Check FORWARD_Q length (bounded — see above).
     match with_storage_timeout(
         state.storage_timeout(),
-        "get_forward_tasks_len",
+        "forward_queue_len",
         "NA",
-        state.database.get_forward_tasks_len(),
+        state.database.forward_queue_len(),
     )
     .await
     {
@@ -389,7 +389,7 @@ impl LoadState {
         }
 
         // Check queue depth
-        if let Ok(queue_len) = state.database.get_forward_tasks_len().await {
+        if let Ok(queue_len) = state.database.forward_queue_len().await {
             let limit = state.config.limits.forward_task_queue;
             if queue_len >= limit {
                 return LoadState::Critical;

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -13,6 +13,7 @@ use crate::{
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
+use affinidi_messaging_mediator_common::store::StatCounter;
 use affinidi_messaging_sdk::messages::problem_report::{
     ProblemReport, ProblemReportScope, ProblemReportSorter,
 };
@@ -326,7 +327,10 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
             }
         }
 
-        let _ = state.database.global_stats_increment_websocket_open().await;
+        let _ = state
+            .database
+            .stats_increment(StatCounter::WebsocketOpen, 1)
+            .await;
         info!("Websocket connection established");
 
         // Set a timeout for the websocket connection for when the JWT Auth token expires
@@ -492,7 +496,7 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
         }
         let _ = state
             .database
-            .global_stats_increment_websocket_close()
+            .stats_increment(StatCounter::WebsocketClose, 1)
             .await;
 
         info!("Websocket connection closed");

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
@@ -400,7 +400,7 @@ pub(crate) async fn process(
 
                 // If here, then it is a simple type change at this point
 
-                match state.database.account_change_type(&did_hash, &_type).await {
+                match state.database.account_set_role(&did_hash, &_type).await {
                     Ok(_) => {
                         let current_type = if let Some(current) = &current {
                             current._type.to_string()

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -553,7 +553,7 @@ async fn deliver_forward(
 
             state
                 .database
-                .forward_queue_enqueue_with_limit(&entry, state.config.limits.forward_task_queue)
+                .forward_queue_enqueue(&entry, state.config.limits.forward_task_queue)
                 .await
                 .map_err(|e| {
                     MediatorError::problem_with_log(
@@ -904,9 +904,9 @@ pub(crate) async fn process(
         if !ephemeral
             && with_storage_timeout(
                 state.storage_timeout(),
-                "get_forward_tasks_len",
+                "forward_queue_len",
                 &session.session_id,
-                state.database.get_forward_tasks_len(),
+                state.database.forward_queue_len(),
             )
             .await?
                 >= state.config.limits.forward_task_queue

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -23,7 +23,7 @@ pub async fn statistics(
 
         loop {
             interval.tick().await;
-            let stats = database.get_db_metadata().await?;
+            let stats = database.get_global_stats().await?;
             let delta = stats.delta(&previous_stats);
             info!(
                 event_type = "UpdateStats",

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -27,7 +27,7 @@ use crate::common::metrics::names::{
 use crate::tasks::supervisor::TaskSupervisor;
 use affinidi_messaging_mediator_common::{
     errors::MediatorError,
-    store::{MediatorStore, types::PubSubRecord},
+    store::{MediatorStore, StreamingClientState, types::PubSubRecord},
     types::messages::FetchOptions,
 };
 use ahash::AHashMap as HashMap;
@@ -222,7 +222,7 @@ impl StreamingTask {
                                         entry.active = true;
                                     };
 
-                                    if let Err(err) = database.streaming_start_live(&value.did_hash, &self.uuid).await {
+                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Live).await {
                                         error!("Error starting streaming to client ({}) streaming: {}",value.did_hash, err);
                                     }
                                 },
@@ -233,7 +233,7 @@ impl StreamingTask {
                                         entry.active = false;
                                     };
 
-                                    if let Err(err) = database.streaming_stop_live(&value.did_hash, &self.uuid).await {
+                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Registered).await {
                                         error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
                                     }
                                 },
@@ -245,7 +245,7 @@ impl StreamingTask {
                                         0
                                     };
                                     info!("Deregistered streaming for DID: ({}) registered_clients({})", value.did_hash, count);
-                                    if let Err(err) = database.streaming_deregister_client(&value.did_hash, &self.uuid).await {
+                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Deregistered).await {
                                         error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
                                     }
                                     clients.remove(value.did_hash.as_str());
@@ -282,7 +282,11 @@ impl StreamingTask {
                         );
                         clients.remove(&payload.did_hash);
                         if let Err(e) = database
-                            .streaming_deregister_client(&payload.did_hash, &self.uuid)
+                            .streaming_set_state(
+                                &payload.did_hash,
+                                &self.uuid,
+                                StreamingClientState::Deregistered,
+                            )
                             .await
                         {
                             error!(
@@ -299,7 +303,11 @@ impl StreamingTask {
                         payload.did_hash
                     );
                     if let Err(err) = database
-                        .streaming_stop_live(&payload.did_hash, &self.uuid)
+                        .streaming_set_state(
+                            &payload.did_hash,
+                            &self.uuid,
+                            StreamingClientState::Registered,
+                        )
                         .await
                     {
                         error!(
@@ -401,7 +409,11 @@ impl StreamingTask {
         );
 
         if let Err(err) = database
-            .streaming_register_client(&value.did_hash, &self.uuid)
+            .streaming_set_state(
+                &value.did_hash,
+                &self.uuid,
+                StreamingClientState::Registered,
+            )
             .await
         {
             error!(


### PR DESCRIPTION
## What

T16 part 2 of the mediator simplification effort: removes the ten pure
rename-only **legacy aliases** from the `MediatorStore` trait and migrates the
call sites to the canonical methods. Part 1 (#420) extracted shared decision
logic to `store::ops`; this is the bulk of the trait method-count reduction.

Each removed alias was a default method delegating 1:1 to its canonical
counterpart:

| Removed alias | Canonical method |
|---|---|
| `get_db_metadata` | `get_global_stats` |
| `get_forward_tasks_len` | `forward_queue_len` |
| `forward_queue_enqueue_with_limit` | `forward_queue_enqueue` |
| `account_change_type` | `account_set_role` |
| `streaming_register_client` | `streaming_set_state(Registered)` |
| `streaming_start_live` | `streaming_set_state(Live)` |
| `streaming_stop_live` | `streaming_set_state(Registered)` |
| `streaming_deregister_client` | `streaming_set_state(Deregistered)` |
| `global_stats_increment_websocket_open` | `stats_increment(WebsocketOpen, 1)` |
| `global_stats_increment_websocket_close` | `stats_increment(WebsocketClose, 1)` |

~15 call sites in the mediator crate updated. The multi-step legacy helpers
(`create_session`, `update_send_stats`, `add_admin_accounts`,
`strip_admin_accounts`, the session-rename helpers) and `circuit_breaker_state`
(kept for T17) are retained.

## Why it's safe

Every alias was a thin delegate, so this is byte-behaviour-identical. Two
points worth noting for review:

- The **Redis backend has inherent methods of the same names** (e.g.
  `get_db_metadata`, `streaming_register_client`) in `store/redis/database/*`.
  The trait impl delegates canonical methods *to* those inherent methods, and
  inherent-method resolution wins over trait methods — so the Redis internals
  are untouched by removing the trait aliases.
- The `account_change_type` in the SDK and helpers crates is a **different
  method** (different signature) and is intentionally left alone.

## Verification

- `cargo clippy --all-targets` clean on **both** feature sets (redis default;
  `--no-default-features --features didcomm,memory-backend,fjall-backend`)
- store-conformance suite: 20/20 (Memory + Fjall)
- mediator lib: 192 passed; mediator-common lib: 138 passed
- e2e: `cross_mediator_forwarding` (6), `local_did_websocket`,
  `streaming_forwarding_acl`, `websocket_per_did_cap` — all green
- `cargo fmt` applied
- `cargo-deny` not run (not installed locally); this PR makes no
  dependency-graph changes

## Versions

- `affinidi-messaging-mediator-common` 0.15.8 → 0.15.9
- `affinidi-messaging-mediator` 0.15.35 → 0.15.36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
