### PR TITLE
refactor: unify the non-interactive setup paths + add a config-equivalence test (simplification T22)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## 12th June 2026
 
+### 0.1.12 — Unify the non-interactive setup paths (simplification T22)
+
+- The interactive, `--non-interactive`, and `--from <recipe>` flows each inlined
+  the same re-run safety guard (`inspect_existing` + `refuse_overwrite`); the two
+  non-interactive flows also duplicated the config-summary banner. Extracted
+  `guard_existing_setup` (now shared by all three) and `print_config_summary`
+  (shared by both non-interactive flows). The `--non-interactive` config build is
+  now a testable `build_config_from_args` helper.
+- New **config-equivalence test**: the CLI-args path and the recipe path render a
+  byte-identical `mediator.toml` for the same logical setup, so the two
+  non-interactive entry points can't drift apart. Behaviour-identical refactor.
+
 ### 0.1.11 — Centralise secret-backend opening (simplification T21)
 
 - The online (`provision_secret_backend`) and sealed/headless

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.11"
+version = "0.1.12"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 
-#[derive(Parser)]
+// `Default` lets tests construct an `Args` with `..Default::default()` (all
+// flags off / `None`) and set only the fields under test — clap always fully
+// populates it at runtime, so the derive is test-only ergonomics.
+#[derive(Parser, Default)]
 #[command(
     name = "mediator-setup",
     about = "Interactive setup wizard for Affinidi Messaging Mediator"

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -797,6 +797,45 @@ mod tests {
         }
     }
 
+    /// Config-equivalence guard (mediator T22): the two non-interactive setup
+    /// paths — `--non-interactive` (CLI args → `build_config_from_args`) and
+    /// `--from <recipe>` (`recipe::to_wizard_config`) — must produce the SAME
+    /// `mediator.toml` for the same logical setup, so they can't drift apart.
+    /// Both build on `WizardConfig::default()`, so an equivalent recipe yields a
+    /// byte-identical render.
+    #[test]
+    fn cli_and_recipe_paths_produce_identical_config() {
+        // The non-interactive defaults: local / VTA-online / didcomm / did:vta /
+        // keyring / redis / generate-admin (a bare `Args` applies exactly these).
+        let cli_config =
+            crate::build_config_from_args(&crate::cli::Args::default()).expect("build from args");
+
+        // The same setup expressed as a recipe.
+        let recipe_toml = r#"
+[deployment]
+type = "local"
+protocols = ["didcomm"]
+use_vta = true
+vta_mode = "online"
+
+[identity]
+did_method = "vta"
+
+[secrets]
+storage = "keyring://affinidi-mediator"
+"#;
+        let recipe: crate::recipe::BuildRecipe = toml::from_str(recipe_toml).expect("parse recipe");
+        let recipe_config = crate::recipe::to_wizard_config(&recipe).expect("recipe -> config");
+
+        let generated = test_generated();
+        assert_eq!(
+            generate_toml(&cli_config, &generated).expect("cli generate_toml"),
+            generate_toml(&recipe_config, &generated).expect("recipe generate_toml"),
+            "the --non-interactive and --from <recipe> paths must render identical \
+             mediator.toml for the same setup",
+        );
+    }
+
     #[test]
     fn test_generate_toml_vta() {
         let config = WizardConfig {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -140,12 +140,7 @@ async fn main() -> anyhow::Result<()> {
     // file-level backup below still runs from `mediator.toml` alone.
     let config_path = args.config.clone();
     let config_path_obj = std::path::Path::new(&config_path);
-    if !args.force_reprovision
-        && let Some(setup) = reprovision::inspect_existing(config_path_obj).await?
-        && setup.is_provisioned()
-    {
-        reprovision::refuse_overwrite(config_path_obj, &setup);
-    }
+    guard_existing_setup(config_path_obj, args.force_reprovision).await?;
     if config_path_obj.exists() {
         // Operator opted in (or there were no provisioned keys —
         // e.g. backend was wiped manually). Back up the existing
@@ -255,20 +250,30 @@ fn apply_cli_args(args: &Args, config: &mut WizardConfig) {
     }
 }
 
-/// Non-interactive mode: build config from CLI args + deployment defaults, then generate.
-async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
-    // Same re-run safety story as the interactive flow — refuse to
-    // overwrite an existing setup unless `--force-reprovision` is
-    // set. Skip the keyring scan when the operator has already opted
-    // in (see the matching note in `main()` above).
-    let existing_path = std::path::Path::new(&args.config);
-    if !args.force_reprovision
-        && let Some(setup) = reprovision::inspect_existing(existing_path).await?
+/// Refuse to overwrite an existing *provisioned* setup unless
+/// `--force-reprovision` is set — shared by the interactive, non-interactive,
+/// and recipe flows so none can silently rotate live keys (the unified backend
+/// holds the JWT key, admin credential, and operating keys). When the operator
+/// has opted in, the keyring scan is skipped (it can trigger one macOS Keychain
+/// prompt per well-known key). Diverges (process exit) when it refuses.
+async fn guard_existing_setup(
+    config_path: &std::path::Path,
+    force_reprovision: bool,
+) -> anyhow::Result<()> {
+    if !force_reprovision
+        && let Some(setup) = reprovision::inspect_existing(config_path).await?
         && setup.is_provisioned()
     {
-        reprovision::refuse_overwrite(existing_path, &setup);
+        reprovision::refuse_overwrite(config_path, &setup);
     }
+    Ok(())
+}
 
+/// Build a [`WizardConfig`] from CLI args layered over deployment defaults — the
+/// non-interactive (`--non-interactive`) path's config source. Extracted so the
+/// CLI-args path is unit-testable and can be checked for equivalence against the
+/// recipe path's [`recipe::to_wizard_config`].
+pub(crate) fn build_config_from_args(args: &Args) -> anyhow::Result<WizardConfig> {
     let deployment = args.deployment.unwrap_or(cli::DeploymentType::Local);
 
     let mut config = WizardConfig::default();
@@ -286,14 +291,20 @@ async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
     config.admin_did_mode = ADMIN_GENERATE.into();
 
     // Override with any explicit CLI args
-    apply_cli_args(&args, &mut config);
+    apply_cli_args(args, &mut config);
 
     // Validate required fields for did:webvh
     if config.did_method == DID_WEBVH && config.public_url.is_empty() {
         anyhow::bail!("--public-url is required when using did:webvh in non-interactive mode");
     }
 
-    println!("Mediator Setup (non-interactive)");
+    Ok(config)
+}
+
+/// Print the shared "what we're about to generate" summary used by both
+/// non-interactive entry points (`--non-interactive` and `--from <recipe>`),
+/// so the two stay consistent.
+fn print_config_summary(config: &WizardConfig) {
     println!("  Deployment:   {}", config.deployment_type);
     println!(
         "  VTA:          {}",
@@ -309,6 +320,20 @@ async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
     println!("  SSL/TLS:      {}", config.ssl_mode);
     println!("  Database:     {}", config.database_url);
     println!("  Admin:        {}", config.admin_did_mode);
+    println!("  Config file:  {}", config.config_path);
+    println!("  Listen:       {}", config.listen_address);
+}
+
+/// Non-interactive mode: build config from CLI args + deployment defaults, then generate.
+async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
+    // Same re-run safety story as the interactive flow — refuse to
+    // overwrite an existing setup unless `--force-reprovision` is set.
+    guard_existing_setup(std::path::Path::new(&args.config), args.force_reprovision).await?;
+
+    let config = build_config_from_args(&args)?;
+
+    println!("Mediator Setup (non-interactive)");
+    print_config_summary(&config);
     println!();
     println!("Generating cryptographic material...");
 
@@ -334,13 +359,7 @@ async fn run_from_recipe(
     // Re-run safety: refuse to overwrite an existing provisioned setup
     // unless the operator opts in. This matches the interactive flow so
     // recipe-driven CI can't silently rotate live keys.
-    let target = std::path::Path::new(&config.config_path);
-    if let Some(setup) = reprovision::inspect_existing(target).await?
-        && setup.is_provisioned()
-        && !force_reprovision
-    {
-        reprovision::refuse_overwrite(target, &setup);
-    }
+    guard_existing_setup(std::path::Path::new(&config.config_path), force_reprovision).await?;
 
     // Check if database URL needs credentials — allow env var override
     if let Ok(env_url) = std::env::var("DATABASE_URL") {
@@ -353,23 +372,7 @@ async fn run_from_recipe(
 
     print_banner();
     println!("  \x1b[2mFrom recipe: {recipe_path}\x1b[0m\n");
-    println!("  Deployment:   {}", config.deployment_type);
-    println!(
-        "  VTA:          {}",
-        if config.use_vta {
-            format!("Enabled ({})", config.vta_mode)
-        } else {
-            "Disabled".into()
-        }
-    );
-    println!("  Protocol:     {}", config.protocol_display());
-    println!("  DID method:   {}", config.did_method);
-    println!("  Key storage:  {}", config.secret_storage);
-    println!("  SSL/TLS:      {}", config.ssl_mode);
-    println!("  Database:     {}", config.database_url);
-    println!("  Admin:        {}", config.admin_did_mode);
-    println!("  Config file:  {}", config.config_path);
-    println!("  Listen:       {}", config.listen_address);
+    print_config_summary(&config);
     println!();
 
     // Sealed-handoff dispatch:


### PR DESCRIPTION
## Summary

**T22 (Phase 5)** — unifies the wizard's non-interactive setup paths and adds a config-equivalence guard.

The wizard has three config-producing entry points — interactive TUI, `--non-interactive` (CLI args), and `--from <recipe>` — all converging on `generate_and_write`. But each **inlined the same re-run safety guard**, and the two non-interactive flows also **duplicated the config-summary banner**.

## Changes

Extracted shared helpers in `main.rs`:
- **`guard_existing_setup(path, force_reprovision)`** — the `inspect_existing` + `is_provisioned` + `refuse_overwrite` re-run guard, now shared by **all three** flows so none can silently rotate live keys.
- **`print_config_summary(config)`** — the Deployment/VTA/Protocol/… banner shared by both non-interactive flows.
- **`build_config_from_args(args)`** — the `--non-interactive` config build, lifted out so it's unit-testable. `Args` gains `#[derive(Default)]` for test construction (clap fully populates it at runtime).

## Config-equivalence test (T22 acceptance, builds on T19)

New test proves the **CLI-args path** (`build_config_from_args`) and the **recipe path** (`recipe::to_wizard_config`) render a **byte-identical `mediator.toml`** for the same logical setup — so the two non-interactive entry points can't drift apart. Both build on `WizardConfig::default()`, so an equivalent recipe yields the same render.

## Scope note

The paths can't *fully* merge — `--from <recipe>` adds sealed-handoff dispatch + auto-install + its own TOML format; `--non-interactive` is CLI-args-only. The genuinely shared surface is the guard + summary + the equivalence guarantee, which is what this unifies. (Same "plan overstates, audit right-sizes" pattern as T20/T21.)

## Verification

Behaviour-identical. Full `mediator-setup` suite **363** green (362 + the equivalence test); clippy clean (`--all-targets`). `mediator-setup 0.1.12` (`publish = false`).

## Phase 5 status
- T21 ✅ (merged), **T22 ✅** (this PR).
- **T23** next: feature-gate secrets backends — 3 in the default build, all kept maintained + CI-tested (per the locked-in decision).
