### PR TITLE
refactor: seal core+identity error enums with non_exhaustive (W7 sweep)

### DIFF
--- a/crates/core/affinidi-cesr/CHANGELOG.md
+++ b/crates/core/affinidi-cesr/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Affinidi CESR
+
+## Changelog history
+
+## 14th June 2026
+
+### 0.1.2 — non_exhaustive CesrError (W7 sweep)
+
+- `CesrError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/core/affinidi-cesr/Cargo.toml
+++ b/crates/core/affinidi-cesr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-cesr"
 description = "CESR (Composable Event Streaming Representation) encoding and decoding"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-cesr/src/error.rs
+++ b/crates/core/affinidi-cesr/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CesrError {
     #[error("unknown code: {0}")]
     UnknownCode(String),

--- a/crates/core/affinidi-encoding/CHANGELOG.md
+++ b/crates/core/affinidi-encoding/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi Encoding Changelog
 
+## 14th June 2026 (0.1.5)
+
+- **SEMVER:** `EncodingError` is now `#[non_exhaustive]` (ADR-0003), so new
+  variants land additively. Patch bump keeps the `0.1` pin valid; consumers that
+  `match` it must add a `_` wildcard arm. No behaviour change.
+
 ## 18th April 2026 (0.1.3)
 
 - **FEATURE:** Added post-quantum multicodec constants aligned with the

--- a/crates/core/affinidi-encoding/Cargo.toml
+++ b/crates/core/affinidi-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-encoding"
 description = "Multibase and multicodec encoding utilities for Affinidi TDK"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-encoding/src/error.rs
+++ b/crates/core/affinidi-encoding/src/error.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum EncodingError {
     #[error("Invalid multibase prefix: expected 'z' (base58btc), got '{0}'")]
     InvalidMultibasePrefix(char),

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2026-06-14
+
+### Changed
+
+- `DIDError`, `KeyError`, `KeyNegotiationError`, and `PeerError` are now
+  `#[non_exhaustive]` (ADR-0003) so future variants are additive. Patch bump to
+  keep the `0.3` pin — including the `didwebvh-rs` `[patch.crates-io]` redirect —
+  valid; consumers that `match` these must add a `_` arm. No behaviour change.
+
 ## [0.3.6] - 2026-06-13
 
 ### Changed

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.6"
+version = "0.3.7"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-common/src/did.rs
+++ b/crates/identity/affinidi-did-common/src/did.rs
@@ -54,6 +54,7 @@ pub struct DID {
 
 /// Errors that can occur when parsing or constructing a DID
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DIDError {
     /// DID string does not start with "did:"
     MissingPrefix,

--- a/crates/identity/affinidi-did-common/src/did_method/key.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/key.rs
@@ -16,6 +16,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Errors related to key material operations
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum KeyError {
     #[error("Key error: {0}")]
     Key(String),

--- a/crates/identity/affinidi-did-common/src/did_method/peer.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/peer.rs
@@ -98,6 +98,7 @@ impl PeerPurpose {
 
 /// Errors specific to did:peer operations
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum PeerError {
     #[error("Unsupported key type")]
     UnsupportedKeyType,

--- a/crates/identity/affinidi-did-common/src/key_negotiation.rs
+++ b/crates/identity/affinidi-did-common/src/key_negotiation.rs
@@ -47,6 +47,7 @@ pub const DEFAULT_CURVE_PREFERENCE: [Curve; 5] = [
 /// Neutral by design: each call site maps these into its own error type so
 /// the message context (`DIDAuthError` / `ATMError`) stays at the boundary.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum KeyNegotiationError {
     /// No verification method matched the given key id.
     #[error("verification method not found: {0}")]

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.8.10 — non_exhaustive DIDCacheError (W7 sweep)
+
+- `DIDCacheError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.8` pin valid; consumers that `match` it
+  must add a `_` arm. No behaviour change.
+
 ## 13th June 2026
 
 ### 0.8.9 — supervise the network task (W15)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.9"
+version = "0.8.10"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/errors.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/errors.rs
@@ -8,6 +8,7 @@ use wasm_bindgen::JsValue;
 ///
 /// This error type is used for all errors that can occur in the DID Cache Client SDK.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DIDCacheError {
     /// There was an error in resolving the DID.
     #[error("DID error: {0}")]

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.9.2 — non_exhaustive error enums (W7 sweep)
+
+- `CacheError` and `SessionError` are now `#[non_exhaustive]` (ADR-0003) so new
+  variants land additively. Patch bump keeps the `0.9` pin valid; consumers that
+  `match` them must add a `_` arm. No behaviour change.
+
 ## 13th June 2026
 
 ### 0.9.1 — statistics task on the shared supervisor (W15)

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.1"
+version = "0.9.2"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/src/errors.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/errors.rs
@@ -25,6 +25,7 @@ where
 
 /// CacheError the first String is always the session_id
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CacheError {
     #[error("Error in handling errors! {1}")]
     ErrorHandlingError(SessId, String),

--- a/crates/identity/affinidi-did-resolver-cache-server/src/session.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/session.rs
@@ -14,6 +14,7 @@ use std::{
 use tracing::{info, warn};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SessionError {
     SessionError(String),
 }

--- a/crates/identity/affinidi-did-resolver-traits/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-traits/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Affinidi DID Resolver Traits
+
+## Changelog history
+
+## 14th June 2026
+
+### 0.1.2 — non_exhaustive ResolverError (W7 sweep)
+
+- `ResolverError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/identity/affinidi-did-resolver-traits/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-traits"
-version = "0.1.1"
+version = "0.1.2"
 description = "Resolver traits for pluggable DID resolution"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-traits/src/error.rs
+++ b/crates/identity/affinidi-did-resolver-traits/src/error.rs
@@ -8,6 +8,7 @@ use affinidi_did_common::{DIDError, DocumentError};
 /// `ResolverError` covers failures during the resolution process itself:
 /// network errors, invalid documents, unsupported methods, etc.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ResolverError {
     /// The DID method is not supported by this resolver.
     #[error("Unsupported DID method: {0}")]

--- a/crates/identity/did-methods/did-ebsi/CHANGELOG.md
+++ b/crates/identity/did-methods/did-ebsi/CHANGELOG.md
@@ -1,0 +1,11 @@
+# did:ebsi
+
+## Changelog history
+
+## 14th June 2026
+
+### 0.1.3 — non_exhaustive EbsiError (W7 sweep)
+
+- `EbsiError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/identity/did-methods/did-ebsi/Cargo.toml
+++ b/crates/identity/did-methods/did-ebsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ebsi"
-version = "0.1.2"
+version = "0.1.3"
 description = "Implementation of did:ebsi (EBSI DID method for legal entities) in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-ebsi/src/lib.rs
+++ b/crates/identity/did-methods/did-ebsi/src/lib.rs
@@ -36,6 +36,7 @@ use thiserror::Error;
 
 /// EBSI DID method errors.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum EbsiError {
     /// The DID format is invalid.
     #[error("Invalid EBSI DID: {0}")]

--- a/crates/identity/did-methods/did-example/CHANGELOG.md
+++ b/crates/identity/did-methods/did-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# did:example
+
+## Changelog history
+
+## 14th June 2026
+
+### 0.5.8 — non_exhaustive DidExampleError (W7 sweep)
+
+- `DidExampleError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.5` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/identity/did-methods/did-example/Cargo.toml
+++ b/crates/identity/did-methods/did-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-example"
-version = "0.5.7"
+version = "0.5.8"
 description = "Implementation of did:example in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-example/src/lib.rs
+++ b/crates/identity/did-methods/did-example/src/lib.rs
@@ -11,6 +11,7 @@ use ahash::AHashMap as HashMap;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DidExampleError {
     #[error("Error parsing DID document: {0}")]
     DocumentParseError(String),

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,0 +1,11 @@
+# did:scid
+
+## Changelog history
+
+## 14th June 2026
+
+### 0.1.9 — non_exhaustive DIDSCIDError (W7 sweep)
+
+- `DIDSCIDError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.8"
+version = "0.1.9"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-scid/src/errors.rs
+++ b/crates/identity/did-methods/did-scid/src/errors.rs
@@ -2,6 +2,7 @@ use didwebvh_rs::DIDWebVHError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DIDSCIDError {
     #[error("Unsupported format")]
     UnsupportedFormat,

--- a/crates/identity/did-methods/did-web/CHANGELOG.md
+++ b/crates/identity/did-methods/did-web/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### Affinidi DID Web (0.1.2)
+
+- `DidWebError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` arm. No behaviour change.
+
 ## 28th May 2026
 
 ### Affinidi DID Web (0.1.1)

--- a/crates/identity/did-methods/did-web/Cargo.toml
+++ b/crates/identity/did-methods/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-web"
-version = "0.1.1"
+version = "0.1.2"
 description = "Minimal did:web DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-web/src/lib.rs
+++ b/crates/identity/did-methods/did-web/src/lib.rs
@@ -56,6 +56,7 @@ use tracing::debug;
 
 /// did:web resolver errors.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DidWebError {
     /// The supplied DID was not a syntactically valid `did:web`.
     #[error("invalid did:web DID: {0}")]


### PR DESCRIPTION
## W7 follow-up sweep — core + identity layer (PR 1 of 5)

Finishes the **Checkpoint W-2** `#[non_exhaustive]` policy (ADR-0003) for the
error enums the original W7 (#446) left out. This is the first of five
layer-scoped PRs (core+identity → credentials → protocols → messaging → trust).
Docs/API-hardening only — **no behaviour change**.

### Sealed — 14 enums across 10 crates (all patch bumps)
| Crate | Enum(s) | Bump |
|-------|---------|------|
| affinidi-cesr | `CesrError` | 0.1.1 → 0.1.2 |
| affinidi-encoding | `EncodingError` | 0.1.4 → 0.1.5 |
| affinidi-did-common | `DIDError`, `KeyError`, `KeyNegotiationError`, `PeerError` | 0.3.6 → 0.3.7 |
| affinidi-did-resolver-cache-sdk | `DIDCacheError` | 0.8.9 → 0.8.10 |
| affinidi-did-resolver-cache-server | `CacheError`, `SessionError` | 0.9.1 → 0.9.2 |
| affinidi-did-resolver-traits | `ResolverError` | 0.1.1 → 0.1.2 |
| affinidi-did-web | `DidWebError` | 0.1.1 → 0.1.2 |
| did-scid | `DIDSCIDError` | 0.1.8 → 0.1.9 |
| did-ebsi | `EbsiError` | 0.1.2 → 0.1.3 |
| did-example | `DidExampleError` | 0.5.7 → 0.5.8 |

### Why patch bumps
Per **ADR-0003**: adding `#[non_exhaustive]` is technically breaking, but a minor
bump would break every internal `major.minor` pin **and** the external
`[patch.crates-io]` redirects (`didwebvh-rs` / `vta-sdk` pin `did-common`,
`cache-sdk`, etc.). Patch bumps keep all pins valid; the change is safe for any
consumer already using wildcard match arms.

### Verification
- `cargo check --workspace --all-targets` — clean; **no cross-crate exhaustive
  match broke** (incl. the patched `didwebvh-rs`/`vta-sdk` built from source).
- `cargo clippy --workspace --all-targets -- -D warnings` (+ cache-sdk `network`) — clean.
- Touched crates' tests green; `cargo fmt` clean.
- Release guards: `check-version-bumps.sh` ✅ (all 10 bumped) + `check-toolchain-sync.sh` ✅.

Remaining layers follow in separate PRs once this merges.
