### PR TITLE
fix: define DatabaseConfigRaw in mediator-config so it publishes against the released mediator-common 0.15.10

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -48,7 +48,10 @@
   `MediatorError`; they move together in T18b (with a crate-local config error
   type) rather than dragging the server stack into the schema crate. Behaviour is
   byte-identical; a golden test parses the shipped `conf/mediator.toml` into the
-  relocated `ConfigRaw`. mediator-common bumped to 0.15.11 (additive).
+  relocated `ConfigRaw`. (`DatabaseConfigRaw` — the one raw field type that
+  previously lived in mediator-common — is defined in the config crate itself, so
+  mediator-common is unchanged and the schema crate stays publishable against any
+  0.15.x.)
 
 ### 0.15.39 — Schema-version marker for the Fjall backend (simplification T17, part 2)
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,19 +4,6 @@
 
 ## 12th June 2026
 
-### 0.15.11 — Make `DatabaseConfigRaw` available without the `server` feature (simplification T18, part a)
-
-- The `database` module (and its `config` submodule holding `DatabaseConfigRaw`
-  / `DatabaseConfig`) is no longer gated behind the `server` feature — it's now
-  always available. The new dependency-light `affinidi-messaging-mediator-config`
-  crate embeds `DatabaseConfigRaw` in its top-level `ConfigRaw` and needs it with
-  `default-features = false`.
-- Only the parts that require the server tier stay gated: the
-  `TryFrom<DatabaseConfigRaw> for DatabaseConfig` conversion (it returns
-  `MediatorError`) is now `#[cfg(feature = "server")]`, and `DatabaseHandler` +
-  its redis helpers remain on `redis-backend`. Purely additive for lean
-  consumers; server builds are unchanged.
-
 ### 0.15.10 — Consolidate the access-list method family (simplification T16, part 3)
 
 - Extracts the access-list admission *decision* into `store::ops`: a new

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.11"
+version = "0.15.10"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/config.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/config.rs
@@ -1,10 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-// The raw/typed structs below are lean (pure serde) so the
-// `affinidi-messaging-mediator-config` crate can embed `DatabaseConfigRaw`
-// without the `server` stack. Only the `TryFrom` conversion needs
-// `MediatorError`, so it (and this import) is gated on `server`.
-#[cfg(feature = "server")]
 use crate::errors::MediatorError;
 
 /// Database Struct contains database and storage of messages related configuration details
@@ -50,7 +45,6 @@ impl Default for DatabaseConfig {
     }
 }
 
-#[cfg(feature = "server")]
 impl std::convert::TryFrom<DatabaseConfigRaw> for DatabaseConfig {
     type Error = MediatorError;
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -24,13 +24,12 @@ pub mod types;
 
 #[cfg(feature = "server")]
 pub mod circuit_breaker;
-/// Database wiring. The raw serde structs in `database::config`
-/// (`DatabaseConfigRaw`, `DatabaseConfig`) are **always available** —
-/// the lean `affinidi-messaging-mediator-config` crate embeds
-/// `DatabaseConfigRaw` in its top-level `ConfigRaw` and must reach it
-/// with `default-features = false`. The `DatabaseConfig` `TryFrom`
-/// (which returns `MediatorError`) is gated on `server`, and
-/// `DatabaseHandler` + its redis helpers are gated on `redis-backend`.
+/// Database wiring: the lean `DatabaseConfig` serde struct is always
+/// available under `server` (the mediator's main config parses it
+/// regardless of which storage backend is selected). The
+/// `DatabaseHandler` and its redis-specific helpers are gated inside
+/// the module on `redis-backend`.
+#[cfg(feature = "server")]
 pub mod database;
 #[cfg(feature = "server")]
 pub mod errors;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
@@ -26,6 +26,9 @@
   these types and keeps all runtime resolution; the goal is one schema shared
   with the `mediator-setup` wizard.
 - Dependency-light by design: serde + the lean (`default-features = false`) tier
-  of `affinidi-messaging-mediator-common` (for `DatabaseConfigRaw`). No
-  server/runtime dependencies.
+  of `affinidi-messaging-mediator-common` (only for the always-available ACL
+  types used by validation). The raw `DatabaseConfigRaw` is defined in this crate
+  rather than imported from mediator-common's `server`-gated `database` module,
+  so the crate builds and publishes against any 0.15.x without needing that
+  module un-gated. No server/runtime dependencies.
 - A golden test parses the shipped `conf/mediator.toml` into `ConfigRaw`.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -21,17 +21,15 @@ toml = "1"
 thiserror = "2"
 # Structured logging in the file-reading helpers, matching the mediator.
 tracing = "0.1"
-# For `DatabaseConfigRaw` (the one raw field type that lives in mediator-common)
-# and the lean ACL types used by validation. `default-features = false` keeps
-# this crate off the axum/redis/secrets stack.
-#
-# Pinned to >=0.15.11 (not the looser "0.15"): the lean `database::config`
-# module — which holds `DatabaseConfigRaw` — only became available without the
-# `server` feature in 0.15.11. The older published 0.15.10 still gates it behind
-# `server`, so a "0.15" requirement lets `cargo publish` resolve to 0.15.10 and
-# fail with "cannot find `database`". This floor also tells the release tooling
-# that this crate must publish *after* mediator-common 0.15.11.
-affinidi-messaging-mediator-common = { version = "0.15.11", path = "../affinidi-messaging-mediator-common", default-features = false }
+# Only for the lean ACL types used by validation (`types::acls`, always available
+# regardless of features). `default-features = false` keeps this crate off the
+# axum/redis/secrets stack. `DatabaseConfigRaw` is defined locally (see
+# `schema.rs`) rather than imported from mediator-common's `database` module —
+# that module is `server`-gated in the published mediator-common, so importing it
+# would force this lean crate to require an unpublished mediator-common just to
+# `cargo publish`. Keeping the raw DB schema here (it *is* config schema) lets
+# this crate build against any published 0.15.x.
+affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator-common", default-features = false }
 
 [dev-dependencies]
 # `check_tls` test writes temp cert/key files.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
@@ -1,10 +1,27 @@
 //! Top-level raw config schema (`[server]`, `[streaming]`, `[did_resolver]`,
 //! `[secrets]`, `[storage]`, and the `ConfigRaw` root).
 
-use affinidi_messaging_mediator_common::database::config::DatabaseConfigRaw;
 use serde::{Deserialize, Serialize};
 
 use crate::{LimitsConfigRaw, ProcessorsConfigRaw, SecurityConfigRaw};
+
+/// `[database]` section schema (raw, all-strings TOML form).
+///
+/// Defined here rather than imported from mediator-common: that crate gates its
+/// `database` module behind the `server` feature, so importing `DatabaseConfigRaw`
+/// would force this lean schema crate to depend on a build of mediator-common
+/// that exposes `database` without `server` — a publish-ordering hazard (the
+/// published mediator-common keeps `database` gated). The raw DB config is config
+/// schema, so it lives here; the resolved `DatabaseConfig` (with circuit-breaker
+/// tuning, used by the runtime `DatabaseHandler`) stays in mediator-common, and
+/// the mediator converts between them.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DatabaseConfigRaw {
+    pub functions_file: String,
+    pub database_url: String,
+    pub database_timeout: String,
+    pub scripts_path: Option<String>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerConfig {

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -78,6 +78,24 @@ fn did_resolver_cache_config(raw: &DIDResolverConfig) -> DIDCacheConfig {
     config.build()
 }
 
+/// Build the runtime [`DatabaseConfig`] from the raw `[database]` schema.
+/// `DatabaseConfigRaw` lives in the config crate and `DatabaseConfig` in
+/// mediator-common, so this is a free function (the orphan rule forbids a
+/// `TryFrom` impl here). Mirrors mediator-common's former
+/// `TryFrom<DatabaseConfigRaw>` exactly: the circuit-breaker tuning is fixed
+/// here and `database_timeout` falls back to 2 on a parse error.
+fn database_config_from_raw(
+    raw: affinidi_messaging_mediator_config::DatabaseConfigRaw,
+) -> DatabaseConfig {
+    DatabaseConfig {
+        functions_file: Some(raw.functions_file),
+        database_url: raw.database_url,
+        database_timeout: raw.database_timeout.parse().unwrap_or(2),
+        circuit_breaker_threshold: 5,
+        circuit_breaker_recovery_secs: 10,
+    }
+}
+
 /// Default VTA cache TTL when `[secrets].cache_ttl` is not set.
 const DEFAULT_CACHE_TTL_SECS: u64 = 30 * 86_400; // 30 days
 
@@ -644,7 +662,7 @@ impl TryFrom<ConfigRaw> for Config {
             mediator_did,
             admin_did: read_did_config(&raw.server.admin_did, &aws_config, "admin_did").await?,
             local_endpoints: raw.server.local_endpoints,
-            database: raw.database.try_into()?,
+            database: database_config_from_raw(raw.database),
             streaming_enabled: raw.streaming.enabled.parse().unwrap_or_else(|_| {
                 warn!(
                     "Could not parse streaming.enabled value '{}', using default: true",


### PR DESCRIPTION
## Problem

Publishing `affinidi-messaging-mediator-config` keeps failing — even after #430:

```
failed to select a version for the requirement `affinidi-messaging-mediator-common = "^0.15.11"`
candidate versions found which didn't match: 0.15.10, 0.15.9, ...
```

The crate embedded `DatabaseConfigRaw` from mediator-common's `database` module, which is **`server`-gated in the released 0.15.10**. T18a un-gated it in an **unreleased 0.15.11** and #430 pinned config to `>=0.15.11` — but **0.15.11 can't be published right now**, so `cargo publish` of config has no satisfiable mediator-common.

## Fix — remove the coupling instead of depending on an unpublished crate

- **mediator-config defines its own `DatabaseConfigRaw`** (it *is* config schema, so it belongs here) and depends on mediator-common only for the always-available `types::acls` used by validation. Its requirement is back to the normal `"0.15"`, so it builds/publishes against the **released 0.15.10**. (`cargo tree` confirms the crate is still lean — no server stack.)
- **mediator-common reverted to 0.15.10**: the `database` module is `server`-gated again (the un-gating is now unused), so the workspace matches crates.io and the release has **no unpublishable mediator-common to attempt**.
- The mediator converts the now-config-owned `DatabaseConfigRaw` → mediator-common's runtime `DatabaseConfig` via a small free fn (`database_config_from_raw`); the orphan rule forbids the old `TryFrom` once both types are foreign. The conversion mirrors the former impl exactly.
- CHANGELOG entries corrected to drop the references to the reverted 0.15.11.

This also **permanently removes** the cross-crate version coupling that caused #430 and this failure — `mediator-config` no longer cares which mediator-common patch is published.

## Publish impact

- mediator-common: **0.15.10** (already on crates.io — release skips it).
- mediator-config: **0.1.1**, now builds against 0.15.10 → publishes.
- mediator: **0.15.41** (unpublished) — builds with the new conversion.
- mediator-setup: `publish = false`.

## Verification

Behaviour-identical. config **11** (golden parse), mediator lib **134**, store-conformance **20/20**, test-mediator e2e **all green**; clippy clean on both feature sets; mediator-common lean build + mediator-setup build OK. No version bumps.
