### PR TITLE
refactor: seal sd-jwt / vc / data-integrity credential structs (W10)

### DIFF
--- a/crates/credentials/affinidi-data-integrity/examples/prepare_sign_input.rs
+++ b/crates/credentials/affinidi-data-integrity/examples/prepare_sign_input.rs
@@ -48,15 +48,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---- 2. Build the proof configuration (everything except the signature)
     let suite = CryptoSuite::EddsaJcs2022;
     let created = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let proof_config = DataIntegrityProof {
-        type_: "DataIntegrityProof".into(),
-        cryptosuite: suite,
-        created: Some(created),
-        verification_method: vm.clone(),
-        proof_purpose: "assertionMethod".into(),
-        proof_value: None,
-        context: None,
-    };
+    let proof_config = DataIntegrityProof::new(
+        suite,
+        vm.clone(),
+        "assertionMethod".into(),
+        None,
+        Some(created),
+        None,
+    );
 
     // ---- 3. Compute the exact bytes a remote signer would receive ---
     //
@@ -73,10 +72,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signature = simulate_remote_sign(&backend_key, &sign_input).await?;
 
     // ---- 5. Assemble the final proof --------------------------------
-    let proof = DataIntegrityProof {
-        proof_value: Some(multibase::encode(Base::Base58Btc, &signature)),
-        ..proof_config
-    };
+    // Fields stay public for reads/writes; only literal construction is sealed.
+    let mut proof = proof_config.clone();
+    proof.proof_value = Some(multibase::encode(Base::Base58Btc, &signature));
 
     // ---- 6. Sanity-check: verify against the same public key --------
     proof.verify_with_public_key(&credential, &public_key, VerifyOptions::new())?;

--- a/crates/credentials/affinidi-data-integrity/src/lib.rs
+++ b/crates/credentials/affinidi-data-integrity/src/lib.rs
@@ -107,8 +107,13 @@ pub use error::{DataIntegrityError, SignatureFailure};
 pub use options::{SignOptions, VerifyOptions};
 
 /// Serialized Data Integrity proof.
+///
+/// `#[non_exhaustive]`: produce via [`DataIntegrityProof::sign`] or
+/// [`DataIntegrityProof::new`] rather than a struct literal. Fields stay public
+/// for reads.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct DataIntegrityProof {
     /// Must be 'DataIntegrityProof'
     #[serde(rename = "type")]
@@ -131,6 +136,30 @@ pub struct DataIntegrityProof {
 }
 
 impl DataIntegrityProof {
+    /// Assemble a Data Integrity proof from its parts. `type_` is fixed to
+    /// `"DataIntegrityProof"`. Most callers should use [`DataIntegrityProof::sign`];
+    /// this is for reconstructing a proof from known components (e.g. tests or
+    /// custom flows).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        cryptosuite: CryptoSuite,
+        verification_method: String,
+        proof_purpose: String,
+        proof_value: Option<String>,
+        created: Option<String>,
+        context: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            type_: "DataIntegrityProof".to_string(),
+            cryptosuite,
+            created,
+            verification_method,
+            proof_purpose,
+            proof_value,
+            context,
+        }
+    }
+
     /// Produces a Data Integrity proof over `data_doc`.
     ///
     /// The cryptosuite is picked from [`SignOptions::cryptosuite`] if

--- a/crates/credentials/affinidi-sd-jwt/src/lib.rs
+++ b/crates/credentials/affinidi-sd-jwt/src/lib.rs
@@ -44,7 +44,11 @@ pub use signer::{JwtSigner, JwtVerifier};
 pub use verifier::{VerificationOptions, VerificationResult};
 
 /// An SD-JWT: a signed JWT with selective disclosures and optional key binding.
+///
+/// `#[non_exhaustive]`: construct via [`SdJwt::new`] rather than a struct
+/// literal. Fields stay public for reads.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SdJwt {
     /// The issuer-signed compact JWS (header.payload.signature)
     pub jws: String,
@@ -55,6 +59,16 @@ pub struct SdJwt {
 }
 
 impl SdJwt {
+    /// Construct an SD-JWT from its issuer-signed JWS, disclosures, and optional
+    /// key-binding JWT.
+    pub fn new(jws: String, disclosures: Vec<Disclosure>, kb_jwt: Option<String>) -> Self {
+        Self {
+            jws,
+            disclosures,
+            kb_jwt,
+        }
+    }
+
     /// Serialize the SD-JWT to the compact format:
     /// `<jws>~<disclosure1>~<disclosure2>~...~[<kb_jwt>]`
     pub fn serialize(&self) -> String {

--- a/crates/credentials/affinidi-sd-jwt/tests/rfc9901_vectors.rs
+++ b/crates/credentials/affinidi-sd-jwt/tests/rfc9901_vectors.rs
@@ -366,11 +366,11 @@ fn error_disclosure_digest_not_in_payload() {
     let fake_disclosure =
         affinidi_sd_jwt::Disclosure::new_claim("fake_claim", json!("fake"), &hasher).unwrap();
 
-    let tampered = SdJwt {
-        jws: sd_jwt.jws.clone(),
-        disclosures: vec![sd_jwt.disclosures[0].clone(), fake_disclosure],
-        kb_jwt: None,
-    };
+    let tampered = SdJwt::new(
+        sd_jwt.jws.clone(),
+        vec![sd_jwt.disclosures[0].clone(), fake_disclosure],
+        None,
+    );
 
     let result = verifier::verify(&tampered, &jwt_verifier, &hasher, &Default::default(), None);
     assert!(result.is_err());

--- a/crates/credentials/affinidi-vc/src/credential.rs
+++ b/crates/credentials/affinidi-vc/src/credential.rs
@@ -29,7 +29,11 @@ use crate::error::{Result, VcError};
 ///
 /// This is the core credential type. The proof is external to the data model —
 /// it can be a Data Integrity proof, JWT envelope, SD-JWT-VC, or COSE signature.
+/// `#[non_exhaustive]`: obtain via deserialization/issuance rather than a struct
+/// literal, so new VCDM properties are not a breaking change. Fields stay public
+/// for reads.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct VerifiableCredential {
     /// JSON-LD context(s). First MUST be the W3C base context.
     #[serde(rename = "@context")]
@@ -152,7 +156,10 @@ pub enum SubjectValue {
 }
 
 /// Credential status information for revocation/suspension checking.
+/// `#[non_exhaustive]`: obtain via deserialization rather than a struct literal.
+/// Fields stay public for reads.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CredentialStatus {
     /// Status entry identifier.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/tdk/affinidi-tdk/src/lib.rs
+++ b/crates/tdk/affinidi-tdk/src/lib.rs
@@ -208,18 +208,17 @@ mod tests {
         }
 
         fn proof_with_vm(verification_method: &str) -> DataIntegrityProof {
-            DataIntegrityProof {
-                type_: "DataIntegrityProof".to_string(),
-                cryptosuite: CryptoSuite::EddsaJcs2022,
-                created: Some("2025-01-01T00:00:00Z".to_string()),
-                verification_method: verification_method.to_string(),
-                proof_purpose: "assertionMethod".to_string(),
-                proof_value: Some(
+            DataIntegrityProof::new(
+                CryptoSuite::EddsaJcs2022,
+                verification_method.to_string(),
+                "assertionMethod".to_string(),
+                Some(
                     "z2RPk8MWLoULfcbtpULoEsgfDsaAvyfD1PvQC2v3BjqqNtzGu8YJ4Nxq8CmJCZpPqA49uJhkxmxSztUQhBxqnVrYj"
                         .to_string(),
                 ),
-                context: None,
-            }
+                Some("2025-01-01T00:00:00Z".to_string()),
+                None,
+            )
         }
 
         #[tokio::test]


### PR DESCRIPTION
## W10 — seal sd-jwt / vc / data-integrity credential structs (semver wave 4/5)

Seals the 0.1.x credential crates now, while migration is cheap (before adoption hardens).

### Sealed (+ constructors)
- **affinidi-sd-jwt:** `#[non_exhaustive]` on `SdJwt` + `SdJwt::new(jws, disclosures, kb_jwt)`.
- **affinidi-vc:** `#[non_exhaustive]` on `VerifiableCredential` and `CredentialStatus` — obtained via deserialization/issuance; no external struct-literal construction, so no new constructor needed.
- **affinidi-data-integrity:** `#[non_exhaustive]` on `DataIntegrityProof` + `DataIntegrityProof::new(..)` to reconstruct a proof from parts (`sign()` remains the primary path).

### Migrated literal sites
`tests/` and `examples/` are separate compilation units, so `#[non_exhaustive]` affects them:
- sd-jwt `tests/rfc9901_vectors.rs` → `SdJwt::new`.
- data-integrity `examples/prepare_sign_input.rs` → `DataIntegrityProof::new`; the `..proof_config` struct-update became `clone()` + field assignment (fields stay public for writes — only literal construction is sealed).
- tdk `lib.rs` test helper → `DataIntegrityProof::new`.

### Versioning — deferred to W11
No bumps here. (sd-jwt also changed in W6/W7; vc/data-integrity in W7.) All bumps + pins + release happen once in W11.

### Verification
- `cargo build --workspace --all-targets` ✅ · `cargo clippy --workspace --all-targets` ✅
- sd-jwt / vc / data-integrity / sd-jwt-vc / tdk tests green; `fmt --check` clean.
