### PR TITLE
feat: cache-server request limits, CORS, task supervision, client reuse (W2)

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 13th June 2026
 
+### 0.9.0 — request limits, CORS tightening, task supervision, client reuse (W2)
+
+- **DID size limit.** New `max_did_size` setting (default 1024 bytes,
+  `MAX_DID_SIZE`). Oversized DIDs are rejected before resolution — HTTP `400`
+  on `/resolve/{did}`, a WebSocket error response on `/ws` — and the WebSocket
+  upgrade caps frame/message size to the DID limit plus envelope overhead.
+- **CORS tightened to GET.** The server only exposes GET endpoints, so the CORS
+  layer no longer advertises POST/PUT/DELETE/PATCH (origin stays `Any` — DID
+  documents are public).
+- **Statistics task supervised.** The stats loop is now cancellation-aware and
+  exits cleanly on shutdown; the server installs a Ctrl-C handler that cancels
+  background tasks and gracefully drains in-flight requests
+  (`axum_server` graceful shutdown), then joins the stats task so a panic is
+  logged rather than swallowed.
+- **Shared WebVH HTTP client.** `fetch_webvh_log` now takes a single
+  `reqwest::Client` built once at startup (pooled connections) instead of
+  constructing a fresh client per request.
+- New `pub` fields `SharedData.max_did_size` / `SharedData.webvh_client`
+  (minor-version bump).
+
 ### 0.8.0 — remove request/startup panics, bound upstream resolution (W1)
 
 - **No more panics on the request path.** The four

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -44,6 +44,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 toml = "1"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"

--- a/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
@@ -16,6 +16,12 @@ statistics_interval = "${STATISTICS_INTERVAL:10}"
 ### Default: 30 seconds
 resolve_timeout = "${RESOLVE_TIMEOUT:30}"
 
+### max_did_size: maximum accepted DID length in bytes. Longer DIDs are
+### rejected before resolution (HTTP 400 / WebSocket error) so a crafted
+### request can't drive unbounded work. Also bounds the WebSocket frame size.
+### Default: 1024 bytes
+max_did_size = "${MAX_DID_SIZE:1024}"
+
 ### enable_http_endpoint: true/false
 ### Default: true
 ### If true, the server will make available /resolve endpoint for HTTP GET requests

--- a/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
@@ -39,6 +39,8 @@ struct ConfigRaw {
     pub statistics_interval: String,
     #[serde(default = "default_resolve_timeout")]
     pub resolve_timeout: String,
+    #[serde(default = "default_max_did_size")]
+    pub max_did_size: String,
     pub cache: CacheConfig,
 }
 
@@ -46,6 +48,12 @@ struct ConfigRaw {
 /// predates the `resolve_timeout` key.
 fn default_resolve_timeout() -> String {
     "30".into()
+}
+
+/// Default maximum accepted DID length in bytes, used when the config file
+/// predates the `max_did_size` key.
+fn default_max_did_size() -> String {
+    "1024".into()
 }
 
 pub struct Config {
@@ -57,6 +65,9 @@ pub struct Config {
     /// Maximum time a single upstream DID resolution may take before the
     /// request path gives up and returns an error instead of blocking.
     pub resolve_timeout: Duration,
+    /// Maximum accepted DID length in bytes; longer DIDs are rejected before
+    /// resolution so a crafted request can't drive unbounded work.
+    pub max_did_size: usize,
     pub cache_capacity_count: u32,
     pub cache_expire: u32,
 }
@@ -76,6 +87,7 @@ impl fmt::Debug for Config {
                 "resolve_timeout",
                 &format!("{} seconds", self.resolve_timeout.as_secs()),
             )
+            .field("max_did_size", &format!("{} bytes", self.max_did_size))
             .field("cache_capacity_count", &self.cache_capacity_count)
             .field("cache_expire", &format!("{} seconds", self.cache_expire))
             .finish()
@@ -91,6 +103,7 @@ impl Default for Config {
             enable_websocket_endpoint: true,
             statistics_interval: Duration::from_secs(60),
             resolve_timeout: Duration::from_secs(30),
+            max_did_size: 1024,
             cache_capacity_count: CacheConfig::default()
                 .capacity_count
                 .parse()
@@ -118,6 +131,7 @@ impl TryFrom<ConfigRaw> for Config {
             enable_websocket_endpoint: raw.enable_websocket_endpoint.parse().unwrap_or(true),
             statistics_interval: Duration::from_secs(raw.statistics_interval.parse().unwrap_or(60)),
             resolve_timeout: Duration::from_secs(raw.resolve_timeout.parse().unwrap_or(30)),
+            max_did_size: raw.max_did_size.parse().unwrap_or(1024),
             cache_capacity_count: raw.cache.capacity_count.parse().unwrap_or(1000),
             cache_expire: raw.cache.expire.parse().unwrap_or(300),
         })

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/http.rs
@@ -1,6 +1,6 @@
 use crate::{
     SharedData,
-    handlers::{fetch_webvh_log, resolve_with_timeout},
+    handlers::{did_within_size_limit, fetch_webvh_log, resolve_with_timeout},
 };
 use affinidi_did_resolver_cache_sdk::DIDMethod;
 use axum::{
@@ -15,6 +15,19 @@ pub async fn resolver_handler(
     State(state): State<SharedData>,
     Path(did): Path<String>,
 ) -> (StatusCode, Json<Value>) {
+    if !did_within_size_limit(&did, state.max_did_size) {
+        state.stats.lock().await.increment_resolver_error();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "DID exceeds maximum length of {} bytes",
+                    state.max_did_size
+                )
+            })),
+        );
+    }
+
     match resolve_with_timeout(&state.resolver, state.resolve_timeout, &did).await {
         Ok(doc) => {
             let mut stats = state.stats.lock().await;
@@ -27,7 +40,7 @@ pub async fn resolver_handler(
 
             // For WebVH DIDs, include the raw log so clients can verify
             let (did_log, did_witness_log) = if doc.method == DIDMethod::WEBVH {
-                fetch_webvh_log(&did).await
+                fetch_webvh_log(&state.webvh_client, &did).await
             } else {
                 (None, None)
             };

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
@@ -52,6 +52,12 @@ pub(crate) async fn resolve_with_timeout(
     apply_timeout(timeout, resolver.resolve(did)).await
 }
 
+/// Whether `did` is within the configured byte-length limit. Oversized DIDs are
+/// rejected before resolution so a crafted request can't drive unbounded work.
+pub(crate) fn did_within_size_limit(did: &str, max: usize) -> bool {
+    did.len() <= max
+}
+
 /// Read a response body as UTF-8 text, refusing anything larger than `limit` bytes.
 async fn read_text_limited(mut resp: reqwest::Response, limit: usize) -> Option<String> {
     let mut buf = Vec::new();
@@ -80,7 +86,10 @@ async fn read_text_limited(mut resp: reqwest::Response, limit: usize) -> Option<
 /// The target host is derived from the caller-supplied DID, so this client
 /// refuses redirects and caps the response body to avoid being used as an SSRF
 /// pivot / reflection oracle or memory-exhaustion vector.
-pub(crate) async fn fetch_webvh_log(did: &str) -> (Option<String>, Option<String>) {
+pub(crate) async fn fetch_webvh_log(
+    client: &reqwest::Client,
+    did: &str,
+) -> (Option<String>, Option<String>) {
     let parsed_url = match didwebvh_rs::url::WebVHURL::parse_did_url(did) {
         Ok(url) => url,
         Err(e) => {
@@ -93,18 +102,6 @@ pub(crate) async fn fetch_webvh_log(did: &str) -> (Option<String>, Option<String
         Ok(url) => url,
         Err(e) => {
             warn!("Failed to construct log URL for WebVH DID: {e}");
-            return (None, None);
-        }
-    };
-
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("Failed to create HTTP client for WebVH log fetch: {e}");
             return (None, None);
         }
     };
@@ -207,5 +204,12 @@ mod tests {
         let fut = std::future::ready(Err::<(), _>(DIDCacheError::DIDError("bad".into())));
         let res = apply_timeout(Duration::from_secs(5), fut).await;
         assert!(matches!(res, Err(ResolveError::Resolver(_))));
+    }
+
+    #[test]
+    fn did_size_limit_boundary() {
+        assert!(did_within_size_limit("did:key:zABC", 1024));
+        assert!(did_within_size_limit(&"d".repeat(1024), 1024)); // exactly at limit
+        assert!(!did_within_size_limit(&"d".repeat(1025), 1024)); // one over
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
@@ -14,13 +14,13 @@ use tracing::{Instrument, debug, info, span, warn};
 
 use crate::{
     SharedData,
-    handlers::{fetch_webvh_log, resolve_with_timeout},
+    handlers::{did_within_size_limit, fetch_webvh_log, resolve_with_timeout},
 };
 
 /// Build a WSResponse, fetching the raw DID log for WebVH DIDs.
-async fn build_response(response: ResolveResponse) -> WSResponseType {
+async fn build_response(client: &reqwest::Client, response: ResolveResponse) -> WSResponseType {
     let (did_log, did_witness_log) = if response.method == DIDMethod::WEBVH {
-        fetch_webvh_log(&response.did).await
+        fetch_webvh_log(client, &response.did).await
     } else {
         (None, None)
     };
@@ -62,6 +62,18 @@ async fn send_response(socket: &mut WebSocket, message: &WSResponseType) -> bool
 /// an error response if resolution fails or times out. Returns `false` if the
 /// connection should be closed.
 async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: String) -> bool {
+    if !did_within_size_limit(&did, state.max_did_size) {
+        let hash = DIDCacheClient::hash_did(&did);
+        warn!("ws: rejecting oversized DID ({} bytes)", did.len());
+        state.stats().await.increment_resolver_error();
+        let message = WSResponseType::Error(WSResponseError {
+            did,
+            hash,
+            error: format!("DID exceeds maximum length of {} bytes", state.max_did_size),
+        });
+        return send_response(socket, &message).await;
+    }
+
     match resolve_with_timeout(&state.resolver, state.resolve_timeout, &did).await {
         Ok(response) => {
             {
@@ -76,7 +88,7 @@ async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: St
                 "resolved DID: ({}) cache_hit?({})",
                 response.did, response.cache_hit
             );
-            let message = build_response(response).await;
+            let message = build_response(&state.webvh_client, response).await;
             send_response(socket, &message).await
         }
         Err(e) => {
@@ -109,6 +121,13 @@ pub async fn websocket_handler(
     .instrument(_span)
     .await*/
 
+    // Bound incoming frames so a crafted client can't buffer huge messages
+    // before we even parse them. A DID request is tiny; size it to the DID
+    // limit plus envelope overhead.
+    let max_message_size = state.max_did_size.saturating_add(1024);
+    let ws = ws
+        .max_message_size(max_message_size)
+        .max_frame_size(max_message_size);
     async move { ws.on_upgrade(move |socket| handle_socket(socket, state)) }
         .instrument(_span)
         .await

--- a/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
@@ -25,6 +25,12 @@ pub struct SharedData {
     /// Upper bound on a single upstream resolution before the request path
     /// returns an error rather than blocking the connection.
     pub resolve_timeout: Duration,
+    /// Maximum accepted DID length in bytes; longer DIDs are rejected before
+    /// resolution.
+    pub max_did_size: usize,
+    /// Shared HTTP client for did:webvh log fetches, built once at startup so
+    /// connections are pooled instead of a fresh client per request.
+    pub webvh_client: reqwest::Client,
 }
 
 impl<S> FromRequestParts<S> for SharedData

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -9,8 +9,9 @@ use affinidi_did_resolver_cache_sdk::{
 };
 use axum::{Router, routing::get};
 use http::Method;
-use std::{env, net::SocketAddr, sync::Arc};
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tower_http::{
     cors::CorsLayer,
     trace::{self, TraceLayer},
@@ -88,20 +89,37 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
 
     let resolver = DIDCacheClient::new(cache_config).await?;
 
+    // One shared HTTP client for did:webvh log fetches, built once so
+    // connections are pooled (was previously rebuilt per request). Refuses
+    // redirects to avoid SSRF pivots, matching the previous per-call config.
+    let webvh_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| {
+            DIDCacheError::ConfigError(format!("Failed to build WebVH HTTP client: {e}"))
+        })?;
+
     // Create the shared application State
     let shared_state = SharedData {
         service_start_timestamp: chrono::Utc::now(),
         stats: Arc::new(Mutex::new(Statistics::default())),
         resolver,
         resolve_timeout: config.resolve_timeout,
+        max_did_size: config.max_did_size,
+        webvh_client,
     };
 
-    // Start the statistics thread. A panic here previously killed the task
-    // silently; log the error instead (full supervision lands in W2).
+    // Supervise the statistics task: it now exits cleanly when `shutdown` is
+    // cancelled, and we join it after the server stops so a panic is logged.
+    let shutdown = CancellationToken::new();
     let _stats = shared_state.stats.clone();
     let _cache = shared_state.resolver.get_cache();
-    tokio::spawn(async move {
-        if let Err(e) = statistics(config.statistics_interval, &_stats, _cache).await {
+    let stats_shutdown = shutdown.clone();
+    let stats_handle = tokio::spawn(async move {
+        if let Err(e) =
+            statistics(config.statistics_interval, &_stats, _cache, stats_shutdown).await
+        {
             event!(Level::ERROR, "Statistics task exited with error: {e}");
         }
     });
@@ -113,16 +131,12 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
     let app = Router::new()
         .merge(app)
         .layer(
+            // DID documents are public, so any origin is fine, but the server
+            // only exposes GET endpoints — don't advertise write methods.
             CorsLayer::new()
                 .allow_origin(tower_http::cors::Any)
                 .allow_headers([http::header::CONTENT_TYPE])
-                .allow_methods([
-                    Method::GET,
-                    Method::POST,
-                    Method::PUT,
-                    Method::DELETE,
-                    Method::PATCH,
-                ]),
+                .allow_methods([Method::GET]),
         )
         .layer(
             TraceLayer::new_for_http()
@@ -145,10 +159,39 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
             ))
         })?;
 
+    // On Ctrl-C, cancel background tasks and let in-flight requests drain.
+    let server_handle = axum_server::Handle::new();
+    {
+        let server_handle = server_handle.clone();
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            match tokio::signal::ctrl_c().await {
+                Ok(()) => event!(
+                    Level::INFO,
+                    "Shutdown signal received; draining connections"
+                ),
+                Err(e) => {
+                    event!(Level::ERROR, "Failed to listen for shutdown signal: {e}");
+                    return;
+                }
+            }
+            shutdown.cancel();
+            server_handle.graceful_shutdown(Some(Duration::from_secs(10)));
+        });
+    }
+
     axum_server::bind(listen_address)
+        .handle(server_handle)
         .serve(app.into_make_service_with_connect_info::<SocketAddr>())
         .await
         .map_err(|e| DIDCacheError::TransportError(format!("server error: {e}")))?;
+
+    // Server has stopped — make sure the stats task is cancelled and observe
+    // its outcome so a panic surfaces in the logs rather than being swallowed.
+    shutdown.cancel();
+    if let Err(e) = stats_handle.await {
+        event!(Level::ERROR, "Statistics task terminated abnormally: {e}");
+    }
 
     Ok(())
 }

--- a/crates/identity/affinidi-did-resolver-cache-server/src/statistics.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/statistics.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level, debug, info, span};
 
 /// Statistics struct for the cache server
@@ -125,10 +126,14 @@ impl Statistics {
 
 /// Periodically logs statistics about the cache.
 /// Is spawned as a task from main().
+///
+/// Runs until `shutdown` is cancelled, at which point it returns cleanly so the
+/// supervising spawn can join it during graceful shutdown.
 pub async fn statistics(
     interval: Duration,
     stats: &Arc<Mutex<Statistics>>,
     cache: Cache<[u64; 2], Document>,
+    shutdown: CancellationToken,
 ) -> Result<(), CacheError> {
     let _span = span!(Level::INFO, "statistics");
 
@@ -138,19 +143,49 @@ pub async fn statistics(
 
         let mut previous_stats = Statistics::default();
         loop {
-            wait.tick().await;
+            tokio::select! {
+                _ = wait.tick() => {
+                    let mut stats = stats.lock().await;
 
-            let mut stats = stats.lock().await;
+                    cache.run_pending_tasks().await;
+                    stats.cache_size = cache.entry_count() as i64;
 
-            cache.run_pending_tasks().await;
-            stats.cache_size = cache.entry_count() as i64;
+                    info!("Statistics: {}", stats);
+                    info!("Delta: {}", stats.delta(&previous_stats));
 
-            info!("Statistics: {}", stats);
-            info!("Delta: {}", stats.delta(&previous_stats));
-
-            previous_stats = stats.clone();
+                    previous_stats = stats.clone();
+                }
+                _ = shutdown.cancelled() => {
+                    debug!("Statistics thread shutting down");
+                    break;
+                }
+            }
         }
+        Ok(())
     }
     .instrument(_span)
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn statistics_exits_promptly_on_cancel() {
+        let stats = Arc::new(Mutex::new(Statistics::default()));
+        let cache: Cache<[u64; 2], Document> = Cache::new(10);
+        let token = CancellationToken::new();
+        // Pre-cancel: with a 1h interval the loop can only leave via the
+        // cancellation branch, so the call must return promptly (and Ok).
+        token.cancel();
+
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            statistics(Duration::from_secs(3600), &stats, cache, token),
+        )
+        .await;
+        assert!(res.is_ok(), "stats task must exit promptly after cancel");
+        assert!(res.unwrap().is_ok());
+    }
 }


### PR DESCRIPTION
## W2 — cache-server: limits, CORS, task supervision, client reuse

Follow-on to W1 (#441) on the same crate. Closes out the cache-server availability/abuse-surface findings.

### DID size limit
New **`max_did_size`** setting (default 1024 bytes, `MAX_DID_SIZE`), documented in `conf/cache-conf.toml`. Oversized DIDs are rejected **before resolution**:
- HTTP `/resolve/{did}` → `400` with a JSON error
- WebSocket `/ws` → a `WSResponseError`
- the WS upgrade also caps frame/message size to the DID limit + envelope overhead, so a crafted client can't buffer huge frames pre-parse.

### CORS tightened to GET
The server exposes only GET endpoints, so the CORS layer no longer advertises POST/PUT/DELETE/PATCH. Origin stays `Any` — DID documents are public.

### Statistics task supervised
- The stats loop is now cancellation-aware (`tokio::select!` on a `CancellationToken`) and returns cleanly on shutdown.
- The server installs a Ctrl-C handler that cancels background tasks and triggers `axum_server` graceful shutdown (10s drain), then **joins the stats task** so a panic surfaces as a logged `JoinError` instead of vanishing.

### Shared WebVH HTTP client
`fetch_webvh_log` now takes one `reqwest::Client` built once at startup (pooled connections, redirects refused) instead of constructing a fresh client per request. grep-verified: no `Client::builder()` remains in `handlers/`.

### Verification
- Unit tests: stats-task exits promptly on cancel; DID-size boundary (at/over limit).
- Existing `integration_test` (real server + SDK resolving 4 DIDs over WebSocket, incl. the refactored `build_response`) — green.
- `cargo clippy --all-targets -- -D warnings` clean on **default** and **`--no-default-features`**; `cargo fmt --check` clean.

New `pub` fields `SharedData.max_did_size` / `SharedData.webvh_client`; new dep `tokio-util` (already in the workspace tree). `affinidi-did-resolver-cache-server` `0.8.0 → 0.9.0`.
