### PR TITLE
feat: emit dead metrics and add VTA health metrics (simplification T24)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Changelog history
 
+## 13th June 2026
+
+### 0.15.42 — Activate dead metrics + add VTA health metrics (simplification T24)
+
+- Observability depth. The metrics registry defined many metric names that were
+  never emitted; this wires up the ones with a natural, non-invasive home and
+  adds the previously-missing VTA health metrics.
+- **Histogram buckets:** `init_metrics` now configures fixed second-scale buckets
+  for every `*_duration_seconds` histogram (was relying on exporter defaults).
+- **Forwarding queue depth:** the statistics task now publishes
+  `forward_queue_length` (a gauge) by sampling `forward_queue_len()` each cycle —
+  works on every backend (Redis/Fjall/Memory).
+- **Store totals → Prometheus:** the statistics task already polled the store's
+  cumulative metadata every 60s but only *logged* it. It now also publishes those
+  totals as counters via `.absolute()` — `messages_stored/delivered/deleted_total`,
+  `store_{received,sent,deleted}_bytes_total`,
+  `websocket_connections_{opened,closed}_total`,
+  `sessions_{created,authenticated}_total`, and `oob_invites_{created,claimed}_total`.
+- **VTA health:** the refresh task now emits `vta_refresh_total{result=vta|cache|error}`,
+  the `vta_refresh_duration_seconds` histogram, and the
+  `vta_last_success_timestamp_seconds` gauge (alert on staleness when the VTA has
+  been unreachable across refresh windows).
+- Hot request/WS paths are untouched — all new emission is in the existing 60s
+  statistics poll and the VTA refresh loop. HTTP request metrics, per-store-op
+  latency histograms, and circuit-breaker metrics remain for later increments.
+  No version change to any other crate.
+
 ## 12th June 2026
 
 ### 0.15.41 — Move config loading + validation into the mediator-config crate (simplification T18, part b)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.41"
+version = "0.15.42"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
@@ -6,7 +6,7 @@
 
 use axum::{extract::State, response::IntoResponse};
 use http::{StatusCode, header};
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use tracing::{Level, event};
 
 /// Metric names used across the mediator.
@@ -106,12 +106,78 @@ pub mod names {
     pub const ACTIVE_SESSIONS: &str = "active_sessions";
     /// counter: Requests denied by ACL checks (label: action)
     pub const ACL_DENIALS_TOTAL: &str = "acl_denials_total";
+
+    // ── VTA secrets refresh ───────────────────────────────────────────────────
+
+    /// counter: VTA secrets-refresh attempts (label: result = vta|cache|error).
+    /// `vta` = fresh material fetched, `cache` = VTA unreachable so the cache was
+    /// reused, `error` = the refresh call itself failed.
+    pub const VTA_REFRESH_TOTAL: &str = "vta_refresh_total";
+    /// histogram: VTA refresh round-trip duration in seconds
+    pub const VTA_REFRESH_DURATION_SECONDS: &str = "vta_refresh_duration_seconds";
+    /// gauge: Unix timestamp (seconds) of the last successful refresh *from the
+    /// VTA*. Alert on `time() - <this>` exceeding the expected cadence to catch a
+    /// VTA that has been unreachable across several refresh windows.
+    pub const VTA_LAST_SUCCESS_TIMESTAMP_SECONDS: &str = "vta_last_success_timestamp_seconds";
+
+    // ── Global store totals ───────────────────────────────────────────────────
+    //
+    // Sampled once per cycle by the statistics task from the store's own
+    // cumulative metadata (`get_global_stats`) and published with `.absolute()`.
+    // These are authoritative server-side totals — distinct from the per-request
+    // counters above (e.g. `messages_inbound_total` counts inbound HTTP requests,
+    // while `messages_stored_total` — defined in the Messaging section above and
+    // activated here — is the store's persisted total).
+
+    /// counter: Message bytes received/stored (cumulative store total)
+    pub const STORE_RECEIVED_BYTES_TOTAL: &str = "store_received_bytes_total";
+    /// counter: Message bytes sent/delivered (cumulative store total)
+    pub const STORE_SENT_BYTES_TOTAL: &str = "store_sent_bytes_total";
+    /// counter: Message bytes deleted (cumulative store total)
+    pub const STORE_DELETED_BYTES_TOTAL: &str = "store_deleted_bytes_total";
+    /// counter: WebSocket connections opened (cumulative store total)
+    pub const WEBSOCKET_CONNECTIONS_OPENED_TOTAL: &str = "websocket_connections_opened_total";
+    /// counter: WebSocket connections closed (cumulative store total)
+    pub const WEBSOCKET_CONNECTIONS_CLOSED_TOTAL: &str = "websocket_connections_closed_total";
+    /// counter: Sessions created (cumulative store total)
+    pub const SESSIONS_CREATED_TOTAL: &str = "sessions_created_total";
+    /// counter: Sessions that completed authentication (cumulative store total)
+    pub const SESSIONS_AUTHENTICATED_TOTAL: &str = "sessions_authenticated_total";
+    /// counter: OOB invitations created (cumulative store total)
+    pub const OOB_INVITES_CREATED_TOTAL: &str = "oob_invites_created_total";
+    /// counter: OOB invitations claimed (cumulative store total)
+    pub const OOB_INVITES_CLAIMED_TOTAL: &str = "oob_invites_claimed_total";
 }
+
+/// Histogram bucket boundaries (seconds) applied to every `*_duration_seconds`
+/// metric. Without this, the Prometheus exporter falls back to its default
+/// summary/quantile rendering, which loses the cross-instance aggregatability
+/// that fixed buckets give. The range spans sub-millisecond local work up to the
+/// ~10s tail of a slow VTA round-trip or contended store operation.
+const DURATION_BUCKETS_SECONDS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
 
 /// Initialize the Prometheus metrics recorder and return a handle
 /// that can be used to render the metrics output.
 pub fn init_metrics() -> Option<PrometheusHandle> {
-    match PrometheusBuilder::new().install_recorder() {
+    let builder = match PrometheusBuilder::new().set_buckets_for_metric(
+        Matcher::Suffix("_duration_seconds".into()),
+        DURATION_BUCKETS_SECONDS,
+    ) {
+        Ok(builder) => builder,
+        Err(e) => {
+            // A bad bucket set is a programming error, not a runtime one — fall
+            // back to the default exporter rather than dropping metrics entirely.
+            event!(
+                Level::WARN,
+                "Failed to configure metrics histogram buckets: {}. Using exporter defaults.",
+                e
+            );
+            PrometheusBuilder::new()
+        }
+    };
+    match builder.install_recorder() {
         Ok(handle) => {
             event!(Level::INFO, "Prometheus metrics recorder installed");
             Some(handle)
@@ -138,4 +204,30 @@ pub async fn metrics_handler(State(handle): State<PrometheusHandle>) -> impl Int
         )],
         body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The histogram buckets must be strictly ascending and accepted by the
+    /// exporter — otherwise `init_metrics` silently falls back to the default
+    /// (bucket-less) renderer, and the duration histograms lose their fixed
+    /// boundaries without any compile- or boot-time signal.
+    #[test]
+    fn duration_buckets_are_sorted_and_accepted() {
+        assert!(
+            DURATION_BUCKETS_SECONDS.windows(2).all(|w| w[0] < w[1]),
+            "duration buckets must be strictly ascending"
+        );
+        assert!(
+            PrometheusBuilder::new()
+                .set_buckets_for_metric(
+                    Matcher::Suffix("_duration_seconds".into()),
+                    DURATION_BUCKETS_SECONDS,
+                )
+                .is_ok(),
+            "exporter rejected the duration bucket set"
+        );
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -1,3 +1,4 @@
+use crate::common::metrics::names;
 use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{MediatorStore, types::MetadataStats},
@@ -59,9 +60,56 @@ pub async fn statistics(
                 oob_invites_claimed = delta.oob_invites_claimed
             );
 
+            publish_metrics(&database, &stats).await;
+
             previous_stats = stats;
         }
     }
     .instrument(_span)
     .await
+}
+
+/// Bridge the store's cumulative metadata into Prometheus on each statistics
+/// cycle. The byte/count/connection/session totals are monotonic absolute
+/// values, so they are published as counters via `.absolute()`; the forwarding
+/// queue length is a point-in-time depth, so it is a gauge.
+///
+/// This is the only place these totals reach Prometheus — they are otherwise
+/// log-only (the `UpdateStats` event above). Sampling them here (rather than
+/// incrementing at each call site) keeps the hot paths untouched and the store's
+/// own counters authoritative.
+async fn publish_metrics(database: &Arc<dyn MediatorStore>, stats: &MetadataStats) {
+    // Forwarding queue depth — point-in-time gauge. Best-effort: a transient
+    // store error here must not disturb the stats loop.
+    match database.forward_queue_len().await {
+        Ok(len) => metrics::gauge!(names::FORWARD_QUEUE_LENGTH).set(len as f64),
+        Err(e) => debug!("forward_queue_len for metrics unavailable this cycle: {e}"),
+    }
+
+    // Cumulative store totals → absolute counters. `i64` values are clamped at 0
+    // before the `u64` cast (the store never reports negatives, but the cast must
+    // be saturating rather than wrapping).
+    let totals: [(&str, i64); 12] = [
+        (names::MESSAGES_STORED_TOTAL, stats.received_count),
+        (names::MESSAGES_DELIVERED_TOTAL, stats.sent_count),
+        (names::MESSAGES_DELETED_TOTAL, stats.deleted_count),
+        (names::STORE_RECEIVED_BYTES_TOTAL, stats.received_bytes),
+        (names::STORE_SENT_BYTES_TOTAL, stats.sent_bytes),
+        (names::STORE_DELETED_BYTES_TOTAL, stats.deleted_bytes),
+        (
+            names::WEBSOCKET_CONNECTIONS_OPENED_TOTAL,
+            stats.websocket_open,
+        ),
+        (
+            names::WEBSOCKET_CONNECTIONS_CLOSED_TOTAL,
+            stats.websocket_close,
+        ),
+        (names::SESSIONS_CREATED_TOTAL, stats.sessions_created),
+        (names::SESSIONS_AUTHENTICATED_TOTAL, stats.sessions_success),
+        (names::OOB_INVITES_CREATED_TOTAL, stats.oob_invites_created),
+        (names::OOB_INVITES_CLAIMED_TOTAL, stats.oob_invites_claimed),
+    ];
+    for (name, value) in totals {
+        metrics::counter!(name).absolute(value.max(0) as u64);
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
@@ -26,9 +26,13 @@
 //! [`vta_bootstrap`]: crate::common::config::vta_bootstrap
 
 use crate::common::config::vta_cache::MediatorSecretCache;
+use crate::common::metrics::names;
 use affinidi_messaging_mediator_common::MediatorSecrets;
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use vta_sdk::integration::{self, SecretSource, VtaServiceConfig};
@@ -108,9 +112,19 @@ impl VtaRefresher {
                 _ = tokio::time::sleep(self.interval) => {}
             }
 
-            match integration::startup(&self.service_config, &cache).await {
+            let started = Instant::now();
+            let outcome = integration::startup(&self.service_config, &cache).await;
+            metrics::histogram!(names::VTA_REFRESH_DURATION_SECONDS)
+                .record(started.elapsed().as_secs_f64());
+
+            match outcome {
                 Ok(result) => match result.source {
                     SecretSource::Vta => {
+                        metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "vta").increment(1);
+                        if let Ok(since_epoch) = SystemTime::now().duration_since(UNIX_EPOCH) {
+                            metrics::gauge!(names::VTA_LAST_SUCCESS_TIMESTAMP_SECONDS)
+                                .set(since_epoch.as_secs_f64());
+                        }
                         debug!(
                             secrets = result.bundle.secrets.len(),
                             "VTA refresh OK — refreshed cache and runtime secrets"
@@ -122,6 +136,8 @@ impl VtaRefresher {
                         }
                     }
                     SecretSource::Cache => {
+                        metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "cache")
+                            .increment(1);
                         // Refresh fell back to cache — VTA is unreachable
                         // right now. The cache write didn't actually
                         // re-fetch fresh material; the runtime secrets
@@ -133,6 +149,7 @@ impl VtaRefresher {
                     }
                 },
                 Err(err) => {
+                    metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "error").increment(1);
                     warn!(
                         context = %self.service_config.context.id,
                         error = %err,


### PR DESCRIPTION
## T24 — metrics depth (Phase 6)

Activates metric names that were defined but never emitted, and adds the previously-missing VTA health metrics. **Audit finding: 14 of 31 named metrics were actually emitted; 17 were dead constants.** This wires up the subset with a natural, non-invasive home (the existing 60s statistics poll + the VTA refresh loop) — no hot-path instrumentation.

### What it adds
- **Histogram buckets:** `init_metrics` configures fixed second-scale buckets for every `*_duration_seconds` histogram (was relying on exporter defaults; guarded by a unit test).
- **Forwarding queue depth:** `forward_queue_length` gauge, sampled via `forward_queue_len()` each statistics cycle — works on Redis/Fjall/Memory.
- **Store totals → Prometheus:** the statistics task already polled the store's cumulative metadata every 60s but only *logged* it. It now also publishes those totals as `.absolute()` counters — `messages_stored/delivered/deleted_total`, `store_{received,sent,deleted}_bytes_total`, `websocket_connections_{opened,closed}_total`, `sessions_{created,authenticated}_total`, `oob_invites_{created,claimed}_total`.
- **VTA health:** `vta_refresh_total{result=vta|cache|error}`, `vta_refresh_duration_seconds` histogram, `vta_last_success_timestamp_seconds` gauge (alert on staleness).

### Deliberately out of scope (later increments)
Per the agreed focused scope: HTTP request metrics (need a tower middleware — overlaps T26), per-store-op latency histograms (invasive hot-path wrapping), circuit-breaker state/trips, `websocket_messages_total`, and `active_sessions` (no live source). These stay dead for now.

### Verification
- clippy `-D warnings` on both feature sets (default redis-backend + `--no-default-features --features didcomm,memory-backend,fjall-backend`)
- mediator lib suite 135 passed (+1 new bucket-config test)
- `affinidi-messaging-test-mediator` e2e green
- `cargo fmt --check` clean; no new dependencies (graph unchanged)

Mediator patch bump 0.15.41 → 0.15.42; no other crate changes.
