### PR TITLE
fix: cfg-gate Android-incompatible extra-roots TLS path (#483)

### DIFF
--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,22 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.5 — 2026-06-16
+
+### Fixed
+
+- **`create_http_client` no longer fails to compile for Android targets.** The
+  extra-roots branch called `Verifier::new_with_extra_roots`, which
+  `rustls-platform-verifier` 0.7 does not implement on its Android backend, so
+  any downstream crate cross-compiling to a `*-linux-android` target failed to
+  build (host builds were unaffected, hiding the breakage). That branch — and
+  its `Verifier`/`Arc` imports — is now `cfg`-gated out on
+  `target_os = "android"`. Passing an empty `extra_roots` slice (platform trust
+  store only) works on all platforms; passing non-empty `extra_roots`
+  (`ssl_certificate_paths`) on Android now returns a clear `TDKError::Config`
+  error at runtime rather than silently dropping the requested roots. No change
+  in behaviour on non-Android platforms. (#483)
+
 ## 0.6.4 — 2026-06-13
 
 ### Added

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/tdk/affinidi-tdk-common/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-common/src/lib.rs
@@ -58,7 +58,12 @@ deliberately deferred: the abstractions mostly already exist and the concrete
 churn it would isolate is rare, so it isn't worth pre-abstracting.
 */
 
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
+
+// `Arc` is only used by the extra-roots TLS path, which is compiled out on
+// Android (see `create_http_client`).
+#[cfg(not(target_os = "android"))]
+use std::sync::Arc;
 
 use affinidi_did_authentication::{AuthorizationTokens, errors::DIDAuthError};
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
@@ -69,7 +74,11 @@ use errors::TDKError;
 use profiles::TDKProfile;
 use reqwest::Client;
 use rustls::{ClientConfig, pki_types::CertificateDer};
-use rustls_platform_verifier::{ConfigVerifierExt, Verifier};
+use rustls_platform_verifier::ConfigVerifierExt;
+// `Verifier::new_with_extra_roots` is not available on the Android backend of
+// `rustls-platform-verifier` (see `create_http_client`).
+#[cfg(not(target_os = "android"))]
+use rustls_platform_verifier::Verifier;
 use tracing::warn;
 
 pub mod config;
@@ -103,17 +112,26 @@ pub struct TDKSharedState {
 ///
 /// Pass an empty slice for the default behaviour (platform trust store only).
 /// Non-empty `extra_roots` are added on top of the platform store via
-/// [`Verifier::new_with_extra_roots`] — useful for environments with
+/// `Verifier::new_with_extra_roots` — useful for environments with
 /// internal/private CAs (see
 /// [`TDKEnvironment::ssl_certificate_paths`](environments::TDKEnvironment::ssl_certificate_paths)).
 ///
 /// Installs `rustls`'s `aws-lc-rs` crypto provider as the process default
 /// exactly once via [`OnceLock`] — repeated calls are a no-op.
 ///
+/// # Platform support
+///
+/// `extra_roots` is **not supported on Android**: `rustls-platform-verifier`'s
+/// Android backend delegates entirely to the platform trust store and provides
+/// no API to append extra roots. On `target_os = "android"`, passing non-empty
+/// `extra_roots` returns a [`TDKError::Config`] error; an empty slice (platform
+/// trust store only) works on all platforms.
+///
 /// # Errors
 ///
 /// Returns [`TDKError::Config`] if the platform TLS verifier or the
-/// [`reqwest::Client`] cannot be constructed.
+/// [`reqwest::Client`] cannot be constructed, or if non-empty `extra_roots`
+/// are supplied on Android (see *Platform support*).
 pub fn create_http_client(extra_roots: &[CertificateDer<'static>]) -> Result<Client, TDKError> {
     static CRYPTO_INIT: OnceLock<()> = OnceLock::new();
     CRYPTO_INIT.get_or_init(|| {
@@ -124,22 +142,44 @@ pub fn create_http_client(extra_roots: &[CertificateDer<'static>]) -> Result<Cli
         ClientConfig::with_platform_verifier()
             .map_err(|e| TDKError::Config(format!("rustls platform verifier init failed: {e}")))?
     } else {
-        let crypto_provider = rustls::crypto::CryptoProvider::get_default()
-            .cloned()
-            .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
-        let verifier =
-            Verifier::new_with_extra_roots(extra_roots.iter().cloned(), crypto_provider.clone())
+        // `rustls-platform-verifier` 0.7 only implements
+        // `Verifier::new_with_extra_roots` on the non-Android backends; the
+        // Android backend delegates to the platform trust store and exposes no
+        // way to append extra roots. Referencing it on Android is a compile
+        // error, so the extra-roots path is `cfg`-gated out there and we
+        // surface a clear runtime error instead of breaking the cross-compile
+        // or silently dropping the requested roots (issue #483).
+        #[cfg(target_os = "android")]
+        {
+            return Err(TDKError::Config(
+                "extra TLS roots (ssl_certificate_paths) are not supported on Android: \
+                 rustls-platform-verifier has no `new_with_extra_roots` on the Android backend"
+                    .to_string(),
+            ));
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let crypto_provider = rustls::crypto::CryptoProvider::get_default()
+                .cloned()
+                .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+            let verifier = Verifier::new_with_extra_roots(
+                extra_roots.iter().cloned(),
+                crypto_provider.clone(),
+            )
+            .map_err(|e| {
+                TDKError::Config(format!(
+                    "rustls platform verifier (with extra roots) init failed: {e}"
+                ))
+            })?;
+            ClientConfig::builder_with_provider(crypto_provider)
+                .with_safe_default_protocol_versions()
                 .map_err(|e| {
-                    TDKError::Config(format!(
-                        "rustls platform verifier (with extra roots) init failed: {e}"
-                    ))
-                })?;
-        ClientConfig::builder_with_provider(crypto_provider)
-            .with_safe_default_protocol_versions()
-            .map_err(|e| TDKError::Config(format!("rustls protocol-version setup failed: {e}")))?
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(verifier))
-            .with_no_client_auth()
+                    TDKError::Config(format!("rustls protocol-version setup failed: {e}"))
+                })?
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(verifier))
+                .with_no_client_auth()
+        }
     };
     reqwest::ClientBuilder::new()
         .use_rustls_tls()


### PR DESCRIPTION
## Summary

Fixes #483 — `affinidi-tdk-common::create_http_client` failed to compile for **Android** targets because it unconditionally called `rustls_platform_verifier::Verifier::new_with_extra_roots`, which `rustls-platform-verifier` 0.7 does **not** implement on its Android backend (only `new`). Any downstream crate cross-compiling to `*-linux-android` failed with `E0599`. Host builds (Linux/macOS/Windows) were unaffected, which is why it slipped past normal `cargo build`/CI.

## Change

- The extra-roots branch of `create_http_client` (and its now-Android-unused `Verifier`/`Arc` imports) is `cfg`-gated out on `target_os = "android"`.
- An **empty** `extra_roots` slice (platform trust store only) compiles and works on **all** platforms — unchanged.
- A **non-empty** `extra_roots` (`ssl_certificate_paths`) on Android now returns a clear `TDKError::Config` runtime error rather than silently dropping the requested trust roots. Silently ignoring extra roots would be a trust/security footgun, so we fail loudly (issue suggestion #3, combined with the `cfg`-gate from #1).
- **Non-Android behaviour is byte-for-byte unchanged.**
- Patch bump `affinidi-tdk-common` 0.6.4 → 0.6.5 + CHANGELOG entry.

## Verification

- `cargo fmt`, `cargo clippy -p affinidi-tdk-common --all-targets` — clean.
- `cargo test -p affinidi-tdk-common` — all pass (lib, end-to-end smoke, keyring, doctests).
- The `cfg`-gating + never-type coercion on the Android path was validated with a standalone reproduction compiled under `-D warnings` for both `cfg(not(android))` and `cfg(android)`: empty-roots → builds, non-empty-roots on Android → returns the error.

> Note: a full `cargo build --target aarch64-linux-android` could not be completed in this environment — a transitive `openssl-sys` (`ssi-dids-core` → `reqwest 0.11` → `native-tls`) needs the Android NDK C toolchain, which isn't installed here. That C build aborts before reaching `affinidi-tdk-common`'s own Rust compile and is unrelated to this fix. A reviewer with the NDK can confirm the original `E0599` is gone end-to-end.

Closes #483
