### PR TITLE
feat: add off-by-default arbitrary feature for wire types (#477 PR-B)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3] - 2026-06-14
+
+### Added
+
+- **Off-by-default `arbitrary` feature (#477).** Adds hand-written, depth- and
+  width-bounded `arbitrary::Arbitrary` impls for the wire types (`Message`,
+  `Attachment`, `AttachmentData`) for structure-aware coverage-guided fuzzing.
+  No runtime/behaviour change and nothing is pulled in unless the feature is
+  enabled. Patch bump (additive) keeps the `vta-sdk` `[patch.crates-io]`
+  coupling valid — see ADR 0003.
+
 ## [0.15.2] - 2026-06-13
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.2"
+version = "0.15.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -15,6 +15,10 @@ rust-version.workspace = true
 [features]
 default = []
 messaging-core = ["dep:affinidi-messaging-core", "dep:async-trait"]
+# Off-by-default. Adds `arbitrary::Arbitrary` impls for the wire types (Message,
+# Attachment, AttachmentData) for structure-aware coverage-guided fuzzing. No
+# runtime/behaviour change; pull it in only from a fuzz harness or dev build.
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 # JOSE crypto primitives (#327) — this crate owns only the DIDComm/JOSE
@@ -45,6 +49,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 # Optional — messaging-core trait integration
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1", optional = true }
 async-trait = { version = "0.1", optional = true }
+
+# Optional — structure-aware fuzzing support (see the `arbitrary` feature).
+arbitrary = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/messaging/affinidi-messaging-didcomm/src/arbitrary_support.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/arbitrary_support.rs
@@ -1,0 +1,172 @@
+//! `arbitrary::Arbitrary` impls for the DIDComm wire types (issue #477).
+//!
+//! Enables **structure-aware** coverage-guided fuzzing: a libFuzzer harness
+//! turns raw bytes into well-formed-ish [`Message`] / [`Attachment`] values
+//! rather than mutating bytes blindly, which reaches far more of the parser /
+//! handler surface than byte mutation alone.
+//!
+//! Gated behind the off-by-default `arbitrary` feature — it adds no runtime
+//! behaviour and is only pulled into a fuzz harness or dev build.
+//!
+//! The `body`/`extra`/attachment-`json` fields are `serde_json::Value`, for
+//! which `arbitrary` ships no upstream impl, so these impls are hand-written
+//! around a **depth- and width-bounded** JSON generator ([`arbitrary_json`]).
+//! The bound is the whole point: an unbounded generator would have the fuzzer
+//! building pathologically deep / huge JSON and exercising the allocator
+//! instead of the parser.
+
+use std::collections::HashMap;
+
+use arbitrary::{Arbitrary, Result, Unstructured};
+use serde_json::{Map, Number, Value};
+
+use crate::message::{Attachment, AttachmentData, Message};
+
+/// Max nesting depth of a generated JSON value. Past this depth only leaves are
+/// produced, so recursion always terminates.
+const MAX_JSON_DEPTH: usize = 4;
+/// Max children per generated array / object level (and per `extra` map).
+const MAX_JSON_WIDTH: usize = 4;
+
+/// Generate a depth-bounded arbitrary [`Value`]. At `depth == 0` only scalar
+/// leaves are produced; otherwise arrays/objects may appear, recursing with
+/// `depth - 1` and at most [`MAX_JSON_WIDTH`] children.
+fn arbitrary_json(u: &mut Unstructured<'_>, depth: usize) -> Result<Value> {
+    // 4 leaf shapes always; add array + object only while we still have depth.
+    let variants: u32 = if depth == 0 { 4 } else { 6 };
+    Ok(match u.int_in_range(0..=variants - 1)? {
+        0 => Value::Null,
+        1 => Value::Bool(bool::arbitrary(u)?),
+        // i64 → Number is always finite/valid (unlike an arbitrary f64, which
+        // could be NaN/Inf and is not representable as a JSON number).
+        2 => Value::Number(Number::from(i64::arbitrary(u)?)),
+        3 => Value::String(String::arbitrary(u)?),
+        4 => {
+            let len = u.int_in_range(0..=MAX_JSON_WIDTH)?;
+            let mut arr = Vec::with_capacity(len);
+            for _ in 0..len {
+                arr.push(arbitrary_json(u, depth - 1)?);
+            }
+            Value::Array(arr)
+        }
+        _ => Value::Object(arbitrary_json_map(u, depth - 1)?),
+    })
+}
+
+/// Generate a bounded JSON object: up to [`MAX_JSON_WIDTH`] `String → Value`
+/// entries, each value generated at `depth`.
+fn arbitrary_json_map(u: &mut Unstructured<'_>, depth: usize) -> Result<Map<String, Value>> {
+    let len = u.int_in_range(0..=MAX_JSON_WIDTH)?;
+    let mut map = Map::new();
+    for _ in 0..len {
+        map.insert(String::arbitrary(u)?, arbitrary_json(u, depth)?);
+    }
+    Ok(map)
+}
+
+impl<'a> Arbitrary<'a> for Message {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        // `extra` is the `#[serde(flatten)]` catch-all; bound it like any object.
+        let extra_len = u.int_in_range(0..=MAX_JSON_WIDTH)?;
+        let mut extra: HashMap<String, Value> = HashMap::new();
+        for _ in 0..extra_len {
+            extra.insert(String::arbitrary(u)?, arbitrary_json(u, MAX_JSON_DEPTH)?);
+        }
+
+        Ok(Message {
+            id: String::arbitrary(u)?,
+            typ: String::arbitrary(u)?,
+            from: Option::arbitrary(u)?,
+            to: Option::arbitrary(u)?,
+            body: arbitrary_json(u, MAX_JSON_DEPTH)?,
+            thid: Option::arbitrary(u)?,
+            pthid: Option::arbitrary(u)?,
+            created_time: Option::arbitrary(u)?,
+            expires_time: Option::arbitrary(u)?,
+            attachments: Option::arbitrary(u)?,
+            extra,
+        })
+    }
+}
+
+impl<'a> Arbitrary<'a> for Attachment {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        Ok(Attachment {
+            id: Option::arbitrary(u)?,
+            description: Option::arbitrary(u)?,
+            filename: Option::arbitrary(u)?,
+            media_type: Option::arbitrary(u)?,
+            format: Option::arbitrary(u)?,
+            lastmod_time: Option::arbitrary(u)?,
+            byte_count: Option::arbitrary(u)?,
+            data: AttachmentData::arbitrary(u)?,
+        })
+    }
+}
+
+impl<'a> Arbitrary<'a> for AttachmentData {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        // `json` is a Value; gate it on a bool so "no json" is reachable, then
+        // generate a bounded value when present.
+        let json = if bool::arbitrary(u)? {
+            Some(arbitrary_json(u, MAX_JSON_DEPTH)?)
+        } else {
+            None
+        };
+        Ok(AttachmentData {
+            json,
+            base64: Option::arbitrary(u)?,
+            links: Option::arbitrary(u)?,
+            hash: Option::arbitrary(u)?,
+            jws: Option::arbitrary(u)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Driving the impls over a block of bytes must never panic, and every
+    /// generated `Message` must serialize to JSON that the real parser accepts.
+    /// That — not struct identity — is the contract a fuzz harness relies on.
+    ///
+    /// (Round-trip is intentionally *not* asserted lossless: `extra` is a
+    /// `#[serde(flatten)]` catch-all, so a generated `extra` key that collides
+    /// with a reserved field name like `id`/`type` deserializes back into the
+    /// named field, not `extra`. Fine for fuzzing — the harness feeds the
+    /// serialized bytes to the parser, it doesn't compare structs.)
+    #[test]
+    fn generated_messages_serialize_to_parseable_json() {
+        // A few fixed byte patterns — deterministic, no RNG. Each seeds a
+        // different walk through the generator.
+        for pattern in [0x00u8, 0x5A, 0xA5, 0xFF] {
+            let data = vec![pattern; 512];
+            let mut u = Unstructured::new(&data);
+            let msg = Message::arbitrary(&mut u).expect("generation should not fail");
+
+            let json = msg.to_json().expect("generated message should serialize");
+            Message::from_json(&json).expect("serialized generated message should re-parse");
+        }
+    }
+
+    #[test]
+    fn json_depth_is_bounded() {
+        fn depth(v: &Value) -> usize {
+            match v {
+                Value::Array(a) => 1 + a.iter().map(depth).max().unwrap_or(0),
+                Value::Object(o) => 1 + o.values().map(depth).max().unwrap_or(0),
+                _ => 0,
+            }
+        }
+        // Lots of structure-biased bytes; depth must still respect the cap.
+        let data = vec![0xF4u8; 4096];
+        let mut u = Unstructured::new(&data);
+        let v = arbitrary_json(&mut u, MAX_JSON_DEPTH).unwrap();
+        assert!(
+            depth(&v) <= MAX_JSON_DEPTH,
+            "depth {} exceeded cap",
+            depth(&v)
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
@@ -26,6 +26,11 @@ pub mod store;
 #[cfg(feature = "messaging-core")]
 pub mod adapter;
 
+// `arbitrary::Arbitrary` impls for the wire types, for structure-aware fuzzing.
+// Off by default; see the `arbitrary` feature. No public items — impls only.
+#[cfg(feature = "arbitrary")]
+mod arbitrary_support;
+
 // Re-export core types at crate root for convenience and legacy API compat.
 pub use crate::error::DIDCommError;
 pub use crate::message::unpack::UnpackResult;


### PR DESCRIPTION
## What

PR-B of the fuzzing-support work for #477. Adds an **off-by-default `arbitrary` feature** to `affinidi-messaging-didcomm` with hand-written `arbitrary::Arbitrary` impls for the wire types (`Message`, `Attachment`, `AttachmentData`), enabling **structure-aware** coverage-guided fuzzing — a harness turns raw bytes into well-formed-ish messages instead of mutating bytes blindly.

## Why on the production crate (and why that's still safe)

Unlike PR-A's key fixtures, this one can't live in the dev crate: Rust's orphan rule means `impl Arbitrary for Message` must be defined in the crate that owns `Message`. We discussed this trade-off on the issue and chose the optional-feature route. It stays safe because it's **strictly additive**: off by default, no runtime/behaviour change, no secrets, and the `arbitrary` dep isn't compiled unless the feature is enabled.

## The `serde_json::Value` blocker

`Message.body` / `extra` and `AttachmentData.json` are `serde_json::Value`, for which `arbitrary` ships **no upstream impl** — so a blanket `#[derive(Arbitrary)]` won't compile. The impls are hand-written around a **depth- and width-bounded** JSON generator (`MAX_JSON_DEPTH = 4`, `MAX_JSON_WIDTH = 4`). The bound is the point: an unbounded generator would have the fuzzer building pathologically deep/huge JSON and exercising the allocator instead of the parser.

## Versioning

Patch bump **0.15.2 → 0.15.3**. `affinidi-messaging-didcomm` is patched by the external `vta-sdk` crate via `[patch.crates-io]`, so per **ADR 0003 point 3** an additive change ships as a patch within the current minor to keep every `0.15` pin (internal + external) valid — a minor bump would break the redirect.

## Test

- `generated_messages_serialize_to_parseable_json` — generated messages never panic and always serialize to JSON the real parser accepts. (Round-trip is intentionally **not** asserted lossless: `extra` is a `#[serde(flatten)]` catch-all, so a generated key colliding with a reserved field name deserializes into the named field — fine for fuzzing, which feeds serialized bytes to the parser rather than comparing structs.)
- `json_depth_is_bounded` — verifies the depth cap holds under structure-biased input.
- Default build unchanged; `cargo clippy --all-targets` clean with **default**, **`--features arbitrary`**, and **`--all-features`**.

## Follow-ups

- **PR-C** — in-repo `fuzz/` workspace + nightly CI (`[workspace] exclude`d), with targets combining PR-A's seed corpus and these `Arbitrary` impls.
- **#3 audit** — which of `DIDCommAgent::unpack` / SD-JWT verify / credential verify warrant a resolver-injected sync core.

Refs #477
