### PR TITLE
refactor: seal credentials error enums with non_exhaustive (W7 sweep)

### DIFF
--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi mdoc Changelog
 
+## 14th June 2026 Release 0.2.2
+
+- `MdocError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.2` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 1st June 2026 Release 0.2.1
 
 ### Security

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-mdoc/src/error.rs
+++ b/crates/credentials/affinidi-mdoc/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors that can occur during mdoc operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum MdocError {
     /// CBOR encoding/decoding failed.
     #[error("CBOR error: {0}")]

--- a/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
+++ b/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi RDF Encoding Changelog
 
+## 14th June 2026 Release 0.1.6
+
+- `RdfError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 8th June 2026 Release 0.1.5
 
 ### Added

--- a/crates/credentials/affinidi-rdf-encoding/Cargo.toml
+++ b/crates/credentials/affinidi-rdf-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-rdf-encoding"
 description = "RDF Dataset Canonicalization (RDFC-1.0) and JSON-LD expansion for W3C Verifiable Credentials"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-rdf-encoding/src/error.rs
+++ b/crates/credentials/affinidi-rdf-encoding/src/error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 /// Errors that can occur during RDF processing.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RdfError {
     #[error("N-Quads parse error: {0}")]
     NQuadsParseError(String),

--- a/crates/credentials/affinidi-status-list/CHANGELOG.md
+++ b/crates/credentials/affinidi-status-list/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi Status List Changelog
 
+## 14th June 2026 Release 0.1.4
+
+- `StatusListError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 1st June 2026 Release 0.1.3
 
 ### Fixed

--- a/crates/credentials/affinidi-status-list/Cargo.toml
+++ b/crates/credentials/affinidi-status-list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-status-list"
 description = "Credential status and revocation lists (Bitstring Status List, eIDAS ASL/ARL)."
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-status-list/src/error.rs
+++ b/crates/credentials/affinidi-status-list/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors that can occur during status list operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum StatusListError {
     /// The status list index is out of bounds.
     #[error("Index out of bounds: {index} (list size: {size})")]

--- a/crates/credentials/affinidi-vc/CHANGELOG.md
+++ b/crates/credentials/affinidi-vc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi VC Changelog
 
+## 14th June 2026 (0.2.1)
+
+`SdJwtVcError` is now `#[non_exhaustive]` (ADR-0003), completing the sealing the
+W7 wave started on `VcError`. Patch bump keeps the `0.2` pin valid; match it with
+a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 13th June 2026 (0.1.2)
 
 Semver wave (W7/W10 — release W11). `VcError`, `VerifiableCredential`, and

--- a/crates/credentials/affinidi-vc/Cargo.toml
+++ b/crates/credentials/affinidi-vc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-vc"
 description = "W3C Verifiable Credentials Data Model 1.1 and 2.0 implementation."
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-vc/src/sd_jwt_vc/error.rs
+++ b/crates/credentials/affinidi-vc/src/sd_jwt_vc/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors specific to SD-JWT VC operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SdJwtVcError {
     /// The `vct` (Verifiable Credential Type) claim is missing or invalid.
     #[error("Invalid vct: {0}")]


### PR DESCRIPTION
## W7 follow-up sweep — credentials layer (PR 2 of 5)

Continues the **Checkpoint W-2** `#[non_exhaustive]` policy (ADR-0003), after
PR #471 (core+identity). API-hardening only — **no behaviour change**.

### Sealed — 4 enums (patch bumps)
| Crate | Enum | Bump |
|-------|------|------|
| affinidi-mdoc | `MdocError` | 0.2.1 → 0.2.2 |
| affinidi-status-list | `StatusListError` | 0.1.3 → 0.1.4 |
| affinidi-rdf-encoding | `RdfError` | 0.1.5 → 0.1.6 |
| affinidi-vc | `SdJwtVcError` | 0.2.0 → 0.2.1 |

`affinidi-vc`'s `SdJwtVcError` was the last unsealed error enum in that crate
(W7 already sealed `VcError`). Patch bumps per ADR-0003 keep every internal
`major.minor` pin valid (e.g. test-support pins mdoc `0.2`, status-list `0.1`,
vc `0.2`).

### Verification
- `cargo check --workspace --all-targets` — clean; no cross-crate exhaustive match broke.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Touched crates' tests green (mdoc 103, status-list 63, vc 36, …); `cargo fmt` clean.
- Release guards: version-bumps ✅ (all 4) + toolchain-sync ✅.

Next: PR3 protocols (oid4vc-core ×2, openid4vci, openid4vp, siopv2).
