### PR TITLE
feat: record privileged changes to a bounded audit log (simplification T25a)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 13th June 2026
 
+### 0.15.43 — Record privileged changes to an audit log (simplification T25, part a)
+
+- Every privileged change is now recorded to a bounded, newest-first audit log:
+  ACL set, access-list add/remove/clear, account add/remove/change-type/
+  change-queue-limits, and admin promote/strip. Each entry captures *who*
+  (`actor_did_hash`), *what* (action + short detail), *to whom*
+  (`target_did_hash`), and *when* (timestamp).
+- Recording is wired into the ACL, account-management, and administration
+  DIDComm handlers via a shared `record_audit` helper, fired only after the
+  underlying change succeeds. It is best-effort: a failure to record logs a
+  warning but never turns a successful admin action into an error.
+- The Fjall and Memory backends gain the `audit_log_record` / `audit_log_list`
+  store methods (Fjall: a dedicated `audit_log` partition, insertion-ordered
+  with an oldest-first trim; Memory: a capped `VecDeque`). The Redis
+  implementation ships in mediator-common 0.15.11.
+- Conformance suite extended (eleven areas now): a new `audit_log_lifecycle`
+  check exercises record, newest-first ordering, and cursor pagination across
+  Memory, Fjall, and Redis. Querying the log back over the admin protocol is the
+  next increment (T25b). Requires mediator-common >= 0.15.11.
+
 ### 0.15.42 — Activate dead metrics + add VTA health metrics (simplification T24)
 
 - Observability depth. The metrics registry defined many metric names that were

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.42"
+version = "0.15.43"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 13th June 2026
+
+### 0.15.11 — Audit-log store API for privileged changes (simplification T25, part a)
+
+- Adds the storage layer for a privileged-change audit log. New
+  `types::audit` module: `AuditLogEntry` (timestamp, actor/target DID hash,
+  `AuditAction`, detail), `AuditAction` (set-acl, access-list add/remove/clear,
+  account add/remove/change-type/change-queue-limits, admin add/strip),
+  `MediatorAuditLogList` (cursor-paginated page), and `AUDIT_LOG_MAX_ENTRIES`
+  (10,000 — the log is a bounded ring).
+- New `MediatorStore` trait methods `audit_log_record` (append + trim) and
+  `audit_log_list` (newest-first, cursor-paginated). Implemented for the Redis
+  backend here as a capped `LPUSH`/`LTRIM` list with `LRANGE` paging.
+- Additive only — no behaviour change to existing methods. The mediator's
+  Fjall/Memory backends implement the same trait methods, and recording is
+  wired into the admin/ACL handlers, in the mediator crate. Reading the log
+  back over the admin protocol is a later increment (T25b).
+
 ## 12th June 2026
 
 ### 0.15.10 — Consolidate the access-list method family (simplification T16, part 3)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.10"
+version = "0.15.11"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -50,6 +50,7 @@ use crate::types::{
         MediatorAccessListListResponse,
     },
     administration::MediatorAdminList,
+    audit::{AuditLogEntry, MediatorAuditLogList},
     messages::{FetchOptions, Folder, GetMessagesResponse, MessageList, MessageListElement},
 };
 use async_trait::async_trait;
@@ -433,6 +434,29 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
         cursor: u32,
         limit: u32,
     ) -> Result<MediatorAdminList, MediatorError>;
+
+    // ─── Audit log ───────────────────────────────────────────────────────────
+
+    /// Append a privileged-change record to the audit log.
+    ///
+    /// The log is a bounded ring of [`AUDIT_LOG_MAX_ENTRIES`](crate::types::audit::AUDIT_LOG_MAX_ENTRIES):
+    /// once full, recording drops the oldest entry. The entry arrives fully
+    /// formed (the caller stamps `timestamp` and the actor/target), so backends
+    /// only persist + trim; ordering is the backend's insertion order.
+    ///
+    /// Recording is best-effort at the call sites (a failure here must not abort
+    /// the privileged change that already succeeded), so callers log and
+    /// continue rather than propagate.
+    async fn audit_log_record(&self, entry: &AuditLogEntry) -> Result<(), MediatorError>;
+
+    /// Page through the audit log, newest-first. Pass `0` to start; feed the
+    /// returned `cursor` back in for the next page. A returned `cursor` of `0`
+    /// means the listing is exhausted (same convention as `account_list`).
+    async fn audit_log_list(
+        &self,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<MediatorAuditLogList, MediatorError>;
 
     // ─── OOB Discovery invitations ──────────────────────────────────────────
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/audit.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/audit.rs
@@ -1,0 +1,119 @@
+//! Database routines for the privileged-change audit log.
+//!
+//! Stored as a Redis LIST keyed `AUDIT_LOG`: `LPUSH` puts the newest entry at
+//! the head (index 0), so the list is naturally newest-first, and `LTRIM` after
+//! each push bounds it to [`AUDIT_LOG_MAX_ENTRIES`] — a fixed-size ring.
+
+use crate::errors::MediatorError;
+use crate::types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditLogEntry, MediatorAuditLogList};
+use tracing::{Instrument, Level, span};
+
+use super::Database;
+
+/// Redis key for the audit-log list.
+const AUDIT_LOG_KEY: &str = "AUDIT_LOG";
+
+// Redis-backend implementation behind `RedisStore`.
+impl Database {
+    pub(crate) async fn audit_log_record(
+        &self,
+        entry: &AuditLogEntry,
+    ) -> Result<(), MediatorError> {
+        let _span = span!(Level::DEBUG, "audit_log_record");
+        async move {
+            let json = serde_json::to_string(entry).map_err(|e| {
+                MediatorError::InternalError(
+                    14,
+                    "NA".into(),
+                    format!("audit_log_record: serialise failed: {e}"),
+                )
+            })?;
+
+            let mut con = self.get_connection().await?;
+            // LPUSH (newest at head) then LTRIM to the cap — atomic so a reader
+            // never sees the list briefly over the cap.
+            redis::pipe()
+                .atomic()
+                .cmd("LPUSH")
+                .arg(AUDIT_LOG_KEY)
+                .arg(&json)
+                .cmd("LTRIM")
+                .arg(AUDIT_LOG_KEY)
+                .arg(0)
+                .arg(AUDIT_LOG_MAX_ENTRIES as isize - 1)
+                .exec_async(&mut con)
+                .await
+                .map_err(|e| {
+                    MediatorError::DatabaseError(
+                        14,
+                        "NA".into(),
+                        format!("audit_log_record failed: {e}"),
+                    )
+                })?;
+            Ok(())
+        }
+        .instrument(_span)
+        .await
+    }
+
+    pub(crate) async fn audit_log_list(
+        &self,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<MediatorAuditLogList, MediatorError> {
+        let _span = span!(
+            Level::DEBUG,
+            "audit_log_list",
+            cursor = cursor,
+            limit = limit
+        );
+        async move {
+            let limit = limit.min(100);
+            let mut con = self.get_connection().await?;
+
+            // The list is already newest-first; page directly by index.
+            let start = cursor as isize;
+            let stop = start + limit as isize - 1;
+            let (items, total): (Vec<String>, u64) = redis::pipe()
+                .cmd("LRANGE")
+                .arg(AUDIT_LOG_KEY)
+                .arg(start)
+                .arg(stop)
+                .cmd("LLEN")
+                .arg(AUDIT_LOG_KEY)
+                .query_async(&mut con)
+                .await
+                .map_err(|e| {
+                    MediatorError::DatabaseError(
+                        14,
+                        "NA".into(),
+                        format!("audit_log_list failed at cursor ({cursor}): {e}"),
+                    )
+                })?;
+
+            let mut entries = Vec::with_capacity(items.len());
+            for item in &items {
+                let entry: AuditLogEntry = serde_json::from_str(item).map_err(|e| {
+                    MediatorError::InternalError(
+                        14,
+                        "NA".into(),
+                        format!("audit_log_list: deserialise failed: {e}"),
+                    )
+                })?;
+                entries.push(entry);
+            }
+
+            let next_cursor = if cursor as u64 + entries.len() as u64 >= total {
+                0
+            } else {
+                cursor + entries.len() as u32
+            };
+            Ok(MediatorAuditLogList {
+                entries,
+                cursor: next_cursor,
+            })
+        }
+        .instrument(_span)
+        .await
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/mod.rs
@@ -10,6 +10,7 @@
 pub mod accounts;
 pub(crate) mod acls;
 pub mod admin_accounts;
+pub(crate) mod audit;
 pub mod fetch;
 pub mod forwarding;
 pub mod get;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -25,6 +25,7 @@ use crate::types::{
         MediatorAccessListListResponse,
     },
     administration::MediatorAdminList,
+    audit::{AuditLogEntry, MediatorAuditLogList},
     messages::{FetchOptions, Folder, GetMessagesResponse, MessageList, MessageListElement},
 };
 use crate::{
@@ -747,6 +748,18 @@ impl MediatorStore for RedisStore {
         limit: u32,
     ) -> Result<MediatorAdminList, MediatorError> {
         self.list_admin_accounts(cursor, limit).await
+    }
+
+    async fn audit_log_record(&self, entry: &AuditLogEntry) -> Result<(), MediatorError> {
+        self.audit_log_record(entry).await
+    }
+
+    async fn audit_log_list(
+        &self,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<MediatorAuditLogList, MediatorError> {
+        self.audit_log_list(cursor, limit).await
     }
 
     // ─── OOB Discovery invitations ──────────────────────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/audit.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/audit.rs
@@ -1,0 +1,87 @@
+//! Audit-log vocabulary for privileged (admin / self-service) changes.
+//!
+//! Every mutation to a DID's ACLs, access list, account record, or admin
+//! status is recorded as an [`AuditLogEntry`] so operators have a tamper-evident
+//! trail of *who changed what, when*. The log is a bounded ring — see
+//! [`AUDIT_LOG_MAX_ENTRIES`] — kept newest-first; the oldest entries are dropped
+//! once the cap is reached.
+//!
+//! The store layer (`MediatorStore::audit_log_record` / `audit_log_list`)
+//! produces and serves these; the admin query protocol (a later increment)
+//! exposes [`MediatorAuditLogList`] over DIDComm.
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of audit entries retained per mediator. The log is a ring:
+/// once full, recording a new entry drops the oldest. Admin changes are
+/// infrequent, so this bounds disk/memory while keeping a long history.
+pub const AUDIT_LOG_MAX_ENTRIES: usize = 10_000;
+
+/// The kind of privileged change an [`AuditLogEntry`] records. Serialized with
+/// stable snake_case names so the wire form is independent of the Rust spelling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuditAction {
+    /// A DID's ACL bitmask was replaced (`set_did_acl`).
+    #[serde(rename = "set_acl")]
+    SetAcl,
+    /// Hashes were added to a DID's access list.
+    #[serde(rename = "access_list_add")]
+    AccessListAdd,
+    /// Hashes were removed from a DID's access list.
+    #[serde(rename = "access_list_remove")]
+    AccessListRemove,
+    /// A DID's entire access list was cleared.
+    #[serde(rename = "access_list_clear")]
+    AccessListClear,
+    /// An account was created.
+    #[serde(rename = "account_add")]
+    AccountAdd,
+    /// An account was removed.
+    #[serde(rename = "account_remove")]
+    AccountRemove,
+    /// An account's role/type was changed.
+    #[serde(rename = "account_change_type")]
+    AccountChangeType,
+    /// An account's send/receive queue limits were changed.
+    #[serde(rename = "account_change_queue_limits")]
+    AccountChangeQueueLimits,
+    /// One or more DIDs were promoted to admin.
+    #[serde(rename = "admin_add")]
+    AdminAdd,
+    /// One or more DIDs had admin status stripped.
+    #[serde(rename = "admin_strip")]
+    AdminStrip,
+}
+
+/// A single audit-log record: one privileged change, by one actor, at one time.
+///
+/// `actor_did_hash` is the authenticated caller that made the change (an admin,
+/// or the account owner for self-service changes); `target_did_hash` is the DID
+/// whose record changed. `detail` is a short human-readable summary (e.g. the
+/// new ACL value, or the number of hashes added) — not machine-parsed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditLogEntry {
+    /// Unix timestamp (seconds) when the change was recorded.
+    pub timestamp: u64,
+    /// SHA-256 hash of the DID that performed the change.
+    pub actor_did_hash: String,
+    /// SHA-256 hash of the DID whose record was changed.
+    pub target_did_hash: String,
+    /// What kind of change this was.
+    pub action: AuditAction,
+    /// Short human-readable detail of the change.
+    pub detail: String,
+}
+
+/// A page of audit-log entries (newest-first) plus the cursor for the next page.
+///
+/// `cursor` is an opaque offset to feed back into the next `audit_log_list`
+/// call; `0` means there are no more pages (the same convention as
+/// `MediatorAccountList` / `MediatorAdminList`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MediatorAuditLogList {
+    /// The entries on this page, ordered newest-first.
+    pub entries: Vec<AuditLogEntry>,
+    /// Offset for the next page, or `0` when the listing is exhausted.
+    pub cursor: u32,
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/mod.rs
@@ -17,5 +17,6 @@ pub mod accounts;
 pub mod acls;
 pub mod acls_handler;
 pub mod administration;
+pub mod audit;
 pub mod messages;
 pub mod problem_report;

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
@@ -7,6 +7,7 @@ use super::acls::check_permissions;
 use crate::{SharedData, common::session::Session, messages::ProcessMessageResponse};
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::types::audit::AuditAction;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::{
     messages::problem_report::{ProblemReportScope, ProblemReportSorter},
@@ -222,12 +223,22 @@ pub(crate) async fn process(
                     .account_add(&did_hash, &acls, None)
                     .await
                 {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccountAdd,
+                            "account created".to_string(),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error adding account. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -299,12 +310,22 @@ pub(crate) async fn process(
                     .account_remove(&session.to_store_session(), &did_hash)
                     .await
                 {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccountRemove,
+                            "account removed".to_string(),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error removing account. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -389,6 +410,14 @@ pub(crate) async fn process(
                         // Need to add admin rights
                         state.database.setup_admin_account(&did_hash, _type, &MediatorACLSet::from_u64(current.acls)).await?;
                         info!("Added admin ({}) rights to DID: {}", _type, did_hash);
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccountChangeType,
+                            format!("type -> {_type}"),
+                        )
+                        .await;
                         return _generate_response_message(
                             &msg.id,
                             &session.did,
@@ -408,6 +437,14 @@ pub(crate) async fn process(
                             "Unknown".to_string()
                         };
                         info!("Changed account type for DID: ({}) from ({}) to ({})", did_hash, current_type, _type);
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccountChangeType,
+                            format!("type {current_type} -> {_type}"),
+                        )
+                        .await;
                         _generate_response_message(
                         &msg.id,
                         &session.did,
@@ -492,6 +529,14 @@ pub(crate) async fn process(
                 match state.database.account_change_queue_limits(&did_hash, send_queue_limit, receive_queue_limit).await {
                     Ok(_) => {
                         info!("Changed account queue_limits for DID: ({}) to send({:?}) receive({:?})", did_hash, send_queue_limit, receive_queue_limit);
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccountChangeQueueLimits,
+                            format!("send={send_queue_limit:?} receive={receive_queue_limit:?}"),
+                        )
+                        .await;
                         _generate_response_message(
                         &msg.id,
                         &session.did,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
@@ -6,6 +6,7 @@ use crate::common::time::unix_timestamp_secs;
 use crate::{SharedData, common::session::Session, messages::ProcessMessageResponse};
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::types::audit::AuditAction;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::{
     messages::problem_report::{ProblemReportScope, ProblemReportSorter},
@@ -227,12 +228,22 @@ pub(crate) async fn process(
                     .set_did_acl(&did_hash, &MediatorACLSet::from_u64(acls))
                     .await
                 {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!({"acls": response}),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::SetAcl,
+                            format!("acls=0x{acls:016x}"),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!({"acls": response}),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error setting ACLs. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -356,12 +367,22 @@ pub(crate) async fn process(
                     .access_list_add(state.config.limits.access_list_limit, &did_hash, &hashes)
                     .await
                 {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccessListAdd,
+                            format!("added {} hash(es)", hashes.len()),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error Add to Access List. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -434,12 +455,22 @@ pub(crate) async fn process(
                 }
 
                 match state.database.access_list_remove(&did_hash, &hashes).await {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccessListRemove,
+                            format!("removed {response} of {} requested", hashes.len()),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error Remove from Access List. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -495,12 +526,22 @@ pub(crate) async fn process(
                 }
 
                 match state.database.access_list_clear(&did_hash).await {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        super::record_audit(
+                            state,
+                            session,
+                            &did_hash,
+                            AuditAction::AccessListClear,
+                            "cleared access list".to_string(),
+                        )
+                        .await;
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error Clearing Access List. Reason: {}", e);
                         Err(MediatorError::problem_with_log(

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
@@ -4,6 +4,7 @@ use crate::common::authz;
 use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::types::audit::AuditAction;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::{
     messages::problem_report::{ProblemReportScope, ProblemReportSorter},
@@ -149,17 +150,30 @@ pub(crate) async fn process(
                 }
             }
             MediatorAdminRequest::AdminAdd(attr) => {
+                let targets = attr.clone();
                 match state
                     .database
                     .add_admin_accounts(attr, &state.config.security.global_acl_default)
                     .await
                 {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        for target in &targets {
+                            super::record_audit(
+                                state,
+                                session,
+                                target,
+                                AuditAction::AdminAdd,
+                                "promoted to admin".to_string(),
+                            )
+                            .await;
+                        }
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error adding admin accounts. Reason: {}", e);
                         Err(MediatorError::problem_with_log(
@@ -209,13 +223,26 @@ pub(crate) async fn process(
                         StatusCode::BAD_REQUEST,
                     ));
                 }
+                let targets = attr.clone();
                 match state.database.strip_admin_accounts(attr).await {
-                    Ok(response) => _generate_response_message(
-                        &msg.id,
-                        &session.did,
-                        &state.config.mediator_did,
-                        &json!(response),
-                    ),
+                    Ok(response) => {
+                        for target in &targets {
+                            super::record_audit(
+                                state,
+                                session,
+                                target,
+                                AuditAction::AdminStrip,
+                                "admin status stripped".to_string(),
+                            )
+                            .await;
+                        }
+                        _generate_response_message(
+                            &msg.id,
+                            &session.did,
+                            &state.config.mediator_did,
+                            &json!(response),
+                        )
+                    }
                     Err(e) => {
                         warn!("Error removing admin accounts. Reason: {}", e);
                         Err(MediatorError::problem_with_log(

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/mod.rs
@@ -1,3 +1,38 @@
 pub(crate) mod accounts;
 pub(crate) mod acls;
 pub(crate) mod administration;
+
+use crate::common::time::unix_timestamp_secs;
+use crate::{SharedData, common::session::Session};
+use affinidi_messaging_mediator_common::types::audit::{AuditAction, AuditLogEntry};
+use tracing::warn;
+
+/// Record a privileged-change audit entry, best-effort.
+///
+/// Called *after* the mutation has already succeeded, so a failure to record
+/// must not turn a successful admin/self-service action into an error — we log
+/// and move on. The actor is the authenticated caller (`session.did_hash`);
+/// `target_did_hash` is the DID whose record changed; `detail` is a short
+/// human-readable summary (not machine-parsed).
+pub(crate) async fn record_audit(
+    state: &SharedData,
+    session: &Session,
+    target_did_hash: &str,
+    action: AuditAction,
+    detail: String,
+) {
+    let entry = AuditLogEntry {
+        timestamp: unix_timestamp_secs(),
+        actor_did_hash: session.did_hash.clone(),
+        target_did_hash: target_did_hash.to_string(),
+        action,
+        detail,
+    };
+    if let Err(e) = state.database.audit_log_record(&entry).await {
+        warn!(
+            action = ?action,
+            target = %target_did_hash,
+            "Failed to record audit-log entry: {e}"
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -36,6 +36,8 @@
 //! - `globals`            — counter name → `i64` little-endian
 //! - `streaming_clients`  — `{uuid}:{did_hash}` →
 //!   [`StreamingClientState`] tag byte
+//! - `audit_log`          — `{stream_id}` → JSON-serialised
+//!   [`AuditLogEntry`]; ascending by insertion (oldest-first), bounded ring
 //!
 //! # In-process state
 //!
@@ -52,6 +54,7 @@ use affinidi_messaging_mediator_common::{
         MessageMetaData, MetadataStats, PubSubRecord, Session, SessionState, SessionSweepReport,
         StatCounter, StoreHealth, StreamingClientState, ops,
     },
+    types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditLogEntry, MediatorAuditLogList},
 };
 use affinidi_messaging_sdk::{
     messages::{
@@ -100,6 +103,7 @@ const PARTITION_FORWARD_QUEUE: &str = "forward_queue";
 const PARTITION_FORWARD_PENDING: &str = "forward_pending";
 const PARTITION_GLOBALS: &str = "globals";
 const PARTITION_STREAMING_CLIENTS: &str = "streaming_clients";
+const PARTITION_AUDIT_LOG: &str = "audit_log";
 
 /// Fjall-backed [`MediatorStore`].
 ///
@@ -135,6 +139,7 @@ pub struct FjallStore {
     forward_pending: Keyspace,
     globals: Keyspace,
     streaming_clients: Keyspace,
+    audit_log: Keyspace,
 
     // ─── In-process state ───────────────────────────────────────────
     /// Serializes writes across multiple partitions so composite ops
@@ -423,6 +428,7 @@ impl FjallStore {
             forward_pending: open_partition(PARTITION_FORWARD_PENDING)?,
             globals: open_partition(PARTITION_GLOBALS)?,
             streaming_clients: open_partition(PARTITION_STREAMING_CLIENTS)?,
+            audit_log: open_partition(PARTITION_AUDIT_LOG)?,
             db,
             path,
             write_lock: Arc::new(Mutex::new(())),
@@ -527,6 +533,20 @@ impl FjallStore {
             let _ = guard
                 .into_inner()
                 .map_err(|e| Self::db_err("forward_queue_count:iter", e))?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// O(n) count of audit-log entries. Used by `audit_log_record` for the
+    /// ring trim and by `audit_log_list` for cursor maths. Bounded by
+    /// `AUDIT_LOG_MAX_ENTRIES`.
+    fn audit_log_count_inner(&self) -> Result<usize, MediatorError> {
+        let mut count = 0usize;
+        for guard in self.audit_log.iter() {
+            let _ = guard
+                .into_inner()
+                .map_err(|e| Self::db_err("audit_log_count:iter", e))?;
             count += 1;
         }
         Ok(count)
@@ -1974,6 +1994,81 @@ impl MediatorStore for FjallStore {
         Ok(MediatorAdminList {
             accounts,
             cursor: next,
+        })
+    }
+
+    async fn audit_log_record(&self, entry: &AuditLogEntry) -> Result<(), MediatorError> {
+        let _guard = self.write_lock.lock().await;
+        let id = self.alloc_stream_id();
+
+        let mut batch = self.db.batch();
+        batch.insert(
+            &self.audit_log,
+            encode_stream_id(id.0, id.1).to_vec(),
+            Self::encode(entry)?,
+        );
+
+        // Bounded ring: drop the oldest entries (lowest keys, first in ascending
+        // order) once we'd exceed the cap. `+1` accounts for the entry we're
+        // adding in this same batch.
+        let current = self.audit_log_count_inner()?;
+        if current >= AUDIT_LOG_MAX_ENTRIES {
+            let over = current - AUDIT_LOG_MAX_ENTRIES + 1;
+            let mut to_remove = Vec::with_capacity(over);
+            for guard in self.audit_log.iter().take(over) {
+                let (key, _) = guard
+                    .into_inner()
+                    .map_err(|e| Self::db_err("audit_log_record:trim", e))?;
+                to_remove.push(key);
+            }
+            for k in to_remove {
+                batch.remove(&self.audit_log, k.as_ref());
+            }
+        }
+
+        batch
+            .commit()
+            .map_err(|e| Self::db_err("audit_log_record:commit", e))?;
+        Ok(())
+    }
+
+    async fn audit_log_list(
+        &self,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<MediatorAuditLogList, MediatorError> {
+        let limit = limit.min(100) as usize;
+        let total = self.audit_log_count_inner()?;
+
+        // Entries are stored oldest-first (ascending key). The newest-first page
+        // [cursor, cursor+limit) maps onto the oldest-first index window
+        // [start, end); we decode only that window, then reverse it.
+        let end = total.saturating_sub(cursor as usize);
+        let start = end.saturating_sub(limit);
+
+        let mut entries: Vec<AuditLogEntry> = Vec::with_capacity(end - start);
+        for (i, guard) in self.audit_log.iter().enumerate() {
+            if i < start {
+                continue;
+            }
+            if i >= end {
+                break;
+            }
+            let (_, value) = guard
+                .into_inner()
+                .map_err(|e| Self::db_err("audit_log_list:iter", e))?;
+            entries.push(Self::decode(&value)?);
+        }
+        entries.reverse(); // oldest-first window → newest-first page
+
+        let next_cursor = if cursor as usize + entries.len() >= total {
+            0
+        } else {
+            cursor + entries.len() as u32
+        };
+        Ok(MediatorAuditLogList {
+            entries,
+            cursor: next_cursor,
         })
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -31,6 +31,7 @@ use affinidi_messaging_mediator_common::{
         MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
         StoreHealth, StreamingClientState, ops,
     },
+    types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditLogEntry, MediatorAuditLogList},
 };
 use affinidi_messaging_sdk::{
     messages::{
@@ -50,7 +51,7 @@ use affinidi_messaging_sdk::{
 use async_trait::async_trait;
 use sha256::digest;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -202,6 +203,12 @@ struct MemoryState {
     known_dids: Vec<String>, // ordered for cursor pagination
     access_lists: HashMap<String, Vec<String>>, // ordered for cursor pagination
     admins: HashSet<String>,
+
+    // ─── Audit log ──────────────────────────────────────────────────
+    /// Privileged-change records, newest-first. Bounded ring capped at
+    /// `AUDIT_LOG_MAX_ENTRIES` — the oldest (back) entry is dropped once
+    /// full.
+    audit_log: VecDeque<AuditLogEntry>,
 
     // ─── OOB invitations ────────────────────────────────────────────
     oob_invites: HashMap<String, OobInvite>,
@@ -1205,6 +1212,42 @@ impl MediatorStore for MemoryStore {
         Ok(MediatorAdminList {
             accounts,
             cursor: next,
+        })
+    }
+
+    async fn audit_log_record(&self, entry: &AuditLogEntry) -> Result<(), MediatorError> {
+        let mut state = self.state.lock().await;
+        // Newest-first: push to the front, drop the oldest (back) past the cap.
+        state.audit_log.push_front(entry.clone());
+        while state.audit_log.len() > AUDIT_LOG_MAX_ENTRIES {
+            state.audit_log.pop_back();
+        }
+        Ok(())
+    }
+
+    async fn audit_log_list(
+        &self,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<MediatorAuditLogList, MediatorError> {
+        let limit = limit.min(100) as usize;
+        let state = self.state.lock().await;
+        // Already newest-first; page by offset.
+        let entries: Vec<AuditLogEntry> = state
+            .audit_log
+            .iter()
+            .skip(cursor as usize)
+            .take(limit)
+            .cloned()
+            .collect();
+        let next_cursor = if cursor as usize + entries.len() >= state.audit_log.len() {
+            0
+        } else {
+            cursor + entries.len() as u32
+        };
+        Ok(MediatorAuditLogList {
+            entries,
+            cursor: next_cursor,
         })
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
@@ -14,12 +14,12 @@
 //!   --test store_conformance
 //! ```
 //!
-//! Coverage (against **Memory** and **Fjall**) — ten semantic areas:
+//! Coverage (against **Memory** and **Fjall**) — eleven semantic areas:
 //! account lifecycle; ACL set/get; message store + inbox counters;
 //! forward-queue consumer-group claim/ack, delete, and autoclaim (crashed-
 //! consumer recovery); session put/get/delete lifecycle; session-expiry sweep;
 //! access-list add/count/remove/clear; access-list *mode* (allow-list vs
-//! deny-list) evaluation.
+//! deny-list) evaluation; audit-log record + newest-first cursor pagination.
 //!
 //! Memory and Fjall agree on all of these, with **one documented divergence**
 //! the suite surfaced: `sweep_expired_sessions`'s `now_secs` argument is
@@ -44,6 +44,7 @@ use std::time::Duration;
 
 use affinidi_messaging_mediator_common::store::MediatorStore;
 use affinidi_messaging_mediator_common::store::types::{ForwardQueueEntry, Session, SessionState};
+use affinidi_messaging_mediator_common::types::audit::{AuditAction, AuditLogEntry};
 use affinidi_messaging_sdk::protocols::mediator::{
     accounts::{Account, AccountType},
     acls::{AccessListModeType, MediatorACLSet},
@@ -649,6 +650,73 @@ async fn redis_backend(db_index: u8) -> Option<Backend> {
     })
 }
 
+/// Audit log: recording, newest-first ordering, cursor pagination, and
+/// round-trip fidelity of a record. (The bounded-ring trim at
+/// `AUDIT_LOG_MAX_ENTRIES` is not exercised here — filling it would cost tens of
+/// thousands of writes; the trim is small and reviewed at each backend.)
+async fn check_audit_log_lifecycle(store: Arc<dyn MediatorStore>) {
+    // Fresh store: empty, terminal cursor.
+    let page = store.audit_log_list(0, 100).await.expect("list empty");
+    assert!(page.entries.is_empty(), "fresh store has no audit entries");
+    assert_eq!(page.cursor, 0);
+
+    // Record five entries in order 0..5.
+    for i in 0..5u64 {
+        let entry = AuditLogEntry {
+            timestamp: 1000 + i,
+            actor_did_hash: format!("admin{i}"),
+            target_did_hash: format!("target{i}"),
+            action: AuditAction::SetAcl,
+            detail: format!("entry {i}"),
+        };
+        store.audit_log_record(&entry).await.expect("record");
+    }
+
+    // Single page: newest-first (entry 4 first, entry 0 last), cursor exhausted.
+    let page = store.audit_log_list(0, 100).await.expect("list all");
+    assert_eq!(page.entries.len(), 5);
+    assert_eq!(page.entries[0].detail, "entry 4");
+    assert_eq!(page.entries[4].detail, "entry 0");
+    assert_eq!(page.cursor, 0, "single page exhausts the log");
+
+    // Round-trip fidelity of the newest record.
+    assert_eq!(page.entries[0].actor_did_hash, "admin4");
+    assert_eq!(page.entries[0].target_did_hash, "target4");
+    assert_eq!(page.entries[0].action, AuditAction::SetAcl);
+    assert_eq!(page.entries[0].timestamp, 1004);
+
+    // Pagination, 2 per page, newest-first across page boundaries.
+    let p0 = store.audit_log_list(0, 2).await.expect("page 0");
+    assert_eq!(
+        p0.entries
+            .iter()
+            .map(|e| e.detail.as_str())
+            .collect::<Vec<_>>(),
+        ["entry 4", "entry 3"]
+    );
+    assert_ne!(p0.cursor, 0, "more pages remain");
+
+    let p1 = store.audit_log_list(p0.cursor, 2).await.expect("page 1");
+    assert_eq!(
+        p1.entries
+            .iter()
+            .map(|e| e.detail.as_str())
+            .collect::<Vec<_>>(),
+        ["entry 2", "entry 1"]
+    );
+    assert_ne!(p1.cursor, 0);
+
+    let p2 = store.audit_log_list(p1.cursor, 2).await.expect("page 2");
+    assert_eq!(
+        p2.entries
+            .iter()
+            .map(|e| e.detail.as_str())
+            .collect::<Vec<_>>(),
+        ["entry 0"]
+    );
+    assert_eq!(p2.cursor, 0, "last page is terminal");
+}
+
 /// Generate one `#[tokio::test]` per check for a backend `$ctor`.
 /// Gated to the in-process backends that use it — a Redis-only build drives the
 /// async `conformance_for_redis!` instead, so an ungated def would warn (unused)
@@ -699,6 +767,10 @@ macro_rules! conformance_for {
             async fn access_list_mode_semantics() {
                 check_access_list_mode_semantics(ready($ctor).await).await;
             }
+            #[tokio::test]
+            async fn audit_log_lifecycle() {
+                check_audit_log_lifecycle(ready($ctor).await).await;
+            }
         }
     };
 }
@@ -742,4 +814,5 @@ conformance_for_redis!(redis,
     forward_queue_autoclaim  => check_forward_queue_autoclaim  @ 8,
     session_expiry_sweep     => check_session_expiry_sweep     @ 9,
     access_list_mode_semantics => check_access_list_mode_semantics @ 10,
+    audit_log_lifecycle      => check_audit_log_lifecycle      @ 11,
 );


### PR DESCRIPTION
## T25a — privileged-change audit log: store layer (Phase 6)

First half of T25 (split a/b per plan). Adds a tamper-evident trail of *who changed what, when* for every privileged change, and wires recording into the admin/ACL handlers. **Reading the log back over the admin protocol is T25b** — this PR fills the log; it is not yet queryable over DIDComm.

Audit confirmed this is genuinely greenfield (no prior audit/history existed).

### mediator-common (0.15.10 → 0.15.11)
- New `types::audit`: `AuditLogEntry` {timestamp, actor_did_hash, target_did_hash, action, detail}, `AuditAction` (10 variants), `MediatorAuditLogList` (cursor page), `AUDIT_LOG_MAX_ENTRIES` = 10,000 (bounded ring).
- New `MediatorStore` methods `audit_log_record` (append + trim) and `audit_log_list` (newest-first, cursor-paginated).
- Redis impl: capped `LPUSH`/`LTRIM` list with `LRANGE` paging.

### mediator (0.15.42 → 0.15.43)
- Fjall backend: dedicated `audit_log` partition, insertion-ordered with an oldest-first trim. Memory backend: capped `VecDeque`.
- Recording wired into the **acls**, **accounts**, and **administration** handlers via a shared `record_audit` helper, fired only *after* the change succeeds. **Best-effort** — a record failure logs a warning, never turns a successful admin action into an error.
- Covered: set-acl, access-list add/remove/clear, account add/remove/change-type/change-queue-limits, admin add/strip (all 10 actions).

### Scope per agreed decisions (Glenn, 2026-06-13)
- **All admin/security mutations** captured (not just ACLs) — admin promotion & account removal are the highest-value security events.
- **Split a/b** — this is part a (store + recording + tests); part b is the admin read query.

### Verification
- Conformance suite extended to **11 areas**: new `audit_log_lifecycle` (record, newest-first ordering, cursor pagination) green across **Memory, Fjall, AND Redis** (Redis run locally with `REDIS_URL`).
- clippy `-D warnings`: mediator (both feature sets) + common (default + redis-backend + no-default-features).
- mediator lib 135 · common lib 141 · test-mediator e2e green · full workspace build · `fmt --check` clean.
- No new dependencies. Publishing-trap checked: mediator-config (lean, published) still builds against common 0.15.11; common builds `--no-default-features`.

Additive only — no behaviour change to existing store methods. Requires mediator-common >= 0.15.11.
