### PR TITLE
fix: auth/sd-jwt hygiene — remove expect, redact logs, constant-time compare (W6)

### DIFF
--- a/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
+++ b/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi SD-JWT Changelog
 
+## 13th June 2026 Release 0.1.3
+
+### Security
+
+- The test-only `HmacSha256Verifier` now compares signatures in constant time
+  via `subtle::ConstantTimeEq` instead of `!=`, removing the timing side channel
+  and the copy-paste hazard if the verifier is ever lifted out of the test-only
+  module. `subtle` is pulled in by the existing `_test-utils` feature.
+
 ## 28th May 2026 Release 0.1.2
 
 ### Security

--- a/crates/credentials/affinidi-sd-jwt/Cargo.toml
+++ b/crates/credentials/affinidi-sd-jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-sd-jwt"
 description = "SD-JWT (Selective Disclosure JWT) implementation per IETF SD-JWT specification."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -14,7 +14,9 @@ rust-version.workspace = true
 
 [features]
 default = []
-_test-utils = []
+# Test-only helpers (HMAC signer/verifier). Pulls `subtle` for the
+# constant-time signature comparison in the verifier.
+_test-utils = ["dep:subtle"]
 
 [dependencies]
 base64 = "0.22"
@@ -22,6 +24,7 @@ rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+subtle = { version = "2", optional = true }
 thiserror = "2"
 tracing = "0.1"
 

--- a/crates/credentials/affinidi-sd-jwt/src/signer.rs
+++ b/crates/credentials/affinidi-sd-jwt/src/signer.rs
@@ -137,8 +137,12 @@ pub mod test_utils {
                 .decode(parts[2])
                 .map_err(|e| SdJwtError::Verification(format!("sig decode: {e}")))?;
 
-            // WARNING: Not constant-time. For testing only.
-            if expected_sig != actual_sig {
+            // Constant-time comparison via `subtle` — removes the timing side
+            // channel and the copy-paste hazard if this verifier is ever lifted
+            // out of the test-only module. (`ct_eq` on slices first checks the
+            // non-secret length, then compares the bytes in constant time.)
+            use subtle::ConstantTimeEq;
+            if !bool::from(expected_sig.ct_eq(&actual_sig)) {
                 return Err(SdJwtError::Verification("signature mismatch".into()));
             }
 

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Affinidi DID Authentication
 
+## 13th June 2026 (0.3.7)
+
+Auth hygiene (W6):
+
+- Removed the `.expect("negotiated curve came from sender_curves")` in the
+  authcrypt packing path; a missing sender key now returns a `DIDComm` error
+  instead of panicking.
+- Sensitive authentication artifacts — the challenge, the signed challenge
+  response, the packed auth message, the received tokens, and the raw HTTP
+  request/response bodies — now log at `TRACE` via a `trace_sensitive` helper
+  rather than `DEBUG`. `DEBUG` keeps only non-sensitive breadcrumbs
+  ("Challenge received", "Tokens received", request URL + status). A capture
+  test asserts no sensitive value appears at `DEBUG`.
+
 ## 6th June 2026 (0.3.6)
 
 - Robust sender/recipient key-agreement negotiation (#357). The authcrypt

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -29,3 +29,7 @@ thiserror = "2"
 tokio = { workspace = true, features = ["time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
+
+[dev-dependencies]
+## Captures tracing output to assert sensitive values never log at DEBUG.
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -30,7 +30,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::SystemTime;
-use tracing::{Instrument, Level, debug, error, info, span};
+use tracing::{Instrument, Level, debug, error, info, span, trace};
 use uuid::Uuid;
 
 pub mod custom_auth;
@@ -397,15 +397,16 @@ impl DIDAuthentication {
                 }
             }
 
-            debug!("Challenge received:\n{:#?}", step1_response);
+            debug!("Challenge received");
+            trace_sensitive("Challenge received", &format!("{step1_response:#?}"));
 
             // Step 2. Sign the challenge
 
             let auth_response =
                 self._create_auth_challenge_response(profile_did, endpoint_did, &step1_response)?;
-            debug!(
-                "Auth response message:\n{}",
-                serde_json::to_string_pretty(&auth_response).unwrap()
+            trace_sensitive(
+                "Auth response message",
+                &serde_json::to_string_pretty(&auth_response).unwrap_or_default(),
             );
 
             let auth_msg = _pack_encrypted_for_did(
@@ -417,7 +418,7 @@ impl DIDAuthentication {
             )
             .await?;
 
-            debug!("Successfully packed auth message\n{:#?}", auth_msg);
+            trace_sensitive("Packed auth message", &format!("{auth_msg:#?}"));
 
             let step2_body = if let DidChallenges::Complex(_) = step1_response {
                 auth_msg
@@ -431,7 +432,8 @@ impl DIDAuthentication {
             let step2_response =
                 _http_post::<TokensType>(client, &[&endpoint, ""].concat(), &step2_body).await?;
 
-            debug!("Tokens received:\n{:#?}", step2_response);
+            debug!("Tokens received");
+            trace_sensitive("Tokens received", &format!("{step2_response:#?}"));
 
             debug!("Successfully authenticated");
 
@@ -646,12 +648,20 @@ impl DIDAuthentication {
     }
 }
 
+/// Log a sensitive authentication artifact (challenge, token, packed message,
+/// HTTP body) at `TRACE` only — never `DEBUG` — so operational debug logs never
+/// contain raw tokens or challenges. Enabling `TRACE` is an explicit opt-in for
+/// deep debugging.
+fn trace_sensitive(label: &str, value: &str) {
+    trace!("{label}:\n{value}");
+}
+
 async fn _http_post<T>(client: &Client, url: &str, body: &str) -> Result<T>
 where
     T: for<'de> Deserialize<'de>,
 {
     debug!("POSTing to {}", url);
-    debug!("Body: {}", body);
+    trace_sensitive("HTTP POST body", body);
     let response = client
         .post(url)
         .header("Content-Type", "application/json")
@@ -666,10 +676,8 @@ where
         .await
         .map_err(|e| DIDAuthError::Authentication(format!("Couldn't get HTTP body: {e:?}")))?;
 
-    debug!(
-        "status: {} response body: {}",
-        response_status, response_body
-    );
+    debug!("POST {url} -> status {response_status}");
+    trace_sensitive("HTTP response body", &response_body);
     if !response_status.is_success() {
         if response_status.as_u16() == 401 {
             return Err(DIDAuthError::ACLDenied("Authentication Denied".into()));
@@ -750,12 +758,17 @@ where
     )
     .map_err(|e| DIDAuthError::DIDComm(e.to_string()))?;
 
-    // The negotiated curve was drawn from `sender_curves`, so a matching
-    // sender key is guaranteed present.
+    // The negotiated curve was drawn from `sender_curves`, so a matching sender
+    // key should always be present; return an error rather than panicking if a
+    // future change to the negotiation ever breaks that invariant.
     let (sender_kid, sender_private, _) = sender_keys
         .iter()
         .find(|(_, _, c)| *c == pairing.curve)
-        .expect("negotiated curve came from sender_curves");
+        .ok_or_else(|| {
+            DIDAuthError::DIDComm(
+                "internal error: negotiated curve has no matching sender key".into(),
+            )
+        })?;
 
     // 3. Pack with authcrypt.
     pack::pack_encrypted_authcrypt(
@@ -828,6 +841,55 @@ pub fn refresh_check(tokens: &AuthorizationTokens) -> RefreshCheck {
 mod tests {
     use crate::{AuthorizationTokens, RefreshCheck, refresh_check};
     use std::time::SystemTime;
+
+    /// Sensitive auth artifacts must be logged via `trace_sensitive` (TRACE),
+    /// never at DEBUG, so operational debug logs can't leak tokens/challenges.
+    #[test]
+    fn sensitive_artifacts_are_not_logged_at_debug() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl Write for BufWriter {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_ansi(false)
+            .with_writer(BufWriter(buf.clone()))
+            .finish();
+
+        let secret = "SUPER_SECRET_JWT.header.payload.sig";
+        tracing::subscriber::with_default(subscriber, || {
+            crate::trace_sensitive("Tokens received", secret);
+            tracing::debug!("Tokens received");
+        });
+
+        let logged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            !logged.contains(secret),
+            "sensitive value must not appear at DEBUG level; got:\n{logged}"
+        );
+        assert!(
+            logged.contains("Tokens received"),
+            "the non-sensitive breadcrumb should still be logged at DEBUG"
+        );
+    }
 
     #[test]
     fn refresh_check_valid() {


### PR DESCRIPTION
## W6 — auth / sd-jwt hygiene

The final Wave-A edge-hardening task. Two small crates; independent of the rest.

### affinidi-did-authentication `0.3.6 → 0.3.7`

- **No `expect()` on the runtime path.** The `.expect("negotiated curve came from sender_curves")` in the authcrypt packing helper is replaced with an `ok_or_else(..)?` returning a `DIDComm` error — a future change to curve negotiation can no longer panic the caller.
- **Sensitive logs moved off DEBUG.** The challenge, the signed challenge response, the packed auth message, the received tokens, and the raw HTTP request/response bodies now log at **TRACE** via a single `trace_sensitive` helper. **DEBUG** keeps only non-sensitive breadcrumbs (request URL, response status, "Challenge received", "Tokens received"). A **capture-and-assert test** installs a DEBUG-level subscriber and verifies a token value never appears in DEBUG output while the breadcrumb does.

### affinidi-sd-jwt `0.1.2 → 0.1.3`

- The test-only `HmacSha256Verifier` now compares signatures in **constant time** (`subtle::ConstantTimeEq`) instead of `!=`, removing the timing side channel and the copy-paste hazard flagged in the review. `subtle` is an optional dep pulled by the existing `_test-utils` feature (which tests already enable via the crate's self dev-dependency).

### Verification
- did-auth: new `sensitive_artifacts_are_not_logged_at_debug` test + existing tests green; `clippy --all-targets -- -D warnings` clean.
- sd-jwt: 53 + 19 + 18 tests green; clippy clean on **default** and **`--features _test-utils`**.
- `fmt --check` clean; dependents (tdk-common, messaging-sdk, sd-jwt-vc) build unchanged; `"0.3"`/`"0.1"` pins preserved.
