### PR TITLE
feat: deterministic DIDComm envelope fixtures for fuzzing (#477 PR-A)

### DIFF
--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.7.0"
+version = "0.8.0"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -41,8 +41,14 @@ thiserror = "2"
 affinidi-vc = { version = "0.2", path = "../../credentials/affinidi-vc" }
 affinidi-sd-jwt = { version = "0.1", path = "../../credentials/affinidi-sd-jwt" }
 affinidi-status-list = { version = "0.1", path = "../../credentials/affinidi-status-list" }
-## `ed25519_pub_to_did_key` for deterministic issuer/holder/verifier DIDs.
+## `ed25519_pub_to_did_key` for deterministic issuer/holder/verifier DIDs;
+## `jose::key_agreement` backs the didcomm_fuzz deterministic keypairs.
 affinidi-crypto = { version = "0.2", path = "../../core/affinidi-crypto" }
+
+# ── #477: deterministic DIDComm envelope fixtures for fuzzing ──────────────
+## pack/unpack + Message types the didcomm_fuzz seed corpus packs against. A
+## dev-only edge — didcomm does not depend on test-support, so this is acyclic.
+affinidi-messaging-didcomm = { version = "0.15", path = "../../messaging/affinidi-messaging-didcomm" }
 
 # ── TI4a: seeded did:peer generation (determinism module) ─────────────────
 ## Seeded `Secret` constructors (generate_ed25519(.., Some(seed)) etc.) +

--- a/crates/tdk/affinidi-tdk-test-support/README.md
+++ b/crates/tdk/affinidi-tdk-test-support/README.md
@@ -24,6 +24,7 @@ you don't want to stand up external services.
 |----------------------------|-----------------------------------------------------------------|
 | `did_web` / `resolver`     | did:web / did:webvh mock server (fault injection) + injectable `StaticResolver` |
 | `determinism`              | Seeded `did:peer` generation (same seed → same identity)        |
+| `didcomm_fuzz`             | Deterministic DIDComm envelope fixtures + seed corpus for fuzzing `unpack`/`decrypt` |
 | `credential_scenario`      | `CredentialScenario` — SD-JWT VC issue / present / verify + revocation |
 | `mdoc_scenario` / `oid4vp` | mdoc (COSE) flows + OID4VP present / verify (both eIDAS formats) |
 | `vectors`                  | Shared `tests/vectors/` layout + loader                         |

--- a/crates/tdk/affinidi-tdk-test-support/src/didcomm_fuzz.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/didcomm_fuzz.rs
@@ -1,0 +1,371 @@
+/*!
+ * Deterministic DIDComm envelope fixtures for coverage-guided fuzzing (issue #477).
+ *
+ * Coverage-guided fuzzers (cargo-fuzz / libFuzzer) targeting
+ * [`affinidi_messaging_didcomm::message::unpack::unpack`] and
+ * [`affinidi_messaging_didcomm::jwe::decrypt::decrypt`] hit a wall: those
+ * entry points are already pure and synchronous (no resolver, no network — the
+ * recipient key is a *parameter*, not a lookup), but a mutated envelope only
+ * reaches the post-decrypt code (`Message::from_json` on the recovered
+ * plaintext) when it decrypts under a key the harness actually holds. With
+ * random keys every input dies at the AEAD tag check and that coverage is never
+ * explored.
+ *
+ * This module closes that gap with **deterministic** key material plus packing
+ * helpers, so a harness can mint valid-ish envelopes from a seed and fuzz from
+ * there. Each [`PackedEnvelope`] carries the envelope string *and* the exact key
+ * parameters `unpack()` needs to open it, so the harness never has to track keys
+ * separately. [`seed_corpus`] returns a representative set to seed the corpus.
+ *
+ * **TEST-ONLY.** These keys are predictable by construction; never use them on a
+ * production key path. That is why this lives in the dev-dependency-only
+ * `affinidi-tdk-test-support` crate rather than behind a feature on the
+ * production `affinidi-messaging-didcomm` crate — a known private key must never
+ * reach a production dependency tree. See the sibling [`crate::determinism`]
+ * module, which derives seeded `did:peer` identities on the same principle.
+ *
+ * ```
+ * use affinidi_tdk_test_support::didcomm_fuzz::seed_corpus;
+ * use affinidi_messaging_didcomm::message::unpack::unpack;
+ *
+ * // Every seed envelope opens cleanly under the keys it ships with — exactly
+ * // what a fuzz harness needs as a starting corpus before it mutates.
+ * for env in seed_corpus() {
+ *     unpack(
+ *         &env.envelope,
+ *         env.recipient_kid.as_deref(),
+ *         env.recipient_private.as_ref(),
+ *         env.sender_public.as_ref(),
+ *         env.signer_public.as_ref(),
+ *     )
+ *     .expect("seed corpus envelope should unpack");
+ * }
+ * ```
+ */
+
+use affinidi_crypto::CryptoError;
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_didcomm::message::pack::{
+    pack_encrypted_anoncrypt, pack_encrypted_authcrypt, pack_signed,
+};
+
+// Re-exported so callers can name the curve / key types without depending on
+// affinidi-crypto directly.
+pub use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
+
+/// Errors from building a deterministic envelope fixture.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DidcommFuzzError {
+    /// A seeded key could not be constructed on the requested curve. For the
+    /// NIST curves a small fraction of seeds map to a scalar outside the field;
+    /// bump the seed and retry. X25519 (the default DIDComm shape) accepts any
+    /// 32-byte seed.
+    #[error("seeded key: {0}")]
+    Key(#[from] CryptoError),
+
+    /// Packing the message into an envelope failed.
+    #[error("pack: {0}")]
+    Pack(String),
+}
+
+/// A deterministic key-agreement keypair with its key id, ready to pass to the
+/// DIDComm pack/unpack APIs.
+pub struct FixtureKey {
+    /// The key id (DID URL fragment) this key is addressed by in an envelope.
+    pub kid: String,
+    /// The private key. Deterministic for a given `(curve, seed)`.
+    pub private: PrivateKeyAgreement,
+}
+
+impl FixtureKey {
+    /// The matching public key.
+    pub fn public(&self) -> PublicKeyAgreement {
+        self.private.public_key()
+    }
+}
+
+/// A packed DIDComm envelope plus the exact parameters
+/// [`affinidi_messaging_didcomm::message::unpack::unpack`] needs to open it.
+///
+/// The field shape mirrors `unpack`'s argument list one-to-one so a harness can
+/// forward them directly. Which fields are populated depends on the envelope:
+/// authcrypt fills recipient + `sender_public`; anoncrypt fills recipient only;
+/// a signed envelope fills `signer_public` only; plaintext fills none.
+pub struct PackedEnvelope {
+    /// The serialized JWE / JWS / plaintext envelope — the fuzzer's seed input.
+    pub envelope: String,
+    /// Recipient key id, for encrypted envelopes.
+    pub recipient_kid: Option<String>,
+    /// Recipient private key, for encrypted envelopes.
+    pub recipient_private: Option<PrivateKeyAgreement>,
+    /// Sender public key, for authcrypt (ECDH-1PU) envelopes.
+    pub sender_public: Option<PublicKeyAgreement>,
+    /// Signer Ed25519 public key, for signed (JWS) envelopes.
+    pub signer_public: Option<[u8; 32]>,
+}
+
+/// Derive a deterministic key-agreement keypair from `seed` on `curve`.
+///
+/// **Same `(curve, seed)` → same key**, every run. X25519 accepts any seed
+/// (the scalar is clamped); the NIST curves reject the rare seed that lands
+/// outside the field — see [`DidcommFuzzError::Key`].
+pub fn key_agreement_from_seed(
+    curve: Curve,
+    seed: u64,
+    kid: impl Into<String>,
+) -> Result<FixtureKey, DidcommFuzzError> {
+    let bytes = expand_seed(seed, KEY_DOMAIN_KA);
+    let private = PrivateKeyAgreement::from_raw_bytes(curve, &bytes)?;
+    Ok(FixtureKey {
+        kid: kid.into(),
+        private,
+    })
+}
+
+/// Derive a deterministic Ed25519 signing keypair from `seed`, returning
+/// `(secret_bytes, public_bytes)` in the `[u8; 32]` form the DIDComm signing
+/// APIs use.
+pub fn signing_keypair_from_seed(seed: u64) -> ([u8; 32], [u8; 32]) {
+    let secret = expand_seed(seed, KEY_DOMAIN_SIGN);
+    let signing = ed25519_dalek::SigningKey::from_bytes(&secret);
+    (secret, signing.verifying_key().to_bytes())
+}
+
+/// Pack `msg` as an authcrypt (ECDH-1PU, sender-authenticated) JWE addressed to
+/// a deterministic recipient/sender derived from `seed`.
+pub fn authcrypt_envelope(seed: u64, msg: &Message) -> Result<PackedEnvelope, DidcommFuzzError> {
+    let sender = key_agreement_from_seed(Curve::X25519, seed ^ SENDER_SALT, sender_kid(seed))?;
+    let recipient = key_agreement_from_seed(Curve::X25519, seed, recipient_kid(seed))?;
+
+    let envelope = pack_encrypted_authcrypt(
+        msg,
+        &sender.kid,
+        &sender.private,
+        &[(recipient.kid.as_str(), &recipient.public())],
+    )
+    .map_err(|e| DidcommFuzzError::Pack(e.to_string()))?;
+
+    Ok(PackedEnvelope {
+        envelope,
+        recipient_kid: Some(recipient.kid),
+        recipient_private: Some(recipient.private),
+        sender_public: Some(sender.public()),
+        signer_public: None,
+    })
+}
+
+/// Pack `msg` as an anoncrypt (ECDH-ES, anonymous) JWE addressed to a
+/// deterministic recipient derived from `seed`.
+pub fn anoncrypt_envelope(seed: u64, msg: &Message) -> Result<PackedEnvelope, DidcommFuzzError> {
+    let recipient = key_agreement_from_seed(Curve::X25519, seed, recipient_kid(seed))?;
+
+    let envelope = pack_encrypted_anoncrypt(msg, &[(recipient.kid.as_str(), &recipient.public())])
+        .map_err(|e| DidcommFuzzError::Pack(e.to_string()))?;
+
+    Ok(PackedEnvelope {
+        envelope,
+        recipient_kid: Some(recipient.kid),
+        recipient_private: Some(recipient.private),
+        sender_public: None,
+        signer_public: None,
+    })
+}
+
+/// Pack `msg` as a signed (JWS, EdDSA) envelope under a deterministic Ed25519
+/// key derived from `seed`.
+pub fn signed_envelope(seed: u64, msg: &Message) -> Result<PackedEnvelope, DidcommFuzzError> {
+    let (secret, public) = signing_keypair_from_seed(seed);
+
+    let envelope = pack_signed(msg, &signer_kid(seed), &secret)
+        .map_err(|e| DidcommFuzzError::Pack(e.to_string()))?;
+
+    Ok(PackedEnvelope {
+        envelope,
+        recipient_kid: None,
+        recipient_private: None,
+        sender_public: None,
+        signer_public: Some(public),
+    })
+}
+
+/// A small, representative set of valid envelopes to seed a fuzz corpus: one of
+/// each protected shape (authcrypt, anoncrypt, signed, plaintext) over a couple
+/// of message bodies. Every entry opens cleanly under the keys it ships with.
+///
+/// The *keys* are deterministic (seeded), but the envelope bytes are not stable
+/// across runs: encryption draws a fresh ephemeral key + IV and `Message::new`
+/// mints a random UUID — exactly as production does. That is fine for seeding;
+/// the harness wants valid-and-openable inputs, not byte-identical ones. Dump
+/// `.envelope` to files if a committed on-disk corpus is wanted.
+pub fn seed_corpus() -> Vec<PackedEnvelope> {
+    let mut out = Vec::new();
+    for (seed, msg) in sample_messages().into_iter().enumerate() {
+        let seed = seed as u64;
+        // `expect` is fine here: X25519 + Ed25519 derivation is total, and the
+        // sample messages are valid by construction. A panic means a genuine
+        // regression in the pack path, which is exactly what we want surfaced.
+        out.push(authcrypt_envelope(seed, &msg).expect("authcrypt seed"));
+        out.push(anoncrypt_envelope(seed, &msg).expect("anoncrypt seed"));
+        out.push(signed_envelope(seed, &msg).expect("signed seed"));
+        out.push(plaintext_envelope(&msg));
+    }
+    out
+}
+
+/// Pack `msg` as a bare plaintext DIDComm message (no crypto protection).
+fn plaintext_envelope(msg: &Message) -> PackedEnvelope {
+    // Plaintext serialization is infallible for a well-formed Message.
+    let envelope = serde_json::to_string(msg).expect("plaintext serialize");
+    PackedEnvelope {
+        envelope,
+        recipient_kid: None,
+        recipient_private: None,
+        sender_public: None,
+        signer_public: None,
+    }
+}
+
+/// A couple of structurally varied sample messages for the seed corpus.
+fn sample_messages() -> Vec<Message> {
+    vec![
+        Message::new(
+            "https://didcomm.org/basicmessage/2.0/message",
+            serde_json::json!({ "content": "hello" }),
+        ),
+        Message::new(
+            "https://didcomm.org/trust-ping/2.0/ping",
+            serde_json::json!({ "response_requested": true, "nested": { "a": [1, 2, 3] } }),
+        )
+        .from("did:example:alice"),
+    ]
+}
+
+// ── deterministic key derivation ──────────────────────────────────────────
+
+/// Domain tag separating key-agreement keys from signing keys derived off the
+/// same seed.
+const KEY_DOMAIN_KA: u8 = 0x01;
+const KEY_DOMAIN_SIGN: u8 = 0x02;
+
+/// Salt mixed into a seed to derive the authcrypt *sender* key, so sender and
+/// recipient never collide.
+const SENDER_SALT: u64 = 0xA5A5_A5A5_A5A5_A5A5;
+
+/// Fill 32 deterministic bytes from `(seed, domain)` via SplitMix64. Not
+/// cryptographic — these are throwaway test keys — but stable across runs and
+/// platforms, which is all the corpus needs.
+fn expand_seed(seed: u64, domain: u8) -> [u8; 32] {
+    let mut state = seed ^ ((domain as u64) << 56) ^ 0x9E37_79B9_7F4A_7C15;
+    let mut out = [0u8; 32];
+    for chunk in out.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        chunk.copy_from_slice(&z.to_le_bytes()[..chunk.len()]);
+    }
+    out
+}
+
+fn recipient_kid(seed: u64) -> String {
+    format!("did:example:recipient-{seed}#key-1")
+}
+
+fn sender_kid(seed: u64) -> String {
+    format!("did:example:sender-{seed}#key-1")
+}
+
+fn signer_kid(seed: u64) -> String {
+    format!("did:example:signer-{seed}#key-1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_messaging_didcomm::UnpackResult;
+    use affinidi_messaging_didcomm::message::unpack::unpack;
+
+    fn unpack_envelope(env: &PackedEnvelope) -> UnpackResult {
+        unpack(
+            &env.envelope,
+            env.recipient_kid.as_deref(),
+            env.recipient_private.as_ref(),
+            env.sender_public.as_ref(),
+            env.signer_public.as_ref(),
+        )
+        .expect("envelope should unpack")
+    }
+
+    #[test]
+    fn key_agreement_is_deterministic() {
+        let a = key_agreement_from_seed(Curve::X25519, 7, "kid").unwrap();
+        let b = key_agreement_from_seed(Curve::X25519, 7, "kid").unwrap();
+        assert_eq!(a.public().to_public_bytes(), b.public().to_public_bytes());
+
+        let c = key_agreement_from_seed(Curve::X25519, 8, "kid").unwrap();
+        assert_ne!(a.public().to_public_bytes(), c.public().to_public_bytes());
+    }
+
+    #[test]
+    fn signing_keypair_is_deterministic() {
+        assert_eq!(signing_keypair_from_seed(3), signing_keypair_from_seed(3));
+        assert_ne!(signing_keypair_from_seed(3), signing_keypair_from_seed(4));
+    }
+
+    #[test]
+    fn authcrypt_round_trips_and_authenticates() {
+        let msg = Message::new("t", serde_json::json!({ "x": 1 }));
+        let env = authcrypt_envelope(42, &msg).unwrap();
+        match unpack_envelope(&env) {
+            UnpackResult::Encrypted {
+                message,
+                authenticated,
+                ..
+            } => {
+                assert_eq!(message.body["x"], 1);
+                assert!(authenticated, "authcrypt must bind the sender");
+            }
+            _ => panic!("expected Encrypted"),
+        }
+    }
+
+    #[test]
+    fn anoncrypt_round_trips_without_auth() {
+        let msg = Message::new("t", serde_json::json!({ "x": 2 }));
+        let env = anoncrypt_envelope(42, &msg).unwrap();
+        match unpack_envelope(&env) {
+            UnpackResult::Encrypted {
+                message,
+                authenticated,
+                ..
+            } => {
+                assert_eq!(message.body["x"], 2);
+                assert!(!authenticated, "anoncrypt is anonymous");
+            }
+            _ => panic!("expected Encrypted"),
+        }
+    }
+
+    #[test]
+    fn signed_round_trips() {
+        let msg = Message::new("t", serde_json::json!({ "x": 3 }));
+        let env = signed_envelope(42, &msg).unwrap();
+        match unpack_envelope(&env) {
+            UnpackResult::Signed { message, .. } => assert_eq!(message.body["x"], 3),
+            _ => panic!("expected Signed"),
+        }
+    }
+
+    #[test]
+    fn seed_corpus_all_unpack() {
+        let corpus = seed_corpus();
+        assert!(!corpus.is_empty());
+        // Every seed envelope must open cleanly under the keys it ships with —
+        // that is the whole contract a fuzz harness relies on.
+        for env in &corpus {
+            unpack_envelope(env);
+        }
+    }
+}

--- a/crates/tdk/affinidi-tdk-test-support/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/lib.rs
@@ -16,6 +16,8 @@
  * - [`did_web`] / [`resolver`] — in-process did:web / did:webvh mock server with
  *   fault injection, plus an injectable `StaticResolver`.
  * - [`determinism`] — seeded `did:peer` generation (same seed → same identity).
+ * - [`didcomm_fuzz`] — deterministic DIDComm envelope fixtures + seed corpus for
+ *   coverage-guided fuzzing of the `unpack`/`decrypt` entry points.
  * - [`credential_scenario`] — issuer/holder/verifier `CredentialScenario` for
  *   SD-JWT VC, with the [`mdoc_scenario`] and [`oid4vp`] flows layered on top.
  * - [`vectors`] — shared `tests/vectors/` layout and loader.
@@ -37,6 +39,7 @@
 pub mod credential_scenario;
 pub mod determinism;
 pub mod did_web;
+pub mod didcomm_fuzz;
 pub mod mdoc_scenario;
 pub mod oid4vp;
 pub mod resolver;


### PR DESCRIPTION
## What

PR-A of the fuzzing-support work for #477. Adds a `didcomm_fuzz` module to the **dev-dependency-only** `affinidi-tdk-test-support` crate: deterministic key material plus pack helpers so a coverage-guided fuzzer can mint decryptable DIDComm envelopes and reach the post-decrypt code path.

## Why

`message::unpack::unpack` and `jwe::decrypt::decrypt` are already pure and synchronous (the recipient key is a parameter, not a lookup — no resolver, no network). But with random keys, every mutated envelope dies at the AEAD tag check, so the fuzzer never reaches `Message::from_json` on the recovered plaintext. Seeded keys + a helper that packs valid-ish envelopes unblock that coverage.

See the [plan comment on #477](https://github.com/affinidi/affinidi-tdk-rs/issues/477#issuecomment-4701059362) for the full review (several of the issue's original premises were stale — the two named entry points are already pure, so #3 is largely a no-op for them).

## Design: dev crate, not a production feature

Everything lives in `affinidi-tdk-test-support` — never in a production dependency tree — rather than behind a `fuzzing` feature on the production `affinidi-messaging-didcomm` crate. A known/deterministic private key must never be reachable from production, and a new public feature would be a permanent SemVer commitment. Same principle as the existing `determinism` module. The crate already depends on `affinidi-crypto`; `PrivateKeyAgreement::from_raw_bytes` lets us build deterministic keypairs directly.

## API

- `key_agreement_from_seed(curve, seed, kid)` / `signing_keypair_from_seed(seed)` — deterministic keys (SplitMix64 seed expansion; same seed → same key).
- `authcrypt_envelope` / `anoncrypt_envelope` / `signed_envelope` → `PackedEnvelope { envelope, recipient_kid, recipient_private, sender_public, signer_public }` — fields mirror `unpack()`'s argument list one-to-one.
- `seed_corpus()` — representative authcrypt / anoncrypt / signed / plaintext set.

## Notes

- **Keys are deterministic; envelope bytes are not** — encryption draws a fresh ephemeral key + IV and `Message::new` mints a random UUID, exactly as production does. The corpus is freshly-minted-but-always-valid each run, which is what a fuzz harness needs (not byte-identical inputs). Docs say so explicitly.
- Adds an **acyclic** dev-graph edge `test-support → affinidi-messaging-didcomm` (didcomm does not depend on test-support).
- Version bump **0.7.0 → 0.8.0** (additive).

## Test

- 6 unit tests (determinism, authcrypt/anoncrypt/signed round-trips, corpus-all-unpack) + 1 runnable doctest — all green.
- `cargo clippy -p affinidi-tdk-test-support --all-targets` clean; `cargo fmt` clean.

## Follow-ups (separate PRs, per one-task-per-PR)

- **PR-B** — depth-bounded `Arbitrary` for `Message` (note: `serde_json::Value` has no upstream `Arbitrary` impl, so a blanket derive won't compile — custom bounded impl required).
- **PR-C** — in-repo `fuzz/` workspace + nightly CI (`[workspace] exclude`d to protect the stable 1.95.0 pin).
- **#3 audit** — which of `DIDCommAgent::unpack` / SD-JWT verify / credential verify actually warrant a resolver-injected sync core.

Refs #477
