### PR TITLE
fix: remove cache-server panics and bound upstream resolution (W1)

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Affinidi DID Resolver Cache Server
+
+## Changelog history
+
+## 13th June 2026
+
+### 0.8.0 — remove request/startup panics, bound upstream resolution (W1)
+
+- **No more panics on the request path.** The four
+  `serde_json::to_string(..).unwrap()` calls in the WebSocket handler — a
+  serialization failure used to panic the per-connection task — now serialize
+  safely and close the connection gracefully on failure. The duplicated
+  text/binary resolve-and-respond blocks are consolidated into shared
+  `resolve_and_respond` / `send_response` helpers.
+- **Bounded upstream resolution.** Both the HTTP (`/resolve/{did}`) and
+  WebSocket handlers wrap `resolver.resolve()` in a timeout, so a hung upstream
+  returns a clean error to the client instead of blocking the request/socket.
+  Configurable via the new `resolve_timeout` setting (default 30s,
+  `RESOLVE_TIMEOUT` env var).
+- **No more startup panics.** Config-init failure, an invalid `listen_address`,
+  and a server bind/serve error now propagate as `DIDCacheError` instead of
+  `unwrap()`/`expect()`. The statistics task logs its error instead of
+  `expect()`-panicking (full supervision lands in W2).
+- `errors.rs`: the `StatusCode::from_u16(..).unwrap()` in `IntoResponse`
+  defaults to `500` instead of panicking.
+- New `pub` field `SharedData.resolve_timeout` (minor-version bump).

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.7.5"
+version = "0.8.0"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
@@ -10,6 +10,12 @@ listen_address = "${LISTEN_ADDRESS:0.0.0.0:8080}"
 ### Default: 60 second
 statistics_interval = "${STATISTICS_INTERVAL:10}"
 
+### resolve_timeout: max seconds a single upstream DID resolution may take
+### before the request path gives up and returns an error (rather than
+### blocking the HTTP request / WebSocket connection on a hung upstream).
+### Default: 30 seconds
+resolve_timeout = "${RESOLVE_TIMEOUT:30}"
+
 ### enable_http_endpoint: true/false
 ### Default: true
 ### If true, the server will make available /resolve endpoint for HTTP GET requests

--- a/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
@@ -37,7 +37,15 @@ struct ConfigRaw {
     pub enable_http_endpoint: String,
     pub enable_websocket_endpoint: String,
     pub statistics_interval: String,
+    #[serde(default = "default_resolve_timeout")]
+    pub resolve_timeout: String,
     pub cache: CacheConfig,
+}
+
+/// Default upstream-resolution timeout (seconds), used when the config file
+/// predates the `resolve_timeout` key.
+fn default_resolve_timeout() -> String {
+    "30".into()
 }
 
 pub struct Config {
@@ -46,6 +54,9 @@ pub struct Config {
     pub enable_http_endpoint: bool,
     pub enable_websocket_endpoint: bool,
     pub statistics_interval: Duration,
+    /// Maximum time a single upstream DID resolution may take before the
+    /// request path gives up and returns an error instead of blocking.
+    pub resolve_timeout: Duration,
     pub cache_capacity_count: u32,
     pub cache_expire: u32,
 }
@@ -61,6 +72,10 @@ impl fmt::Debug for Config {
                 "statistics_interval",
                 &format!("{} seconds", self.statistics_interval.as_secs()),
             )
+            .field(
+                "resolve_timeout",
+                &format!("{} seconds", self.resolve_timeout.as_secs()),
+            )
             .field("cache_capacity_count", &self.cache_capacity_count)
             .field("cache_expire", &format!("{} seconds", self.cache_expire))
             .finish()
@@ -75,6 +90,7 @@ impl Default for Config {
             enable_http_endpoint: true,
             enable_websocket_endpoint: true,
             statistics_interval: Duration::from_secs(60),
+            resolve_timeout: Duration::from_secs(30),
             cache_capacity_count: CacheConfig::default()
                 .capacity_count
                 .parse()
@@ -101,6 +117,7 @@ impl TryFrom<ConfigRaw> for Config {
             enable_http_endpoint: raw.enable_http_endpoint.parse().unwrap_or(true),
             enable_websocket_endpoint: raw.enable_websocket_endpoint.parse().unwrap_or(true),
             statistics_interval: Duration::from_secs(raw.statistics_interval.parse().unwrap_or(60)),
+            resolve_timeout: Duration::from_secs(raw.resolve_timeout.parse().unwrap_or(30)),
             cache_capacity_count: raw.cache.capacity_count.parse().unwrap_or(1000),
             cache_expire: raw.cache.expire.parse().unwrap_or(300),
         })

--- a/crates/identity/affinidi-did-resolver-cache-server/src/errors.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/errors.rs
@@ -98,7 +98,7 @@ impl IntoResponse for AppError {
             }
         };
         (
-            StatusCode::from_u16(response.httpCode).ok().unwrap(),
+            StatusCode::from_u16(response.httpCode).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             Json(response),
         )
             .into_response()

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
@@ -1,4 +1,7 @@
-use crate::{SharedData, handlers::fetch_webvh_log};
+use crate::{
+    SharedData,
+    handlers::{fetch_webvh_log, resolve_with_timeout},
+};
 use affinidi_did_resolver_cache_sdk::DIDMethod;
 use axum::{
     Json,
@@ -12,7 +15,7 @@ pub async fn resolver_handler(
     State(state): State<SharedData>,
     Path(did): Path<String>,
 ) -> (StatusCode, Json<Value>) {
-    match state.resolver.resolve(&did).await {
+    match resolve_with_timeout(&state.resolver, state.resolve_timeout, &did).await {
         Ok(doc) => {
             let mut stats = state.stats.lock().await;
             stats.increment_resolver_success();

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
@@ -1,5 +1,8 @@
 use crate::{SharedData, config::Config};
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, ResolveResponse, errors::DIDCacheError};
 use axum::{Json, Router, extract::State, response::IntoResponse, routing::get};
+use std::future::Future;
+use std::time::Duration;
 use tracing::{info, warn};
 
 pub(crate) mod http;
@@ -7,6 +10,47 @@ pub(crate) mod http;
 pub(crate) mod websocket;
 
 const MAX_WEBVH_LOG_BYTES: usize = 1024 * 1024;
+
+/// Outcome of a timeout-bounded upstream resolution.
+#[derive(Debug)]
+pub(crate) enum ResolveError {
+    /// The resolver itself returned an error.
+    Resolver(DIDCacheError),
+    /// Resolution did not complete within the configured timeout (seconds).
+    Timeout(u64),
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::Resolver(e) => write!(f, "{e}"),
+            ResolveError::Timeout(secs) => write!(f, "resolution timed out after {secs}s"),
+        }
+    }
+}
+
+/// Bound a resolution future by `timeout`, turning a hung upstream into a
+/// distinct [`ResolveError::Timeout`] so the request path returns an error to
+/// the client instead of blocking the connection indefinitely.
+async fn apply_timeout<T>(
+    timeout: Duration,
+    fut: impl Future<Output = Result<T, DIDCacheError>>,
+) -> Result<T, ResolveError> {
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(e)) => Err(ResolveError::Resolver(e)),
+        Err(_elapsed) => Err(ResolveError::Timeout(timeout.as_secs())),
+    }
+}
+
+/// Resolve `did` through `resolver`, bounded by `timeout`.
+pub(crate) async fn resolve_with_timeout(
+    resolver: &DIDCacheClient,
+    timeout: Duration,
+    did: &str,
+) -> Result<ResolveResponse, ResolveError> {
+    apply_timeout(timeout, resolver.resolve(did)).await
+}
 
 /// Read a response body as UTF-8 text, refusing anything larger than `limit` bytes.
 async fn read_text_limited(mut resp: reqwest::Response, limit: usize) -> Option<String> {
@@ -134,4 +178,34 @@ pub async fn health_checker_handler(State(state): State<SharedData>) -> impl Int
         "message": message,
     });
     Json(response_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn apply_timeout_trips_on_hung_resolution() {
+        // A never-resolving future must surface as a timeout, not a hang.
+        let fut = std::future::pending::<Result<(), DIDCacheError>>();
+        let res = apply_timeout(Duration::from_millis(50), fut).await;
+        assert!(matches!(res, Err(ResolveError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn apply_timeout_passes_fast_success() {
+        let res = apply_timeout(
+            Duration::from_secs(5),
+            std::future::ready(Ok::<_, DIDCacheError>(42)),
+        )
+        .await;
+        assert_eq!(res.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn apply_timeout_passes_resolver_error() {
+        let fut = std::future::ready(Err::<(), _>(DIDCacheError::DIDError("bad".into())));
+        let res = apply_timeout(Duration::from_secs(5), fut).await;
+        assert!(matches!(res, Err(ResolveError::Resolver(_))));
+    }
 }

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
@@ -12,7 +12,10 @@ use axum::{
 use tokio::select;
 use tracing::{Instrument, debug, info, span, warn};
 
-use crate::{SharedData, handlers::fetch_webvh_log};
+use crate::{
+    SharedData,
+    handlers::{fetch_webvh_log, resolve_with_timeout},
+};
 
 /// Build a WSResponse, fetching the raw DID log for WebVH DIDs.
 async fn build_response(response: ResolveResponse) -> WSResponseType {
@@ -29,6 +32,66 @@ async fn build_response(response: ResolveResponse) -> WSResponseType {
         did_log,
         did_witness_log,
     }))
+}
+
+/// Serialize and send a WS response. Returns `false` if the connection should
+/// be closed (serialization failure or send error). Never panics — a
+/// serialization failure that previously `unwrap()`ed and killed the task now
+/// logs and closes the connection gracefully.
+async fn send_response(socket: &mut WebSocket, message: &WSResponseType) -> bool {
+    let text = match serde_json::to_string(message) {
+        Ok(text) => text,
+        Err(e) => {
+            warn!("ws: failed to serialize response, closing connection: {e:?}");
+            return false;
+        }
+    };
+    match socket.send(Message::Text(text.into())).await {
+        Ok(()) => {
+            debug!("Sent response: {message:?}");
+            true
+        }
+        Err(e) => {
+            warn!("ws: Error sending response: {e:?}");
+            false
+        }
+    }
+}
+
+/// Resolve `did` (bounded by the configured timeout) and send the response, or
+/// an error response if resolution fails or times out. Returns `false` if the
+/// connection should be closed.
+async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: String) -> bool {
+    match resolve_with_timeout(&state.resolver, state.resolve_timeout, &did).await {
+        Ok(response) => {
+            {
+                let mut stats = state.stats().await;
+                stats.increment_resolver_success();
+                if response.cache_hit {
+                    stats.increment_cache_hit();
+                }
+                stats.increment_did_method_success(response.method.clone());
+            }
+            debug!(
+                "resolved DID: ({}) cache_hit?({})",
+                response.did, response.cache_hit
+            );
+            let message = build_response(response).await;
+            send_response(socket, &message).await
+        }
+        Err(e) => {
+            // Couldn't resolve the DID (or timed out), send an error back.
+            let hash = DIDCacheClient::hash_did(&did);
+            warn!("Couldn't resolve DID: ({did}) Reason: {e}");
+            state.stats().await.increment_resolver_error();
+            let message = WSResponseType::Error(WSResponseError {
+                did,
+                hash,
+                error: e.to_string(),
+            });
+            send_response(socket, &message).await
+        }
+    }
 }
 
 // Handles the switching of the protocol to a websocket connection
@@ -80,32 +143,8 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData) {
                                             }
                                         };
 
-                                        match state.resolver.resolve(&request.did).await {
-                                            Ok(response) => {
-                                                let mut stats = state.stats().await;
-                                                stats.increment_resolver_success();
-                                                if response.cache_hit { stats.increment_cache_hit();}
-                                                stats.increment_did_method_success(response.method.clone());
-                                                drop(stats);
-                                                debug!("resolved DID: ({}) cache_hit?({})", response.did, response.cache_hit);
-                                                let message = build_response(response).await;
-                                                if let Err(e) = socket.send(Message::Text(serde_json::to_string(&message).unwrap().into())).await {
-                                                    warn!("ws: Error sending response: {:?}", e);
-                                                    break;
-                                                } else {
-                                                    debug!("Sent response: {:?}", message);
-                                                }
-                                            }
-                                            Err(e) => {
-                                                // Couldn't resolve the DID, send an error back
-                                                let hash = DIDCacheClient::hash_did(&request.did);
-                                                warn!("Couldn't resolve DID: ({}) Reason: {}", &request.did, e);
-                                                state.stats().await.increment_resolver_error();
-                                                if let Err(e) = socket.send(Message::Text(serde_json::to_string(&WSResponseType::Error(WSResponseError {did: request.did, hash, error: e.to_string()})).unwrap().into())).await {
-                                                    warn!("ws: Error sending error response: {:?}", e);
-                                                    break;
-                                                }
-                                            }
+                                        if !resolve_and_respond(&mut socket, &state, request.did).await {
+                                            break;
                                         }
                                     }
                                     Message::Binary(msg) => {
@@ -118,32 +157,8 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData) {
                                             }
                                         };
 
-                                        match state.resolver.resolve(&request.did).await {
-                                            Ok(response) => {
-                                                let mut stats = state.stats().await;
-                                                stats.increment_resolver_success();
-                                                if response.cache_hit { stats.increment_cache_hit();}
-                                                stats.increment_did_method_success(response.method.clone());
-                                                drop(stats);
-                                                debug!("resolved DID: ({}) cache_hit?({})", response.did, response.cache_hit);
-                                                let message = build_response(response).await;
-                                                if let Err(e) = socket.send(Message::Text(serde_json::to_string(&message).unwrap().into())).await {
-                                                    warn!("ws: Error sending response: {:?}", e);
-                                                    break;
-                                                } else {
-                                                    debug!("Sent response: {:?}", message);
-                                                }
-                                            }
-                                            Err(e) => {
-                                                // Couldn't resolve the DID, send an error back
-                                                let hash = DIDCacheClient::hash_did(&request.did);
-                                                warn!("Couldn't resolve DID: ({}) Reason: {}", &request.did, e);
-                                                state.stats().await.increment_resolver_error();
-                                                if let Err(e) = socket.send(Message::Text(serde_json::to_string(&WSResponseType::Error(WSResponseError {did: request.did, hash, error: e.to_string()})).unwrap().into())).await {
-                                                    warn!("ws: Error sending error response: {:?}", e);
-                                                    break;
-                                                }
-                                            }
+                                        if !resolve_and_respond(&mut socket, &state, request.did).await {
+                                            break;
                                         }
                                     }
                                     Message::Ping(_) => {

--- a/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
@@ -6,7 +6,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use session::SessionError;
 use statistics::Statistics;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, MutexGuard};
 
 pub(crate) mod common;
@@ -22,6 +22,9 @@ pub struct SharedData {
     pub service_start_timestamp: DateTime<Utc>,
     pub stats: Arc<Mutex<Statistics>>,
     pub resolver: DIDCacheClient,
+    /// Upper bound on a single upstream resolution before the request path
+    /// returns an error rather than blocking the connection.
+    pub resolve_timeout: Duration,
 }
 
 impl<S> FromRequestParts<S> for SharedData

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -77,7 +77,8 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
 
     event!(Level::INFO, "[Loading Affinidi DID Cache configuration]");
 
-    let config = init(config_path, Some(reload_handle)).expect("Couldn't initialize DID Cache!");
+    let config = init(config_path, Some(reload_handle))
+        .map_err(|e| DIDCacheError::ConfigError(format!("Couldn't initialize DID Cache: {e}")))?;
 
     // Use the affinidi-did-resolver-cache-sdk in local mode
     let cache_config = DIDCacheConfigBuilder::default()
@@ -92,15 +93,17 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
         service_start_timestamp: chrono::Utc::now(),
         stats: Arc::new(Mutex::new(Statistics::default())),
         resolver,
+        resolve_timeout: config.resolve_timeout,
     };
 
-    // Start the statistics thread
+    // Start the statistics thread. A panic here previously killed the task
+    // silently; log the error instead (full supervision lands in W2).
     let _stats = shared_state.stats.clone();
     let _cache = shared_state.resolver.get_cache();
     tokio::spawn(async move {
-        statistics(config.statistics_interval, &_stats, _cache)
-            .await
-            .expect("Error starting statistics thread");
+        if let Err(e) = statistics(config.statistics_interval, &_stats, _cache).await {
+            event!(Level::ERROR, "Statistics task exited with error: {e}");
+        }
     });
 
     // build our application routes
@@ -132,15 +135,20 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
             get(health_checker_handler).with_state(shared_state),
         );
 
-    axum_server::bind(
-        config
-            .listen_address
-            .parse::<std::net::SocketAddr>()
-            .unwrap(),
-    )
-    .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-    .await
-    .unwrap();
+    let listen_address = config
+        .listen_address
+        .parse::<std::net::SocketAddr>()
+        .map_err(|e| {
+            DIDCacheError::ConfigError(format!(
+                "Invalid listen_address ({}): {e}",
+                config.listen_address
+            ))
+        })?;
+
+    axum_server::bind(listen_address)
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+        .await
+        .map_err(|e| DIDCacheError::TransportError(format!("server error: {e}")))?;
 
     Ok(())
 }


### PR DESCRIPTION
## W1 — cache-server: remove panics, bound upstream resolution

First security fix of the workspace-hardening track (W-series), built on the TI2 test harness. The edge equivalent of the mediator's T1–T3 quick wins.

### Request path

- **No more WS panics.** The four `serde_json::to_string(..).unwrap()` calls in the WebSocket handler — a serialization failure panicked the per-connection task — now serialize safely and close the connection gracefully on failure. The near-identical text/binary resolve-and-respond blocks are consolidated into shared `resolve_and_respond` / `send_response` helpers (the fix lands once, not four times).
- **Bounded upstream resolution.** Both the HTTP (`/resolve/{did}`) and WebSocket handlers wrap `resolver.resolve()` in `tokio::time::timeout`, so a hung upstream returns a clean error to the client instead of blocking the request / socket. Configurable via the new **`resolve_timeout`** setting (default 30s, `RESOLVE_TIMEOUT` env var), documented in `conf/cache-conf.toml`.
- `errors.rs`: `StatusCode::from_u16(..).unwrap()` → `unwrap_or(500)`.

### Startup

- Config-init failure, an invalid `listen_address`, and a server bind/serve error now propagate as `DIDCacheError` instead of `unwrap()`/`expect()`.
- The statistics task logs its error rather than `expect()`-panicking — full task supervision is **W2**.

### Tests / verification

- 3 new unit tests on the timeout boundary: a never-resolving future → `Timeout`; a fast `Ok` and a resolver `Err` pass through unchanged.
- The WS resolve/respond refactor is covered end-to-end by the **existing `integration_test`** (real server + SDK resolving real DIDs over the WS endpoint) — passed.
- `cargo clippy --all-targets -- -D warnings` clean on **default** and **`--no-default-features`**; `cargo fmt --check` clean.

### Notes

- The one `unwrap()` remaining outside tests is the infallible compile-time-constant env-var `Regex` in `config.rs` — the standard Rust idiom, deliberately left (not request/IO input).
- A full WS-integration test for malformed input / end-to-end hang would need either resolver injection (`SharedData.resolver` is a concrete `DIDCacheClient`) or a second test server (the existing one hardcodes port 8080) — deferred; the malformed-input path itself is unchanged (already breaks on parse error).
- `affinidi-did-resolver-cache-server` `0.7.5 → 0.8.0` (new `pub` `SharedData.resolve_timeout` field + behaviour change; leaf crate, nothing else pins it).
