### PR TITLE
fix(release): bump affinidi-meeting-place to 0.4.3 to unblock publishing

### DIFF
--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Meeting Place Changelog
 
+## 13th June 2026 (0.4.3)
+
+- **Publish fix.** The W9 semver wave (#448) added a wildcard match arm here
+  for `affinidi-did-common`'s now-`#[non_exhaustive]` `Endpoint` enum, but the
+  crate version was not bumped, so the fix never reached crates.io. The
+  published `0.4.2` therefore fails to compile against `affinidi-did-common`
+  `0.3.6` (`error[E0004]: non-exhaustive patterns`), which broke the release
+  pipeline's publish-verify for downstream crates that pull Meeting Place
+  transitively. This bump publishes the already-fixed source. No API or
+  behaviour change beyond the W9 match arm.
+
 ## 1st June 2026 (0.4.2)
 
 - Release on `affinidi-messaging-didcomm` 0.15 (#327). Dependency-only;

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.4.2"
+version = "0.4.3"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Problem

The release pipeline is failing in the publish-verify step ([run](https://github.com/affinidi/affinidi-tdk-rs/actions/runs/27463999182/job/81183186510)):

```
[1/10] publish affinidi-messaging-mediator@0.15.46
   Verifying affinidi-messaging-mediator v0.15.46
error[E0004]: non-exhaustive patterns: `&_` not covered
 --> affinidi-meeting-place-0.4.2/src/lib.rs:158
```

## Root cause

The W9 semver wave (#448, 13 Jun) added a wildcard match arm in `meeting-place` for `affinidi-did-common`'s newly `#[non_exhaustive]` `Endpoint` enum — **but did not bump the crate version**. So:

- crates.io still has `affinidi-meeting-place 0.4.2` with the **old, exhaustive** match (published 1 Jun, pre-W9).
- `affinidi-did-common 0.3.6` (with `#[non_exhaustive] Endpoint`) **is** on crates.io.
- The old 0.4.2 source no longer compiles against 0.3.6 → `E0004`.

`cargo publish` verify ignores `[patch.crates-io]` and resolves from the registry, so the mediator's verify pulls the broken 0.4.2 transitively:

```
affinidi-messaging-mediator → vta-sdk 0.11.3 (external) → affinidi-tdk 0.7.4 → affinidi-meeting-place "0.4" → 0.4.2 (broken)
```

`0.4.2` is immutable on crates.io, so the already-fixed source must ship under a new version.

## Fix

Version-only bump `affinidi-meeting-place 0.4.2 → 0.4.3` (the W9 wildcard arm is already in the tree). Once 0.4.3 publishes, the `"0.4"` requirement in `affinidi-tdk 0.7.4` resolves to it and downstream verifies compile. The pipeline's retry-on-progress loop converges within the run.

No API or behaviour change beyond the W9 match arm.

## Notes

- This is fallout from the W11 prepare-only semver wave: source was sealed/migrated but a few crates' versions weren't bumped, and the first real publish (triggered by W15) surfaced it. `meeting-place` is the one broken node in the failing transitive chain (did-common/crypto/etc. were bumped + already published with their sealed source).
- The fragility of auto-publishing the prepared backlog is squarely **W17** (release automation) — flagging for that task.