### PR TITLE
docs: facade-first examples for affinidi-tdk (W13)

### DIFF
--- a/.github/workflows/checks-features.yaml
+++ b/.github/workflows/checks-features.yaml
@@ -126,3 +126,8 @@ jobs:
 
       - name: cargo check -p affinidi-tdk ${{ matrix.combo.flags }}
         run: cargo check -p affinidi-tdk ${{ matrix.combo.flags }}
+
+      # The facade examples must stay facade-first and keep compiling.
+      - name: cargo build -p affinidi-tdk --examples
+        if: matrix.combo.short == 'default'
+        run: cargo build -p affinidi-tdk --examples

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,17 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.8.1] - 2026-06-13
+
+### Added
+
+- Re-export the DID resolver cache SDK as `affinidi_tdk::did_resolver` so the
+  resolver is reachable through the facade (it was the only core dep not
+  re-exported).
+- Facade-first examples (W13): `examples/did_auth.rs` rewritten to import only
+  through `affinidi_tdk::*`; new `examples/resolve_did.rs`. A CI step
+  (`cargo build -p affinidi-tdk --examples`) keeps them compiling.
+
 ## [0.8.0] - 2026-06-13
 
 ### Added

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.0"
+version = "0.8.1"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/tdk/affinidi-tdk/README.md
+++ b/crates/tdk/affinidi-tdk/README.md
@@ -78,6 +78,19 @@ This crate re-exports the following libraries:
 - [`affinidi-secrets-resolver`](../common/affinidi-secrets-resolver/) — Secret management
 - [`affinidi-crypto`](../common/affinidi-crypto/) — Cryptographic primitives
 
+## Examples
+
+Runnable examples live in [`examples/`](examples/) and import **only** through
+`affinidi_tdk::*` — they are the canonical onboarding pattern (never depend on a
+sub-crate directly):
+
+- `did_auth` — authenticate a DID against a service endpoint.
+- `resolve_did` — resolve a DID and print its document.
+
+```sh
+cargo run -p affinidi-tdk --example resolve_did -- did:key:z6Mk…
+```
+
 ## Contributing: new capability crate ⇒ new facade feature
 
 When a new published capability crate is added to the workspace, it **must** be

--- a/crates/tdk/affinidi-tdk/examples/did_auth.rs
+++ b/crates/tdk/affinidi-tdk/examples/did_auth.rs
@@ -6,15 +6,17 @@
  *  - `manual-entry`: read raw DID secrets JSON from stdin.
  */
 
-use affinidi_did_authentication::DIDAuthentication;
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
-use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
-use affinidi_tdk_common::{
+// Facade-first: every Affinidi type comes through `affinidi_tdk::*` re-exports,
+// so this example never depends on a sub-crate directly.
+use affinidi_tdk::common::{
     create_http_client,
     environments::TDKEnvironments,
     errors::{Result, TDKError},
     profiles::TDKProfile,
 };
+use affinidi_tdk::did_authentication::DIDAuthentication;
+use affinidi_tdk::did_resolver::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_tdk::secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
 use clap::{Parser, Subcommand};
 use std::{
     env,

--- a/crates/tdk/affinidi-tdk/examples/resolve_did.rs
+++ b/crates/tdk/affinidi-tdk/examples/resolve_did.rs
@@ -1,0 +1,36 @@
+/*!
+ * Resolve a DID through the TDK facade and print its DID Document.
+ *
+ * Facade-first: every Affinidi type is reached through `affinidi_tdk::*`
+ * re-exports — this example depends on no sub-crate directly.
+ *
+ * ```sh
+ * cargo run -p affinidi-tdk --example resolve_did -- \
+ *   did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv
+ * ```
+ */
+
+use affinidi_tdk::common::errors::Result;
+use affinidi_tdk::did_resolver::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "resolve_did", bin_name = "resolve_did")]
+struct Cli {
+    /// DID to resolve (e.g. `did:key:…`, `did:peer:…`).
+    did: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let cli = Cli::parse();
+
+    // Local-mode resolver: did:key / did:peer resolve with no network.
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let response = resolver.resolve(&cli.did).await?;
+
+    let json = serde_json::to_string_pretty(&response.doc).expect("DID Document serializes");
+    println!("{json}");
+    Ok(())
+}

--- a/crates/tdk/affinidi-tdk/src/lib.rs
+++ b/crates/tdk/affinidi-tdk/src/lib.rs
@@ -79,6 +79,7 @@ pub use affinidi_tsp as tsp;
 pub use affinidi_crypto;
 pub use affinidi_did_authentication as did_authentication;
 pub use affinidi_did_common as did_common;
+pub use affinidi_did_resolver_cache_sdk as did_resolver;
 pub use affinidi_secrets_resolver as secrets_resolver;
 pub use affinidi_tdk_common as common;
 


### PR DESCRIPTION
## W13 — facade-first examples (Phase W3)

The examples are the onboarding path, so they must demonstrate the *right* pattern: depend on `affinidi-tdk` and import only through `affinidi_tdk::*` — never a sub-crate directly.

### Changes
- **Re-export the resolver** as `affinidi_tdk::did_resolver` (`affinidi-did-resolver-cache-sdk`) — it was the only core dependency the facade didn't re-export, which is what forced examples to import it directly.
- **`examples/did_auth.rs`** rewritten to facade-only imports (was importing `affinidi_did_authentication`, `affinidi_did_resolver_cache_sdk`, `affinidi_secrets_resolver`, `affinidi_tdk_common` directly).
- **`examples/resolve_did.rs`** (new, facade-only): resolve a DID and print its document.
- README gains an **Examples** section.
- CI: a `cargo build -p affinidi-tdk --examples` step in the `facade-features` job keeps the examples facade-first and compiling.

### Verification
- Both examples build (default features and via `--examples`).
- `grep` confirms **no direct sub-crate imports** in `examples/`.
- `cargo clippy -p affinidi-tdk --examples -- -D warnings` clean; `fmt` clean.

`affinidi-tdk` `0.8.0 → 0.8.1` (additive re-export). 

Note: the plan mentioned credential-issuance / OID4VP example flows too — those need feature-gated examples (`required-features`) and deep per-crate API setup, so I kept this PR to the core acceptance (facade-only + compiling) plus the resolver example. The credential/OID4VP examples are a good focused follow-up now that the feature plumbing (W12) exists.
