### PR TITLE
chore(release): semver wave version bumps + ADR + migration guide (W11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ docs/*
 !docs/adr/
 # Security audit-readiness / threat-model docs are tracked.
 !docs/security/
+# Consumer migration guides are tracked.
+!docs/migration/
 
 # mediator-setup wizard generated artifacts (may land in any directory)
 **/conf/secrets.json

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi Crypto Changelog
 
+## 13th June 2026 (0.2.2)
+
+Semver wave (W7/W8 — release W11). `CryptoError` and `Params` are now
+`#[non_exhaustive]`, and `JWK` / `ECParams` / `OctectParams` / `KeyPair` are
+`#[non_exhaustive]` with `new(..)` constructors (fields stay public for reads).
+Patch bump (not minor) so the `[patch.crates-io]` redirect keeps resolving for
+external consumers — see [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md)
+and [the migration guide](../../../docs/migration/2026-06-semver-wave.md).
+
 ## 13th June 2026 (0.2.1)
 
 RNG hygiene (W4): the PQC key generators (ML-DSA, SLH-DSA) now seed a CSPRNG

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.1"
+version = "0.2.2"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi Secrets Manager
 
+## 13th June 2026 (0.5.8)
+
+Semver wave (W7 — release W11). `SecretsResolverError` is now `#[non_exhaustive]`
+(match with a wildcard arm). Patch bump preserves the `didwebvh-rs`
+`[patch.crates-io]` coupling — see ADR 0003 and the migration guide.
+
 ## 6th June 2026 (0.5.7)
 
 - **Full P-521 secret support (#357).** Added `Secret::generate_p521`

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.7"
+version = "0.5.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi Data Integrity Changelog
 
+## 13th June 2026 Release 0.7.6
+
+Semver wave (W10 — release W11). `DataIntegrityProof` is now `#[non_exhaustive]`
+with a `DataIntegrityProof::new(..)` constructor for assembling a proof from
+parts (`sign()` remains the primary path; fields stay public for reads). Patch
+bump preserves the `didwebvh-rs` `[patch.crates-io]` coupling — see ADR 0003 and
+the migration guide.
+
 ## 8th June 2026 Release 0.7.5
 
 ### Fixed

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
+++ b/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi SD-JWT Changelog
 
+## 13th June 2026 Release 0.1.4
+
+Semver wave (W7/W10 — release W11). `SdJwtError` and `SdJwt` are now
+`#[non_exhaustive]`; `SdJwt::new(jws, disclosures, kb_jwt)` is the construction
+path (fields stay public for reads). Patch bump — see ADR 0003 and the migration
+guide.
+
 ## 13th June 2026 Release 0.1.3
 
 ### Security

--- a/crates/credentials/affinidi-sd-jwt/Cargo.toml
+++ b/crates/credentials/affinidi-sd-jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-sd-jwt"
 description = "SD-JWT (Selective Disclosure JWT) implementation per IETF SD-JWT specification."
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-vc/CHANGELOG.md
+++ b/crates/credentials/affinidi-vc/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Affinidi VC Changelog
+
+## 13th June 2026 (0.1.2)
+
+Semver wave (W7/W10 — release W11). `VcError`, `VerifiableCredential`, and
+`CredentialStatus` are now `#[non_exhaustive]`: match `VcError` with a wildcard
+arm; obtain the structs via deserialization/issuance (fields stay public for
+reads). Patch bump — see
+[ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) and
+[the migration guide](../../../docs/migration/2026-06-semver-wave.md).

--- a/crates/credentials/affinidi-vc/Cargo.toml
+++ b/crates/credentials/affinidi-vc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-vc"
 description = "W3C Verifiable Credentials Data Model 1.1 and 2.0 implementation."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Affinidi DID Authentication
 
+## 13th June 2026 (0.3.8)
+
+Semver wave (W7 — release W11). `DIDAuthError` is now `#[non_exhaustive]` (match
+with a wildcard arm). Patch bump — see ADR 0003 and the migration guide.
+
 ## 13th June 2026 (0.3.7)
 
 Auth hygiene (W6):

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-06-13
+
+### Changed
+
+- Sealed the public API for future-proofing (semver wave W9, released W11):
+  `DocumentError`, `Endpoint`, `VerificationRelationship`, and `OneOrMany` are
+  now `#[non_exhaustive]` (match with a wildcard arm); `Document`, `Service`, and
+  `VerificationMethod` are `#[non_exhaustive]` (construct via the existing
+  builders / `Document::new`; fields stay public for reads). Patch bump preserves
+  the `didwebvh-rs` `[patch.crates-io]` coupling — see ADR 0003 and
+  `docs/migration/2026-06-semver-wave.md`.
+
 ## [0.3.5] - 2026-06-06
 
 ### Added

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.5"
+version = "0.3.6"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - 2026-06-13
+
+### Changed
+
+- `DIDCommError` is now `#[non_exhaustive]` (semver wave W7, released W11). Match
+  with a wildcard arm. Patch bump preserves the `vta-sdk` `[patch.crates-io]`
+  coupling — see ADR 0003 and `docs/migration/2026-06-semver-wave.md`.
+
 ## [0.15.1] - 2026-06-06
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.1"
+version = "0.15.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/docs/adr/0003-public-api-semver-policy.md
+++ b/docs/adr/0003-public-api-semver-policy.md
@@ -1,0 +1,71 @@
+# ADR 0003 — Public-API semver policy: `#[non_exhaustive]` by default
+
+- **Status:** Accepted
+- **Date:** 2026-06-13
+- **Relates to:** the workspace semver wave (W7–W11); `DataIntegrityError` as the original exemplar; the `didwebvh-rs` / `vta-sdk` `[patch.crates-io]` coupling.
+
+## Context
+
+Most published crates in the workspace shipped exhaustive public enums and
+struct-literal-constructible public structs. Adding a variant to an enum, or a
+field to a struct, is then a **breaking** change for downstream consumers (their
+`match` arms / struct literals stop compiling). `affinidi-data-integrity` was
+the lone exemplar that had already applied `#[non_exhaustive]` to its error and
+proof types.
+
+Pre-1.0, the cost of repeated breaking majors as the DID/VC/DIDComm data models
+evolve is high. We want new variants/fields to be **non-breaking by
+construction**, so the API can grow without a major bump each time.
+
+A second, hard constraint shapes *how* we version these changes. Several of our
+foundational crates are consumed by **external crates.io crates** that we also
+depend on and redirect to local paths via `[patch.crates-io]` — most notably
+`didwebvh-rs` (pins `affinidi-did-common "0.3"`, `affinidi-secrets-resolver
+"0.5"`, `affinidi-data-integrity "0.7"`) and `vta-sdk` (pins
+`affinidi-messaging-didcomm`). A `[patch]` redirect only applies while our local
+version **satisfies the external crate's requirement**. Minor-bumping a patched
+crate past the externally-pinned minor breaks the redirect, so cargo pulls a
+second copy from crates.io and the build fails with duplicate-type errors.
+
+## Decision
+
+1. **`#[non_exhaustive]` by default on public, consumer-facing types.** Public
+   error enums, data-model enums (e.g. `Endpoint`, `OneOrMany`,
+   `VerificationRelationship`, `Params`), and public structs that consumers
+   should not literal-construct (e.g. `JWK`, `Document`, `VerifiableCredential`,
+   `DataIntegrityProof`) carry `#[non_exhaustive]`.
+   - **Option B (keep public fields):** struct fields stay `pub` for *reads*;
+     `#[non_exhaustive]` only blocks external struct-literal construction and
+     exhaustive destructuring. Each sealed struct provides a `new(..)`
+     constructor and/or builder as the construction path.
+   - Consumers `match` these enums with a wildcard arm and build these structs
+     via constructors/builders/deserialization.
+
+2. **New trait methods get default implementations** where the trait is a public
+   extension point (e.g. `Resolver`, `AsyncResolver`, `Signer`,
+   `SecretsResolver`), so adding a method is non-breaking.
+
+3. **Versioning is constrained by the external `[patch.crates-io]` coupling.**
+   Because adding `#[non_exhaustive]` is *technically* breaking but, in this
+   workspace, would break externally-pinned `[patch]` redirects if shipped as a
+   minor bump, such changes are released as **patch bumps** within the current
+   minor when the crate has external crates.io consumers. This keeps every `0.X`
+   pin (internal and external) valid. The change is safe in practice: adding
+   `#[non_exhaustive]` does not break any consumer that already uses wildcard
+   arms (and the workspace — including the patched external crates built from
+   source — compiles green against the sealed types). A *true* minor/major bump
+   of these crates requires first coordinating new releases of the external
+   consumers (`didwebvh-rs`, `vta-sdk`) that depend on the new version.
+
+## Consequences
+
+- New variants and fields can be added to sealed types without a breaking
+  release. This is the precondition for a stable 1.0 surface.
+- Downstream `match` on these enums must include a `_` arm; struct literals must
+  become constructor/builder calls. Migration is mechanical (see the migration
+  guide).
+- The semver wave (W7–W10) sealed the types; W11 released them as patch bumps
+  per point 3. A future 1.0 push that wants true minor/major versioning must
+  sequence the external-consumer releases first.
+- New capability crates should adopt this policy from the start (`#[non_exhaustive]`
+  on public enums/errors/consumer structs, constructors over literals).

--- a/docs/migration/2026-06-semver-wave.md
+++ b/docs/migration/2026-06-semver-wave.md
@@ -1,0 +1,87 @@
+# Migration guide — public-API sealing wave (June 2026)
+
+This release adds `#[non_exhaustive]` to a set of public error enums,
+data-model enums, and structs across the workspace, and adds constructors to the
+sealed structs. The policy is recorded in
+[ADR 0003](../adr/0003-public-api-semver-policy.md).
+
+The changes are **future-proofing**: they let new variants/fields be added later
+without a breaking release. For most consumers there is **no migration** — only
+code that exhaustively matched these enums *without* a wildcard, or constructed
+the sealed structs via struct literals, needs a small edit.
+
+## Affected crates / versions
+
+| Crate | Version | Sealed |
+|-------|---------|--------|
+| `affinidi-crypto` | 0.2.2 | `CryptoError`; `Params`; `JWK`, `ECParams`, `OctectParams`, `KeyPair` (+ `new`) |
+| `affinidi-messaging-didcomm` | 0.15.2 | `DIDCommError` |
+| `affinidi-did-common` | 0.3.6 | `DocumentError`; `Endpoint`, `VerificationRelationship`, `OneOrMany`; `Document`, `Service`, `VerificationMethod` |
+| `affinidi-secrets-resolver` | 0.5.8 | `SecretsResolverError` |
+| `affinidi-did-authentication` | 0.3.8 | `DIDAuthError` |
+| `affinidi-vc` | 0.1.2 | `VcError`; `VerifiableCredential`, `CredentialStatus` |
+| `affinidi-sd-jwt` | 0.1.4 | `SdJwtError`; `SdJwt` (+ `new`) |
+| `affinidi-data-integrity` | 0.7.6 | `DataIntegrityProof` (+ `new`) |
+
+> These are **patch bumps**. They stay within each crate's current minor so the
+> `[patch.crates-io]` redirects for external consumers (`didwebvh-rs`,
+> `vta-sdk`) keep resolving — see ADR 0003 for why.
+
+## 1. Matching a now-`#[non_exhaustive]` enum → add a wildcard arm
+
+```rust
+// Before — exhaustive match, breaks when a variant is added:
+match err {
+    CryptoError::KeyError(m) => ...,
+    CryptoError::Signing(m)  => ...,
+}
+
+// After — wildcard arm absorbs future variants:
+match err {
+    CryptoError::KeyError(m) => ...,
+    CryptoError::Signing(m)  => ...,
+    _ => ...,
+}
+```
+
+Applies to: `CryptoError`, `DIDCommError`, `VcError`, `SdJwtError`,
+`DIDAuthError`, `DocumentError`, `SecretsResolverError`, `Params`, `Endpoint`,
+`VerificationRelationship`, `OneOrMany`.
+
+## 2. Constructing a now-sealed struct → use the constructor/builder
+
+```rust
+// Before — struct literal, no longer allowed from another crate:
+let jwk = JWK { key_id: None, params };
+
+// After — use the constructor:
+let jwk = JWK::new(None, params);
+```
+
+Constructors added this release:
+
+- `JWK::new(key_id, params)`
+- `ECParams::new(curve, x, y, d)` · `OctectParams::new(curve, x, d)`
+- `KeyPair::new(key_type, private_bytes, public_bytes, jwk)`
+- `SdJwt::new(jws, disclosures, kb_jwt)`
+- `DataIntegrityProof::new(cryptosuite, verification_method, proof_purpose, proof_value, created, context)`
+
+`Document` / `Service` / `VerificationMethod` use the existing
+`DocumentBuilder` / `ServiceBuilder` / `VerificationMethodBuilder` (and
+`Document::new`). `VerifiableCredential` / `CredentialStatus` are obtained via
+deserialization or issuance.
+
+Fields remain **public for reading and mutation** — only literal *construction*
+and `..spread` updates are sealed:
+
+```rust
+// `..proof_config` struct-update is no longer allowed cross-crate; instead:
+let mut proof = proof_config.clone();
+proof.proof_value = Some(sig);
+```
+
+## 3. Deserialization is unaffected
+
+`serde` deserialization of these types is unchanged — the `Deserialize` impls
+are generated in the defining crate, which is allowed to construct its own
+non-exhaustive types.


### PR DESCRIPTION
## W11 — semver wave release prep (wave 5/5, finale)

Closes the semver wave: releases the already-merged W7–W10 `#[non_exhaustive]` sealing, with the policy ADR and consumer migration guide. **Prepare-only — no `cargo publish` here.**

### The version-strategy pivot: patch, not minor

The wave was framed as minor (breaking) bumps, but executing that **broke the build**: external crates.io crates we redirect via `[patch.crates-io]` — `didwebvh-rs` (pins `affinidi-did-common "0.3"`, `affinidi-secrets-resolver "0.5"`, `affinidi-data-integrity "0.7"`; used by 5 of our crates) and `vta-sdk` (pins `affinidi-messaging-didcomm`) — only resolve while our path version *satisfies* their pin. A minor bump breaks the redirect → cargo pulls a second copy from crates.io → duplicate-type errors.

The sealing changes are **already merged and proven compatible** (the workspace built green through W7–W10) — only the version *number* matters. So they ship as **patch bumps**, keeping every `"0.X"` pin valid (no pin edits, no external breakage). Recorded in **ADR 0003**. *(Decision confirmed with the maintainer.)*

| Crate | Bump |
|---|---|
| affinidi-crypto | 0.2.1 → 0.2.2 |
| affinidi-messaging-didcomm | 0.15.1 → 0.15.2 |
| affinidi-did-common | 0.3.5 → 0.3.6 |
| affinidi-secrets-resolver | 0.5.7 → 0.5.8 |
| affinidi-did-authentication | 0.3.7 → 0.3.8 |
| affinidi-vc | 0.1.1 → 0.1.2 |
| affinidi-sd-jwt | 0.1.3 → 0.1.4 |
| affinidi-data-integrity | 0.7.5 → 0.7.6 |

### Docs
- `docs/adr/0003-public-api-semver-policy.md` — `#[non_exhaustive]`-by-default policy + the external-coupling versioning constraint.
- `docs/migration/2026-06-semver-wave.md` — wildcard-arm + constructor migration (now whitelisted in `.gitignore`, like ADRs).
- CHANGELOG entries for all 8 crates (created `affinidi-vc`'s).

### Scope / notes
- **Prepare-only** (`workspace_publish: false`): the 8 form a coherent publishable set; the actual `cargo publish` is the separate gated step.
- Non-wave dependents (mediator, sdk, tdk, …) need no bump — they carry the unchanged minors; they'll pick up these patches via caret on their next release.
- **W12 facade 0.8 stays a separate task** (your call), so it's not in this release.
- Verified: `cargo build --workspace` clean.

Closes the semver wave → Checkpoint W-2.
