### PR TITLE
test: scaffold affinidi-tdk-test-support crate (TI0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   # TDK: unified entry point
   "crates/tdk/affinidi-tdk-common",
   "crates/tdk/affinidi-tdk",
+  "crates/tdk/affinidi-tdk-test-support",
 
   # Applications
   "crates/applications/affinidi-meeting-place",

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Affinidi TDK Test Support
+
+## Changelog history
+
+## 13th June 2026
+
+### 0.1.0 — scaffold (TI0)
+
+- New `affinidi-tdk-test-support` crate: the shared home for cross-cutting,
+  in-process integration-test fixtures across the TDK workspace, complementing
+  the mediator-specific `affinidi-messaging-test-mediator`.
+- Scaffold only — `publish = false`, no fixtures yet. Establishes the crate, its
+  workspace membership, and CI coverage so each TI-series harness lands as a
+  thin, self-contained PR. First fixture (the did:web mock server) arrives in
+  TI2.

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "affinidi-tdk-test-support"
+version = "0.1.0"
+description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+readme = "README.md"
+# Scaffold only — flipped to `true` once the fixture API stabilises (TI-series)
+# so external consumers can pull it in as a dev-dependency. Empty crates should
+# not hit crates.io.
+publish = false
+
+[dependencies]
+# Fixture dependencies are added per task as each harness lands:
+#   TI2  did:web/webvh mock server + StaticResolver  → did-common, resolver-traits, did-web, axum
+#   TI1  multi-mediator TestTopology                  → test-mediator, mediator
+#   TI4  seeded did:peer + injectable clock           → affinidi-tdk, secrets-resolver
+#   TI5  CredentialScenario                           → vc, sd-jwt, status-list
+#   TI7  shared vectors/ loader                        → serde, serde_json
+
+[lints]
+workspace = true

--- a/crates/tdk/affinidi-tdk-test-support/README.md
+++ b/crates/tdk/affinidi-tdk-test-support/README.md
@@ -1,0 +1,33 @@
+# affinidi-tdk-test-support
+
+[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://github.com/affinidi/affinidi-tdk-rs/blob/main/LICENSE)
+
+Shared in-process test fixtures and harnesses for the Affinidi TDK workspace.
+
+This crate is the single home for cross-cutting integration-test infrastructure,
+so a fixture is written once and reused by every workspace member (and,
+eventually, by external consumers writing their own e2e tests). It complements
+[`affinidi-messaging-test-mediator`], which owns the embedded-mediator fixture;
+this crate covers the rest of the workspace (DID resolution, credentials,
+multi-service topologies, deterministic test inputs).
+
+## When to use
+
+Pull it in as a `dev-dependency` when a test needs infrastructure that isn't
+mediator-specific — a mock did:web server, a deterministic resolver, a
+credential issuer/holder/verifier scenario, or a multi-mediator topology — and
+you don't want to stand up external services.
+
+## Status
+
+Scaffold. Fixtures land per task in the TI-series (see `tasks/testing-todo.md`):
+
+| Task | Module        | Fixture                                                       |
+|------|---------------|---------------------------------------------------------------|
+| TI1  | `topology`    | Multi-mediator `TestTopology` (in-process, no Redis)          |
+| TI2  | `did_web`     | did:web / did:webvh mock server + injectable `StaticResolver` |
+| TI4  | `determinism` | Seeded did:peer generation + injectable clock                 |
+| TI5  | `credentials` | `CredentialScenario` (issuer / holder / verifier)             |
+| TI7  | `vectors`     | Shared `tests/vectors/` layout + loader                       |
+
+[`affinidi-messaging-test-mediator`]: ../../messaging/affinidi-messaging-test-mediator

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -1,0 +1,30 @@
+/*!
+ * Shared in-process test fixtures for the Affinidi TDK workspace.
+ *
+ * This crate is the single home for cross-cutting integration-test
+ * infrastructure so that fixtures are written once and reused by every
+ * workspace member (and, eventually, by external consumers writing their own
+ * e2e tests).
+ *
+ * It deliberately sits in the `tdk` layer — above messaging, credentials and
+ * identity — so it may depend on any lower-layer crate. Consumers pull it in as
+ * a `dev-dependency`; nothing in the normal build graph depends on it, so the
+ * upward dev-dependency edges create no cycle.
+ *
+ * # Roadmap (TI-series, see `tasks/testing-todo.md`)
+ *
+ * Modules are added by the task that needs them; this scaffold establishes the
+ * crate, its workspace wiring, and CI coverage so each fixture lands as a thin,
+ * self-contained PR.
+ *
+ * - **TI1** — `topology`: multi-mediator [`TestTopology`] (in-process, no Redis).
+ * - **TI2** — `did_web`: in-process did:web / did:webvh mock server with fault
+ *   injection, plus an injectable `StaticResolver`.
+ * - **TI4** — `determinism`: seeded did:peer generation and an injectable clock.
+ * - **TI5** — `credentials`: issuer/holder/verifier `CredentialScenario`.
+ * - **TI7** — `vectors`: shared `tests/vectors/` layout and loader.
+ */
+
+// Fixtures land here per TI-series task. The crate is intentionally empty until
+// TI2 adds the first harness — this keeps the scaffold a no-op while reserving
+// the name, location, and CI slot.


### PR DESCRIPTION
## TI0 — scaffold the shared test-support crate

First task of the integration-testing track (TI-series). Decides the fixture-crate home and lays down the scaffold so subsequent fixtures land as thin, self-contained PRs.

### Decision: split (new crate), not extend `test-mediator`

A new `affinidi-tdk-test-support` crate at `crates/tdk/affinidi-tdk-test-support`:

- Sits in the **tdk layer** so it may depend on any lower-layer crate. Consumers pull it in as a `dev-dependency`, so the upward edges form no build-graph cycle.
- **Complements** `affinidi-messaging-test-mediator`, which keeps the embedded-mediator fixture. This crate covers the rest of the workspace (DID resolution, credentials, multi-service topologies, deterministic inputs).

### What's in this PR

- New crate: `publish = false`, empty `lib.rs` (documented roadmap), `README.md`, `CHANGELOG.md`.
- Added to workspace members — CI covers it automatically (workspace-wide via `pipeline-rust`).

Fixtures land per task: **TI2** `did_web` (mock did:web/webvh server + `StaticResolver`), TI1 `topology`, TI4 `determinism`, TI5 `credentials`, TI7 `vectors`.

### Verification

- `cargo build -p affinidi-tdk-test-support` ✅
- `cargo clippy -p affinidi-tdk-test-support --all-targets -- -D warnings` ✅
- `cargo fmt` ✅ · workspace metadata resolves ✅

Test-infrastructure only — no version bump to any other crate, no behaviour change.
