### PR TITLE
refactor: seal messaging error enums with non_exhaustive (W7 sweep)

### DIFF
--- a/crates/messaging/affinidi-messaging-core/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Affinidi Messaging Core Changelog
+
+## 14th June 2026
+
+### 0.1.2 — non_exhaustive MessagingError (W7 sweep)
+
+- `MessagingError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/messaging/affinidi-messaging-core/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-core"
 description = "Protocol-agnostic messaging traits for DIDComm and TSP"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-core/src/error.rs
+++ b/crates/messaging/affinidi-messaging-core/src/error.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 /// Errors from the unified messaging layer.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MessagingError {
     #[error("pack error: {0}")]
     Pack(String),

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.6] - 2026-06-14
+
+### Changed
+
+- `TransportError`, `StartupError`, and `DIDCommServiceError` are now
+  `#[non_exhaustive]` (ADR-0003) so new variants land additively. Patch bump
+  keeps the `0.3` pin valid; match them with a `_` wildcard arm. No behaviour
+  change. (W7 sweep)
+
 ## [0.3.5] - 2026-06-10
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.5"
+version = "0.3.6"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
@@ -19,6 +19,7 @@ pub enum PolicyViolation {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TransportError {
     #[error("Message has no sender DID")]
     MissingSenderDid,
@@ -28,6 +29,7 @@ pub enum TransportError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StartupError {
     #[error("Failed to build ATM config")]
     Config(#[source] affinidi_messaging_sdk::errors::ATMError),
@@ -49,6 +51,7 @@ pub enum StartupError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DIDCommServiceError {
     #[error("ATM error: {0}")]
     ATM(#[from] affinidi_messaging_sdk::errors::ATMError),

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 14th June 2026
 
+### 0.16.1 — non_exhaustive AuthError (W7 sweep)
+
+- `AuthError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.16` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.
+
 ### 0.16.0 — injectable clock on the request path (TI4b)
 
 - `SharedData` now carries an `Arc<dyn Clock>`; all request-path expiry / TTL /

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.0"
+version = "0.16.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 14th June 2026
 
+### 0.15.15 — non_exhaustive ProcessorError + SecretStoreError (W7 sweep)
+
+- `ProcessorError` and `SecretStoreError` are now `#[non_exhaustive]` (ADR-0003)
+  so new variants land additively. Patch bump keeps the `0.15` pin valid;
+  consumers that `match` them must add a `_` wildcard arm. No behaviour change.
+
 ### 0.15.14 — build fix: drop deprecated `GenericArray::from_slice`
 
 - The file-encrypted secrets backend (`secrets/backends/file_encrypted.rs`) no

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.14"
+version = "0.15.15"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/errors.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/errors.rs
@@ -66,6 +66,7 @@ where
 /// Errors relating to the Mediator Processors. These are largely internal to the Mediator errors
 /// They should not be exposed to the user
 #[derive(Clone, Error, Debug)]
+#[non_exhaustive]
 pub enum ProcessorError {
     /// A general-purpose internal error in a background processor.
     #[error("CommonError: {0}")]

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/error.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, SecretStoreError>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SecretStoreError {
     #[error("invalid backend URL '{url}': {reason}")]
     InvalidUrl { url: String, reason: String },

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.1.2 — non_exhaustive ConfigError (W7 sweep)
+
+- `ConfigError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.
+
 ## 12th June 2026
 
 ### 0.1.1 — Config loading + validation (simplification T18, part b)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-config"
-version = "0.1.1"
+version = "0.1.2"
 description = "Raw TOML configuration schema for the Affinidi Messaging Mediator (shared by the mediator and its setup tool)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/error.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/error.rs
@@ -6,6 +6,7 @@
 
 /// Failure while reading or parsing a `mediator.toml`.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ConfigError {
     /// The config file could not be opened/read.
     #[error("could not open config file ({path}): {source}")]

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -42,6 +42,7 @@ pub struct TokenPayload {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AuthError {
     WrongCredentials,
     MissingCredentials,

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.12] - 2026-06-14
+
+`ATMError` is now `#[non_exhaustive]` (ADR-0003) so new variants land additively.
+Patch bump keeps the `0.18` pin valid; match it with a `_` wildcard arm. No
+behaviour change. (W7 sweep)
+
 ## [0.18.11] - 2026-06-14
 
 Injectable clock for the SDK's expiry/TTL reads (TI4b-2).

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.11"
+version = "0.18.12"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/errors.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/errors.rs
@@ -8,6 +8,7 @@ use crate::messages::{known::MessageType, problem_report::ProblemReport};
 
 /// ATMError
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ATMError {
     #[error("DID error: {0}")]
     DIDError(String),

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 14th June 2026
 
+### 0.2.12 — non_exhaustive error enums (W7 sweep)
+
+- `TestEnvironmentError`, `TestMediatorError`, and `TestTopologyError` are now
+  `#[non_exhaustive]` (ADR-0003) so new variants land additively. Patch bump
+  keeps the `0.2` pin valid; consumers that `match` them must add a `_` wildcard
+  arm. No behaviour change.
+
 ### 0.2.11 — inject a clock for fast expiry tests (TI4b)
 
 - `TestMediatorBuilder::clock(Arc<dyn Clock>)` injects a clock into the spawned

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.11"
+version = "0.2.12"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -40,6 +40,7 @@ use crate::{AdminIdentity, TestMediator, TestMediatorHandle};
 /// Errors specific to the e2e test environment, as opposed to the
 /// mediator-only fixture in [`crate::TestMediatorError`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum TestEnvironmentError {
     /// The underlying mediator fixture failed to start.
     #[error(transparent)]

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -121,6 +121,7 @@ use url::Url;
 
 /// Errors returned by the test mediator fixture.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TestMediatorError {
     /// A DID generation step failed.
     #[error("did:peer generation failed: {0}")]

--- a/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
@@ -46,6 +46,7 @@ use crate::{
 
 /// Errors from constructing or driving a [`TestTopology`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum TestTopologyError {
     /// `mediators(0)` — a topology needs at least one mediator.
     #[error("a topology needs at least one mediator")]

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 14th June 2026
 
+### 0.1.3 — non_exhaustive TspError (W7 sweep)
+
+- `TspError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.
+
 ### 0.1.2 — build fix: drop deprecated `GenericArray::from_slice`
 
 - The HPKE module (`crypto/hpke.rs`) no longer calls the now-deprecated

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/error.rs
+++ b/crates/messaging/affinidi-tsp/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TspError {
     #[error("CESR encoding error: {0}")]
     Cesr(#[from] affinidi_cesr::CesrError),


### PR DESCRIPTION
## W7 follow-up sweep — messaging layer (PR 4 of 5)

The largest batch of the **Checkpoint W-2** `#[non_exhaustive]` policy (ADR-0003),
after PR #471/#472/#473. API-hardening only — **no behaviour change**.

### Sealed — 13 enums across 8 crates (patch bumps)
| Crate | Enum(s) | Bump |
|-------|---------|------|
| affinidi-messaging-core | `MessagingError` | 0.1.1 → 0.1.2 |
| affinidi-messaging-sdk | `ATMError` | 0.18.11 → 0.18.12 |
| affinidi-messaging-mediator | `AuthError` | 0.16.0 → 0.16.1 |
| affinidi-messaging-mediator-common | `ProcessorError`, `SecretStoreError` | 0.15.14 → 0.15.15 |
| affinidi-messaging-mediator-config | `ConfigError` | 0.1.1 → 0.1.2 |
| affinidi-messaging-didcomm-service | `TransportError`, `StartupError`, `DIDCommServiceError` | 0.3.5 → 0.3.6 |
| affinidi-tsp | `TspError` | 0.1.2 → 0.1.3 |
| affinidi-messaging-test-mediator | `TestEnvironmentError`, `TestMediatorError`, `TestTopologyError` | 0.2.11 → 0.2.12 |

Patch bumps per ADR-0003 keep every internal `major.minor` pin valid (no
cascade — dependents pin `0.16`/`0.18`/`0.15`/etc.). `tsp` and `mediator-common`
bump from their post-#474 versions.

### Verification
- `cargo check --workspace --all-targets` — clean; **no cross-crate exhaustive
  match broke** (this was the layer most at risk).
- Dual-feature `clippy -D warnings`: redis-backend default **and**
  `--no-default-features --features didcomm,memory-backend` — both clean.
- Tests green: mediator 166, mediator-common 153, sdk 73, tsp 66, plus the
  test-mediator e2e (lifecycle/websocket/conformance).
- Release guards: version-bumps ✅ (all 8) + toolchain-sync ✅.

Last layer next: **PR5 trust** (`trust-lists` — `TrustListError`), which closes
the W7 sweep.
