### PR TITLE
feat: documented testing API + scenario cookbook (TI6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,25 @@ let mut atm = ATM::new(config, vec![]).await?;
 atm.send_ping("did:peer:2...", true, true).await?;
 ```
 
+## Testing
+
+You can write messaging / DID / credential integration tests with **no external
+infrastructure** — no Redis, no network, no standing services. Two paths:
+
+- **Rust fixtures** — pull a fixture crate in as a `dev-dependency`:
+  [`affinidi-messaging-test-mediator`](./crates/messaging/affinidi-messaging-test-mediator/)
+  for embedded mediators (`TestMediator` / `TestEnvironment` / `TestTopology`),
+  and [`affinidi-tdk-test-support`](./crates/tdk/affinidi-tdk-test-support/) for
+  did:web mocks, deterministic resolvers, seeded DIDs, and credential scenarios.
+  A mediator is three lines; an issue/present/verify round trip is a handful.
+- **Language-agnostic** — `docker compose -f docker-compose.test.yml up` a
+  known-good mediator + Redis + did:web host with fixed TEST-ONLY identities and
+  point any client at it.
+
+Copy-paste scenarios for both paths are in the
+[testing cookbook](./docs/testing/cookbook.md); the composed stack is documented
+in [`docs/testing/docker-compose.md`](./docs/testing/docker-compose.md).
+
 ## Using affinidi-* crates from outside this workspace
 
 This workspace's root `Cargo.toml` defines a non-trivial

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 14th June 2026
 
+### 0.7.0 — documented testing API + cookbook (TI6)
+
+- **Published.** `publish` flipped to `true` — the fixture API stabilised with
+  the TI-series and external consumers can now pull this in as a
+  `dev-dependency` from crates.io. It remains a `0.x` testing crate (additive
+  where possible; breaking changes get a minor bump + a `CHANGELOG` entry).
+- **Stability.** The fixture config enums (`did_web::Fault`, `resolver::Outcome`)
+  and the error enums (`ScenarioError`, `DeterminismError`, `VectorError`) are
+  now `#[non_exhaustive]`, so new variants land additively. Match arms over them
+  must carry a `_` wildcard.
+- **Docs.** Each module now carries a runnable, CI-compiled (`cargo test --doc`)
+  doc example of its happy path (`did_web` was the last one without). A
+  copy-paste scenario cookbook spanning these fixtures, the embedded mediator
+  (`affinidi-messaging-test-mediator`), and the language-agnostic
+  `docker-compose.test.yml` path lives at `docs/testing/cookbook.md`.
+- No behaviour change to any fixture.
+
 ### 0.6.0 — seeded did:peer generation (TI4a)
 
 - `determinism`: deterministic `did:peer` identities. `did_peer_from_seed(seed,

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.6.0"
+version = "0.7.0"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -10,10 +10,10 @@ license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 readme = "README.md"
-# Scaffold only — flipped to `true` once the fixture API stabilises (TI-series)
-# so external consumers can pull it in as a dev-dependency. Empty crates should
-# not hit crates.io.
-publish = false
+# Published so external consumers can pull it in as a `dev-dependency`. The
+# fixture API stabilised with the TI-series; it is a `0.x` testing crate (see
+# the crate docs' Stability note).
+publish = true
 
 [dependencies]
 # ── TI2: did:web/webvh mock server + StaticResolver ──────────────────────

--- a/crates/tdk/affinidi-tdk-test-support/README.md
+++ b/crates/tdk/affinidi-tdk-test-support/README.md
@@ -18,18 +18,35 @@ mediator-specific — a mock did:web server, a deterministic resolver, a
 credential issuer/holder/verifier scenario, or a multi-mediator topology — and
 you don't want to stand up external services.
 
-## Status
+## Fixtures
 
-Fixtures land per task in the TI-series (see `tasks/testing-todo.md`):
+| Module                     | Fixture                                                          |
+|----------------------------|-----------------------------------------------------------------|
+| `did_web` / `resolver`     | did:web / did:webvh mock server (fault injection) + injectable `StaticResolver` |
+| `determinism`              | Seeded `did:peer` generation (same seed → same identity)        |
+| `credential_scenario`      | `CredentialScenario` — SD-JWT VC issue / present / verify + revocation |
+| `mdoc_scenario` / `oid4vp` | mdoc (COSE) flows + OID4VP present / verify (both eIDAS formats) |
+| `vectors`                  | Shared `tests/vectors/` layout + loader                         |
 
-| Task  | Module                | Fixture                                                       | Status |
-|-------|-----------------------|---------------------------------------------------------------|:------:|
-| TI1   | `topology`            | Multi-mediator `TestTopology` (in-process, no Redis)          |  ⏳   |
-| TI2   | `did_web` / `resolver`| did:web / did:webvh mock server + injectable `StaticResolver` |  ✅   |
-| TI4a  | `determinism`         | Seeded `did:peer` generation (reproducible identities)        |  ✅   |
-| TI4b  | `determinism`         | Injectable clock (`Clock` trait through mediator + SDK)        |  ⏳   |
-| TI5a  | `credential_scenario` | `CredentialScenario` SD-JWT VC issue / present / verify        |  ✅   |
-| TI5b  | `mdoc_scenario` / `oid4vp` | mdoc (COSE) flows + OID4VP present / verify (both eIDAS formats) |  ✅   |
-| TI7   | `vectors`             | Shared `tests/vectors/` layout + loader                       |  ✅   |
+The embedded-mediator fixtures (`TestMediator`, `TestEnvironment`,
+`TestTopology`) live in the sibling [`affinidi-messaging-test-mediator`] crate.
+
+## Cookbook
+
+Copy-paste scenarios for both crates — three-line in-process mediator, two-hop
+forward, did:web rotation, seeded identities, issue / present / verify,
+revocation — plus the language-agnostic `docker compose` path are in
+[`docs/testing/cookbook.md`](../../../docs/testing/cookbook.md). Every Rust
+snippet there mirrors a runnable, CI-compiled doc example on the corresponding
+module.
+
+## Stability
+
+A `0.x` testing crate. Minor releases may evolve the API, but breaking changes
+get a minor bump and a `CHANGELOG` entry. The fixture config enums
+(`did_web::Fault`, `resolver::Outcome`) and the error enums are
+`#[non_exhaustive]`, so new variants land additively — match arms over them must
+carry a `_` wildcard. Each module ships a runnable doc example
+(`cargo test --doc`) of its happy path.
 
 [`affinidi-messaging-test-mediator`]: ../../messaging/affinidi-messaging-test-mediator

--- a/crates/tdk/affinidi-tdk-test-support/src/credential_scenario.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/credential_scenario.rs
@@ -68,6 +68,7 @@ use crate::resolver::StaticResolver;
 
 /// Errors from the credential scenario fixture.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ScenarioError {
     /// An sd-jwt-vc issuance call failed.
     #[error("sd-jwt-vc: {0}")]

--- a/crates/tdk/affinidi-tdk-test-support/src/determinism.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/determinism.rs
@@ -40,6 +40,7 @@ pub use affinidi_secrets_resolver::secrets::{KeyType, Secret};
 
 /// Errors from seeded identity generation.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DeterminismError {
     /// Assembling the `did:peer` failed.
     #[error("did:peer: {0}")]

--- a/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
@@ -18,6 +18,31 @@
 //! `localhost%3A<port>` for minting `did:webvh:…:localhost%3A<port>:…` DIDs.
 //! That path relies on `localhost` resolving to the loopback the server is
 //! bound on (the standard configuration).
+//!
+//! ```
+//! use affinidi_tdk_test_support::did_web::{Fault, MockDidWebServer};
+//!
+//! // The server is async; drive it from a runtime (your test would be
+//! // `#[tokio::test]`).
+//! tokio::runtime::Runtime::new().unwrap().block_on(async {
+//!     let server = MockDidWebServer::start().await;
+//!     server.register(
+//!         "/.well-known/did.json",
+//!         200,
+//!         "application/did+ld+json",
+//!         r#"{"id":"did:web:localhost"}"#,
+//!     );
+//!
+//!     // A resolver would now fetch `<base_url>/.well-known/did.json`.
+//!     assert!(server.base_url().starts_with("http://127.0.0.1:"));
+//!     assert_eq!(server.hits("/.well-known/did.json"), 0, "no fetch yet");
+//!
+//!     // Inject a fault to exercise the resolver's hardening (timeouts,
+//!     // status handling, …); every later response carries it until cleared.
+//!     server.set_fault(Fault::Status(503));
+//!     server.clear_fault();
+//! });
+//! ```
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -35,7 +60,11 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 /// A fault applied to every response until cleared.
+///
+/// `#[non_exhaustive]`: new fault kinds may be added in a minor release, so
+/// match arms over `Fault` must include a `_` wildcard.
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub enum Fault {
     /// Serve registered responses normally.
     #[default]

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -11,20 +11,27 @@
  * a `dev-dependency`; nothing in the normal build graph depends on it, so the
  * upward dev-dependency edges create no cycle.
  *
- * # Roadmap (TI-series, see `tasks/testing-todo.md`)
+ * # Fixtures
  *
- * Modules are added by the task that needs them; this scaffold establishes the
- * crate, its workspace wiring, and CI coverage so each fixture lands as a thin,
- * self-contained PR.
+ * - [`did_web`] / [`resolver`] — in-process did:web / did:webvh mock server with
+ *   fault injection, plus an injectable `StaticResolver`.
+ * - [`determinism`] — seeded `did:peer` generation (same seed → same identity).
+ * - [`credential_scenario`] — issuer/holder/verifier `CredentialScenario` for
+ *   SD-JWT VC, with the [`mdoc_scenario`] and [`oid4vp`] flows layered on top.
+ * - [`vectors`] — shared `tests/vectors/` layout and loader.
  *
- * - **TI1** — `topology`: multi-mediator `TestTopology` (in-process, no Redis).
- * - **TI2** — [`did_web`] / [`resolver`]: in-process did:web / did:webvh mock
- *   server with fault injection, plus an injectable `StaticResolver`. ✅
- * - **TI4** — [`determinism`]: seeded did:peer generation (TI4a ✅); an
- *   injectable clock follows in TI4b.
- * - **TI5** — [`credential_scenario`]: issuer/holder/verifier `CredentialScenario`
- *   for SD-JWT VC (TI5a) plus the [`mdoc_scenario`] and [`oid4vp`] flows (TI5b). ✅
- * - **TI7** — [`vectors`]: shared `tests/vectors/` layout and loader. ✅
+ * The embedded-mediator fixtures (`TestMediator` / `TestEnvironment` /
+ * `TestTopology`) live in the sibling `affinidi-messaging-test-mediator` crate.
+ * A copy-paste cookbook covering both crates plus the language-agnostic
+ * `docker-compose.test.yml` path is in
+ * [`docs/testing/cookbook.md`](https://github.com/affinidi/affinidi-tdk-rs/blob/main/docs/testing/cookbook.md).
+ *
+ * # Stability
+ *
+ * This is a `0.x` testing crate: minor releases may evolve the API, but breaking
+ * changes get a minor bump and a `CHANGELOG` entry, and the fixture config and
+ * error enums are `#[non_exhaustive]` so new variants land additively. Each
+ * module carries a runnable, CI-compiled doc example of its happy path.
  */
 
 pub mod credential_scenario;

--- a/crates/tdk/affinidi-tdk-test-support/src/resolver.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/resolver.rs
@@ -31,7 +31,10 @@ use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
 /// `Delays` wraps another outcome so a test can express "resolve after 2s" or
 /// "fail after 500ms"; `Hangs` never completes, which is the lever for
 /// request-path timeout tests.
+/// `#[non_exhaustive]`: new outcome kinds may be added in a minor release, so
+/// match arms over `Outcome` must include a `_` wildcard.
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum Outcome {
     /// Resolve to this document — the happy path. Boxed because a `Document`
     /// dwarfs the other variants.

--- a/crates/tdk/affinidi-tdk-test-support/src/vectors.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/vectors.rs
@@ -41,6 +41,7 @@ use serde_json::Value;
 
 /// Errors from loading a test vector.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum VectorError {
     /// The vector file could not be read.
     #[error("reading vector `{path}`: {source}")]

--- a/docs/testing/cookbook.md
+++ b/docs/testing/cookbook.md
@@ -1,0 +1,293 @@
+# Testing cookbook
+
+Copy-paste scenarios for writing Affinidi TDK integration tests with **no
+external infrastructure** — no Redis, no network, no standing services.
+
+There are two paths:
+
+- **Rust fixtures** (this page, most of it) — pull a fixture crate in as a
+  `dev-dependency` and stand up mediators, DID resolution, and credential flows
+  in-process. Three lines for a working mediator; a handful for an
+  issue/present/verify round trip.
+- **Language-agnostic** — `docker compose up` a known-good mediator + Redis +
+  did:web host and point any client (any language) at it. See
+  [Composed test stack](#composed-test-stack-any-language) below and
+  [`docker-compose.md`](docker-compose.md).
+
+The two fixture crates:
+
+| Crate | Owns | Pull in as |
+|-------|------|------------|
+| [`affinidi-messaging-test-mediator`] | embedded mediator(s): `TestMediator`, `TestEnvironment`, `TestTopology` | `affinidi-messaging-test-mediator = "0.2"` |
+| [`affinidi-tdk-test-support`] | did:web mock, deterministic resolver, seeded DIDs, credential scenarios, vector loader | `affinidi-tdk-test-support = "0.7"` |
+
+> Every `affinidi-tdk-test-support` snippet below mirrors a **runnable,
+> CI-compiled doc example** on the corresponding module (`cargo test --doc`), so
+> the API shown here is the API that compiles. The mediator/SDK snippets are
+> marked `ignore` because they need an async runtime and the full SDK; they
+> follow the patterns covered by that crate's own integration tests.
+
+---
+
+## 1. A mediator in three lines
+
+```rust,ignore
+use affinidi_messaging_test_mediator::TestMediator;
+
+let mediator = TestMediator::spawn().await.unwrap();
+let endpoint = mediator.endpoint();   // http://127.0.0.1:<ephemeral>
+let did = mediator.did();             // freshly-generated did:peer
+// ... drive the SDK against `endpoint` / `did` ...
+mediator.shutdown();
+mediator.join().await.unwrap();
+```
+
+A fully-functional mediator on an ephemeral `127.0.0.1` port, `MemoryStore`
+backend, random JWT signing key — all `did:peer`, so no network. For on-disk
+persistence semantics, the builder takes a `FjallStore` backend.
+
+## 2. Named users, end to end
+
+`TestEnvironment` bundles a mediator, an SDK client (`env.atm`), and named users
+whose DIDs already point at the mediator as their DIDComm service.
+
+```rust,ignore
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+let env = TestEnvironment::spawn().await.unwrap();
+let alice = env.add_user("Alice").await.unwrap();
+let bob = env.add_user("Bob").await.unwrap();
+
+// Exercise the SDK against `env.atm`, `alice.profile`, `bob.profile` ...
+
+env.shutdown().await.unwrap();
+```
+
+Each user is registered `LOCAL, ALLOW_ALL` and their secrets inserted into the
+mediator's resolver, so you can pack/unpack without further wiring. See the
+crate's README for ACL modes, WebSocket auth, and the local-vs-remote routing
+footgun (use the mediator's **DID**, not its URL, as a user's service URI).
+
+## 3. Two-hop forward across two mediators
+
+`TestTopology` spawns N relay mediators in one process and routes a message
+through them — the routing-2.0 double-forward, no Redis. This is the home for
+the relay e2e (#385/#388).
+
+```rust,ignore
+use std::time::Duration;
+use affinidi_messaging_test_mediator::TestTopology;
+
+let topology = TestTopology::builder()
+    .mediators(2)
+    .spawn()
+    .await
+    .unwrap();
+
+let alice = topology.add_user(0, "Alice").await.unwrap();  // on mediator 0
+let bob = topology.add_user(1, "Bob").await.unwrap();      // on mediator 1
+
+// Alice -> Bob, traversing both mediators; returns Bob's received text.
+let received = topology
+    .forward(0, &alice, 1, &bob, "hello across two hops", Duration::from_secs(15))
+    .await
+    .unwrap();
+assert_eq!(received.as_deref(), Some("hello across two hops"));
+
+topology.shutdown().await.unwrap();
+```
+
+`.rewrap()` switches the relay to rewrap mode (preserving the inner
+recipient-addressed envelope); `.configure_each(|b| ...)` sets per-node backend
+knobs (e.g. Fjall or Redis).
+
+## 4. did:web / did:webvh mock + fault injection
+
+`MockDidWebServer` serves DID documents and `did:webvh` logs from an ephemeral
+loopback port so a test exercises the real HTTP fetch path — including the
+failure modes that matter for resolver hardening.
+
+```rust,ignore
+use affinidi_tdk_test_support::did_web::{Fault, MockDidWebServer};
+
+let server = MockDidWebServer::start().await;
+server.register_did_document(&[], &did_document);   // serves /.well-known/did.json
+
+// "Rotation": re-register the same location with the next document version.
+server.register_did_document(&[], &rotated_document);
+
+// Resolver hardening — every later response carries the fault until cleared:
+server.set_fault(Fault::Delay(std::time::Duration::from_secs(5))); // slow origin
+server.set_fault(Fault::Status(503));                               // error status
+server.set_fault(Fault::Hang);                                      // never responds
+server.set_fault(Fault::Oversize(10_000_000));                     // size-limit guard
+server.clear_fault();
+
+assert_eq!(server.hits("/.well-known/did.json"), 0); // count actual fetches
+```
+
+`Fault` is `#[non_exhaustive]` — match arms need a `_`. For `did:webvh`, mint the
+DID with `server.webvh_authority()` (`localhost%3A<port>`).
+
+## 5. A deterministic resolver (no network, no faults)
+
+When you don't need an HTTP server, `StaticResolver` returns canned outcomes for
+known DIDs and records every call — ideal for cache-stampede / fall-through
+tests.
+
+```rust,ignore
+use affinidi_tdk_test_support::resolver::{Outcome, StaticResolver};
+
+let resolver = StaticResolver::new()
+    .resolves("did:web:good.example", good_doc)          // happy path
+    .outcome("did:web:flaky.example", Outcome::Fails("boom".into()))
+    .default_outcome(Outcome::NotHandled);               // unknown -> falls through
+
+// ... drive resolution-dependent code against `resolver` ...
+assert_eq!(resolver.call_count("did:web:good.example"), 1);
+```
+
+`Outcome` is `#[non_exhaustive]` and also models `Delays { after, then }` and
+`Hangs` for timeout tests; `Outcome::resolves_after(dur, doc)` is the shorthand.
+
+## 6. Reproducible identities (seeded `did:peer`)
+
+Random test DIDs can't reproduce a CI failure or back a golden-file assertion.
+Seed them instead: **same seed → same DID, keys, and key ids**, every run.
+
+```rust,ignore
+use affinidi_tdk_test_support::determinism::didcomm_identity_from_seed;
+
+// Ed25519 verification + X25519 encryption did:peer, with a DIDComm service.
+let (did, secrets) =
+    didcomm_identity_from_seed(7, Some("https://mediator.example/".into())).unwrap();
+
+// Same seed, same identity — anywhere, any run.
+let (did_again, _) = didcomm_identity_from_seed(7, None).unwrap(); // (no service: a different DID)
+```
+
+`did_peer_from_seed(seed, &[(purpose, key_type), ...], service)` gives explicit
+control over the key list; `seeded_secret(key_type, &seed)` is the low-level
+primitive. **TEST-ONLY** — seeded keys are predictable; never a production key.
+
+## 7. Credentials: issue → present → verify
+
+`CredentialScenario` stands up a deterministic issuer, holder, and verifier plus
+an in-memory revocation status list — the home for the W4/W5 negatives. All
+synchronous, no network.
+
+```rust
+use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+use serde_json::json;
+
+let scenario = CredentialScenario::new();
+let aud = scenario.verifier.did().to_string();
+
+let vc = scenario
+    .issue_sd_jwt_vc(
+        "https://example.com/IdentityCredential",
+        &json!({ "given_name": "Alice", "email": "alice@example.com" }),
+        &json!({ "_sd": ["given_name", "email"] }),   // selectively disclosable
+    )
+    .unwrap();
+
+// Holder presents only `given_name`, bound to the verifier (aud) + nonce.
+let presentation = scenario.present(&vc, &["given_name"], &aud, "nonce-1").unwrap();
+
+let result = scenario.verify(&presentation, &aud, "nonce-1").unwrap();
+assert!(result.is_verified());
+assert_eq!(result.claims["given_name"], "Alice");
+assert!(result.claims.get("email").is_none(), "email was not disclosed");
+```
+
+### Revocation
+
+```rust
+let mut scenario = CredentialScenario::new();
+let index = scenario.allocate_status();   // bind the VC to a status-list index
+// ... issue a VC carrying `index`, present it ...
+
+assert!(!scenario.is_revoked(index).unwrap());
+scenario.revoke(index).unwrap();
+assert!(scenario.is_revoked(index).unwrap());
+// A status-aware verifier accepts only when crypto verifies AND not revoked.
+```
+
+The signature still verifies after revocation (revocation is orthogonal to
+signing) — the accept decision must additionally consult `is_revoked`. The
+disallowed-`alg` and wrong-holder-key negatives use `verify_with` /
+`issue_sd_jwt_vc_with_signer`; see `tests/credential_scenario.rs`.
+
+## 8. mdoc (ISO 18013-5) and OID4VP
+
+The same three identities back the mdoc path and the OID4VP envelope, so one
+scenario covers both eIDAS mandatory formats (`vc+sd-jwt` and `mso_mdoc`).
+
+```rust
+use affinidi_tdk_test_support::credential_scenario::CredentialScenario;
+use std::collections::BTreeMap;
+use serde_json::json;
+
+let scenario = CredentialScenario::new();
+const DOC_TYPE: &str = "eu.europa.ec.eudi.pid.1";
+
+let mdoc = scenario
+    .issue_mdoc(DOC_TYPE, DOC_TYPE, &json!({ "given_name": "Erika", "age_over_18": true }))
+    .unwrap();
+
+let mut requested = BTreeMap::new();
+requested.insert(DOC_TYPE.to_string(), vec!["age_over_18".to_string()]);
+let response = scenario.present_mdoc(&mdoc, &requested).unwrap();
+
+let mso = scenario.verify_mdoc(&response).unwrap();   // issuerAuth + digests
+assert_eq!(mso.doc_type, DOC_TYPE);
+assert_eq!(response.disclosed_names(DOC_TYPE), vec!["age_over_18"]); // selective
+```
+
+For the OID4VP envelope (`oid4vp_request` / `oid4vp_present_sd_jwt` /
+`oid4vp_present_mdoc` / `oid4vp_verify_*`), holder binding via device auth, and
+the nonce-replay / tampered-token negatives, see `tests/oid4vp_flow.rs` and
+`tests/mdoc_scenario.rs`.
+
+## 9. Shared test vectors (KATs)
+
+Keep known-answer-test vectors under `<crate>/tests/vectors/<source>/…` and load
+them through one helper:
+
+```rust,no_run
+use affinidi_tdk_test_support::vectors;
+
+// Resolves relative to `<crate>/tests/vectors/`.
+let kat: serde_json::Value = vectors::load_json("dif-bbs/signature.json").unwrap();
+let all = vectors::load_json_dir("dif-bbs").unwrap();   // every *.json in a dir
+```
+
+---
+
+## Composed test stack (any language)
+
+For non-Rust clients — or a realistic Redis-backed target this repo's
+`MemoryStore` can't model — bring up a known-good mediator + Redis + static
+did:web host with fixed, committed **TEST-ONLY** identities:
+
+```bash
+docker compose -f docker-compose.test.yml up --build
+# mediator → http://localhost:7037/mediator/v1/   did:web → http://localhost:8080
+```
+
+Fixed identities, the regeneration recipe, and the smoke test are documented in
+[`docker-compose.md`](docker-compose.md).
+
+---
+
+## Stability
+
+`affinidi-tdk-test-support` is a `0.x` testing crate: minor releases may evolve
+the API, but breaking changes get a minor bump and a `CHANGELOG` entry. Fixture
+config enums (`Fault`, `Outcome`) and error enums are `#[non_exhaustive]`, so new
+variants land additively — match arms need a `_` wildcard.
+`affinidi-messaging-test-mediator` follows the same convention; see each crate's
+README and `CHANGELOG`.
+
+[`affinidi-messaging-test-mediator`]: ../../crates/messaging/affinidi-messaging-test-mediator
+[`affinidi-tdk-test-support`]: ../../crates/tdk/affinidi-tdk-test-support


### PR DESCRIPTION
## TI6 — documented testing API + scenario cookbook (last TI-series task)

Promotes the TDK test fixtures into a documented, semver-aware, **published**
testing API. Docs + stability only — **no fixture behaviour changes**.

### What's here
- **`docs/testing/cookbook.md`** — copy-paste scenarios spanning **both** fixture
  crates: three-line in-process mediator, named-user e2e, two-hop `TestTopology`
  forward, did:web mock (fault injection + rotation), `StaticResolver`, seeded
  `did:peer`, SD-JWT VC issue/present/verify + revocation, mdoc + OID4VP, and the
  vector loader — plus the language-agnostic `docker compose` path. The root
  README gains a **Testing** section linking both paths.
- **Published the crate** — `affinidi-tdk-test-support` `0.6.0 → 0.7.0` and
  `publish = false → true`. First crates.io release of the fixture crate; stays
  `0.x` to match the workspace. `cargo publish --dry-run` packages **and**
  verifies clean against registry deps.
- **Stability** — fixture config enums (`Fault`, `Outcome`) and the error enums
  (`ScenarioError` / `DeterminismError` / `VectorError`) are now
  `#[non_exhaustive]` so new variants land additively. Each module carries a
  runnable, CI-compiled doc example of its happy path (`did_web` was the only one
  missing one).

### Notes
- **TI1 `TestTopology` lives in `affinidi-messaging-test-mediator`, not
  test-support** — corrected the stale README status table that listed
  `topology` as a test-support module.
- Only `affinidi-bbs` consumes the crate, as a path-only **dev-dependency**
  (stripped on publish) → no publish-order or version cascade.

### Verification
- `cargo test --doc` — **7/7** doctests green (6 pre-existing + the new `did_web`).
- `cargo test --tests` — **14** integration tests green.
- `cargo clippy --all-targets -D warnings` + `cargo fmt --check` — clean.
- `cargo publish --dry-run` — packaged + verified.

Closes the **TI-series**.
