### PR TITLE
fix: make did:cheqd opt-in so the resolver SDK no longer forces the rustls ring backend

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -30,6 +30,12 @@
   cannot be fixed from this workspace (1.0.1 is the latest published version and
   `tonic 0.12` hardcodes `ring`); making cheqd opt-in is the durable in-workspace
   mitigation. Patch bump keeps the `0.8` pin valid.
+- **`rustls-platform-verifier` bumped `0.6` → `0.7`** to match the rest of the
+  workspace (`affinidi-tdk-common` is already on `0.7`), consolidating the lock
+  to a single version. The SDK only calls `ClientConfig::with_platform_verifier()`
+  (available on all backends, incl. Android) and does not use
+  `Verifier::new_with_extra_roots`, so the Android cross-compile gap from #483/#484
+  does not apply here. No source change required.
 
 ## 14th June 2026
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Changelog history
 
+## 17th June 2026
+
+### 0.8.11 — `did-cheqd` is now opt-in (no forced rustls `ring` backend)
+
+- **`did-cheqd` removed from the default `did-methods` set.** It pulled
+  `did-resolver-cheqd`, whose `tonic 0.12` dependency hardcodes the rustls
+  `ring` backend on `tokio-rustls`/`rustls 0.23`. Combined with `network`
+  (which uses `aws_lc_rs`) — or any downstream binary that selects `aws_lc_rs`
+  via `kube`/`reqwest`/`jsonwebtoken` — both rustls backends were compiled and
+  `rustls` could no longer auto-select one, panicking with "no process-level
+  CryptoProvider available" at the first TLS call (e.g. `ClientConfig::builder()`).
+  `did-methods` is now `["did-webvh", "did-scid"]`; a default + `network` build
+  compiles `aws_lc_rs` only.
+- **The `did-scid` dependency now uses `default-features = false` + `did-webvh`**
+  so it no longer drags `did-resolver-cheqd` (and the `ring` stack) in
+  transitively.
+- **The fix is purely about not forcing a backend.** No runtime
+  `install_default()` was added here — installing a process-global rustls
+  `CryptoProvider` remains the application's decision and belongs in the
+  downstream binary's `main`.
+- **Opt back in** with `features = ["did-cheqd"]` (or `did-cheqd` +
+  `network`) when you need `did:cheqd` resolution; that re-enables the `ring`
+  backend, so install a `CryptoProvider` in your binary's `main`. See the
+  README's "did-cheqd and the rustls ring backend" section.
+- Root cause is the external `did-resolver-cheqd 1.0.1` + `tonic 0.12.3`, which
+  cannot be fixed from this workspace (1.0.1 is the latest published version and
+  `tonic 0.12` hardcodes `ring`); making cheqd opt-in is the durable in-workspace
+  mitigation. Patch bump keeps the `0.8` pin valid.
+
 ## 14th June 2026
 
 ### 0.8.10 — non_exhaustive DIDCacheError (W7 sweep)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.10"
+version = "0.8.11"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -30,7 +30,15 @@ network = [
   "tokio/net",
   "tokio/io-util",
 ]
-did-methods = ["did-cheqd", "did-webvh", "did-scid"]
+# `did-cheqd` is intentionally NOT part of `did-methods` (and so not in
+# `default`): it pulls `did-resolver-cheqd`, whose `tonic 0.12` dependency
+# hardcodes the rustls `ring` backend on `tokio-rustls`/`rustls 0.23`. With
+# `network` (which uses `aws_lc_rs`) or any downstream that selects `aws_lc_rs`
+# (kube/reqwest/jsonwebtoken), compiling both backends makes rustls unable to
+# auto-select one, panicking with "no process-level CryptoProvider available"
+# at the first TLS call. Enable `did-cheqd` explicitly only when you accept the
+# `ring` backend and install a CryptoProvider in your binary's `main`.
+did-methods = ["did-webvh", "did-scid"]
 did_example = ["dep:did-example"]
 did-jwk = ["dep:did-jwk"]
 did-cheqd = ["dep:did-resolver-cheqd"]
@@ -45,7 +53,12 @@ affinidi-did-resolver-traits = { version = "0.1", path = "../affinidi-did-resolv
 # Shared background-task supervision (network mode only)
 affinidi-task-utils = { version = "0.1", optional = true }
 did-example = { version = "0.5", optional = true }
-did-scid = { version = "0.1", optional = true }
+# `default-features = false` keeps did-scid's own optional `did-cheqd` backend
+# (and its `tonic`/`ring` TLS stack) out of this SDK's default build; pulling
+# `did-cheqd` here re-enables it deliberately.
+did-scid = { version = "0.1", optional = true, default-features = false, features = [
+  "did-webvh",
+] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
 
 # External Crates

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -72,7 +72,7 @@ rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
   "tls12",
 ], optional = true }
-rustls-platform-verifier = { version = "0.6", optional = true }
+rustls-platform-verifier = { version = "0.7", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -27,8 +27,8 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | `did:ethr` | Yes | — |
 | `did:pkh` | Yes | — |
 | `did:webvh` | Yes | `did-methods` |
-| `did:cheqd` | Yes | `did-methods` |
 | `did:scid` | Yes | `did-methods` |
+| `did:cheqd` | No | `did-cheqd` (opt-in — pulls a `ring` TLS backend, see below) |
 | `did:ebsi` | No | `did-ebsi` (EBSI DID Registry API) |
 | `did:example` | No | `did_example` (must be manually loaded) |
 
@@ -37,13 +37,36 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | Feature | Default | Description |
 |---|---|---|
 | `local` | Yes | Reserved for future local-only features |
-| `did-methods` | Yes | Includes `did-webvh`, `did-cheqd`, `did-scid` |
+| `did-methods` | Yes | Includes `did-webvh`, `did-scid` |
 | `did-ebsi` | No | EBSI DID method (requires network access to EU API) |
 | `network` | No | Enable network mode for remote cache server |
 | `did-webvh` | — | WebVH DID method support |
-| `did-cheqd` | — | Cheqd blockchain DID method support |
+| `did-cheqd` | No | Cheqd blockchain DID method support (opt-in, see TLS note) |
 | `did-scid` | — | Self-Certifying Identifier DID method |
 | `did_example` | — | Example DID method for testing |
+
+### `did-cheqd` and the rustls `ring` backend
+
+`did-cheqd` is **not** enabled by default. It pulls `did-resolver-cheqd`, whose
+gRPC client (`tonic 0.12`) hardcodes the `ring` backend on
+`tokio-rustls`/`rustls 0.23`. This SDK's `network` feature — and most downstream
+binaries (via `kube`, `reqwest`, `jsonwebtoken`, …) — select the `aws_lc_rs`
+backend instead. When both backends are compiled, `rustls` cannot auto-select
+one and panics at the first TLS call with:
+
+```text
+no process-level CryptoProvider available
+```
+
+If you enable `did-cheqd`, you accept the `ring` backend. Because installing a
+process-global `CryptoProvider` is the application's decision, your binary's
+`main` must do it before any TLS is used, e.g.:
+
+```rust,ignore
+rustls::crypto::aws_lc_rs::default_provider()
+    .install_default()
+    .expect("install default rustls CryptoProvider");
+```
 
 ## Usage
 

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+## 17th June 2026
+
+### 0.1.10 — drop `did-cheqd` from default features (no forced `ring` TLS)
+
+- **`did-cheqd` is no longer a default feature.** It pulled `did-resolver-cheqd`,
+  whose `tonic 0.12` dependency hardcodes the rustls `ring` backend on
+  `tokio-rustls`/`rustls 0.23`. That clashed with downstream binaries selecting
+  `aws_lc_rs` (the ecosystem default via `kube`/`reqwest`/`jsonwebtoken`),
+  compiling both backends and panicking with "no process-level CryptoProvider
+  available" at the first TLS call. `default` is now `["did-webvh"]`.
+- **Opt back in** with `features = ["did-cheqd"]` when you need `did:scid`
+  anchored on `did:cheqd`; doing so re-enables the `ring` backend, so install a
+  `CryptoProvider` in your binary's `main`.
+- Patch bump keeps the `0.1` pin valid. No API or behaviour change beyond the
+  default feature set.
+
 ## 14th June 2026
 
 ### 0.1.9 — non_exhaustive DIDSCIDError (W7 sweep)

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.9"
+version = "0.1.10"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -14,7 +14,14 @@ readme = "README.md"
 rust-version.workspace = true
 
 [features]
-default = ["did-webvh", "did-cheqd"]
+# `did-cheqd` is intentionally NOT in `default`: it pulls `did-resolver-cheqd`,
+# whose `tonic 0.12` dependency hardcodes the rustls `ring` backend on
+# `tokio-rustls`/`rustls 0.23`. Forcing `ring` clashes with downstream binaries
+# that select `aws_lc_rs` (the ecosystem default via kube/reqwest/jsonwebtoken),
+# producing a "no process-level CryptoProvider available" panic. Opt in to
+# `did-cheqd` only when you accept the `ring` backend (and install a
+# CryptoProvider in your binary's `main`).
+default = ["did-webvh"]
 
 did-cheqd = ["dep:did-resolver-cheqd"]
 did-webvh = ["dep:didwebvh-rs"]

--- a/crates/identity/did-methods/did-scid/src/lib.rs
+++ b/crates/identity/did-methods/did-scid/src/lib.rs
@@ -109,6 +109,25 @@ pub async fn resolve(
     }
 }
 
+/// Derive a `did:cheqd` method DID from a URL-mode `?src=did:cheqd:...` source.
+///
+/// `did-cheqd` is optional because `did-resolver-cheqd` forces the rustls `ring`
+/// TLS backend (via `tonic 0.12`); see the crate's feature docs. When the
+/// feature is disabled this returns a clear error instead of failing to compile.
+#[cfg(feature = "did-cheqd")]
+fn derive_cheqd_url(src: &str, scid: &str) -> Result<ScidMethod, DIDSCIDError> {
+    let cheqd = format!("{src}:{scid}");
+    debug!("derived cheqd DID: {cheqd}");
+    Ok(ScidMethod::Cheqd(cheqd))
+}
+
+#[cfg(not(feature = "did-cheqd"))]
+fn derive_cheqd_url(_src: &str, _scid: &str) -> Result<ScidMethod, DIDSCIDError> {
+    Err(DIDSCIDError::CheqdError(
+        "did:cheqd source requires the `did-cheqd` feature".to_string(),
+    ))
+}
+
 /// Converts a SCID DID to a valid Method DID Identifier
 /// peer_src: Optional meta_data if operating in peer mode
 fn convert_scid_to_method(
@@ -123,9 +142,7 @@ fn convert_scid_to_method(
 
     if let Some(src) = caps.get(2).map(|m| m.as_str()) {
         if src.starts_with("did:cheqd:") {
-            let cheqd = format!("{src}:{scid}");
-            debug!("derived cheqd DID: {cheqd}");
-            Ok(ScidMethod::Cheqd(cheqd))
+            derive_cheqd_url(src, scid)
         } else if src.starts_with("did:") {
             Err(DIDSCIDError::UnsupportedFormat)
         } else {
@@ -143,6 +160,7 @@ fn convert_scid_to_method(
                 debug!("derived peer webvh DID: {webvh}");
                 Ok(ScidMethod::WebVH(webvh))
             }
+            #[cfg(feature = "did-cheqd")]
             Some(ScidMethod::Cheqd(src)) => {
                 let cheqd = format!("did:cheqd:{src}:{scid}");
                 debug!("derived peer cheqd DID: {cheqd}");
@@ -369,6 +387,7 @@ mod tests {
 
     // -- pre-existing happy paths ------------------------------------------
 
+    #[cfg(feature = "did-cheqd")]
     #[test]
     fn test_cheqd_conversion() {
         match convert_scid_to_method("did:scid:vh:1:abcde?src=did:cheqd:mainnet", None) {
@@ -377,6 +396,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "did-cheqd")]
     #[test]
     fn test_cheqd_peer_conversion() {
         match convert_scid_to_method(
@@ -449,6 +469,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "did-cheqd")]
     #[tokio::test]
     #[ignore = "requires external network (cheqd.net)"]
     async fn test_scid_cheqd_resolution() {


### PR DESCRIPTION
## Problem

A downstream binary that links `affinidi-did-resolver-cache-sdk` panics at the
first TLS call:

```
thread 'main' panicked at 'no process-level CryptoProvider available'
```

This fires from `ClientConfig::builder()` (e.g. when `kube-client` initialises
its HTTP client) before any network connection is made, because `rustls 0.23`
has **both** the `aws_lc_rs` and `ring` backends compiled in and cannot
auto-select one.

## Diagnosis (verified in this workspace)

`cargo tree -i rustls@0.23 -e features` pinpoints the forcing edge:

```
rustls feature "ring"
  └── tokio-rustls feature "ring"
      └── tonic v0.12.3
```

`tonic 0.12.3` hardcodes `features = ["ring"]` on `tokio-rustls`, which forces
the `ring` feature onto `rustls 0.23` via feature unification. `tonic 0.12.3`
enters the build through **`did-resolver-cheqd v1.0.1`**, reached two ways:

1. directly — the SDK's `did-cheqd` feature (part of the default `did-methods`);
2. transitively — the SDK's `did-scid` feature → `did-scid`, whose own
   `default` enabled `did-cheqd` → `did-resolver-cheqd`.

When the consumer also brings `aws_lc_rs` (kube/reqwest/jsonwebtoken), both
backends are compiled → panic.

**Sibling sweep (task item #5):** the only other tonic/gRPC path is
mediator-common's opt-in `secrets-gcp` (`google-cloud-*`). Under that feature
tonic isn't even pulled and rustls stays `aws_lc_rs`-only — it does **not**
force ring. So the cheqd path is the sole offender.

## Why not just upgrade tonic?

`did-resolver-cheqd 1.0.1` is the **latest published version** and pins
`tonic 0.12`. Upgrading tonic requires an upstream change to an external crate,
so option (a) is not feasible from this workspace. `tonic 0.12` hardcodes
`ring`, so it can't be decoupled either (option b). The durable in-workspace
fix is option (c): stop forcing the backend by making the cheqd/tonic path
**opt-in**, so a single backend is compiled per build.

Per the workspace convention (fix the cause, not the symptom), **no runtime
`install_default()` was added** — installing a process-global rustls
`CryptoProvider` is the application's decision and stays in downstream `main()`.

## Changes

- **did-scid 0.1.10** — drop `did-cheqd` from `default` (now `["did-webvh"]`);
  gate the cheqd code paths and tests behind the feature so it compiles without
  it (returns a clear `CheqdError` for a `did:cheqd` source when disabled).
- **affinidi-did-resolver-cache-sdk 0.8.11** — drop `did-cheqd` from
  `did-methods` (now `["did-webvh", "did-scid"]`); consume `did-scid` with
  `default-features = false, features = ["did-webvh"]`. README documents the
  `did-cheqd` opt-in and the `ring` implications.

Both are **patch bumps**, keeping the `0.1`/`0.8` pins and `[patch.crates-io]`
redirects valid per ADR-0003.

## Proof

```text
# default + network (the panic-prone combo) — ring is GONE:
$ cargo tree -p affinidi-did-resolver-cache-sdk --features network -i rustls@0.23 -f "{f}"
aws-lc-rs,aws_lc_rs,log,logging,std,tls12

# whole workspace — no 'rustls feature ring' edge, tonic 0.12.3 absent entirely.

# opt-in still works (ring expected):
$ cargo tree -p affinidi-did-resolver-cache-sdk --features network,did-cheqd -i rustls@0.23 -f "{f}"
aws-lc-rs,aws_lc_rs,log,logging,ring,std,tls12
```

- `cargo check --workspace --all-targets` — green.
- `cargo clippy` on did-scid and the SDK, **both** with and without `did-cheqd` — green.
- did-scid lib tests pass in both feature configs (cheqd tests gated).

## Behaviour change

`did:cheqd` resolution is no longer available by default. Consumers that need it
add `features = ["did-cheqd"]` (which re-enables the `ring` backend) and install
a `CryptoProvider` in their binary's `main`.