### PR TITLE
fix: guard qb64 parsers against non-ASCII input

### DIFF
--- a/crates/core/affinidi-cesr/CHANGELOG.md
+++ b/crates/core/affinidi-cesr/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 16th June 2026
+
+### 0.1.3 — guard qb64 parsers against non-ASCII input
+
+- `Matter::from_qb64`, `Counter::from_qb64`, and `Indexer::from_qb64` now
+  reject non-ASCII input up front (returning `CesrError::InvalidCharacter`)
+  instead of panicking. qb64 is base64url (pure ASCII); the parsers slice the
+  input on byte offsets derived from character counts, so a multi-byte UTF-8
+  character could land mid-slice and panic with "byte index N is not a char
+  boundary". Hardening only — no production caller is affected (the wire path
+  uses the binary `from_qb2`). Patch bump; no behaviour change for ASCII input.
+
 ## 14th June 2026
 
 ### 0.1.2 — non_exhaustive CesrError (W7 sweep)

--- a/crates/core/affinidi-cesr/Cargo.toml
+++ b/crates/core/affinidi-cesr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-cesr"
 description = "CESR (Composable Event Streaming Representation) encoding and decoding"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/core/affinidi-cesr/src/codec.rs
+++ b/crates/core/affinidi-cesr/src/codec.rs
@@ -16,6 +16,21 @@ const B64_DECODE: [u8; 128] = {
     table
 };
 
+/// Reject non-ASCII input before any byte-offset slicing.
+///
+/// qb64 (the CESR text domain) is defined over base64url, which is pure
+/// ASCII. The `from_qb64` parsers compute sizes as character counts and then
+/// slice the input on those values as *byte* offsets. For ASCII input the two
+/// coincide, but a multi-byte UTF-8 character would let a byte offset land
+/// mid-character and panic the slice. Guarding here makes every downstream
+/// slice in the caller safe by construction.
+pub fn ensure_ascii(qb64: &str) -> Result<(), CesrError> {
+    if let Some((position, ch)) = qb64.char_indices().find(|(_, c)| !c.is_ascii()) {
+        return Err(CesrError::InvalidCharacter { position, ch });
+    }
+    Ok(())
+}
+
 /// Encode raw bytes to URL-safe Base64 (no padding).
 pub fn b64_encode(data: &[u8]) -> String {
     use base64ct::{Base64UrlUnpadded, Encoding};

--- a/crates/core/affinidi-cesr/src/counter.rs
+++ b/crates/core/affinidi-cesr/src/counter.rs
@@ -33,6 +33,7 @@ impl Counter {
         if qb64.is_empty() {
             return Err(CesrError::EmptyInput);
         }
+        codec::ensure_ascii(qb64)?;
 
         let first_char = qb64.chars().next().ok_or(CesrError::EmptyInput)?;
         if first_char != '-' {
@@ -122,6 +123,15 @@ impl std::fmt::Display for Counter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn from_qb64_rejects_non_ascii_without_panicking() {
+        // Would previously panic slicing the soft portion on a char boundary.
+        assert!(matches!(
+            Counter::from_qb64("-C\u{FFFD}"),
+            Err(CesrError::InvalidCharacter { .. })
+        ));
+    }
 
     #[test]
     fn test_counter_new() {

--- a/crates/core/affinidi-cesr/src/indexer.rs
+++ b/crates/core/affinidi-cesr/src/indexer.rs
@@ -67,6 +67,7 @@ impl Indexer {
         if qb64.is_empty() {
             return Err(CesrError::EmptyInput);
         }
+        codec::ensure_ascii(qb64)?;
 
         let first_char = qb64.chars().next().ok_or(CesrError::EmptyInput)?;
         let hs = hardage(first_char).ok_or(CesrError::UnknownCode(first_char.to_string()))?;
@@ -243,6 +244,16 @@ impl std::fmt::Display for Indexer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn from_qb64_rejects_non_ascii_without_panicking() {
+        // Would previously panic at `&qb64[..hs]` (hardage('0')==2 slices into
+        // the multi-byte U+FFFD).
+        assert!(matches!(
+            Indexer::from_qb64("0\u{FFFD}"),
+            Err(CesrError::InvalidCharacter { .. })
+        ));
+    }
 
     #[test]
     fn test_indexer_new_ed25519() {

--- a/crates/core/affinidi-cesr/src/matter.rs
+++ b/crates/core/affinidi-cesr/src/matter.rs
@@ -47,6 +47,7 @@ impl Matter {
         if qb64.is_empty() {
             return Err(CesrError::EmptyInput);
         }
+        codec::ensure_ascii(qb64)?;
 
         // Determine hard size from first character
         let first_char = qb64.chars().next().ok_or(CesrError::EmptyInput)?;
@@ -393,6 +394,22 @@ impl std::fmt::Display for Matter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn from_qb64_rejects_non_ascii_without_panicking() {
+        // Each of these would previously panic on a char-boundary slice
+        // because the byte offset lands inside the multi-byte U+FFFD.
+        assert!(matches!(
+            Matter::from_qb64("-\u{FFFD}"),
+            Err(CesrError::InvalidCharacter { .. })
+        ));
+        assert!(matches!(
+            Matter::from_qb64(&format!("B{}\u{FFFD}", "A".repeat(41))),
+            Err(CesrError::InvalidCharacter { .. })
+        ));
+        // ASCII input still parses or returns a normal (non-panicking) error.
+        let _ = Matter::from_qb64(&"B".repeat(44));
+    }
 
     #[test]
     fn test_matter_raw_size() {


### PR DESCRIPTION
## Summary

Fixes a panic-on-non-ASCII hardening issue in the text-domain CESR parsers, raised in an external security review (Low severity).

`Matter::from_qb64`, `Counter::from_qb64`, and `Indexer::from_qb64` compute sizes as **character counts** and then slice the input on those values as **byte offsets**. qb64 is base64url (pure ASCII), so the two coincide for ASCII input — but a multi-byte UTF-8 character can land mid-slice and panic with `byte index N is not a char boundary`.

## Severity: Low (hardening)

- **Not reachable from untrusted input today.** Every `from_qb64` call site in the repo is `#[cfg(test)]`. The single production consumer (`affinidi-tsp` `Envelope::decode`) uses the binary `Matter::from_qb2`, which operates on base64-encoder output (always ASCII).
- A future caller wiring untrusted text into a `from_qb64` would inherit a remote panic / DoS. Cheap to seal now.

## Fix

Add a shared `codec::ensure_ascii` guard at the top of each `from_qb64` entry point, returning the **existing** `CesrError::InvalidCharacter { position, ch }` variant instead of panicking. Guarding once at the top makes *every* downstream byte slice in the function safe by construction — not just the enumerated sites.

> Note: the original review's suggested snippet used `CesrError::InvalidCharacter(String)`, but that variant is already a struct variant (`{ position, ch }`) and already exists — no new variant is added, so there's no SemVer consideration here.

## Tests

A regression test per entry point. Each input was independently verified to panic on the *unguarded* slice (via `catch_unwind` against the raw slice logic) before being added, so the tests guard against re-introduction rather than just exercising the new guard:

| input | unguarded failure |
|---|---|
| `Matter::from_qb64("-\u{FFFD}")` | panic at `&qb64[..2]` |
| `Matter::from_qb64("B" + 41×"A" + "\u{FFFD}")` | panic at `extract_raw` `&qb64[..44]` |
| `Counter::from_qb64("-C\u{FFFD}")` | panic at `&qb64[2..4]` |
| `Indexer::from_qb64("0\u{FFFD}")` | panic at `&qb64[..2]` |

## Versioning

`affinidi-cesr` 0.1.2 → 0.1.3 (patch; no behaviour change for ASCII input). Dependents pin at `0.1`, so the pin stays valid — no cascade.

## Verification

- `cargo fmt`
- `cargo clippy -p affinidi-cesr --all-targets` — clean
- `cargo test -p affinidi-cesr` — 47 passed (incl. 3 new)
- DCO-signed
