### PR TITLE
feat: schema-version marker for the Fjall backend (simplification T17, part 2)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ## 12th June 2026
 
+### 0.15.39 — Schema-version marker for the Fjall backend (simplification T17, part 2)
+
+- Completes the Fjall/Redis operational-parity work: the Redis backend records
+  applied schema migrations in a `SCHEMA_MIGRATIONS` set so a record-shape
+  change runs exactly once, but Fjall had no equivalent — a future change to an
+  on-disk record shape would silently deserialise old bytes as `serde` defaults
+  with no signal. `FjallStore` now writes a **schema-version marker** into the
+  `globals` partition and checks it on every `initialize()`.
+- New `store::fjall_migrations` module: a `CURRENT_SCHEMA_VERSION` constant, an
+  append-only migration registry (`all_migrations()`, empty until the first
+  record-shape change), and a `run_migrations` runner. On startup it stamps the
+  current version on a fresh (or pre-versioning) data dir, runs any pending
+  migrations in ascending order on an older one — advancing the marker only
+  after each migration's `up` succeeds, so a crash mid-migration re-runs from
+  the same point — and **aborts with a clear `DB_SCHEMA_VERSION_ERROR`** when
+  the marker is *newer* than the running binary supports, rather than risk
+  misreading records it doesn't understand.
+- The version-comparison logic is a pure `plan_schema` function (initialise /
+  up-to-date / migrate / too-new), unit-tested across every branch; registry
+  invariants (unique, ascending, in-range versions; unique non-empty names) are
+  enforced by tests mirroring the Redis migration suite. Behaviour tests cover
+  fresh-init stamping, idempotent re-init across a reopen, and the newer-schema
+  rejection. No config-file change; no behaviour change for existing data dirs
+  (their current shape is the version-1 baseline).
+
 ### 0.15.38 — Circuit breaker for the Fjall backend (simplification T17, part 1)
 
 - Gives `FjallStore` a circuit breaker for operational parity with the Redis

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.38"
+version = "0.15.39"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_migrations.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_migrations.rs
@@ -1,0 +1,277 @@
+//! Schema-version marker and migration runner for the Fjall backend.
+//!
+//! The Redis backend tracks applied schema migrations in a `SCHEMA_MIGRATIONS`
+//! set (`store::redis::database::migrations`) so a record-shape change is
+//! applied exactly once. Fjall previously had no equivalent: a future change to
+//! an on-disk record shape would silently deserialise old bytes as defaults
+//! (`serde(default)`), corrupting state with no signal. This module gives the
+//! embedded backend the same guard — a single version marker in the `globals`
+//! partition plus a minimal, append-only migration registry.
+//!
+//! ## Adding a migration
+//!
+//! 1. Bump [`CURRENT_SCHEMA_VERSION`].
+//! 2. Append a [`FjallMigration`] whose `version` equals the new value.
+//! 3. Implement its `up` to rewrite the affected partition(s).
+//!
+//! On startup [`run_migrations`] reads the marker and compares it to
+//! [`CURRENT_SCHEMA_VERSION`]:
+//! - **no marker** → a fresh data dir, or one created before schema versioning
+//!   existed. Both are at the baseline shape, so the current version is stamped
+//!   and nothing is migrated.
+//! - **marker == current** → up to date, no-op.
+//! - **marker < current** → each pending migration runs in ascending order and
+//!   the marker is advanced as each one lands.
+//! - **marker > current** → the data dir was written by a *newer* mediator.
+//!   Startup aborts with a clear error rather than risk misreading records the
+//!   running binary doesn't understand.
+
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use tracing::info;
+
+use super::FjallStore;
+use crate::common::error_codes;
+
+/// `globals`-partition key holding the applied schema version, stored as
+/// little-endian `u32`. Namespaced with leading/trailing underscores like the
+/// circuit-breaker probe key so it can never collide with a counter name.
+pub(super) const SCHEMA_VERSION_KEY: &[u8] = b"__schema_version__";
+
+/// Schema version this binary understands. The current on-disk record shapes
+/// are the baseline, version `1`. Bump this (and append a [`FjallMigration`])
+/// whenever a stored record shape changes.
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// A single, idempotent forward migration that brings the data dir from
+/// `version - 1` to `version`. The registry is append-only: a migration's
+/// `version` must never change once released.
+pub(super) struct FjallMigration {
+    /// Target version this migration produces. Must equal the
+    /// [`CURRENT_SCHEMA_VERSION`] it was introduced with.
+    pub version: u32,
+    /// Short name for logging.
+    pub name: &'static str,
+    /// Human-readable description of what the migration rewrites.
+    pub description: &'static str,
+    /// Rewrites the affected partition(s). Runs under no lock — a migration
+    /// must be safe to re-run if the process dies mid-way (the marker is only
+    /// advanced after `up` returns `Ok`).
+    pub up: fn(&FjallStore) -> Result<(), MediatorError>,
+}
+
+/// All known migrations in ascending `version` order. New migrations are
+/// appended here; the list is empty until the first record-shape change.
+///
+/// **Invariants** (enforced by tests): versions are unique, ascending, and
+/// each is `> 0` and `<= CURRENT_SCHEMA_VERSION`; names are unique and
+/// non-empty.
+pub(super) fn all_migrations() -> Vec<FjallMigration> {
+    vec![]
+}
+
+/// What [`run_migrations`] should do given the on-disk marker. Extracted as a
+/// pure function so every branch is unit-testable without a real data dir.
+#[derive(Debug, PartialEq, Eq)]
+enum SchemaAction {
+    /// No marker — stamp the current version, migrate nothing.
+    Initialise,
+    /// Marker equals current — no-op.
+    UpToDate,
+    /// Marker behind current — run these migration versions in order.
+    Migrate(Vec<u32>),
+    /// Marker ahead of current — abort; data dir is from a newer binary.
+    TooNew { found: u32 },
+}
+
+/// Decide what to do for a stored marker against `current`, given the set of
+/// `available` migration versions. Pending = available versions strictly above
+/// the marker and at or below `current`, ascending.
+fn plan_schema(stored: Option<u32>, current: u32, available: &[u32]) -> SchemaAction {
+    match stored {
+        None => SchemaAction::Initialise,
+        Some(v) if v == current => SchemaAction::UpToDate,
+        Some(v) if v < current => {
+            let mut pending: Vec<u32> = available
+                .iter()
+                .copied()
+                .filter(|&av| av > v && av <= current)
+                .collect();
+            pending.sort_unstable();
+            SchemaAction::Migrate(pending)
+        }
+        Some(found) => SchemaAction::TooNew { found },
+    }
+}
+
+/// Bring the store's data dir up to [`CURRENT_SCHEMA_VERSION`], running any
+/// pending migrations. Called once from [`FjallStore::initialize`].
+pub(super) fn run_migrations(store: &FjallStore) -> Result<(), MediatorError> {
+    let stored = store.read_schema_version()?;
+    let available: Vec<u32> = all_migrations().iter().map(|m| m.version).collect();
+
+    match plan_schema(stored, CURRENT_SCHEMA_VERSION, &available) {
+        SchemaAction::Initialise => {
+            store.write_schema_version(CURRENT_SCHEMA_VERSION)?;
+            info!("Fjall schema initialised at version {CURRENT_SCHEMA_VERSION}");
+        }
+        SchemaAction::UpToDate => {
+            info!("Fjall schema up to date (version {CURRENT_SCHEMA_VERSION})");
+        }
+        SchemaAction::Migrate(versions) => {
+            let from = stored.unwrap_or(0);
+            info!(
+                "Fjall schema behind (found {from}, want {CURRENT_SCHEMA_VERSION}); applying {} migration(s)",
+                versions.len()
+            );
+            let registry = all_migrations();
+            for v in versions {
+                let migration = registry
+                    .iter()
+                    .find(|m| m.version == v)
+                    .expect("planned migration version is present in the registry");
+                info!(
+                    "Running Fjall migration {} ({}) — {}",
+                    migration.version, migration.name, migration.description
+                );
+                (migration.up)(store)?;
+                // Advance the marker only after `up` succeeds, so a crash
+                // mid-migration re-runs from the same point next boot.
+                store.write_schema_version(migration.version)?;
+                info!(
+                    "Fjall migration {} ({}) applied",
+                    migration.version, migration.name
+                );
+            }
+            // Land the marker on the current version even when the latest
+            // migration's version is below it (a pure marker bump with no data
+            // change — normally they are equal).
+            store.write_schema_version(CURRENT_SCHEMA_VERSION)?;
+            info!("Fjall schema now at version {CURRENT_SCHEMA_VERSION}");
+        }
+        SchemaAction::TooNew { found } => {
+            return Err(MediatorError::DatabaseError(
+                error_codes::DB_SCHEMA_VERSION_ERROR,
+                "fjall".into(),
+                format!(
+                    "Fjall data directory schema version {found} is newer than this \
+                     mediator supports (max {CURRENT_SCHEMA_VERSION}). Upgrade the \
+                     mediator binary, or point it at a data directory written by a \
+                     compatible version."
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // ─── Registry invariants (mirror the Redis migration suite) ──────────────
+
+    #[test]
+    fn migration_versions_are_unique() {
+        let mut seen = HashSet::new();
+        for m in all_migrations() {
+            assert!(
+                seen.insert(m.version),
+                "duplicate migration version {}",
+                m.version
+            );
+        }
+    }
+
+    #[test]
+    fn migration_versions_are_ascending() {
+        let migrations = all_migrations();
+        for w in migrations.windows(2) {
+            assert!(
+                w[0].version < w[1].version,
+                "migration versions not ascending: {} before {}",
+                w[0].version,
+                w[1].version
+            );
+        }
+    }
+
+    #[test]
+    fn migration_versions_are_in_supported_range() {
+        for m in all_migrations() {
+            assert!(m.version > 0, "migration {} has version 0", m.name);
+            assert!(
+                m.version <= CURRENT_SCHEMA_VERSION,
+                "migration {} ({}) targets version above CURRENT_SCHEMA_VERSION {}",
+                m.version,
+                m.name,
+                CURRENT_SCHEMA_VERSION
+            );
+        }
+    }
+
+    #[test]
+    fn migration_names_are_unique_and_non_empty() {
+        let mut names = HashSet::new();
+        for m in all_migrations() {
+            assert!(
+                !m.name.is_empty(),
+                "migration {} has an empty name",
+                m.version
+            );
+            assert!(
+                !m.description.is_empty(),
+                "migration {} has an empty description",
+                m.version
+            );
+            assert!(names.insert(m.name), "duplicate migration name {}", m.name);
+        }
+    }
+
+    // ─── plan_schema decision logic ──────────────────────────────────────────
+
+    #[test]
+    fn no_marker_initialises() {
+        assert_eq!(plan_schema(None, 1, &[]), SchemaAction::Initialise);
+    }
+
+    #[test]
+    fn marker_equal_to_current_is_up_to_date() {
+        assert_eq!(plan_schema(Some(3), 3, &[1, 2, 3]), SchemaAction::UpToDate);
+    }
+
+    #[test]
+    fn marker_ahead_of_current_is_too_new() {
+        assert_eq!(
+            plan_schema(Some(9), 3, &[1, 2, 3]),
+            SchemaAction::TooNew { found: 9 }
+        );
+    }
+
+    #[test]
+    fn marker_behind_collects_pending_in_order() {
+        // Out-of-order registry input is normalised to ascending pending.
+        assert_eq!(
+            plan_schema(Some(1), 4, &[4, 2, 3]),
+            SchemaAction::Migrate(vec![2, 3, 4])
+        );
+    }
+
+    #[test]
+    fn marker_behind_with_no_registered_migrations_is_a_bare_bump() {
+        // A version bump that needs no data rewrite: pending is empty, but the
+        // runner still advances the marker to current.
+        assert_eq!(plan_schema(Some(1), 2, &[]), SchemaAction::Migrate(vec![]));
+    }
+
+    #[test]
+    fn pending_excludes_versions_above_current() {
+        // A registry that knows about a future version must not run it when the
+        // binary's current is lower.
+        assert_eq!(
+            plan_schema(Some(1), 2, &[2, 3]),
+            SchemaAction::Migrate(vec![2])
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -555,6 +555,36 @@ impl FjallStore {
             .unwrap_or(0)
     }
 
+    /// Read the persisted schema-version marker from the `globals`
+    /// partition. `None` means no marker has ever been written — a fresh
+    /// data dir, or one created before schema versioning existed.
+    ///
+    /// `pub(super)` so the sibling [`fjall_migrations`](super::fjall_migrations)
+    /// runner can read it without exposing the `globals` partition itself.
+    pub(super) fn read_schema_version(&self) -> Result<Option<u32>, MediatorError> {
+        let raw = self
+            .globals
+            .get(super::fjall_migrations::SCHEMA_VERSION_KEY)
+            .map_err(|e| Self::db_err("read_schema_version:get", e))?;
+        Ok(raw.and_then(|v| {
+            let bytes: [u8; 4] = v.as_ref().try_into().ok()?;
+            Some(u32::from_le_bytes(bytes))
+        }))
+    }
+
+    /// Persist the schema-version marker into the `globals` partition as
+    /// little-endian `u32`. Matches the durability of the other `globals`
+    /// writes (counters, cursors) — survives a clean reopen.
+    pub(super) fn write_schema_version(&self, version: u32) -> Result<(), MediatorError> {
+        self.globals
+            .insert(
+                super::fjall_migrations::SCHEMA_VERSION_KEY,
+                version.to_le_bytes().to_vec(),
+            )
+            .map_err(|e| Self::db_err("write_schema_version:insert", e))?;
+        Ok(())
+    }
+
     /// Path the database was opened from.
     pub fn path(&self) -> &Path {
         &self.path
@@ -574,10 +604,12 @@ impl MediatorStore for FjallStore {
     // ─── Bootstrap & health ─────────────────────────────────────────────────
 
     async fn initialize(&self) -> Result<(), MediatorError> {
-        // All partitions opened in `open`; nothing further to do at
-        // the moment. Future commits may seed schema versions or run
-        // migrations here.
-        Ok(())
+        // Partitions are opened eagerly in `open`. The remaining bootstrap
+        // step is the schema-version check: stamp the current version on a
+        // fresh data dir, run any pending migrations on an older one, and
+        // refuse to start on a data dir written by a newer mediator rather
+        // than silently misread its records. See `fjall_migrations`.
+        super::fjall_migrations::run_migrations(self)
     }
 
     async fn health(&self) -> StoreHealth {
@@ -2481,6 +2513,80 @@ mod tests {
         store.initialize().await.expect("initialize");
         assert!(matches!(store.health().await, StoreHealth::Healthy));
         store.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn initialize_stamps_current_schema_version_on_a_fresh_store() {
+        use crate::store::fjall_migrations::CURRENT_SCHEMA_VERSION;
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+
+        // Fresh data dir: no marker yet.
+        assert_eq!(store.read_schema_version().expect("read"), None);
+
+        store.initialize().await.expect("initialize");
+        assert_eq!(
+            store.read_schema_version().expect("read"),
+            Some(CURRENT_SCHEMA_VERSION),
+            "fresh init stamps the current schema version"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_is_idempotent_across_restarts() {
+        use crate::store::fjall_migrations::CURRENT_SCHEMA_VERSION;
+        let dir = TempDir::new().expect("tempdir");
+
+        {
+            let store = FjallStore::open(dir.path()).expect("open");
+            store.initialize().await.expect("first initialize");
+            store.shutdown().await.expect("shutdown");
+        }
+
+        // Re-open the same dir: the marker persisted, and a second initialize
+        // is a clean no-op (UpToDate), not a re-stamp or error.
+        let store = FjallStore::open(dir.path()).expect("reopen");
+        assert_eq!(
+            store.read_schema_version().expect("read"),
+            Some(CURRENT_SCHEMA_VERSION),
+            "marker survives a reopen"
+        );
+        store
+            .initialize()
+            .await
+            .expect("second initialize is a no-op");
+        assert_eq!(
+            store.read_schema_version().expect("read"),
+            Some(CURRENT_SCHEMA_VERSION)
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_rejects_a_data_dir_from_a_newer_mediator() {
+        use crate::store::fjall_migrations::CURRENT_SCHEMA_VERSION;
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+
+        // Simulate a data dir written by a future mediator.
+        store
+            .write_schema_version(CURRENT_SCHEMA_VERSION + 1)
+            .expect("seed newer version");
+
+        let err = store
+            .initialize()
+            .await
+            .expect_err("must refuse a newer schema");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("newer than this mediator supports"),
+            "error should name the version mismatch, got: {msg}"
+        );
+
+        // The marker must be left untouched — we never downgrade it.
+        assert_eq!(
+            store.read_schema_version().expect("read"),
+            Some(CURRENT_SCHEMA_VERSION + 1)
+        );
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -18,6 +18,9 @@ pub use affinidi_messaging_mediator_common::store::redis::RedisStore;
 pub mod fjall_store;
 
 #[cfg(feature = "fjall-backend")]
+mod fjall_migrations;
+
+#[cfg(feature = "fjall-backend")]
 pub use fjall_store::FjallStore;
 
 #[cfg(feature = "memory-backend")]


### PR DESCRIPTION
## Summary

Completes **T17 (Fjall operational parity)** — part 2 of 2. Part 1 (#423) gave `FjallStore` a circuit breaker; this adds the **schema-version marker + migration runner**, the other half of Redis parity.

The Redis backend records applied schema migrations in a `SCHEMA_MIGRATIONS` set so a record-shape change runs exactly once. Fjall had no equivalent — a future change to an on-disk record shape would silently deserialise old bytes as `serde` defaults, corrupting state with no signal. `FjallStore` now writes a version marker into the `globals` partition and checks it on every `initialize()`.

## What changed

- **New `store::fjall_migrations` module** — `CURRENT_SCHEMA_VERSION` (baseline `1`), an append-only migration registry (`all_migrations()`, empty until the first real record-shape change), and a `run_migrations` runner.
- **`FjallStore::initialize()`** now runs `run_migrations`. The marker lives in the existing `globals` partition under `__schema_version__` (reused like the consumer cursors, following the established idiom rather than opening a new partition).
- **Startup behaviour:**
  - *no marker* → fresh or pre-versioning data dir, both at the v1 baseline → stamp current, migrate nothing.
  - *marker == current* → no-op.
  - *marker < current* → run pending migrations ascending, advancing the marker only **after** each `up()` succeeds (so a crash mid-migration re-runs from the same point).
  - *marker > current* → abort with a clear `DB_SCHEMA_VERSION_ERROR` ("…newer than this mediator supports…") rather than risk misreading newer records.
- **Two `pub(super)` helpers** on `FjallStore` (`read_schema_version` / `write_schema_version`) keep the `globals` partition encapsulated; the sibling runner orchestrates via them.

## Design notes

- The version-comparison logic is a **pure `plan_schema` function** (initialise / up-to-date / migrate / too-new), so every branch is unit-tested without a real data dir — matching the codebase's "decision logic extracted + unit-tested" convention (cf. `store::ops`).
- Marker stored as a separate `u32` key (not reusing the `i64` counter codec) so it's self-describing and can never be confused with a counter.

## Tests

- **Registry invariants** (mirror the Redis migration suite): versions unique, ascending, in `(0, CURRENT]`; names unique + non-empty.
- **`plan_schema`**: all four branches, incl. out-of-order normalisation, bare version bump (empty pending), and excluding versions above current.
- **Behaviour** (temp-dir store): fresh-init stamps the current version; idempotent re-init across a reopen (marker persists, second init is a clean no-op); a data dir seeded with a newer version is rejected and the marker left untouched.

## Verification

- `cargo fmt`; clippy clean on both feature sets (default redis-backend; `--no-default-features --features didcomm,memory-backend,fjall-backend`).
- Mediator lib suite **208 passed**; store-conformance **20/20** green.
- No new dependencies; no config-file change; no behaviour change for existing data dirs. mediator `0.15.38 → 0.15.39`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
