### PR TITLE
test: round-trip guard for the setup wizard's config against the shared schema (simplification T19)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -162,6 +162,9 @@ serial_test = "3"
 ## VTA's `/auth/challenge` and `/auth/` endpoints so we can verify
 ## the wrapper returns the right `AttemptOutcome` without a live VTA.
 wiremock = "0.6"
+## Round-trip guard: the config-writer tests parse the wizard's generated TOML
+## into the mediator's shared `ConfigRaw` schema so the two can't drift apart.
+affinidi-messaging-mediator-config = { path = "../../affinidi-messaging-mediator-config" }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -729,6 +729,74 @@ mod tests {
         assert!(!toml.contains("context = "));
     }
 
+    /// Round-trip drift guard (mediator T19): every wizard-generated config must
+    /// deserialize into the mediator's shared `ConfigRaw` schema. The wizard
+    /// renders TOML from a commented template via `toml_edit` (so operators keep
+    /// the inline docs); this proves that output still matches the types the
+    /// mediator actually parses, so the wizard and the mediator can't silently
+    /// drift apart. Covers the renderer's main branches (network mode, storage
+    /// backend, CORS, secret backend, VTA vs self-hosted).
+    #[test]
+    fn generated_config_parses_as_shared_config_schema() {
+        use crate::consts;
+        use affinidi_messaging_mediator_config::ConfigRaw;
+
+        let cases: Vec<(&str, WizardConfig)> = vec![
+            (
+                "open / redis / string-backend",
+                WizardConfig {
+                    network_mode: consts::NETWORK_MODE_OPEN.into(),
+                    secret_storage: consts::STORAGE_STRING.into(),
+                    database_url: consts::DEFAULT_REDIS_URL.into(),
+                    listen_address: consts::DEFAULT_LISTEN_ADDR.into(),
+                    ..WizardConfig::default()
+                },
+            ),
+            (
+                "closed / fjall / cors-list",
+                WizardConfig {
+                    network_mode: consts::NETWORK_MODE_CLOSED.into(),
+                    storage_backend: consts::STORAGE_BACKEND_FJALL.into(),
+                    fjall_data_dir: "./data".into(),
+                    cors_mode: consts::CORS_MODE_LIST.into(),
+                    cors_domains: "https://app.affinidi.com".into(),
+                    ..WizardConfig::default()
+                },
+            ),
+            (
+                "vta-online",
+                WizardConfig {
+                    use_vta: true,
+                    vta_mode: consts::VTA_MODE_ONLINE.into(),
+                    did_method: consts::DID_VTA.into(),
+                    secret_storage: consts::STORAGE_VTA.into(),
+                    ..WizardConfig::default()
+                },
+            ),
+        ];
+
+        for (label, cfg) in cases {
+            let generated = test_generated();
+            let toml = generate_toml(&cfg, &generated)
+                .unwrap_or_else(|e| panic!("[{label}] generate_toml failed: {e}"));
+            let parsed: ConfigRaw = toml::from_str(&toml).unwrap_or_else(|e| {
+                panic!(
+                    "[{label}] wizard output must parse as the mediator's ConfigRaw schema: {e}\n\
+                     --- generated ---\n{toml}"
+                )
+            });
+            // Spot-check that wizard-set values survived the round trip.
+            assert!(
+                parsed.mediator_did.contains(&generated.mediator_did),
+                "[{label}] mediator_did round-trips into the schema"
+            );
+            assert!(
+                !parsed.secrets.backend.is_empty(),
+                "[{label}] secrets.backend is populated"
+            );
+        }
+    }
+
     #[test]
     fn test_generate_toml_vta() {
         let config = WizardConfig {


### PR DESCRIPTION
## Summary

**T19** — closes the structural drift gap between the `mediator-setup` wizard and the mediator's config schema.

Per the agreed approach (chosen over the literal "rip out toml_edit and serde-serialize" plan): the wizard renders `mediator.toml` from a **commented template** via `toml_edit`, which gives operators a richly-documented config. Replacing that with bare typed serialization would lose every comment — an operator-UX regression that also fights **T20** (whose point is documenting limits inline). So instead of changing the renderer, this adds a **CI round-trip guard**.

## What's added

- **`generated_config_parses_as_shared_config_schema`** — for representative wizard configurations spanning the renderer's branches (open/closed network mode, redis/fjall storage, CORS list, string/VTA secret backends), the generated TOML must deserialize into the mediator's shared `affinidi_messaging_mediator_config::ConfigRaw`. A renamed or dropped field now breaks the build, so the wizard and mediator can't silently drift apart.
- The wizard's `DEFAULT_TEMPLATE` is `include_str!("…/conf/mediator.toml")` — the shipped config — which the config crate's **golden parse test already covers** (T18a). So both the template *and* the filled-in wizard output are guarded.

`affinidi-messaging-mediator-config` added as a **dev-dependency**.

## Why no renderer change

Keeping `toml_edit` + the commented template preserves operator UX and sets up T20 cleanly. The shared-schema *guarantee* comes from the round-trip test, not from forcing a single serialization code path. (If you'd prefer the full typed-serialization route later, it's a clean follow-up — the schema crate already supports it.)

## Verification

- New test passes; full `mediator-setup` suite **361** green; clippy clean.
- **Test/CI-only** — no renderer change (wizard output byte-identical), no version bump. The guard runs in the normal workspace `cargo test` CI job.

## Follow-up
- **T20:** consolidate the `[vta]` config section + document every limit inline with scale guidance (closes Phase 4).
