### PR TITLE
refactor: consolidate the access-list method family (simplification T16, part 3)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## Changelog history
 
-## 11th June 2026
+## 12th June 2026
+
+### 0.15.37 — Route access-list admission through `store::ops` (simplification T16, part 3)
+
+- `FjallStore` and `MemoryStore` now call `mediator-common`'s new
+  `store::ops::access_list_allowed` for the sender-admission decision instead
+  of each inlining the mode/anon-bit logic. Pure refactor — the decision is
+  unchanged and now unit-tested in one place; the backends still perform their
+  own account and access-list-membership lookups.
+- Drops the backends' `access_list_count` trait implementations following its
+  removal from the trait (no production caller). Backend-internal count helpers
+  used by `account_get`/`access_list_add` are unchanged.
+- Requires `affinidi-messaging-mediator-common` 0.15.10.
 
 ### 0.15.36 — Migrate off the removed `MediatorStore` legacy aliases (simplification T16, part 2)
 

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.36"
+version = "0.15.37"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## Changelog history
 
-## 11th June 2026
+## 12th June 2026
+
+### 0.15.10 — Consolidate the access-list method family (simplification T16, part 3)
+
+- Extracts the access-list admission *decision* into `store::ops`: a new
+  `ops::access_list_allowed(recipient_acls, Sender)` captures the pure logic
+  the in-process backends each inlined — anonymous senders follow the
+  `anon_receive` ACL bit; known senders are judged by the recipient's
+  access-list mode (`ExplicitAllow` admits only listed senders, `ExplicitDeny`
+  admits all but listed). `FjallStore` and `MemoryStore` now call it (they
+  still do their own backend-specific account/membership lookups); the decision
+  can no longer drift between them. Unit-tested directly. (Redis evaluates the
+  equivalent in Lua and is unaffected.)
+- Removes the `access_list_count` trait method. It had no production caller —
+  callers read a DID's entry count from `account_get().access_list_count` or by
+  paging `access_list_list`, and the standalone primitive was redundant. The
+  backends' internal count helpers (used by `account_get`/`access_list_add`)
+  are retained.
+- Trait method count: 61 → 60. `get_did_acl` was evaluated for folding into
+  `account_get` but kept deliberately — it is an O(1) read on the per-message
+  inbound ACL gate, whereas `account_get` additionally computes the
+  access-list count (an O(list) scan on Fjall), so folding would regress that
+  hot path. No behaviour change.
 
 ### 0.15.9 — Remove legacy 1:1 aliases from `MediatorStore` (simplification T16, part 2)
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.9"
+version = "0.15.10"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -371,9 +371,6 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
         cursor: u64,
     ) -> Result<MediatorAccessListListResponse, MediatorError>;
 
-    /// Number of entries currently in a DID's access list.
-    async fn access_list_count(&self, did_hash: &str) -> Result<usize, MediatorError>;
-
     /// Add `hashes` to a DID's access list. Truncates if the addition
     /// would exceed `access_list_limit`; the response signals truncation
     /// and reports which hashes were actually inserted.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/ops.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/ops.rs
@@ -11,6 +11,7 @@
 //! what keeps Redis aligned with them.
 
 use crate::store::types::DeletionAuthority;
+use crate::types::acls::{AccessListModeType, MediatorACLSet};
 
 /// Whether `authority` may delete a message addressed to `to_did_hash` and
 /// (optionally) from `from_did_hash`.
@@ -29,6 +30,37 @@ pub fn delete_message_permitted(
         DeletionAuthority::Owner { did_hash } => {
             did_hash == to_did_hash || from_did_hash == Some(did_hash.as_str())
         }
+    }
+}
+
+/// A prospective sender, from the recipient's access-control perspective.
+pub enum Sender {
+    /// An anonymous sender (no authenticated DID).
+    Anonymous,
+    /// A known (authenticated) sender, with whether it is currently on the
+    /// recipient's access list.
+    Known { on_access_list: bool },
+}
+
+/// Whether `sender` is allowed to deliver a message to a recipient whose
+/// ACLs are `recipient_acls`.
+///
+/// - [`Sender::Anonymous`] is allowed iff the recipient's `anon_receive`
+///   ACL bit is set.
+/// - [`Sender::Known`] is judged by the recipient's access-list mode:
+///   `ExplicitAllow` admits only senders on the list; `ExplicitDeny` admits
+///   everyone except those on the list.
+///
+/// The caller is responsible for the (backend-specific) lookups that produce
+/// `recipient_acls` and the `on_access_list` membership flag; this function
+/// is the pure decision the in-process backends previously each inlined.
+pub fn access_list_allowed(recipient_acls: &MediatorACLSet, sender: Sender) -> bool {
+    match sender {
+        Sender::Anonymous => recipient_acls.get_anon_receive().0,
+        Sender::Known { on_access_list } => match recipient_acls.get_access_list_mode().0 {
+            AccessListModeType::ExplicitAllow => on_access_list,
+            AccessListModeType::ExplicitDeny => !on_access_list,
+        },
     }
 }
 
@@ -76,5 +108,64 @@ mod tests {
         // With no sender, only the recipient is a party.
         assert!(delete_message_permitted(&owner("to"), "to", None));
         assert!(!delete_message_permitted(&owner("from"), "to", None));
+    }
+
+    fn acls(mode: AccessListModeType, anon_receive: bool) -> MediatorACLSet {
+        let mut a = MediatorACLSet::default();
+        // admin = true so the change is always permitted in the test.
+        a.set_access_list_mode(mode, false, true).unwrap();
+        a.set_anon_receive(anon_receive, false, true).unwrap();
+        a
+    }
+
+    #[test]
+    fn explicit_allow_admits_only_listed_known_senders() {
+        let a = acls(AccessListModeType::ExplicitAllow, false);
+        assert!(access_list_allowed(
+            &a,
+            Sender::Known {
+                on_access_list: true
+            }
+        ));
+        assert!(!access_list_allowed(
+            &a,
+            Sender::Known {
+                on_access_list: false
+            }
+        ));
+    }
+
+    #[test]
+    fn explicit_deny_admits_everyone_except_listed() {
+        let a = acls(AccessListModeType::ExplicitDeny, false);
+        assert!(!access_list_allowed(
+            &a,
+            Sender::Known {
+                on_access_list: true
+            }
+        ));
+        assert!(access_list_allowed(
+            &a,
+            Sender::Known {
+                on_access_list: false
+            }
+        ));
+    }
+
+    #[test]
+    fn anonymous_sender_follows_the_anon_receive_bit() {
+        // Mode is irrelevant for anonymous senders — only the anon_receive bit.
+        assert!(access_list_allowed(
+            &acls(AccessListModeType::ExplicitAllow, true),
+            Sender::Anonymous
+        ));
+        assert!(!access_list_allowed(
+            &acls(AccessListModeType::ExplicitAllow, false),
+            Sender::Anonymous
+        ));
+        assert!(access_list_allowed(
+            &acls(AccessListModeType::ExplicitDeny, true),
+            Sender::Anonymous
+        ));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -695,10 +695,6 @@ impl MediatorStore for RedisStore {
         self.access_list_list(did_hash, cursor).await
     }
 
-    async fn access_list_count(&self, did_hash: &str) -> Result<usize, MediatorError> {
-        self.access_list_count(did_hash).await
-    }
-
     async fn access_list_add(
         &self,
         access_list_limit: usize,

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -1635,16 +1635,13 @@ impl MediatorStore for FjallStore {
             Err(_) => return false,
         };
         let acls = MediatorACLSet::from_u64(acc.acls);
-        match from_hash {
-            Some(from) => {
-                let in_list = self.access_list_contains(to_hash, from).unwrap_or(false);
-                match acls.get_access_list_mode().0 {
-                    AccessListModeType::ExplicitAllow => in_list,
-                    AccessListModeType::ExplicitDeny => !in_list,
-                }
-            }
-            None => acls.get_anon_receive().0,
-        }
+        let sender = match from_hash {
+            Some(from) => ops::Sender::Known {
+                on_access_list: self.access_list_contains(to_hash, from).unwrap_or(false),
+            },
+            None => ops::Sender::Anonymous,
+        };
+        ops::access_list_allowed(&acls, sender)
     }
 
     async fn access_list_list(
@@ -1688,10 +1685,6 @@ impl MediatorStore for FjallStore {
             cursor: next,
             did_hashes: entries,
         })
-    }
-
-    async fn access_list_count(&self, did_hash: &str) -> Result<usize, MediatorError> {
-        self.access_list_count_inner(did_hash)
     }
 
     async fn access_list_add(
@@ -2968,7 +2961,7 @@ mod tests {
             .expect("add");
         assert_eq!(resp.did_hashes.len(), 2);
         assert!(!resp.truncated);
-        assert_eq!(store.access_list_count(&alice).await.unwrap(), 2);
+        assert_eq!(store.access_list_count_inner(&alice).unwrap(), 2);
 
         let got = store
             .access_list_get(&alice, &[bob.clone(), hash("eve")])
@@ -2981,11 +2974,11 @@ mod tests {
             .await
             .expect("remove");
         assert_eq!(removed, 1);
-        assert_eq!(store.access_list_count(&alice).await.unwrap(), 1);
+        assert_eq!(store.access_list_count_inner(&alice).unwrap(), 1);
 
         // Clear leaves the list empty.
         store.access_list_clear(&alice).await.expect("clear");
-        assert_eq!(store.access_list_count(&alice).await.unwrap(), 0);
+        assert_eq!(store.access_list_count_inner(&alice).unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -1035,20 +1035,17 @@ impl MediatorStore for MemoryStore {
         let Some(account) = state.accounts.get(to_hash) else {
             return false;
         };
-        match from_hash {
-            Some(from) => {
-                let in_list = state
+        let sender = match from_hash {
+            Some(from) => ops::Sender::Known {
+                on_access_list: state
                     .access_lists
                     .get(to_hash)
                     .map(|v| v.iter().any(|d| d == from))
-                    .unwrap_or(false);
-                match account.acls.get_access_list_mode().0 {
-                    AccessListModeType::ExplicitAllow => in_list,
-                    AccessListModeType::ExplicitDeny => !in_list,
-                }
-            }
-            None => account.acls.get_anon_receive().0,
-        }
+                    .unwrap_or(false),
+            },
+            None => ops::Sender::Anonymous,
+        };
+        ops::access_list_allowed(&account.acls, sender)
     }
 
     async fn access_list_list(
@@ -1074,17 +1071,6 @@ impl MediatorStore for MemoryStore {
             cursor: next,
             did_hashes: entries,
         })
-    }
-
-    async fn access_list_count(&self, did_hash: &str) -> Result<usize, MediatorError> {
-        Ok(self
-            .state
-            .lock()
-            .await
-            .access_lists
-            .get(did_hash)
-            .map(|v| v.len())
-            .unwrap_or(0))
     }
 
     async fn access_list_add(
@@ -1973,7 +1959,15 @@ mod tests {
             .expect("add");
         assert_eq!(resp.did_hashes.len(), 2);
         assert!(!resp.truncated);
-        assert_eq!(store.access_list_count("alice").await.unwrap(), 2);
+        assert_eq!(
+            store
+                .access_list_list("alice", 0)
+                .await
+                .unwrap()
+                .did_hashes
+                .len(),
+            2
+        );
 
         let got = store
             .access_list_get("alice", &["bob".into(), "eve".into()])
@@ -1986,7 +1980,15 @@ mod tests {
             .await
             .expect("remove");
         assert_eq!(removed, 1);
-        assert_eq!(store.access_list_count("alice").await.unwrap(), 1);
+        assert_eq!(
+            store
+                .access_list_list("alice", 0)
+                .await
+                .unwrap()
+                .did_hashes
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
@@ -69,6 +69,26 @@ fn admin_session(admin_did_hash: &str) -> Session {
     }
 }
 
+/// Count a DID's access-list entries by paging `access_list_list`. The store
+/// has no standalone count primitive (callers derive it from the listing or
+/// from `account_get().access_list_count`); this mirrors that.
+async fn access_list_len(store: &Arc<dyn MediatorStore>, did_hash: &str) -> usize {
+    let mut total = 0;
+    let mut cursor = 0u64;
+    loop {
+        let page = store
+            .access_list_list(did_hash, cursor)
+            .await
+            .expect("access_list_list");
+        total += page.did_hashes.len();
+        match page.cursor {
+            Some(next) => cursor = next,
+            None => break,
+        }
+    }
+    total
+}
+
 // ─── Conformance checks (backend-agnostic) ──────────────────────────────────
 
 /// Account create → exists → fetch → remove → gone.
@@ -289,7 +309,7 @@ async fn check_access_list_lifecycle(store: Arc<dyn MediatorStore>) {
         .expect("account_add owner");
 
     assert_eq!(
-        store.access_list_count(owner).await.expect("count empty"),
+        access_list_len(&store, owner).await,
         0,
         "access list starts empty"
     );
@@ -300,10 +320,7 @@ async fn check_access_list_lifecycle(store: Arc<dyn MediatorStore>) {
         .await
         .expect("access_list_add");
     assert_eq!(
-        store
-            .access_list_count(owner)
-            .await
-            .expect("count after add"),
+        access_list_len(&store, owner).await,
         1,
         "count reflects the added entry"
     );
@@ -313,10 +330,7 @@ async fn check_access_list_lifecycle(store: Arc<dyn MediatorStore>) {
         .await
         .expect("access_list_remove");
     assert_eq!(
-        store
-            .access_list_count(owner)
-            .await
-            .expect("count after remove"),
+        access_list_len(&store, owner).await,
         0,
         "count returns to zero after remove"
     );
@@ -326,13 +340,7 @@ async fn check_access_list_lifecycle(store: Arc<dyn MediatorStore>) {
         .access_list_clear(owner)
         .await
         .expect("access_list_clear");
-    assert_eq!(
-        store
-            .access_list_count(owner)
-            .await
-            .expect("count after clear"),
-        0,
-    );
+    assert_eq!(access_list_len(&store, owner).await, 0);
 }
 
 /// Forward-queue: an unread enqueued entry can be deleted directly, dropping


### PR DESCRIPTION
## What

T16 part 3 of the mediator simplification: two **quality-first** consolidations
of the ACL/access-list family, both byte-behaviour-identical.

**1. Extract the access-list admission decision into `store::ops`.** New
`ops::access_list_allowed(recipient_acls, Sender)` captures the pure logic that
`FjallStore` and `MemoryStore` each inlined verbatim:
- anonymous senders → the recipient's `anon_receive` ACL bit;
- known senders → the recipient's access-list mode (`ExplicitAllow` admits only
  listed senders; `ExplicitDeny` admits everyone except listed).

Both backends now call it (they still perform their own backend-specific account
and membership lookups), so the decision can't drift between them. Unit-tested
directly. Redis evaluates the equivalent in Lua and is unaffected — same pattern
as part 1's `delete_message_permitted`.

**2. Remove the `access_list_count` trait method.** It had **no production
caller** — callers read a DID's entry count from
`account_get().access_list_count` or by paging `access_list_list`. The
backends' internal count helpers (used by `account_get`/`access_list_add`) are
retained. Trait method count **61 → 60**.

## A deliberate non-change: `get_did_acl`

`get_did_acl` was on the consolidation list (fold into `account_get`), but the
audit found that would be a **hot-path efficiency regression**: it's an O(1) ACL
read on the per-message inbound direct-delivery gate (`inbound.rs`), whereas
`account_get` additionally computes the access-list count — an O(list) prefix
scan on Fjall. Folding would add that scan to every inbound message. Kept as the
efficient primitive it is.

This is the quality-first tradeoff in action: cumulative T16 trait reduction is
71 → 60 (~15%), short of a strict 20%, because the remaining ACL methods
(`set_did_acl`, `get_did_acls`, and the access-list CRUD `add`/`remove`/`clear`/
`get`/`list`) map to distinct admin operations with distinct return types.
Collapsing them into opaque enum-dispatch to hit a number would contradict the
plan's own "consolidate, don't redesign" rule. Happy to revisit if you'd prefer
the aggressive merge.

## Verification

- `cargo clippy --all-targets` clean on **both** feature sets (redis default;
  `--no-default-features --features didcomm,memory-backend,fjall-backend`)
- new `ops::access_list_allowed` unit tests (3); store-conformance 20/20
- mediator lib 192
- e2e: `cross_mediator_forwarding` (6) — incl. `rewrap_relay_admits_trusted_peer`
  / `rewrap_relay_rejects_untrusted_peer`, which exercise the forward-path ACL
  allow/deny that this decision feeds
- `cargo fmt` applied; `cargo-deny` not run (not installed locally); no
  dependency-graph changes

## Versions

- `affinidi-messaging-mediator-common` 0.15.9 → 0.15.10
- `affinidi-messaging-mediator` 0.15.36 → 0.15.37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
