### PR TITLE
feat: messaging-sdk WS token refresh + delete-handler supervision (W16 pt2)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.18.10] - 2026-06-13
+
+WS resilience (W16, part 2 of 2).
+
+### Added
+
+- **Proactive WebSocket token refresh.** The mediator force-closes a WebSocket
+  at access-token expiry (it only checks the JWT at upgrade, and has no in-band
+  refresh). The transport now records the token's expiry and, at ~80% of its
+  lifetime, refreshes the token via the refresh-token flow
+  (`AuthenticationCache::refresh`, which has the mediator re-verify the DID is
+  still allowed to connect) and reconnects with the fresh token — *before* the
+  forced close — rather than waiting to be kicked and reconnecting reactively.
+
+### Changed
+
+- **The background deletion handler is now supervised** via the shared
+  `affinidi-task-utils` `TaskSupervisor`: a panic or error is detected and the
+  task restarted with capped backoff (it previously died silently, leaving
+  background deletions unprocessed for the life of the process). Shutdown now
+  flows through a `CancellationToken`. Public method signatures are unchanged.
+
 ## [0.18.9] - 2026-06-13
 
 SDK request-path hardening (W16, part 1 of 2).

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.9"
+version = "0.18.10"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -25,6 +25,8 @@ affinidi-did-authentication = "0.3"
 affinidi-did-common = { version = "0.3", features = ["key-agreement"] }
 affinidi-encoding = "0.1"
 affinidi-secrets-resolver = "0.5"
+## Shared background-task supervision (delete-handler restart + health)
+affinidi-task-utils = "0.1"
 
 # External Crates
 ahash = { version = "0.8", features = ["serde"] }

--- a/crates/messaging/affinidi-messaging-sdk/src/delete_handler/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/delete_handler/mod.rs
@@ -14,10 +14,14 @@
 use crate::{
     ATM, SharedState, errors::ATMError, messages::DeleteMessageRequest, profiles::ATMProfile,
 };
+use affinidi_task_utils::{CancellationToken, TaskSupervisor};
 use std::sync::Arc;
 use tokio::{
     select,
-    sync::mpsc::{Receiver, Sender},
+    sync::{
+        Mutex,
+        mpsc::{Receiver, Sender},
+    },
     task::JoinHandle,
 };
 use tracing::{Instrument, Level, debug, span};
@@ -28,31 +32,53 @@ pub enum DeletionHandlerCommands {
 }
 
 impl ATM {
-    /// Starts the Deletion Handler
+    /// Starts the Deletion Handler under the shared [`TaskSupervisor`].
+    ///
+    /// A panic or error in the handler is detected and the task is restarted
+    /// with capped backoff (it is non-load-bearing — a wedged deletion loop
+    /// must never take the SDK down), rather than silently dying and leaving
+    /// background deletions unprocessed for the life of the process.
+    ///
+    /// The returned `JoinHandle` completes when the handler's shutdown token
+    /// is cancelled (see [`abort_deletion_handler`](Self::abort_deletion_handler)).
     pub async fn start_deletion_handler(
         &self,
-        mut from_sdk: Receiver<DeletionHandlerCommands>,
+        from_sdk: Receiver<DeletionHandlerCommands>,
         to_sdk: Sender<DeletionHandlerCommands>,
     ) -> Result<JoinHandle<()>, ATMError> {
         let shared_state = self.inner.clone();
+        let shutdown = self.inner.deletion_shutdown.clone();
 
-        let handle = tokio::spawn(async move {
-            let _ = ATM::deletion_handler(shared_state, &mut from_sdk, to_sdk).await;
+        // The SDK→handler receiver isn't clonable, so share it behind a Mutex
+        // and re-lock it on each (re)start.
+        let from_sdk = Arc::new(Mutex::new(from_sdk));
+
+        TaskSupervisor::new(shutdown.clone()).spawn("deletion_handler", false, move || {
+            let shared_state = shared_state.clone();
+            let from_sdk = from_sdk.clone();
+            let to_sdk = to_sdk.clone();
+            let shutdown = shutdown.clone();
+            async move {
+                let mut from_sdk = from_sdk.lock().await;
+                ATM::deletion_handler(shared_state, &mut from_sdk, to_sdk, shutdown).await
+            }
         });
 
-        debug!("Deletion handler started");
+        debug!("Deletion handler started (supervised)");
 
-        Ok(handle)
+        // Preserve the historical `JoinHandle<()>` contract: the handle
+        // completes once the handler is shut down.
+        let shutdown = self.inner.deletion_shutdown.clone();
+        Ok(tokio::spawn(async move {
+            shutdown.cancelled().await;
+        }))
     }
 
-    /// Close the Deletion task gracefully
+    /// Close the Deletion task gracefully by cancelling its shutdown token.
+    /// The supervisor stops the handler (no restart) and the handler sends a
+    /// final `Exit` back to the SDK.
     pub async fn abort_deletion_handler(&self) -> Result<(), ATMError> {
-        let _ = self
-            .inner
-            .deletion_handler_send_stream
-            .send(DeletionHandlerCommands::Exit)
-            .await;
-
+        self.inner.deletion_shutdown.cancel();
         Ok(())
     }
 
@@ -60,6 +86,7 @@ impl ATM {
         shared_state: Arc<SharedState>,
         from_sdk: &mut Receiver<DeletionHandlerCommands>,
         to_sdk: Sender<DeletionHandlerCommands>,
+        shutdown: CancellationToken,
     ) -> Result<(), ATMError> {
         let _span = span!(Level::INFO, "deletion_handler");
         async move {
@@ -68,15 +95,18 @@ impl ATM {
             };
             loop {
                 select! {
+                    _ = shutdown.cancelled() => {
+                        break;
+                    }
                     value = from_sdk.recv() => {
                         match value {
                             Some(DeletionHandlerCommands::DeleteMessage(profile, message_id)) => {
                                 let _ = atm.delete_messages_direct(&profile, &DeleteMessageRequest { message_ids: vec![message_id.clone()] }).await;
                             }
-                            Some(DeletionHandlerCommands::Exit) => {
-                                break;
-                            }
-                            None => {
+                            Some(DeletionHandlerCommands::Exit) | None => {
+                                // Intentional stop: cancel so the supervisor
+                                // records the task stopped rather than restarting it.
+                                shutdown.cancel();
                                 break;
                             }
                         }
@@ -90,5 +120,71 @@ impl ATM {
         }
         .instrument(_span)
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use affinidi_task_utils::{CancellationToken, ComponentState, TaskSupervisor};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+    use tokio::sync::{Mutex, mpsc};
+
+    /// A panic in the supervised deletion handler must be caught and the task
+    /// restarted (it would otherwise die silently, leaving background
+    /// deletions unprocessed for the life of the process), with the fault
+    /// recorded. Mirrors `start_deletion_handler`'s wiring — the SDK→handler
+    /// receiver shared behind a `Mutex` and re-locked per (re)start — with an
+    /// injected panic, and confirms cancellation stops it without restart.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn supervised_deletion_handler_restarts_after_panic() {
+        let (_tx, rx) = mpsc::channel::<u8>(4);
+        let rx = Arc::new(Mutex::new(rx));
+        let supervisor = TaskSupervisor::new(CancellationToken::new());
+        let registry = supervisor.registry();
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        {
+            let rx = rx.clone();
+            let attempts = attempts.clone();
+            supervisor.spawn("deletion_handler", false, move || {
+                let rx = rx.clone();
+                let attempts = attempts.clone();
+                async move {
+                    // Re-lock the shared receiver across restarts.
+                    let _guard = rx.lock().await;
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        panic!("injected deletion-handler panic");
+                    }
+                    std::future::pending::<()>().await; // stay Running until cancel
+                    Ok::<(), crate::errors::ATMError>(())
+                }
+            });
+        }
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let restarted = attempts.load(Ordering::SeqCst) >= 2;
+            let running = registry
+                .get("deletion_handler")
+                .map(|h| h.state == ComponentState::Running && h.restarts >= 1)
+                .unwrap_or(false);
+            if restarted && running {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "supervisor did not restart the deletion handler after a panic"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            registry
+                .get("deletion_handler")
+                .and_then(|h| h.last_error.clone())
+                .is_some_and(|e| e.contains("panicked")),
+            "the panic must be recorded as the last error"
+        );
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -184,6 +184,7 @@ use crate::protocols::{
     message_pickup::MessagePickupOps, oob_discovery::OOBDiscoveryOps, routing::RoutingOps,
     trust_ping::TrustPingOps,
 };
+use affinidi_task_utils::CancellationToken;
 use affinidi_tdk_common::TDKSharedState;
 use config::ATMConfig;
 use delete_handler::DeletionHandlerCommands;
@@ -220,6 +221,9 @@ pub(crate) struct SharedState {
     pub(crate) deletion_handler_send_stream: Sender<delete_handler::DeletionHandlerCommands>, // Sends MPSC messages to the Deletion Handler
     pub(crate) deletion_handler_recv_stream:
         Mutex<Receiver<delete_handler::DeletionHandlerCommands>>, // Receives MPSC messages from the Deletion Handler
+    /// Shutdown token for the supervised deletion-handler task. Cancelling it
+    /// stops the handler (and tells its supervisor not to restart it).
+    pub(crate) deletion_shutdown: CancellationToken,
 }
 
 /// Affinidi Trusted Messaging SDK
@@ -249,6 +253,7 @@ impl ATM {
             profiles: Arc::new(RwLock::new(Profiles::default())),
             deletion_handler_send_stream: sdk_deletion_tx,
             deletion_handler_recv_stream: Mutex::new(sdk_deletion_rx),
+            deletion_shutdown: CancellationToken::new(),
         };
 
         let atm = ATM {

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -49,6 +49,12 @@ pub(crate) struct WebSocketTransport {
     /// Used to help with detecting when a websocket connection is lost
     awaiting_pong: bool,
 
+    /// Unix-seconds expiry of the access token the current socket was opened
+    /// with. The mediator force-closes the socket at this time, so we use it
+    /// to proactively refresh the token and reconnect *before* expiry rather
+    /// than waiting to be kicked. `None` until the first successful connect.
+    access_expires_at: Option<u64>,
+
     /// Cache of inbound messages awaiting to be sent to the SDK
     /// If a MPSC delivery channel is enabled, then this cache isn't used
     inbound_cache: MessageCache,
@@ -116,6 +122,7 @@ impl WebSocketTransport {
                 connect_delay_timer: None,
                 connect_delay: 0,
                 awaiting_pong: false,
+                access_expires_at: None,
                 inbound_cache: MessageCache {
                     fetch_cache_limit_count: shared.config.fetch_cache_limit_count,
                     fetch_cache_limit_bytes: shared.config.fetch_cache_limit_bytes,
@@ -148,6 +155,7 @@ impl WebSocketTransport {
                 connect_delay_timer: None,
                 connect_delay: 0,
                 awaiting_pong: false,
+                access_expires_at: None,
                 inbound_cache: MessageCache {
                     fetch_cache_limit_count: shared.config.fetch_cache_limit_count,
                     fetch_cache_limit_bytes: shared.config.fetch_cache_limit_bytes,
@@ -182,6 +190,11 @@ impl WebSocketTransport {
 
             let mut notify_connection: Option<oneshot::Sender<bool>> = None;
 
+            // Armed on each successful connect; drives a proactive token
+            // refresh + reconnect before the mediator closes the socket at
+            // access-token expiry.
+            let mut refresh_deadline: Option<tokio::time::Instant> = None;
+
             loop {
                 if self.web_socket.is_none() && self.connect_delay_timer.is_none() {
                     debug!("WebSocket not connected, starting connection attempt in {} seconds", self.connect_delay);
@@ -203,10 +216,42 @@ impl WebSocketTransport {
                     Some(_) = WebSocketTransport::conditional_reconnect_delay(&mut self.connect_delay_timer), if self.web_socket.is_none() => {
                         debug!("Attempt to reconnect");
                         self.web_socket = self._handle_connection(&atm).await;
-                        if self.web_socket.is_some() && notify_connection.is_some() {
-                            let _ = notify_connection.unwrap().send(true);
-                            notify_connection = None;
+                        if self.web_socket.is_some() {
+                            // Arm the proactive-refresh timer for this socket.
+                            refresh_deadline = self.refresh_deadline();
+                            if notify_connection.is_some() {
+                                let _ = notify_connection.unwrap().send(true);
+                                notify_connection = None;
+                            }
                         }
+                    },
+                    Some(_) = Self::conditional_refresh(refresh_deadline), if self.web_socket.is_some() => {
+                        debug!("Access token nearing expiry; refreshing and reconnecting");
+                        refresh_deadline = None; // re-armed on the next connect
+                        if let Ok((profile_did, mediator_did)) = self.profile.dids() {
+                            // Mint a fresh access token via the refresh-token
+                            // flow (mediator re-checks the DID is still allowed
+                            // to connect) so the reconnect below carries a token
+                            // good for another full lifetime.
+                            if let Err(e) = self
+                                .shared
+                                .tdk_common
+                                .authentication()
+                                .refresh(profile_did.to_string(), mediator_did.to_string())
+                                .await
+                            {
+                                warn!("Proactive token refresh failed ({e}); reconnecting to re-authenticate");
+                            }
+                        }
+                        // Reconnect immediately (no backoff) so the new socket
+                        // uses the fresh token before the old one expires.
+                        if let Some(web_socket) = self.web_socket.as_mut() {
+                            let _ = web_socket.close(None).await;
+                        }
+                        self.web_socket = None;
+                        self.fail_pending_requests();
+                        self.connect_delay = 0;
+                        self.connect_delay_timer = None;
                     },
                     _ = watchdog.tick(), if self.web_socket.is_some() => {
                         if self.awaiting_pong {
@@ -317,6 +362,32 @@ impl WebSocketTransport {
     async fn conditional_reconnect_delay(delay: &mut Option<Interval>) -> Option<()> {
         if let Some(delay) = delay.as_mut() {
             delay.tick().await;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    /// Proactive token-refresh deadline for the freshly-connected socket:
+    /// fire at ~80% of the access token's remaining lifetime, leaving the
+    /// last ~20% as budget to refresh the token and reconnect *before* the
+    /// mediator force-closes the socket at expiry. `None` if expiry is unknown.
+    fn refresh_deadline(&self) -> Option<tokio::time::Instant> {
+        let expires_at = self.access_expires_at?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let ttl = expires_at.saturating_sub(now);
+        Some(tokio::time::Instant::now() + Duration::from_secs(refresh_after_secs(ttl)))
+    }
+
+    // Sleeps until the proactive-refresh deadline, if one is armed. Mirrors the
+    // other `conditional_*` helpers so the `select!` branch simply never fires
+    // when no deadline is set.
+    async fn conditional_refresh(deadline: Option<tokio::time::Instant>) -> Option<()> {
+        if let Some(deadline) = deadline {
+            tokio::time::sleep_until(deadline).await;
             Some(())
         } else {
             None
@@ -551,6 +622,9 @@ impl WebSocketTransport {
             .authentication()
             .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
             .await?;
+        // Remember when this token expires so we can refresh+reconnect before
+        // the mediator force-closes the socket at expiry.
+        self.access_expires_at = Some(tokens.access_expires_at);
 
         debug!("Creating websocket connection");
         // Create a custom websocket request, turn this into a client_request
@@ -633,9 +707,37 @@ fn jittered_backoff(base_secs: u8) -> Duration {
     Duration::from_secs_f64(base_secs as f64 * factor)
 }
 
+/// How long after connecting to proactively refresh the access token and
+/// reconnect: 80% of the token's remaining lifetime, leaving the final ~20%
+/// as budget to refresh + reconnect before the mediator force-closes the
+/// socket at expiry.
+fn refresh_after_secs(ttl_secs: u64) -> u64 {
+    // `*4` first for accuracy on short TTLs; token lifetimes can't overflow u64.
+    (ttl_secs * 4) / 5
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn refresh_fires_before_expiry_with_budget_to_spare() {
+        // Always strictly before expiry (so we beat the mediator's forced
+        // close) and never zero for a non-trivial TTL (so we don't hot-loop).
+        for ttl in [10u64, 60, 300, 900, 86_400] {
+            let after = refresh_after_secs(ttl);
+            assert!(
+                after < ttl,
+                "ttl {ttl}: refresh at {after} not before expiry"
+            );
+            assert!(after > 0, "ttl {ttl}: refresh delay must be positive");
+            // ~80% of the lifetime.
+            assert_eq!(after, (ttl * 4) / 5);
+        }
+        // Degenerate inputs don't panic.
+        assert_eq!(refresh_after_secs(0), 0);
+        assert_eq!(refresh_after_secs(1), 0);
+    }
 
     #[test]
     fn jittered_backoff_stays_within_15_percent() {

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,20 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.4 — 2026-06-13
+
+### Added
+
+- `AuthenticationCache::refresh(profile_did, service_endpoint_did)` — forces a
+  token refresh regardless of whether the cached access token is still within
+  its validity window (driving the refresh-token flow, with the mediator
+  re-checking the DID is still allowed to connect), falling back to a full
+  handshake only if the refresh token has itself expired. Enables *proactive*
+  refresh ahead of expiry — e.g. a long-lived WebSocket reconnecting with a
+  fresh token before the mediator force-closes the socket at token expiry
+  (affinidi-messaging-sdk W16). Existing `authenticate()` behaviour is
+  unchanged.
+
 ## 0.6.3 — 2026-06-07
 
 ### Fixed

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/tdk/affinidi-tdk-common/src/tasks/authentication.rs
+++ b/crates/tdk/affinidi-tdk-common/src/tasks/authentication.rs
@@ -100,6 +100,11 @@ pub(crate) enum AuthenticationCommand {
         service_endpoint_did: Arc<String>,
         retry_limit: u8,
         timeout: Duration,
+        /// Force a token refresh even when the cached access token is still
+        /// within its validity window (used for proactive refresh ahead of
+        /// expiry). Falls back to a full handshake only if the refresh token
+        /// has itself expired.
+        force_refresh: bool,
         tx: oneshot::Sender<Result<AuthorizationTokens, DIDAuthError>>,
     },
 
@@ -270,6 +275,7 @@ impl AuthenticationCache {
             service_endpoint_did: Arc::new(service_endpoint_did),
             retry_limit,
             timeout,
+            force_refresh: false,
             tx,
         }) {
             Ok(_) => {}
@@ -321,6 +327,68 @@ impl AuthenticationCache {
             None,
         )
         .await
+    }
+
+    /// Force a token refresh for the given pair, regardless of whether the
+    /// cached access token is still within its validity window.
+    ///
+    /// This drives the refresh-token flow (a fresh access token is minted from
+    /// the still-valid refresh token, with the mediator re-checking that the
+    /// DID is still allowed to connect); it falls back to a full handshake only
+    /// if the refresh token has itself expired or there is no cached record.
+    ///
+    /// Used for *proactive* refresh ahead of expiry (e.g. a long-lived
+    /// WebSocket that must reconnect with a fresh token before the server
+    /// closes the socket at token expiry). After this returns, a subsequent
+    /// [`authenticate`](Self::authenticate) returns the freshly cached token.
+    pub async fn refresh(
+        &self,
+        profile_did: String,
+        service_endpoint_did: String,
+    ) -> Result<AuthorizationTokens, DIDAuthError> {
+        let timeout = DEFAULT_AUTH_TIMEOUT;
+        let (tx, rx) = oneshot::channel();
+        match self.tx.try_send(AuthenticationCommand::Authenticate {
+            profile_did: Arc::new(profile_did),
+            service_endpoint_did: Arc::new(service_endpoint_did),
+            retry_limit: DEFAULT_AUTH_RETRIES,
+            timeout,
+            force_refresh: true,
+            tx,
+        }) {
+            Ok(_) => {}
+            Err(TrySendError::Closed(_)) => {
+                warn!("Authentication task channel closed unexpectedly");
+                return Err(DIDAuthError::AuthenticationAbort(
+                    "Authentication Task channel closed unexpectedly".to_string(),
+                ));
+            }
+            Err(TrySendError::Full(_)) => {
+                warn!(
+                    "Authentication task channel full (capacity {})",
+                    COMMAND_CHANNEL_CAPACITY
+                );
+                return Err(DIDAuthError::AuthenticationAbort(
+                    "Authentication Task channel full".to_string(),
+                ));
+            }
+        }
+
+        let sleep = tokio::time::sleep(timeout);
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            value = rx => match value {
+                Ok(tokens) => tokens,
+                Err(_) => Err(DIDAuthError::AuthenticationAbort(
+                    "Authentication Task channel closed unexpectedly".to_string(),
+                )),
+            },
+            _ = &mut sleep => {
+                warn!("Timeout reached during refresh()");
+                Err(DIDAuthError::AuthenticationAbort("Timeout reached".to_string()))
+            }
+        }
     }
 
     /// Send an Invalidate command for the given pair, dropping any cached
@@ -384,12 +452,14 @@ impl AuthenticationCacheInner {
                 tx,
                 retry_limit,
                 timeout,
+                force_refresh,
             }) => {
                 self.handle_authenticate(
                     profile_did,
                     service_endpoint_did,
                     retry_limit,
                     timeout,
+                    force_refresh,
                     tx,
                 )
                 .await;
@@ -422,17 +492,30 @@ impl AuthenticationCacheInner {
         service_endpoint_did: Arc<String>,
         retry_limit: u8,
         timeout: Duration,
+        force_refresh: bool,
         tx: oneshot::Sender<Result<AuthorizationTokens, DIDAuthError>>,
     ) {
         let key = hash(&profile_did, &service_endpoint_did);
         debug!(
             profile = %profile_did,
             service = %service_endpoint_did,
+            force_refresh,
             "authenticating"
         );
 
         let mut auth = if let Some(record) = self.cache.get(&key).await {
-            match refresh_check(&record.tokens) {
+            // `force_refresh` skips the "still valid → return cached" path and
+            // forces a refresh, but still degrades to a full handshake if the
+            // refresh token has itself expired.
+            let check = if force_refresh {
+                match refresh_check(&record.tokens) {
+                    RefreshCheck::Expired => RefreshCheck::Expired,
+                    _ => RefreshCheck::Refresh,
+                }
+            } else {
+                refresh_check(&record.tokens)
+            };
+            match check {
                 RefreshCheck::Ok => {
                     debug!("Cached tokens valid; returning");
                     let _ = tx.send(Ok(record.tokens));


### PR DESCRIPTION
## What

**Part 2 of 2 of W16** (resilience), building on pt1 (#455). Two independent WS-path changes.

### (a) Proactive WebSocket token refresh

The mediator validates the JWT **only at the WS upgrade** and **force-closes the socket at `session.expires_at`** (default 900s) — there is no in-band refresh. Today the SDK reconnects *reactively* after being kicked, dropping in-flight requests in the gap.

Now the transport records the access-token expiry and, at **~80% of its lifetime**, refreshes the token via the refresh-token flow and reconnects with the fresh token **before** the forced close.

- New `tdk-common` `AuthenticationCache::refresh(profile, mediator)` forces the refresh-token flow regardless of the internal 5s `refresh_check` window (full handshake only if the refresh token itself expired). Existing `authenticate()` behaviour is unchanged.
- **Per your instruction — already satisfied server-side:** the mediator's `/authenticate/refresh` handler *already* re-checks `Capability::NotBlocked` before minting a new token (refresh.rs:251-266), symmetric with initial auth. Audit-confirmed, **no mediator change needed.**

### (b) Delete-handler supervision

The background deletion handler is now supervised by the shared `affinidi-task-utils` `TaskSupervisor` (the W15 crate): a panic or error is **detected and restarted** with capped backoff (it previously died silently, leaving background deletions unprocessed for the process lifetime). Shutdown flows through a `CancellationToken`; the non-clonable SDK→handler receiver is shared behind a `Mutex` and re-locked per restart. **Public method signatures are unchanged** (non-breaking — keeps the `JoinHandle<()>` contract, which now completes on shutdown).

## Versions

- `tdk-common 0.6.3 → 0.6.4` (additive `refresh()`)
- `sdk 0.18.9 → 0.18.10` (additive config/API + internal; no breaking change)

## Tests

- `refresh_after_secs`: proactive refresh always fires **before** expiry with budget to spare, never zero for a real TTL (deterministic).
- delete-handler panic → supervisor restart + recorded fault (mirrors the W15 relock+panic pattern).
- jitter band (pt1), full `tdk-common` suite. `clippy -D warnings`, fmt, and full-workspace dependents build all green.

**On the e2e "WS survives token expiry" acceptance:** session *continuity* past expiry is already provided by the pre-existing **reactive** reconnect, so an e2e test would pass with or without this change — it can't isolate the new *proactive* behaviour without flaky sub-second timing assertions. The proactive timing is therefore validated by the deterministic `refresh_after_secs` unit test instead. (Consistent with the T26 precedent on costly/non-isolating integration tests.)

Closes W16.