### PR TITLE
ci: add release guards — toolchain-sync + version-bump checks (W17)

### DIFF
--- a/.github/workflows/release-guards.yaml
+++ b/.github/workflows/release-guards.yaml
@@ -1,0 +1,40 @@
+name: release-guards
+# Cheap, build-free PR guards that protect the release pipeline:
+#
+#   1. toolchain-sync  — every `toolchain:` pin in .github/workflows/* and the
+#      Cargo.toml MSRV must match rust-toolchain.toml's channel. Kills the
+#      multi-file edit trap where a toolchain bump misses a workflow.
+#
+#   2. version-bump    — any publishable crate whose source changed in this PR
+#      must also bump its Cargo.toml version. Stops the 2026-06-13 trap where an
+#      edited-but-unbumped crate left stale source on crates.io that broke the
+#      registry-resolved publish verify build downstream.
+#
+# Deliberately standalone and outside the shared affinidi/pipeline-rust workflow
+# (those are org-owned). Pure bash + git + jq + `cargo metadata`; no Rust build.
+# It carries NO hardcoded `toolchain:` pin of its own — the toolchain is taken
+# from rust-toolchain.toml via rustup auto-install, so this workflow adds nothing
+# new for the toolchain-sync check to police.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  guards:
+    name: release guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the version-bump guard can diff against, and read
+          # manifests from, the PR's base commit.
+          fetch-depth: 0
+
+      - name: Toolchain version sync
+        run: bash scripts/check-toolchain-sync.sh
+
+      - name: Version-bump guard for changed publishable crates
+        run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"

--- a/docs/adr/0004-release-automation.md
+++ b/docs/adr/0004-release-automation.md
@@ -1,0 +1,112 @@
+# ADR 0004 — Release automation: keep pipeline-rust, add local guards
+
+- **Status:** Accepted (interim — see "Open: release-plz adoption")
+- **Date:** 2026-06-13
+- **Relates to:** Task W17; the 2026-06-13 publish-pipeline break (PR #456); the
+  semver wave (W7–W11, [ADR 0003](0003-public-api-semver-policy.md)); the
+  `didwebvh-rs` / `vta-sdk` `[patch.crates-io]` coupling.
+
+## Context
+
+Releases are driven by the org-owned shared workflow
+`affinidi/pipeline-rust/.github/workflows/release.yaml@main`, triggered on push
+to `main`. It compares each publishable crate's local version against crates.io
+and publishes those that moved. The workspace currently sets
+`workspace_publish: false` so the pipeline uses the legacy per-crate path that
+**skips already-published crates** — `cargo publish --workspace` instead errors
+on the first crate already at its current version, which blocks targeted patch
+releases (the common case here: a security fix touches four of ~39 crates).
+
+Two recurring pain points motivated W17:
+
+1. **Manual version bumping across ~39 crates.** Every release hand-edits
+   versions and CHANGELOGs across many manifests in dependency order. Tedious
+   and error-prone.
+
+2. **The 2026-06-13 break (PR #456).** W9 (#448) edited
+   `affinidi-meeting-place`'s source to add a wildcard arm for the newly
+   `#[non_exhaustive]` `Endpoint`, but left its version at 0.4.2. crates.io kept
+   the *pre-seal* 0.4.2 source. When `affinidi-did-common 0.3.6` later published,
+   the pipeline's `cargo publish` verify build — which resolves dependencies
+   from the **registry**, ignoring our `[patch.crates-io]` redirects — compiled
+   the stale 0.4.2 source against the new did-common and hit `error[E0004]:
+   non-exhaustive patterns`, failing the whole release. The local workspace
+   build (which *does* apply `[patch.crates-io]`) was green throughout, so
+   nothing caught it before merge.
+
+   **Root cause:** a published crate's source changed without a version bump, so
+   the registry kept incompatible source at a version we still treated as
+   current. The `[patch]` workspace build masks this class of bug entirely.
+
+A third, smaller trap: the pinned Rust toolchain (`1.95.0`) is duplicated across
+`rust-toolchain.toml`, `Cargo.toml`'s MSRV, and every `toolchain:` pin in the
+workflow files (11 references, 6 files). Bumping it means editing all of them;
+miss one and CI builds on a different compiler than local dev.
+
+## Decision
+
+### 1. Keep the pipeline-rust release workflow; do **not** swap to release-plz now.
+
+Adopting `release-plz` (or `cargo-workspaces`) to automate version bumps and the
+release PR is attractive, but the release workflow is **org-owned**
+(`affinidi/pipeline-rust`). Swapping it is an org-level decision that must be
+coordinated with whoever owns that pipeline — it cannot be made unilaterally in
+this repo. We therefore keep `workspace_publish: false` + the skip-published
+per-crate path for now, and treat release-plz adoption as a separate, sequenced
+effort (below).
+
+### 2. Add two build-free local PR guards (`.github/workflows/release-guards.yaml`).
+
+These run on every PR, outside the shared pipeline, and protect the release path
+without depending on the org pipeline:
+
+- **`scripts/check-version-bumps.sh`** — for every *publishable* crate whose
+  **source** changed in the PR (vs. the base), require its `Cargo.toml` version
+  to differ from the base. This directly catches the 2026-06-13 trap: an
+  edited-but-unbumped published crate now fails the PR. "Source" excludes
+  `tests/`, `benches/`, `examples/`, `*.md`, and `CHANGELOG*` (test-/doc-only
+  changes get no bump, per repo convention); `publish = false` crates are
+  skipped (they never reach crates.io).
+
+  Forcing a bump alongside any source edit means `main` never accumulates an
+  unpublished source delta against a stale registry version — the pipeline then
+  publishes the new source at a fresh version, and crates.io never goes
+  incompatible.
+
+- **`scripts/check-toolchain-sync.sh`** — assert every workflow `toolchain:` pin
+  equals `rust-toolchain.toml`'s channel, and the workspace MSRV is `<=` it. A
+  toolchain bump that misses a file now fails CI with the exact file:line.
+
+Both scripts are pure bash + git + `jq` + `cargo metadata` (no Rust build),
+portable to macOS bash 3.2, and runnable locally. The guards workflow carries no
+`toolchain:` pin of its own (toolchain comes from `rust-toolchain.toml`), so it
+adds nothing for the sync check to police.
+
+## Consequences
+
+- The PR that breaks the release the way #456 did is now caught **at PR time**,
+  not after merge when the pipeline fails. The fix is mechanical: bump the
+  crate's version (and CHANGELOG).
+- Toolchain bumps become a one-line edit to `rust-toolchain.toml` plus whatever
+  the sync check flags — no more silent per-file drift.
+- These guards are complementary to, not a replacement for, the org pipeline.
+  They reduce the pipeline's failure surface but do not change how it publishes.
+
+## Open: release-plz adoption (deferred, org-level)
+
+Parts (a) and (b) of W17 — automated version bumps / release PRs via release-plz,
+and a single `unreleased.md` that tooling splits into per-crate CHANGELOGs — are
+**deferred pending an org-level decision** on the pipeline-rust integration. When
+revisited, the key constraints to honour:
+
+- **Skip-already-published behaviour is mandatory** for targeted patch releases
+  (the `workspace_publish: false` rationale). release-plz's per-crate publish
+  satisfies this; `cargo publish --workspace` does not.
+- **The `[patch.crates-io]` external coupling** ([ADR 0003](0003-public-api-semver-policy.md))
+  constrains *which* bumps are legal: foundational crates pinned by external
+  `didwebvh-rs` / `vta-sdk` must stay patch-level within their current minor
+  until those external consumers are re-released. Any automation must respect
+  that (e.g. release-plz `[[package]]` overrides), or it will propose
+  minor/major bumps that break the redirect.
+- **A dry run on a fork first** (per the W17 risk register) before touching the
+  shared release path.

--- a/scripts/check-toolchain-sync.sh
+++ b/scripts/check-toolchain-sync.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Verify the Rust toolchain version is consistent across the repo.
+#
+# `rust-toolchain.toml`'s `channel` is the single source of truth. Bumping it
+# used to require hand-editing the same version into Cargo.toml's MSRV and every
+# `toolchain:` pin scattered across .github/workflows/* (11 references across 6
+# files at the time of writing). Miss one and CI silently builds on a different
+# compiler than local dev. This check fails the build with a precise list of the
+# stragglers so the bump stays a one-line edit + a green check.
+#
+# Rules:
+#   - every `toolchain: "X"` in .github/workflows/* MUST equal the channel
+#   - Cargo.toml's `rust-version` (workspace MSRV) MUST be <= the channel
+#
+# Portable to macOS bash 3.2 / BSD userland (no mapfile, no `sort -V`, no
+# associative arrays).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+
+extract_quoted() { # $1 = line containing  key: "value"  -> prints value
+  printf '%s\n' "$1" | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# returns 0 if $1 <= $2 (dotted numeric versions), via portable component sort
+ver_le() {
+  [ "$1" = "$2" ] && return 0
+  local lowest
+  lowest=$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)
+  [ "$lowest" = "$1" ]
+}
+
+# --- source of truth -------------------------------------------------------
+channel_line=$(grep -E '^[[:space:]]*channel[[:space:]]*=' rust-toolchain.toml | head -1 || true)
+if [ -z "$channel_line" ]; then
+  echo "${RED}error:${NC} could not find 'channel = ...' in rust-toolchain.toml" >&2
+  exit 2
+fi
+channel=$(extract_quoted "$channel_line")
+echo "Source of truth: rust-toolchain.toml channel = ${GREEN}${channel}${NC}"
+echo ""
+
+fail=0
+
+# --- workflow toolchain pins ----------------------------------------------
+# Matches both the shared-workflow `with: toolchain: "X"` form and the
+# dtolnay/rust-toolchain `with: toolchain: "X"` form. The `uses:
+# dtolnay/rust-toolchain@master` lines do NOT start with `toolchain:` so they
+# are not matched.
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  file=$(printf '%s\n' "$hit" | cut -d: -f1)
+  lineno=$(printf '%s\n' "$hit" | cut -d: -f2)
+  content=$(printf '%s\n' "$hit" | cut -d: -f3-)
+  ver=$(extract_quoted "$content")
+  if [ "$ver" = "$channel" ]; then
+    echo "  ${GREEN}ok${NC}   $file:$lineno -> $ver"
+  else
+    echo "  ${RED}DIFF${NC} $file:$lineno -> ${RED}$ver${NC} (expected $channel)"
+    fail=1
+  fi
+done < <(grep -rnE '^[[:space:]]*toolchain:[[:space:]]*"' .github/workflows/ || true)
+
+# --- workspace MSRV --------------------------------------------------------
+rustver_line=$(grep -nE '^[[:space:]]*rust-version[[:space:]]*=' Cargo.toml | head -1 || true)
+if [ -n "$rustver_line" ]; then
+  rv_no=$(printf '%s\n' "$rustver_line" | cut -d: -f1)
+  rv=$(extract_quoted "$rustver_line")
+  if [ "$rv" = "$channel" ]; then
+    echo "  ${GREEN}ok${NC}   Cargo.toml:$rv_no rust-version -> $rv"
+  elif ver_le "$rv" "$channel"; then
+    echo "  ${YELLOW}note${NC} Cargo.toml:$rv_no rust-version $rv < channel $channel (MSRV below toolchain, allowed)"
+  else
+    echo "  ${RED}DIFF${NC} Cargo.toml:$rv_no rust-version ${RED}$rv${NC} > channel $channel (MSRV above toolchain)"
+    fail=1
+  fi
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "${GREEN}Toolchain in sync.${NC}"
+else
+  echo "${RED}Toolchain OUT OF SYNC.${NC} Update the flagged values to match rust-toolchain.toml's channel ($channel)."
+  exit 1
+fi

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Guard against the "edited a published crate's source but forgot to bump its
+# version" trap that broke the release pipeline on 2026-06-13.
+#
+# What happened: W9 (#448) edited affinidi-meeting-place's source to add a
+# wildcard match arm for the newly `#[non_exhaustive]` `Endpoint`, but left its
+# version at 0.4.2. crates.io therefore kept the *pre-seal* 0.4.2 source. Later,
+# when did-common 0.3.6 published, `cargo publish`'s registry-resolved verify
+# build (which ignores `[patch.crates-io]`) compiled the stale 0.4.2 source
+# against the new did-common and hit `error[E0004]: non-exhaustive patterns`,
+# blocking the whole release. The local `[patch.crates-io]` workspace build was
+# green the whole time, so nothing caught it pre-merge.
+#
+# This guard runs on PRs: for every PUBLISHABLE workspace crate whose *source*
+# changed between the base ref and HEAD, it requires the crate's Cargo.toml
+# `version` to differ from the base ref's version. Forcing a bump alongside any
+# source edit means main never accumulates an unpublished source delta against a
+# stale crates.io version — the release pipeline then publishes the new source
+# at a fresh version and the registry never goes incompatible.
+#
+# "Source" = anything under the crate dir EXCEPT tests/, benches/, examples/,
+# *.md and CHANGELOG* (test-/doc-only changes get no bump, per repo convention).
+# `publish = false` crates are skipped — they never reach crates.io, so a stale
+# registry source is impossible for them.
+#
+# Usage: scripts/check-version-bumps.sh [BASE_REF]   (default: origin/main)
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "${RED}error:${NC} base ref '$BASE' not found. Pass a reachable ref, e.g. origin/main." >&2
+  exit 2
+fi
+
+# Files changed between the merge-base of BASE and HEAD (three-dot = PR diff).
+changed=$(git diff --name-only "$BASE"...HEAD)
+if [ -z "$changed" ]; then
+  echo "${GREEN}No changes vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+# Publishable crates as  name<TAB>relative-crate-dir  lines, longest dir first
+# so the most specific crate wins for nested manifests (e.g. affinidi-tdk vs
+# affinidi-tdk/common).
+crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | select(.publish == null or .publish == ["crates.io"])
+      | "\(.name)\t\(.manifest_path)"' \
+  | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||" \
+  | awk -F'\t' '{ print length($2)"\t"$0 }' \
+  | sort -rn \
+  | cut -f2-)
+
+# classify a path (relative to a crate dir) as source-or-not
+is_source() {
+  case "$1" in
+    tests/*|*/tests/*) return 1 ;;
+    benches/*|*/benches/*) return 1 ;;
+    examples/*|*/examples/*) return 1 ;;
+    *.md) return 1 ;;
+    CHANGELOG*|*/CHANGELOG*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# attribute a changed file to its most-specific publishable crate dir
+crate_of() { # $1 = changed path -> prints "name<TAB>dir" or nothing
+  local path="$1" name dir
+  while IFS=$'\t' read -r name dir; do
+    [ -z "$dir" ] && continue
+    case "$path" in
+      "$dir"/*) printf '%s\t%s\n' "$name" "$dir"; return 0 ;;
+    esac
+  done <<EOF
+$crates
+EOF
+}
+
+# collect publishable crates with a real source change (newline-separated "name\tdir")
+touched=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  hit=$(crate_of "$f") || true
+  [ -z "$hit" ] && continue
+  name=$(printf '%s' "$hit" | cut -f1)
+  dir=$(printf '%s' "$hit" | cut -f2)
+  rel=${f#"$dir"/}
+  is_source "$rel" || continue
+  case "
+$touched" in
+    *"
+$name	$dir"*) : ;;            # already recorded
+    *) touched="$touched
+$name	$dir" ;;
+  esac
+done <<EOF
+$changed
+EOF
+
+touched=$(printf '%s\n' "$touched" | sed '/^$/d')
+
+if [ -z "$touched" ]; then
+  echo "${GREEN}No publishable-crate source changed vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+echo "${CYAN}=== Version-bump guard (base: $BASE) ===${NC}"
+echo ""
+
+fail=0
+while IFS=$'\t' read -r name dir; do
+  [ -z "$name" ] && continue
+  manifest="$dir/Cargo.toml"
+  cur=$(grep -E '^[[:space:]]*version[[:space:]]*=' "$manifest" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+  base=$(git show "$BASE:$manifest" 2>/dev/null | grep -E '^[[:space:]]*version[[:space:]]*=' | head -1 | sed -E 's/.*"([^"]+)".*/\1/' || true)
+  if [ -z "$base" ]; then
+    echo "  ${GREEN}ok${NC}   $name: new crate (no version at $BASE) -> $cur"
+  elif [ "$cur" != "$base" ]; then
+    echo "  ${GREEN}ok${NC}   $name: $base -> $cur"
+  else
+    echo "  ${RED}MISS${NC} $name: source changed but version still $cur (unchanged from $BASE)"
+    fail=1
+  fi
+done <<EOF
+$touched
+EOF
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "${GREEN}All changed publishable crates were version-bumped.${NC}"
+else
+  echo "${RED}Some changed publishable crates were NOT version-bumped.${NC}"
+  echo "Bump the crate's Cargo.toml version (and CHANGELOG) so the source change actually"
+  echo "publishes. If the change is genuinely test-/doc-only, move it out of the crate's"
+  echo "source paths or adjust this guard's exclusions."
+  exit 1
+fi


### PR DESCRIPTION
## W17 — release automation + toolchain-sync (local hardening)

Adds two **build-free PR guards** that protect the release pipeline, plus an ADR
recording the release-automation direction. No changes to the org-owned
`affinidi/pipeline-rust` release workflow.

### Why
The release pipeline broke on 2026-06-13 (#456): W9 (#448) edited
`affinidi-meeting-place`'s source for the `#[non_exhaustive]` `Endpoint` seal but
left its version at `0.4.2`. crates.io kept the **pre-seal** source, so when
`affinidi-did-common 0.3.6` later published, `cargo publish`'s registry-resolved
verify build (which ignores `[patch.crates-io]`) compiled the stale source
against the new did-common and failed with `error[E0004]`. The local `[patch]`
workspace build was green throughout — nothing caught it pre-merge.

### What

- **`scripts/check-version-bumps.sh`** — for every *publishable* crate whose
  **source** changed in a PR (vs. the base), require its `Cargo.toml` version to
  differ from the base. Catches the trap above at PR time. Excludes
  `tests/`/`benches/`/`examples/`/`*.md`/`CHANGELOG*` (test-/doc-only → no bump,
  per repo convention); skips `publish = false` crates.
- **`scripts/check-toolchain-sync.sh`** — every workflow `toolchain:` pin and the
  `Cargo.toml` MSRV must match `rust-toolchain.toml`'s channel (11 refs, 6 files).
  Fails with the exact `file:line` on drift.
- **`.github/workflows/release-guards.yaml`** — runs both on every PR. Pure bash +
  git + `jq` + `cargo metadata`, no Rust build. Carries no `toolchain:` pin of its
  own, so it adds nothing for the sync check to police.
- **`docs/adr/0004-release-automation.md`** — records the decision to keep
  pipeline-rust + add local guards, and defers release-plz adoption (W17 a/b) as
  an org-level pipeline-rust call, with the constraints to honour (skip-published,
  the `[patch.crates-io]` external coupling, fork dry-run).

### Scope note
W17 parts (a) release-plz/cargo-workspaces adoption and (b) the single
`unreleased.md` → per-crate CHANGELOG flow are **deferred**: the release workflow
is org-owned and swapping it is not a unilateral call. This PR hardens the
local-side fragility that actually broke CI, which is independent of that decision.

### Verification
- Both scripts: `bash -n` clean; manually exercised pass/fail/skip paths
  (source-edit-no-bump → fail; +bump → pass; test-/doc-only → skip; toolchain
  drift → fail with file:line).
- `release-guards.yaml`: valid YAML.
- This PR's own diff touches no crate source → guards pass.
- No Rust source changed → no fmt/clippy/test/version bumps required.
