### PR TITLE
refactor: seal affinidi-crypto JWK/key structs + Params enum (W8)

### DIFF
--- a/crates/core/affinidi-crypto/src/ed25519.rs
+++ b/crates/core/affinidi-crypto/src/ed25519.rs
@@ -11,12 +11,29 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use crate::{CryptoError, JWK, KeyType, OctectParams, Params, error::Result};
 
 /// Generated key pair with raw bytes and JWK representation
+///
+/// `#[non_exhaustive]`: construct via [`KeyPair::new`] rather than a struct
+/// literal. Fields stay public for reads.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct KeyPair {
     pub key_type: KeyType,
     pub private_bytes: Vec<u8>,
     pub public_bytes: Vec<u8>,
     pub jwk: JWK,
+}
+
+impl KeyPair {
+    /// Construct a key pair from its key type, raw private/public bytes, and
+    /// JWK representation.
+    pub fn new(key_type: KeyType, private_bytes: Vec<u8>, public_bytes: Vec<u8>, jwk: JWK) -> Self {
+        Self {
+            key_type,
+            private_bytes,
+            public_bytes,
+            jwk,
+        }
+    }
 }
 
 /// Generates a random Ed25519 signing key pair

--- a/crates/core/affinidi-crypto/src/jwk.rs
+++ b/crates/core/affinidi-crypto/src/jwk.rs
@@ -9,7 +9,12 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::{CryptoError, KeyType};
 
 /// RFC 7517 JWK Struct
+///
+/// `#[non_exhaustive]`: construct via [`JWK::new`] (or deserialization) rather
+/// than a struct literal, so new fields are not a breaking change. Fields stay
+/// public for reads.
 #[derive(Debug, Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub struct JWK {
     #[serde(rename = "kid")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,6 +24,11 @@ pub struct JWK {
 }
 
 impl JWK {
+    /// Construct a JWK from an optional key id and its parameters.
+    pub fn new(key_id: Option<String>, params: Params) -> Self {
+        Self { key_id, params }
+    }
+
     /// Returns the KeyType for a JWK
     pub fn key_type(&self) -> KeyType {
         match &self.params {
@@ -69,19 +79,32 @@ impl JWK {
 /// JWK Key Types and associated Parameters
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Zeroize, ZeroizeOnDrop)]
 #[serde(tag = "kty")]
+#[non_exhaustive]
 pub enum Params {
     EC(ECParams),
     OKP(OctectParams),
 }
 
 /// Elliptic Curve parameters (P-256, P-384, secp256k1)
+///
+/// `#[non_exhaustive]`: construct via [`ECParams::new`] rather than a struct
+/// literal. Fields stay public for reads.
 #[derive(Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub struct ECParams {
     #[serde(rename = "crv")]
     pub curve: String,
     pub x: String,
     pub y: String,
     pub d: Option<String>,
+}
+
+impl ECParams {
+    /// Construct EC parameters (`d` is the private scalar, `None` for a public
+    /// key).
+    pub fn new(curve: String, x: String, y: String, d: Option<String>) -> Self {
+        Self { curve, x, y, d }
+    }
 }
 
 impl std::fmt::Debug for ECParams {
@@ -96,12 +119,24 @@ impl std::fmt::Debug for ECParams {
 }
 
 /// Octet Key Pair parameters (Ed25519, X25519)
+///
+/// `#[non_exhaustive]`: construct via [`OctectParams::new`] rather than a struct
+/// literal. Fields stay public for reads.
 #[derive(Serialize, Deserialize, Clone, Zeroize, PartialEq, ZeroizeOnDrop)]
+#[non_exhaustive]
 pub struct OctectParams {
     #[serde(rename = "crv")]
     pub curve: String,
     pub x: String,
     pub d: Option<String>,
+}
+
+impl OctectParams {
+    /// Construct octet key-pair parameters (`d` is the private key, `None` for
+    /// a public key).
+    pub fn new(curve: String, x: String, d: Option<String>) -> Self {
+        Self { curve, x, d }
+    }
 }
 
 impl std::fmt::Debug for OctectParams {

--- a/crates/core/affinidi-secrets-resolver/src/crypto/ed25519.rs
+++ b/crates/core/affinidi-secrets-resolver/src/crypto/ed25519.rs
@@ -52,14 +52,14 @@ impl Secret {
         Ok(Secret {
             id: kid.unwrap_or("x25519").to_string(),
             type_: SecretType::JsonWebKey2020,
-            secret_material: SecretMaterial::JWK(JWK {
-                key_id: None,
-                params: Params::OKP(OctectParams {
-                    curve: "X25519".to_string(),
-                    x: BASE64_URL_SAFE_NO_PAD.encode(x25519_public.as_bytes()),
-                    d: Some(BASE64_URL_SAFE_NO_PAD.encode(x25519.as_bytes())),
-                }),
-            }),
+            secret_material: SecretMaterial::JWK(JWK::new(
+                None,
+                Params::OKP(OctectParams::new(
+                    "X25519".to_string(),
+                    BASE64_URL_SAFE_NO_PAD.encode(x25519_public.as_bytes()),
+                    Some(BASE64_URL_SAFE_NO_PAD.encode(x25519.as_bytes())),
+                )),
+            )),
             private_bytes: x25519.to_bytes().to_vec(),
             public_bytes: x25519_public.to_bytes().to_vec(),
             key_type: KeyType::X25519,

--- a/crates/core/affinidi-secrets-resolver/src/secrets.rs
+++ b/crates/core/affinidi-secrets-resolver/src/secrets.rs
@@ -172,6 +172,10 @@ impl Secret {
                 public_bytes: Secret::convert_to_raw(&params.x)?,
                 key_type: KeyType::try_from(params.curve.as_str())?,
             }),
+            // `Params` is `#[non_exhaustive]`; reject unknown future kinds.
+            _ => Err(SecretsResolverError::KeyError(
+                "unsupported JWK parameter kind".to_string(),
+            )),
         }
     }
 

--- a/crates/identity/affinidi-did-common/src/did.rs
+++ b/crates/identity/affinidi-did-common/src/did.rs
@@ -459,6 +459,13 @@ impl DID {
                             params.x.clone(),
                             Some(params.y.clone()),
                         ),
+                        // `Params` is `#[non_exhaustive]`; a future kind carries
+                        // no multibase key material to record here.
+                        _ => {
+                            return Err(DIDError::ResolutionError(
+                                "unsupported JWK parameter kind for did:peer key".to_string(),
+                            ));
+                        }
                     };
 
                     created_keys.push(PeerCreatedKey {

--- a/crates/identity/affinidi-did-common/src/did_method/key.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/key.rs
@@ -245,6 +245,8 @@ impl KeyMaterial {
                 public_bytes: Self::decode_base64url(&params.x)?,
                 key_type: KeyType::try_from(params.curve.as_str())?,
             }),
+            // `Params` is `#[non_exhaustive]`; reject unknown future kinds.
+            _ => Err(KeyError::Key("unsupported JWK parameter kind".into())),
         }
     }
 
@@ -363,14 +365,14 @@ impl KeyMaterial {
         let x25519_sk = x25519_dalek::StaticSecret::from(x25519_private);
         let x25519_pk = x25519_dalek::PublicKey::from(&x25519_sk);
 
-        let jwk = JWK {
-            key_id: None,
-            params: Params::OKP(affinidi_crypto::OctectParams {
-                curve: "X25519".to_string(),
-                x: BASE64_URL_SAFE_NO_PAD.encode(x25519_pk.as_bytes()),
-                d: Some(BASE64_URL_SAFE_NO_PAD.encode(x25519_sk.as_bytes())),
-            }),
-        };
+        let jwk = JWK::new(
+            None,
+            Params::OKP(affinidi_crypto::OctectParams::new(
+                "X25519".to_string(),
+                BASE64_URL_SAFE_NO_PAD.encode(x25519_pk.as_bytes()),
+                Some(BASE64_URL_SAFE_NO_PAD.encode(x25519_sk.as_bytes())),
+            )),
+        );
 
         let mut key = Self::from_jwk(&jwk)?;
         key.id = self.id.clone();


### PR DESCRIPTION
## W8 — seal affinidi-crypto JWK/key structs + `Params` (semver wave 2/5)

Future-proofs affinidi-crypto's public API using `#[non_exhaustive]` + constructors (the plan's "Option B" — keep public fields for reads, block external struct-literal construction), so new fields/variants aren't breaking changes.

### Sealed
- **Enums:** `#[non_exhaustive]` on `Params`. (`PublicKeyAgreement` / `PrivateKeyAgreement` already carry it from the 0.2 release; `Curve` / `KeyType` too — so `Params` was the only gap.)
- **Structs:** `#[non_exhaustive]` + a `new(..)` constructor on `JWK`, `ECParams`, `OctectParams`, `KeyPair`. Fields stay `pub`.

### Consumers migrated (same PR)
- `affinidi-secrets-resolver` `crypto/ed25519.rs` → `JWK::new` + `OctectParams::new`.
- `affinidi-did-common` `did_method/key.rs` → `JWK::new` + `OctectParams::new`.
- Exhaustive `match jwk.params` sites gained wildcard arms now that `Params` is non-exhaustive: secrets-resolver `secrets.rs`, did-common `did.rs` + `did_method/key.rs`.

### Versioning — deferred to W11
No bump here: crypto also changed in W7, so it bumps once at the coordinated release.

### Verification
- `cargo build --workspace --all-targets` ✅ · `cargo clippy --workspace --all-targets` ✅
- crypto tests incl. ML-DSA/SLH-DSA **KATs** (51) and all curve features; secrets-resolver (191) and did-common green; `fmt --check` clean.
