### PR TITLE
refactor: seal affinidi-did-common enums + document structs (W9)

### DIFF
--- a/crates/applications/affinidi-meeting-place/src/lib.rs
+++ b/crates/applications/affinidi-meeting-place/src/lib.rs
@@ -164,6 +164,8 @@ pub(crate) fn find_mediator_service_endpoints(doc: &Document) -> Vec<String> {
                 extract_uri(map).into_iter().collect()
             }
         }
+        // `Endpoint` is `#[non_exhaustive]`; unknown shapes yield no URIs.
+        _ => Vec::new(),
     }
 }
 

--- a/crates/identity/affinidi-did-common/src/lib.rs
+++ b/crates/identity/affinidi-did-common/src/lib.rs
@@ -57,8 +57,11 @@ pub enum DocumentError {
 /// A [DID Document]
 ///
 /// [DID Document]: https://www.w3.org/TR/did-1.1/
+/// `#[non_exhaustive]`: build via [`DocumentBuilder`] / [`Document::new`] (or
+/// deserialization) rather than a struct literal. Fields stay public for reads.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Document {
     /// DID Subject Identifier
     /// <https://www.w3.org/TR/cid-1.0/#subjects>

--- a/crates/identity/affinidi-did-common/src/one_or_many.rs
+++ b/crates/identity/affinidi-did-common/src/one_or_many.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Serializes/deserializes into/from either a value, or an array of values.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum OneOrMany<T> {
     /// A single value.
     One(T),

--- a/crates/identity/affinidi-did-common/src/service.rs
+++ b/crates/identity/affinidi-did-common/src/service.rs
@@ -11,8 +11,11 @@ use url::Url;
 
 use crate::Document;
 
+/// `#[non_exhaustive]`: build via [`ServiceBuilder`] (or deserialization) rather
+/// than a struct literal. Fields stay public for reads.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Service {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Url>,
@@ -80,9 +83,13 @@ impl Document {
 }
 
 /// Service Endpoint definitions
+///
+/// `#[non_exhaustive]`: match with a wildcard arm so new endpoint shapes are
+/// not a breaking change.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum Endpoint {
     /// Single String (URL)
     Url(Url),

--- a/crates/identity/affinidi-did-common/src/verification_method.rs
+++ b/crates/identity/affinidi-did-common/src/verification_method.rs
@@ -8,8 +8,11 @@ use url::Url;
 
 use crate::DocumentError;
 
+/// `#[non_exhaustive]`: build via [`VerificationMethodBuilder`] (or
+/// deserialization) rather than a struct literal. Fields stay public for reads.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct VerificationMethod {
     pub id: Url,
 
@@ -132,8 +135,12 @@ impl VerificationMethod {
 }
 
 /// https://www.w3.org/TR/cid-1.0/#verification-relationships
+///
+/// `#[non_exhaustive]`: match with a wildcard arm so new relationship shapes are
+/// not a breaking change.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum VerificationRelationship {
     /// Reference to a Verification Method (may be an absolute DID URL or a
     /// relative fragment like `"#0"`, so we keep it as a plain `String`).

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -469,6 +469,8 @@ pub(crate) async fn load_forwarding_protection_blocks(
                         );
                     }
                 }
+                // `Endpoint` is `#[non_exhaustive]`; ignore unknown shapes.
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
## W9 — seal affinidi-did-common enums + document structs (semver wave 3/5)

Future-proofs did-common's public API (Option B — `#[non_exhaustive]`, keep public fields/builders).

### Sealed
- **Enums:** `#[non_exhaustive]` on `Endpoint`, `VerificationRelationship`, `OneOrMany<T>`.
- **Structs:** `#[non_exhaustive]` on `Document`, `Service`, `VerificationMethod`. Fields stay `pub` for reads; the existing `DocumentBuilder` / `ServiceBuilder` / `VerificationMethodBuilder` (+ `Document::new`) are the construction path. **No external code constructs these via struct literals**, so no construction migration was needed.

### Consumer fixes
Only `Endpoint` had external exhaustive matches (now needing a wildcard):
- `affinidi-meeting-place` `lib.rs` — unknown endpoint shape → no URIs.
- mediator `config/helpers.rs` — ignore unknown shape.

`affinidi-messaging-sdk` `profiles.rs` already had a `_` arm. `OneOrMany` / `VerificationRelationship` have **no** external exhaustive match-arms (all references are construction or `if let`), so nothing else broke.

### Versioning — deferred to W11
No bump here (did-common also changed in W7/W8; it bumps once at the coordinated release).

### Verification
- `cargo build --workspace --all-targets` ✅ · `cargo clippy --workspace --all-targets` ✅
- did-common tests (203) + meeting-place green; `fmt --check` clean.
