### PR TITLE
feat: seeded did:peer generation for reproducible test identities (TI4a)

### DIFF
--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.6.0 — seeded did:peer generation (TI4a)
+
+- `determinism`: deterministic `did:peer` identities. `did_peer_from_seed(seed,
+  keys, service)` and the `didcomm_identity_from_seed(seed, service)` convenience
+  (Ed25519 verification + X25519 encryption) derive their keys from a caller seed
+  so **same seed → same DID, keys, and key ids** across runs — reproducible CI
+  failures and golden-file assertions. The assembled DID and default `dm` service
+  match `DID::generate_did_peer` byte-for-byte. `seeded_secret(key_type, &seed)`
+  exposes the underlying primitive (Ed25519 / X25519 / P256 / Secp256k1).
+  TEST-ONLY (seeded keys are predictable; never a production key path).
+- TI4's injectable clock follows separately as TI4b (a `Clock` trait threaded
+  through the mediator + SDK).
+
 ## 13th June 2026
 
 ### 0.5.0 — mdoc (COSE) + OID4VP present/verify flows (TI5b)

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.5.0"
+version = "0.6.0"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -43,6 +43,11 @@ affinidi-sd-jwt = { version = "0.1", path = "../../credentials/affinidi-sd-jwt" 
 affinidi-status-list = { version = "0.1", path = "../../credentials/affinidi-status-list" }
 ## `ed25519_pub_to_did_key` for deterministic issuer/holder/verifier DIDs.
 affinidi-crypto = { version = "0.2", path = "../../core/affinidi-crypto" }
+
+# ── TI4a: seeded did:peer generation (determinism module) ─────────────────
+## Seeded `Secret` constructors (generate_ed25519(.., Some(seed)) etc.) +
+## KeyType; did-common's generate_peer / PeerCreateKey assemble the did:peer.
+affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 ## EdDSA signer/verifier backing the scenario's JWS signing (the workspace
 ## sd-jwt crate ships only an HMAC test signer).
 ed25519-dalek = { version = "2" }

--- a/crates/tdk/affinidi-tdk-test-support/README.md
+++ b/crates/tdk/affinidi-tdk-test-support/README.md
@@ -26,7 +26,8 @@ Fixtures land per task in the TI-series (see `tasks/testing-todo.md`):
 |-------|-----------------------|---------------------------------------------------------------|:------:|
 | TI1   | `topology`            | Multi-mediator `TestTopology` (in-process, no Redis)          |  ⏳   |
 | TI2   | `did_web` / `resolver`| did:web / did:webvh mock server + injectable `StaticResolver` |  ✅   |
-| TI4   | `determinism`         | Seeded did:peer generation + injectable clock                 |  ⏳   |
+| TI4a  | `determinism`         | Seeded `did:peer` generation (reproducible identities)        |  ✅   |
+| TI4b  | `determinism`         | Injectable clock (`Clock` trait through mediator + SDK)        |  ⏳   |
 | TI5a  | `credential_scenario` | `CredentialScenario` SD-JWT VC issue / present / verify        |  ✅   |
 | TI5b  | `mdoc_scenario` / `oid4vp` | mdoc (COSE) flows + OID4VP present / verify (both eIDAS formats) |  ✅   |
 | TI7   | `vectors`             | Shared `tests/vectors/` layout + loader                       |  ✅   |

--- a/crates/tdk/affinidi-tdk-test-support/src/determinism.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/determinism.rs
@@ -1,0 +1,155 @@
+/*!
+ * Determinism primitives (TI4a): seeded `did:peer` generation.
+ *
+ * Test identities are random by default (`DID::generate_did_peer` draws from the
+ * OS RNG), so a failing CI run can't be reproduced and golden-file assertions
+ * are impossible. This module derives the keys from a caller-supplied `seed`
+ * instead: **same seed → same DID, same keys, same key ids**, every run.
+ *
+ * It builds on the seed support that already exists in the crypto stack
+ * (`Secret::generate_ed25519(None, Some(seed))` and friends) and assembles the
+ * `did:peer:2` with the same `affinidi-did-common` API and default `dm` service
+ * that `DID::generate_did_peer` uses — so a seeded identity is byte-for-byte
+ * what `TestEnvironment::add_user` would have produced, only reproducible.
+ *
+ * **TEST-ONLY.** Seeded keys are predictable by construction; never use this on
+ * a production key path.
+ *
+ * ```
+ * use affinidi_tdk_test_support::determinism::didcomm_identity_from_seed;
+ *
+ * let (did_a, secrets_a) = didcomm_identity_from_seed(42, None).unwrap();
+ * let (did_b, secrets_b) = didcomm_identity_from_seed(42, None).unwrap();
+ * assert_eq!(did_a, did_b); // same seed → same DID
+ * assert_eq!(secrets_a[0].id, secrets_b[0].id);
+ *
+ * let (did_c, _) = didcomm_identity_from_seed(43, None).unwrap();
+ * assert_ne!(did_a, did_c); // a different seed → a different DID
+ * ```
+ */
+
+use affinidi_did_common::{
+    DID, PeerCreateKey, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
+    one_or_many::OneOrMany,
+};
+use affinidi_secrets_resolver::errors::SecretsResolverError;
+
+// Re-exported so callers name the key purpose / type / secret from one place.
+pub use affinidi_did_common::PeerKeyPurpose;
+pub use affinidi_secrets_resolver::secrets::{KeyType, Secret};
+
+/// Errors from seeded identity generation.
+#[derive(Debug, thiserror::Error)]
+pub enum DeterminismError {
+    /// Assembling the `did:peer` failed.
+    #[error("did:peer: {0}")]
+    DidPeer(String),
+
+    /// A seeded key could not be built.
+    #[error("secret: {0}")]
+    Secret(#[from] SecretsResolverError),
+
+    /// The key type has no 32-byte-seed constructor in this helper.
+    #[error("unsupported key type for seeded generation: {0:?}")]
+    UnsupportedKeyType(KeyType),
+}
+
+/// Build a single deterministic [`Secret`] of `key_type` from a 32-byte `seed`.
+///
+/// Supports the key types used by `did:peer` DIDComm identities — `Ed25519`,
+/// `X25519`, `P256`, `Secp256k1` (all keyed by a 32-byte scalar). Other types
+/// (e.g. `P384`, which needs 48 bytes) return [`DeterminismError::UnsupportedKeyType`].
+/// The `id` is a throwaway here — [`did_peer_from_seed`] rewrites it to
+/// `{did}#key-N` once the DID is known.
+pub fn seeded_secret(key_type: KeyType, seed: &[u8; 32]) -> Result<Secret, DeterminismError> {
+    Ok(match key_type {
+        KeyType::Ed25519 => Secret::generate_ed25519(None, Some(seed)),
+        KeyType::X25519 => Secret::generate_x25519(None, Some(seed))?,
+        KeyType::P256 => Secret::generate_p256(None, Some(seed))?,
+        KeyType::Secp256k1 => Secret::generate_secp256k1(None, Some(seed))?,
+        other => return Err(DeterminismError::UnsupportedKeyType(other)),
+    })
+}
+
+/// Build a deterministic `did:peer:2` from `seed` with an explicit key list
+/// (each `(purpose, key_type)` becomes one key). With `didcomm_service_uri`, a
+/// single default `dm` DIDComm service is attached — the same service
+/// `DID::generate_did_peer` emits.
+///
+/// Returns the DID and its [`Secret`]s, their ids set to `{did}#key-N`. Same
+/// `seed` + same key list → identical DID and secrets across runs.
+pub fn did_peer_from_seed(
+    seed: u64,
+    keys: &[(PeerKeyPurpose, KeyType)],
+    didcomm_service_uri: Option<String>,
+) -> Result<(String, Vec<Secret>), DeterminismError> {
+    // Build one seeded Secret per requested key, with a distinct per-key seed.
+    let mut secrets: Vec<Secret> = keys
+        .iter()
+        .enumerate()
+        .map(|(index, (_purpose, key_type))| seeded_secret(*key_type, &key_seed(seed, index)))
+        .collect::<Result<_, _>>()?;
+
+    let peer_keys: Vec<PeerCreateKey> = keys
+        .iter()
+        .zip(secrets.iter())
+        .map(|((purpose, _), secret)| {
+            Ok(PeerCreateKey::from_multibase(
+                *purpose,
+                secret.get_public_keymultibase()?,
+            ))
+        })
+        .collect::<Result<_, SecretsResolverError>>()?;
+
+    let services = didcomm_service_uri.map(default_didcomm_services);
+    let (peer_did, _created) = DID::generate_peer(&peer_keys, services.as_deref())
+        .map_err(|e| DeterminismError::DidPeer(e.to_string()))?;
+    let did = peer_did.to_string();
+
+    // Match the secret ids to the freshly-minted DID (`{did}#key-N`), exactly as
+    // the facade's `generate_did_peer` does.
+    for (index, secret) in secrets.iter_mut().enumerate() {
+        secret.id = format!("{did}#key-{}", index + 1);
+    }
+
+    Ok((did, secrets))
+}
+
+/// Convenience: the default DIDComm identity shape — `Ed25519` verification +
+/// `X25519` encryption — that `TestEnvironment::add_user` produces, derived
+/// deterministically from `seed`.
+pub fn didcomm_identity_from_seed(
+    seed: u64,
+    didcomm_service_uri: Option<String>,
+) -> Result<(String, Vec<Secret>), DeterminismError> {
+    did_peer_from_seed(
+        seed,
+        &[
+            (PeerKeyPurpose::Verification, KeyType::Ed25519),
+            (PeerKeyPurpose::Encryption, KeyType::X25519),
+        ],
+        didcomm_service_uri,
+    )
+}
+
+/// A distinct, fully-determined 32-byte seed per key from `(seed, index)`.
+fn key_seed(seed: u64, index: usize) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[0..8].copy_from_slice(&seed.to_le_bytes());
+    bytes[8] = index as u8;
+    bytes
+}
+
+/// The default service set `DID::generate_did_peer` attaches: one DIDComm
+/// Messaging service (`type: "dm"`) at `service_uri`.
+fn default_didcomm_services(service_uri: String) -> Vec<PeerService> {
+    vec![PeerService {
+        type_: "dm".into(),
+        endpoint: PeerServiceEndpoint::Long(OneOrMany::One(PeerServiceEndpointLong {
+            uri: service_uri,
+            accept: vec!["didcomm/v2".into()],
+            routing_keys: vec![],
+        })),
+        id: None,
+    }]
+}

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -20,13 +20,15 @@
  * - **TI1** — `topology`: multi-mediator `TestTopology` (in-process, no Redis).
  * - **TI2** — [`did_web`] / [`resolver`]: in-process did:web / did:webvh mock
  *   server with fault injection, plus an injectable `StaticResolver`. ✅
- * - **TI4** — `determinism`: seeded did:peer generation and an injectable clock.
+ * - **TI4** — [`determinism`]: seeded did:peer generation (TI4a ✅); an
+ *   injectable clock follows in TI4b.
  * - **TI5** — [`credential_scenario`]: issuer/holder/verifier `CredentialScenario`
  *   for SD-JWT VC (TI5a) plus the [`mdoc_scenario`] and [`oid4vp`] flows (TI5b). ✅
  * - **TI7** — [`vectors`]: shared `tests/vectors/` layout and loader. ✅
  */
 
 pub mod credential_scenario;
+pub mod determinism;
 pub mod did_web;
 pub mod mdoc_scenario;
 pub mod oid4vp;

--- a/crates/tdk/affinidi-tdk-test-support/tests/determinism.rs
+++ b/crates/tdk/affinidi-tdk-test-support/tests/determinism.rs
@@ -1,0 +1,113 @@
+//! TI4a — seeded `did:peer` generation: same seed → same DID/keys/ids across
+//! runs; different seeds diverge; the seeded DID is well-formed and resolves.
+
+use affinidi_did_common::DID;
+use affinidi_tdk_test_support::determinism::{
+    KeyType, PeerKeyPurpose, did_peer_from_seed, didcomm_identity_from_seed, seeded_secret,
+};
+
+/// The core guarantee: the same seed yields an identical DID, the same number of
+/// secrets, and the same key ids and public key material every time.
+#[test]
+fn same_seed_is_reproducible() {
+    let (did_a, secrets_a) = didcomm_identity_from_seed(7, None).expect("first");
+    let (did_b, secrets_b) = didcomm_identity_from_seed(7, None).expect("second");
+
+    assert_eq!(did_a, did_b, "same seed must yield the same DID");
+    assert_eq!(secrets_a.len(), secrets_b.len());
+    for (a, b) in secrets_a.iter().zip(&secrets_b) {
+        assert_eq!(a.id, b.id, "key ids must match");
+        assert_eq!(
+            a.get_public_keymultibase().unwrap(),
+            b.get_public_keymultibase().unwrap(),
+            "public key material must match"
+        );
+    }
+}
+
+/// Different seeds must produce different identities (no accidental collisions).
+#[test]
+fn different_seeds_diverge() {
+    let (did_7, _) = didcomm_identity_from_seed(7, None).expect("seed 7");
+    let (did_8, _) = didcomm_identity_from_seed(8, None).expect("seed 8");
+    assert_ne!(did_7, did_8, "different seeds must yield different DIDs");
+}
+
+/// The default DIDComm shape is a `did:peer:2` with two keys whose ids are bound
+/// to the DID, and it resolves locally (no network) like any did:peer.
+#[test]
+fn default_identity_is_a_resolvable_did_peer() {
+    let (did, secrets) =
+        didcomm_identity_from_seed(1, Some("https://mediator.example/".to_string()))
+            .expect("identity");
+
+    assert!(did.starts_with("did:peer:2"), "got {did}");
+    assert_eq!(secrets.len(), 2, "Ed25519 verification + X25519 encryption");
+    assert_eq!(secrets[0].id, format!("{did}#key-1"));
+    assert_eq!(secrets[0].get_key_type(), KeyType::Ed25519);
+    assert_eq!(secrets[1].id, format!("{did}#key-2"));
+    assert_eq!(secrets[1].get_key_type(), KeyType::X25519);
+
+    // did:peer resolves locally — confirms the assembled DID is well-formed.
+    let parsed: DID = did.parse().expect("parse did:peer");
+    let document = parsed.resolve().expect("resolve did:peer");
+    assert_eq!(document.id.to_string(), did);
+    assert!(!document.verification_method.is_empty());
+    assert!(!document.key_agreement.is_empty(), "X25519 key agreement");
+}
+
+/// The DIDComm service URI is carried through when supplied, and omitted when
+/// not — a seeded identity without a service still resolves.
+#[test]
+fn service_uri_is_optional() {
+    let (did_no_svc, _) = didcomm_identity_from_seed(2, None).expect("no service");
+    let parsed: DID = did_no_svc.parse().expect("parse");
+    let doc = parsed.resolve().expect("resolve");
+    assert!(
+        doc.service.is_empty(),
+        "no service URI → no service entries"
+    );
+
+    let (did_svc, _) =
+        didcomm_identity_from_seed(2, Some("https://m.example/".to_string())).expect("service");
+    // Same keys (same seed) but the service changes the DID's last segment.
+    assert_ne!(did_no_svc, did_svc, "adding a service changes the DID");
+    let doc = did_svc.parse::<DID>().unwrap().resolve().unwrap();
+    assert!(!doc.service.is_empty(), "service URI → a service entry");
+}
+
+/// An explicit key list is honoured (purpose + type), and a single seeded
+/// secret of a supported type can be built on its own.
+#[test]
+fn explicit_keys_and_low_level_secret() {
+    let (_did, secrets) = did_peer_from_seed(
+        99,
+        &[
+            (PeerKeyPurpose::Verification, KeyType::Ed25519),
+            (PeerKeyPurpose::Verification, KeyType::P256),
+            (PeerKeyPurpose::Encryption, KeyType::X25519),
+        ],
+        None,
+    )
+    .expect("three-key did:peer");
+    assert_eq!(secrets.len(), 3);
+    assert_eq!(secrets[0].get_key_type(), KeyType::Ed25519);
+    assert_eq!(secrets[1].get_key_type(), KeyType::P256);
+    assert_eq!(secrets[2].get_key_type(), KeyType::X25519);
+
+    // The low-level primitive is deterministic for a raw 32-byte seed.
+    let seed = [9u8; 32];
+    let a = seeded_secret(KeyType::Ed25519, &seed).unwrap();
+    let b = seeded_secret(KeyType::Ed25519, &seed).unwrap();
+    assert_eq!(
+        a.get_public_keymultibase().unwrap(),
+        b.get_public_keymultibase().unwrap()
+    );
+}
+
+/// A key type without a 32-byte-seed constructor here is a clean error, not a
+/// panic.
+#[test]
+fn unsupported_key_type_errors() {
+    assert!(seeded_secret(KeyType::P384, &[0u8; 32]).is_err());
+}


### PR DESCRIPTION
## TI4a — seeded `did:peer` generation

First half of **TI4** (test determinism). Test identities are random by default (`generate_did_peer` draws from the OS RNG), so a failing CI run can't be reproduced and golden-file assertions are impossible. This adds **deterministic** `did:peer` generation **entirely in `affinidi-tdk-test-support`** — **no production-code changes**. 0.5.0 → 0.6.0 (additive; `publish = false`).

### `determinism` module
- `did_peer_from_seed(seed, keys, service)` — assembles a `did:peer:2` whose keys derive from the seed (a distinct per-key seed by index).
- `didcomm_identity_from_seed(seed, service)` — the default **Ed25519 verification + X25519 encryption** shape that `TestEnvironment::add_user` produces, made deterministic.
- `seeded_secret(key_type, &seed)` — the low-level primitive (Ed25519 / X25519 / P256 / Secp256k1; 32-byte seeds). Unsupported types (e.g. P384, which needs 48 bytes) return a clean error rather than panicking.

### Faithful to the existing path
Builds on the seed support already in the crypto stack (`Secret::generate_ed25519(None, Some(seed))` etc.) and assembles the DID with the same `affinidi-did-common` API and default `dm` service as `DID::generate_did_peer` — so a seeded identity is **byte-for-byte** what the random path would have produced, only reproducible. **Same seed → same DID, keys, and key ids**; secret ids are bound to the DID as `{did}#key-N`.

### Deps
`affinidi-secrets-resolver` 0.5 (seeded `Secret` constructors + `KeyType`); `affinidi-did-common` was already a dependency. Deliberately avoids pulling the `affinidi-tdk` facade — it has `generate_did_peer_from_secrets`, but dragging in the whole SDK for a ~6-line assembly isn't worth it.

**TEST-ONLY:** seeded keys are predictable by construction; never use on a production key path.

### Scope note
TI4 was split after a spike (the injectable clock is the High-risk, prod-touching half). **TI4b** — the injectable clock — follows separately as a `Clock` trait threaded through the mediator + SDK (the chosen design over a narrow feature-gated hook).

### Tests
6 covering reproducibility, divergence across seeds, a resolvable `did:peer`, optional DIDComm service, explicit multi-key lists, and the unsupported-key-type error, plus a determinism doctest. Full crate suite green; `clippy -D warnings` and `cargo fmt` clean.