### PR TITLE
feat: complete the affinidi-tdk facade — capability features (W12)

### DIFF
--- a/.github/workflows/checks-features.yaml
+++ b/.github/workflows/checks-features.yaml
@@ -16,6 +16,7 @@ on:
       - synchronize
     paths:
       - "crates/messaging/affinidi-messaging-mediator/**"
+      - "crates/tdk/affinidi-tdk/**"
       - ".github/workflows/checks-features.yaml"
 
 jobs:
@@ -81,3 +82,47 @@ jobs:
             -p ${{ matrix.crate.package }} \
             --no-default-features \
             --features "${{ steps.features.outputs.list }}"
+
+  # Build the affinidi-tdk facade across its feature surface so a new feature
+  # (or a broken re-export) can't silently fail to compile in some combination.
+  facade-features:
+    name: facade / ${{ matrix.combo.short }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - short: default
+            flags: ""
+          - short: no-default
+            flags: "--no-default-features"
+          - short: credentials
+            flags: "--no-default-features --features credentials"
+          - short: protocols
+            flags: "--no-default-features --features protocols"
+          - short: did-methods
+            flags: "--no-default-features --features did-methods"
+          - short: trust+tsp
+            flags: "--no-default-features --features trust,tsp"
+          - short: all-features
+            flags: "--all-features"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install native deps for aws_lc_rs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libssl-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+
+      - name: Cache cargo registry + build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: facade-${{ matrix.combo.short }}
+
+      - name: cargo check -p affinidi-tdk ${{ matrix.combo.flags }}
+        run: cargo check -p affinidi-tdk ${{ matrix.combo.flags }}

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -36,7 +36,7 @@ affinidi-did-common = "0.3"
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
 affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator" }
-affinidi-tdk = { version = "0.7", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 
 
 [[example]]

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/mediator_administration/main.rs"
 ## SDK for connecting to and communicating with a running mediator
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.7", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.7" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-resolver-cache-sdk = "0.8"

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,30 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.8.0] - 2026-06-13
+
+### Added
+
+- **Facade feature completion (W12).** Every published capability crate is now
+  reachable through a facade feature and re-exported under a module:
+  - `credentials` group → `vc`, `sd-jwt`, `sd-jwt-vc`, `mdoc`, `status-list`
+    (+ `data-integrity`).
+  - `protocols` group → `oid4vc-core`, `siopv2`, `openid4vci`, `openid4vp`.
+  - `did-methods` group → `did-web`, `did-ebsi`, `did-scid`.
+  - `trust` (`affinidi-trust-lists`), `tsp` (`affinidi-tsp`).
+  - All optional and `dep:`-gated; individual + group features both available.
+- Facade feature-matrix CI job (`checks-features.yaml`) building default,
+  no-default, each group, and all-features.
+
+### Changed
+
+- Foundation deps (`affinidi-crypto`, `affinidi-tdk-common`) kept at
+  `major.minor` (caret), **not** exact-pinned: these crates ship frequent patch
+  releases (see ADR 0003), so an exact pin would break the facade on every
+  patch. Use the facade **or** direct sub-crate deps, not both.
+- `did-peer` documented as a code-gate feature (no extra dependency; gates the
+  did:peer helpers in `dids`).
+
 ## [0.7.4] - 2026-06-06
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.7.4"
+version = "0.8.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -14,10 +14,41 @@ rust-version.workspace = true
 
 [features]
 default = ["messaging", "meeting-place", "did-peer", "data-integrity"]
+
+# ── Messaging / application clients ──────────────────────────────────────
 messaging = ["dep:affinidi-messaging-sdk"]
 meeting-place = ["dep:affinidi-meeting-place"]
+
+# did:peer helper API in `dids` — a pure code-gate backed by the always-present
+# `affinidi-did-common` (no extra dependency).
 did-peer = []
+
+# ── Credentials: formats, status, and proofs ─────────────────────────────
+credentials = ["vc", "sd-jwt", "sd-jwt-vc", "mdoc", "status-list", "data-integrity"]
+vc = ["dep:affinidi-vc"]
+sd-jwt = ["dep:affinidi-sd-jwt"]
+sd-jwt-vc = ["dep:affinidi-sd-jwt-vc"]
+mdoc = ["dep:affinidi-mdoc"]
+status-list = ["dep:affinidi-status-list"]
 data-integrity = ["dep:affinidi-data-integrity", "dep:serde"]
+
+# ── Protocols: OID4VC family ─────────────────────────────────────────────
+protocols = ["oid4vc-core", "siopv2", "openid4vci", "openid4vp"]
+oid4vc-core = ["dep:affinidi-oid4vc-core"]
+siopv2 = ["dep:affinidi-siopv2"]
+openid4vci = ["dep:affinidi-openid4vci"]
+openid4vp = ["dep:affinidi-openid4vp"]
+
+# ── DID methods (key/peer are always available; web also lives in the
+#    resolver). These add the standalone method crates. ───────────────────
+did-methods = ["did-web", "did-ebsi", "did-scid"]
+did-web = ["dep:affinidi-did-web"]
+did-ebsi = ["dep:did-ebsi"]
+did-scid = ["dep:did-scid"]
+
+# ── Trust + TSP ──────────────────────────────────────────────────────────
+trust = ["dep:affinidi-trust-lists"]
+tsp = ["dep:affinidi-tsp"]
 
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
@@ -25,11 +56,38 @@ affinidi-did-common = "0.3"
 affinidi-messaging-sdk = { version = "0.18", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"
+# Foundations are re-exported by the facade. Kept at major.minor (caret), NOT
+# exact-pinned: these crates ship frequent patch releases (see ADR 0003 / the
+# June-2026 semver wave), so an exact pin would break the facade build on every
+# patch. Caret already prevents incompatible within-minor skew; consumers should
+# use the facade OR direct sub-crate deps, not both.
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 affinidi-crypto = "0.2"
 affinidi-meeting-place = { version = "0.4", optional = true }
-affinidi-data-integrity = { version = "0.7",  optional = true }
+affinidi-data-integrity = { version = "0.7", optional = true }
+
+# Credentials
+affinidi-vc = { version = "0.1", path = "../../credentials/affinidi-vc", optional = true }
+affinidi-sd-jwt = { version = "0.1", path = "../../credentials/affinidi-sd-jwt", optional = true }
+affinidi-sd-jwt-vc = { version = "0.1", path = "../../credentials/affinidi-sd-jwt-vc", optional = true }
+affinidi-mdoc = { version = "0.2", path = "../../credentials/affinidi-mdoc", optional = true }
+affinidi-status-list = { version = "0.1", path = "../../credentials/affinidi-status-list", optional = true }
+
+# Protocols
+affinidi-oid4vc-core = { version = "0.1", path = "../../protocols/affinidi-oid4vc-core", optional = true }
+affinidi-siopv2 = { version = "0.1", path = "../../protocols/affinidi-siopv2", optional = true }
+affinidi-openid4vci = { version = "0.1", path = "../../protocols/affinidi-openid4vci", optional = true }
+affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4vp", optional = true }
+
+# DID methods
+affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
+did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
+did-scid = { version = "0.1", path = "../../identity/did-methods/did-scid", optional = true }
+
+# Trust + TSP
+affinidi-trust-lists = { version = "0.1", path = "../../trust/affinidi-trust-lists", optional = true }
+affinidi-tsp = { version = "0.1", path = "../../messaging/affinidi-tsp", optional = true }
 
 # External Crates
 clap = { version = "4", features = ["derive"] }

--- a/crates/tdk/affinidi-tdk/README.md
+++ b/crates/tdk/affinidi-tdk/README.md
@@ -15,24 +15,52 @@ single crate and enable feature flags to pull in only the libraries you need.
 
 ```toml
 [dependencies]
-affinidi-tdk = "0.7"
+affinidi-tdk = "0.8"
 ```
 
 ## Feature Flags
 
-| Feature | Default | Description |
-|---|---|---|
-| `messaging` | Yes | Affinidi Messaging SDK |
-| `meeting-place` | Yes | Affinidi Meeting Place SDK |
-| `did-peer` | Yes | Peer DID method support |
-| `data-integrity` | Yes | W3C Data Integrity proof support |
+Every published capability crate is reachable through a facade feature. Group
+features (e.g. `credentials`, `protocols`) enable a whole layer; the individual
+features let you pull in just one crate. The `*` re-export column is the module
+name the crate is re-exported as (e.g. `affinidi_tdk::vc`).
+
+| Feature | Default | Enables | Re-export | Description |
+|---|---|---|---|---|
+| `messaging` | Yes | `affinidi-messaging-sdk` | `messaging` | Affinidi Messaging SDK |
+| `meeting-place` | Yes | `affinidi-meeting-place` | `meeting_place` | Affinidi Meeting Place SDK |
+| `did-peer` | Yes | — (code-gate) | — | did:peer helpers in `dids` |
+| `data-integrity` | Yes | `affinidi-data-integrity` | `data_integrity` | W3C Data Integrity proofs |
+| **`credentials`** | No | group ↓ | — | All credential formats + status + proofs |
+| `vc` | No | `affinidi-vc` | `vc` | W3C Verifiable Credentials |
+| `sd-jwt` | No | `affinidi-sd-jwt` | `sd_jwt` | SD-JWT |
+| `sd-jwt-vc` | No | `affinidi-sd-jwt-vc` | `sd_jwt_vc` | SD-JWT VC |
+| `mdoc` | No | `affinidi-mdoc` | `mdoc` | ISO mdoc / mDL |
+| `status-list` | No | `affinidi-status-list` | `status_list` | Bitstring status lists |
+| **`protocols`** | No | group ↓ | — | OID4VC protocol family |
+| `oid4vc-core` | No | `affinidi-oid4vc-core` | `oid4vc_core` | OID4VC core |
+| `siopv2` | No | `affinidi-siopv2` | `siopv2` | SIOPv2 |
+| `openid4vci` | No | `affinidi-openid4vci` | `openid4vci` | OpenID4VCI |
+| `openid4vp` | No | `affinidi-openid4vp` | `openid4vp` | OpenID4VP |
+| **`did-methods`** | No | group ↓ | — | Standalone DID method crates |
+| `did-web` | No | `affinidi-did-web` | `did_web` | did:web |
+| `did-ebsi` | No | `did-ebsi` | `did_ebsi` | did:ebsi |
+| `did-scid` | No | `did-scid` | `did_scid` | did:scid |
+| `trust` | No | `affinidi-trust-lists` | `trust_lists` | Trust lists |
+| `tsp` | No | `affinidi-tsp` | `tsp` | Trust Spanning Protocol |
+
+> **Use the facade _or_ direct sub-crate deps, not both.** Mixing
+> `affinidi-tdk` with a direct dependency on a crate it re-exports can resolve
+> two copies of that crate. Foundation crates (`affinidi-crypto`,
+> `affinidi-tdk-common`) are pinned at `major.minor` (caret), so any compatible
+> patch resolves to a single version within the facade's tree.
 
 Disable defaults with `default-features = false` in your `Cargo.toml` or
 `--no-default-features` on the command line, then enable only what you need:
 
 ```toml
 [dependencies]
-affinidi-tdk = { version = "0.7", default-features = false, features = ["data-integrity"] }
+affinidi-tdk = { version = "0.8", default-features = false, features = ["credentials", "protocols"] }
 ```
 
 ## Re-exported Crates
@@ -49,6 +77,18 @@ This crate re-exports the following libraries:
 - [`affinidi-tdk-common`](../common/affinidi-tdk-common/) — Shared utilities
 - [`affinidi-secrets-resolver`](../common/affinidi-secrets-resolver/) — Secret management
 - [`affinidi-crypto`](../common/affinidi-crypto/) — Cryptographic primitives
+
+## Contributing: new capability crate ⇒ new facade feature
+
+When a new published capability crate is added to the workspace, it **must** be
+made reachable through this facade in the same change:
+
+1. Add it as an `optional = true` dependency (path + `major.minor` version).
+2. Add a `dep:`-gated feature for it (and fold it into the relevant group
+   feature — `credentials` / `protocols` / `did-methods`).
+3. Re-export it under a `#[cfg(feature = "…")]` in `src/lib.rs`.
+4. Add a row to the Feature Flags table above.
+5. Extend the facade feature-matrix CI job.
 
 ## Related Crates
 

--- a/crates/tdk/affinidi-tdk/src/lib.rs
+++ b/crates/tdk/affinidi-tdk/src/lib.rs
@@ -40,6 +40,42 @@ pub use affinidi_messaging_sdk as messaging;
 #[cfg(feature = "data-integrity")]
 pub use affinidi_data_integrity as data_integrity;
 
+// ── Credentials ──────────────────────────────────────────────────────────
+#[cfg(feature = "mdoc")]
+pub use affinidi_mdoc as mdoc;
+#[cfg(feature = "sd-jwt")]
+pub use affinidi_sd_jwt as sd_jwt;
+#[cfg(feature = "sd-jwt-vc")]
+pub use affinidi_sd_jwt_vc as sd_jwt_vc;
+#[cfg(feature = "status-list")]
+pub use affinidi_status_list as status_list;
+#[cfg(feature = "vc")]
+pub use affinidi_vc as vc;
+
+// ── Protocols ────────────────────────────────────────────────────────────
+#[cfg(feature = "oid4vc-core")]
+pub use affinidi_oid4vc_core as oid4vc_core;
+#[cfg(feature = "openid4vci")]
+pub use affinidi_openid4vci as openid4vci;
+#[cfg(feature = "openid4vp")]
+pub use affinidi_openid4vp as openid4vp;
+#[cfg(feature = "siopv2")]
+pub use affinidi_siopv2 as siopv2;
+
+// ── DID methods ──────────────────────────────────────────────────────────
+#[cfg(feature = "did-web")]
+pub use affinidi_did_web as did_web;
+#[cfg(feature = "did-ebsi")]
+pub use did_ebsi;
+#[cfg(feature = "did-scid")]
+pub use did_scid;
+
+// ── Trust + TSP ──────────────────────────────────────────────────────────
+#[cfg(feature = "trust")]
+pub use affinidi_trust_lists as trust_lists;
+#[cfg(feature = "tsp")]
+pub use affinidi_tsp as tsp;
+
 pub use affinidi_crypto;
 pub use affinidi_did_authentication as did_authentication;
 pub use affinidi_did_common as did_common;


### PR DESCRIPTION
## W12 — complete the affinidi-tdk facade (Phase W3)

Makes every published capability crate reachable through the umbrella facade, so consumers depend on one crate and toggle features. `affinidi-tdk` `0.7.4 → 0.8.0`.

### New features (all optional, `dep:`-gated; group + individual)

| Group | Individual features → crates |
|---|---|
| `credentials` | `vc`, `sd-jwt`, `sd-jwt-vc`, `mdoc`, `status-list` (+ `data-integrity`) |
| `protocols` | `oid4vc-core`, `siopv2`, `openid4vci`, `openid4vp` |
| `did-methods` | `did-web`, `did-ebsi`, `did-scid` |
| — | `trust` (trust-lists), `tsp` |

Each is re-exported under `#[cfg(feature = "…")]` in `lib.rs` (`affinidi_tdk::vc`, `::oid4vc_core`, `::did_web`, …). Full map in the README table.

### Decisions / notes
- **`did-peer` is not inert** — it's a code-gate for the did:peer helpers in `dids` (backed by always-present `affinidi-did-common`). Documented as such; kept.
- **Foundations kept at `major.minor` caret, not exact-pinned.** The plan called for exact-pinning `affinidi-crypto`/`affinidi-tdk-common`, but W11 just established these patch *frequently* (and more crypto churn is coming in W15/16) — an exact pin would break the facade build on every patch. Caret already prevents incompatible within-minor skew; the README documents the "facade **or** direct deps, not both" rule that the exact-pin was meant to enforce. **Flagging this deviation for your veto** — trivial to switch to `=x.y.z` if you'd rather.
- README gains a "new capability crate ⇒ new facade feature" contributor rule.
- New **`facade-features` CI job** building default / no-default / each group / all-features.
- Bumped the 4 workspace facade dependents' pins `0.7 → 0.8` for a green workspace (didcomm-service, messaging-helpers, text-client, test-mediator). Facade isn't consumed by external crates.io crates, so the minor bump is safe (unlike the W11 foundational crates).

### Verification
- Facade builds: default, `--no-default-features`, each group, `--all-features` ✅
- `cargo clippy -p affinidi-tdk --all-targets -- -D warnings` (default + all-features) ✅; facade tests green; `cargo build --workspace` clean; `fmt` clean.

W13 (facade-first examples) and W14 (tdk-common split) remain separate tasks in Phase W3.
