### PR TITLE
feat: multi-mediator TestTopology fixture (TI1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+### Added
+
+- **`TestTopology` multi-mediator fixture (TI1).** `affinidi-messaging-test-mediator`
+  0.2.10 adds `TestTopology` — spawns N in-process relay-enabled mediators (Blind
+  or Rewrap), each wired to its own SDK environment, and a `forward(..)` helper
+  that drives the routing-2.0 double forward hop-to-hop. Cross-mediator and
+  relay-REWRAP scenarios become plain `#[tokio::test]`s with no Redis and no
+  external network. Additive (patch).
+
 ### Security
 
 - **OID4VC JWT algorithm allowlist (W5).** `affinidi-oid4vc-core` 0.1.4 adds

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.9"
+version = "0.2.10"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -67,6 +67,11 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 ## Used to hash DIDs into their canonical account-store key shape when
 ## pre-registering local DIDs at startup.
 sha256 = "1"
+## `serde_json` + the DIDComm `Message` builder back the `TestTopology`
+## forwarding helper, which constructs the routing-2.0 double forward in
+## library code (the SDK doesn't re-export `Message`).
+serde_json = "1"
+affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-didcomm" }
 
 [dev-dependencies]
 ## Used by integration tests to hit the mediator's HTTP endpoints
@@ -83,10 +88,6 @@ futures-util = "0.3"
 ## browser scenario can't go through tokio-tungstenite's client, which
 ## errors when it offers a subprotocol the server doesn't echo back).
 tokio = { workspace = true, features = ["io-util"] }
-serde_json = "1"
-## DIDComm `Message` builder for the cross-mediator forwarding test, which
-## hand-rolls the routing-2.0 double forward (the SDK doesn't re-export it).
-affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-didcomm" }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -77,7 +77,9 @@
 
 pub mod acl;
 pub mod environment;
+pub mod topology;
 pub use environment::{TestEnvironment, TestEnvironmentError, TestUser};
+pub use topology::{TestTopology, TestTopologyBuilder, TestTopologyError};
 
 // Re-exports so consumers don't have to add a direct dep on
 // mediator-common just to construct an `acl_mode(...)` argument or

--- a/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
@@ -1,0 +1,340 @@
+/*!
+ * Multi-mediator topology fixture.
+ *
+ * [`TestTopology`] spawns N in-process [`TestMediator`]s — each relay-enabled
+ * and wired to its own SDK [`TestEnvironment`] — so a cross-mediator scenario
+ * is a plain `#[tokio::test]` with no Redis and no external network. Every
+ * mediator and user identity is `did:peer:2.*`, which carries its own service
+ * endpoint, so all DIDs resolve locally: the mediators form a fully-connected,
+ * trust-any relay mesh without a shared resolver registry. The only real socket
+ * traffic is the loopback HTTP hop a relaying mediator makes to the next hop's
+ * `/inbound`.
+ *
+ * This generalises the routing-2.0 double-forward that
+ * `tests/cross_mediator_forwarding.rs` previously hand-rolled per test: spawn a
+ * mesh, add users on whichever mediators, and [`forward`](TestTopology::forward)
+ * a message hop-to-hop.
+ *
+ * ```no_run
+ * # use affinidi_messaging_test_mediator::TestTopology;
+ * # use std::time::Duration;
+ * # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+ * let topology = TestTopology::builder().mediators(2).spawn().await?;
+ * let alice = topology.add_user(0, "Alice").await?; // homed on mediator 0
+ * let bob = topology.add_user(1, "Bob").await?;      // homed on mediator 1
+ *
+ * let got = topology
+ *     .forward(0, &alice, 1, &bob, "Hello Bob", Duration::from_secs(15))
+ *     .await?;
+ * assert_eq!(got.as_deref(), Some("Hello Bob"));
+ *
+ * topology.shutdown().await?;
+ * # Ok(()) }
+ * ```
+ */
+
+use std::time::Duration;
+
+use affinidi_messaging_didcomm::Message;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{
+    RelayMode, TestEnvironment, TestEnvironmentError, TestMediator, TestMediatorBuilder, TestUser,
+    acl,
+};
+
+/// Errors from constructing or driving a [`TestTopology`].
+#[derive(Debug, thiserror::Error)]
+pub enum TestTopologyError {
+    /// `mediators(0)` — a topology needs at least one mediator.
+    #[error("a topology needs at least one mediator")]
+    NoMediators,
+
+    /// A node index passed to [`TestTopology::node`] / `forward` / `add_user`
+    /// was out of range.
+    #[error("mediator node index {index} out of range (topology has {count} mediators)")]
+    NodeOutOfRange {
+        /// The offending index.
+        index: usize,
+        /// How many mediators the topology actually has.
+        count: usize,
+    },
+
+    /// Wiring the SDK environment to a spawned mediator failed.
+    #[error(transparent)]
+    Environment(#[from] TestEnvironmentError),
+
+    /// Spawning a mediator failed.
+    #[error("spawn mediator: {0}")]
+    Mediator(String),
+
+    /// An SDK operation (pack / forward / send / receive) failed.
+    #[error("sdk: {0}")]
+    Sdk(String),
+}
+
+/// Builder for a [`TestTopology`]. Create with [`TestTopology::builder`].
+///
+/// Every mediator is spawned relay-enabled (`enable_forwarding`,
+/// `enable_external_forwarding`, an allow-all global default ACL so
+/// cross-mediator forward senders auto-register, and the chosen
+/// [`RelayMode`]). The trusted-peer allowlist is left empty, i.e. **trust any
+/// relaying peer** — which is what makes the mesh fully connected without
+/// needing each peer's DID ahead of spawn. Tests that need an explicit
+/// trusted-peer allowlist (or a non-relay mediator) should drop to
+/// [`TestMediator::builder`] directly.
+pub struct TestTopologyBuilder {
+    mediators: usize,
+    relay_mode: RelayMode,
+    customize: Option<Box<dyn Fn(TestMediatorBuilder) -> TestMediatorBuilder + Send + Sync>>,
+}
+
+impl Default for TestTopologyBuilder {
+    fn default() -> Self {
+        Self {
+            mediators: 2,
+            relay_mode: RelayMode::Blind,
+            customize: None,
+        }
+    }
+}
+
+impl TestTopologyBuilder {
+    /// Number of mediators to spawn (default 2).
+    pub fn mediators(mut self, count: usize) -> Self {
+        self.mediators = count;
+        self
+    }
+
+    /// Relay posture for every mediator (default [`RelayMode::Blind`]).
+    pub fn relay_mode(mut self, mode: RelayMode) -> Self {
+        self.relay_mode = mode;
+        self
+    }
+
+    /// Shorthand for [`relay_mode`](Self::relay_mode)`(RelayMode::Rewrap)` —
+    /// each mediator re-encrypts the inner forward from itself to the next hop.
+    pub fn rewrap(self) -> Self {
+        self.relay_mode(RelayMode::Rewrap)
+    }
+
+    /// Apply extra configuration to every mediator's builder after the relay
+    /// defaults are set — e.g. swap in a Redis/Fjall store for multi-process
+    /// coordination tests, or tune ACLs. The closure runs once per node.
+    ///
+    /// ```no_run
+    /// # use affinidi_messaging_test_mediator::TestTopology;
+    /// # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topology = TestTopology::builder()
+    ///     .mediators(3)
+    ///     .configure_each(|b| b.enable_message_expiry(true))
+    ///     .spawn()
+    ///     .await?;
+    /// # let _ = topology; Ok(()) }
+    /// ```
+    pub fn configure_each<F>(mut self, f: F) -> Self
+    where
+        F: Fn(TestMediatorBuilder) -> TestMediatorBuilder + Send + Sync + 'static,
+    {
+        self.customize = Some(Box::new(f));
+        self
+    }
+
+    /// Spawn the mediators and wire each to its own SDK environment.
+    pub async fn spawn(self) -> Result<TestTopology, TestTopologyError> {
+        if self.mediators == 0 {
+            return Err(TestTopologyError::NoMediators);
+        }
+
+        let mut nodes = Vec::with_capacity(self.mediators);
+        for _ in 0..self.mediators {
+            let mut builder = TestMediator::builder()
+                .enable_forwarding(true)
+                .enable_external_forwarding(true)
+                .global_acl_default(acl::allow_all())
+                .relay_mode(self.relay_mode);
+            if let Some(customize) = &self.customize {
+                builder = customize(builder);
+            }
+            let handle = builder
+                .spawn()
+                .await
+                .map_err(|e| TestTopologyError::Mediator(e.to_string()))?;
+            nodes.push(TestEnvironment::new(handle).await?);
+        }
+
+        Ok(TestTopology { nodes })
+    }
+}
+
+/// A spawned multi-mediator mesh. Each node is a [`TestEnvironment`] (mediator +
+/// SDK). Users are homed on a node by index; [`forward`](Self::forward) routes a
+/// message from a user on one node to a user on another via the routing-2.0
+/// double forward.
+pub struct TestTopology {
+    nodes: Vec<TestEnvironment>,
+}
+
+impl TestTopology {
+    /// Start building a topology.
+    pub fn builder() -> TestTopologyBuilder {
+        TestTopologyBuilder::default()
+    }
+
+    /// Number of mediators in the topology.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Always `false` — a spawned topology has at least one mediator. Present
+    /// for the `len`/`is_empty` lint pairing.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Borrow the [`TestEnvironment`] (mediator + SDK) for node `index`.
+    pub fn node(&self, index: usize) -> Result<&TestEnvironment, TestTopologyError> {
+        self.nodes
+            .get(index)
+            .ok_or(TestTopologyError::NodeOutOfRange {
+                index,
+                count: self.nodes.len(),
+            })
+    }
+
+    /// The `did:peer` of node `index`'s mediator.
+    pub fn mediator_did(&self, index: usize) -> Result<&str, TestTopologyError> {
+        Ok(self.node(index)?.mediator.did())
+    }
+
+    /// Add a user homed on node `index`, with its WebSocket live stream brought
+    /// up so cross-mediator forwards delivered to it surface in real time
+    /// (delivery over plain HTTP isn't unwrapped by the SDK's delivery-request
+    /// path, so the stream must be live before the forward arrives).
+    pub async fn add_user(&self, index: usize, alias: &str) -> Result<TestUser, TestTopologyError> {
+        let env = self.node(index)?;
+        let user = env.add_user(alias).await?;
+        env.atm
+            .profile_enable_websocket(&user.profile)
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+        Ok(user)
+    }
+
+    /// Route a basic message from `sender` (on `from_node`) to `recipient` (on
+    /// `to_node`) as the routing-2.0 double forward, then wait up to `wait` for
+    /// the recipient's live stream to surface the decrypted body.
+    ///
+    /// Returns the recipient's view of the message's `content` field, or `None`
+    /// if nothing arrived within `wait` (use a short `wait` for negative cases
+    /// that expect no delivery). The construction is: authcrypt for the
+    /// recipient, an INNER forward addressed to the recipient's mediator, an
+    /// OUTER forward addressed to the sender's own mediator (so it relays the
+    /// inner forward over the wire to the next hop), then send the outer forward
+    /// to the sender's mediator.
+    pub async fn forward(
+        &self,
+        from_node: usize,
+        sender: &TestUser,
+        to_node: usize,
+        recipient: &TestUser,
+        text: &str,
+        wait: Duration,
+    ) -> Result<Option<String>, TestTopologyError> {
+        let sender_env = self.node(from_node)?;
+        let recipient_env = self.node(to_node)?;
+        let sender_mediator_did = sender_env.mediator.did().to_string();
+        let recipient_mediator_did = recipient_env.mediator.did().to_string();
+
+        let now = unix_secs();
+        let msg = Message::build(
+            Uuid::new_v4().to_string(),
+            "https://didcomm.org/basicmessage/2.0/message".to_string(),
+            json!({ "content": text }),
+        )
+        .to(recipient.did.clone())
+        .from(sender.did.clone())
+        .created_time(now)
+        .expires_time(now + 60)
+        .finalize();
+        let msg_id = msg.id.clone();
+
+        let (packed, _) = sender_env
+            .atm
+            .pack_encrypted(&msg, &recipient.did, Some(&sender.did), Some(&sender.did))
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+
+        // INNER forward: encrypted for the recipient's mediator, next = recipient.
+        let (_inner_id, inner_fwd) = sender_env
+            .atm
+            .routing()
+            .forward_message(
+                &sender.profile,
+                false,
+                &packed,
+                &recipient_mediator_did,
+                &recipient.did,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+
+        // OUTER forward: encrypted for the sender's own mediator, next =
+        // recipient's mediator (so the sender's mediator relays the inner
+        // forward over the wire to the recipient's mediator).
+        let (_outer_id, outer_fwd) = sender_env
+            .atm
+            .routing()
+            .forward_message(
+                &sender.profile,
+                false,
+                &inner_fwd,
+                &sender_mediator_did,
+                &recipient_mediator_did,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+
+        sender_env
+            .atm
+            .send_message(&sender.profile, &outer_fwd, &msg_id, false, false)
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+
+        match recipient_env
+            .atm
+            .message_pickup()
+            .live_stream_get(&recipient.profile, &msg_id, wait, true)
+            .await
+        {
+            Ok(Some((received, _meta))) => Ok(received
+                .body
+                .get("content")
+                .and_then(|c| c.as_str())
+                .map(str::to_string)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Shut every mediator down, consuming the topology.
+    pub async fn shutdown(self) -> Result<(), TestTopologyError> {
+        for node in self.nodes {
+            node.shutdown()
+                .await
+                .map_err(|e| TestTopologyError::Mediator(e.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+fn unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/topology.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/topology.rs
@@ -1,0 +1,99 @@
+//! TI1 — multi-mediator [`TestTopology`] fixture.
+//!
+//! These are the first consumers of the topology fixture and the home for the
+//! pending #385/#388 relay e2e: a two-hop forward over the memory backend, and
+//! a rewrap-mode relay that must preserve the inner (recipient-addressed)
+//! envelope end to end. Both run as plain `#[tokio::test]` with no Redis and no
+//! external network — every identity is `did:peer`, so the only real socket
+//! traffic is the loopback `/inbound` hop between the two mediators.
+//!
+//! The single-mediator builder knobs (explicit trusted-peer allowlists, a
+//! non-relay posture) are exercised in `cross_mediator_forwarding.rs`; this file
+//! covers the fixture itself.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestTopology;
+use common::init_tracing;
+
+/// Alice on mediator 0 sends to Bob on mediator 1; the message must arrive
+/// having traversed both mediators, with no Redis. This is the routing-2.0
+/// double forward wrapped behind `TestTopology::forward`.
+#[tokio::test]
+async fn two_hop_forward_delivers_over_memory_backend() {
+    init_tracing();
+
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .spawn()
+        .await
+        .expect("spawn 2-mediator topology");
+
+    assert_eq!(topology.len(), 2);
+    assert_ne!(
+        topology.mediator_did(0).unwrap(),
+        topology.mediator_did(1).unwrap(),
+        "the two mediators must have distinct DIDs for a real cross-mediator hop"
+    );
+
+    let alice = topology
+        .add_user(0, "Alice")
+        .await
+        .expect("add Alice on node 0");
+    let bob = topology
+        .add_user(1, "Bob")
+        .await
+        .expect("add Bob on node 1");
+
+    let text = "Hello Bob — routed across two mediators via TestTopology.";
+    let received = topology
+        .forward(0, &alice, 1, &bob, text, Duration::from_secs(15))
+        .await
+        .expect("forward Alice -> Bob");
+
+    assert_eq!(
+        received.as_deref(),
+        Some(text),
+        "Bob should receive Alice's message after it routes node 0 -> node 1"
+    );
+
+    topology.shutdown().await.expect("shutdown topology");
+}
+
+/// Relay-REWRAP envelope preservation (#388): in rewrap mode each mediator
+/// re-encrypts the inter-mediator hop from itself to the next mediator, hiding
+/// the original sender on the wire — but the inner authcrypt addressed to Bob is
+/// preserved, so Bob still decrypts Alice's original content. (The on-wire
+/// rewrap crypto properties themselves are covered by the mediator crate's
+/// `tests/relay_rewrap.rs`; here we assert the end-to-end preservation through
+/// the fixture.)
+#[tokio::test]
+async fn rewrap_relay_preserves_inner_envelope_end_to_end() {
+    init_tracing();
+
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .rewrap()
+        .spawn()
+        .await
+        .expect("spawn 2-mediator rewrap topology");
+
+    let alice = topology.add_user(0, "Alice").await.expect("add Alice");
+    let bob = topology.add_user(1, "Bob").await.expect("add Bob");
+
+    let text = "Rewrapped across two mediators — inner envelope intact.";
+    let received = topology
+        .forward(0, &alice, 1, &bob, text, Duration::from_secs(15))
+        .await
+        .expect("forward Alice -> Bob in rewrap mode");
+
+    assert_eq!(
+        received.as_deref(),
+        Some(text),
+        "rewrap relay must preserve the inner envelope so Bob sees Alice's content"
+    );
+
+    topology.shutdown().await.expect("shutdown topology");
+}


### PR DESCRIPTION
## TI1 — multi-mediator `TestTopology` fixture

First of the remaining TI-series tasks (TI0 #439, TI2 #440 already merged). Priority 1 — the fixture the pending #385/#388 relay e2e has been waiting on.

### What
`affinidi-messaging-test-mediator` 0.2.9 → **0.2.10** (additive) adds `TestTopology`:
- `TestTopology::builder().mediators(N).spawn()` — spawns N in-process relay-enabled mediators (Blind or `.rewrap()`), each wired to its own SDK `TestEnvironment`.
- `.configure_each(|b| ...)` — per-node mediator-builder hook (e.g. swap in a Redis/Fjall store for multi-process coordination tests).
- `add_user(node, alias)` — adds a live (WS-enabled) user homed on a node.
- `forward(from_node, &sender, to_node, &recipient, text, wait)` — drives the routing-2.0 double forward and returns the recipient's decrypted content (or `None`).

**Audit win:** since every mediator/user identity is `did:peer:2.*` (service endpoint self-embedded), the plan's "cross-register DIDs in a shared resolver" is a no-op — all DIDs resolve locally, so the mediators form a fully-connected trust-any relay mesh with no registry and no Redis.

This generalises the double-forward that `tests/cross_mediator_forwarding.rs` hand-rolled six times.

### Tests
New `tests/topology.rs`:
- `two_hop_forward_delivers_over_memory_backend` — Alice@0 → Bob@1, no Redis.
- `rewrap_relay_preserves_inner_envelope_end_to_end` — #388: rewrap re-encrypts the wire hop but Bob still decrypts Alice's original content.

### Notes
- Promotes `serde_json` + `affinidi-messaging-didcomm` from dev-deps to deps (the `forward()` helper builds a `Message` in library code; the SDK doesn't re-export it).
- **Patch bump** (additive in 0.x) keeps `affinidi-messaging-didcomm-service`'s `"0.2"` pin valid — no cascade.

### Verification
- `tests/topology.rs` 2/2 pass; existing `cross_mediator_forwarding` 6/6 still pass (no regression).
- `cargo fmt --check` + `cargo clippy -D warnings` green.
- W17 guards green (version-bump confirms the 0.2.10 bump).

Remaining TI-series after this: TI4 (determinism — needs a clock-design spike), TI5 (credential scenario — home for W4/W5 negatives), TI7 (vector loader), TI3 (compose), TI6 (cookbook docs).
