### PR TITLE
test: did:web/webvh mock server + StaticResolver fixtures (TI2)

### DIFF
--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## 13th June 2026
 
+### 0.2.0 — did:web/webvh mock server + StaticResolver (TI2)
+
+- `did_web::MockDidWebServer`: an in-process HTTP origin (ephemeral `127.0.0.1`
+  port) serving `did.json` / `did.jsonl` (+ witness) with fault injection
+  (`Delay`, `Hang`, `Status`, `Garbage`, `Oversize`) and per-path request
+  counts. `webvh_authority()` yields `localhost%3A<port>` for minting
+  `did:webvh` DIDs that resolve over HTTP.
+- `resolver::StaticResolver`: a deterministic, fault-injecting `AsyncResolver`
+  with per-DID outcomes (`Resolves`, `Fails`, `NotHandled`, `Delays`, `Hangs`)
+  and a recorded call log for cache-stampede / dedup assertions.
+- Unblocks the W1/W2/W3 cache-server/SDK hardening regression tests.
+
 ### 0.1.0 — scaffold (TI0)
 
 - New `affinidi-tdk-test-support` crate: the shared home for cross-cutting,

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -16,12 +16,39 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-# Fixture dependencies are added per task as each harness lands:
-#   TI2  did:web/webvh mock server + StaticResolver  → did-common, resolver-traits, did-web, axum
-#   TI1  multi-mediator TestTopology                  → test-mediator, mediator
-#   TI4  seeded did:peer + injectable clock           → affinidi-tdk, secrets-resolver
-#   TI5  CredentialScenario                           → vc, sd-jwt, status-list
-#   TI7  shared vectors/ loader                        → serde, serde_json
+# ── TI2: did:web/webvh mock server + StaticResolver ──────────────────────
+## `DID`/`Document` types and the resolver traits the StaticResolver implements.
+## Path + explicit version so the crate stays publishable once the API settles.
+affinidi-did-common = { version = "0.3", path = "../../identity/affinidi-did-common" }
+affinidi-did-resolver-traits = { version = "0.1", path = "../../identity/affinidi-did-resolver-traits" }
+## In-process HTTP server backing MockDidWebServer.
+axum = "0.8"
+tokio = { workspace = true, features = [
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "time",
+  "sync",
+  "macros",
+] }
+serde_json = "1"
+tracing = "0.1"
+
+# Later tasks add their own deps as each harness lands:
+#   TI1  multi-mediator TestTopology  → test-mediator, mediator
+#   TI4  seeded did:peer + clock      → affinidi-tdk, secrets-resolver
+#   TI5  CredentialScenario           → vc, sd-jwt, status-list
+#   TI7  shared vectors/ loader       → serde
+
+[dev-dependencies]
+## Drives the mock server over HTTP in the crate's own tests.
+reqwest = { version = "0.13", default-features = false, features = [
+  "rustls",
+  "json",
+] }
+## `test-util` enables `#[tokio::test(start_paused = true)]` for the
+## virtual-clock delay/hang tests.
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
@@ -1,0 +1,367 @@
+//! An in-process HTTP server that stands in for a `did:web` / `did:webvh`
+//! origin, with fault injection.
+//!
+//! [`MockDidWebServer`] serves DID documents (`did.json`) and `did:webvh` logs
+//! (`did.jsonl` + witness) from an ephemeral `127.0.0.1` port so tests can
+//! exercise the real HTTP fetch path — including the failure modes that matter
+//! for hardening the resolver edge: slow responses, hangs, error statuses,
+//! malformed bodies, and oversized bodies. Every request is counted so a test
+//! can assert how many fetches actually hit the origin.
+//!
+//! # Addressing
+//!
+//! The listener binds `127.0.0.1`; [`MockDidWebServer::base_url`] returns the
+//! `http://127.0.0.1:<port>` form used directly by HTTP clients in tests.
+//!
+//! `did:webvh` is the one method whose resolver emits `http://` (only) for the
+//! host `localhost`, so [`MockDidWebServer::webvh_authority`] returns
+//! `localhost%3A<port>` for minting `did:webvh:…:localhost%3A<port>:…` DIDs.
+//! That path relies on `localhost` resolving to the loopback the server is
+//! bound on (the standard configuration).
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use affinidi_did_common::Document;
+use axum::{
+    Router,
+    extract::{Request, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// A fault applied to every response until cleared.
+#[derive(Clone, Default)]
+pub enum Fault {
+    /// Serve registered responses normally.
+    #[default]
+    None,
+    /// Sleep this long before serving (still serves the registered response).
+    Delay(Duration),
+    /// Accept the request but never respond — drives client read timeouts.
+    Hang,
+    /// Replace every response with this status code and an empty body.
+    Status(u16),
+    /// Serve a 200 with a body that is not valid JSON.
+    Garbage,
+    /// Serve a 200 with a body of this many bytes — drives size-limit guards.
+    Oversize(usize),
+}
+
+#[derive(Clone)]
+struct Canned {
+    status: u16,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Inner {
+    routes: RwLock<HashMap<String, Canned>>,
+    fault: RwLock<Fault>,
+    hits: RwLock<HashMap<String, usize>>,
+}
+
+#[derive(Clone, Default)]
+struct MockState {
+    inner: Arc<Inner>,
+}
+
+/// Aborts the server task when the [`MockDidWebServer`] is dropped, so tests
+/// don't leak listeners.
+struct AbortOnDrop(JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// In-process did:web / did:webvh origin. See the module docs.
+pub struct MockDidWebServer {
+    addr: SocketAddr,
+    state: MockState,
+    _task: AbortOnDrop,
+}
+
+impl MockDidWebServer {
+    /// Bind an ephemeral `127.0.0.1` port and start serving.
+    pub async fn start() -> Self {
+        let state = MockState::default();
+        let app = Router::new().fallback(handle).with_state(state.clone());
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind mock did:web server");
+        let addr = listener.local_addr().expect("mock server local_addr");
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            addr,
+            state,
+            _task: AbortOnDrop(task),
+        }
+    }
+
+    /// The bound address (`127.0.0.1:<port>`).
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The bound port.
+    pub fn port(&self) -> u16 {
+        self.addr.port()
+    }
+
+    /// Base URL for direct HTTP clients, e.g. `http://127.0.0.1:54321`.
+    pub fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// `localhost%3A<port>` — the authority to embed in a `did:webvh` DID so
+    /// its resolver fetches the log over `http://localhost:<port>/…`.
+    pub fn webvh_authority(&self) -> String {
+        format!("localhost%3A{}", self.addr.port())
+    }
+
+    /// Register a raw response at an exact request path (e.g.
+    /// `/.well-known/did.json`).
+    pub fn register(
+        &self,
+        path: impl Into<String>,
+        status: u16,
+        content_type: impl Into<String>,
+        body: impl Into<String>,
+    ) {
+        self.state.inner.routes.write().unwrap().insert(
+            path.into(),
+            Canned {
+                status,
+                content_type: content_type.into(),
+                body: body.into(),
+            },
+        );
+    }
+
+    /// Register a DID document at the `did:web` location for `segments`
+    /// (empty ⇒ `/.well-known/did.json`, else `/seg1/seg2/did.json`).
+    pub fn register_did_document(&self, segments: &[&str], document: &Document) {
+        let body = serde_json::to_string(document).expect("serialize DID document");
+        self.register(
+            doc_path(segments, "did.json"),
+            200,
+            "application/did+ld+json",
+            body,
+        );
+    }
+
+    /// Register a `did:webvh` JSONL log at the location for `segments`
+    /// (empty ⇒ `/.well-known/did.jsonl`, else `/seg1/seg2/did.jsonl`).
+    pub fn register_webvh_log(&self, segments: &[&str], jsonl: impl Into<String>) {
+        self.register(
+            doc_path(segments, "did.jsonl"),
+            200,
+            "application/jsonl",
+            jsonl,
+        );
+    }
+
+    /// Apply a fault to every subsequent response.
+    pub fn set_fault(&self, fault: Fault) {
+        *self.state.inner.fault.write().unwrap() = fault;
+    }
+
+    /// Clear any active fault.
+    pub fn clear_fault(&self) {
+        self.set_fault(Fault::None);
+    }
+
+    /// How many requests have hit an exact path.
+    pub fn hits(&self, path: &str) -> usize {
+        self.state
+            .inner
+            .hits
+            .read()
+            .unwrap()
+            .get(path)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Total requests across all paths.
+    pub fn total_hits(&self) -> usize {
+        self.state.inner.hits.read().unwrap().values().sum()
+    }
+}
+
+/// Build the document path for a did:web/webvh location.
+fn doc_path(segments: &[&str], file: &str) -> String {
+    if segments.is_empty() {
+        format!("/.well-known/{file}")
+    } else {
+        format!("/{}/{file}", segments.join("/"))
+    }
+}
+
+async fn handle(State(state): State<MockState>, req: Request) -> Response {
+    let path = req.uri().path().to_string();
+    *state
+        .inner
+        .hits
+        .write()
+        .unwrap()
+        .entry(path.clone())
+        .or_insert(0) += 1;
+
+    let fault = state.inner.fault.read().unwrap().clone();
+    match fault {
+        Fault::Hang => {
+            // Hold the connection open without ever responding.
+            std::future::pending::<()>().await;
+            unreachable!("pending() never resolves")
+        }
+        Fault::Delay(d) => tokio::time::sleep(d).await,
+        Fault::Status(code) => {
+            let status = StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            return (status, "").into_response();
+        }
+        Fault::Garbage => {
+            return (
+                [(header::CONTENT_TYPE, "application/json")],
+                "}{ not valid json",
+            )
+                .into_response();
+        }
+        Fault::Oversize(n) => {
+            return ([(header::CONTENT_TYPE, "application/json")], "x".repeat(n)).into_response();
+        }
+        Fault::None => {}
+    }
+
+    match state.inner.routes.read().unwrap().get(&path) {
+        Some(canned) => {
+            let status =
+                StatusCode::from_u16(canned.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (
+                status,
+                [(header::CONTENT_TYPE, canned.content_type.clone())],
+                canned.body.clone(),
+            )
+                .into_response()
+        }
+        None => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn serves_registered_did_document() {
+        let server = MockDidWebServer::start().await;
+        let did = "did:web:example.com";
+        server.register_did_document(&[], &Document::new(did).unwrap());
+
+        let url = format!("{}/.well-known/did.json", server.base_url());
+        let resp = reqwest::get(&url).await.unwrap();
+        assert!(resp.status().is_success());
+        let doc: Document = resp.json().await.unwrap();
+        assert_eq!(doc.id.as_str(), did);
+        assert_eq!(server.hits("/.well-known/did.json"), 1);
+    }
+
+    #[tokio::test]
+    async fn serves_path_scoped_document() {
+        let server = MockDidWebServer::start().await;
+        let did = "did:web:example.com:user:alice";
+        server.register_did_document(&["user", "alice"], &Document::new(did).unwrap());
+
+        let url = format!("{}/user/alice/did.json", server.base_url());
+        let resp = reqwest::get(&url).await.unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn unregistered_path_is_404() {
+        let server = MockDidWebServer::start().await;
+        let resp = reqwest::get(format!("{}/.well-known/did.json", server.base_url()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    #[tokio::test]
+    async fn status_fault_overrides_response() {
+        let server = MockDidWebServer::start().await;
+        server.register_did_document(&[], &Document::new("did:web:example.com").unwrap());
+        server.set_fault(Fault::Status(503));
+
+        let resp = reqwest::get(format!("{}/.well-known/did.json", server.base_url()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 503);
+
+        server.clear_fault();
+        let resp = reqwest::get(format!("{}/.well-known/did.json", server.base_url()))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn garbage_fault_serves_invalid_json() {
+        let server = MockDidWebServer::start().await;
+        server.register_did_document(&[], &Document::new("did:web:example.com").unwrap());
+        server.set_fault(Fault::Garbage);
+
+        let resp = reqwest::get(format!("{}/.well-known/did.json", server.base_url()))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.text().await.unwrap();
+        assert!(serde_json::from_str::<Document>(&body).is_err());
+    }
+
+    #[tokio::test]
+    async fn oversize_fault_serves_large_body() {
+        let server = MockDidWebServer::start().await;
+        server.set_fault(Fault::Oversize(2048));
+        let resp = reqwest::get(format!("{}/.well-known/did.json", server.base_url()))
+            .await
+            .unwrap();
+        assert_eq!(resp.text().await.unwrap().len(), 2048);
+    }
+
+    #[tokio::test]
+    async fn hang_fault_never_responds() {
+        let server = MockDidWebServer::start().await;
+        server.set_fault(Fault::Hang);
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!("{}/.well-known/did.json", server.base_url()))
+            .timeout(Duration::from_millis(300))
+            .send()
+            .await;
+        assert!(
+            res.is_err(),
+            "client should time out against a hanging server"
+        );
+    }
+
+    #[tokio::test]
+    async fn counts_hits_per_path() {
+        let server = MockDidWebServer::start().await;
+        server.register_did_document(&[], &Document::new("did:web:example.com").unwrap());
+        for _ in 0..2 {
+            let _ = reqwest::get(format!("{}/.well-known/did.json", server.base_url())).await;
+        }
+        let _ = reqwest::get(format!("{}/other", server.base_url())).await;
+        assert_eq!(server.hits("/.well-known/did.json"), 2);
+        assert_eq!(server.total_hits(), 3);
+    }
+}

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -17,14 +17,13 @@
  * crate, its workspace wiring, and CI coverage so each fixture lands as a thin,
  * self-contained PR.
  *
- * - **TI1** — `topology`: multi-mediator [`TestTopology`] (in-process, no Redis).
- * - **TI2** — `did_web`: in-process did:web / did:webvh mock server with fault
- *   injection, plus an injectable `StaticResolver`.
+ * - **TI1** — `topology`: multi-mediator `TestTopology` (in-process, no Redis).
+ * - **TI2** — [`did_web`] / [`resolver`]: in-process did:web / did:webvh mock
+ *   server with fault injection, plus an injectable `StaticResolver`. ✅
  * - **TI4** — `determinism`: seeded did:peer generation and an injectable clock.
  * - **TI5** — `credentials`: issuer/holder/verifier `CredentialScenario`.
  * - **TI7** — `vectors`: shared `tests/vectors/` layout and loader.
  */
 
-// Fixtures land here per TI-series task. The crate is intentionally empty until
-// TI2 adds the first harness — this keeps the scaffold a no-op while reserving
-// the name, location, and CI slot.
+pub mod did_web;
+pub mod resolver;

--- a/crates/tdk/affinidi-tdk-test-support/src/resolver.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/resolver.rs
@@ -1,0 +1,252 @@
+//! A deterministic, fault-injecting [`AsyncResolver`] for tests.
+//!
+//! [`StaticResolver`] returns canned outcomes for known DIDs without touching
+//! the network, so a test can drive any code that depends on DID resolution
+//! through exactly the path it wants: a successful document, a recognised-but-
+//! failed resolution, an unhandled method (`None`), a slow resolution, or one
+//! that never returns. It records every call so concurrency tests (e.g.
+//! cache-stampede deduplication) can assert how many resolutions actually
+//! happened.
+//!
+//! ```
+//! use affinidi_tdk_test_support::resolver::{Outcome, StaticResolver};
+//! use affinidi_did_common::Document;
+//!
+//! let did = "did:web:example.com";
+//! let resolver = StaticResolver::new()
+//!     .resolves(did, Document::new(did).unwrap());
+//! ```
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use affinidi_did_common::{DID, Document};
+use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
+
+/// What a [`StaticResolver`] does when asked to resolve a particular DID.
+///
+/// `Delays` wraps another outcome so a test can express "resolve after 2s" or
+/// "fail after 500ms"; `Hangs` never completes, which is the lever for
+/// request-path timeout tests.
+#[derive(Clone)]
+pub enum Outcome {
+    /// Resolve to this document — the happy path. Boxed because a `Document`
+    /// dwarfs the other variants.
+    Resolves(Box<Document>),
+    /// Recognise the DID but fail resolution
+    /// (`Some(Err(ResolverError::ResolutionFailed))`).
+    Fails(String),
+    /// "Not my DID" — return `None` so a resolver chain falls through.
+    NotHandled,
+    /// Wait `after`, then apply the inner outcome.
+    Delays {
+        /// How long to sleep before applying `then`.
+        after: Duration,
+        /// The outcome to apply once the delay elapses.
+        then: Box<Outcome>,
+    },
+    /// Never return. Drives "upstream resolution hangs" timeout tests.
+    Hangs,
+}
+
+impl Outcome {
+    /// Convenience: delay `after`, then resolve to `document`.
+    pub fn resolves_after(after: Duration, document: Document) -> Self {
+        Outcome::Delays {
+            after,
+            then: Box::new(Outcome::Resolves(Box::new(document))),
+        }
+    }
+}
+
+/// An in-memory [`AsyncResolver`] with per-DID canned outcomes and a recorded
+/// call log.
+///
+/// Unknown DIDs get the `default` outcome, which is [`Outcome::NotHandled`]
+/// (return `None`) unless overridden — matching the resolver-chain convention
+/// that an unrecognised DID passes to the next resolver.
+pub struct StaticResolver {
+    name: String,
+    default: Outcome,
+    entries: HashMap<String, Outcome>,
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl StaticResolver {
+    /// A resolver that handles nothing until outcomes are registered.
+    pub fn new() -> Self {
+        Self {
+            name: "StaticResolver".to_string(),
+            default: Outcome::NotHandled,
+            entries: HashMap::new(),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Override the resolver name (must be unique within a resolver chain).
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Register the outcome for a specific DID.
+    ///
+    /// `did` is matched against the resolved DID's canonical string form
+    /// (`DID::to_string`); register the exact DID your code will resolve.
+    pub fn outcome(mut self, did: impl Into<String>, outcome: Outcome) -> Self {
+        self.entries.insert(did.into(), outcome);
+        self
+    }
+
+    /// Shorthand for `outcome(did, Outcome::Resolves(document))`.
+    pub fn resolves(self, did: impl Into<String>, document: Document) -> Self {
+        self.outcome(did, Outcome::Resolves(Box::new(document)))
+    }
+
+    /// Set the outcome for DIDs with no explicit registration
+    /// (defaults to [`Outcome::NotHandled`]).
+    pub fn default_outcome(mut self, outcome: Outcome) -> Self {
+        self.default = outcome;
+        self
+    }
+
+    /// Every `resolve()` call this resolver has seen, in order, by DID string.
+    pub fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("calls mutex not poisoned").clone()
+    }
+
+    /// How many times a particular DID has been resolved.
+    pub fn call_count(&self, did: &str) -> usize {
+        self.calls
+            .lock()
+            .expect("calls mutex not poisoned")
+            .iter()
+            .filter(|d| d.as_str() == did)
+            .count()
+    }
+
+    /// Total number of `resolve()` calls across all DIDs.
+    pub fn total_calls(&self) -> usize {
+        self.calls.lock().expect("calls mutex not poisoned").len()
+    }
+}
+
+impl Default for StaticResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsyncResolver for StaticResolver {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        did: &'a DID,
+    ) -> Pin<Box<dyn Future<Output = Resolution> + Send + 'a>> {
+        let key = did.to_string();
+        // Record the call and pick the outcome synchronously, releasing the
+        // lock before we await so a `Hangs`/`Delays` outcome never holds it.
+        self.calls
+            .lock()
+            .expect("calls mutex not poisoned")
+            .push(key.clone());
+        let outcome = self
+            .entries
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| self.default.clone());
+        Box::pin(eval(outcome))
+    }
+}
+
+/// Apply an [`Outcome`], awaiting any delay or hanging forever as requested.
+async fn eval(outcome: Outcome) -> Resolution {
+    match outcome {
+        Outcome::Resolves(doc) => Some(Ok(*doc)),
+        Outcome::Fails(msg) => Some(Err(ResolverError::ResolutionFailed(msg))),
+        Outcome::NotHandled => None,
+        Outcome::Delays { after, then } => {
+            tokio::time::sleep(after).await;
+            Box::pin(eval(*then)).await
+        }
+        Outcome::Hangs => std::future::pending().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did(s: &str) -> DID {
+        s.parse().expect("valid DID")
+    }
+
+    #[tokio::test]
+    async fn resolves_registered_did() {
+        let id = "did:web:example.com";
+        let resolver = StaticResolver::new().resolves(id, Document::new(id).unwrap());
+
+        let res = resolver.resolve(&did(id)).await;
+        let doc = res.expect("handled").expect("ok");
+        assert_eq!(doc.id.as_str(), "did:web:example.com");
+        assert_eq!(resolver.call_count(id), 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_did_is_not_handled_by_default() {
+        let resolver = StaticResolver::new();
+        assert!(
+            resolver
+                .resolve(&did("did:web:example.com"))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_outcome_surfaces_error() {
+        let id = "did:web:example.com";
+        let resolver =
+            StaticResolver::new().outcome(id, Outcome::Fails("upstream down".to_string()));
+        let err = resolver.resolve(&did(id)).await.unwrap().unwrap_err();
+        assert!(matches!(err, ResolverError::ResolutionFailed(_)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delays_then_resolves() {
+        let id = "did:web:slow.example";
+        let resolver = StaticResolver::new().outcome(
+            id,
+            Outcome::resolves_after(Duration::from_secs(5), Document::new(id).unwrap()),
+        );
+        // With time paused, the resolution only completes once time advances.
+        let res = tokio::time::timeout(Duration::from_secs(10), resolver.resolve(&did(id))).await;
+        assert!(res.is_ok(), "should resolve within the (virtual) window");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hangs_never_resolves() {
+        let id = "did:web:blackhole.example";
+        let resolver = StaticResolver::new().outcome(id, Outcome::Hangs);
+        let res = tokio::time::timeout(Duration::from_secs(30), resolver.resolve(&did(id))).await;
+        assert!(res.is_err(), "a hanging resolution must trip the timeout");
+    }
+
+    #[tokio::test]
+    async fn records_calls_for_dedup_assertions() {
+        let id = "did:web:counted.example";
+        let resolver = StaticResolver::new().resolves(id, Document::new(id).unwrap());
+        for _ in 0..3 {
+            let _ = resolver.resolve(&did(id)).await;
+        }
+        assert_eq!(resolver.total_calls(), 3);
+        assert_eq!(resolver.call_count(id), 3);
+        assert_eq!(resolver.calls(), vec![id, id, id]);
+    }
+}


### PR DESCRIPTION
## TI2 — did:web/webvh mock server + injectable StaticResolver

Second task of the integration-testing track. Adds the first fixtures to `affinidi-tdk-test-support` (scaffolded in #439), which are the prerequisite for the **W1/W2/W3** cache-server / cache-sdk hardening regression tests.

### `resolver::StaticResolver`

A deterministic, fault-injecting `AsyncResolver` (implements the `affinidi-did-resolver-traits` trait, so it drops into any `Box<dyn AsyncResolver>` slot). Per-DID outcomes:

- `Resolves(doc)` — happy path
- `Fails(msg)` — recognised but failed (`Some(Err(..))`)
- `NotHandled` — `None`, so a resolver chain falls through
- `Delays { after, then }` — slow resolution
- `Hangs` — never returns (drives request-path **timeout** tests, W1)

It records every `resolve()` call (`calls()`, `call_count()`, `total_calls()`) so the **cache-stampede dedup** test (W3) can assert "N concurrent misses ⇒ one upstream".

### `did_web::MockDidWebServer`

An in-process axum HTTP origin on an ephemeral `127.0.0.1` port, serving `did.json` / `did.jsonl` (+ witness) by registered path, with global fault injection — `Delay`, `Hang`, `Status(code)`, `Garbage` (invalid JSON), `Oversize(n)` — and per-path hit counts. `webvh_authority()` returns `localhost%3A<port>` for minting `did:webvh` DIDs (did:webvh is the one method whose resolver emits `http://` for the host `localhost`, verified against `didwebvh-rs` 0.5).

### Verification

- 14 unit tests + 1 doctest ✅ (`cargo test -p affinidi-tdk-test-support`)
- `cargo clippy -p affinidi-tdk-test-support --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅

New deps (`axum`, dev-dep `reqwest`) already exist elsewhere in the workspace tree, so no new advisory/license surface. `publish = false` retained until the fixture API settles; version `0.1.0 → 0.2.0`.
