### PR TITLE
refactor: extract the mediator-config crate — raw TOML schema (simplification T18, part a)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "crates/messaging/affinidi-messaging-helpers",
   "crates/messaging/affinidi-messaging-didcomm-service",
   "crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common",
+  "crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config",
   "crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-processors",
   "crates/messaging/affinidi-messaging-mediator",
   "crates/messaging/affinidi-messaging-mediator/tools/mediator-setup",

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ## 12th June 2026
 
+### 0.15.40 — Extract the `mediator-config` crate: raw TOML schema (simplification T18, part a)
+
+- Phase 4 (config unification) begins. The mediator's TOML *schema* — the
+  `*ConfigRaw` serde types that mirror `mediator.toml` — moves into a new,
+  dependency-light `affinidi-messaging-mediator-config` crate so it can be shared
+  with the `mediator-setup` wizard (which today hand-renders the same TOML with
+  no shared types). The crate pulls only serde + the lean tier of
+  mediator-common; **no** axum/redis/secrets/SDK.
+- Moved: `ConfigRaw` + `ServerConfig` / `StreamingConfig` / `DIDResolverConfig` /
+  `SecretsConfigRaw` / `StorageConfig` / `SecurityConfigRaw` / `LimitsConfigRaw` /
+  `ProcessorsConfigRaw` (+ the forwarding/cleanup raw structs) and their serde
+  default fns. The mediator re-exports them (`pub use
+  affinidi_messaging_mediator_config::*`), so every `crate::common::config::*`
+  path — and external consumers like `affinidi-messaging-test-mediator` — keep
+  resolving unchanged.
+- Stayed in the mediator (all runtime concerns): the resolved `Config` /
+  `SecurityConfig` / `LimitsConfig` / `ProcessorsConfig`, every `ConfigRaw →
+  Config` conversion, the secret-backend/VTA/DID-resolver loading, and (for now)
+  the env-var overrides + boot validation. Three conversions that the orphan rule
+  no longer allows as inherent/`TryFrom` impls became free fns / an extension
+  trait with **verbatim bodies**: `did_resolver_cache_config`,
+  `forwarding_config_from_raw`, and `SecurityConfigRawExt::convert`.
+- **Scope note:** the env-var override logic and boot-time validation were
+  originally slated for this PR but both carry mediator-common's server-tier
+  `MediatorError`; they move together in T18b (with a crate-local config error
+  type) rather than dragging the server stack into the schema crate. Behaviour is
+  byte-identical; a golden test parses the shipped `conf/mediator.toml` into the
+  relocated `ConfigRaw`. mediator-common bumped to 0.15.11 (additive).
+
 ### 0.15.39 — Schema-version marker for the Fjall backend (simplification T17, part 2)
 
 - Completes the Fjall/Redis operational-parity work: the Redis backend records

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.39"
+version = "0.15.40"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -73,6 +73,9 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
 affinidi-messaging-mediator-common = { version = "0.15", path = "affinidi-messaging-mediator-common" }
+## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
+## mediator re-exports them; the runtime `Config` + conversions stay local.
+affinidi-messaging-mediator-config = { version = "0.1", path = "affinidi-messaging-mediator-config" }
 ## Humantime for the VTA cache TTL (`[secrets].cache_ttl = "30d"`).
 humantime = "2"
 ## CLI parsing for the mediator binary's subcommands (`mediator`,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 12th June 2026
 
+### 0.15.11 — Make `DatabaseConfigRaw` available without the `server` feature (simplification T18, part a)
+
+- The `database` module (and its `config` submodule holding `DatabaseConfigRaw`
+  / `DatabaseConfig`) is no longer gated behind the `server` feature — it's now
+  always available. The new dependency-light `affinidi-messaging-mediator-config`
+  crate embeds `DatabaseConfigRaw` in its top-level `ConfigRaw` and needs it with
+  `default-features = false`.
+- Only the parts that require the server tier stay gated: the
+  `TryFrom<DatabaseConfigRaw> for DatabaseConfig` conversion (it returns
+  `MediatorError`) is now `#[cfg(feature = "server")]`, and `DatabaseHandler` +
+  its redis helpers remain on `redis-backend`. Purely additive for lean
+  consumers; server builds are unchanged.
+
 ### 0.15.10 — Consolidate the access-list method family (simplification T16, part 3)
 
 - Extracts the access-list admission *decision* into `store::ops`: a new

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.10"
+version = "0.15.11"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/config.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/config.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+// The raw/typed structs below are lean (pure serde) so the
+// `affinidi-messaging-mediator-config` crate can embed `DatabaseConfigRaw`
+// without the `server` stack. Only the `TryFrom` conversion needs
+// `MediatorError`, so it (and this import) is gated on `server`.
+#[cfg(feature = "server")]
 use crate::errors::MediatorError;
 
 /// Database Struct contains database and storage of messages related configuration details
@@ -45,6 +50,7 @@ impl Default for DatabaseConfig {
     }
 }
 
+#[cfg(feature = "server")]
 impl std::convert::TryFrom<DatabaseConfigRaw> for DatabaseConfig {
     type Error = MediatorError;
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -24,12 +24,13 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub mod circuit_breaker;
-/// Database wiring: the lean `DatabaseConfig` serde struct is always
-/// available under `server` (the mediator's main config parses it
-/// regardless of which storage backend is selected). The
-/// `DatabaseHandler` and its redis-specific helpers are gated inside
-/// the module on `redis-backend`.
-#[cfg(feature = "server")]
+/// Database wiring. The raw serde structs in `database::config`
+/// (`DatabaseConfigRaw`, `DatabaseConfig`) are **always available** —
+/// the lean `affinidi-messaging-mediator-config` crate embeds
+/// `DatabaseConfigRaw` in its top-level `ConfigRaw` and must reach it
+/// with `default-features = false`. The `DatabaseConfig` `TryFrom`
+/// (which returns `MediatorError`) is gated on `server`, and
+/// `DatabaseHandler` + its redis helpers are gated on `redis-backend`.
 pub mod database;
 #[cfg(feature = "server")]
 pub mod errors;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Affinidi Messaging Mediator Config
+
+## Changelog history
+
+## 12th June 2026
+
+### 0.1.0 — Initial release (simplification T18, part a)
+
+- New crate holding the mediator's raw TOML configuration **schema** — the
+  `ConfigRaw` root and its `*ConfigRaw` / plain-serde sub-structs, extracted from
+  `affinidi-messaging-mediator`'s `src/common/config/`. The mediator re-exports
+  these types and keeps all runtime resolution; the goal is one schema shared
+  with the `mediator-setup` wizard.
+- Dependency-light by design: serde + the lean (`default-features = false`) tier
+  of `affinidi-messaging-mediator-common` (for `DatabaseConfigRaw`). No
+  server/runtime dependencies.
+- A golden test parses the shipped `conf/mediator.toml` into `ConfigRaw`.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "affinidi-messaging-mediator-config"
+version = "0.1.0"
+description = "Raw TOML configuration schema for the Affinidi Messaging Mediator (shared by the mediator and its setup tool)"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+# Pure serde schema — no runtime/server dependencies. The resolved
+# (runtime) `Config` and all conversions live in the mediator binary.
+serde = { version = "1", features = ["derive"] }
+# Only for `DatabaseConfigRaw`, the one raw field type that lives in
+# mediator-common. Taken with `default-features = false` so this crate
+# stays lean (no axum/redis/secrets stack).
+affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator-common", default-features = false }
+
+[dev-dependencies]
+# Golden test parses the shipped `mediator.toml` into `ConfigRaw`.
+toml = "1"
+
+[lints]
+workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/README.md
@@ -1,0 +1,15 @@
+# affinidi-messaging-mediator-config
+
+Raw TOML configuration **schema** for the Affinidi Messaging Mediator — the
+serde `*ConfigRaw` types that mirror `mediator.toml`.
+
+This crate is deliberately dependency-light (serde + the lean tier of
+`affinidi-messaging-mediator-common`). It contains **only the on-disk shape**;
+the resolved runtime `Config` (opened secret backends, JWT keys, the
+DID-resolver client, the VTA refresher) and every `ConfigRaw → Config`
+conversion live in the `affinidi-messaging-mediator` binary, which re-exports
+these types.
+
+The goal is one schema with two consumers — the mediator and the
+`mediator-setup` wizard — instead of the wizard hand-rendering TOML that can
+drift from what the mediator parses.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/lib.rs
@@ -1,0 +1,52 @@
+//! Raw TOML configuration schema for the Affinidi Messaging Mediator.
+//!
+//! This crate holds **only the serde deserialization types** that mirror the
+//! mediator's `mediator.toml` — the `*ConfigRaw` structs and their plain-serde
+//! sub-structs. Every field is the on-disk shape (mostly `String`, parsed into
+//! typed/runtime values later).
+//!
+//! It is intentionally dependency-light (serde + the lean tier of
+//! `affinidi-messaging-mediator-common`, for `DatabaseConfigRaw`). The
+//! **resolved** runtime `Config` — opened secret backends, JWT keys, the
+//! DID-resolver client, the VTA refresher — and all `ConfigRaw → Config`
+//! conversions stay in the mediator binary, which re-exports these types so
+//! existing `crate::common::config::*` paths keep resolving.
+//!
+//! The goal (mediator simplification T18) is one schema, two consumers: the
+//! mediator and (later) the `mediator-setup` wizard, which today renders this
+//! TOML by hand with no shared types. Env-var override logic and boot-time
+//! validation move here in a follow-up (T18b), once they carry a crate-local
+//! error type instead of the mediator's server-tier `MediatorError`.
+
+mod limits;
+mod processors;
+mod schema;
+mod security;
+
+pub use limits::*;
+pub use processors::*;
+pub use schema::*;
+pub use security::*;
+
+#[cfg(test)]
+mod golden {
+    use super::ConfigRaw;
+
+    /// The shipped `mediator.toml` must still deserialize into `ConfigRaw`
+    /// after the schema relocation — a structural guard that the moved types
+    /// stay byte-compatible with the real config the mediator parses.
+    #[test]
+    fn shipped_mediator_toml_parses() {
+        let toml = include_str!("../../conf/mediator.toml");
+        let raw: ConfigRaw = ::toml::from_str(toml).expect("conf/mediator.toml parses as ConfigRaw");
+
+        // Spot-check a field from a few different sections so an accidental
+        // rename or moved field is caught, not just "it deserialized".
+        assert!(raw.mediator_did.starts_with("did"));
+        assert!(!raw.server.listen_address.is_empty());
+        assert!(!raw.security.global_acl_default.is_empty());
+        assert!(!raw.limits.message_size.is_empty());
+        assert!(!raw.processors.forwarding.enabled.is_empty());
+        assert!(!raw.secrets.backend.is_empty());
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/limits.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/limits.rs
@@ -1,0 +1,59 @@
+//! Raw `[limits]` config schema.
+//!
+//! The resolved `LimitsConfig` (typed numbers) and the
+//! `LimitsConfigRaw → LimitsConfig` conversion stay in the mediator.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LimitsConfigRaw {
+    pub attachments_max_count: String,
+    pub crypto_operations_per_message: String,
+    pub deleted_messages: String,
+    pub forward_task_queue: String,
+    pub http_size: String,
+    pub listed_messages: String,
+    pub local_max_acl: String,
+    pub message_expiry_seconds: String,
+    pub message_size: String,
+    pub queued_send_messages_soft: String,
+    pub queued_send_messages_hard: String,
+    pub queued_receive_messages_soft: String,
+    pub queued_receive_messages_hard: String,
+    pub to_keys_per_recipient: String,
+    pub to_recipients: String,
+    pub ws_size: String,
+    pub access_list_limit: String,
+    pub oob_invite_ttl: String,
+    #[serde(default = "default_rate_limit_per_ip")]
+    pub rate_limit_per_ip: String,
+    #[serde(default = "default_rate_limit_burst")]
+    pub rate_limit_burst: String,
+    #[serde(default = "default_max_websocket_connections")]
+    pub max_websocket_connections: String,
+    #[serde(default = "default_max_websocket_connections_per_did")]
+    pub max_websocket_connections_per_did: String,
+    #[serde(default = "default_did_rate_limit_per_second")]
+    pub did_rate_limit_per_second: String,
+    #[serde(default = "default_did_rate_limit_burst")]
+    pub did_rate_limit_burst: String,
+}
+
+fn default_rate_limit_per_ip() -> String {
+    "100".to_string()
+}
+fn default_rate_limit_burst() -> String {
+    "50".to_string()
+}
+fn default_max_websocket_connections() -> String {
+    "10000".to_string()
+}
+fn default_max_websocket_connections_per_did() -> String {
+    "100".to_string()
+}
+fn default_did_rate_limit_per_second() -> String {
+    "0".to_string()
+}
+fn default_did_rate_limit_burst() -> String {
+    "10".to_string()
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/processors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/processors.rs
@@ -1,0 +1,113 @@
+//! Raw `[processors]` config schema (forwarding + expiry sweeps).
+//!
+//! The resolved `ProcessorsConfig` / `ForwardingConfig` and all conversions
+//! stay in the mediator (`ForwardingConfig` lives in mediator-common alongside
+//! the forwarding processor).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProcessorsConfigRaw {
+    pub forwarding: ForwardingConfigRaw,
+    pub message_expiry_cleanup: MessageExpiryCleanupConfigRaw,
+    // Added after the first release of this struct; default so configs
+    // written before the session sweeper existed still parse.
+    #[serde(default)]
+    pub session_expiry_cleanup: SessionExpiryCleanupConfigRaw,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MessageExpiryCleanupConfigRaw {
+    pub enabled: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionExpiryCleanupConfigRaw {
+    #[serde(default = "default_true")]
+    pub enabled: String,
+}
+
+impl Default for SessionExpiryCleanupConfigRaw {
+    fn default() -> Self {
+        SessionExpiryCleanupConfigRaw {
+            enabled: default_true(),
+        }
+    }
+}
+
+// `ForwardingConfig` (the typed shape) lives in `mediator-common`
+// alongside `ForwardingProcessor` so the standalone forwarding binary
+// can construct it. `ForwardingConfigRaw` (this struct) is the wizard's
+// all-strings TOML format and stays here, in the schema crate.
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ForwardingConfigRaw {
+    pub enabled: String,
+    pub future_time_limit: String,
+    pub external_forwarding: String,
+    pub report_errors: String,
+    pub blocked_forwarding_dids: String,
+    #[serde(default = "default_300")]
+    pub rate_window_seconds: String,
+    #[serde(default = "default_1")]
+    pub ws_threshold_msgs_per_10s: String,
+    #[serde(default = "default_60")]
+    pub ws_idle_timeout_seconds: String,
+    #[serde(default = "default_50")]
+    pub batch_size: String,
+    #[serde(default = "default_5")]
+    pub max_retries: String,
+    #[serde(default = "default_1000")]
+    pub initial_backoff_ms: String,
+    #[serde(default = "default_60000")]
+    pub max_backoff_ms: String,
+    #[serde(default = "default_forwarding_group")]
+    pub consumer_group: String,
+    #[serde(default = "default_false")]
+    pub accept_invalid_certs: String,
+    #[serde(default = "default_10")]
+    pub max_hops: String,
+    /// Relay mode for remote next-hop forwards: "blind" (default) or "rewrap".
+    #[serde(default = "default_blind")]
+    pub relay_mode: String,
+    /// Comma-separated allowlist of trusted peer-mediator DIDs (rewrap mode).
+    #[serde(default)]
+    pub relay_trusted_mediators: String,
+}
+
+fn default_300() -> String {
+    "300".to_string()
+}
+fn default_1() -> String {
+    "1".to_string()
+}
+fn default_60() -> String {
+    "60".to_string()
+}
+fn default_50() -> String {
+    "50".to_string()
+}
+fn default_5() -> String {
+    "5".to_string()
+}
+fn default_1000() -> String {
+    "1000".to_string()
+}
+fn default_60000() -> String {
+    "60000".to_string()
+}
+fn default_forwarding_group() -> String {
+    "forwarding".to_string()
+}
+fn default_false() -> String {
+    "false".to_string()
+}
+fn default_true() -> String {
+    "true".to_string()
+}
+fn default_10() -> String {
+    "10".to_string()
+}
+fn default_blind() -> String {
+    "blind".to_string()
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
@@ -1,0 +1,99 @@
+//! Top-level raw config schema (`[server]`, `[streaming]`, `[did_resolver]`,
+//! `[secrets]`, `[storage]`, and the `ConfigRaw` root).
+
+use affinidi_messaging_mediator_common::database::config::DatabaseConfigRaw;
+use serde::{Deserialize, Serialize};
+
+use crate::{LimitsConfigRaw, ProcessorsConfigRaw, SecurityConfigRaw};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub listen_address: String,
+    pub api_prefix: String,
+    pub admin_did: String,
+    pub did_web_self_hosted: Option<String>,
+    /// Additional URL aliases the mediator should treat as
+    /// pointing at *itself* when resolving a routing-2.0 next-hop.
+    /// Each entry is a full URL (e.g. `"https://mediator.example.com"`);
+    /// host + port are extracted and compared against the next-hop's
+    /// service endpoint. `listen_address` is automatically included,
+    /// so this is only needed when the mediator is reachable via
+    /// hostnames or ports that differ from its bind address (e.g.,
+    /// behind a load balancer or reverse proxy).
+    #[serde(default)]
+    pub local_endpoints: Vec<String>,
+}
+
+/// Live streaming configuration
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StreamingConfig {
+    pub enabled: String,
+    pub uuid: String,
+}
+
+/// DID resolver configuration.
+///
+/// The conversion to the runtime `DIDCacheConfig` lives in the mediator
+/// (`crate::common::config::did_resolver_cache_config`) so this crate stays
+/// free of the DID-resolver SDK.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DIDResolverConfig {
+    pub address: Option<String>,
+    pub cache_capacity: String,
+    pub cache_ttl: String,
+    pub network_timeout: String,
+    pub network_limit: String,
+}
+
+/// `[secrets]` config section — the unified secret-storage backend.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SecretsConfigRaw {
+    /// Backend URL. Examples: `keyring://affinidi-mediator`,
+    /// `file:///var/lib/mediator/secrets.json`,
+    /// `aws_secrets://us-east-1/prod/mediator/`.
+    pub backend: String,
+    /// Maximum age for the cached VTA bundle (humantime format, e.g.
+    /// `"30d"` or `"12h"`). `None` or `"0"` means no expiry. Defaults to
+    /// 30 days when unset.
+    #[serde(default)]
+    pub cache_ttl: Option<String>,
+}
+
+/// Raw configuration deserialized from the TOML file, converted to the runtime
+/// `Config` in the mediator binary.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ConfigRaw {
+    pub log_level: String,
+    pub log_json: String,
+    pub mediator_did: String,
+    pub server: ServerConfig,
+    pub database: DatabaseConfigRaw,
+    pub security: SecurityConfigRaw,
+    pub streaming: StreamingConfig,
+    pub did_resolver: DIDResolverConfig,
+    pub limits: LimitsConfigRaw,
+    pub processors: ProcessorsConfigRaw,
+    /// Unified secret backend — required whenever the mediator has any
+    /// persistent identity (which is effectively always).
+    pub secrets: SecretsConfigRaw,
+    /// Optional storage backend selector. Absent → Redis (legacy
+    /// behaviour, uses `[database]`). Present with `backend = "fjall"`
+    /// → embedded Fjall at `data_dir`, `[database]` is ignored.
+    #[serde(default)]
+    pub storage: Option<StorageConfig>,
+}
+
+/// `[storage]` section — selects the mediator's storage backend.
+/// Mirrors the wizard recipe shape so a `mediator.toml` produced by
+/// the wizard parses unchanged.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// `"redis"` (default) or `"fjall"`. Memory backend is not
+    /// exposed here — it's a tests-only backend.
+    pub backend: String,
+    /// On-disk path for the Fjall data directory. Required when
+    /// `backend = "fjall"`. The mediator creates this directory if
+    /// it doesn't exist.
+    #[serde(default)]
+    pub data_dir: Option<String>,
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/security.rs
@@ -1,0 +1,29 @@
+//! Raw `[security]` config schema.
+//!
+//! The resolved `SecurityConfig` (parsed ACL set, JWT keys, CORS layer) and the
+//! `SecurityConfigRaw → SecurityConfig` conversion stay in the mediator — they
+//! load secrets and build runtime objects this crate intentionally avoids.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SecurityConfigRaw {
+    pub mediator_acl_mode: String,
+    pub global_acl_default: String,
+    pub local_direct_delivery_allowed: String,
+    pub local_direct_delivery_allow_anon: String,
+    pub use_ssl: String,
+    pub ssl_certificate_file: Option<String>,
+    pub ssl_key_file: Option<String>,
+    pub jwt_access_expiry: String,
+    pub jwt_refresh_expiry: String,
+    pub cors_allow_origin: Option<String>,
+    pub block_anonymous_outer_envelope: String,
+    pub block_remote_admin_msgs: String,
+    pub force_session_did_match: String,
+    pub admin_messages_expiry: String,
+    /// Explicit inter-mediator relay switch. `#[serde(default)]` so configs
+    /// that predate the flag deserialize without it (empty → `false`).
+    #[serde(default)]
+    pub enable_inter_mediator_relay: String,
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
@@ -1,4 +1,7 @@
 use affinidi_messaging_mediator_common::errors::MediatorError;
+// `LimitsConfigRaw` (the raw TOML schema) lives in the config crate; the
+// conversion to the typed `LimitsConfig` (a mediator-local type) stays here.
+use affinidi_messaging_mediator_config::LimitsConfigRaw;
 use serde::{Deserialize, Serialize};
 
 /// Resource limits configuration for the mediator
@@ -67,59 +70,6 @@ impl Default for LimitsConfig {
             did_rate_limit_burst: 10,
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LimitsConfigRaw {
-    pub attachments_max_count: String,
-    pub crypto_operations_per_message: String,
-    pub deleted_messages: String,
-    pub forward_task_queue: String,
-    pub http_size: String,
-    pub listed_messages: String,
-    pub local_max_acl: String,
-    pub message_expiry_seconds: String,
-    pub message_size: String,
-    pub queued_send_messages_soft: String,
-    pub queued_send_messages_hard: String,
-    pub queued_receive_messages_soft: String,
-    pub queued_receive_messages_hard: String,
-    pub to_keys_per_recipient: String,
-    pub to_recipients: String,
-    pub ws_size: String,
-    pub access_list_limit: String,
-    pub oob_invite_ttl: String,
-    #[serde(default = "default_rate_limit_per_ip")]
-    pub rate_limit_per_ip: String,
-    #[serde(default = "default_rate_limit_burst")]
-    pub rate_limit_burst: String,
-    #[serde(default = "default_max_websocket_connections")]
-    pub max_websocket_connections: String,
-    #[serde(default = "default_max_websocket_connections_per_did")]
-    pub max_websocket_connections_per_did: String,
-    #[serde(default = "default_did_rate_limit_per_second")]
-    pub did_rate_limit_per_second: String,
-    #[serde(default = "default_did_rate_limit_burst")]
-    pub did_rate_limit_burst: String,
-}
-
-fn default_rate_limit_per_ip() -> String {
-    "100".to_string()
-}
-fn default_rate_limit_burst() -> String {
-    "50".to_string()
-}
-fn default_max_websocket_connections() -> String {
-    "10000".to_string()
-}
-fn default_max_websocket_connections_per_did() -> String {
-    "100".to_string()
-}
-fn default_did_rate_limit_per_second() -> String {
-    "0".to_string()
-}
-fn default_did_rate_limit_burst() -> String {
-    "10".to_string()
 }
 
 impl std::convert::TryFrom<LimitsConfigRaw> for LimitsConfig {
@@ -351,12 +301,12 @@ mod tests {
             ws_size: "10485760".to_string(),
             access_list_limit: "1000".to_string(),
             oob_invite_ttl: "86400".to_string(),
-            rate_limit_per_ip: default_rate_limit_per_ip(),
-            rate_limit_burst: default_rate_limit_burst(),
-            max_websocket_connections: default_max_websocket_connections(),
-            max_websocket_connections_per_did: default_max_websocket_connections_per_did(),
-            did_rate_limit_per_second: default_did_rate_limit_per_second(),
-            did_rate_limit_burst: default_did_rate_limit_burst(),
+            rate_limit_per_ip: "100".to_string(),
+            rate_limit_burst: "50".to_string(),
+            max_websocket_connections: "10000".to_string(),
+            max_websocket_connections_per_did: "100".to_string(),
+            did_rate_limit_per_second: "0".to_string(),
+            did_rate_limit_burst: "10".to_string(),
         };
         let limits = LimitsConfig::try_from(raw).unwrap();
         // Invalid values should fall back to unwrap_or defaults

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -10,16 +10,22 @@ pub use limits::*;
 pub use processors::*;
 pub use security::*;
 
+// The raw TOML schema (`ConfigRaw`, `ServerConfig`, `StreamingConfig`,
+// `DIDResolverConfig`, `SecretsConfigRaw`, `StorageConfig`, and the `*ConfigRaw`
+// types) now lives in the dependency-light `affinidi-messaging-mediator-config`
+// crate. Re-exported here so existing `crate::common::config::*` paths (and
+// external consumers like `affinidi-messaging-test-mediator`) keep resolving.
+// The resolved runtime `Config` and every `ConfigRaw → Config` conversion stay
+// in this module.
+pub use affinidi_messaging_mediator_config::*;
+
 use affinidi_did_common::Document;
 use affinidi_did_resolver_cache_sdk::{
     DIDCacheClient,
     config::{DIDCacheConfig, DIDCacheConfigBuilder},
 };
 use affinidi_messaging_mediator_common::{
-    MediatorSecrets,
-    database::config::{DatabaseConfig, DatabaseConfigRaw},
-    errors::MediatorError,
-    secrets::open_store,
+    MediatorSecrets, database::config::DatabaseConfig, errors::MediatorError, secrets::open_store,
 };
 use affinidi_secrets_resolver::ThreadedSecretsResolver;
 use async_convert::{TryFrom, async_trait};
@@ -35,7 +41,7 @@ use vta_sdk::credentials::CredentialBundle;
 pub(crate) type AwsConfig = aws_config::SdkConfig;
 #[cfg(not(feature = "aws"))]
 pub(crate) type AwsConfig = ();
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sha256::digest;
 use std::{collections::HashMap, env, fmt, sync::Arc};
 use tracing::{error, info, warn};
@@ -49,111 +55,27 @@ use helpers::{
     preload_self_did, read_config_file, read_did_config, read_document,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ServerConfig {
-    pub listen_address: String,
-    pub api_prefix: String,
-    pub admin_did: String,
-    pub did_web_self_hosted: Option<String>,
-    /// Additional URL aliases the mediator should treat as
-    /// pointing at *itself* when resolving a routing-2.0 next-hop.
-    /// Each entry is a full URL (e.g. `"https://mediator.example.com"`);
-    /// host + port are extracted and compared against the next-hop's
-    /// service endpoint. `listen_address` is automatically included,
-    /// so this is only needed when the mediator is reachable via
-    /// hostnames or ports that differ from its bind address (e.g.,
-    /// behind a load balancer or reverse proxy).
-    #[serde(default)]
-    pub local_endpoints: Vec<String>,
-}
+/// Build the runtime [`DIDCacheConfig`] from the raw [`DIDResolverConfig`]
+/// schema. Was `DIDResolverConfig::convert`; became a free function when the
+/// raw type relocated to `affinidi-messaging-mediator-config` (inherent impls
+/// must live in the type's crate, and this conversion pulls the DID-resolver
+/// SDK, which the schema crate avoids).
+fn did_resolver_cache_config(raw: &DIDResolverConfig) -> DIDCacheConfig {
+    let mut config = DIDCacheConfigBuilder::default()
+        .with_cache_capacity(raw.cache_capacity.parse().unwrap_or(1000))
+        .with_cache_ttl(raw.cache_ttl.parse().unwrap_or(300))
+        .with_network_timeout(raw.network_timeout.parse().unwrap_or(5))
+        .with_network_cache_limit_count(raw.network_limit.parse().unwrap_or(100));
 
-/// Live streaming configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StreamingConfig {
-    pub enabled: String,
-    pub uuid: String,
-}
-
-/// DID resolver configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DIDResolverConfig {
-    pub address: Option<String>,
-    pub cache_capacity: String,
-    pub cache_ttl: String,
-    pub network_timeout: String,
-    pub network_limit: String,
-}
-
-impl DIDResolverConfig {
-    pub fn convert(&self) -> DIDCacheConfig {
-        let mut config = DIDCacheConfigBuilder::default()
-            .with_cache_capacity(self.cache_capacity.parse().unwrap_or(1000))
-            .with_cache_ttl(self.cache_ttl.parse().unwrap_or(300))
-            .with_network_timeout(self.network_timeout.parse().unwrap_or(5))
-            .with_network_cache_limit_count(self.network_limit.parse().unwrap_or(100));
-
-        if let Some(address) = &self.address {
-            config = config.with_network_mode(address);
-        }
-
-        config.build()
+    if let Some(address) = &raw.address {
+        config = config.with_network_mode(address);
     }
-}
 
-/// `[secrets]` config section — the unified secret-storage backend.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SecretsConfigRaw {
-    /// Backend URL. Examples: `keyring://affinidi-mediator`,
-    /// `file:///var/lib/mediator/secrets.json`,
-    /// `aws_secrets://us-east-1/prod/mediator/`.
-    pub backend: String,
-    /// Maximum age for the cached VTA bundle (humantime format, e.g.
-    /// `"30d"` or `"12h"`). `None` or `"0"` means no expiry. Defaults to
-    /// 30 days when unset.
-    #[serde(default)]
-    pub cache_ttl: Option<String>,
+    config.build()
 }
 
 /// Default VTA cache TTL when `[secrets].cache_ttl` is not set.
 const DEFAULT_CACHE_TTL_SECS: u64 = 30 * 86_400; // 30 days
-
-/// Raw configuration deserialized from the TOML file, converted to [`Config`]
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct ConfigRaw {
-    pub log_level: String,
-    pub log_json: String,
-    pub mediator_did: String,
-    pub server: ServerConfig,
-    pub database: DatabaseConfigRaw,
-    pub security: SecurityConfigRaw,
-    pub streaming: StreamingConfig,
-    pub did_resolver: DIDResolverConfig,
-    pub limits: LimitsConfigRaw,
-    pub processors: ProcessorsConfigRaw,
-    /// Unified secret backend — required whenever the mediator has any
-    /// persistent identity (which is effectively always).
-    pub secrets: SecretsConfigRaw,
-    /// Optional storage backend selector. Absent → Redis (legacy
-    /// behaviour, uses `[database]`). Present with `backend = "fjall"`
-    /// → embedded Fjall at `data_dir`, `[database]` is ignored.
-    #[serde(default)]
-    pub storage: Option<StorageConfig>,
-}
-
-/// `[storage]` section — selects the mediator's storage backend.
-/// Mirrors the wizard recipe shape so a `mediator.toml` produced by
-/// the wizard parses unchanged.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StorageConfig {
-    /// `"redis"` (default) or `"fjall"`. Memory backend is not
-    /// exposed here — it's a tests-only backend.
-    pub backend: String,
-    /// On-disk path for the Fjall data directory. Required when
-    /// `backend = "fjall"`. The mediator creates this directory if
-    /// it doesn't exist.
-    #[serde(default)]
-    pub data_dir: Option<String>,
-}
 
 #[derive(Clone, Serialize)]
 pub struct Config {
@@ -726,7 +648,7 @@ impl TryFrom<ConfigRaw> for Config {
                 );
                 true
             }),
-            did_resolver_config: raw.did_resolver.convert(),
+            did_resolver_config: did_resolver_cache_config(&raw.did_resolver),
             api_prefix: {
                 let normalized = helpers::normalize_api_prefix(&raw.server.api_prefix);
                 if normalized != raw.server.api_prefix {
@@ -747,7 +669,9 @@ impl TryFrom<ConfigRaw> for Config {
                 )
                 .await?,
             processors: ProcessorsConfig {
-                forwarding: raw.processors.forwarding.clone().try_into()?,
+                forwarding: processors::forwarding_config_from_raw(
+                    raw.processors.forwarding.clone(),
+                )?,
                 message_expiry_cleanup: raw.processors.message_expiry_cleanup.clone().try_into()?,
                 session_expiry_cleanup: raw.processors.session_expiry_cleanup.clone().try_into()?,
             },

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/processors.rs
@@ -1,6 +1,12 @@
 use affinidi_messaging_mediator_common::errors::MediatorError;
 pub use affinidi_messaging_mediator_common::tasks::forwarding::ForwardingConfig;
 use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
+// Raw TOML schema lives in the config crate; the typed configs + conversions
+// stay here. `ForwardingConfig` is a mediator-common type, so its conversion is
+// a free fn (`forwarding_config_from_raw`) rather than a `TryFrom` (orphan rule).
+use affinidi_messaging_mediator_config::{
+    ForwardingConfigRaw, MessageExpiryCleanupConfigRaw, SessionExpiryCleanupConfigRaw,
+};
 use ahash::AHashSet as HashSet;
 use serde::{Deserialize, Serialize};
 
@@ -10,16 +16,6 @@ pub struct ProcessorsConfig {
     pub forwarding: ForwardingConfig,
     pub message_expiry_cleanup: MessageExpiryCleanupConfig,
     pub session_expiry_cleanup: SessionExpiryCleanupConfig,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct ProcessorsConfigRaw {
-    pub forwarding: ForwardingConfigRaw,
-    pub message_expiry_cleanup: MessageExpiryCleanupConfigRaw,
-    // Added after the first release of this struct; default so configs
-    // written before the session sweeper existed still parse.
-    #[serde(default)]
-    pub session_expiry_cleanup: SessionExpiryCleanupConfigRaw,
 }
 
 /// Configuration for the in-process message expiry sweep. The standalone
@@ -35,11 +31,6 @@ impl Default for MessageExpiryCleanupConfig {
     fn default() -> Self {
         MessageExpiryCleanupConfig { enabled: true }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct MessageExpiryCleanupConfigRaw {
-    pub enabled: String,
 }
 
 impl std::convert::TryFrom<MessageExpiryCleanupConfigRaw> for MessageExpiryCleanupConfig {
@@ -66,20 +57,6 @@ impl Default for SessionExpiryCleanupConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct SessionExpiryCleanupConfigRaw {
-    #[serde(default = "default_true")]
-    pub enabled: String,
-}
-
-impl Default for SessionExpiryCleanupConfigRaw {
-    fn default() -> Self {
-        SessionExpiryCleanupConfigRaw {
-            enabled: default_true(),
-        }
-    }
-}
-
 impl std::convert::TryFrom<SessionExpiryCleanupConfigRaw> for SessionExpiryCleanupConfig {
     type Error = MediatorError;
 
@@ -90,165 +67,90 @@ impl std::convert::TryFrom<SessionExpiryCleanupConfigRaw> for SessionExpiryClean
     }
 }
 
-// `ForwardingConfig` (the typed shape) lives in `mediator-common`
-// alongside `ForwardingProcessor` so the standalone forwarding binary
-// can construct it. `ForwardingConfigRaw` (this file) is the wizard's
-// all-strings TOML format and stays here.
+/// Build the typed [`ForwardingConfig`] (a mediator-common type) from the raw
+/// [`ForwardingConfigRaw`] schema. A free function rather than a `TryFrom` impl
+/// because both types are now foreign to this crate (the raw type moved to
+/// `affinidi-messaging-mediator-config`), which the orphan rule forbids.
+pub(crate) fn forwarding_config_from_raw(
+    raw: ForwardingConfigRaw,
+) -> Result<ForwardingConfig, MediatorError> {
+    let warn_default = |field: &str, default: &str| {
+        eprintln!(
+            "WARN: Could not parse processors.forwarding.{field} config value, using default: {default}"
+        );
+    };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct ForwardingConfigRaw {
-    pub enabled: String,
-    pub future_time_limit: String,
-    pub external_forwarding: String,
-    pub report_errors: String,
-    pub blocked_forwarding_dids: String,
-    #[serde(default = "default_300")]
-    pub rate_window_seconds: String,
-    #[serde(default = "default_1")]
-    pub ws_threshold_msgs_per_10s: String,
-    #[serde(default = "default_60")]
-    pub ws_idle_timeout_seconds: String,
-    #[serde(default = "default_50")]
-    pub batch_size: String,
-    #[serde(default = "default_5")]
-    pub max_retries: String,
-    #[serde(default = "default_1000")]
-    pub initial_backoff_ms: String,
-    #[serde(default = "default_60000")]
-    pub max_backoff_ms: String,
-    #[serde(default = "default_forwarding_group")]
-    pub consumer_group: String,
-    #[serde(default = "default_false")]
-    pub accept_invalid_certs: String,
-    #[serde(default = "default_10")]
-    pub max_hops: String,
-    /// Relay mode for remote next-hop forwards: "blind" (default) or "rewrap".
-    #[serde(default = "default_blind")]
-    pub relay_mode: String,
-    /// Comma-separated allowlist of trusted peer-mediator DIDs (rewrap mode).
-    #[serde(default)]
-    pub relay_trusted_mediators: String,
-}
-
-fn default_300() -> String {
-    "300".to_string()
-}
-fn default_1() -> String {
-    "1".to_string()
-}
-fn default_60() -> String {
-    "60".to_string()
-}
-fn default_50() -> String {
-    "50".to_string()
-}
-fn default_5() -> String {
-    "5".to_string()
-}
-fn default_1000() -> String {
-    "1000".to_string()
-}
-fn default_60000() -> String {
-    "60000".to_string()
-}
-fn default_forwarding_group() -> String {
-    "forwarding".to_string()
-}
-fn default_false() -> String {
-    "false".to_string()
-}
-fn default_true() -> String {
-    "true".to_string()
-}
-fn default_10() -> String {
-    "10".to_string()
-}
-fn default_blind() -> String {
-    "blind".to_string()
-}
-
-impl std::convert::TryFrom<ForwardingConfigRaw> for ForwardingConfig {
-    type Error = MediatorError;
-
-    fn try_from(raw: ForwardingConfigRaw) -> Result<Self, Self::Error> {
-        let warn_default = |field: &str, default: &str| {
-            eprintln!(
-                "WARN: Could not parse processors.forwarding.{field} config value, using default: {default}"
-            );
-        };
-
-        Ok(ForwardingConfig {
-            enabled: raw.enabled.parse().unwrap_or_else(|_| {
-                warn_default("enabled", "true");
-                true
-            }),
-            future_time_limit: raw.future_time_limit.parse().unwrap_or_else(|_| {
-                warn_default("future_time_limit", "86400");
-                86400
-            }),
-            external_forwarding: raw.external_forwarding.parse().unwrap_or_else(|_| {
-                warn_default("external_forwarding", "true");
-                true
-            }),
-            report_errors: raw.report_errors.parse().unwrap_or_else(|_| {
-                warn_default("report_errors", "true");
-                true
-            }),
-            blocked_forwarding: HashSet::new(),
-            rate_window_seconds: raw.rate_window_seconds.parse().unwrap_or_else(|_| {
-                warn_default("rate_window_seconds", "300");
-                300
-            }),
-            ws_threshold_msgs_per_10s: raw.ws_threshold_msgs_per_10s.parse().unwrap_or_else(|_| {
-                warn_default("ws_threshold_msgs_per_10s", "1");
-                1
-            }),
-            ws_idle_timeout_seconds: raw.ws_idle_timeout_seconds.parse().unwrap_or_else(|_| {
-                warn_default("ws_idle_timeout_seconds", "60");
-                60
-            }),
-            batch_size: raw.batch_size.parse().unwrap_or_else(|_| {
-                warn_default("batch_size", "50");
-                50
-            }),
-            max_retries: raw.max_retries.parse().unwrap_or_else(|_| {
-                warn_default("max_retries", "5");
-                5
-            }),
-            initial_backoff_ms: raw.initial_backoff_ms.parse().unwrap_or_else(|_| {
-                warn_default("initial_backoff_ms", "1000");
-                1000
-            }),
-            max_backoff_ms: raw.max_backoff_ms.parse().unwrap_or_else(|_| {
-                warn_default("max_backoff_ms", "60000");
-                60000
-            }),
-            consumer_group: raw.consumer_group,
-            accept_invalid_certs: raw.accept_invalid_certs.parse().unwrap_or_else(|_| {
-                warn_default("accept_invalid_certs", "false");
-                false
-            }),
-            max_hops: raw.max_hops.parse().unwrap_or_else(|_| {
-                warn_default("max_hops", "10");
-                10
-            }),
-            relay_mode: match raw.relay_mode.trim().to_ascii_lowercase().as_str() {
-                "rewrap" => RelayMode::Rewrap,
-                "blind" | "" => RelayMode::Blind,
-                other => {
-                    warn_default(&format!("relay_mode (unrecognised: {other:?})"), "blind");
-                    RelayMode::Blind
-                }
-            },
-            relay_trusted_mediators: raw
-                .relay_trusted_mediators
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-                .collect(),
-        })
-    }
+    Ok(ForwardingConfig {
+        enabled: raw.enabled.parse().unwrap_or_else(|_| {
+            warn_default("enabled", "true");
+            true
+        }),
+        future_time_limit: raw.future_time_limit.parse().unwrap_or_else(|_| {
+            warn_default("future_time_limit", "86400");
+            86400
+        }),
+        external_forwarding: raw.external_forwarding.parse().unwrap_or_else(|_| {
+            warn_default("external_forwarding", "true");
+            true
+        }),
+        report_errors: raw.report_errors.parse().unwrap_or_else(|_| {
+            warn_default("report_errors", "true");
+            true
+        }),
+        blocked_forwarding: HashSet::new(),
+        rate_window_seconds: raw.rate_window_seconds.parse().unwrap_or_else(|_| {
+            warn_default("rate_window_seconds", "300");
+            300
+        }),
+        ws_threshold_msgs_per_10s: raw.ws_threshold_msgs_per_10s.parse().unwrap_or_else(|_| {
+            warn_default("ws_threshold_msgs_per_10s", "1");
+            1
+        }),
+        ws_idle_timeout_seconds: raw.ws_idle_timeout_seconds.parse().unwrap_or_else(|_| {
+            warn_default("ws_idle_timeout_seconds", "60");
+            60
+        }),
+        batch_size: raw.batch_size.parse().unwrap_or_else(|_| {
+            warn_default("batch_size", "50");
+            50
+        }),
+        max_retries: raw.max_retries.parse().unwrap_or_else(|_| {
+            warn_default("max_retries", "5");
+            5
+        }),
+        initial_backoff_ms: raw.initial_backoff_ms.parse().unwrap_or_else(|_| {
+            warn_default("initial_backoff_ms", "1000");
+            1000
+        }),
+        max_backoff_ms: raw.max_backoff_ms.parse().unwrap_or_else(|_| {
+            warn_default("max_backoff_ms", "60000");
+            60000
+        }),
+        consumer_group: raw.consumer_group,
+        accept_invalid_certs: raw.accept_invalid_certs.parse().unwrap_or_else(|_| {
+            warn_default("accept_invalid_certs", "false");
+            false
+        }),
+        max_hops: raw.max_hops.parse().unwrap_or_else(|_| {
+            warn_default("max_hops", "10");
+            10
+        }),
+        relay_mode: match raw.relay_mode.trim().to_ascii_lowercase().as_str() {
+            "rewrap" => RelayMode::Rewrap,
+            "blind" | "" => RelayMode::Blind,
+            other => {
+                warn_default(&format!("relay_mode (unrecognised: {other:?})"), "blind");
+                RelayMode::Blind
+            }
+        },
+        relay_trusted_mediators: raw
+            .relay_trusted_mediators
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+    })
 }
 
 #[cfg(test)]
@@ -283,20 +185,20 @@ mod tests {
             future_time_limit: "3600".to_string(),
             report_errors: "true".to_string(),
             blocked_forwarding_dids: "did:example:blocked1,did:example:blocked2".to_string(),
-            rate_window_seconds: default_300(),
-            ws_threshold_msgs_per_10s: default_1(),
-            ws_idle_timeout_seconds: default_60(),
-            batch_size: default_50(),
-            max_retries: default_5(),
-            initial_backoff_ms: default_1000(),
-            max_backoff_ms: default_60000(),
-            consumer_group: default_forwarding_group(),
-            accept_invalid_certs: default_false(),
-            max_hops: default_10(),
-            relay_mode: default_blind(),
+            rate_window_seconds: "300".to_string(),
+            ws_threshold_msgs_per_10s: "1".to_string(),
+            ws_idle_timeout_seconds: "60".to_string(),
+            batch_size: "50".to_string(),
+            max_retries: "5".to_string(),
+            initial_backoff_ms: "1000".to_string(),
+            max_backoff_ms: "60000".to_string(),
+            consumer_group: "forwarding".to_string(),
+            accept_invalid_certs: "false".to_string(),
+            max_hops: "10".to_string(),
+            relay_mode: "blind".to_string(),
             relay_trusted_mediators: String::new(),
         };
-        let config = ForwardingConfig::try_from(raw).unwrap();
+        let config = forwarding_config_from_raw(raw).unwrap();
         assert!(config.enabled);
         assert!(config.external_forwarding);
         assert!(config.report_errors);
@@ -336,7 +238,7 @@ mod tests {
             relay_mode: "rewrap".to_string(),
             relay_trusted_mediators: "did:peer:alice , did:peer:bob".to_string(),
         };
-        let config = ForwardingConfig::try_from(raw).unwrap();
+        let config = forwarding_config_from_raw(raw).unwrap();
         assert!(!config.enabled);
         assert!(!config.external_forwarding);
         assert!(!config.report_errors);
@@ -376,20 +278,20 @@ mod tests {
             future_time_limit: "3600".to_string(),
             report_errors: "true".to_string(),
             blocked_forwarding_dids: String::new(),
-            rate_window_seconds: default_300(),
-            ws_threshold_msgs_per_10s: default_1(),
-            ws_idle_timeout_seconds: default_60(),
-            batch_size: default_50(),
-            max_retries: default_5(),
-            initial_backoff_ms: default_1000(),
-            max_backoff_ms: default_60000(),
-            consumer_group: default_forwarding_group(),
-            accept_invalid_certs: default_false(),
-            max_hops: default_10(),
+            rate_window_seconds: "300".to_string(),
+            ws_threshold_msgs_per_10s: "1".to_string(),
+            ws_idle_timeout_seconds: "60".to_string(),
+            batch_size: "50".to_string(),
+            max_retries: "5".to_string(),
+            initial_backoff_ms: "1000".to_string(),
+            max_backoff_ms: "60000".to_string(),
+            consumer_group: "forwarding".to_string(),
+            accept_invalid_certs: "false".to_string(),
+            max_hops: "10".to_string(),
             relay_mode: "bogus".to_string(),
             relay_trusted_mediators: String::new(),
         };
-        let config = ForwardingConfig::try_from(raw).unwrap();
+        let config = forwarding_config_from_raw(raw).unwrap();
         assert_eq!(config.relay_mode, RelayMode::Blind);
     }
 
@@ -414,7 +316,7 @@ mod tests {
             relay_mode: "bad".to_string(),
             relay_trusted_mediators: String::new(),
         };
-        let config = ForwardingConfig::try_from(raw).unwrap();
+        let config = forwarding_config_from_raw(raw).unwrap();
         // All invalid values should fall back to unwrap_or defaults
         assert!(config.enabled); // default true
         assert_eq!(config.relay_mode, RelayMode::Blind); // unrecognised → blind

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -1,13 +1,19 @@
 use affinidi_messaging_mediator_common::{MediatorSecrets, errors::MediatorError};
+// `SecurityConfigRaw` (the raw TOML schema) now lives in the config crate; the
+// conversion to the runtime `SecurityConfig` stays here as an extension trait
+// (inherent impls must live in the type's crate, but this conversion loads
+// secrets and builds runtime objects the schema crate avoids).
+use affinidi_messaging_mediator_config::SecurityConfigRaw;
 use affinidi_messaging_sdk::protocols::mediator::acls::{AccessListModeType, MediatorACLSet};
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
+use async_trait::async_trait;
 use http::{
     HeaderValue, Method,
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use ring::signature::{Ed25519KeyPair, KeyPair};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::{
     fmt::{self, Debug},
     sync::Arc,
@@ -198,33 +204,6 @@ fn build_cors_layer(policy: &CorsOriginPolicy) -> CorsLayer {
     }
 }
 
-/// Security configuration for the mediator.
-///
-/// JWT signing secret + operating keys are no longer in this struct — they
-/// live in the unified secret backend (`[secrets] backend = "..."` in
-/// `mediator.toml`) and are loaded during [`SecurityConfigRaw::convert`].
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SecurityConfigRaw {
-    pub mediator_acl_mode: String,
-    pub global_acl_default: String,
-    pub local_direct_delivery_allowed: String,
-    pub local_direct_delivery_allow_anon: String,
-    pub use_ssl: String,
-    pub ssl_certificate_file: Option<String>,
-    pub ssl_key_file: Option<String>,
-    pub jwt_access_expiry: String,
-    pub jwt_refresh_expiry: String,
-    pub cors_allow_origin: Option<String>,
-    pub block_anonymous_outer_envelope: String,
-    pub block_remote_admin_msgs: String,
-    pub force_session_did_match: String,
-    pub admin_messages_expiry: String,
-    /// Explicit inter-mediator relay switch. `#[serde(default)]` so configs
-    /// that predate the flag deserialize without it (empty → `false`).
-    #[serde(default)]
-    pub enable_inter_mediator_relay: String,
-}
-
 #[derive(Clone, Serialize)]
 pub struct SecurityConfig {
     pub mediator_acl_mode: AccessListModeType,
@@ -335,7 +314,24 @@ impl SecurityConfig {
     }
 }
 
-impl SecurityConfigRaw {
+/// Conversion + parsing helpers for the (now foreign) [`SecurityConfigRaw`].
+/// An extension trait because inherent impls must live in the type's crate, but
+/// this logic loads secrets and builds runtime objects the schema crate avoids.
+/// Method bodies are unchanged from the former inherent impl.
+#[async_trait]
+pub(crate) trait SecurityConfigRawExt {
+    fn parse_cors_origins(cors_allow_origin: &str) -> Result<CorsOriginPolicy, MediatorError>;
+    fn parse_origin_matcher(token: &str) -> Result<OriginMatcher, MediatorError>;
+    async fn convert(
+        &self,
+        secrets_resolver: Arc<ThreadedSecretsResolver>,
+        secrets: &MediatorSecrets,
+        vta_bundle: Option<&DidSecretsBundle>,
+    ) -> Result<SecurityConfig, MediatorError>;
+}
+
+#[async_trait]
+impl SecurityConfigRawExt for SecurityConfigRaw {
     /// Parse the raw `cors_allow_origin` config value into a
     /// [`CorsOriginPolicy`].
     ///
@@ -461,7 +457,7 @@ impl SecurityConfigRaw {
     ///
     /// The JWT secret is always loaded from the backend's `JWT_SECRET`
     /// well-known entry — no inline `string://` path.
-    pub(crate) async fn convert(
+    async fn convert(
         &self,
         secrets_resolver: Arc<ThreadedSecretsResolver>,
         secrets: &MediatorSecrets,
@@ -693,7 +689,9 @@ impl SecurityConfigRaw {
 
 #[cfg(test)]
 mod tests {
-    use super::{CorsOriginPolicy, OriginMatcher, SecurityConfigRaw, origin_matches};
+    use super::{
+        CorsOriginPolicy, OriginMatcher, SecurityConfigRaw, SecurityConfigRawExt, origin_matches,
+    };
     use http::HeaderValue;
 
     /// Parse `spec` into a `List` policy and return its matchers, or panic


### PR DESCRIPTION
## Summary

Starts **Phase 4 (config unification)** — **T18, part a**. Extracts the mediator's TOML **schema** (the `*ConfigRaw` serde types) into a new, dependency-light crate `affinidi-messaging-mediator-config`, so it can later be shared with the `mediator-setup` wizard (which today hand-renders the same TOML with zero shared types). Byte-behaviour-identical; the mediator consumes the crate via a re-export shim.

The config module already had a clean **RAW (serde) vs RESOLVED (runtime)** seam — this follows it.

## What moved vs stayed

**Crate (schema only, lean — serde + lean mediator-common):** `ConfigRaw` + `ServerConfig` / `StreamingConfig` / `DIDResolverConfig` / `SecretsConfigRaw` / `StorageConfig` / `SecurityConfigRaw` / `LimitsConfigRaw` / `ProcessorsConfigRaw` (+ forwarding/cleanup raw structs) and their serde default fns. Dep tree is serde + regex/serde_json/thiserror only — **no axum/redis/tokio/SDK**.

**Mediator (all runtime):** the resolved `Config` / `SecurityConfig` / `LimitsConfig` / `ProcessorsConfig`, every `ConfigRaw → Config` conversion, secret-backend/VTA/DID-resolver loading. The mediator re-exports the crate (`pub use affinidi_messaging_mediator_config::*`) so every `crate::common::config::*` path — and external consumers like `affinidi-messaging-test-mediator` — keep resolving unchanged.

Three conversions the orphan rule no longer permits as inherent/`TryFrom` impls became free fns / an extension trait, **bodies verbatim**: `did_resolver_cache_config`, `forwarding_config_from_raw`, `SecurityConfigRawExt::convert`.

## mediator-common change

`DatabaseConfigRaw` is the one raw field type that lives in mediator-common, behind the heavy `server` feature. The `database` module is now un-gated so the lean crate can embed it with `default-features = false`; only the `DatabaseConfig` `TryFrom` (returns `MediatorError`) stays `server`-gated. Additive — server builds unchanged. (mediator-common `0.15.11`.)

## Scope note (refinement found during implementation)

The env-var override logic and boot-time validation were originally slated for this PR, but both carry mediator-common's **server-tier `MediatorError`**. Moving them to the lean schema crate would either pull the server stack or need a crate-local error type — the same coupling validation has. So they move **together in T18b** (with that error type), keeping this PR a clean schema relocation. The natural a/b boundary turned out to be "schema vs loading+validation", not "types vs adoption".

## Verification

- **Golden test** (in the crate): parses the shipped `conf/mediator.toml` into the relocated `ConfigRaw`.
- mediator lib **144**, mediator-common **141**, config crate **1**, `affinidi-messaging-test-mediator` e2e (incl. `cross_mediator_forwarding`, which loads config) — **all green**.
- Clippy clean on both feature sets (default redis-backend; `--no-default-features --features didcomm,memory-backend,fjall-backend`).
- The config crate builds standalone with no server-stack deps (verified via `cargo tree`).
- Versions: mediator `0.15.40`, mediator-common `0.15.11`, mediator-config `0.1.0`.

## Follow-ups
- **T18b:** move env-overrides + validation into the crate (crate-local config error type); golden round-trip tests.
- **T19:** mediator-setup adopts the crate. **T20:** `[vta]` consolidation.
