### PR TITLE
feat: add an admin query for the privileged-change audit log (simplification T25b)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 13th June 2026
 
+### 0.15.44 — Admin query for the audit log (simplification T25, part b)
+
+- Completes T25. The administration protocol gains an `audit_log_list` request
+  (admin-only, gated by the same `check_admin_account` check as the rest of the
+  protocol) that pages the privileged-change audit log recorded in 0.15.43,
+  newest-first via cursor — mirroring the existing `admin_list` handler.
+- Read-only; no new storage. Requires mediator-common >= 0.15.12 (the new
+  `MediatorAdminRequest::AuditLogList` variant) and pairs with the SDK's
+  `Mediator::list_audit_log` client method (affinidi-messaging-sdk 0.18.8).
+
 ### 0.15.43 — Record privileged changes to an audit log (simplification T25, part a)
 
 - Every privileged change is now recorded to a bounded, newest-first audit log:

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.43"
+version = "0.15.44"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 13th June 2026
 
+### 0.15.12 — Admin audit-log query request (simplification T25, part b)
+
+- Adds the `AuditLogList { cursor, limit }` variant to `MediatorAdminRequest`
+  (wire tag `audit_log_list`) so the audit log recorded in 0.15.11 can be paged
+  back over the admin-management protocol. Additive; a serde wire-contract test
+  guards the tag. Response is the existing `MediatorAuditLogList`.
+
 ### 0.15.11 — Audit-log store API for privileged changes (simplification T25, part a)
 
 - Adds the storage layer for a privileged-change audit log. New

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.11"
+version = "0.15.12"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/administration.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/administration.rs
@@ -17,6 +17,14 @@ pub enum MediatorAdminRequest {
         cursor: u32,
         limit: u32,
     },
+    /// Page through the privileged-change audit log (newest-first). Admin-only,
+    /// like every other request in this protocol. The response is a
+    /// [`MediatorAuditLogList`](crate::types::audit::MediatorAuditLogList).
+    #[serde(rename = "audit_log_list")]
+    AuditLogList {
+        cursor: u32,
+        limit: u32,
+    },
     Configuration(Value),
 }
 
@@ -34,4 +42,27 @@ pub struct AdminAccount {
     pub did_hash: String,
     #[serde(rename = "type")]
     pub _type: AccountType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the SDK↔mediator wire contract: the SDK's `list_audit_log` sends
+    /// `{"audit_log_list": {"cursor": N, "limit": M}}` and the mediator handler
+    /// deserializes it into the `AuditLogList` variant. A rename drift here would
+    /// otherwise only surface as a runtime parse failure.
+    #[test]
+    fn audit_log_list_request_wire_format() {
+        let json = serde_json::json!({"audit_log_list": {"cursor": 5, "limit": 25}});
+        let req: MediatorAdminRequest =
+            serde_json::from_value(json).expect("deserialize audit_log_list");
+        match req {
+            MediatorAdminRequest::AuditLogList { cursor, limit } => {
+                assert_eq!(cursor, 5);
+                assert_eq!(limit, 25);
+            }
+            _ => panic!("expected AuditLogList variant"),
+        }
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
@@ -149,6 +149,33 @@ pub(crate) async fn process(
                     }
                 }
             }
+            MediatorAdminRequest::AuditLogList { cursor, limit } => {
+                // Admin-gated already (the whole protocol checks
+                // `check_admin_account` above). Read-only page over the audit log.
+                match state.database.audit_log_list(cursor, limit).await {
+                    Ok(response) => _generate_response_message(
+                        &msg.id,
+                        &session.did,
+                        &state.config.mediator_did,
+                        &json!(response),
+                    ),
+                    Err(e) => {
+                        warn!("Error listing audit log. Reason: {}", e);
+                        Err(MediatorError::problem_with_log(
+                            14,
+                            &session.session_id,
+                            Some(msg.id.to_string()),
+                            ProblemReportSorter::Error,
+                            ProblemReportScope::Protocol,
+                            "me.res.storage.error",
+                            "Database transaction error: {1}",
+                            vec![e.to_string()],
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!("Database transaction error: {e}"),
+                        ))
+                    }
+                }
+            }
             MediatorAdminRequest::AdminAdd(attr) => {
                 let targets = attr.clone();
                 match state

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.8] - 2026-06-13
+
+### Added
+
+- **`Mediator::list_audit_log` (and `MediatorOps::list_audit_log`)** — admin
+  client method to page the mediator's privileged-change audit log (newest-first,
+  cursor-paginated), sending the new `audit_log_list` administration request.
+  Re-exports `AuditLogEntry`, `AuditAction`, and `MediatorAuditLogList` from
+  `affinidi-messaging-mediator-common`. Pairs with mediator 0.15.44 / simplification T25b.
+
 ## [0.18.7] - 2026-06-06
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.7"
+version = "0.18.8"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/administration.rs
@@ -18,6 +18,9 @@ use uuid::Uuid;
 pub use affinidi_messaging_mediator_common::types::administration::{
     AdminAccount, MediatorAdminList, MediatorAdminRequest,
 };
+pub use affinidi_messaging_mediator_common::types::audit::{
+    AuditAction, AuditLogEntry, MediatorAuditLogList,
+};
 
 #[derive(Default)]
 pub struct Mediator {}
@@ -318,6 +321,82 @@ impl Mediator {
         .instrument(_span)
         .await
     }
+
+    /// Parses the response from the mediator for a page of the audit log
+    fn _parse_audit_log_response(
+        &self,
+        message: &Message,
+    ) -> Result<MediatorAuditLogList, ATMError> {
+        serde_json::from_value(message.body.clone()).map_err(|err| {
+            ATMError::MsgReceiveError(format!(
+                "Mediator Audit Log response could not be parsed. Reason: {err}"
+            ))
+        })
+    }
+
+    /// Pages through the mediator's privileged-change audit log (newest-first).
+    /// Admin-only.
+    /// - `atm` - The ATM client to use
+    /// - `cursor` - The cursor to start from (Defaults to 0 if not provided)
+    /// - `limit` - The maximum number of entries to return (Defaults to 100)
+    /// # Returns
+    /// A page of audit-log entries plus the cursor for the next page.
+    pub async fn list_audit_log(
+        &self,
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<MediatorAuditLogList, ATMError> {
+        let _span = span!(Level::DEBUG, "list_audit_log");
+
+        async move {
+            debug!(
+                "Requesting audit log from mediator. Cursor: {} Limit: {}",
+                cursor.unwrap_or(0),
+                limit.unwrap_or(100)
+            );
+
+            let (profile_did, mediator_did) = profile.dids()?;
+
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+
+            let msg = Message::build(
+                Uuid::new_v4().to_string(),
+                "https://didcomm.org/mediator/1.0/admin-management".to_owned(),
+                json!({"audit_log_list": {"cursor": cursor.unwrap_or(0), "limit": limit.unwrap_or(100)}}),
+            )
+            .to(mediator_did.into())
+            .from(profile_did.into())
+            .created_time(now)
+            .expires_time(now + 10)
+            .finalize();
+
+            let msg_id = msg.id.clone();
+
+            // Pack the message
+            let (msg, _) = atm
+                .inner
+                .pack_encrypted(&msg, mediator_did, Some(profile_did))
+                .await
+                .map_err(|e| ATMError::MsgSendError(format!("Error packing message: {e}")))?;
+
+                match atm
+                .send_message(profile, &msg, &msg_id, true, true)
+                .await? { SendMessageResponse::Message(message) => {
+                self._parse_audit_log_response(&message)
+                } _ => {
+                    Err(ATMError::MsgReceiveError(
+                        "No response from mediator".to_owned(),
+                    ))
+                }}
+        }
+        .instrument(_span)
+        .await
+    }
 }
 
 /// Wrapper struct that holds a reference to ATM, enabling the `atm.mediator().method()` pattern
@@ -366,6 +445,19 @@ impl<'a> MediatorOps<'a> {
     ) -> Result<MediatorAdminList, ATMError> {
         Mediator::default()
             .list_admins(self.atm, profile, cursor, limit)
+            .await
+    }
+
+    /// Pages through the mediator's privileged-change audit log
+    /// See [`Mediator::list_audit_log`] for full documentation
+    pub async fn list_audit_log(
+        &self,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<MediatorAuditLogList, ATMError> {
+        Mediator::default()
+            .list_audit_log(self.atm, profile, cursor, limit)
             .await
     }
 }


### PR DESCRIPTION
## T25b — admin query for the audit log (completes T25)

Second half of T25. The privileged-change audit log recorded in T25a (#436) is now readable back over the admin-management protocol. Small, additive — the store layer was already built and tested.

### Changes
- **mediator-common (0.15.11 → 0.15.12):** new `MediatorAdminRequest::AuditLogList { cursor, limit }` variant (wire tag `audit_log_list`). Response is the existing `MediatorAuditLogList`. A serde wire-contract unit test guards the tag against drift.
- **mediator (0.15.43 → 0.15.44):** admin-gated handler arm calling `audit_log_list`, mirroring the existing `admin_list` handler. The whole administration protocol is already gated by `check_admin_account`, so the audit log is admin-only. Read-only; no new storage.
- **sdk (0.18.7 → 0.18.8):** `Mediator::list_audit_log` + `MediatorOps::list_audit_log` client methods (newest-first, cursor-paginated), re-exporting `AuditLogEntry` / `AuditAction` / `MediatorAuditLogList`.

### Verification
- clippy `-D warnings`: mediator (both feature sets), common, sdk.
- common lib **142** (+1 wire-contract test) · mediator lib 135 · sdk lib 60 · test-mediator e2e green · full workspace build · `fmt --check` clean.
- No new dependencies. Publishing-trap clear: mediator-config still builds against common 0.15.12.

**This closes T25.** Additive only — no behaviour change to existing requests.
