### PR TITLE
chore: bump vta-sdk to 0.16 in mediator crates

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.2"
+version = "0.16.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -89,7 +89,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.13", features = ["integration"] }
+vta-sdk = { version = "0.16", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.13"
+version = "0.1.14"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5.4"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.13", features = ["provision-client"] }
+vta-sdk = { version = "0.16", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.13", features = ["test-support"] }
+vta-sdk = { version = "0.16", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
## Summary

The new `vta-sdk` crates were published (latest 0.16.0). This bumps the mediator and mediator-setup from `vta-sdk` 0.13 to 0.16.

- **affinidi-messaging-mediator**: `vta-sdk` 0.13 → 0.16 (`integration`); crate `0.16.2 → 0.16.3` (patch — published crate, dep-only change).
- **affinidi-messaging-mediator-setup**: `vta-sdk` 0.13 → 0.16 in both the runtime dep (`provision-client`) and the dev-dep (`test-support`); crate `0.1.13 → 0.1.14` (`publish = false`, bumped for changelog tidiness).

No code changes were required across the three 0.x minor bumps — the `integration`, `provision-client`, and `test-support` feature surfaces remain compatible and `reqwest 0.13` still lines up.

`vta-sdk` only appears in these two crates; no other workspace member references it.

## Verification

- `cargo build -p affinidi-messaging-mediator -p affinidi-messaging-mediator-setup` ✅
- `cargo clippy --all-targets` ✅ clean
- `cargo test` ✅ 363 passed, 0 failed