### PR TITLE
feat: oid4vc JWT algorithm allowlist + nonce replay helper (W5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+### Security
+
+- **OID4VC JWT algorithm allowlist (W5).** `affinidi-oid4vc-core` 0.1.4 adds
+  `jwt::decode_compact_jws_verified_with_algs(jws, verifier, allowed_algs)`,
+  which rejects a JWS whose header `alg` is not in the caller's allowlist
+  **before** verifying the signature — closing algorithm-substitution attacks.
+  The old `decode_compact_jws_verified` (any alg but `none`) is **deprecated**.
+  **`affinidi-openid4vci` 0.2.0** threads an `allowed_algs` argument through
+  `KeyProof::verify` / `verify_signature` (breaking) and ships a
+  `DEFAULT_PROOF_ALGS = ["ES256", "EdDSA"]` default; `affinidi-tdk` 0.8.3 picks
+  up the new openid4vci. Also adds `oid4vc-core::nonce::NonceStore`, an optional
+  in-memory single-use TTL helper, and documents that **replay prevention is a
+  MUST** (matching a nonce value is not sufficient).
+
 ### Changed
 
 - **`affinidi-sd-jwt-vc` merged into `affinidi-vc` (W18b).** SD-JWT VC is a

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
@@ -159,7 +159,7 @@ impl JwtVerifier for EdDsaVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jwt::{decode_compact_jws_verified, encode_compact_jws};
+    use crate::jwt::{decode_compact_jws_verified_with_algs, encode_compact_jws};
     use serde_json::json;
 
     #[test]
@@ -172,7 +172,7 @@ mod tests {
 
         let jws = encode_compact_jws(&header, &payload, &signer).unwrap();
         let (decoded_header, decoded_payload) =
-            decode_compact_jws_verified(&jws, &verifier).unwrap();
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["EdDSA"]).unwrap();
 
         assert_eq!(decoded_header["alg"], "EdDSA");
         assert_eq!(decoded_payload["sub"], "user123");
@@ -185,7 +185,7 @@ mod tests {
         let verifier = EdDsaVerifier::from_bytes(&other.public_key_bytes()).unwrap();
 
         let jws = encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"x": 1}), &signer).unwrap();
-        assert!(decode_compact_jws_verified(&jws, &verifier).is_err());
+        assert!(decode_compact_jws_verified_with_algs(&jws, &verifier, &["EdDSA"]).is_err());
     }
 
     #[test]
@@ -198,7 +198,8 @@ mod tests {
         let verifier = EdDsaVerifier::from_jwk(&jwk).unwrap();
         let jws =
             encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"test": true}), &signer).unwrap();
-        let (_, payload) = decode_compact_jws_verified(&jws, &verifier).unwrap();
+        let (_, payload) =
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["EdDSA"]).unwrap();
         assert_eq!(payload["test"], true);
     }
 
@@ -226,7 +227,7 @@ mod tests {
         let signer = EdDsaSigner::generate();
         let verifier = EdDsaVerifier::from_bytes(&signer.public_key_bytes()).unwrap();
         let jws = encode_compact_jws(&json!({"alg": "EdDSA"}), &json!({"ok": 1}), &signer).unwrap();
-        assert!(decode_compact_jws_verified(&jws, &verifier).is_ok());
+        assert!(decode_compact_jws_verified_with_algs(&jws, &verifier, &["EdDSA"]).is_ok());
     }
 
     #[test]

--- a/crates/protocols/affinidi-oid4vc-core/src/es256.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/es256.rs
@@ -146,7 +146,7 @@ impl JwtVerifier for Es256Verifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jwt::{decode_compact_jws_verified, encode_compact_jws};
+    use crate::jwt::{decode_compact_jws_verified_with_algs, encode_compact_jws};
     use serde_json::json;
 
     #[test]
@@ -159,7 +159,7 @@ mod tests {
 
         let jws = encode_compact_jws(&header, &payload, &signer).unwrap();
         let (decoded_header, decoded_payload) =
-            decode_compact_jws_verified(&jws, &verifier).unwrap();
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["ES256"]).unwrap();
 
         assert_eq!(decoded_header["alg"], "ES256");
         assert_eq!(decoded_payload["sub"], "user123");
@@ -173,7 +173,7 @@ mod tests {
 
         let jws = encode_compact_jws(&json!({"alg": "ES256"}), &json!({"x": 1}), &signer).unwrap();
 
-        assert!(decode_compact_jws_verified(&jws, &verifier).is_err());
+        assert!(decode_compact_jws_verified_with_algs(&jws, &verifier, &["ES256"]).is_err());
     }
 
     #[test]
@@ -186,7 +186,8 @@ mod tests {
         let jws =
             encode_compact_jws(&json!({"alg": "ES256"}), &json!({"test": true}), &signer).unwrap();
 
-        let (_, payload) = decode_compact_jws_verified(&jws, &verifier).unwrap();
+        let (_, payload) =
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["ES256"]).unwrap();
         assert_eq!(payload["test"], true);
     }
 

--- a/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
@@ -128,12 +128,57 @@ pub fn decode_compact_jws_unverified(jws: &str) -> Result<(Value, Value), JwtErr
     Ok((header, payload))
 }
 
+/// Decode and verify a compact JWS, enforcing a per-context **algorithm
+/// allowlist**.
+///
+/// The header `alg` must be one of `allowed_algs` (exact, case-sensitive match
+/// against the JWA registered name, e.g. `"ES256"`, `"EdDSA"`). This is checked
+/// **before** the signature, so a token presenting an algorithm the caller
+/// doesn't expect is rejected outright — closing the class of algorithm-
+/// substitution attacks where an attacker swaps the `alg` header to one the
+/// verifier mishandles. `alg=none`, a missing `alg`, and an empty signature are
+/// always rejected regardless of the list.
+///
+/// Pass the set the relying party actually accepts for this context (e.g. the
+/// `request_object_signing_alg_values_supported` you advertised). An empty list
+/// rejects every token.
+///
+/// Returns the header and payload if the algorithm is allowed and the signature
+/// is valid.
+pub fn decode_compact_jws_verified_with_algs(
+    jws: &str,
+    verifier: &dyn JwtVerifier,
+    allowed_algs: &[&str],
+) -> Result<(Value, Value), JwtError> {
+    decode_compact_jws_checked(jws, verifier, Some(allowed_algs))
+}
+
 /// Decode and verify a compact JWS string.
 ///
 /// Returns the header and payload if the signature is valid.
+///
+/// **Deprecated:** this entry point accepts any algorithm except `none`, which
+/// leaves the caller open to algorithm-substitution. Prefer
+/// [`decode_compact_jws_verified_with_algs`], which enforces a per-context
+/// allowlist before verifying the signature.
+#[deprecated(
+    since = "0.1.4",
+    note = "use decode_compact_jws_verified_with_algs to enforce a per-context algorithm allowlist; this entry point accepts any alg except `none`"
+)]
 pub fn decode_compact_jws_verified(
     jws: &str,
     verifier: &dyn JwtVerifier,
+) -> Result<(Value, Value), JwtError> {
+    decode_compact_jws_checked(jws, verifier, None)
+}
+
+/// Shared decode-and-verify core. `allowed_algs == None` accepts any algorithm
+/// except `none` (the legacy behaviour); `Some(list)` enforces the allowlist
+/// before signature verification.
+fn decode_compact_jws_checked(
+    jws: &str,
+    verifier: &dyn JwtVerifier,
+    allowed_algs: Option<&[&str]>,
 ) -> Result<(Value, Value), JwtError> {
     let parts: Vec<&str> = jws.splitn(3, '.').collect();
     if parts.len() != 3 {
@@ -150,15 +195,26 @@ pub fn decode_compact_jws_verified(
     // RFC 7515/7519: an Unsecured JWS (`alg: none`, empty signature) must
     // never satisfy a verified decode. Don't rely on every JwtVerifier impl
     // happening to reject a zero-length signature.
-    match header.get("alg").and_then(Value::as_str) {
+    let alg = match header.get("alg").and_then(Value::as_str) {
         Some(alg) if alg.eq_ignore_ascii_case("none") => {
             return Err(JwtError::Verification("alg=none is not permitted".into()));
         }
-        Some(_) => {}
+        Some(alg) => alg,
         None => {
             return Err(JwtError::Verification("missing alg in JWS header".into()));
         }
+    };
+
+    // Per-context allowlist: reject a disallowed `alg` before touching the
+    // signature, so the attacker-controlled header can't steer verification.
+    if let Some(allowed) = allowed_algs
+        && !allowed.contains(&alg)
+    {
+        return Err(JwtError::Verification(format!(
+            "JWS alg \"{alg}\" is not in the allowed set {allowed:?}"
+        )));
     }
+
     if parts[2].is_empty() {
         return Err(JwtError::Verification("empty JWS signature".into()));
     }
@@ -288,7 +344,7 @@ mod tests {
         assert_eq!(jws.split('.').count(), 3);
 
         let (decoded_header, decoded_payload) =
-            decode_compact_jws_verified(&jws, &verifier).unwrap();
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["HS256"]).unwrap();
         assert_eq!(decoded_header["alg"], "HS256");
         assert_eq!(decoded_payload["sub"], "user123");
     }
@@ -310,7 +366,41 @@ mod tests {
 
         let jws = encode_compact_jws(&json!({"alg": "HS256"}), &json!({"x": 1}), &signer).unwrap();
 
-        assert!(decode_compact_jws_verified(&jws, &wrong_verifier).is_err());
+        assert!(decode_compact_jws_verified_with_algs(&jws, &wrong_verifier, &["HS256"]).is_err());
+    }
+
+    #[test]
+    fn rejects_disallowed_alg() {
+        // A correctly-signed HS256 token is still rejected when the caller only
+        // allows ES256 — and rejected before the signature is checked, so even
+        // the matching verifier can't rescue it.
+        let signer = HmacTestSigner::new(b"shared-key-for-alg-allowlist!!!");
+        let verifier = HmacTestVerifier::new(b"shared-key-for-alg-allowlist!!!");
+
+        let jws = encode_compact_jws(&json!({"alg": "HS256"}), &json!({"x": 1}), &signer).unwrap();
+
+        let err = decode_compact_jws_verified_with_algs(&jws, &verifier, &["ES256"]).unwrap_err();
+        assert!(
+            matches!(&err, JwtError::Verification(m) if m.contains("not in the allowed set")),
+            "got {err:?}"
+        );
+
+        // The same token passes once HS256 is allowed.
+        assert!(
+            decode_compact_jws_verified_with_algs(&jws, &verifier, &["ES256", "HS256"]).is_ok()
+        );
+
+        // An empty allowlist rejects everything.
+        assert!(decode_compact_jws_verified_with_algs(&jws, &verifier, &[]).is_err());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_decode_still_accepts_any_alg() {
+        let signer = HmacTestSigner::new(b"legacy-path-key-still-supported");
+        let verifier = HmacTestVerifier::new(b"legacy-path-key-still-supported");
+        let jws = encode_compact_jws(&json!({"alg": "HS256"}), &json!({"x": 1}), &signer).unwrap();
+        assert!(decode_compact_jws_verified(&jws, &verifier).is_ok());
     }
 
     #[test]
@@ -319,7 +409,7 @@ mod tests {
         let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
         let payload = URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let jws = format!("{header}.{payload}.");
-        let err = decode_compact_jws_verified(&jws, &verifier).unwrap_err();
+        let err = decode_compact_jws_verified_with_algs(&jws, &verifier, &["HS256"]).unwrap_err();
         assert!(matches!(err, JwtError::Verification(_)), "got {err:?}");
     }
 

--- a/crates/protocols/affinidi-oid4vc-core/src/lib.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/lib.rs
@@ -13,6 +13,9 @@
 
 pub mod jwt;
 
+/// In-memory nonce replay-prevention helper (single-process deployments).
+pub mod nonce;
+
 /// ES256 (ECDSA P-256) signer and verifier for production JWT operations.
 #[cfg(feature = "es256")]
 pub mod es256;

--- a/crates/protocols/affinidi-oid4vc-core/src/nonce.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/nonce.rs
@@ -1,0 +1,133 @@
+/*!
+ * Replay prevention for OID4VC nonces.
+ *
+ * OID4VC binds a server-issued nonce into signed artifacts (the OpenID4VCI
+ * `c_nonce` echoed in a key-binding proof; the OpenID4VP request `nonce` echoed
+ * in a presentation). Checking that the echoed nonce *matches* (which the
+ * protocol crates already do) stops a value being forged — but **not** a
+ * captured-and-replayed artifact within the freshness window. Preventing replay
+ * by ensuring each issued nonce is accepted **at most once** is a **MUST** for
+ * issuers and verifiers; the matching check alone is not sufficient.
+ *
+ * [`NonceStore`] is a minimal, dependency-free helper for **single-process**
+ * deployments. Multi-instance deployments must back replay prevention with
+ * shared storage (e.g. Redis) so a nonce consumed on one node is rejected on
+ * the others — this in-memory store does not coordinate across processes.
+ */
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// An in-memory, single-use nonce store with a per-entry time-to-live.
+///
+/// Register each nonce you issue with [`register`](Self::register), then
+/// [`consume`](Self::consume) it when it comes back. `consume` returns `true`
+/// exactly once per registered, unexpired nonce; a replay (or an unknown or
+/// expired nonce) returns `false`. Cloning isn't provided — share via `Arc`.
+///
+/// ```
+/// use affinidi_oid4vc_core::nonce::NonceStore;
+/// use std::time::Duration;
+///
+/// let store = NonceStore::new();
+/// store.register("c_nonce-abc", Duration::from_secs(300));
+///
+/// assert!(store.consume("c_nonce-abc"));  // first use: accepted
+/// assert!(!store.consume("c_nonce-abc")); // replay: rejected
+/// assert!(!store.consume("never-issued")); // unknown: rejected
+/// ```
+#[derive(Default)]
+pub struct NonceStore {
+    // nonce -> expiry instant. A monotonic `Instant` (not wall-clock) so TTLs
+    // are immune to system clock changes.
+    inner: Mutex<HashMap<String, Instant>>,
+}
+
+impl NonceStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an issued nonce, valid for `ttl` from now. Re-registering an
+    /// existing nonce refreshes its expiry. Opportunistically evicts expired
+    /// entries so the map can't grow without bound.
+    pub fn register(&self, nonce: impl Into<String>, ttl: Duration) {
+        let mut map = self.lock();
+        let now = Instant::now();
+        map.retain(|_, expiry| *expiry > now);
+        map.insert(nonce.into(), now + ttl);
+    }
+
+    /// Atomically check-and-consume a nonce. Returns `true` iff the nonce was
+    /// registered and has not expired or been consumed; the entry is removed so
+    /// any later call for the same nonce (a replay) returns `false`. Unknown and
+    /// expired nonces return `false`.
+    pub fn consume(&self, nonce: &str) -> bool {
+        let mut map = self.lock();
+        match map.remove(nonce) {
+            Some(expiry) => expiry > Instant::now(),
+            None => false,
+        }
+    }
+
+    /// Number of live (registered, unexpired, unconsumed) nonces, after evicting
+    /// expired entries.
+    pub fn len(&self) -> usize {
+        let mut map = self.lock();
+        let now = Instant::now();
+        map.retain(|_, expiry| *expiry > now);
+        map.len()
+    }
+
+    /// Whether the store holds no live nonces.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, Instant>> {
+        // Recover from a poisoned lock rather than propagating the panic: a
+        // replay-prevention store should keep working after an unrelated panic.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consume_succeeds_once_then_rejects_replay() {
+        let store = NonceStore::new();
+        store.register("abc", Duration::from_secs(300));
+        assert!(store.consume("abc"), "first use accepted");
+        assert!(!store.consume("abc"), "replay rejected");
+    }
+
+    #[test]
+    fn unknown_nonce_rejected() {
+        let store = NonceStore::new();
+        assert!(!store.consume("never-issued"));
+    }
+
+    #[test]
+    fn expired_nonce_rejected() {
+        let store = NonceStore::new();
+        // Zero TTL: expiry == register-time instant, which is <= the (later)
+        // consume-time instant, so it reads as expired.
+        store.register("stale", Duration::ZERO);
+        assert!(!store.consume("stale"));
+    }
+
+    #[test]
+    fn len_counts_live_and_evicts_expired() {
+        let store = NonceStore::new();
+        store.register("live", Duration::from_secs(300));
+        store.register("dead", Duration::ZERO);
+        assert_eq!(store.len(), 1);
+        assert!(!store.is_empty());
+        assert!(store.consume("live"));
+        assert!(store.is_empty());
+    }
+}

--- a/crates/protocols/affinidi-openid4vci/Cargo.toml
+++ b/crates/protocols/affinidi-openid4vci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-openid4vci"
 description = "OpenID for Verifiable Credential Issuance (OpenID4VCI) implementation."
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-openid4vci/src/proof.rs
+++ b/crates/protocols/affinidi-openid4vci/src/proof.rs
@@ -16,18 +16,18 @@
  * [`KeyProof::verify`].
  *
  * ```no_run
- * # use affinidi_openid4vci::proof::{KeyProof, ProofPolicy};
+ * # use affinidi_openid4vci::proof::{KeyProof, ProofPolicy, DEFAULT_PROOF_ALGS};
  * # use affinidi_oid4vc_core::jwt::JwtVerifier;
  * # fn resolve(_kid: Option<&str>) -> Box<dyn JwtVerifier> { unimplemented!() }
  * # fn demo(jwt: &str, issuer_id: &str, c_nonce: &str, now: i64) -> Result<(), Box<dyn std::error::Error>> {
  * let proof = KeyProof::parse(jwt)?;                 // structural decode, no crypto
  * let verifier = resolve(proof.kid());               // caller resolves kid -> key
- * let claims = proof.verify(&*verifier, &ProofPolicy {
+ * let claims = proof.verify(&*verifier, DEFAULT_PROOF_ALGS, &ProofPolicy {
  *     audience: issuer_id,
  *     nonce: Some(c_nonce),                          // bind to the issued c_nonce
  *     now,
  *     max_age_secs: 300,
- * })?;                                               // sig + aud + nonce + freshness
+ * })?;                                               // alg + sig + aud + nonce + freshness
  * // `proof.kid()` is now a cryptographically-proven holder identifier.
  * # let _ = claims; Ok(())
  * # }
@@ -44,6 +44,14 @@ use crate::error::{Oid4vciError, Result};
 /// The required `typ` header value of an OpenID4VCI key-binding proof JWT
 /// (OpenID4VCI §8.2.1.1).
 pub const KEY_PROOF_TYP: &str = "openid4vci-proof+jwt";
+
+/// A sensible default algorithm allowlist for key-binding proofs: the
+/// asymmetric JWS algorithms this workspace ships verifiers for
+/// (`affinidi-oid4vc-core`'s `es256` / `eddsa`). Pass this to
+/// [`KeyProof::verify`] / [`verify_signature`](KeyProof::verify_signature)
+/// unless your issuer advertises a different set. Symmetric algorithms (HS\*)
+/// and `none` are intentionally excluded — a key-binding proof is asymmetric.
+pub const DEFAULT_PROOF_ALGS: &[&str] = &["ES256", "EdDSA"];
 
 /// Default tolerance, in seconds, for a proof `iat` slightly ahead of the
 /// verifier's clock (wallet clock drift).
@@ -180,7 +188,14 @@ impl KeyProof {
         &self.claims
     }
 
-    /// Verify the proof's signature with a caller-resolved verifier.
+    /// Verify the proof's signature with a caller-resolved verifier, enforcing
+    /// an algorithm allowlist.
+    ///
+    /// `allowed_algs` is the set of JWS `alg` values this issuer accepts for
+    /// key-binding proofs (e.g. `&["ES256", "EdDSA"]`). The proof's `alg` is
+    /// checked against it **before** the signature, so a token presenting an
+    /// unexpected algorithm is rejected outright. `alg=none` and empty
+    /// signatures are always rejected regardless.
     ///
     /// **Caller contract (load-bearing):** the `verifier` MUST wrap the key
     /// named by this proof's own [`kid`](Self::kid) / [`jwk`](Self::jwk) —
@@ -188,10 +203,13 @@ impl KeyProof {
     /// algorithm matches [`algorithm`](Self::algorithm). Resolving a verifier
     /// from anywhere else, or picking one by `alg` rather than by key, defeats
     /// the proof: this crate is crypto-agnostic by design and cannot police the
-    /// key↔proof binding for you. (`alg=none` and empty signatures are still
-    /// rejected here regardless.)
-    pub fn verify_signature(&self, verifier: &dyn JwtVerifier) -> Result<()> {
-        jwt::decode_compact_jws_verified(&self.jwt, verifier)
+    /// key↔proof binding for you.
+    pub fn verify_signature(
+        &self,
+        verifier: &dyn JwtVerifier,
+        allowed_algs: &[&str],
+    ) -> Result<()> {
+        jwt::decode_compact_jws_verified_with_algs(&self.jwt, verifier, allowed_algs)
             .map(|_| ())
             .map_err(jwt_err)
     }
@@ -234,14 +252,15 @@ impl KeyProof {
 
     /// Verify the signature **and** the bound claims, returning the proven
     /// claims. The convenience composition of [`verify_signature`](Self::verify_signature)
-    /// then [`verify_claims`](Self::verify_claims) — see those for the caller
-    /// contract and the checks performed.
+    /// (with the `allowed_algs` allowlist) then [`verify_claims`](Self::verify_claims)
+    /// — see those for the caller contract and the checks performed.
     pub fn verify(
         &self,
         verifier: &dyn JwtVerifier,
+        allowed_algs: &[&str],
         policy: &ProofPolicy<'_>,
     ) -> Result<&KeyProofClaims> {
-        self.verify_signature(verifier)?;
+        self.verify_signature(verifier, allowed_algs)?;
         self.verify_claims(policy)?;
         Ok(&self.claims)
     }
@@ -338,6 +357,7 @@ mod tests {
         let claims = proof
             .verify(
                 &v,
+                DEFAULT_PROOF_ALGS,
                 &ProofPolicy {
                     audience: ISSUER,
                     nonce: Some("c-nonce-1"),
@@ -356,12 +376,33 @@ mod tests {
         let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
         let proof = KeyProof::parse(&jwt).unwrap();
         let err = proof
-            .verify(&v, &policy("https://other.example", NOW))
+            .verify(
+                &v,
+                DEFAULT_PROOF_ALGS,
+                &policy("https://other.example", NOW),
+            )
             .unwrap_err();
         assert!(
             matches!(&err, Oid4vciError::InvalidProof(m) if m.contains("aud")),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn verify_signature_rejects_disallowed_alg() {
+        // A correctly-signed EdDSA proof is rejected when the issuer only
+        // allows ES256 — the alg allowlist fires before signature checking.
+        let s = signer(21, "did:key:zH#0");
+        let v = EdDsaVerifier::from_bytes(&s.public_key_bytes()).unwrap();
+        let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
+        let proof = KeyProof::parse(&jwt).unwrap();
+
+        assert!(
+            proof.verify_signature(&v, &["ES256"]).is_err(),
+            "EdDSA proof must be rejected when only ES256 is allowed"
+        );
+        // Allowed once EdDSA is in the set (and DEFAULT_PROOF_ALGS includes it).
+        assert!(proof.verify_signature(&v, DEFAULT_PROOF_ALGS).is_ok());
     }
 
     #[test]
@@ -413,7 +454,7 @@ mod tests {
         let v = EdDsaVerifier::from_bytes(&other.public_key_bytes()).unwrap();
         let jwt = build_key_proof_jwt(&s, ISSUER, None, NOW).unwrap();
         let proof = KeyProof::parse(&jwt).unwrap();
-        assert!(proof.verify_signature(&v).is_err());
+        assert!(proof.verify_signature(&v, DEFAULT_PROOF_ALGS).is_err());
     }
 
     #[test]

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.2"
+version = "0.8.3"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -78,7 +78,7 @@ affinidi-status-list = { version = "0.1", path = "../../credentials/affinidi-sta
 # Protocols
 affinidi-oid4vc-core = { version = "0.1", path = "../../protocols/affinidi-oid4vc-core", optional = true }
 affinidi-siopv2 = { version = "0.1", path = "../../protocols/affinidi-siopv2", optional = true }
-affinidi-openid4vci = { version = "0.1", path = "../../protocols/affinidi-openid4vci", optional = true }
+affinidi-openid4vci = { version = "0.2", path = "../../protocols/affinidi-openid4vci", optional = true }
 affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4vp", optional = true }
 
 # DID methods

--- a/docs/adr/0002-interoperable-bbs-vc-selective-disclosure.md
+++ b/docs/adr/0002-interoperable-bbs-vc-selective-disclosure.md
@@ -248,3 +248,22 @@ ADR 0001).
 - **Big-bang single PR.** Rejected for the same reason as ADR 0001:
   unreviewable and unsafe for wire-affecting crypto. The KAT-gated stages
   are the safe path.
+
+## Discharges the workspace-hardening "BBS signing KATs" item (W19)
+
+The workspace-hardening plan carried a task (W19) to add external-vector KATs
+for the BBS **signing** path, noting it had "only round-trip tests." That gap is
+**closed by the KAT-gated work above** — the signing surface now has exact-match
+IETF/DIF vector coverage end to end, so no separate W19 work is warranted:
+
+- **Base sign** — `affinidi-bbs/tests/interop_kat.rs` reproduces the DIF
+  `bls12-381-sha-256` signature vectors byte-for-byte and verifies them
+  (`signature001`, `signature004`), plus proof-verify KATs.
+- **Blind sign** — `affinidi-bbs/src/blind.rs` against the
+  `draft-irtf-cfrg-bbs-blind-signatures` vectors (`tests/fixtures/blind/`), with
+  deterministic mocked scalars for exact reproduction.
+- **Pseudonym / holder binding** — `affinidi-bbs/src/nym.rs` against the
+  `draft-irtf-cfrg-bbs-per-verifier-linkability` vectors (`tests/fixtures/pseudonym/`).
+
+(Audited 2026-06-13: every shipped fixture is wired to a test; the full
+`affinidi-bbs` suite is green.) W19 is therefore considered satisfied.


### PR DESCRIPTION
## W5 — OID4VC JWT algorithm allowlist + nonce replay helper (also discharges W19)

`affinidi-oid4vc-core`'s verified JWT decode rejected `alg=none`/missing but enforced **no per-context algorithm allowlist** — the attacker-controlled `alg` header was never checked against caller policy, leaving the door open to algorithm-substitution. W5 closes that and adds an optional replay-prevention helper.

### Changes
- **`affinidi-oid4vc-core` 0.1.3 → 0.1.4 (additive):**
  - `jwt::decode_compact_jws_verified_with_algs(jws, verifier, allowed_algs)` — rejects a header `alg` not in the allowlist **before** signature verification. `alg=none` / missing / empty-sig still always rejected. Empty list rejects everything.
  - `jwt::decode_compact_jws_verified` is now `#[deprecated]` (delegates; accepts any alg but `none`). Kept one release for back-compat.
  - New `nonce::NonceStore` — optional in-memory, single-use, TTL replay-prevention helper. Module docs state replay prevention is a **MUST** (matching the nonce value is not sufficient) and that multi-instance deployments need shared storage.
- **`affinidi-openid4vci` 0.1.3 → 0.2.0 (breaking):** `KeyProof::verify` / `verify_signature` take an `allowed_algs` argument so the relying party sets policy; new `DEFAULT_PROOF_ALGS = ["ES256", "EdDSA"]` (asymmetric only — HS\*/none excluded). Sole production call site updated.
- **`affinidi-tdk` 0.8.2 → 0.8.3:** picks up openid4vci 0.2 (pin `"0.1"` → `"0.2"`).
- **siopv2 / openid4vp untouched** — they depend only on oid4vc-core, which stays additively compatible at `"0.1"`, so no cascade.

### Discharges W19 (BBS signing KATs)
The hardening plan's W19 ("signing path has no external-vector coverage") is **already satisfied** by ADR-0002's KAT-gated work — base / blind / pseudonym signing all have exact-match IETF/DIF vector KATs (88 `affinidi-bbs` tests green). Recorded in `docs/adr/0002`'s implementation log; **no `affinidi-bbs` change**.

### Verification
- `cargo test`: oid4vc-core 36 + nonce (incl. disallowed-alg rejected *before* sig, empty-list rejects all, deprecated-path under `#[allow(deprecated)]`); openid4vci 26 (incl. `verify_signature_rejects_disallowed_alg`).
- `cargo fmt --check` + `cargo clippy -D warnings` green (deprecation is `-D warnings`-clean — internal callers migrated).
- Facade resolves under `--features protocols`.
- W17 guards green; version-bump guard confirmed all 3 changed crates bumped.

### Notes
- Follow-up (future): remove the deprecated `decode_compact_jws_verified` one release on.
- `CHANGELOG.md` `[Unreleased]` updated (Security section).
