### PR TITLE
feat: mdoc (COSE) + OID4VP present/verify flows on CredentialScenario (TI5b)

### DIFF
--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 ## 13th June 2026
 
+### 0.5.0 — mdoc (COSE) + OID4VP present/verify flows (TI5b)
+
+- `mdoc_scenario`: mdoc flows on `CredentialScenario` reusing the shared
+  issuer/holder/verifier identities — `issue_mdoc` (MSO signed with the issuer's
+  EdDSA COSE key, holder key bound into `deviceKeyInfo`), `present_mdoc` /
+  `present_mdoc_with_binding` (selective disclosure, optional device-auth holder
+  binding), and `verify_mdoc` / `verify_mdoc_with_alg` (`verify_issuer_auth` with
+  an EdDSA algorithm allowlist + digest checks). `session_transcript()` yields a
+  deterministic QR-engagement transcript for binding tests.
+- `oid4vp`: OID4VP present/verify flows carrying both eIDAS mandatory formats
+  through the authorization request/response envelope —
+  `oid4vp_present_sd_jwt` / `oid4vp_verify_sd_jwt` (`vp_token` = SD-JWT compact
+  serialization, KB-JWT bound to `client_id`/`nonce`) and `oid4vp_present_mdoc` /
+  `oid4vp_verify_mdoc` (`vp_token` = base64url(CBOR) `DeviceResponse` transport).
+  Envelope validation runs before the credential is cryptographically verified.
+- `Party` gains the COSE accessors `cose_signer` / `cose_verifier` /
+  `cose_signer_with_alg` / `device_cose_key`; `ScenarioError` gains `Mdoc` and
+  `Oid4vp` variants. Closes the credentials/protocols e2e gap for both eIDAS
+  formats (TI5 acceptance criteria).
+
+### 0.4.0 — shared test-vector layout + loader (TI7)
+
+- `vectors`: a documented `tests/vectors/<source>/…` convention plus a loader
+  (`load_json`, `load_str`, `load_json_dir`, `vectors_root`) so interop vectors
+  drop in without bespoke loader code. `affinidi-bbs` migrated onto it as the
+  reference. Supports the BBS-signing KAT and JOSE-crypto vector work.
+
+### 0.3.0 — CredentialScenario sd-jwt-vc fixture (TI5a)
+
+- `credential_scenario`: `CredentialScenario` stands up deterministic
+  issuer/holder/verifier `did:key` identities, an in-memory `BitstringStatusList`,
+  and a `StaticResolver` pre-populated with their DID documents. Helpers cover the
+  SD-JWT VC `issue → present → verify` round trip plus the W4/W5 negatives
+  (status-list revocation, holder-binding failure, disallowed `alg`). Ships
+  `Ed25519Signer` / `Ed25519Verifier` (the SD-JWT crate provides only an HMAC
+  test signer); the verifier enforces an algorithm allowlist before the signature.
+
 ### 0.2.0 — did:web/webvh mock server + StaticResolver (TI2)
 
 - `did_web::MockDidWebServer`: an in-process HTTP origin (ephemeral `127.0.0.1`

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.4.0"
+version = "0.5.0"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -47,6 +47,21 @@ affinidi-crypto = { version = "0.2", path = "../../core/affinidi-crypto" }
 ## sd-jwt crate ships only an HMAC test signer).
 ed25519-dalek = { version = "2" }
 base64 = "0.22"
+
+# ── TI5b: mdoc (COSE sign_mso/verify_issuer_auth) + OID4VP present/verify ──
+## mdoc issue/present/verify on the EdDSA COSE path; default-features off drops
+## the ES256/P-256 path the scenario's Ed25519 identities don't use.
+affinidi-mdoc = { version = "0.2", path = "../../credentials/affinidi-mdoc", default-features = false, features = [
+  "eddsa",
+] }
+## OID4VP authorization request/response + presentation-submission envelope.
+affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4vp" }
+## CBOR for mdoc attribute values + the fixture's DeviceResponse transport;
+## coset for the COSE_Sign1 (de)serialisation that transport round-trips.
+ciborium = "0.2"
+coset = "0.3"
+## `derive` backs the DeviceResponseTransport (de)serialisation.
+serde = { version = "1", features = ["derive"] }
 
 # Later tasks add their own deps as each harness lands:
 #   TI4  seeded did:peer + clock      → affinidi-tdk, secrets-resolver

--- a/crates/tdk/affinidi-tdk-test-support/README.md
+++ b/crates/tdk/affinidi-tdk-test-support/README.md
@@ -20,14 +20,15 @@ you don't want to stand up external services.
 
 ## Status
 
-Scaffold. Fixtures land per task in the TI-series (see `tasks/testing-todo.md`):
+Fixtures land per task in the TI-series (see `tasks/testing-todo.md`):
 
-| Task | Module        | Fixture                                                       |
-|------|---------------|---------------------------------------------------------------|
-| TI1  | `topology`    | Multi-mediator `TestTopology` (in-process, no Redis)          |
-| TI2  | `did_web`     | did:web / did:webvh mock server + injectable `StaticResolver` |
-| TI4  | `determinism` | Seeded did:peer generation + injectable clock                 |
-| TI5  | `credentials` | `CredentialScenario` (issuer / holder / verifier)             |
-| TI7  | `vectors`     | Shared `tests/vectors/` layout + loader                       |
+| Task  | Module                | Fixture                                                       | Status |
+|-------|-----------------------|---------------------------------------------------------------|:------:|
+| TI1   | `topology`            | Multi-mediator `TestTopology` (in-process, no Redis)          |  ⏳   |
+| TI2   | `did_web` / `resolver`| did:web / did:webvh mock server + injectable `StaticResolver` |  ✅   |
+| TI4   | `determinism`         | Seeded did:peer generation + injectable clock                 |  ⏳   |
+| TI5a  | `credential_scenario` | `CredentialScenario` SD-JWT VC issue / present / verify        |  ✅   |
+| TI5b  | `mdoc_scenario` / `oid4vp` | mdoc (COSE) flows + OID4VP present / verify (both eIDAS formats) |  ✅   |
+| TI7   | `vectors`             | Shared `tests/vectors/` layout + loader                       |  ✅   |
 
 [`affinidi-messaging-test-mediator`]: ../../messaging/affinidi-messaging-test-mediator

--- a/crates/tdk/affinidi-tdk-test-support/src/credential_scenario.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/credential_scenario.rs
@@ -47,6 +47,12 @@ use serde_json::{Value, json};
 
 use affinidi_crypto::did_key::ed25519_pub_to_did_key;
 use affinidi_did_common::DID;
+use affinidi_mdoc::{
+    cose::CoseSigner,
+    cose_key::CoseKey,
+    eddsa_cose::{EdDsaCoseSigner, EdDsaCoseVerifier},
+    error::Result as MdocResult,
+};
 use affinidi_sd_jwt::{
     SdJwt, SdJwtError,
     hasher::Sha256Hasher,
@@ -56,6 +62,7 @@ use affinidi_sd_jwt::{
 };
 use affinidi_status_list::bitstring::{BitstringStatusList, StatusPurpose};
 use affinidi_vc::sd_jwt_vc::{self, SdJwtVc};
+use coset::iana::Algorithm as CoseAlgorithm;
 
 use crate::resolver::StaticResolver;
 
@@ -73,6 +80,14 @@ pub enum ScenarioError {
     /// A status-list operation failed.
     #[error("status list: {0}")]
     Status(String),
+
+    /// An mdoc issue/present/verify call failed.
+    #[error("mdoc: {0}")]
+    Mdoc(String),
+
+    /// An OID4VP envelope (request/response) operation failed.
+    #[error("oid4vp: {0}")]
+    Oid4vp(String),
 
     /// A `did:key` failed to parse or resolve while building the resolver.
     #[error("did: {0}")]
@@ -203,6 +218,26 @@ impl JwtVerifier for Ed25519Verifier {
     }
 }
 
+/// A COSE signer that signs with an Ed25519 key but declares a caller-chosen
+/// algorithm in the protected header. The mdoc analogue of
+/// [`Ed25519Signer::with_alg`]: it lets a test forge an `issuerAuth` whose
+/// declared `alg` an allowlisting verifier should reject before checking the
+/// (otherwise valid) signature.
+pub struct ForgedAlgCoseSigner {
+    key: SigningKey,
+    alg: CoseAlgorithm,
+}
+
+impl CoseSigner for ForgedAlgCoseSigner {
+    fn algorithm(&self) -> CoseAlgorithm {
+        self.alg
+    }
+
+    fn sign(&self, data: &[u8]) -> MdocResult<Vec<u8>> {
+        Ok(self.key.sign(data).to_bytes().to_vec())
+    }
+}
+
 /// One party in a [`CredentialScenario`] — a deterministic Ed25519 `did:key`.
 pub struct Party {
     did: String,
@@ -239,6 +274,37 @@ impl Party {
     /// A verifier for this party's key, accepting only `allowed_algs`.
     pub fn verifier(&self, allowed_algs: &[&str]) -> Ed25519Verifier {
         Ed25519Verifier::new(self.key.verifying_key(), allowed_algs)
+    }
+
+    /// An `EdDSA` COSE signer for this party (the mdoc issuer / device signer),
+    /// with `kid` = its DID.
+    pub fn cose_signer(&self) -> EdDsaCoseSigner {
+        EdDsaCoseSigner::from_bytes(&self.key.to_bytes())
+            .expect("32-byte Ed25519 key is valid")
+            .with_kid(self.did.clone().into_bytes())
+    }
+
+    /// An `EdDSA` COSE verifier for this party's key.
+    pub fn cose_verifier(&self) -> EdDsaCoseVerifier {
+        EdDsaCoseVerifier::from_bytes(&self.key.verifying_key().to_bytes())
+            .expect("32-byte Ed25519 public key is valid")
+    }
+
+    /// A COSE signer that signs with this party's key but declares `alg` in the
+    /// protected header — for the disallowed-`alg` mdoc negative.
+    pub fn cose_signer_with_alg(&self, alg: CoseAlgorithm) -> ForgedAlgCoseSigner {
+        ForgedAlgCoseSigner {
+            key: self.key.clone(),
+            alg,
+        }
+    }
+
+    /// This party's public key as an mdoc device `COSE_Key` (OKP/Ed25519), for
+    /// the MSO `deviceKeyInfo` holder-binding slot.
+    pub fn device_cose_key(&self) -> ciborium::Value {
+        CoseKey::new_ed25519(self.key.verifying_key().to_bytes().to_vec())
+            .expect("32-byte Ed25519 public key is a valid COSE_Key")
+            .to_cbor_value()
     }
 }
 

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -21,11 +21,14 @@
  * - **TI2** — [`did_web`] / [`resolver`]: in-process did:web / did:webvh mock
  *   server with fault injection, plus an injectable `StaticResolver`. ✅
  * - **TI4** — `determinism`: seeded did:peer generation and an injectable clock.
- * - **TI5** — `credentials`: issuer/holder/verifier `CredentialScenario`.
- * - **TI7** — `vectors`: shared `tests/vectors/` layout and loader.
+ * - **TI5** — [`credential_scenario`]: issuer/holder/verifier `CredentialScenario`
+ *   for SD-JWT VC (TI5a) plus the [`mdoc_scenario`] and [`oid4vp`] flows (TI5b). ✅
+ * - **TI7** — [`vectors`]: shared `tests/vectors/` layout and loader. ✅
  */
 
 pub mod credential_scenario;
 pub mod did_web;
+pub mod mdoc_scenario;
+pub mod oid4vp;
 pub mod resolver;
 pub mod vectors;

--- a/crates/tdk/affinidi-tdk-test-support/src/mdoc_scenario.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/mdoc_scenario.rs
@@ -1,0 +1,190 @@
+/*!
+ * mdoc flows on the [`CredentialScenario`] (TI5b).
+ *
+ * Extends the shared issuer/holder/verifier fixture with the ISO/IEC 18013-5
+ * mdoc path: issue an mdoc whose Mobile Security Object is signed with the
+ * issuer's EdDSA COSE key (`sign_mso`), present a selective-disclosure
+ * `DeviceResponse` (optionally with a holder device signature), and verify
+ * `issuerAuth` (`verify_issuer_auth`) plus the disclosed digests.
+ *
+ * The same three [`crate::credential_scenario::Party`] identities back both the
+ * SD-JWT VC path (TI5a) and this mdoc path, so a test can exercise both eIDAS
+ * mandatory credential formats from one scenario. The issuer's Ed25519 key
+ * doubles as the EdDSA COSE signing key; the holder's public key is bound into
+ * the MSO `deviceKeyInfo` and used for device-auth holder binding.
+ *
+ * Like the SD-JWT verifier, [`CredentialScenario::verify_mdoc`] enforces an
+ * algorithm allowlist (EdDSA) on `issuerAuth` *before* the signature is checked
+ * — the W5 principle in the mdoc context, which is what makes the disallowed-
+ * `alg` negative ([`crate::credential_scenario::Party::cose_signer_with_alg`])
+ * expressible.
+ *
+ * ```
+ * use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+ * use serde_json::json;
+ * use std::collections::BTreeMap;
+ *
+ * let scenario = CredentialScenario::new();
+ * let mdoc = scenario
+ *     .issue_mdoc(
+ *         "eu.europa.ec.eudi.pid.1",
+ *         "eu.europa.ec.eudi.pid.1",
+ *         &json!({ "given_name": "Erika", "age_over_18": true }),
+ *     )
+ *     .unwrap();
+ *
+ * let mut requested = BTreeMap::new();
+ * requested.insert("eu.europa.ec.eudi.pid.1".to_string(), vec!["age_over_18".to_string()]);
+ * let response = scenario.present_mdoc(&mdoc, &requested).unwrap();
+ *
+ * let mso = scenario.verify_mdoc(&response).unwrap();
+ * assert_eq!(mso.doc_type, "eu.europa.ec.eudi.pid.1");
+ * ```
+ */
+
+use std::collections::BTreeMap;
+
+use affinidi_mdoc::{
+    DeviceResponse, IssuerSigned, MdocBuilder, MobileSecurityObject, SessionTranscript,
+    ValidityInfo, cose::CoseSigner, cose::verify_issuer_auth_with_alg,
+    device_engagement::DeviceEngagement,
+};
+use coset::iana::Algorithm as CoseAlgorithm;
+
+use crate::credential_scenario::{CredentialScenario, ScenarioError};
+
+impl CredentialScenario {
+    /// Issue an mdoc credential: each entry of the `claims` JSON object becomes
+    /// an attribute in `namespace`, the MSO is signed with the issuer's EdDSA
+    /// COSE key, and the holder's public key is bound into `deviceKeyInfo`.
+    pub fn issue_mdoc(
+        &self,
+        doc_type: &str,
+        namespace: &str,
+        claims: &serde_json::Value,
+    ) -> Result<IssuerSigned, ScenarioError> {
+        self.issue_mdoc_with_signer(&self.issuer.cose_signer(), doc_type, namespace, claims)
+    }
+
+    /// Issue with a caller-supplied COSE signer — e.g. a forged-`alg` signer
+    /// (`self.issuer.cose_signer_with_alg(..)`) for the disallowed-`alg`
+    /// negative.
+    pub fn issue_mdoc_with_signer(
+        &self,
+        signer: &dyn CoseSigner,
+        doc_type: &str,
+        namespace: &str,
+        claims: &serde_json::Value,
+    ) -> Result<IssuerSigned, ScenarioError> {
+        let object = claims
+            .as_object()
+            .ok_or_else(|| ScenarioError::Mdoc("mdoc claims must be a JSON object".to_string()))?;
+        let mut builder = MdocBuilder::new(doc_type)
+            .device_key(self.holder.device_cose_key())
+            .validity(default_validity());
+        for (id, value) in object {
+            builder = builder.add_json_attribute(namespace, id, value);
+        }
+        builder
+            .build(signer)
+            .map_err(|e| ScenarioError::Mdoc(e.to_string()))
+    }
+
+    /// Holder presents the `requested` attributes (per namespace) with no device
+    /// signature — issuer-signed selective disclosure only.
+    pub fn present_mdoc(
+        &self,
+        mdoc: &IssuerSigned,
+        requested: &BTreeMap<String, Vec<String>>,
+    ) -> Result<DeviceResponse, ScenarioError> {
+        DeviceResponse::create(mdoc, requested).map_err(|e| ScenarioError::Mdoc(e.to_string()))
+    }
+
+    /// Holder presents with a device signature (holder binding): the device key
+    /// signs `DeviceAuthentication` over `transcript`.
+    pub fn present_mdoc_with_binding(
+        &self,
+        mdoc: &IssuerSigned,
+        requested: &BTreeMap<String, Vec<String>>,
+        transcript: &SessionTranscript,
+    ) -> Result<DeviceResponse, ScenarioError> {
+        DeviceResponse::create_with_device_auth(
+            mdoc,
+            requested,
+            transcript,
+            &self.holder.cose_signer(),
+            None,
+        )
+        .map_err(|e| ScenarioError::Mdoc(e.to_string()))
+    }
+
+    /// Verify a device response with the issuer's key and the EdDSA allowlist:
+    /// `issuerAuth` algorithm + signature, then every disclosed digest. Returns
+    /// the decoded MSO. The default for the happy path; use
+    /// [`verify_mdoc_with_alg`](Self::verify_mdoc_with_alg) to assert a
+    /// different declared algorithm.
+    pub fn verify_mdoc(
+        &self,
+        response: &DeviceResponse,
+    ) -> Result<MobileSecurityObject, ScenarioError> {
+        self.verify_mdoc_with_alg(response, CoseAlgorithm::EdDSA)
+    }
+
+    /// Verify a device response requiring `expected_alg` in the `issuerAuth`
+    /// protected header — the algorithm is checked *before* the signature, so a
+    /// credential whose declared `alg` is outside the allowlist is rejected even
+    /// though its signature is otherwise valid.
+    pub fn verify_mdoc_with_alg(
+        &self,
+        response: &DeviceResponse,
+        expected_alg: CoseAlgorithm,
+    ) -> Result<MobileSecurityObject, ScenarioError> {
+        let mso = verify_issuer_auth_with_alg(
+            &response.issuer_auth,
+            &self.issuer.cose_verifier(),
+            expected_alg,
+        )
+        .map_err(|e| ScenarioError::Mdoc(e.to_string()))?;
+        if !response
+            .verify_digests()
+            .map_err(|e| ScenarioError::Mdoc(e.to_string()))?
+        {
+            return Err(ScenarioError::Mdoc(
+                "a disclosed item's digest does not match the MSO".to_string(),
+            ));
+        }
+        Ok(mso)
+    }
+
+    /// Verify the holder's device signature against `transcript` and the holder
+    /// key. For the wrong-key negative, call
+    /// [`DeviceResponse::verify_device_auth`] directly with another party's
+    /// [`cose_verifier`](crate::credential_scenario::Party::cose_verifier).
+    pub fn verify_mdoc_binding(
+        &self,
+        response: &DeviceResponse,
+        transcript: &SessionTranscript,
+    ) -> Result<bool, ScenarioError> {
+        response
+            .verify_device_auth(transcript, &self.holder.cose_verifier())
+            .map_err(|e| ScenarioError::Mdoc(e.to_string()))
+    }
+
+    /// A deterministic QR-engagement [`SessionTranscript`] for holder-binding
+    /// tests (empty device / reader keys — fixed across runs).
+    pub fn session_transcript(&self) -> Result<SessionTranscript, ScenarioError> {
+        let engagement = DeviceEngagement::new(ciborium::Value::Map(vec![]))
+            .map_err(|e| ScenarioError::Mdoc(e.to_string()))?;
+        SessionTranscript::new_qr(&engagement, ciborium::Value::Map(vec![]))
+            .map_err(|e| ScenarioError::Mdoc(e.to_string()))
+    }
+}
+
+/// Fixed validity window for fixture mdocs (TEST-ONLY; dates are arbitrary).
+fn default_validity() -> ValidityInfo {
+    ValidityInfo {
+        signed: "2024-06-15T12:00:00Z".to_string(),
+        valid_from: "2024-06-15T12:00:00Z".to_string(),
+        valid_until: "2034-06-15T12:00:00Z".to_string(),
+    }
+}

--- a/crates/tdk/affinidi-tdk-test-support/src/oid4vp.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/oid4vp.rs
@@ -1,0 +1,269 @@
+/*!
+ * OpenID4VP present/verify flows on the [`CredentialScenario`] (TI5b).
+ *
+ * Wires the scenario's credentials into the OID4VP authorization
+ * request/response envelope (from `affinidi-openid4vp`) so an issue → present →
+ * verify round trip can be driven through OID4VP rather than as a bare crypto
+ * call. Both eIDAS mandatory formats are covered:
+ *
+ * - **`vc+sd-jwt`** — the `vp_token` is the SD-JWT VC's compact serialization
+ *   (`<issuer-jwt>~<disclosure>~…~<kb-jwt>`), exactly the OID4VP wire form. The
+ *   KB-JWT is bound to the request's `client_id` (audience) and `nonce`.
+ * - **`mso_mdoc`** — the `vp_token` is a base64url-encoded CBOR transport of the
+ *   mdoc [`DeviceResponse`] (see [`encode_device_response`]).
+ *
+ * On the verifier side, [`CredentialScenario::oid4vp_verify_sd_jwt`] /
+ * [`oid4vp_verify_mdoc`](CredentialScenario::oid4vp_verify_mdoc) first validate
+ * the envelope (definition id, state, non-empty descriptor map) with
+ * `affinidi-openid4vp`, then cryptographically verify the carried credential
+ * with the scenario's verifiers — so an envelope that parses but carries an
+ * invalid or replayed credential is still rejected.
+ *
+ * ```
+ * use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+ * use affinidi_openid4vp::{PresentationDefinition, verifier::create_input_descriptor};
+ * use serde_json::json;
+ *
+ * let scenario = CredentialScenario::new();
+ * let definition = PresentationDefinition {
+ *     id: "pd-1".into(),
+ *     name: None,
+ *     purpose: None,
+ *     input_descriptors: vec![create_input_descriptor("cred", "identity", vec![("given_name", None)])],
+ *     submission_requirements: None,
+ *     format: None,
+ * };
+ * let request = scenario.oid4vp_request("https://verifier.example", "nonce-1", definition);
+ *
+ * let vc = scenario
+ *     .issue_sd_jwt_vc(
+ *         "https://example.com/IdentityCredential",
+ *         &json!({ "given_name": "Alice" }),
+ *         &json!({ "_sd": ["given_name"] }),
+ *     )
+ *     .unwrap();
+ * let response = scenario.oid4vp_present_sd_jwt(&request, &vc, &["given_name"]).unwrap();
+ * let result = scenario.oid4vp_verify_sd_jwt(&request, &response).unwrap();
+ * assert!(result.is_verified());
+ * ```
+ */
+
+use std::collections::BTreeMap;
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use affinidi_mdoc::{
+    DeviceResponse, IssuerSigned, IssuerSignedItem, MobileSecurityObject, Tag24,
+    cose::verify_issuer_auth_with_alg,
+};
+use affinidi_openid4vp::{
+    AuthorizationRequest, AuthorizationResponse, PresentationDefinition,
+    verifier::{create_authorization_request, validate_authorization_response},
+    wallet::{build_authorization_response, build_presentation_submission},
+};
+use affinidi_sd_jwt::{SdJwt, hasher::Sha256Hasher, verifier::VerificationResult};
+use affinidi_vc::sd_jwt_vc::SdJwtVc;
+use coset::{CborSerializable, CoseSign1, iana::Algorithm as CoseAlgorithm};
+
+use crate::credential_scenario::{CredentialScenario, ScenarioError};
+
+/// OID4VP credential-format identifier for SD-JWT VC.
+pub const FORMAT_SD_JWT_VC: &str = "vc+sd-jwt";
+/// OID4VP credential-format identifier for ISO mdoc.
+pub const FORMAT_MSO_MDOC: &str = "mso_mdoc";
+
+/// Disclosed mdoc items, grouped by namespace (Tag24-wrapped per ISO 18013-5).
+type DisclosedNamespaces = BTreeMap<String, Vec<Tag24<IssuerSignedItem>>>;
+
+impl CredentialScenario {
+    /// Build a verifier OID4VP authorization request (`response_type=vp_token`,
+    /// `direct_post`) for `definition`. The `client_id` is the KB-JWT audience
+    /// and `nonce` the replay nonce a holder must echo.
+    pub fn oid4vp_request(
+        &self,
+        client_id: &str,
+        nonce: &str,
+        definition: PresentationDefinition,
+    ) -> AuthorizationRequest {
+        let redirect_uri = format!("{client_id}/callback");
+        create_authorization_request(client_id, &redirect_uri, nonce, definition)
+    }
+
+    /// Holder answers `request` by presenting an SD-JWT VC, revealing `reveal`.
+    /// The KB-JWT is bound to the request's `client_id` and `nonce`; the result
+    /// is an [`AuthorizationResponse`] with a `vc+sd-jwt` `vp_token`.
+    pub fn oid4vp_present_sd_jwt(
+        &self,
+        request: &AuthorizationRequest,
+        vc: &SdJwtVc,
+        reveal: &[&str],
+    ) -> Result<AuthorizationResponse, ScenarioError> {
+        let presentation = self.present(vc, reveal, &request.client_id, &request.nonce)?;
+        let vp_token = Value::String(presentation.serialize());
+        let submission = build_presentation_submission(
+            definition_id(request)?,
+            vec![(descriptor_id(request)?, FORMAT_SD_JWT_VC, "$")],
+        );
+        Ok(build_authorization_response(
+            vp_token,
+            submission,
+            request.state.clone(),
+        ))
+    }
+
+    /// Verifier validates the OID4VP envelope and cryptographically verifies the
+    /// SD-JWT VC carried in the `vp_token` (issuer signature, KB-JWT binding to
+    /// `client_id`/`nonce`, EdDSA allowlist). Returns the verification result.
+    pub fn oid4vp_verify_sd_jwt(
+        &self,
+        request: &AuthorizationRequest,
+        response: &AuthorizationResponse,
+    ) -> Result<VerificationResult, ScenarioError> {
+        validate_authorization_response(
+            response,
+            definition_id(request)?,
+            request.state.as_deref(),
+        )
+        .map_err(|e| ScenarioError::Oid4vp(e.to_string()))?;
+        let token = vp_token_str(response)?;
+        let presentation =
+            SdJwt::parse(token, &Sha256Hasher).map_err(|e| ScenarioError::SdJwt(e.to_string()))?;
+        self.verify(&presentation, &request.client_id, &request.nonce)
+    }
+
+    /// Holder answers `request` by presenting an mdoc, revealing `requested`
+    /// (per namespace). The [`DeviceResponse`] is CBOR-encoded and
+    /// base64url-wrapped as an `mso_mdoc` `vp_token`.
+    pub fn oid4vp_present_mdoc(
+        &self,
+        request: &AuthorizationRequest,
+        mdoc: &IssuerSigned,
+        requested: &BTreeMap<String, Vec<String>>,
+    ) -> Result<AuthorizationResponse, ScenarioError> {
+        let device_response = self.present_mdoc(mdoc, requested)?;
+        let vp_token = Value::String(encode_device_response(&device_response)?);
+        let submission = build_presentation_submission(
+            definition_id(request)?,
+            vec![(descriptor_id(request)?, FORMAT_MSO_MDOC, "$")],
+        );
+        Ok(build_authorization_response(
+            vp_token,
+            submission,
+            request.state.clone(),
+        ))
+    }
+
+    /// Verifier validates the OID4VP envelope, decodes the mdoc `vp_token`, and
+    /// verifies `issuerAuth` (EdDSA allowlist) plus every disclosed digest.
+    /// Returns the decoded MSO.
+    pub fn oid4vp_verify_mdoc(
+        &self,
+        request: &AuthorizationRequest,
+        response: &AuthorizationResponse,
+    ) -> Result<MobileSecurityObject, ScenarioError> {
+        validate_authorization_response(
+            response,
+            definition_id(request)?,
+            request.state.as_deref(),
+        )
+        .map_err(|e| ScenarioError::Oid4vp(e.to_string()))?;
+        let token = vp_token_str(response)?;
+        let (issuer_auth, disclosed) = decode_device_response(token)?;
+        let mso = verify_issuer_auth_with_alg(
+            &issuer_auth,
+            &self.issuer.cose_verifier(),
+            CoseAlgorithm::EdDSA,
+        )
+        .map_err(|e| ScenarioError::Mdoc(e.to_string()))?;
+        for (namespace, items) in &disclosed {
+            for item in items {
+                if !mso
+                    .verify_item_digest(namespace, &item.inner)
+                    .map_err(|e| ScenarioError::Mdoc(e.to_string()))?
+                {
+                    return Err(ScenarioError::Mdoc(
+                        "a disclosed item's digest does not match the MSO".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(mso)
+    }
+}
+
+// ── OID4VP envelope helpers ──────────────────────────────────────────────────
+
+fn definition_id(request: &AuthorizationRequest) -> Result<&str, ScenarioError> {
+    request
+        .presentation_definition
+        .as_ref()
+        .map(|d| d.id.as_str())
+        .ok_or_else(|| ScenarioError::Oid4vp("request has no presentation_definition".to_string()))
+}
+
+fn descriptor_id(request: &AuthorizationRequest) -> Result<&str, ScenarioError> {
+    request
+        .presentation_definition
+        .as_ref()
+        .and_then(|d| d.input_descriptors.first())
+        .map(|d| d.id.as_str())
+        .ok_or_else(|| ScenarioError::Oid4vp("request has no input descriptor".to_string()))
+}
+
+fn vp_token_str(response: &AuthorizationResponse) -> Result<&str, ScenarioError> {
+    response
+        .vp_token
+        .as_str()
+        .ok_or_else(|| ScenarioError::Oid4vp("vp_token is not a string".to_string()))
+}
+
+// ── mdoc DeviceResponse transport ────────────────────────────────────────────
+
+/// The fixture's wire encoding of a [`DeviceResponse`] for the `mso_mdoc`
+/// `vp_token`. This is a **test transport**, not the ISO/IEC 18013-7
+/// `DeviceResponse` CBOR (there is no SessionTranscript / OID4VP handover
+/// binding) — it carries just enough (the issuer-signed COSE_Sign1 and the
+/// disclosed items) to round-trip the credential through the OID4VP envelope and
+/// re-verify it.
+#[derive(Serialize, Deserialize)]
+struct DeviceResponseTransport {
+    version: String,
+    doc_type: String,
+    issuer_auth: Vec<u8>,
+    namespaces: BTreeMap<String, Vec<Tag24<IssuerSignedItem>>>,
+    status: u32,
+}
+
+/// Encode a [`DeviceResponse`] as the base64url(CBOR) `mso_mdoc` `vp_token`.
+pub fn encode_device_response(response: &DeviceResponse) -> Result<String, ScenarioError> {
+    let issuer_auth = response
+        .issuer_auth
+        .clone()
+        .to_vec()
+        .map_err(|e| ScenarioError::Mdoc(format!("issuerAuth encode: {e}")))?;
+    let transport = DeviceResponseTransport {
+        version: response.version.clone(),
+        doc_type: response.doc_type.clone(),
+        issuer_auth,
+        namespaces: response.disclosed.clone(),
+        status: response.status,
+    };
+    let mut buf = Vec::new();
+    ciborium::into_writer(&transport, &mut buf)
+        .map_err(|e| ScenarioError::Mdoc(format!("DeviceResponse encode: {e}")))?;
+    Ok(URL_SAFE_NO_PAD.encode(buf))
+}
+
+/// Decode an `mso_mdoc` `vp_token` into its `issuerAuth` and disclosed items.
+fn decode_device_response(token: &str) -> Result<(CoseSign1, DisclosedNamespaces), ScenarioError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(token)
+        .map_err(|e| ScenarioError::Mdoc(format!("vp_token base64: {e}")))?;
+    let transport: DeviceResponseTransport = ciborium::from_reader(&bytes[..])
+        .map_err(|e| ScenarioError::Mdoc(format!("DeviceResponse decode: {e}")))?;
+    let issuer_auth = CoseSign1::from_slice(&transport.issuer_auth)
+        .map_err(|e| ScenarioError::Mdoc(format!("issuerAuth decode: {e}")))?;
+    Ok((issuer_auth, transport.namespaces))
+}

--- a/crates/tdk/affinidi-tdk-test-support/tests/mdoc_scenario.rs
+++ b/crates/tdk/affinidi-tdk-test-support/tests/mdoc_scenario.rs
@@ -1,0 +1,139 @@
+//! TI5b — `CredentialScenario` mdoc COSE flows: the issue → present → verify
+//! round trip (`sign_mso` / `verify_issuer_auth`), selective disclosure, holder
+//! binding via device auth, and the wrong-key / disallowed-`alg` negatives. All
+//! synchronous, no network.
+
+use std::collections::BTreeMap;
+
+use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+use coset::iana::Algorithm;
+use serde_json::json;
+
+const DOC_TYPE: &str = "eu.europa.ec.eudi.pid.1";
+const NS: &str = "eu.europa.ec.eudi.pid.1";
+
+fn pid_claims() -> serde_json::Value {
+    json!({
+        "family_name": "Mueller",
+        "given_name": "Erika",
+        "birth_date": "1964-08-12",
+        "age_over_18": true,
+        "nationality": "DE",
+    })
+}
+
+fn request(namespace: &str, names: &[&str]) -> BTreeMap<String, Vec<String>> {
+    let mut requested = BTreeMap::new();
+    requested.insert(
+        namespace.to_string(),
+        names.iter().map(|s| s.to_string()).collect(),
+    );
+    requested
+}
+
+/// Happy path: issue, present a subset, verify issuer auth + digests, and
+/// selective disclosure holds (only requested attributes are present).
+#[test]
+fn mdoc_issue_present_verify_round_trip() {
+    let scenario = CredentialScenario::new();
+
+    let mdoc = scenario
+        .issue_mdoc(DOC_TYPE, NS, &pid_claims())
+        .expect("issue mdoc");
+
+    let response = scenario
+        .present_mdoc(&mdoc, &request(NS, &["age_over_18", "nationality"]))
+        .expect("present subset");
+
+    let mso = scenario.verify_mdoc(&response).expect("verify mdoc");
+    assert_eq!(mso.doc_type, DOC_TYPE);
+
+    // Only the requested attributes are disclosed.
+    let disclosed = response.disclosed_names(NS);
+    assert_eq!(disclosed.len(), 2);
+    assert!(disclosed.contains(&"age_over_18"));
+    assert!(disclosed.contains(&"nationality"));
+    assert!(!disclosed.contains(&"family_name"));
+}
+
+/// Holder binding: a device-signed presentation verifies against the holder
+/// key, and fails against any other party's key.
+#[test]
+fn mdoc_holder_binding_succeeds_and_wrong_key_fails() {
+    let scenario = CredentialScenario::new();
+    let transcript = scenario.session_transcript().expect("transcript");
+
+    let mdoc = scenario
+        .issue_mdoc(DOC_TYPE, NS, &pid_claims())
+        .expect("issue");
+    let response = scenario
+        .present_mdoc_with_binding(&mdoc, &request(NS, &["given_name"]), &transcript)
+        .expect("present with binding");
+
+    // Issuer auth still verifies, and the device signature checks out.
+    scenario.verify_mdoc(&response).expect("issuer auth");
+    assert!(
+        scenario
+            .verify_mdoc_binding(&response, &transcript)
+            .expect("device auth"),
+        "device signature must verify against the holder key"
+    );
+
+    // The same signature must NOT verify against the issuer's key.
+    let wrong = response.verify_device_auth(&transcript, &scenario.issuer.cose_verifier());
+    assert!(
+        wrong.is_err() || !wrong.unwrap(),
+        "device auth must fail against the wrong key"
+    );
+}
+
+/// Negative: an mdoc signed by the issuer must not verify against another
+/// party's key (the wrong issuer-auth key).
+#[test]
+fn mdoc_wrong_issuer_key_fails() {
+    let scenario = CredentialScenario::new();
+    let mdoc = scenario
+        .issue_mdoc(DOC_TYPE, NS, &pid_claims())
+        .expect("issue");
+    let response = scenario
+        .present_mdoc(&mdoc, &request(NS, &["given_name"]))
+        .expect("present");
+
+    // Verify issuerAuth against the holder's key instead of the issuer's.
+    let result = response.verify_issuer_auth(&scenario.holder.cose_verifier());
+    assert!(
+        result.is_err(),
+        "issuerAuth verified against the wrong key must fail"
+    );
+}
+
+/// Negative (W5 in the mdoc context): an `issuerAuth` whose protected header
+/// declares a disallowed `alg` is rejected before the signature is checked.
+#[test]
+fn mdoc_disallowed_alg_is_rejected() {
+    let scenario = CredentialScenario::new();
+
+    // Sign with Ed25519 but forge the protected-header `alg` as ES256.
+    let forged = scenario.issuer.cose_signer_with_alg(Algorithm::ES256);
+    let mdoc = scenario
+        .issue_mdoc_with_signer(&forged, DOC_TYPE, NS, &pid_claims())
+        .expect("issue with forged alg");
+    let response = scenario
+        .present_mdoc(&mdoc, &request(NS, &["given_name"]))
+        .expect("present");
+
+    // Default verify enforces EdDSA → the ES256-declared issuerAuth is rejected
+    // on the algorithm check, before any signature verification.
+    assert!(
+        scenario.verify_mdoc(&response).is_err(),
+        "an issuerAuth alg outside the allowlist must be rejected"
+    );
+
+    // Sanity: the same credential verifies once ES256 is the expected alg,
+    // proving it's the allowlist — not a broken signature — doing the rejecting.
+    let allowed = scenario.verify_mdoc_with_alg(&response, Algorithm::ES256);
+    assert!(
+        allowed.is_ok(),
+        "ES256-expected verify should accept the Ed25519 signature"
+    );
+}

--- a/crates/tdk/affinidi-tdk-test-support/tests/oid4vp_flow.rs
+++ b/crates/tdk/affinidi-tdk-test-support/tests/oid4vp_flow.rs
@@ -1,0 +1,171 @@
+//! TI5b — OID4VP present/verify flows on `CredentialScenario`: both eIDAS
+//! mandatory formats (`vc+sd-jwt` and `mso_mdoc`) carried through the OID4VP
+//! authorization request/response envelope, plus the nonce-replay and
+//! envelope-mismatch negatives. All synchronous, no network.
+
+use std::collections::BTreeMap;
+
+use affinidi_openid4vp::{PresentationDefinition, verifier::create_input_descriptor};
+use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+use serde_json::json;
+
+const CLIENT_ID: &str = "https://verifier.example";
+const NONCE: &str = "oid4vp-nonce-1";
+const VCT: &str = "https://example.com/IdentityCredential";
+const DOC_TYPE: &str = "eu.europa.ec.eudi.pid.1";
+const NS: &str = "eu.europa.ec.eudi.pid.1";
+
+fn definition(id: &str) -> PresentationDefinition {
+    PresentationDefinition {
+        id: id.to_string(),
+        name: None,
+        purpose: Some("identity".to_string()),
+        input_descriptors: vec![create_input_descriptor(
+            "credential",
+            "identity",
+            vec![("given_name", None)],
+        )],
+        submission_requirements: None,
+        format: None,
+    }
+}
+
+fn sd_jwt_claims() -> serde_json::Value {
+    json!({ "given_name": "Alice", "family_name": "Smith", "email": "alice@example.com" })
+}
+
+fn sd_frame() -> serde_json::Value {
+    json!({ "_sd": ["given_name", "family_name", "email"] })
+}
+
+fn mdoc_request(namespace: &str, names: &[&str]) -> BTreeMap<String, Vec<String>> {
+    let mut requested = BTreeMap::new();
+    requested.insert(
+        namespace.to_string(),
+        names.iter().map(|s| s.to_string()).collect(),
+    );
+    requested
+}
+
+/// SD-JWT VC over OID4VP: verifier requests, holder presents (vp_token = SD-JWT
+/// compact serialization), verifier validates the envelope and verifies the
+/// credential.
+#[test]
+fn oid4vp_sd_jwt_round_trip() {
+    let scenario = CredentialScenario::new();
+    let request = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-sd-jwt"));
+
+    let vc = scenario
+        .issue_sd_jwt_vc(VCT, &sd_jwt_claims(), &sd_frame())
+        .expect("issue sd-jwt-vc");
+    let response = scenario
+        .oid4vp_present_sd_jwt(&request, &vc, &["given_name"])
+        .expect("present over oid4vp");
+
+    let result = scenario
+        .oid4vp_verify_sd_jwt(&request, &response)
+        .expect("verify over oid4vp");
+    assert!(result.is_verified());
+    assert_eq!(
+        result.claims.get("given_name").and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+    // Withheld selectively-disclosable claims must not surface.
+    assert!(result.claims.get("email").is_none());
+}
+
+/// Negative: a presentation bound to one nonce must be rejected when the
+/// verifier checks it against a request carrying a different nonce (replay /
+/// freshness binding), even though the envelope itself is well-formed.
+#[test]
+fn oid4vp_sd_jwt_nonce_mismatch_is_rejected() {
+    let scenario = CredentialScenario::new();
+    let request = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-sd-jwt"));
+
+    let vc = scenario
+        .issue_sd_jwt_vc(VCT, &sd_jwt_claims(), &sd_frame())
+        .expect("issue");
+    let response = scenario
+        .oid4vp_present_sd_jwt(&request, &vc, &["given_name"])
+        .expect("present");
+
+    // Same client_id + definition (envelope validates) but a different nonce →
+    // the KB-JWT nonce check fails.
+    let stale = scenario.oid4vp_request(CLIENT_ID, "different-nonce", definition("pd-sd-jwt"));
+    assert!(
+        scenario.oid4vp_verify_sd_jwt(&stale, &response).is_err(),
+        "a nonce mismatch must be rejected"
+    );
+}
+
+/// Negative: an envelope referencing the wrong presentation definition is
+/// rejected by envelope validation before any credential check.
+#[test]
+fn oid4vp_definition_mismatch_is_rejected() {
+    let scenario = CredentialScenario::new();
+    let request = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-sd-jwt"));
+
+    let vc = scenario
+        .issue_sd_jwt_vc(VCT, &sd_jwt_claims(), &sd_frame())
+        .expect("issue");
+    let response = scenario
+        .oid4vp_present_sd_jwt(&request, &vc, &["given_name"])
+        .expect("present");
+
+    let other = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-other"));
+    assert!(
+        scenario.oid4vp_verify_sd_jwt(&other, &response).is_err(),
+        "a definition_id mismatch must be rejected by envelope validation"
+    );
+}
+
+/// mdoc over OID4VP: verifier requests, holder presents (vp_token =
+/// base64url(CBOR(DeviceResponse))), verifier validates the envelope and
+/// verifies issuer auth + digests.
+#[test]
+fn oid4vp_mdoc_round_trip() {
+    let scenario = CredentialScenario::new();
+    let request = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-mdoc"));
+
+    let mdoc = scenario
+        .issue_mdoc(
+            DOC_TYPE,
+            NS,
+            &json!({ "given_name": "Erika", "age_over_18": true, "nationality": "DE" }),
+        )
+        .expect("issue mdoc");
+    let response = scenario
+        .oid4vp_present_mdoc(
+            &request,
+            &mdoc,
+            &mdoc_request(NS, &["given_name", "age_over_18"]),
+        )
+        .expect("present mdoc over oid4vp");
+
+    let mso = scenario
+        .oid4vp_verify_mdoc(&request, &response)
+        .expect("verify mdoc over oid4vp");
+    assert_eq!(mso.doc_type, DOC_TYPE);
+}
+
+/// Negative: a tampered `mso_mdoc` vp_token fails decoding/verification while
+/// the surrounding envelope still validates.
+#[test]
+fn oid4vp_mdoc_tampered_token_is_rejected() {
+    let scenario = CredentialScenario::new();
+    let request = scenario.oid4vp_request(CLIENT_ID, NONCE, definition("pd-mdoc"));
+
+    let mdoc = scenario
+        .issue_mdoc(DOC_TYPE, NS, &json!({ "given_name": "Erika" }))
+        .expect("issue");
+    let mut response = scenario
+        .oid4vp_present_mdoc(&request, &mdoc, &mdoc_request(NS, &["given_name"]))
+        .expect("present");
+
+    // Corrupt the vp_token (not valid base64url) — the envelope is untouched.
+    response.vp_token = serde_json::Value::String("!!!not-base64!!!".to_string());
+    assert!(
+        scenario.oid4vp_verify_mdoc(&request, &response).is_err(),
+        "a tampered vp_token must be rejected"
+    );
+}


### PR DESCRIPTION
## TI5b — mdoc + OID4VP flows on `CredentialScenario`

Completes **TI5** by extending the shared issuer/holder/verifier `CredentialScenario` (TI5a, SD-JWT VC) across the ISO mdoc path and the OID4VP envelope — closing the credentials/protocols e2e gap for **both eIDAS mandatory credential formats**. `affinidi-tdk-test-support` 0.4.0 → 0.5.0 (additive; `publish = false`, so the release guard skips it).

### mdoc (`mdoc_scenario`) — COSE `sign_mso` / `verify_issuer_auth`
- `issue_mdoc` / `issue_mdoc_with_signer` — MSO signed with the issuer's **EdDSA COSE key** (the party's Ed25519 key reused via `EdDsaCoseSigner::from_bytes`); the holder's public key is bound into the MSO `deviceKeyInfo` as an OKP `COSE_Key`.
- `present_mdoc` / `present_mdoc_with_binding` — selective-disclosure `DeviceResponse`, optionally with a device-auth holder signature over a deterministic QR `SessionTranscript`.
- `verify_mdoc` / `verify_mdoc_with_alg` — `verify_issuer_auth_with_alg` enforcing an **EdDSA algorithm allowlist before the signature** (the W5 principle in the mdoc context) plus per-item digest checks; `verify_mdoc_binding`; `session_transcript`.

### OID4VP (`oid4vp`) — present/verify for both formats
- `oid4vp_present_sd_jwt` / `oid4vp_verify_sd_jwt` — `vp_token` is the SD-JWT compact serialization (the actual OID4VP wire form); KB-JWT bound to the request's `client_id` (audience) and `nonce`.
- `oid4vp_present_mdoc` / `oid4vp_verify_mdoc` — `vp_token` is a base64url(CBOR) `DeviceResponse` **fixture transport** (documented as *not* the ISO 18013-7 wire form — no SessionTranscript/handover binding; enough to round-trip + re-verify the credential).
- Envelope validation (`affinidi-openid4vp::validate_authorization_response`) runs **before** the carried credential is cryptographically verified — `affinidi-openid4vp` is envelope-only (`vp_token: Value`), so the fixture pairs envelope-validate with real crypto verify.

### Supporting changes
- `Party` gains `cose_signer` / `cose_verifier` / `cose_signer_with_alg` / `device_cose_key`; `ScenarioError` gains `Mdoc` and `Oid4vp` variants.
- Deps: `affinidi-mdoc` (`default-features = false`, `eddsa` only — drops the unused ES256/P-256 path), `affinidi-openid4vp`, `ciborium`, `coset`, `serde` (derive).

### Tests
4 mdoc + 5 OID4VP integration tests: both issue→present→verify round trips plus the **holder-binding**, **wrong-key**, **disallowed-alg**, **nonce-replay**, **definition-mismatch**, and **tampered-token** negatives. Full crate suite green (TI2 14 + TI5a 4 + vectors 4 + 5 doctests); `clippy -D warnings` and `cargo fmt` clean.

Acceptance criteria from `tasks/testing-plan.md` (TI5): issue→present→verify round trips for sd-jwt-vc **and mdoc**; revocation, holder-binding failure, and disallowed-alg negatives — all satisfied across the two PRs.