### PR TITLE
refactor: seal protocols error enums with non_exhaustive (W7 sweep)

### DIFF
--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi OID4VC Core Changelog
 
+## 14th June 2026 Release 0.1.5
+
+- `JwtError` and `OAuthError` are now `#[non_exhaustive]` (ADR-0003) so new
+  variants land additively. Patch bump keeps the `0.1` pin valid; consumers that
+  `match` them must add a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 3rd June 2026 Release 0.1.3
 
 ### Added

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/jwt.rs
@@ -44,6 +44,7 @@ impl Audience {
 
 /// Error type for JWT operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum JwtError {
     /// The JWT format is invalid (not 3 dot-separated parts).
     #[error("Invalid JWT format: {0}")]

--- a/crates/protocols/affinidi-oid4vc-core/src/lib.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/lib.rs
@@ -225,6 +225,7 @@ pub struct ClientMetadata {
 
 /// Standard OAuth 2.0 error codes used across OID4VC.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[non_exhaustive]
 pub enum OAuthError {
     #[error("invalid_request")]
     #[serde(rename = "invalid_request")]

--- a/crates/protocols/affinidi-openid4vci/CHANGELOG.md
+++ b/crates/protocols/affinidi-openid4vci/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi OpenID4VCI Changelog
 
+## 14th June 2026 Release 0.2.1
+
+- `Oid4vciError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.2` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)
+
 ## 3rd June 2026 Release 0.1.3
 
 ### Added

--- a/crates/protocols/affinidi-openid4vci/Cargo.toml
+++ b/crates/protocols/affinidi-openid4vci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-openid4vci"
 description = "OpenID for Verifiable Credential Issuance (OpenID4VCI) implementation."
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-openid4vci/src/error.rs
+++ b/crates/protocols/affinidi-openid4vci/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors that can occur during OpenID4VCI operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Oid4vciError {
     /// The credential issuer metadata is invalid.
     #[error("Invalid metadata: {0}")]

--- a/crates/protocols/affinidi-openid4vp/CHANGELOG.md
+++ b/crates/protocols/affinidi-openid4vp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Affinidi OpenID4VP Changelog
+
+## 14th June 2026 Release 0.1.3
+
+- `Oid4vpError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)

--- a/crates/protocols/affinidi-openid4vp/Cargo.toml
+++ b/crates/protocols/affinidi-openid4vp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-openid4vp"
 description = "OpenID for Verifiable Presentations (OpenID4VP) implementation."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-openid4vp/src/error.rs
+++ b/crates/protocols/affinidi-openid4vp/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors that can occur during OpenID4VP operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Oid4vpError {
     /// The authorization request is invalid.
     #[error("Invalid request: {0}")]

--- a/crates/protocols/affinidi-siopv2/CHANGELOG.md
+++ b/crates/protocols/affinidi-siopv2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Affinidi SIOPv2 Changelog
+
+## 14th June 2026 Release 0.1.2
+
+- `SiopError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change. (W7 sweep)

--- a/crates/protocols/affinidi-siopv2/Cargo.toml
+++ b/crates/protocols/affinidi-siopv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-siopv2"
 description = "Self-Issued OpenID Provider v2 (SIOPv2) for decentralized authentication."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/protocols/affinidi-siopv2/src/error.rs
+++ b/crates/protocols/affinidi-siopv2/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors specific to SIOPv2 operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SiopError {
     /// The authorization request is invalid.
     #[error("Invalid request: {0}")]


### PR DESCRIPTION
## W7 follow-up sweep — protocols layer (PR 3 of 5)

Continues the **Checkpoint W-2** `#[non_exhaustive]` policy (ADR-0003), after
PR #471 (core+identity) and #472 (credentials). API-hardening only — **no
behaviour change**.

### Sealed — 5 enums (patch bumps)
| Crate | Enum(s) | Bump |
|-------|---------|------|
| affinidi-oid4vc-core | `JwtError`, `OAuthError` | 0.1.4 → 0.1.5 |
| affinidi-openid4vci | `Oid4vciError` | 0.2.0 → 0.2.1 |
| affinidi-openid4vp | `Oid4vpError` | 0.1.2 → 0.1.3 |
| affinidi-siopv2 | `SiopError` | 0.1.1 → 0.1.2 |

Patch bumps per ADR-0003 keep every internal `major.minor` pin valid (the facade
and test-support pin these protocol crates).

### Verification
- `cargo check --workspace --all-targets` — clean; no cross-crate exhaustive match broke.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Touched crates' tests green (oid4vc-core 36, vci 26, vp 34, siopv2 19); `cargo fmt` clean.
- Release guards: version-bumps ✅ (all 4) + toolchain-sync ✅.

Next: PR4 messaging (the largest batch — sdk/mediator/mediator-common/
mediator-config/didcomm-service/tsp/test-mediator/messaging-core).
