### PR TITLE
refactor: seal trust error enum with non_exhaustive (W7 sweep)

### DIFF
--- a/crates/trust/affinidi-trust-lists/CHANGELOG.md
+++ b/crates/trust/affinidi-trust-lists/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Affinidi Trust Lists Changelog
+
+## 14th June 2026
+
+### 0.1.2 — non_exhaustive TrustListError (W7 sweep)
+
+- `TrustListError` is now `#[non_exhaustive]` (ADR-0003) so new variants land
+  additively. Patch bump keeps the `0.1` pin valid; consumers that `match` it
+  must add a `_` wildcard arm. No behaviour change.

--- a/crates/trust/affinidi-trust-lists/Cargo.toml
+++ b/crates/trust/affinidi-trust-lists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-trust-lists"
 description = "EU Trusted Lists (ETSI TS 119 612) for eIDAS 2.0 trust infrastructure."
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/trust/affinidi-trust-lists/src/error.rs
+++ b/crates/trust/affinidi-trust-lists/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 /// Errors that can occur during Trust List operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum TrustListError {
     /// The Trust List XML is malformed or cannot be parsed.
     #[error("Parse error: {0}")]


### PR DESCRIPTION
## W7 follow-up sweep — trust layer (PR 5 of 5, closes the sweep)

The final layer of the **Checkpoint W-2** `#[non_exhaustive]` policy (ADR-0003),
after PR #471/#472/#473/#475. API-hardening only — **no behaviour change**.

### Sealed
| Crate | Enum | Bump |
|-------|------|------|
| affinidi-trust-lists | `TrustListError` | 0.1.1 → 0.1.2 |

### Sweep complete
A full workspace audit confirms **zero publishable error enums remain unsealed**
after this PR. Across the five layer PRs the sweep added `#[non_exhaustive]` to
**38 error enums** (the original W7 had sealed 7 of the workspace's ~45):

- PR #471 core+identity — 14 enums / 10 crates
- PR #472 credentials — 4 / 4
- PR #473 protocols — 5 / 4
- PR #475 messaging — 13 / 8
- PR #476 trust — 1 / 1 (this PR)

All patch bumps per ADR-0003, so every internal `major.minor` pin and the
external `[patch.crates-io]` redirects stay valid. New error variants are now
non-breaking across the whole workspace.

### Verification
- `cargo check --workspace --all-targets` — clean; no cross-crate exhaustive match broke.
- `cargo clippy -p affinidi-trust-lists --all-targets -- -D warnings` — clean.
- Tests green (35); release guards: version-bumps ✅ + toolchain-sync ✅.
