### PR TITLE
feat: injectable Clock on the mediator request path (TI4b-1)

### DIFF
--- a/.github/workflows/release-guards.yaml
+++ b/.github/workflows/release-guards.yaml
@@ -10,6 +10,10 @@ name: release-guards
 #      edited-but-unbumped crate left stale source on crates.io that broke the
 #      registry-resolved publish verify build downstream.
 #
+#   3. test-clock      — the mediator-common `test-clock` feature (the
+#      advanceable TestClock, TI4b) must never be enabled for the mediator
+#      binary. Keeps the test-only clock out of production builds.
+#
 # Deliberately standalone and outside the shared affinidi/pipeline-rust workflow
 # (those are org-owned). Pure bash + git + jq + `cargo metadata`; no Rust build.
 # It carries NO hardcoded `toolchain:` pin of its own — the toolchain is taken
@@ -38,3 +42,6 @@ jobs:
 
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
+
+      - name: Test-clock isolation guard (mediator binary)
+        run: bash scripts/check-test-clock-isolation.sh

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.16.0 — injectable clock on the request path (TI4b)
+
+- `SharedData` now carries an `Arc<dyn Clock>`; all request-path expiry / TTL /
+  session decisions read it instead of the wall clock directly — so tests can
+  inject a `TestClock` and exercise expiry in milliseconds. Production wires a
+  `SystemClock`; `MediatorBuilder::clock(..)` injects an alternative.
+- **Token validation is now clock-aware.** `jsonwebtoken`'s `exp` check (which
+  reads the real wall clock) is disabled and replaced with a manual check
+  against the injected clock, preserving the previous 60s leeway and boundary
+  exactly (`common::jwt_auth::{clock_aware_validation, jwt_exp_is_expired}`).
+  Both the access-token and refresh-token decode sites are covered; an expired
+  refresh token is still rejected.
+- Converted the auth, message-store TTL, session/audit, protocol expiry-check,
+  routing, and websocket request-path sites to the injected clock. Background
+  components (the standalone message-expiry processor, circuit breaker, store
+  lazy-expiry internals) remain on the wall clock — a documented follow-up.
+- **Breaking:** `SharedData` gained a field and `server::serve_internal` gained
+  a `clock` parameter (hence the minor bump). The embedding API
+  (`MediatorBuilder`) is unchanged except for the additive `clock(..)` setter.
+
 ## 13th June 2026
 
 ### 0.15.46 — adopt the shared task-supervision crate (W15)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.15.46"
+version = "0.16.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.15.13 — injectable `Clock` trait (TI4b)
+
+- New `types::clock` module: the `Clock` trait (`unix_secs` / `unix_millis`)
+  plus `SystemClock` (production; delegates to the existing
+  `time::unix_timestamp_*` helpers). Lives in always-built `types` so both the
+  mediator and the SDK can share it.
+- Adds a non-default `test-clock` feature compiling `TestClock`, a
+  manually-advanced clock for fast expiry/TTL/session tests. Never enabled for
+  the mediator binary (a release guard enforces this); test fixtures opt in.
+- Additive — no change to existing APIs.
+
 ## 13th June 2026
 
 ### 0.15.12 — Admin audit-log query request (simplification T25, part b)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.12"
+version = "0.15.13"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -85,6 +85,13 @@ secrets-azure = [
   "dep:azure_core",
 ]
 secrets-vault = ["server", "dep:vaultrs"]
+
+# ── Test-only injectable clock ──────────────────────────────────────
+## Compiles `types::clock::TestClock`, a manually-advanced clock for fast
+## expiry/TTL/session tests. NON-DEFAULT and never enabled by the mediator
+## binary, so the advanceable clock can't reach a production build. Test
+## harnesses (e.g. affinidi-messaging-test-mediator) opt in.
+test-clock = []
 
 [dependencies]
 # ── Always-on: lean types module deps ───────────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/clock.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/clock.rs
@@ -1,0 +1,156 @@
+//! An injectable clock so expiry / TTL / session-cleanup logic can be driven by
+//! a virtual clock in tests instead of waiting on real wall-clock time.
+//!
+//! [`Clock`] is the abstraction; [`SystemClock`] is the production implementation
+//! (the real system clock) and is what the mediator wires in at startup.
+//! [`TestClock`] — a manually-advanced clock — is compiled only under the
+//! non-default `test-clock` feature, so it can never reach a production build.
+//!
+//! The trait lives in `types` (always built, no server deps) so both the
+//! mediator and the client SDK can share it without pulling the server stack.
+
+#[cfg(not(feature = "server"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A source of the current Unix time.
+///
+/// Production code holds an `Arc<dyn Clock>` (a [`SystemClock`]); tests inject a
+/// [`TestClock`] they can advance by hand to exercise expiry paths instantly.
+pub trait Clock: Send + Sync + std::fmt::Debug {
+    /// The current Unix time in **seconds**.
+    fn unix_secs(&self) -> u64;
+
+    /// The current Unix time in **milliseconds**.
+    fn unix_millis(&self) -> u128;
+}
+
+/// The production clock: reads the real system clock.
+///
+/// Falls back to `0` (logging an error) if the system clock is set before the
+/// UNIX epoch — the same non-panicking behaviour as the free
+/// [`unix_timestamp_secs`](crate::time::unix_timestamp_secs) helpers, which it
+/// delegates to.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+#[cfg(feature = "server")]
+impl Clock for SystemClock {
+    fn unix_secs(&self) -> u64 {
+        crate::time::unix_timestamp_secs()
+    }
+
+    fn unix_millis(&self) -> u128 {
+        crate::time::unix_timestamp_millis()
+    }
+}
+
+// Without the `server` feature the `time` helpers aren't compiled, so provide an
+// equivalent inline implementation for lean (SDK-style) consumers.
+#[cfg(not(feature = "server"))]
+impl Clock for SystemClock {
+    fn unix_secs(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    fn unix_millis(&self) -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    }
+}
+
+/// A manually-advanced clock for tests — **never compiled into production**
+/// (gated on the `test-clock` feature).
+///
+/// Cheap to clone; clones share the same underlying time, so a test can hold one
+/// handle, hand another to the mediator, and advance both at once. Start it at a
+/// fixed instant, then [`advance_secs`](Self::advance_secs) past a token's
+/// expiry to make the expiry path fire without any real time passing.
+#[cfg(feature = "test-clock")]
+#[derive(Debug, Clone)]
+pub struct TestClock {
+    /// Shared current time in milliseconds since the UNIX epoch.
+    millis: std::sync::Arc<std::sync::atomic::AtomicU64>,
+}
+
+#[cfg(feature = "test-clock")]
+impl TestClock {
+    /// A clock fixed at `unix_secs` seconds past the epoch.
+    pub fn at_secs(unix_secs: u64) -> Self {
+        Self {
+            millis: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(unix_secs * 1_000)),
+        }
+    }
+
+    /// A clock seeded from the real system clock (so tokens look freshly issued).
+    pub fn now() -> Self {
+        Self::at_secs(SystemClock.unix_secs())
+    }
+
+    /// Move the clock forward by `secs` seconds.
+    pub fn advance_secs(&self, secs: u64) {
+        self.advance_millis(secs * 1_000);
+    }
+
+    /// Move the clock forward by `millis` milliseconds.
+    pub fn advance_millis(&self, millis: u64) {
+        self.millis
+            .fetch_add(millis, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Set the clock to exactly `unix_secs` seconds past the epoch.
+    pub fn set_secs(&self, unix_secs: u64) {
+        self.millis
+            .store(unix_secs * 1_000, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[cfg(feature = "test-clock")]
+impl Clock for TestClock {
+    fn unix_secs(&self) -> u64 {
+        self.millis.load(std::sync::atomic::Ordering::SeqCst) / 1_000
+    }
+
+    fn unix_millis(&self) -> u128 {
+        self.millis.load(std::sync::atomic::Ordering::SeqCst) as u128
+    }
+}
+
+#[cfg(all(test, feature = "test-clock"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clock_advances() {
+        let clock = TestClock::at_secs(1_000);
+        assert_eq!(clock.unix_secs(), 1_000);
+        assert_eq!(clock.unix_millis(), 1_000_000);
+
+        clock.advance_secs(50);
+        assert_eq!(clock.unix_secs(), 1_050);
+
+        clock.advance_millis(500);
+        assert_eq!(clock.unix_millis(), 1_050_500);
+        assert_eq!(clock.unix_secs(), 1_050);
+
+        clock.set_secs(42);
+        assert_eq!(clock.unix_secs(), 42);
+    }
+
+    #[test]
+    fn clones_share_time() {
+        let a = TestClock::at_secs(100);
+        let b = a.clone();
+        a.advance_secs(10);
+        assert_eq!(b.unix_secs(), 110, "a clone observes the advance");
+    }
+
+    #[test]
+    fn system_clock_is_nonzero() {
+        assert!(SystemClock.unix_secs() > 0);
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/mod.rs
@@ -18,5 +18,6 @@ pub mod acls;
 pub mod acls_handler;
 pub mod administration;
 pub mod audit;
+pub mod clock;
 pub mod messages;
 pub mod problem_report;

--- a/crates/messaging/affinidi-messaging-mediator/src/builder.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/builder.rs
@@ -220,6 +220,10 @@ pub struct MediatorBuilder {
     /// websocket streaming). The store is wired into `SharedData`
     /// directly. Memory and Fjall backends use this path.
     store: Option<Arc<dyn MediatorStore>>,
+    /// Optional injected clock. When `None`, the server wires a
+    /// [`SystemClock`](affinidi_messaging_mediator_common::types::clock::SystemClock).
+    /// Tests pass a `TestClock` here to drive expiry/TTL deterministically.
+    clock: Option<Arc<dyn affinidi_messaging_mediator_common::types::clock::Clock>>,
 }
 
 impl MediatorBuilder {
@@ -252,7 +256,23 @@ impl MediatorBuilder {
             streaming_uuid_set: false,
             opts: StartOpts::default(),
             store: None,
+            clock: None,
         }
+    }
+
+    /// Inject a clock for all expiry / TTL / session-cleanup decisions.
+    ///
+    /// Defaults to the real
+    /// [`SystemClock`](affinidi_messaging_mediator_common::types::clock::SystemClock)
+    /// when unset. Tests pass a `TestClock` to advance time by hand and
+    /// exercise token-expiry / message-TTL paths without waiting on the wall
+    /// clock.
+    pub fn clock(
+        mut self,
+        clock: Arc<dyn affinidi_messaging_mediator_common::types::clock::Clock>,
+    ) -> Self {
+        self.clock = Some(clock);
+        self
     }
 
     /// Supply a pre-built [`MediatorStore`]. When set, the server uses
@@ -541,7 +561,11 @@ impl MediatorBuilder {
             self.config.tags.insert("hostname".to_string(), host);
         }
 
-        crate::server::serve_internal(self.config, self.opts, shutdown_token, self.store).await
+        let clock = self.clock.unwrap_or_else(|| {
+            Arc::new(affinidi_messaging_mediator_common::types::clock::SystemClock)
+        });
+        crate::server::serve_internal(self.config, self.opts, shutdown_token, self.store, clock)
+            .await
     }
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -88,6 +88,33 @@ impl IntoResponse for AuthError {
     }
 }
 
+/// `jsonwebtoken`'s default expiry leeway (seconds). We move the `exp` time
+/// comparison off `jsonwebtoken` — which reads the real wall clock and so
+/// ignores an injected [`Clock`](affinidi_messaging_mediator_common::types::clock::Clock)
+/// — and onto the mediator's clock, but preserve this exact leeway so the
+/// accept/reject boundary is unchanged from the previous behaviour.
+pub(crate) const JWT_EXP_LEEWAY_SECS: u64 = 60;
+
+/// A [`Validation`] with `exp` *required* but its time check disabled, so expiry
+/// is judged against the injected clock (via [`jwt_exp_is_expired`]) rather than
+/// `jsonwebtoken`'s internal `SystemTime::now()`. Signature, audience, and the
+/// required-claims set are validated exactly as before.
+pub(crate) fn clock_aware_validation() -> Validation {
+    let mut validation = Validation::new(jsonwebtoken::Algorithm::EdDSA);
+    validation.set_audience(&["ATM"]);
+    validation.set_required_spec_claims(&["exp", "sub", "aud", "session_id"]);
+    // Defer the expiry check to the injected clock; `exp` stays a required claim.
+    validation.validate_exp = false;
+    validation
+}
+
+/// Whether a token with the given `exp` is expired at `now`, using the same
+/// leeway `jsonwebtoken` applied by default (`exp < now - leeway`). Written as
+/// `exp + leeway < now` to avoid underflow.
+pub(crate) fn jwt_exp_is_expired(exp: u64, now: u64) -> bool {
+    exp + JWT_EXP_LEEWAY_SECS < now
+}
+
 /// Validate a raw JWT bearer token and resolve it to an authenticated
 /// [`Session`].
 ///
@@ -107,14 +134,10 @@ pub(crate) async fn authenticate_token(
     state: &SharedData,
     token: &str,
 ) -> Result<Session, AuthError> {
-    let mut validation = Validation::new(jsonwebtoken::Algorithm::EdDSA);
-    validation.set_audience(&["ATM"]);
-    validation.set_required_spec_claims(&["exp", "sub", "aud", "session_id"]);
-
     let token_data: TokenData<SessionClaims> = match jsonwebtoken::decode::<SessionClaims>(
         token,
         &state.config.security.jwt_decoding_key,
-        &validation,
+        &clock_aware_validation(),
     ) {
         Ok(token_data) => token_data,
         Err(err) => {
@@ -122,6 +145,13 @@ pub(crate) async fn authenticate_token(
             return Err(AuthError::InvalidToken);
         }
     };
+
+    // Expiry is checked here (not by jsonwebtoken) so it honours the injected
+    // clock. Same leeway/boundary as before — see `clock_aware_validation`.
+    if jwt_exp_is_expired(token_data.claims.exp, state.clock.unix_secs()) {
+        event!(Level::WARN, "JWT access token expired");
+        return Err(AuthError::ExpiredToken);
+    }
 
     let session_id = token_data.claims.session_id.clone();
     let did = token_data.claims.sub.clone();
@@ -325,6 +355,31 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jwt_exp_uses_the_same_leeway_as_jsonwebtoken() {
+        // Boundary equivalent to jsonwebtoken's default (`exp < now - leeway`,
+        // i.e. expired iff `exp + leeway < now`), with leeway = 60.
+        let exp = 1_000_u64;
+        // Well within validity.
+        assert!(!jwt_exp_is_expired(exp, exp));
+        // Exactly at the leeway edge — still accepted.
+        assert!(!jwt_exp_is_expired(exp, exp + JWT_EXP_LEEWAY_SECS));
+        // One second past the leeway — now expired.
+        assert!(jwt_exp_is_expired(exp, exp + JWT_EXP_LEEWAY_SECS + 1));
+        // A token issued "in the future" is certainly not expired (no underflow).
+        assert!(!jwt_exp_is_expired(exp, 0));
+    }
+
+    #[test]
+    fn clock_aware_validation_defers_expiry_but_keeps_exp_required() {
+        let validation = clock_aware_validation();
+        // jsonwebtoken must NOT check expiry (the injected clock does).
+        assert!(!validation.validate_exp);
+        // ...but `exp` is still a required claim, so a token without it is
+        // rejected at decode time exactly as before.
+        assert!(validation.required_spec_claims.contains("exp"));
+    }
 
     #[test]
     fn anon_inbound_allowed_when_global_default_grants_send_forwarded() {

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/helpers.rs
@@ -1,5 +1,8 @@
 use crate::SharedData;
 use crate::common::session::SessionClaims;
+// Production token creation now takes `now` from the injected clock; the only
+// remaining caller of this helper is the test module below.
+#[cfg(test)]
 use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat::MetaEnvelope;
 use affinidi_messaging_didcomm::Message;
@@ -89,6 +92,7 @@ pub(super) fn _create_access_token(
     did: &str,
     session_id: &str,
     expiry: u64,
+    now: u64,
     encoding_key: &EncodingKey,
 ) -> Result<(String, u64), MediatorError> {
     // Passed all the checks, now create the JWT tokens
@@ -96,7 +100,7 @@ pub(super) fn _create_access_token(
         aud: "ATM".to_string(),
         sub: did.to_owned(),
         session_id: session_id.to_owned(),
-        exp: (unix_timestamp_secs() + expiry),
+        exp: (now + expiry),
     };
 
     let access_token = encode(
@@ -128,13 +132,14 @@ pub(super) fn _create_refresh_token(
     did: &str,
     session_id: &str,
     expiry: u64,
+    now: u64,
     encoding_key: &EncodingKey,
 ) -> Result<(String, u64, String), MediatorError> {
     let refresh_claims = SessionClaims {
         aud: "ATM".to_string(),
         sub: did.to_owned(),
         session_id: session_id.to_owned(),
-        exp: (unix_timestamp_secs() + expiry),
+        exp: (now + expiry),
     };
 
     let refresh_token = encode(
@@ -203,9 +208,14 @@ mod tests {
     fn create_access_token_produces_valid_jwt() {
         let (encoding_key, decoding_key) = test_ed25519_keys();
 
-        let (token, _exp) =
-            _create_access_token("did:example:123", "session-1", 3600, &encoding_key)
-                .expect("should create access token");
+        let (token, _exp) = _create_access_token(
+            "did:example:123",
+            "session-1",
+            3600,
+            unix_timestamp_secs(),
+            &encoding_key,
+        )
+        .expect("should create access token");
 
         let mut validation = Validation::new(Algorithm::EdDSA);
         validation.set_audience(&["ATM"]);
@@ -224,15 +234,18 @@ mod tests {
         let (encoding_key, decoding_key) = test_ed25519_keys();
         let expiry_delta = 7200_u64;
 
-        let before = unix_timestamp_secs();
-        let (_token, exp) =
-            _create_access_token("did:example:456", "session-2", expiry_delta, &encoding_key)
-                .expect("should create access token");
-        let after = unix_timestamp_secs();
+        let now = unix_timestamp_secs();
+        let (_token, exp) = _create_access_token(
+            "did:example:456",
+            "session-2",
+            expiry_delta,
+            now,
+            &encoding_key,
+        )
+        .expect("should create access token");
 
-        // The expiry should be roughly now + expiry_delta (within the before/after window).
-        assert!(exp >= before + expiry_delta);
-        assert!(exp <= after + expiry_delta);
+        // The expiry is exactly the supplied `now` plus the delta.
+        assert_eq!(exp, now + expiry_delta);
 
         // Also verify through the JWT claims
         let mut validation = Validation::new(Algorithm::EdDSA);
@@ -248,9 +261,14 @@ mod tests {
     fn create_refresh_token_returns_token_expiry_and_hash() {
         let (encoding_key, _decoding_key) = test_ed25519_keys();
 
-        let (token, exp, hash) =
-            _create_refresh_token("did:example:789", "session-3", 3600, &encoding_key)
-                .expect("should create refresh token");
+        let (token, exp, hash) = _create_refresh_token(
+            "did:example:789",
+            "session-3",
+            3600,
+            unix_timestamp_secs(),
+            &encoding_key,
+        )
+        .expect("should create refresh token");
 
         assert!(!token.is_empty(), "token should not be empty");
         assert!(exp > 0, "expiry should be positive");
@@ -261,9 +279,14 @@ mod tests {
     fn create_refresh_token_hash_matches_sha256_of_token() {
         let (encoding_key, _decoding_key) = test_ed25519_keys();
 
-        let (token, _exp, hash) =
-            _create_refresh_token("did:example:abc", "session-4", 3600, &encoding_key)
-                .expect("should create refresh token");
+        let (token, _exp, hash) = _create_refresh_token(
+            "did:example:abc",
+            "session-4",
+            3600,
+            unix_timestamp_secs(),
+            &encoding_key,
+        )
+        .expect("should create refresh token");
 
         let expected_hash = digest(&token);
         assert_eq!(hash, expected_hash, "hash should be SHA-256 of the token");

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
@@ -1,7 +1,7 @@
 use super::super::message_inbound::InboundMessage;
 use super::AuthRefreshResponse;
 use super::helpers::{_create_access_token, _create_refresh_token};
-use crate::common::time::unix_timestamp_secs;
+use crate::common::jwt_auth::{clock_aware_validation, jwt_exp_is_expired};
 use crate::didcomm_compat::MetaEnvelope;
 use crate::{
     SharedData,
@@ -15,7 +15,6 @@ use affinidi_messaging_sdk::messages::{
 };
 use axum::{Json, extract::State};
 use http::StatusCode;
-use jsonwebtoken::Validation;
 use sha256::digest;
 use subtle::ConstantTimeEq;
 use tracing::{Instrument, Level, info, span};
@@ -98,7 +97,7 @@ pub async fn authentication_refresh(
         }
 
         // Ensure the message hasn't expired
-        let now = unix_timestamp_secs();
+        let now = state.clock.unix_secs();
         if let Some(expires) = msg.expires_time {
             if expires <= now {
                 return Err(MediatorError::problem_with_log(
@@ -165,14 +164,12 @@ pub async fn authentication_refresh(
             .into());
         };
 
-        // Decode the refresh token
-        let mut validation = Validation::new(jsonwebtoken::Algorithm::EdDSA);
-        validation.set_audience(&["ATM"]);
-        validation.set_required_spec_claims(&["exp", "sub", "aud", "session_id"]);
+        // Decode the refresh token. Expiry is checked against the injected
+        // clock below (not by jsonwebtoken) — see `clock_aware_validation`.
         let results = match jsonwebtoken::decode::<SessionClaims>(
             refresh_token,
             &state.config.security.jwt_decoding_key,
-            &validation,
+            &clock_aware_validation(),
         ) {
             Ok(token) => token,
             Err(err) => {
@@ -191,6 +188,25 @@ pub async fn authentication_refresh(
                 .into());
             }
         };
+
+        // Reject an expired refresh token. jsonwebtoken no longer does this
+        // (its `exp` check is disabled so the injected clock governs expiry),
+        // so we must — same leeway/boundary as before.
+        if jwt_exp_is_expired(results.claims.exp, now) {
+            return Err(MediatorError::problem_with_log(
+                38,
+                "",
+                None,
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "authentication.session.refresh_token.expired",
+                "Refresh token has expired",
+                vec![],
+                StatusCode::BAD_REQUEST,
+                "Refresh token has expired",
+            )
+            .into());
+        }
 
         // Refresh token is valid - check against database and ensure it still exists.
         // Convert from the trait-layer Session to the local Session shape so the rest
@@ -310,6 +326,7 @@ pub async fn authentication_refresh(
             &session_check.did,
             &session_check.session_id,
             state.config.security.jwt_access_expiry,
+            now,
             &state.config.security.jwt_encoding_key,
         )?;
 
@@ -320,6 +337,7 @@ pub async fn authentication_refresh(
             &session_check.did,
             &session_check.session_id,
             refresh_expiry,
+            now,
             &state.config.security.jwt_encoding_key,
         )?;
 

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
@@ -1,7 +1,6 @@
 use super::super::message_inbound::InboundMessage;
 use super::AuthenticationChallenge;
 use super::helpers::{_create_access_token, _create_refresh_token, create_random_string};
-use crate::common::time::unix_timestamp_secs;
 use crate::didcomm_compat::MetaEnvelope;
 use crate::{
     SharedData,
@@ -215,7 +214,7 @@ pub async fn authentication_response(
         }
 
         // Ensure the message hasn't expired
-        let now = unix_timestamp_secs();
+        let now = state.clock.unix_secs();
         if let Some(expires) = msg.expires_time {
             if expires <= now {
                 return Err(MediatorError::problem_with_log(
@@ -336,6 +335,7 @@ pub async fn authentication_response(
             &session.did,
             &session.session_id,
             state.config.security.jwt_access_expiry,
+            now,
             &state.config.security.jwt_encoding_key,
         )?;
 
@@ -345,6 +345,7 @@ pub async fn authentication_response(
             &session.did,
             &session.session_id,
             refresh_expiry,
+            now,
             &state.config.security.jwt_encoding_key,
         )?;
 

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/oob_discovery.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/oob_discovery.rs
@@ -66,7 +66,11 @@ pub async fn oob_invite_handler(
         Ok(b) => b,
         Err(e) => return Err(e.into()),
     };
-    let expires_at = crate::store::oob_expires_at(&body, state.config.limits.oob_invite_ttl as u64);
+    let expires_at = crate::store::oob_expires_at(
+        &body,
+        state.config.limits.oob_invite_ttl as u64,
+        state.clock.unix_secs(),
+    );
 
     let oob_id = match state
         .database

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -1,5 +1,4 @@
 use crate::common::metrics::names::ACTIVE_WEBSOCKET_CONNECTIONS;
-use crate::common::time::unix_timestamp_secs;
 #[cfg(feature = "didcomm")]
 use crate::didcomm_compat;
 use crate::{
@@ -367,7 +366,7 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
         info!("Websocket connection established");
 
         // Set a timeout for the websocket connection for when the JWT Auth token expires
-        let epoch = unix_timestamp_secs();
+        let epoch = state.clock.unix_secs();
         if session.expires_at <= epoch {
             warn!("JWT access token has expired. Closing Session");
             let _ = socket
@@ -583,7 +582,7 @@ async fn _package_problem_report(
     )
     .from(state.config.mediator_did.clone())
     .to(session.did.to_string())
-    .created_time(unix_timestamp_secs());
+    .created_time(state.clock.unix_secs());
 
     if let Some(msg_id) = msg_id {
         pr_msg = pr_msg.pthid(msg_id);

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -72,6 +72,12 @@ pub struct SharedData {
     /// handler reads this to fail `/readyz` when a load-bearing component is
     /// down and to report `degraded` for non-load-bearing ones.
     pub component_health: HealthRegistry,
+    /// Source of the current time for all expiry / TTL / session-cleanup
+    /// decisions on the request path. Production wires a
+    /// [`SystemClock`](affinidi_messaging_mediator_common::types::clock::SystemClock);
+    /// tests can inject a `TestClock` (via `TestMediatorBuilder::clock`) and
+    /// advance it to exercise expiry instantly.
+    pub clock: Arc<dyn affinidi_messaging_mediator_common::types::clock::Clock>,
 }
 
 impl SharedData {

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/error_response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/error_response.rs
@@ -2,7 +2,6 @@
 //! Mainly useful for WebSocket transport where an inbound message causes an error
 //! and we want to communicate that back to the sender
 
-use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_sdk::messages::problem_report::ProblemReport;
@@ -28,7 +27,7 @@ pub(crate) fn generate_error_response(
     problem: ProblemReport,
     store_message: bool,
 ) -> Result<ProcessMessageResponse, MediatorError> {
-    let now = unix_timestamp_secs();
+    let now = state.clock.unix_secs();
 
     // Build the message
     let mut error_msg = Message::build(

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "didcomm")]
-use crate::common::time::unix_timestamp_secs;
-#[cfg(feature = "didcomm")]
 use crate::didcomm_compat::MetaEnvelope;
 #[cfg(feature = "didcomm")]
 use crate::messages::MessageHandler;
@@ -290,7 +288,7 @@ async fn handle_inbound_didcomm(
                         data: WrapperType::Envelope(
                             to_did.into(),
                             message.into(),
-                            unix_timestamp_secs()
+                            state.clock.unix_secs()
                                 + state.config.limits.message_expiry_seconds,
                         ),
                     };

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "didcomm")]
 use self::protocols::ping;
 #[cfg(feature = "didcomm")]
-use crate::common::time::unix_timestamp_secs;
-#[cfg(feature = "didcomm")]
 use crate::didcomm_compat;
 #[cfg(feature = "didcomm")]
 use crate::messages::protocols::discover_features;
@@ -65,7 +63,7 @@ impl MessageType {
             SDKMessageType::MediatorACLManagement => {
                 acls::process(message, state, session, metadata).await
             }
-            SDKMessageType::TrustPing => ping::process(message, session),
+            SDKMessageType::TrustPing => ping::process(message, session, state.clock.unix_secs()),
             SDKMessageType::MessagePickupStatusRequest => {
                 message_pickup::status_request(message, state, session).await
             }
@@ -249,7 +247,7 @@ impl MessageHandler for Message {
         })?);
 
         // Check if message expired
-        let now = unix_timestamp_secs();
+        let now = state.clock.unix_secs();
         if let Some(expires) = self.expires_time
             && expires <= now
         {

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/discover_features.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/discover_features.rs
@@ -1,4 +1,3 @@
-use crate::common::time::unix_timestamp_secs;
 use crate::{
     SharedData,
     common::session::Session,
@@ -22,7 +21,7 @@ pub(crate) fn process(
         session_id = session.session_id.as_str()
     )
     .entered();
-    let now = unix_timestamp_secs();
+    let now = state.clock.unix_secs();
 
     if let Some(expires) = msg.expires_time
         && expires <= now

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/accounts.rs
@@ -38,7 +38,7 @@ pub(crate) async fn process(
         if session.account_type == AccountType::Admin
         || session.account_type == AccountType::RootAdmin
         {
-            let now = unix_timestamp_secs();
+            let now = state.clock.unix_secs();
             match authz::admin_message_ttl_status(
                 msg.created_time,
                 state.config.security.admin_messages_expiry,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/acls.rs
@@ -35,7 +35,7 @@ pub(crate) async fn process(
         if session.account_type == AccountType::Admin
             || session.account_type == AccountType::RootAdmin
         {
-            let now = unix_timestamp_secs();
+            let now = state.clock.unix_secs();
             match authz::admin_message_ttl_status(
                 msg.created_time,
                 state.config.security.admin_messages_expiry,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/administration.rs
@@ -34,7 +34,7 @@ pub(crate) async fn process(
         // Check if message is valid from an expiry perspective. Always enforced
         // (independent of `block_remote_admin_msgs`) to bound replay of captured
         // admin messages.
-        let now = unix_timestamp_secs();
+        let now = state.clock.unix_secs();
         match authz::admin_message_ttl_status(
             msg.created_time,
             state.config.security.admin_messages_expiry,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mediator/mod.rs
@@ -2,7 +2,6 @@ pub(crate) mod accounts;
 pub(crate) mod acls;
 pub(crate) mod administration;
 
-use crate::common::time::unix_timestamp_secs;
 use crate::{SharedData, common::session::Session};
 use affinidi_messaging_mediator_common::types::audit::{AuditAction, AuditLogEntry};
 use tracing::warn;
@@ -22,7 +21,7 @@ pub(crate) async fn record_audit(
     detail: String,
 ) {
     let entry = AuditLogEntry {
-        timestamp: unix_timestamp_secs(),
+        timestamp: state.clock.unix_secs(),
         actor_did_hash: session.did_hash.clone(),
         target_did_hash: target_did_hash.to_string(),
         action,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/message_pickup.rs
@@ -4,7 +4,6 @@
  * NOTE: All messages generated from this protocol are ephemeral and are not stored in the database
  * They are fire and forget messages
  */
-use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::{Attachment, Message};
 use affinidi_messaging_mediator_common::{errors::MediatorError, store::DeletionAuthority};
 use affinidi_messaging_sdk::{
@@ -154,7 +153,7 @@ async fn generate_status_reply(
             status.live_delivery = live_delivery;
         }
 
-        let now = _get_time_now();
+        let now = state.clock.unix_secs();
 
         if let Some(t) = status.oldest_received_time {
             // Using wrapping sub because result could overflow u64
@@ -366,7 +365,7 @@ pub(crate) async fn delivery_request(
                     attachments.push(attachment.finalize())
                 }
             }
-            let now = _get_time_now();
+            let now = state.clock.unix_secs();
 
             let response_msg = response_msg
                 .attachments(attachments)
@@ -532,16 +531,12 @@ fn _parse_and_validate_delivery_request_body(
     Ok((recipient_did, limit))
 }
 
-fn _get_time_now() -> u64 {
-    unix_timestamp_secs()
-}
-
 fn _validate_msg(
     msg: &Message,
     state: &SharedData,
     session: &Session,
 ) -> Result<(), MediatorError> {
-    let now = _get_time_now();
+    let now = state.clock.unix_secs();
 
     if let Some(expires) = msg.expires_time
         && expires <= now

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/ping.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/ping.rs
@@ -1,4 +1,3 @@
-use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
@@ -31,6 +30,7 @@ impl Default for Ping {
 pub(crate) fn process(
     msg: &Message,
     session: &Session,
+    now: u64,
 ) -> Result<ProcessMessageResponse, MediatorError> {
     let _span = span!(
         tracing::Level::DEBUG,
@@ -38,7 +38,6 @@ pub(crate) fn process(
         session_id = session.session_id.as_str()
     )
     .entered();
-    let now = unix_timestamp_secs();
 
     if let Some(expires) = msg.expires_time
         && expires <= now

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -1,6 +1,5 @@
 use crate::common::authz::{self, Capability};
 use crate::common::storage_timeout::with_storage_timeout;
-use crate::common::time::{unix_timestamp_millis, unix_timestamp_secs};
 
 use crate::didcomm_compat::MetaEnvelope;
 use crate::{
@@ -521,7 +520,7 @@ async fn deliver_forward(
                 ));
             }
 
-            let now_ms = unix_timestamp_millis();
+            let now_ms = state.clock.unix_millis();
 
             // Get the sender's full DID for problem reports
             let from_did = msg.from.as_deref().unwrap_or("").to_string();
@@ -969,7 +968,7 @@ pub(crate) async fn process(
         let data = decode_first_attachment(msg, session, &attachments)?;
 
         let expires_at = if let Some(expires_at) = msg.expires_time {
-            let now = unix_timestamp_secs();
+            let now = state.clock.unix_secs();
 
             if expires_at > now + state.config.limits.message_expiry_seconds {
                 now + state.config.limits.message_expiry_seconds
@@ -977,8 +976,7 @@ pub(crate) async fn process(
                 expires_at
             }
         } else {
-            unix_timestamp_secs()
-                + state.config.limits.message_expiry_seconds
+            state.clock.unix_secs() + state.config.limits.message_expiry_seconds
         };
 
         deliver_forward(

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/store.rs
@@ -1,6 +1,5 @@
 use crate::SharedData;
 use crate::common::session::Session;
-use crate::common::time::unix_timestamp_secs;
 #[cfg(feature = "didcomm")]
 use crate::messages::MessageHandler;
 #[cfg(feature = "didcomm")]
@@ -125,7 +124,7 @@ pub(crate) async fn store_message(
                     }
 
                     let expires_at = if let Some(expires_at) = message.expires_time {
-                        let now = unix_timestamp_secs();
+                        let now = state.clock.unix_secs();
 
                         if expires_at > now + state.config.limits.message_expiry_seconds {
                             now + state.config.limits.message_expiry_seconds
@@ -133,7 +132,7 @@ pub(crate) async fn store_message(
                             expires_at
                         }
                     } else {
-                        unix_timestamp_secs() + state.config.limits.message_expiry_seconds
+                        state.clock.unix_secs() + state.config.limits.message_expiry_seconds
                     };
 
                     for recipient in to_dids {
@@ -336,7 +335,7 @@ pub(crate) async fn store_forwarded_message(
         }
 
         let expires_at = if let Some(expires_at) = expires_at {
-            let now = unix_timestamp_secs();
+            let now = state.clock.unix_secs();
 
             if expires_at > now + state.config.limits.message_expiry_seconds {
                 now + state.config.limits.message_expiry_seconds
@@ -344,7 +343,7 @@ pub(crate) async fn store_forwarded_message(
                 expires_at
             }
         } else {
-            unix_timestamp_secs() + state.config.limits.message_expiry_seconds
+            state.clock.unix_secs() + state.config.limits.message_expiry_seconds
         };
 
         match state

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -178,7 +178,14 @@ pub async fn start(config_path: &str) -> Result<(), MediatorError> {
         };
 
     let shutdown_token = CancellationToken::new();
-    let handle = serve_internal(config, opts, shutdown_token, pre_built_store).await?;
+    let handle = serve_internal(
+        config,
+        opts,
+        shutdown_token,
+        pre_built_store,
+        Arc::new(affinidi_messaging_mediator_common::types::clock::SystemClock),
+    )
+    .await?;
     info!("Mediator listening on {}", handle.bound_addr);
     handle.join().await
 }
@@ -200,6 +207,7 @@ pub async fn serve_internal(
     opts: StartOpts,
     shutdown_token: CancellationToken,
     pre_built_store: Option<Arc<dyn affinidi_messaging_mediator_common::store::MediatorStore>>,
+    clock: Arc<dyn affinidi_messaging_mediator_common::types::clock::Clock>,
 ) -> Result<MediatorHandle, MediatorError> {
     if let TracingMode::InstallProduction {
         log_json,
@@ -579,6 +587,7 @@ pub async fn serve_internal(
         shutdown_token: shutdown_token.clone(),
         self_authorities: Arc::new(self_authorities),
         component_health: supervisor.registry(),
+        clock,
     };
 
     let app: Router = application_routes(&api_prefix, &shared_state);

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -35,17 +35,16 @@ pub use memory_store::MemoryStore;
 // in `redis_store.rs`) so non-Redis builds can still call them from
 // the OOB discovery handler.
 
-use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 
 /// Build the absolute `expires_at` for an OOB invitation given the
-/// invitation's optional `expires_time` and the configured
-/// `oob_invite_ttl`. Mirrors the legacy computation so handlers can
-/// produce the same value before calling the trait method.
-pub fn oob_expires_at(invite: &Message, oob_invite_ttl: u64) -> u64 {
-    let now = unix_timestamp_secs();
+/// invitation's optional `expires_time`, the configured `oob_invite_ttl`, and
+/// the current time `now` (from the caller's injected clock). Mirrors the legacy
+/// computation so handlers can produce the same value before calling the trait
+/// method.
+pub fn oob_expires_at(invite: &Message, oob_invite_ttl: u64, now: u64) -> u64 {
     match invite.expires_time {
         Some(expiry) if expiry > now + oob_invite_ttl => now + oob_invite_ttl,
         Some(expiry) => expiry,

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.2.11 — inject a clock for fast expiry tests (TI4b)
+
+- `TestMediatorBuilder::clock(Arc<dyn Clock>)` injects a clock into the spawned
+  mediator. Pair a `TestClock` with `jwt_expiry(..)` to expire a token in
+  milliseconds: issue with a short lifetime, then `clock.advance_secs(..)` past
+  it. Re-exports `Clock` / `SystemClock` / `TestClock` (enables the
+  `affinidi-messaging-mediator-common/test-clock` feature).
+- New `tests/clock_injection.rs`: authenticate, advance the clock past the token
+  lifetime (no real time passes), and confirm the mediator rejects the token.
+- Tracks the mediator's 0.16 bump.
+
 ## 11th June 2026
 
 ### 0.2.9 — builder support for the per-DID WebSocket cap (mediator T13)

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.10"
+version = "0.2.11"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -27,8 +27,12 @@ fjall-backend = ["affinidi-messaging-mediator/fjall-backend", "dep:tempfile"]
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.15", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
-affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator = { version = "0.16", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+# `test-clock` compiles the advanceable `TestClock` this fixture injects via
+# `TestMediatorBuilder::clock` for fast expiry/TTL tests.
+affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
+  "test-clock",
+] }
 
 # ── Optional: Fjall on-disk backend support (gated on `fjall-backend`) ──
 ## Wraps each FjallStore in a temp directory that's cleaned up when the

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -104,6 +104,8 @@ use affinidi_messaging_mediator_common::{
     MediatorSecrets, errors::MediatorError, secrets::backends::MemoryStore as SecretsMemoryStore,
     store::MediatorStore,
 };
+// Re-exported so tests can build/inject a clock from one import.
+pub use affinidi_messaging_mediator_common::types::clock::{Clock, SystemClock, TestClock};
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
 use affinidi_tdk::dids::{
     DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
@@ -334,6 +336,10 @@ pub struct TestMediatorBuilder {
     /// up while the mediator is still using them.
     #[cfg(feature = "fjall-backend")]
     fjall_dir: Option<tempfile::TempDir>,
+    /// Optional injected clock. `None` uses the real `SystemClock`; tests pass a
+    /// [`TestClock`] to advance time and exercise token-expiry / message-TTL
+    /// instantly (see [`TestMediatorBuilder::clock`]).
+    clock: Option<Arc<dyn Clock>>,
 }
 
 impl Default for TestMediatorBuilder {
@@ -360,6 +366,7 @@ impl Default for TestMediatorBuilder {
             jwt_access_expiry_secs: None,
             jwt_refresh_expiry_secs: None,
             max_websocket_connections_per_did: None,
+            clock: None,
             admin_identity: None,
             #[cfg(feature = "fjall-backend")]
             fjall_dir: None,
@@ -571,6 +578,15 @@ impl TestMediatorBuilder {
         self
     }
 
+    /// Inject a clock for the spawned mediator's expiry / TTL / session
+    /// decisions. Defaults to the real [`SystemClock`]. Pair a [`TestClock`]
+    /// with [`jwt_expiry`](Self::jwt_expiry) to expire a token in milliseconds:
+    /// issue with a short access expiry, then `clock.advance_secs(..)` past it.
+    pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
     // ─── Routing / endpoint config ───────────────────────────────────
 
     /// Declare additional URLs at which the mediator is reachable.
@@ -728,7 +744,7 @@ impl TestMediatorBuilder {
         let store_for_local_accounts = store.clone();
 
         let token = CancellationToken::new();
-        let inner = MediatorBuilder::new(secrets_resolver.clone())
+        let mut builder = MediatorBuilder::new(secrets_resolver.clone())
             .mediator_did(&mediator_did)
             .admin_did(&admin_did)
             .secrets_backend(secrets_backend)
@@ -741,9 +757,11 @@ impl TestMediatorBuilder {
             .processors(processors)
             .streaming_enabled(self.enable_streaming)
             .local_endpoints(self.local_endpoints.clone())
-            .tls(TlsMode::Plain)
-            .start(token.clone())
-            .await?;
+            .tls(TlsMode::Plain);
+        if let Some(clock) = self.clock.clone() {
+            builder = builder.clock(clock);
+        }
+        let inner = builder.start(token.clone()).await?;
 
         // Register caller-supplied DIDs as LOCAL accounts so they can
         // complete the WebSocket upgrade after authenticating. The

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/clock_injection.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/clock_injection.rs
@@ -1,0 +1,59 @@
+//! TI4b-1 — the injected clock governs token-expiry validation end-to-end.
+//!
+//! Authenticate against an embedded mediator wired with a [`TestClock`], then
+//! advance that clock past the token's lifetime — *no real time passes* — and
+//! confirm the mediator now rejects the previously-valid token. This is the
+//! fast, deterministic alternative to sleeping out a real expiry window.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_messaging_sdk::messages::Folder;
+use affinidi_messaging_test_mediator::{TestClock, TestEnvironment, TestMediator};
+use common::init_tracing;
+
+#[tokio::test]
+async fn access_token_expires_against_the_injected_clock() {
+    init_tracing();
+
+    // Seed the mediator's clock from real time so a freshly-issued token still
+    // looks valid to the SDK client (which reads the real wall clock). Clones of
+    // a TestClock share their time, so advancing `clock` advances the mediator's.
+    let clock = TestClock::now();
+    let access = Duration::from_secs(300);
+    let refresh = Duration::from_secs(1_800);
+
+    let mediator = TestMediator::builder()
+        .clock(Arc::new(clock.clone()))
+        .jwt_expiry(access, refresh)
+        .spawn()
+        .await
+        .expect("spawn mediator with an injected clock");
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire test environment");
+    let alice = env.add_user("Alice").await.expect("add Alice");
+
+    // Fresh token: an authenticated REST call succeeds.
+    env.atm
+        .list_messages(&alice.profile, Folder::Inbox)
+        .await
+        .expect("authenticated call succeeds with a fresh token");
+
+    // Advance ONLY the mediator clock past BOTH the access and refresh
+    // lifetimes (+ the 60s validation leeway). Past refresh expiry too, so the
+    // call fails whether the SDK reuses the cached token or tries to refresh it.
+    clock.advance_secs(refresh.as_secs() + 60 + 5);
+
+    // The same authenticated call is now rejected: the token the mediator issued
+    // is expired against the advanced clock.
+    let result = env.atm.list_messages(&alice.profile, Folder::Inbox).await;
+    assert!(
+        result.is_err(),
+        "the access token must be rejected once the injected clock passes its expiry"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}

--- a/scripts/check-test-clock-isolation.sh
+++ b/scripts/check-test-clock-isolation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# TI4b guard: the advanceable `TestClock` must never compile into the mediator
+# binary.
+#
+# `TestClock` lives behind mediator-common's NON-DEFAULT `test-clock` feature so
+# it can be injected by test fixtures (e.g. affinidi-messaging-test-mediator)
+# but never reaches production. Cargo feature unification means that if a crate
+# in the *mediator binary's* dependency graph ever turned `test-clock` on, it
+# would silently ship. This check fails the build if that ever happens.
+#
+# Pure `cargo tree` (no compile). Resolves features as if building only the
+# mediator binary — test fixtures are not in that graph, so `test-clock` must
+# be absent.
+set -euo pipefail
+
+echo "Checking that 'test-clock' is not enabled for the mediator binary..."
+
+graph=$(cargo tree -p affinidi-messaging-mediator -f '{p} {f}' 2>/dev/null)
+
+# Lines for mediator-common carry its activated feature list as the last field.
+offenders=$(echo "$graph" | grep 'affinidi-messaging-mediator-common' | grep 'test-clock' || true)
+
+if [ -n "$offenders" ]; then
+  echo "ERROR: the 'test-clock' feature is enabled in the mediator binary's graph:" >&2
+  echo "$offenders" >&2
+  echo "TestClock must stay test-only — do not enable 'test-clock' for the mediator." >&2
+  exit 1
+fi
+
+echo "OK: 'test-clock' is not enabled for the mediator binary."


### PR DESCRIPTION
## TI4b-1 — injectable `Clock` (mediator core)

First half of **TI4b**: a `Clock` trait threaded through the mediator so token-expiry / message-TTL / session-cleanup tests can advance a **virtual clock** instead of waiting on real time. (The SDK follows as TI4b-2.) This is the composable, DI-based design chosen over a global feature-gated hook.

### `Clock` trait — `affinidi-messaging-mediator-common` 0.15.13 (additive)
- New `types::clock` module: the `Clock` trait (`unix_secs` / `unix_millis`) + `SystemClock` (production; delegates to the existing `time::unix_timestamp_*` helpers). In always-built `types`, so the mediator **and** the SDK can share it.
- Non-default **`test-clock`** feature compiles `TestClock`, a manually-advanced clock. Never enabled for the mediator binary.

### Mediator — `affinidi-messaging-mediator` 0.16.0 (⚠️ breaking)
- `SharedData` carries an `Arc<dyn Clock>`; the request path reads it instead of the wall clock. `server.rs` wires a `SystemClock`; `MediatorBuilder::clock(..)` injects.
- **Clock-aware token validation.** `jsonwebtoken`'s `exp` check reads the real wall clock (and so ignores an injected clock), so it's disabled and replaced with a manual check against the injected clock — **preserving the previous 60s leeway and boundary exactly** (`clock_aware_validation` / `jwt_exp_is_expired`). Both the access- and refresh-token decode sites are covered; an expired refresh token is still rejected. This is the security-sensitive change — reviewed for behavioural equivalence (unit-tested boundary + leeway).
- Converted the auth, message-store TTL, session/audit, protocol expiry-check, routing and websocket request-path sites. Background components (the standalone expiry-cleanup processor, circuit breaker, store lazy-expiry internals, in-tree store tests) stay on the wall clock — a documented follow-up; none are on the fast-test path.
- **Breaking:** `SharedData` gained a field and `server::serve_internal` gained a `clock` param (hence the minor bump). The embedding API (`MediatorBuilder`) is unchanged except the additive `clock(..)` setter. Only `test-mediator` pins the mediator → its pin moves to `0.16`.

### Test fixture — `affinidi-messaging-test-mediator` 0.2.11
- `TestMediatorBuilder::clock(..)` injects a clock; re-exports `Clock`/`SystemClock`/`TestClock` (enables `mediator-common/test-clock`).
- `tests/clock_injection.rs`: authenticate, **advance the clock past the token lifetime with no real time passing**, confirm the mediator rejects the now-expired token (~1.6s).

### Release guard
- `scripts/check-test-clock-isolation.sh` asserts (via `cargo tree`) that `test-clock` is never enabled for the mediator binary — wired into `release-guards.yaml`. (`cfg(feature=..)` only sees the current crate's features, so a `compile_error!` can't police a dependency's feature; the cargo-tree check can.)

### Tests
mediator lib **133**, mediator-common **145** (incl. the new clock + jwt-leeway unit tests), test-mediator integration green — **lifecycle 22** and **websocket_subprotocol_auth 5** confirm the auth path behaves identically. `clippy -D warnings` and `cargo fmt` clean.

Scope and the design decisions (split, clock-aware validation, leeway preservation) were agreed up front after a spike.