### PR TITLE
chore: bump vta-sdk to 0.13 in mediator crates

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 14th June 2026
 
+### 0.16.2 — bump vta-sdk to 0.13
+
+- Updated the `vta-sdk` dependency requirement from `0.11` to `0.13` (the
+  `integration` feature). No behaviour change; patch bump keeps the `0.16` pin
+  valid for consumers.
+
 ### 0.16.1 — non_exhaustive AuthError (W7 sweep)
 
 - `AuthError` is now `#[non_exhaustive]` (ADR-0003) so new variants land

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.1"
+version = "0.16.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -89,7 +89,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.11", features = ["integration"] }
+vta-sdk = { version = "0.13", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Changelog history
 
+## 14th June 2026
+
+### 0.1.13 — bump vta-sdk to 0.13
+
+- Updated the `vta-sdk` dependency requirement from `0.11` to `0.13` (the
+  `provision-client` and `test-support` features). No behaviour change.
+
 ## 12th June 2026
 
 ### 0.1.12 — Unify the non-interactive setup paths (simplification T22)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.12"
+version = "0.1.13"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5.4"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.11", features = ["provision-client"] }
+vta-sdk = { version = "0.13", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.11", features = ["test-support"] }
+vta-sdk = { version = "0.13", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
## Summary

Updates the `vta-sdk` dependency from `0.11` to the latest `0.13` (resolves to 0.13.1) in the two workspace crates that consume it.

## Changes

- **affinidi-messaging-mediator** (`integration` feature): `0.16.1` → `0.16.2`
- **affinidi-messaging-mediator-setup** (`provision-client` dep + `test-support` dev-dep): `0.1.12` → `0.1.13`
- CHANGELOG entries added for both crates.

Version requirements left as caret (`0.13`) to match the existing `0.11` style; lock pins 0.13.1.

## Verification

`cargo check -p affinidi-messaging-mediator -p affinidi-messaging-mediator-setup --all-features` passes — `--all-features` exercises all three vta-sdk feature sets, so the 0.11→0.13 jump (two breaking 0.x minors) introduced no breakage in our code. No behaviour change.
