### PR TITLE
refactor: #[non_exhaustive] on the wave's public error enums (W7)

### DIFF
--- a/crates/core/affinidi-crypto/src/error.rs
+++ b/crates/core/affinidi-crypto/src/error.rs
@@ -2,7 +2,10 @@
 
 use thiserror::Error;
 
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CryptoError {
     #[error("Key error: {0}")]
     KeyError(String),

--- a/crates/core/affinidi-secrets-resolver/src/errors.rs
+++ b/crates/core/affinidi-secrets-resolver/src/errors.rs
@@ -7,7 +7,11 @@ use affinidi_encoding::EncodingError;
 use thiserror::Error;
 
 /// Affinidi Secrets Resolver Errors
+///
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SecretsResolverError {
     #[error("Encoding error: {0}")]
     EncodingError(#[from] EncodingError),

--- a/crates/credentials/affinidi-sd-jwt/src/error.rs
+++ b/crates/credentials/affinidi-sd-jwt/src/error.rs
@@ -5,7 +5,11 @@
 use thiserror::Error;
 
 /// Errors that can occur during SD-JWT operations.
+///
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SdJwtError {
     /// The SD-JWT string could not be parsed (malformed JWS, missing parts, etc.).
     #[error("Invalid SD-JWT format: {0}")]

--- a/crates/credentials/affinidi-vc/src/error.rs
+++ b/crates/credentials/affinidi-vc/src/error.rs
@@ -5,7 +5,11 @@
 use thiserror::Error;
 
 /// Errors that can occur during Verifiable Credential operations.
+///
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum VcError {
     /// The credential is missing required fields or has invalid structure.
     #[error("Invalid credential: {0}")]

--- a/crates/identity/affinidi-did-authentication/src/errors.rs
+++ b/crates/identity/affinidi-did-authentication/src/errors.rs
@@ -8,7 +8,11 @@ use affinidi_secrets_resolver::errors::SecretsResolverError;
 use thiserror::Error;
 
 /// DID Authentication Errors
+///
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DIDAuthError {
     /// Authentication error, can be retried
     #[error("Authentication failed: {0}")]

--- a/crates/identity/affinidi-did-common/src/lib.rs
+++ b/crates/identity/affinidi-did-common/src/lib.rs
@@ -36,7 +36,10 @@ pub use did_method::peer::{
 };
 pub use document::DocumentExt;
 
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DocumentError {
     #[error("URL Error")]
     URL(#[from] url::ParseError),

--- a/crates/messaging/affinidi-messaging-didcomm/src/error.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/error.rs
@@ -2,7 +2,10 @@
 
 use thiserror::Error;
 
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DIDCommError {
     #[error("key agreement failed: {0}")]
     KeyAgreement(String),
@@ -53,6 +56,9 @@ impl From<affinidi_crypto::CryptoError> for DIDCommError {
             C::UnsupportedKeyType(m) => DIDCommError::UnsupportedAlgorithm(m),
             C::KeyError(m) | C::Decoding(m) => DIDCommError::KeyAgreement(m),
             C::Encoding(err) => DIDCommError::KeyAgreement(err.to_string()),
+            // `CryptoError` is `#[non_exhaustive]`; map any future variant to a
+            // generic key-agreement failure rather than failing to compile.
+            other => DIDCommError::KeyAgreement(other.to_string()),
         }
     }
 }


### PR DESCRIPTION
## W7 — `#[non_exhaustive]` on public error enums (semver wave 1/5)

First step of the **semver wave** (Wave B). Adds `#[non_exhaustive]` to the seven review-flagged public error enums, using the existing `DataIntegrityError` as the template, so future variants can be added without a breaking change:

| Enum | Crate |
|---|---|
| `CryptoError` | affinidi-crypto |
| `DIDCommError` | affinidi-messaging-didcomm |
| `VcError` | affinidi-vc |
| `SdJwtError` | affinidi-sd-jwt |
| `DIDAuthError` | affinidi-did-authentication |
| `DocumentError` | affinidi-did-common |
| `SecretsResolverError` | affinidi-secrets-resolver |

### Internal breakage fixed
One cross-crate exhaustive match broke: didcomm's `From<CryptoError>` impl. Added a wildcard arm mapping any future crypto variant to a generic key-agreement failure (existing variants map exactly as before).

### Versioning — deferred to W11 (deliberate)
No version bumps in this PR. crypto / did-common / sd-jwt / vc are **also** touched by W8–W10, so bumping per-task would double-bump them. The wave's version bumps, dependent-pin updates, CHANGELOGs, and the release all happen **once in W11**. Within the workspace (path deps) the change takes effect immediately, so main builds green throughout the wave.

### Verification
- `cargo build --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets` ✅
- Touched crates' tests green (didcomm 47, did-common 203, crypto, secrets-resolver, vc, sd-jwt, did-auth); `fmt --check` clean.

### Scope note
The plan's W7 names exactly these seven. Other published crates still have exhaustive error enums (mdoc, status-list, siopv2, openid4vci/vp, oid4vc-core, rdf-encoding, trust-lists, messaging-core/sdk, tsp, cesr, encoding, did-web/scid/ebsi). They're outside W7's list — flagging them as a candidate follow-up sweep for fully-clean Checkpoint W-2.
