### PR TITLE
docs: document the secrets-backend feature matrix and lean default build (simplification T23)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/docs/secrets-backend.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/secrets-backend.md
@@ -41,6 +41,38 @@ keys can be fetched live from the VTA at startup — but the mediator's
 admin credential, JWT signing key, and (optionally) cached operating
 keys all live in whichever real backend the operator picks.
 
+## Which backends are compiled in
+
+**Every backend listed above is fully supported and maintained — none is
+deprecated.** What differs is whether a backend is compiled into a given
+binary, which keeps the default build (and its dependency/attack surface)
+small while leaving every backend one feature flag away.
+
+| Backend | Cargo feature | In the default build? |
+|---------|---------------|-----------------------|
+| `file://` / `file://…?encrypt=1` | *(always compiled)* | ✅ yes |
+| `keyring://` | `secrets-keyring` | opt-in |
+| `aws_secrets://` | `secrets-aws` | opt-in |
+| `gcp_secrets://` | `secrets-gcp` | opt-in |
+| `azure_keyvault://` | `secrets-azure` | opt-in |
+| `vault://` | `secrets-vault` | opt-in |
+
+The default build compiles only the dependency-free `file://` backend (plain
+and AEAD-encrypted) — the cloud/OS backends each pull a sizeable SDK, so they
+are gated behind opt-in `secrets-*` features rather than shipped in every
+binary. Enable the ones a deployment needs, e.g.:
+
+```bash
+cargo build --release --features secrets-aws,secrets-vault
+```
+
+Configuring a backend whose feature wasn't compiled in fails fast at startup
+with an actionable message naming the flag — e.g. *"compiled without the
+'secrets-aws' feature; rebuild with `cargo build --features secrets-aws` to
+enable"* — never a silent fallback. CI (`checks-features.yaml`) builds the
+mediator and the setup wizard against **each** `secrets-*` feature on every
+run, so no backend bit-rots even though it isn't in the default build.
+
 ---
 
 ## Well-known key schemas


### PR DESCRIPTION
## Summary

**T23 (closes Phase 5)** — feature-gate the secrets backends so the default build stays lean, while keeping every backend supported and CI-tested.

The audit found the *mechanism* was already implemented in prior work:
- The cloud/OS backends (`keyring`, `aws`, `gcp`, `azure`, `vault`) are gated behind `secrets-*` features (optional SDK deps + internal `#[cfg]`).
- Each emits an **actionable error** when configured-but-not-compiled — *"compiled without the 'secrets-aws' feature; rebuild with `cargo build --features secrets-aws`"*.
- `checks-features.yaml` **compile-checks every backend** for both the mediator and the setup wizard on every run, so none bit-rots.
- The default build already compiles only the dependency-free `file://` backend (plain + AEAD-encrypted).

So this PR is the **one missing acceptance piece**: a "Which backends are compiled in" section in `docs/secrets-backend.md` — the feature/default-build matrix, an explicit statement that **all backends remain supported (none deprecated)**, how to enable opt-in backends, the fail-fast behaviour, and that CI guards each one.

## Decision (per maintainer)

The plan's literal "3 core = `file_encrypted` + **`aws_secrets`** + `memory`" would pull the heavy AWS SDK into every default build. We kept the **leaner default** (no cloud SDK forced in) instead — better dependency/attack-surface posture, and it still meets the Checkpoint-5 "slim default attack surface" goal. All cloud backends stay one feature flag away.

## Verification

Doc-only — no code or version change. The gating, CI matrix, and not-compiled errors it documents already exist and pass.

## Phase 5 — complete
- T21 ✅, T22 ✅, **T23 ✅** (this PR). Setup-tool consolidation + lean default secrets surface done.
- **Phase 6 next:** T24 (metrics depth), T25 (ACL change audit log), T26 (structured request logging + Retry-After + WS close reasons).
