### PR TITLE
fix: BBS proof DoS bound + explicit CSPRNG, drop crypto thread_rng (W4)

### DIFF
--- a/crates/core/affinidi-bbs/CHANGELOG.md
+++ b/crates/core/affinidi-bbs/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Affinidi BBS
+
+## Changelog history
+
+## 13th June 2026
+
+### 0.3.1 — DoS-bound generator creation + explicit CSPRNG (W4)
+
+- **Bounded generator creation.** On the verify path the generator/message
+  count is derived from the *untrusted* proof length; an oversized bogus proof
+  would force `create_generators` to do unbounded `O(n)` hash-to-curve work.
+  `create_generators_with_api_id` now rejects counts above the new
+  `MAX_GENERATORS` (1024) cap **before** the loop, so a multi-megabyte proof is
+  rejected cheaply with `BbsError::InvalidProof`. No legitimate signing
+  approaches the cap.
+- **Explicit CSPRNG.** Proof-blinding and commitment scalars are now drawn from
+  an OS-seeded `StdRng` (`StdRng::try_from_rng(&mut OsRng)`) instead of the
+  thread-local RNG, and the CSPRNG contract is documented at each site.
+- Adds adversarial-input tests (a ~4 MB proof is rejected fast) and a
+  generator-cap boundary test.

--- a/crates/core/affinidi-bbs/Cargo.toml
+++ b/crates/core/affinidi-bbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-bbs"
 description = "BBS Signatures (IETF draft-irtf-cfrg-bbs-signatures) implementation over BLS12-381."
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-bbs/src/blind.rs
+++ b/crates/core/affinidi-bbs/src/blind.rs
@@ -36,7 +36,7 @@
 
 use bls12_381_plus::{G1Projective, Scalar};
 use ff::Field;
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 use zeroize::Zeroize;
 
 use crate::ciphersuite::Ciphersuite;
@@ -501,8 +501,12 @@ pub(crate) fn blind_message_count(cwp_len: usize, cs: Ciphersuite) -> Result<usi
 }
 
 /// Sample `count` non-zero random scalars (production path for [`commit`]).
+///
+/// CSPRNG contract: these scalars blind the commitment, so they MUST come from
+/// a cryptographically secure RNG. Seed a CSPRNG directly from the OS.
 pub(crate) fn random_scalars(count: usize) -> Vec<Scalar> {
-    let mut rng = rand::rng();
+    let mut rng = rand::rngs::StdRng::try_from_rng(&mut rand::rngs::OsRng)
+        .expect("OS entropy unavailable while seeding commitment RNG");
     (0..count)
         .map(|_| {
             loop {

--- a/crates/core/affinidi-bbs/src/generators.rs
+++ b/crates/core/affinidi-bbs/src/generators.rs
@@ -17,9 +17,17 @@ use elliptic_curve::hash2curve::ExpandMsgXmd;
 use sha2::Sha256;
 
 use crate::ciphersuite::Ciphersuite;
-use crate::error::Result;
+use crate::error::{BbsError, Result};
 use crate::hash::hash_to_scalar;
 use crate::types::PublicKey;
+
+/// Hard upper bound on the number of generators (≈ message count) any operation
+/// will build. Generator creation is `O(count)` hash-to-curve work, and on the
+/// verify path `count` is derived from the *untrusted* proof length — without a
+/// cap, a multi-megabyte bogus proof forces unbounded work (a cheap DoS). No
+/// legitimate credential signs anywhere near this many messages, so the bound
+/// is generous for real use while rejecting abuse cheaply, before the loop.
+pub const MAX_GENERATORS: usize = 1024;
 
 /// The BBS ciphersuite constant `P1` for **BLS12-381-SHA-256**, as fixed by
 /// `draft-irtf-cfrg-bbs-signatures`.
@@ -75,6 +83,16 @@ pub fn create_generators_with_api_id(
     // Reject not-yet-implemented ciphersuites (SHAKE-256) at the generator
     // chokepoint: the hash-to-curve below is hard-wired to ExpandMsgXmd<Sha256>.
     cs.ensure_supported()?;
+
+    // Cap the count BEFORE the O(count) hash-to-curve loop. On the verify path
+    // `count` comes from the untrusted proof length, so an oversized bogus proof
+    // would otherwise force unbounded generator work.
+    if count > MAX_GENERATORS {
+        return Err(BbsError::InvalidProof(format!(
+            "generator/message count {count} exceeds maximum {MAX_GENERATORS}"
+        )));
+    }
+
     let seed_dst = [api_id, b"SIG_GENERATOR_SEED_"].concat();
     let generator_dst = [api_id, b"SIG_GENERATOR_DST_"].concat();
     let generator_seed = [api_id, b"MESSAGE_GENERATOR_SEED"].concat();
@@ -195,6 +213,15 @@ mod tests {
     fn create_generators_correct_count() {
         let gens = create_generators(5, Ciphersuite::Bls12381Sha256).unwrap();
         assert_eq!(gens.len(), 5);
+    }
+
+    #[test]
+    fn create_generators_caps_at_max() {
+        // At the limit: allowed.
+        assert!(create_generators(MAX_GENERATORS, Ciphersuite::Bls12381Sha256).is_ok());
+        // One over: rejected cheaply, before building any generators.
+        let err = create_generators(MAX_GENERATORS + 1, Ciphersuite::Bls12381Sha256).unwrap_err();
+        assert!(matches!(err, BbsError::InvalidProof(_)), "got {err:?}");
     }
 
     #[test]

--- a/crates/core/affinidi-bbs/src/proof.rs
+++ b/crates/core/affinidi-bbs/src/proof.rs
@@ -17,7 +17,7 @@ use bls12_381_plus::{
 };
 use ff::Field;
 use group::Group;
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 
 use crate::ciphersuite::Ciphersuite;
 use crate::error::{BbsError, Result};
@@ -155,7 +155,12 @@ impl ProofRandomScalars {
     }
 
     fn random(u: usize) -> Self {
-        let mut rng = rand::rng();
+        // CSPRNG contract: the per-proof blinding scalars MUST come from a
+        // cryptographically secure RNG — predictable randomness here would leak
+        // the undisclosed messages. Seed a CSPRNG directly from the OS rather
+        // than relying on the thread-local RNG.
+        let mut rng = rand::rngs::StdRng::try_from_rng(&mut rand::rngs::OsRng)
+            .expect("OS entropy unavailable while seeding proof RNG");
         ProofRandomScalars {
             r1: random_nonzero_scalar(&mut rng),
             r2: random_nonzero_scalar(&mut rng),
@@ -729,6 +734,22 @@ mod tests {
         let sk = SecretKey(sk_scalar);
         let pk = PublicKey(G2Projective::generator() * sk_scalar);
         (sk, pk)
+    }
+
+    #[test]
+    fn oversized_proof_rejected_without_unbounded_work() {
+        // A multi-megabyte bogus proof implies a huge undisclosed-message count.
+        // Without the generator cap, verification would build that many
+        // generators (O(n) hash-to-curve) — a cheap DoS. It must be rejected
+        // cheaply (the cap fires before the generator loop), never processed.
+        let (_sk, pk) = test_keypair();
+        let cs = Ciphersuite::Bls12381Sha256;
+        let proof = Proof::from_bytes(&vec![0u8; 4 * 1024 * 1024]); // ~4 MB
+        let result = core_proof_verify(&pk, &proof, b"header", b"ph", &[], &[], cs);
+        assert!(
+            matches!(result, Err(BbsError::InvalidProof(_))),
+            "oversized proof must be rejected with InvalidProof, got {result:?}"
+        );
     }
 
     // --- exact proof reproduction against the IETF/DIF vectors ---------------

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Crypto Changelog
 
+## 13th June 2026 (0.2.1)
+
+RNG hygiene (W4): the PQC key generators (ML-DSA, SLH-DSA) now seed a CSPRNG
+directly from the OS (`StdRng::try_from_rng(&mut SysRng)`) instead of the
+thread-local RNG. The `thread_rng` feature is dropped from the `rand` (0.10)
+dependency in favour of `sys_rng` + `std_rng`. No public API change.
+
 ## 6th June 2026 (0.2.0)
 
 **Breaking release.** Adds P-384/P-521 key agreement and makes the

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.0"
+version = "0.2.1"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -70,7 +70,7 @@ slh-dsa = { version = "=0.2.0-rc.5", features = ["zeroize"], optional = true }
 # PQC crates (ml-dsa, slh-dsa) pull rand_core 0.10 transitively via
 # `signature` v3. A second copy coexists with the 0.6 one used by other
 # primitives; we never import it directly, so no explicit dep is needed.
-rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "thread_rng"], optional = true }
+rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "sys_rng"], optional = true }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/core/affinidi-crypto/src/ml_dsa.rs
+++ b/crates/core/affinidi-crypto/src/ml_dsa.rs
@@ -6,7 +6,7 @@
 
 use ml_dsa::signature::{Keypair, Signer, Verifier};
 use ml_dsa::{B32, MlDsa44, MlDsa65, MlDsa87, Signature, SigningKey};
-use rand_10::RngExt;
+use rand_10::{RngExt, SeedableRng};
 
 use crate::{CryptoError, KeyType, error::Result};
 
@@ -19,7 +19,10 @@ pub struct KeyPair {
 }
 
 fn random_seed() -> [u8; 32] {
-    let mut rng = rand_10::rng();
+    // Seed a CSPRNG directly from the OS (no thread-local RNG) — key seeds must
+    // come from a cryptographically secure source.
+    let mut rng = rand_10::rngs::StdRng::try_from_rng(&mut rand_10::rngs::SysRng)
+        .expect("OS entropy unavailable while seeding key RNG");
     let mut s = [0u8; 32];
     rng.fill(&mut s);
     s

--- a/crates/core/affinidi-crypto/src/slh_dsa.rs
+++ b/crates/core/affinidi-crypto/src/slh_dsa.rs
@@ -3,6 +3,7 @@
 //! Private and public keys are stored as their FIPS 205 raw encodings
 //! (64 and 32 bytes respectively for SHA2-128s).
 
+use rand_10::SeedableRng;
 use slh_dsa::signature::{Signer, Verifier};
 use slh_dsa::{Sha2_128s, Signature, SigningKey, VerifyingKey};
 
@@ -18,7 +19,9 @@ pub struct KeyPair {
 
 /// Generates an SLH-DSA-SHA2-128s key pair.
 pub fn generate_slh_dsa_sha2_128s() -> KeyPair {
-    let mut rng = rand_10::rng();
+    // Seed a CSPRNG directly from the OS (no thread-local RNG) for key generation.
+    let mut rng = rand_10::rngs::StdRng::try_from_rng(&mut rand_10::rngs::SysRng)
+        .expect("OS entropy unavailable while seeding key RNG");
     let sk = SigningKey::<Sha2_128s>::new(&mut rng);
     let vk = sk.as_ref();
     KeyPair {


### PR DESCRIPTION
## W4 — BBS proof DoS bound + RNG hygiene

Crypto-layer quick fixes (independent of the cache work). Two crates.

### affinidi-bbs `0.3.0 → 0.3.1`

**Bounded generator creation (DoS fix).** On the verify path the generator/message count `u` is derived from the **untrusted proof length** (`(proof_len − min_len) / scalar_len`), then `create_generators(l+1)` does `O(l)` hash-to-curve work. A multi-megabyte bogus proof would force unbounded generator construction — a cheap DoS. Fixed at the chokepoint: `create_generators_with_api_id` now rejects counts above the new `pub const MAX_GENERATORS = 1024` **before** the loop, returning `BbsError::InvalidProof`. A single guard protects every verify path (plain proof, blind, pseudonym). No legitimate credential signs near 1024 messages.

**Explicit CSPRNG.** Proof-blinding (`proof.rs`) and commitment (`blind.rs`) scalars now come from an OS-seeded `StdRng` (`StdRng::try_from_rng(&mut OsRng)`) rather than the thread-local RNG, with the CSPRNG contract documented at each site.

### affinidi-crypto `0.2.0 → 0.2.1`

The PQC key generators (ML-DSA, SLH-DSA) seed a CSPRNG **directly from the OS** (`StdRng::try_from_rng(&mut SysRng)`) instead of `rand_10::rng()`. The `thread_rng` feature is dropped from the `rand` 0.10 dependency (now `sys_rng` + `std_rng`). `grep thread_rng` in affinidi-crypto is clean. No public API change.

> Note on `OsRng`/`SysRng`: in rand 0.9/0.10 the OS RNG is *fallible* and isn't an infallible `Rng`/`RngCore`, so the signing APIs (which want infallible) won't take it directly. Seeding a `StdRng` from it is the standard pattern — exactly how `ThreadRng` seeds itself, minus the thread-local global — giving explicit OS entropy without the thread RNG.

### Verification
- New tests: `oversized_proof_rejected_without_unbounded_work` (~4 MB proof → fast `InvalidProof`) and `create_generators_caps_at_max` (boundary).
- 82 bbs + 51 PQC tests pass (incl. the IETF proof-verify KATs — the cap doesn't reject legitimate proofs).
- `cargo clippy --all-targets -- -D warnings` clean: bbs, crypto (default **and** `--features ml-dsa,slh-dsa`); `fmt --check` clean.
- Dependents build unchanged (data-integrity `bbs-2023`, secrets-resolver PQC); `"0.3"`/`"0.2"` pins preserved.
