### PR TITLE
fix: require mediator-common >=0.15.11 in mediator-config so publish finds the un-gated database module

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -24,7 +24,14 @@ tracing = "0.1"
 # For `DatabaseConfigRaw` (the one raw field type that lives in mediator-common)
 # and the lean ACL types used by validation. `default-features = false` keeps
 # this crate off the axum/redis/secrets stack.
-affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator-common", default-features = false }
+#
+# Pinned to >=0.15.11 (not the looser "0.15"): the lean `database::config`
+# module — which holds `DatabaseConfigRaw` — only became available without the
+# `server` feature in 0.15.11. The older published 0.15.10 still gates it behind
+# `server`, so a "0.15" requirement lets `cargo publish` resolve to 0.15.10 and
+# fail with "cannot find `database`". This floor also tells the release tooling
+# that this crate must publish *after* mediator-common 0.15.11.
+affinidi-messaging-mediator-common = { version = "0.15.11", path = "../affinidi-messaging-mediator-common", default-features = false }
 
 [dev-dependencies]
 # `check_tls` test writes temp cert/key files.


### PR DESCRIPTION
## Problem

Publishing `affinidi-messaging-mediator-config 0.1.1` fails in CI:

```
error[E0433]: cannot find `database` in `affinidi_messaging_mediator_common`
 --> src/schema.rs:4
note: found an item that was configured out
 --> .../affinidi-messaging-mediator-common-0.15.10/src/lib.rs:33
 32 | #[cfg(feature = "server")]
 33 | pub mod database;
```

## Root cause

This crate embeds `DatabaseConfigRaw` (from `mediator_common::database::config`) in its `ConfigRaw`, and takes mediator-common with `default-features = false` to stay lean. The `database` module only became available **without** the `server` feature in **mediator-common 0.15.11** (the T18a change); the published **0.15.10** still gates it behind `server`.

The dependency was declared `version = "0.15"`, which permits 0.15.10. On `cargo publish` the `path` is stripped and the version requirement alone is used, so the publisher resolved to the stale **0.15.10** and the lean build failed to find `database`.

## Fix

Pin the requirement to `version = "0.15.11"` (`>=0.15.11, <0.16`). This:
- prevents resolving to any mediator-common without the un-gated `database` module, and
- makes the dependency explicit to the release tooling, so **mediator-common 0.15.11 publishes before this crate**.

## Notes / verification

- No code or crate-version change. The local workspace build uses the path dependency (already 0.15.11), so the build, the config-crate tests (11), and the mediator build are unaffected.
- **Release order:** mediator-common 0.15.11 must be on crates.io before this crate publishes — the pin now enforces that ordering. (mediator-setup is `publish = false`, so its path-only dev-dependency on this crate is not a publish concern.)
- Longer-term, this cross-crate coupling could be removed entirely by moving `DatabaseConfigRaw` into this (leaf) crate so it has no mediator-common dependency — happy to do that as a follow-up if the ordering proves fragile.
