### PR TITLE
fix: drop deprecated GenericArray::from_slice in AES-GCM call sites

### DIFF
--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi mdoc Changelog
 
+## 14th June 2026 Release 0.2.3
+
+- **Fix (build):** `session.rs` no longer calls the now-deprecated
+  `GenericArray::from_slice` for the AES-256-GCM key/nonce — the key is built via
+  `KeyInit::new_from_slice` and the nonce via `Nonce::from([u8; 12])`. This keeps
+  the crate compiling under `-D warnings` against `generic-array` 0.14.9+, which
+  deprecated `from_slice`. Behaviour-identical (round-trip tests unchanged).
+  Supersedes 0.2.2, which carried the same `MdocError` sealing below but failed
+  to publish on the deprecation.
+
 ## 14th June 2026 Release 0.2.2
 
 - `MdocError` is now `#[non_exhaustive]` (ADR-0003) so new variants land

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-mdoc/src/session.rs
+++ b/crates/credentials/affinidi-mdoc/src/session.rs
@@ -18,7 +18,7 @@
  * AES-256-GCM with 12-byte nonces (counter-based).
  */
 
-use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce, aead::Aead};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
 use hkdf::Hkdf;
 use sha2::Sha256;
 
@@ -59,11 +59,12 @@ pub fn encrypt_aes256gcm(
     nonce_bytes: &[u8; 12],
     plaintext: &[u8],
 ) -> Result<Vec<u8>> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| MdocError::Cose(format!("AES-256-GCM invalid key: {e}")))?;
+    let nonce = Nonce::from(*nonce_bytes);
 
     cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(&nonce, plaintext)
         .map_err(|e| MdocError::Cose(format!("AES-256-GCM encryption failed: {e}")))
 }
 
@@ -83,11 +84,12 @@ pub fn decrypt_aes256gcm(
     nonce_bytes: &[u8; 12],
     ciphertext: &[u8],
 ) -> Result<Vec<u8>> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| MdocError::Cose(format!("AES-256-GCM invalid key: {e}")))?;
+    let nonce = Nonce::from(*nonce_bytes);
 
     cipher
-        .decrypt(nonce, ciphertext)
+        .decrypt(&nonce, ciphertext)
         .map_err(|e| MdocError::Cose(format!("AES-256-GCM decryption failed: {e}")))
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 14th June 2026
 
+### 0.15.14 — build fix: drop deprecated `GenericArray::from_slice`
+
+- The file-encrypted secrets backend (`secrets/backends/file_encrypted.rs`) no
+  longer calls the now-deprecated `GenericArray::from_slice` for the
+  AES-256-GCM key/nonce — the key is built via `KeyInit::new_from_slice` and the
+  nonce via `Nonce::from([u8; 12])`. Keeps the crate compiling under
+  `-D warnings` against `generic-array` 0.14.9+. Behaviour-identical (seal/open
+  round-trip tests unchanged).
+
 ### 0.15.13 — injectable `Clock` trait (TI4b)
 
 - New `types::clock` module: the `Clock` trait (`unix_secs` / `unix_millis`)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.13"
+version = "0.15.14"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/file_encrypted.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/file_encrypted.rs
@@ -50,7 +50,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use aes_gcm::aead::{Aead, KeyInit, Payload};
-use aes_gcm::{Aes256Gcm, Key, Nonce};
+use aes_gcm::{Aes256Gcm, Nonce};
 use argon2::{Algorithm, Argon2, Params, Version};
 use async_trait::async_trait;
 use base64::Engine;
@@ -258,12 +258,13 @@ fn seal(
     plaintext: &[u8],
     aad: &[u8],
 ) -> Result<(Vec<u8>, [u8; NONCE_BYTES])> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| SecretStoreError::other(format!("AES-GCM invalid key: {e}")))?;
     let nonce_bytes = random_nonce()?;
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce = Nonce::from(nonce_bytes);
     let ct = cipher
         .encrypt(
-            nonce,
+            &nonce,
             Payload {
                 msg: plaintext,
                 aad,
@@ -279,10 +280,11 @@ fn open_aead(
     ciphertext: &[u8],
     aad: &[u8],
 ) -> Result<Vec<u8>> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| SecretStoreError::other(format!("AES-GCM invalid key: {e}")))?;
     cipher
         .decrypt(
-            Nonce::from_slice(nonce),
+            &Nonce::from(*nonce),
             Payload {
                 msg: ciphertext,
                 aad,

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Affinidi TSP Changelog
+
+## 14th June 2026
+
+### 0.1.2 — build fix: drop deprecated `GenericArray::from_slice`
+
+- The HPKE module (`crypto/hpke.rs`) no longer calls the now-deprecated
+  `GenericArray::from_slice` for the AES-128-GCM key/nonce — the key is built via
+  `KeyInit::new_from_slice` and the nonce via `GenericArray::from([u8; 12])`.
+  Keeps the crate compiling under `-D warnings` against `generic-array` 0.14.9+,
+  which deprecated `from_slice`. Behaviour-identical (seal/open round-trip tests
+  unchanged).

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -64,10 +64,11 @@ pub fn seal(
     let (key, base_nonce) = key_schedule(&shared_secret, info)?;
 
     let mut ciphertext = plaintext.to_vec();
-    let cipher = Aes128Gcm::new(GenericArray::from_slice(&key));
-    let nonce = GenericArray::from_slice(&base_nonce);
+    let cipher = Aes128Gcm::new_from_slice(&key)
+        .map_err(|e| TspError::Hpke(format!("AES-GCM invalid key: {e}")))?;
+    let nonce = GenericArray::from(base_nonce);
     cipher
-        .encrypt_in_place(nonce, aad, &mut ciphertext)
+        .encrypt_in_place(&nonce, aad, &mut ciphertext)
         .map_err(|e| TspError::Hpke(format!("AES-GCM seal failed: {e}")))?;
 
     Ok(SealResult { enc, ciphertext })
@@ -104,10 +105,11 @@ pub fn open(
     let (key, base_nonce) = key_schedule(&shared_secret, info)?;
 
     let mut plaintext = ciphertext.to_vec();
-    let cipher = Aes128Gcm::new(GenericArray::from_slice(&key));
-    let nonce = GenericArray::from_slice(&base_nonce);
+    let cipher = Aes128Gcm::new_from_slice(&key)
+        .map_err(|e| TspError::Hpke(format!("AES-GCM invalid key: {e}")))?;
+    let nonce = GenericArray::from(base_nonce);
     cipher
-        .decrypt_in_place(nonce, aad, &mut plaintext)
+        .decrypt_in_place(&nonce, aad, &mut plaintext)
         .map_err(|_| TspError::Hpke("AES-GCM open failed: authentication tag mismatch".into()))?;
 
     Ok(plaintext)


### PR DESCRIPTION
## Fix: drop deprecated `GenericArray::from_slice` in AES-GCM call sites

### What broke
`generic-array 0.14.9` (freshly released) deprecated `GenericArray::from_slice`.
The **release** job compiles each crate with `-D warnings` during
`cargo publish --verify`, which does a *fresh* dependency resolution and pulls
0.14.9 — turning the deprecation into a hard error.

`affinidi-mdoc@0.2.2` failed to publish on exactly this in release run
[#179](https://github.com/affinidi/affinidi-tdk-rs/actions/runs/27490725889/job/81255239874)
(the credentials W7 PR #472 release). `affinidi-tsp` and
`affinidi-messaging-mediator-common` use the same pattern and would fail
identically on their next publish (both are in the upcoming W7 PR4 batch).

> Not caught locally because `crypto-common 0.1.7` pins `generic-array =0.14.7`
> in the workspace lock, so the workspace build never sees 0.14.9; only the
> isolated publish-verify resolution does.

### The fix
Removed every `GenericArray::from_slice` call at the three AES-GCM sites, making
them immune to the generic-array version:
- **key** → `KeyInit::new_from_slice(key)` (these fns already return `Result`)
- **nonce** → owned `Nonce::from([u8; N])` / `GenericArray::from([u8; N])`

Behaviour-identical — the AES-GCM seal/open round-trip tests pass unchanged.

| Crate | Site | Bump |
|-------|------|------|
| affinidi-mdoc | `session.rs` (proximity AES-256-GCM) | 0.2.2 → 0.2.3¹ |
| affinidi-tsp | `crypto/hpke.rs` (HPKE AES-128-GCM) | 0.1.1 → 0.1.2 |
| affinidi-messaging-mediator-common | `secrets/backends/file_encrypted.rs` | 0.15.13 → 0.15.14 |

¹ 0.2.2 never reached crates.io (it failed on the deprecation), so 0.2.3
supersedes it and also carries 0.2.2's `MdocError` `#[non_exhaustive]` sealing.

### Verification
- `RUSTFLAGS="-D warnings"` build + tests on all three — green (mdoc 103,
  mediator-common 142, tsp 66; round-trips unchanged).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Release guards: version-bumps ✅ + toolchain-sync ✅.

Once merged, the next release run republishes mdoc as 0.2.3 (unblocking the
stuck publish) plus tsp/mediator-common patches. Then the W7 sweep resumes with
PR4 (messaging).
