### PR TITLE
feat: messaging-sdk request-path hardening (W16 pt1)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.18.9] - 2026-06-13
+
+SDK request-path hardening (W16, part 1 of 2).
+
+### Added
+
+- **Configurable request timeout.** `ATMConfig::with_request_timeout(Duration)`
+  (default 15s) overrides the per-request timeout for mediator REST calls. The
+  previously hardcoded `MEDIATOR_REQUEST_TIMEOUT` constants (duplicated in
+  `delete.rs`/`list.rs`) are removed in favour of the config value.
+
+### Fixed
+
+- **No panic on a malformed mediator response.** `delete_messages_direct`,
+  `list_messages`, and `get_messages` parsed the response body with
+  `.ok().unwrap()`, panicking the caller (or the deletion-handler task) on any
+  non-JSON 2xx body. They now return `ATMError::TransportError` instead.
+- **`get_messages` had no request timeout** and could hang indefinitely on a
+  network stall; it is now bounded by the configured request timeout like the
+  other REST calls.
+
+### Changed
+
+- **WebSocket reconnect backoff is now jittered (±15%).** The exponential
+  backoff (1→2→4…→60s) previously reconnected in lock-step across clients;
+  jitter spreads reconnections so a recovering mediator isn't stampeded.
+  (`rand` promoted from dev- to normal dependency for non-cryptographic jitter.)
+
 ## [0.18.8] - 2026-06-13
 
 ### Added

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.8"
+version = "0.18.9"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -30,6 +30,8 @@ affinidi-secrets-resolver = "0.5"
 ahash = { version = "0.8", features = ["serde"] }
 base64 = "0.22"
 futures-util = "0.3"
+# Non-cryptographic jitter for WebSocket reconnect backoff (anti-thundering-herd)
+rand = "0.10"
 regex = "1"
 rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
@@ -49,7 +51,6 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 clap = { version = "4", features = ["derive"] }
 console = "0.16"
 dialoguer = "0.12"
-rand = "0.10"
 rcgen = { version = "0.14", default-features = false, features = [
   "aws_lc_rs",
   "pem",

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use affinidi_crypto::jose::key_agreement::Curve;
 use rustls::pki_types::CertificateDer;
-use std::{fs::File, io::BufReader, sync::Arc};
+use std::{fs::File, io::BufReader, sync::Arc, time::Duration};
 use tokio::sync::{RwLock, broadcast::Sender};
 use tracing::error;
 
@@ -37,6 +37,11 @@ pub struct ATMConfig {
     /// (`X25519 > P-256 > P-384 > P-521 > secp256k1`). Set a custom order to
     /// force a specific policy, e.g. P-256 first for a FIPS deployment.
     pub(crate) curve_preference: Option<Vec<Curve>>,
+
+    /// Per-request timeout for mediator REST calls (delete/list/get). Bounded
+    /// so an unreachable mediator surfaces a `TransportError` in seconds
+    /// rather than blocking on the OS-level TCP RTO. Default: 15s.
+    pub(crate) request_timeout: Duration,
 }
 
 impl ATMConfig {
@@ -44,6 +49,11 @@ impl ATMConfig {
     /// the negotiator's built-in default order is used.
     pub fn get_curve_preference(&self) -> Option<&[Curve]> {
         self.curve_preference.as_deref()
+    }
+
+    /// The per-request timeout applied to mediator REST calls.
+    pub fn get_request_timeout(&self) -> Duration {
+        self.request_timeout
     }
 
     /// Returns a builder for `ATMConfig`
@@ -78,6 +88,7 @@ pub struct ATMConfigBuilder {
     unpack_forwards: bool,
     discover_features: DiscoverFeatures,
     curve_preference: Option<Vec<Curve>>,
+    request_timeout: Duration,
 }
 
 impl Default for ATMConfigBuilder {
@@ -90,6 +101,7 @@ impl Default for ATMConfigBuilder {
             unpack_forwards: true,
             discover_features: DiscoverFeatures::default(),
             curve_preference: None,
+            request_timeout: Duration::from_secs(15),
         }
     }
 }
@@ -167,6 +179,23 @@ impl ATMConfigBuilder {
         self
     }
 
+    /// Override the per-request timeout for mediator REST calls
+    /// (delete/list/get). Lower it for snappier failure on flaky links;
+    /// raise it for high-latency mediators. Default: 15s.
+    ///
+    /// ```
+    /// use affinidi_messaging_sdk::config::ATMConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = ATMConfig::builder()
+    ///     .with_request_timeout(Duration::from_secs(30))
+    ///     .build();
+    /// ```
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
     pub fn build(self) -> Result<ATMConfig, ATMError> {
         // Process any custom SSL certificates
         let mut certs = vec![];
@@ -203,6 +232,7 @@ impl ATMConfigBuilder {
             unpack_forwards: self.unpack_forwards,
             discover_features: Arc::new(RwLock::new(self.discover_features)),
             curve_preference: self.curve_preference,
+            request_timeout: self.request_timeout,
         })
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/delete.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/delete.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use tracing::{Instrument, Level, debug, span};
 
@@ -11,10 +10,6 @@ use crate::{
 use super::{DeleteMessageRequest, DeleteMessageResponse};
 
 const MAX_DELETED_MESSAGES: usize = 100;
-/// Per-request HTTP timeout for mediator REST calls. Bounded so that an
-/// unreachable mediator surfaces a TransportError in seconds rather than
-/// blocking the caller for the OS-level TCP RTO (~30–60s on macOS).
-const MEDIATOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 impl ATM {
     /// Deletes a message from ATM in the background
@@ -45,7 +40,8 @@ impl ATM {
     /// NOTE: Use `delete_message_background` as a more efficient way to delete messages
     /// - messages: List of message_ids to delete
     ///
-    /// Each request is bounded by a 15-second timeout; an unreachable
+    /// Each request is bounded by the configured request timeout
+    /// (`ATMConfig::with_request_timeout`, default 15s); an unreachable
     /// mediator returns `ATMError::TransportError` rather than hanging.
     pub async fn delete_messages_direct(
         &self,
@@ -90,7 +86,7 @@ impl ATM {
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", tokens.access_token))
             .body(msg)
-            .timeout(MEDIATOR_REQUEST_TIMEOUT)
+            .timeout(self.inner.config.request_timeout)
             .send()
             .await
             .map_err(|e| {
@@ -112,8 +108,11 @@ impl ATM {
         }
 
         let body = serde_json::from_str::<SuccessResponse<DeleteMessageResponse>>(&body)
-            .ok()
-            .unwrap();
+            .map_err(|e| {
+                ATMError::TransportError(format!(
+                    "Could not parse delete_messages response: {e:?}"
+                ))
+            })?;
 
         let list = if let Some(list) = body.data {
             list

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/get.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/get.rs
@@ -11,6 +11,10 @@ use tracing::{Instrument, Level, debug, span};
 impl ATM {
     /// Returns a list of messages that are stored in the ATM
     /// - messages : List of message IDs to retrieve
+    ///
+    /// Each request is bounded by the configured request timeout
+    /// (`ATMConfig::with_request_timeout`, default 15s); an unreachable
+    /// mediator returns `ATMError::TransportError` rather than hanging.
     pub async fn get_messages(
         &self,
         profile: &Arc<ATMProfile>,
@@ -47,6 +51,7 @@ impl ATM {
                 .header("Content-Type", "application/json")
                 .header("Authorization", format!("Bearer {}", tokens.access_token))
                 .body(body)
+                .timeout(self.inner.config.request_timeout)
                 .send()
                 .await
                 .map_err(|e| {
@@ -68,8 +73,11 @@ impl ATM {
             }
 
             let body = serde_json::from_str::<SuccessResponse<GetMessagesResponse>>(&body)
-                .ok()
-                .unwrap();
+                .map_err(|e| {
+                    ATMError::TransportError(format!(
+                        "Could not parse get_messages response: {e:?}"
+                    ))
+                })?;
 
             let list = if let Some(list) = body.data {
                 list

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/list.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/list.rs
@@ -2,13 +2,7 @@ use super::{Folder, MessageList};
 use crate::{ATM, errors::ATMError, messages::SuccessResponse, profiles::ATMProfile};
 use sha256::digest;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{Instrument, Level, debug, span};
-
-/// Per-request HTTP timeout for mediator REST calls. Bounded so that an
-/// unreachable mediator surfaces a TransportError in seconds rather than
-/// blocking the caller for the OS-level TCP RTO (~30–60s on macOS).
-const MEDIATOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 impl ATM {
     /// Returns a list of messages that are stored in the ATM
@@ -16,7 +10,8 @@ impl ATM {
     /// - `did`: The DID to list messages for
     /// - `folder`: The folder to list messages from
     ///
-    /// Each request is bounded by a 15-second timeout; an unreachable
+    /// Each request is bounded by the configured request timeout
+    /// (`ATMConfig::with_request_timeout`, default 15s); an unreachable
     /// mediator returns `ATMError::TransportError` rather than hanging.
     pub async fn list_messages(
         &self,
@@ -53,7 +48,7 @@ impl ATM {
                 ))
                 .header("Content-Type", "application/json")
                 .header("Authorization", format!("Bearer {}", tokens.access_token))
-                .timeout(MEDIATOR_REQUEST_TIMEOUT)
+                .timeout(self.inner.config.request_timeout)
                 .send()
                 .await
                 .map_err(|e| {
@@ -74,9 +69,12 @@ impl ATM {
                 )));
             }
 
-            let body = serde_json::from_str::<SuccessResponse<MessageList>>(&body)
-                .ok()
-                .unwrap();
+            let body =
+                serde_json::from_str::<SuccessResponse<MessageList>>(&body).map_err(|e| {
+                    ATMError::TransportError(format!(
+                        "Could not parse list_messages response: {e:?}"
+                    ))
+                })?;
 
             let list = if let Some(list) = body.data {
                 list

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -6,6 +6,7 @@ use super::{WebSocketResponses, ws_cache::MessageCache};
 use crate::{ATM, SharedState, errors::ATMError, profiles::ATMProfile};
 use ahash::{HashMap, HashMapExt};
 use futures_util::{SinkExt, StreamExt};
+use rand::RngExt;
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 use tokio::{
     net::TcpStream,
@@ -188,9 +189,13 @@ impl WebSocketTransport {
                         // Tick immediately
                         self.connect_delay_timer = Some(tokio::time::interval(Duration::from_secs(1)));
                     } else {
-                        self.connect_delay_timer = Some(tokio::time::interval_at(tokio::time::Instant::now() + Duration::from_secs(self.connect_delay as u64),Duration::from_secs(
-                            self.connect_delay as u64,
-                        )));
+                        // Apply ±15% jitter so many clients disconnected at
+                        // once don't reconnect in lock-step (thundering herd).
+                        let delay = jittered_backoff(self.connect_delay);
+                        self.connect_delay_timer = Some(tokio::time::interval_at(
+                            tokio::time::Instant::now() + delay,
+                            delay,
+                        ));
                     }
                 }
 
@@ -479,7 +484,9 @@ impl WebSocketTransport {
         }
     }
 
-    /// Calculate exponential backoff delay: 0→1→2→4→8→16→32→60s (capped)
+    /// Calculate exponential backoff delay: 0→1→2→4→8→16→32→60s (capped).
+    /// Jitter is applied separately at timer-creation time
+    /// ([`jittered_backoff`]) so this base sequence stays deterministic.
     fn backoff_delay(&mut self) {
         self.connect_delay = match self.connect_delay {
             0 => 1,
@@ -614,5 +621,35 @@ impl std::fmt::Debug for WebSocketTransport {
             .field("skip_toggle_live_delivery", &self.skip_toggle_live_delivery)
             .field("skip_unpack_messages", &self.skip_unpack_messages)
             .finish()
+    }
+}
+
+/// Apply ±15% random jitter to a base backoff delay (in seconds). When the
+/// mediator recovers, clients that all disconnected together would otherwise
+/// reconnect in lock-step and stampede it; jitter spreads the reconnections
+/// out. Non-cryptographic randomness is fine here.
+fn jittered_backoff(base_secs: u8) -> Duration {
+    let factor = rand::rng().random_range(0.85..1.15);
+    Duration::from_secs_f64(base_secs as f64 * factor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jittered_backoff_stays_within_15_percent() {
+        // Sample repeatedly: every jittered delay must land within ±15% of
+        // the base and never be zero/negative.
+        for base in [1u8, 2, 4, 8, 16, 32, 60] {
+            for _ in 0..1000 {
+                let d = jittered_backoff(base).as_secs_f64();
+                assert!(
+                    d >= base as f64 * 0.85 && d < base as f64 * 1.15,
+                    "jittered {base}s -> {d}s out of ±15% band"
+                );
+                assert!(d > 0.0);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

**Part 1 of 2 of W16** (resilience). Per the agreed split, this PR is the safe, mechanical *request-path* hardening; the behavioral *WS resilience* work (proactive token refresh + delete-handler supervision) follows in part 2.

| Part | Change |
|---|---|
| (c) | **No panic on malformed mediator response.** `delete_messages_direct`, `list_messages`, `get_messages` parsed the body with `.ok().unwrap()` — a non-JSON 2xx body panicked the caller (or the deletion-handler task). Now return `ATMError::TransportError`. |
| (d) | **Configurable request timeout.** `ATMConfig::with_request_timeout(Duration)` (default 15s) replaces the hardcoded `MEDIATOR_REQUEST_TIMEOUT` consts duplicated across `delete.rs`/`list.rs`. **`get_messages` had no timeout at all** (could hang indefinitely on a stall) — now bounded like the others. |
| (e) | **Jittered reconnect backoff.** The exponential WS backoff (1→2→4…→60s) reconnected in lock-step across clients; now ±15% jitter so a recovering mediator isn't stampeded. `rand` promoted from dev- to normal dependency (non-cryptographic jitter). |

## Why a split

W16's five parts span very different size/risk. (c)+(d)+(e) are mechanical and low-risk and mergeable immediately; (a) WS token refresh and (b) delete-handler supervision are behavioral changes (the latter rewires shutdown onto the W15 `TaskSupervisor`) that warrant their own review. The headline acceptance — *a WS session outliving token expiry keeps sending* — lands in part 2.

> Investigation finding shaping part 2: the mediator **force-closes the WS with code 1008 at `session.expires_at`** (default 900s) and has **no in-band WS refresh** — refresh is HTTP-only. So part 2 will proactively refresh+reconnect before the forced close (re-validating the DID is still allowed before minting a new token).

## Verification

- `sdk 0.18.8 → 0.18.9` — additive config + bug fixes, no breaking API.
- New unit test: jitter stays within ±15% across the backoff range.
- `cargo clippy --all-targets -D warnings`, lib + doctests, `cargo fmt --check`, and full-workspace build (SDK dependents: helpers, text-client, test-mediator) all green.

Part 1 of W16.