### PR TITLE
feat: injectable clock for the SDK's expiry/TTL reads (TI4b-2)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.18.11] - 2026-06-14
+
+Injectable clock for the SDK's expiry/TTL reads (TI4b-2).
+
+### Added
+
+- `ATMConfigBuilder::with_clock(Arc<dyn Clock>)` injects the clock the SDK uses
+  for its time reads (defaults to the real `SystemClock`). The `Clock` trait
+  comes from `affinidi-messaging-mediator-common` (shared with the mediator,
+  TI4b-1), so a test can drive both with one `TestClock`.
+
+### Changed
+
+- The SDK's expiry/TTL **decisions** now read the injected clock instead of the
+  wall clock directly: forwarded-message expiry (`extract_forward_payload`) and
+  the WebSocket token-refresh TTL (`refresh_deadline`). Additive — existing
+  callers are unaffected. The refresh deadline is still *scheduled* on tokio's
+  monotonic timer; only the TTL computation moved to the injected clock.
+- Outbound protocol-message `created_time`/`expires_time` stamps still read the
+  wall clock (a documented follow-up); the mediator's own injected clock governs
+  enforcement, so this does not affect expiry tests.
+
 ## [0.18.10] - 2026-06-13
 
 WS resilience (W16, part 2 of 2).

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.10"
+version = "0.18.11"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -3,6 +3,7 @@ use crate::{
     transports::websockets::WebSocketResponses,
 };
 use affinidi_crypto::jose::key_agreement::Curve;
+use affinidi_messaging_mediator_common::types::clock::{Clock, SystemClock};
 use rustls::pki_types::CertificateDer;
 use std::{fs::File, io::BufReader, sync::Arc, time::Duration};
 use tokio::sync::{RwLock, broadcast::Sender};
@@ -42,6 +43,12 @@ pub struct ATMConfig {
     /// so an unreachable mediator surfaces a `TransportError` in seconds
     /// rather than blocking on the OS-level TCP RTO. Default: 15s.
     pub(crate) request_timeout: Duration,
+
+    /// Source of the current time for the SDK's expiry / TTL decisions
+    /// (forwarded-message expiry, the WebSocket token-refresh deadline).
+    /// Defaults to the real [`SystemClock`]; tests inject a `TestClock` via
+    /// [`ATMConfigBuilder::with_clock`] to drive those reads deterministically.
+    pub(crate) clock: Arc<dyn Clock>,
 }
 
 impl ATMConfig {
@@ -54,6 +61,11 @@ impl ATMConfig {
     /// The per-request timeout applied to mediator REST calls.
     pub fn get_request_timeout(&self) -> Duration {
         self.request_timeout
+    }
+
+    /// The clock backing the SDK's expiry / TTL decisions.
+    pub(crate) fn clock(&self) -> &Arc<dyn Clock> {
+        &self.clock
     }
 
     /// Returns a builder for `ATMConfig`
@@ -89,6 +101,7 @@ pub struct ATMConfigBuilder {
     discover_features: DiscoverFeatures,
     curve_preference: Option<Vec<Curve>>,
     request_timeout: Duration,
+    clock: Option<Arc<dyn Clock>>,
 }
 
 impl Default for ATMConfigBuilder {
@@ -102,6 +115,7 @@ impl Default for ATMConfigBuilder {
             discover_features: DiscoverFeatures::default(),
             curve_preference: None,
             request_timeout: Duration::from_secs(15),
+            clock: None,
         }
     }
 }
@@ -196,6 +210,15 @@ impl ATMConfigBuilder {
         self
     }
 
+    /// Inject the clock the SDK uses for expiry / TTL decisions
+    /// (forwarded-message expiry, the WebSocket token-refresh deadline).
+    /// Defaults to the real [`SystemClock`]; pass a `TestClock` to drive those
+    /// reads deterministically in tests.
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
     pub fn build(self) -> Result<ATMConfig, ATMError> {
         // Process any custom SSL certificates
         let mut certs = vec![];
@@ -233,6 +256,43 @@ impl ATMConfigBuilder {
             discover_features: Arc::new(RwLock::new(self.discover_features)),
             curve_preference: self.curve_preference,
             request_timeout: self.request_timeout,
+            clock: self.clock.unwrap_or_else(|| Arc::new(SystemClock)),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A clock fixed at a chosen instant — proves an injected clock flows
+    /// through to the SDK's time reads without pulling the `test-clock` feature.
+    #[derive(Debug)]
+    struct FixedClock(u64);
+    impl Clock for FixedClock {
+        fn unix_secs(&self) -> u64 {
+            self.0
+        }
+        fn unix_millis(&self) -> u128 {
+            self.0 as u128 * 1_000
+        }
+    }
+
+    #[test]
+    fn defaults_to_a_live_system_clock() {
+        let config = ATMConfig::builder().build().unwrap();
+        assert!(
+            config.clock().unix_secs() > 0,
+            "default is the system clock"
+        );
+    }
+
+    #[test]
+    fn injected_clock_is_used() {
+        let config = ATMConfig::builder()
+            .with_clock(Arc::new(FixedClock(1_234)))
+            .build()
+            .unwrap();
+        assert_eq!(config.clock().unix_secs(), 1_234);
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
@@ -2,7 +2,6 @@ use crate::{ATM, SharedState, errors::ATMError, messages::compat::UnpackMetadata
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_secrets_resolver::SecretsResolver;
 use base64::{Engine, prelude::BASE64_URL_SAFE};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{Instrument, Level, debug, span, warn};
 
 impl ATM {
@@ -89,7 +88,8 @@ impl SharedState {
                         )));
                     }
                     // Extract the inner message and loop to unpack it
-                    msg_string = Self::extract_forward_payload(&msg)?;
+                    msg_string =
+                        Self::extract_forward_payload(&msg, self.config.clock().unix_secs())?;
                 } else {
                     return Ok((msg, metadata));
                 }
@@ -419,7 +419,7 @@ impl SharedState {
 
         async move {
             debug!("Attempting to unpack a forwarded message");
-            let inner = Self::extract_forward_payload(message)?;
+            let inner = Self::extract_forward_payload(message, self.config.clock().unix_secs())?;
             self.unpack(&inner).await
         }
         .instrument(_span)
@@ -427,21 +427,18 @@ impl SharedState {
     }
 
     /// Extracts the inner message string from a forward message's attachment.
-    /// Checks expiry and supports JSON and Base64 attachment formats.
-    pub(crate) fn extract_forward_payload(message: &Message) -> Result<String, ATMError> {
+    /// Checks expiry (against the caller-supplied `now`, sourced from the SDK's
+    /// injected clock) and supports JSON and Base64 attachment formats.
+    pub(crate) fn extract_forward_payload(message: &Message, now: u64) -> Result<String, ATMError> {
         debug!("Extracting payload from forwarded message");
 
         // Check expiry time if it exists
-        if let Some(expires_time) = message.expires_time {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            if expires_time <= now {
-                return Err(ATMError::MsgReceiveError(String::from(
-                    "Forwarded Message has expired and cannot be processed",
-                )));
-            }
+        if let Some(expires_time) = message.expires_time
+            && expires_time <= now
+        {
+            return Err(ATMError::MsgReceiveError(String::from(
+                "Forwarded Message has expired and cannot be processed",
+            )));
         }
 
         if let Some(attachments) = &message.attachments
@@ -502,7 +499,10 @@ mod tests {
     use affinidi_tdk_common::TDKSharedState;
     use serde_json::json;
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Fixed "current time" for the `extract_forward_payload` expiry tests — the
+    /// `now` the SDK would source from its injected clock.
+    const NOW_SECS: u64 = 1_000_000_000;
 
     use affinidi_did_common::{DID, PeerCreateKey, PeerKeyPurpose, PeerKeyType};
     use affinidi_messaging_didcomm::message::Message as DcMessage;
@@ -1345,7 +1345,7 @@ mod tests {
         let inner_json = make_plaintext_json(&inner);
         let forward = wrap_in_forward_json(&inner_json, None);
 
-        let extracted = SharedState::extract_forward_payload(&forward).unwrap();
+        let extracted = SharedState::extract_forward_payload(&forward, NOW_SECS).unwrap();
 
         let extracted_value: serde_json::Value = serde_json::from_str(&extracted).unwrap();
         let inner_value: serde_json::Value = serde_json::from_str(&inner_json).unwrap();
@@ -1358,7 +1358,7 @@ mod tests {
         let inner_json = make_plaintext_json(&inner);
         let forward = wrap_in_forward_base64(&inner_json, None);
 
-        let extracted = SharedState::extract_forward_payload(&forward).unwrap();
+        let extracted = SharedState::extract_forward_payload(&forward, NOW_SECS).unwrap();
 
         assert_eq!(extracted, inner_json);
     }
@@ -1369,7 +1369,7 @@ mod tests {
         let inner_json = make_plaintext_json(&inner);
         let forward = wrap_in_forward_json(&inner_json, Some(1));
 
-        let result = SharedState::extract_forward_payload(&forward);
+        let result = SharedState::extract_forward_payload(&forward, NOW_SECS);
 
         assert!(result.is_err());
         assert!(
@@ -1382,14 +1382,10 @@ mod tests {
     fn extract_forward_payload_not_expired() {
         let inner = make_inner_message();
         let inner_json = make_plaintext_json(&inner);
-        let future = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + 3600;
+        let future = NOW_SECS + 3600;
         let forward = wrap_in_forward_json(&inner_json, Some(future));
 
-        let result = SharedState::extract_forward_payload(&forward);
+        let result = SharedState::extract_forward_payload(&forward, NOW_SECS);
 
         assert!(result.is_ok());
     }
@@ -1403,7 +1399,7 @@ mod tests {
         )
         .finalize();
 
-        let result = SharedState::extract_forward_payload(&msg);
+        let result = SharedState::extract_forward_payload(&msg, NOW_SECS);
 
         assert!(result.is_err());
         assert!(
@@ -1422,7 +1418,7 @@ mod tests {
         .finalize();
         msg.attachments = Some(vec![]);
 
-        let result = SharedState::extract_forward_payload(&msg);
+        let result = SharedState::extract_forward_payload(&msg, NOW_SECS);
 
         assert!(result.is_err());
         assert!(
@@ -1447,7 +1443,7 @@ mod tests {
         .attachment(attachment)
         .finalize();
 
-        let result = SharedState::extract_forward_payload(&msg);
+        let result = SharedState::extract_forward_payload(&msg, NOW_SECS);
 
         assert!(result.is_err());
         assert!(
@@ -1469,7 +1465,7 @@ mod tests {
         .attachment(attachment)
         .finalize();
 
-        let result = SharedState::extract_forward_payload(&msg);
+        let result = SharedState::extract_forward_payload(&msg, NOW_SECS);
 
         assert!(result.is_err());
         assert!(
@@ -1514,7 +1510,7 @@ mod tests {
         .attachment(attachment)
         .finalize();
 
-        let result = SharedState::extract_forward_payload(&msg);
+        let result = SharedState::extract_forward_payload(&msg, NOW_SECS);
 
         assert!(result.is_err());
         assert!(

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -374,10 +374,9 @@ impl WebSocketTransport {
     /// mediator force-closes the socket at expiry. `None` if expiry is unknown.
     fn refresh_deadline(&self) -> Option<tokio::time::Instant> {
         let expires_at = self.access_expires_at?;
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        // Wall-clock TTL read goes through the injected clock; the deadline
+        // itself is still scheduled on the tokio monotonic timer below.
+        let now = self.shared.config.clock().unix_secs();
         let ttl = expires_at.saturating_sub(now);
         Some(tokio::time::Instant::now() + Duration::from_secs(refresh_after_secs(ttl)))
     }


### PR DESCRIPTION
## TI4b-2 — injectable clock in the messaging SDK

Second half of **TI4b** (and the last piece of **TI4**): thread the shared `Clock` trait through the SDK so its expiry / TTL **decisions** read an injectable clock instead of the wall clock. `affinidi-messaging-sdk` 0.18.11 (additive).

### What changed
- **`ATMConfigBuilder::with_clock(Arc<dyn Clock>)`** injects the clock the SDK uses for time reads (defaults to the real `SystemClock`). The `Clock` trait comes from `affinidi-messaging-mediator-common` (the same one wired into the mediator in TI4b-1), which the SDK already depends on with `default-features = false` — so a test can drive **both** the mediator and the SDK with one `TestClock`.
- Converted the SDK's expiry/TTL **decision reads**:
  - `messages::unpack::extract_forward_payload` — forwarded-message expiry now checks against a `now` sourced from `config.clock()`.
  - `transports::websockets::refresh_deadline` — the token-refresh TTL calc reads the injected clock. (The deadline is still *scheduled* on tokio's monotonic timer; only the TTL computation moved — see note below.)

### Additive, no cascade
`ATMConfig`'s fields are `pub(crate)` (builder-only construction), so adding the clock field + `with_clock` breaks nothing. All `affinidi-messaging-sdk = "0.18"` pins resolve to 0.18.11 unchanged.

### Deliberately out of scope (documented)
- **The ~30 outbound protocol-message `created_time`/`expires_time` stamps** still read the wall clock. Threading `now` through them would break ~30 public method signatures for cosmetic value, and the **mediator's** injected clock (TI4b-1) already governs enforcement — so it doesn't affect expiry tests.
- `refresh_deadline` still **fires** on tokio's monotonic timer; only its TTL computation reads the clock. A genuinely fast WebSocket-refresh test would additionally need tokio's `start_paused` virtual time — beyond clock injection.

### Tests
Config unit tests (default `SystemClock` + an injected clock), and the `extract_forward_payload` expiry tests reworked onto an explicit `now`. SDK lib suite **65** green; `clippy -D warnings` and `cargo fmt` clean; SDK dependents (test-mediator, helpers, text-client, didcomm-service) build.

With this, **TI4 is complete** (TI4a seeded DIDs #467 + TI4b-1 mediator clock #468 + TI4b-2 SDK clock).