### PR TITLE
refactor: centralise secret-backend opening in mediator-setup (simplification T21)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 12th June 2026
+
+### 0.1.11 — Centralise secret-backend opening (simplification T21)
+
+- The online (`provision_secret_backend`) and sealed/headless
+  (`bootstrap_headless`: seed sweep, phase-1, phase-2) flows each inlined the
+  same `MediatorSecrets::from_url` + `probe()` + error-mapping. Extracted into a
+  small `secret_backend` module — `open_secret_backend` (open) and
+  `open_and_probe_secret_backend` (open + fail-fast probe) — so the four call
+  sites share one implementation. Behaviour-identical refactor; the rest of the
+  VTA session lifecycle was already centralised (`VtaSession` +
+  `provision_secret_backend`), so no further extraction was warranted.
+
 ## 9th June 2026
 
 ### 0.1.10 — optional did:web export for self-hosted webvh DIDs

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.10"
+version = "0.1.11"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
@@ -31,7 +31,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use affinidi_messaging_mediator_common::MediatorSecrets;
 use tracing::{info, warn};
 
 use crate::consts::{VTA_MODE_ONLINE, VTA_MODE_SEALED_EXPORT, VTA_MODE_SEALED_MINT};
@@ -155,7 +154,7 @@ fn resolve_bootstrap_seed_ttl() -> Duration {
 /// more actionable error if the backend is actually broken.
 async fn sweep_stale_bootstrap_seeds(config: &crate::app::WizardConfig) {
     let backend_url = crate::config_writer::build_backend_url(config);
-    let store = match MediatorSecrets::from_url(&backend_url) {
+    let store = match crate::secret_backend::open_secret_backend(&backend_url) {
         Ok(s) => s,
         Err(e) => {
             warn!(
@@ -194,12 +193,7 @@ async fn phase1_emit_request(config: &crate::app::WizardConfig) -> anyhow::Resul
     // secret store — no point minting a request, writing it to disk,
     // and then discovering `aws_secrets://...` can't talk to AWS.
     let backend_url = crate::config_writer::build_backend_url(config);
-    let store = MediatorSecrets::from_url(&backend_url)
-        .map_err(|e| anyhow::anyhow!("open secret backend '{backend_url}': {e}"))?;
-    store
-        .probe()
-        .await
-        .map_err(|e| anyhow::anyhow!("secret backend '{backend_url}' failed probe: {e}"))?;
+    let store = crate::secret_backend::open_and_probe_secret_backend(&backend_url).await?;
 
     // Refuse to clobber an in-flight bootstrap. The backend index is
     // our cross-invocation state now; any entry means "a request is
@@ -313,8 +307,7 @@ async fn phase2_apply(
 
     // Open the backend up front; a broken store is a phase-2 fatal.
     let backend_url = crate::config_writer::build_backend_url(config);
-    let store = MediatorSecrets::from_url(&backend_url)
-        .map_err(|e| anyhow::anyhow!("open secret backend '{backend_url}': {e}"))?;
+    let store = crate::secret_backend::open_secret_backend(&backend_url)?;
 
     // Reconstruct a synthetic `SealedHandoffState` keyed to this
     // bundle. The reconstructed state doesn't need the ephemeral

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -12,6 +12,7 @@ mod generators;
 mod recipe;
 mod reprovision;
 mod sealed_handoff;
+mod secret_backend;
 mod secure_fs;
 mod ui;
 mod vta;
@@ -1408,12 +1409,7 @@ async fn provision_secret_backend(
         );
     }
     let mediator_secrets_store =
-        affinidi_messaging_mediator_common::MediatorSecrets::from_url(&backend_url)
-            .map_err(|e| anyhow::anyhow!("Failed to open secret backend '{backend_url}': {e}"))?;
-    mediator_secrets_store
-        .probe()
-        .await
-        .map_err(|e| anyhow::anyhow!("Secret backend '{backend_url}' failed probe: {e}"))?;
+        secret_backend::open_and_probe_secret_backend(&backend_url).await?;
 
     // JWT signing key — only when generated. Provide-mode skips this
     // and relies on the boot-time env-var/flag path.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
@@ -1,0 +1,50 @@
+//! Opening the unified secret backend (`MediatorSecrets`).
+//!
+//! Every provisioning flow (online via `provision_secret_backend`, and the
+//! sealed/headless flows in `bootstrap_headless`) opens the configured secret
+//! store the same way: `MediatorSecrets::from_url` with consistent error
+//! context, optionally followed by a liveness `probe()`. Centralised here so
+//! that `from_url` + probe + error-mapping isn't re-inlined per flow.
+//!
+//! These take an already-resolved `backend_url` (from
+//! [`config_writer::build_backend_url`](crate::config_writer::build_backend_url))
+//! rather than the wizard config, so callers that also need the URL for their
+//! own output — e.g. the keyring first-access note — resolve it once and pass it
+//! in.
+
+use affinidi_messaging_mediator_common::MediatorSecrets;
+
+/// Open the unified secret backend at `backend_url` (no liveness probe).
+/// Prefer [`open_and_probe_secret_backend`] when you want to fail fast on a
+/// misconfigured/unreachable store before doing real work.
+pub fn open_secret_backend(backend_url: &str) -> anyhow::Result<MediatorSecrets> {
+    MediatorSecrets::from_url(backend_url)
+        .map_err(|e| anyhow::anyhow!("open secret backend '{backend_url}': {e}"))
+}
+
+/// Open the unified secret backend and probe it, so a misconfigured or
+/// unreachable store (e.g. `aws_secrets://` with no credentials) fails fast with
+/// an actionable error instead of part-way through provisioning.
+pub async fn open_and_probe_secret_backend(backend_url: &str) -> anyhow::Result<MediatorSecrets> {
+    let store = open_secret_backend(backend_url)?;
+    store
+        .probe()
+        .await
+        .map_err(|e| anyhow::anyhow!("secret backend '{backend_url}' failed probe: {e}"))?;
+    Ok(store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_round_trips_a_file_backend_url() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let url = format!("file://{}", dir.path().join("secrets.json").display());
+        assert!(
+            open_secret_backend(&url).is_ok(),
+            "a file:// backend URL should open"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**T21 (Phase 5)** — centralises the one piece of genuinely-duplicated VTA-flow setup logic.

The plan framed T21 as "extract the shared VTA session lifecycle (online/sealed/headless)" — an "L, split per flow" refactor. The audit found that was **largely already done**: `VtaSession` is the unified type all three flows converge on, and secret *persistence* is already centralised in `main::provision_secret_backend` (reached by every flow via `generate_and_write`). The only real remaining duplication was the **secret-backend open block** — `MediatorSecrets::from_url` + `probe()` + error-mapping — inlined at four call sites.

## Change

New `secret_backend` module:
- `open_secret_backend(url)` — open (no probe).
- `open_and_probe_secret_backend(url)` — open + fail-fast probe.

Both take an already-resolved backend URL so callers that also print it (the keyring first-access note in `provision_secret_backend`) resolve it once. The four sites — online `provision_secret_backend`, and `bootstrap_headless`'s stale-seed sweep / phase-1 / phase-2 — now share one implementation. The now-unused top-level `MediatorSecrets` import is removed (the tests keep their own local imports).

Behaviour-identical (it's a dedup).

## Verification

- Full `mediator-setup` suite **362** green (361 + the new `secret_backend` file-backend test); clippy clean (`--all-targets`).
- `mediator-setup` `0.1.11` (`publish = false`).

## Phase 5 status
- **T21 ✅** (this PR).
- **T22:** merge headless + CLI setup paths; config-equivalence test.
- **T23:** feature-gate secrets backends (3 in the default build, all kept maintained + CI-tested per the locked-in decision).
