### PR TITLE
feat: affinidi-tsp routed and nested message modes (Routed/Nested)

### DIFF
--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 22nd June 2026
 
+### 0.1.5 — routed & nested message modes (§5.3 / §5.5)
+
+- New `message::routed` module implementing TSP routed mode (multi-hop relay
+  through intermediaries, with the remaining route carried inside each
+  HPKE-sealed routing layer and re-sealed/re-authenticated at every hop) and the
+  nested metadata-privacy wrapper. The inner message stays opaque to every
+  intermediary. Replaces the previous `MessageType::Nested`/`Routed`
+  recognized-but-unimplemented stubs.
+- Public primitives `pack_routed`, `pack_nested`, `next_hop`, and the `RouteStep`
+  / `MAX_HOPS` exports.
+- New high-level `TspAgent` methods `send_routed`, `send_nested`, and
+  `forward_routed` (returning `ForwardOutcome::{Relay, Deliver}`), which resolve
+  each hop's keys via the agent resolver.
+- `TspAdapter::wrap_for_relay` (messaging-core) now implemented (was
+  `NotSupported`): relays an opaque packed message to the next hop toward the
+  final recipient, as the adapter's default VID.
+- Purely additive; patch bump 0.1.4 → 0.1.5. 84 tests incl. a full multi-hop
+  crypto round-trip and a two-intermediary agent-level relay.
+
 ### 0.1.4 — DID-document VID resolver
 
 - New `DidVidResolver` (behind the existing `did-resolver` feature): resolves a

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/adapter.rs
+++ b/crates/messaging/affinidi-tsp/src/adapter.rs
@@ -102,14 +102,37 @@ impl MessagingProtocol for TspAdapter {
 
     async fn wrap_for_relay(
         &self,
-        _packed: &[u8],
-        _next_hop: &str,
-        _final_recipient: &str,
+        packed: &[u8],
+        next_hop: &str,
+        final_recipient: &str,
     ) -> Result<Vec<u8>, MessagingError> {
-        // Nested/routed modes are Phase 3
-        Err(MessagingError::NotSupported(
-            "TSP nested/routed modes not yet implemented".into(),
-        ))
+        // Relay as our default VID: build a routed layer addressed to `next_hop`
+        // carrying the opaque `packed` inner; `next_hop` forwards it to
+        // `final_recipient` (the single remaining route entry).
+        let our_vid = self.default_vid()?;
+        let our_private = self
+            .agent
+            .store
+            .get_private_vid(our_vid)
+            .map_err(|e| MessagingError::Protocol(e.to_string()))?;
+        let next = self
+            .agent
+            .resolver
+            .resolve(next_hop)
+            .map_err(|e| MessagingError::Resolution(e.to_string()))?;
+
+        let relayed = crate::message::routed::pack_routed(
+            packed,
+            &[final_recipient.to_string()],
+            our_vid,
+            next_hop,
+            &our_private.signing_key,
+            &our_private.decryption_key,
+            &next.encryption_key,
+        )
+        .map_err(|e| MessagingError::Protocol(e.to_string()))?;
+
+        Ok(relayed.bytes)
     }
 }
 

--- a/crates/messaging/affinidi-tsp/src/lib.rs
+++ b/crates/messaging/affinidi-tsp/src/lib.rs
@@ -38,6 +38,7 @@ pub mod vid;
 
 pub use error::TspError;
 pub use message::MessageType;
+pub use message::routed::{MAX_HOPS, RouteStep};
 pub use relationship::RelationshipState;
 pub use vid::resolver::VidResolver;
 #[cfg(feature = "did-resolver")]
@@ -232,6 +233,140 @@ impl TspAgent {
         })
     }
 
+    // --- Routed / nested messaging (§5.3 / §5.5) ---
+
+    /// Send a message to `final_vid` routed through `intermediaries` (in order).
+    ///
+    /// The payload is sealed end-to-end to `final_vid` (so intermediaries cannot
+    /// read it), then wrapped in a routed layer addressed to the first
+    /// intermediary. Each intermediary calls [`TspAgent::forward_routed`] to
+    /// advance the message. With an empty `intermediaries` list this is an
+    /// ordinary direct send.
+    ///
+    /// Requires a `Bidirectional` relationship with `final_vid` (the inner is a
+    /// direct message); resolution of every hop's keys is via the agent resolver.
+    pub fn send_routed(
+        &self,
+        our_vid: &str,
+        final_vid: &str,
+        intermediaries: &[&str],
+        payload: &[u8],
+    ) -> Result<PackedMessage, TspError> {
+        // Inner: end-to-end sealed to the final recipient.
+        let inner = self.pack_message(our_vid, final_vid, payload, MessageType::Direct)?;
+
+        if intermediaries.is_empty() {
+            return Ok(inner);
+        }
+
+        // Route is the intermediaries followed by the final recipient, so the
+        // last intermediary forwards the inner directly to `final_vid`.
+        let mut route: Vec<String> = intermediaries[1..].iter().map(|s| s.to_string()).collect();
+        route.push(final_vid.to_string());
+
+        let first_hop = intermediaries[0];
+        let our_private = self.store.get_private_vid(our_vid)?;
+        let first_resolved = self.resolver.resolve(first_hop)?;
+
+        message::routed::pack_routed(
+            &inner.bytes,
+            &route,
+            our_vid,
+            first_hop,
+            &our_private.signing_key,
+            &our_private.decryption_key,
+            &first_resolved.encryption_key,
+        )
+    }
+
+    /// Wrap an already-packed message inside a nested outer message addressed to
+    /// `intermediary_vid`, for metadata privacy (§5.5). The intermediary can
+    /// open the outer but not the opaque inner.
+    pub fn send_nested(
+        &self,
+        our_vid: &str,
+        intermediary_vid: &str,
+        inner: &PackedMessage,
+    ) -> Result<PackedMessage, TspError> {
+        let our_private = self.store.get_private_vid(our_vid)?;
+        let intermediary = self.resolver.resolve(intermediary_vid)?;
+        message::routed::pack_nested(
+            inner,
+            our_vid,
+            intermediary_vid,
+            &our_private.signing_key,
+            &our_private.decryption_key,
+            &intermediary.encryption_key,
+        )
+    }
+
+    /// Process a routed message addressed to `our_vid` as an intermediary:
+    /// open our routing layer, then either re-seal the remaining route to the
+    /// next intermediary, or hand the opaque inner to the final recipient.
+    pub fn forward_routed(&self, our_vid: &str, wire: &[u8]) -> Result<ForwardOutcome, TspError> {
+        // Parse the envelope to authenticate the previous hop (the sender).
+        let (envelope, _) = message::envelope::Envelope::decode(wire)?;
+        if envelope.receiver != our_vid {
+            return Err(TspError::InvalidMessage(format!(
+                "routed message addressed to {}, not {our_vid}",
+                envelope.receiver
+            )));
+        }
+        if envelope.message_type != MessageType::Routed {
+            return Err(TspError::InvalidMessage(format!(
+                "expected a Routed message, got {:?}",
+                envelope.message_type
+            )));
+        }
+
+        let our_private = self.store.get_private_vid(our_vid)?;
+        let prev = self.resolver.resolve(&envelope.sender)?;
+        let unpacked = direct::unpack(
+            wire,
+            &our_private.decryption_key,
+            &prev.encryption_key,
+            &prev.signing_key,
+        )?;
+
+        match message::routed::next_hop(&unpacked.payload)? {
+            // Last intermediary: deliver the opaque inner to the final recipient.
+            message::routed::RouteStep::Forward {
+                next,
+                remaining,
+                inner,
+            } if remaining.is_empty() => Ok(ForwardOutcome::Deliver {
+                to: next,
+                message: inner,
+            }),
+            // Re-seal the remaining route to the next intermediary.
+            message::routed::RouteStep::Forward {
+                next,
+                remaining,
+                inner,
+            } => {
+                let next_resolved = self.resolver.resolve(&next)?;
+                let relayed = message::routed::pack_routed(
+                    &inner,
+                    &remaining,
+                    our_vid,
+                    &next,
+                    &our_private.signing_key,
+                    &our_private.decryption_key,
+                    &next_resolved.encryption_key,
+                )?;
+                Ok(ForwardOutcome::Relay {
+                    to: next,
+                    message: relayed,
+                })
+            }
+            // Empty route: the inner is for us to consume.
+            message::routed::RouteStep::Deliver { inner } => Ok(ForwardOutcome::Deliver {
+                to: our_vid.to_string(),
+                message: inner,
+            }),
+        }
+    }
+
     // --- Internal helpers ---
 
     fn pack_message(
@@ -323,6 +458,26 @@ pub struct ReceivedMessage {
     pub control: Option<ControlMessage>,
 }
 
+/// The result of forwarding a routed message at an intermediary
+/// ([`TspAgent::forward_routed`]).
+#[derive(Debug, Clone)]
+pub enum ForwardOutcome {
+    /// A re-sealed routed layer to relay onward to the next intermediary.
+    Relay {
+        /// The next intermediary's VID (the new envelope receiver).
+        to: String,
+        /// The packed routed layer to send to `to`.
+        message: PackedMessage,
+    },
+    /// The opaque inner message to deliver to the final recipient (last hop).
+    Deliver {
+        /// The final recipient's VID.
+        to: String,
+        /// The opaque inner message bytes (sealed to the final recipient).
+        message: Vec<u8>,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,6 +505,75 @@ mod tests {
             "did:example:alice".to_string(),
             "did:example:bob".to_string(),
         )
+    }
+
+    #[test]
+    fn routed_through_two_intermediaries() {
+        let alice = TspAgent::new();
+        let m1 = TspAgent::new();
+        let m2 = TspAgent::new();
+        let bob = TspAgent::new();
+
+        let alice_v = PrivateVid::generate("did:example:alice");
+        let m1_v = PrivateVid::generate("did:example:m1");
+        let m2_v = PrivateVid::generate("did:example:m2");
+        let bob_v = PrivateVid::generate("did:example:bob");
+        let (a, m1p, m2p, b) = (
+            alice_v.to_resolved(),
+            m1_v.to_resolved(),
+            m2_v.to_resolved(),
+            bob_v.to_resolved(),
+        );
+
+        // Each party knows the VIDs it must resolve along the route.
+        alice.add_private_vid(alice_v);
+        alice.add_verified_vid(m1p.clone()); // first hop
+        alice.add_verified_vid(b.clone()); // final (inner seal)
+
+        m1.add_private_vid(m1_v);
+        m1.add_verified_vid(a.clone()); // previous hop
+        m1.add_verified_vid(m2p.clone()); // next hop
+
+        m2.add_private_vid(m2_v);
+        m2.add_verified_vid(m1p.clone()); // previous hop
+        m2.add_verified_vid(b.clone()); // final
+
+        bob.add_private_vid(bob_v);
+        bob.add_verified_vid(a.clone()); // inner sender
+
+        // Alice routes a message to Bob through m1 then m2.
+        let layer1 = alice
+            .send_routed(
+                "did:example:alice",
+                "did:example:bob",
+                &["did:example:m1", "did:example:m2"],
+                b"hi bob",
+            )
+            .unwrap();
+
+        // m1 relays to m2.
+        let layer2 = match m1.forward_routed("did:example:m1", &layer1.bytes).unwrap() {
+            ForwardOutcome::Relay { to, message } => {
+                assert_eq!(to, "did:example:m2");
+                message
+            }
+            other => panic!("m1 expected Relay, got {other:?}"),
+        };
+
+        // m2 is the last hop: it delivers the opaque inner to bob.
+        let inner = match m2.forward_routed("did:example:m2", &layer2.bytes).unwrap() {
+            ForwardOutcome::Deliver { to, message } => {
+                assert_eq!(to, "did:example:bob");
+                message
+            }
+            other => panic!("m2 expected Deliver, got {other:?}"),
+        };
+
+        // Bob recovers the plaintext; only he could (the inner was sealed to him).
+        let received = bob.receive("did:example:bob", &inner).unwrap();
+        assert_eq!(received.payload, b"hi bob");
+        assert_eq!(received.sender, "did:example:alice");
+        assert_eq!(received.message_type, MessageType::Direct);
     }
 
     #[test]

--- a/crates/messaging/affinidi-tsp/src/message/mod.rs
+++ b/crates/messaging/affinidi-tsp/src/message/mod.rs
@@ -3,6 +3,7 @@
 pub mod control;
 pub mod direct;
 pub mod envelope;
+pub mod routed;
 
 use crate::error::TspError;
 

--- a/crates/messaging/affinidi-tsp/src/message/routed.rs
+++ b/crates/messaging/affinidi-tsp/src/message/routed.rs
@@ -1,0 +1,445 @@
+//! TSP routed mode (§5.3) and nested mode (§5.5).
+//!
+//! **Routed mode** carries a message through one or more intermediaries. The
+//! ordered list of remaining hops travels inside the HPKE-sealed payload of each
+//! routing layer, so only the addressed intermediary can read it. An
+//! intermediary opens its layer, takes the next hop, and re-seals the remaining
+//! route + the (still opaque) inner message to that hop — re-authenticating as
+//! itself. The **inner** message is opaque to every intermediary: it is sealed
+//! end-to-end to the exit/recipient and merely carried.
+//!
+//! Routing-layer wire layout (the plaintext sealed to each hop):
+//! ```text
+//! [hop_count:u16] ( [vid_len:u16][vid utf8] )*  [inner_len:u32][inner bytes]
+//! ```
+//!
+//! **Nested mode** is the degenerate metadata-privacy wrapper: an inner packed
+//! TSP message carried as the opaque payload of an outer message addressed to a
+//! single intermediary. It is `pack`/`unpack` with [`MessageType::Nested`]; the
+//! intermediary forwards the inner bytes without being able to read them.
+//!
+//! Note: in routed mode each intermediary sees the *remaining route* (the hop
+//! VIDs), but never the inner content. Onion-style routing that hides the route
+//! itself from intermediaries is a future extension; the inner stays opaque
+//! today, which is what the metadata-privacy bridge relies on.
+
+use crate::error::TspError;
+use crate::message::MessageType;
+use crate::message::direct::{self, PackedMessage};
+
+/// Maximum number of hops in a route, bounding both memory and forwarding loops.
+pub const MAX_HOPS: usize = 16;
+
+/// Maximum inner-message size carried in a routing layer (mirrors direct mode).
+const MAX_INNER_SIZE: usize = 1_048_576;
+
+/// Encode a routing payload: the remaining hop list followed by the opaque inner
+/// message. This is the plaintext that gets HPKE-sealed to the addressed hop.
+pub(crate) fn encode_route(remaining: &[String], inner: &[u8]) -> Result<Vec<u8>, TspError> {
+    if remaining.len() > MAX_HOPS {
+        return Err(TspError::InvalidMessage(format!(
+            "route has {} hops, exceeds maximum of {MAX_HOPS}",
+            remaining.len()
+        )));
+    }
+    if inner.len() > MAX_INNER_SIZE {
+        return Err(TspError::InvalidMessage(format!(
+            "inner message {} bytes exceeds maximum of {MAX_INNER_SIZE}",
+            inner.len()
+        )));
+    }
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&(remaining.len() as u16).to_be_bytes());
+    for vid in remaining {
+        let bytes = vid.as_bytes();
+        let len = u16::try_from(bytes.len())
+            .map_err(|_| TspError::InvalidMessage("hop VID too long".into()))?;
+        buf.extend_from_slice(&len.to_be_bytes());
+        buf.extend_from_slice(bytes);
+    }
+    buf.extend_from_slice(&(inner.len() as u32).to_be_bytes());
+    buf.extend_from_slice(inner);
+    Ok(buf)
+}
+
+/// Decode a routing payload into `(remaining_route, inner)`.
+pub(crate) fn decode_route(bytes: &[u8]) -> Result<(Vec<String>, Vec<u8>), TspError> {
+    let mut pos = 0usize;
+    let hop_count = read_u16(bytes, &mut pos)? as usize;
+    if hop_count > MAX_HOPS {
+        return Err(TspError::InvalidMessage(format!(
+            "routing header claims {hop_count} hops, exceeds maximum of {MAX_HOPS}"
+        )));
+    }
+
+    let mut route = Vec::with_capacity(hop_count);
+    for _ in 0..hop_count {
+        let len = read_u16(bytes, &mut pos)? as usize;
+        let end = pos
+            .checked_add(len)
+            .filter(|e| *e <= bytes.len())
+            .ok_or_else(|| TspError::InvalidMessage("routing hop VID truncated".into()))?;
+        let vid = std::str::from_utf8(&bytes[pos..end])
+            .map_err(|_| TspError::InvalidMessage("routing hop VID not UTF-8".into()))?
+            .to_string();
+        route.push(vid);
+        pos = end;
+    }
+
+    let inner_len = read_u32(bytes, &mut pos)? as usize;
+    if inner_len > MAX_INNER_SIZE {
+        return Err(TspError::InvalidMessage(format!(
+            "inner message length {inner_len} exceeds maximum of {MAX_INNER_SIZE}"
+        )));
+    }
+    let end = pos
+        .checked_add(inner_len)
+        .filter(|e| *e <= bytes.len())
+        .ok_or_else(|| TspError::InvalidMessage("inner message truncated".into()))?;
+    let inner = bytes[pos..end].to_vec();
+    Ok((route, inner))
+}
+
+fn read_u16(bytes: &[u8], pos: &mut usize) -> Result<u16, TspError> {
+    let end = pos
+        .checked_add(2)
+        .filter(|e| *e <= bytes.len())
+        .ok_or_else(|| TspError::InvalidMessage("routing payload truncated (u16)".into()))?;
+    let v = u16::from_be_bytes(bytes[*pos..end].try_into().unwrap());
+    *pos = end;
+    Ok(v)
+}
+
+fn read_u32(bytes: &[u8], pos: &mut usize) -> Result<u32, TspError> {
+    let end = pos
+        .checked_add(4)
+        .filter(|e| *e <= bytes.len())
+        .ok_or_else(|| TspError::InvalidMessage("routing payload truncated (u32)".into()))?;
+    let v = u32::from_be_bytes(bytes[*pos..end].try_into().unwrap());
+    *pos = end;
+    Ok(v)
+}
+
+/// Pack a routed message addressed to `first_hop`, carrying `remaining_route`
+/// (the hops to visit after `first_hop`, in order) and the opaque `inner`
+/// message (already sealed end-to-end to the exit/recipient).
+///
+/// The full path is `[first_hop] ++ remaining_route`; when an intermediary's
+/// remaining route is empty it is the exit and consumes `inner`.
+#[allow(clippy::too_many_arguments)]
+pub fn pack_routed(
+    inner: &[u8],
+    remaining_route: &[String],
+    sender_vid: &str,
+    first_hop_vid: &str,
+    sender_signing_key: &[u8; 32],
+    sender_encryption_key: &[u8; 32],
+    first_hop_encryption_key: &[u8; 32],
+) -> Result<PackedMessage, TspError> {
+    let routing = encode_route(remaining_route, inner)?;
+    direct::pack(
+        &routing,
+        MessageType::Routed,
+        sender_vid,
+        first_hop_vid,
+        sender_signing_key,
+        sender_encryption_key,
+        first_hop_encryption_key,
+    )
+}
+
+/// Pack a nested message: an inner packed TSP message carried as the opaque
+/// payload of an outer message to `intermediary_vid` (metadata-privacy wrapper).
+#[allow(clippy::too_many_arguments)]
+pub fn pack_nested(
+    inner: &PackedMessage,
+    sender_vid: &str,
+    intermediary_vid: &str,
+    sender_signing_key: &[u8; 32],
+    sender_encryption_key: &[u8; 32],
+    intermediary_encryption_key: &[u8; 32],
+) -> Result<PackedMessage, TspError> {
+    direct::pack(
+        &inner.bytes,
+        MessageType::Nested,
+        sender_vid,
+        intermediary_vid,
+        sender_signing_key,
+        sender_encryption_key,
+        intermediary_encryption_key,
+    )
+}
+
+/// What an intermediary should do after opening a routed layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteStep {
+    /// Re-seal `inner` + `remaining` and forward to `next`.
+    Forward {
+        /// The next hop's VID (the new envelope receiver).
+        next: String,
+        /// The route to carry onward (the hops after `next`).
+        remaining: Vec<String>,
+        /// The opaque inner message, unchanged.
+        inner: Vec<u8>,
+    },
+    /// This hop is the exit: consume / deliver `inner` (sealed to the recipient).
+    Deliver {
+        /// The opaque inner message for this hop to deliver or process.
+        inner: Vec<u8>,
+    },
+}
+
+/// Determine the next routing step from a decrypted routed payload (the
+/// `payload` returned by unpacking a [`MessageType::Routed`] message).
+pub fn next_hop(routing_payload: &[u8]) -> Result<RouteStep, TspError> {
+    let (route, inner) = decode_route(routing_payload)?;
+    match route.split_first() {
+        None => Ok(RouteStep::Deliver { inner }),
+        Some((next, rest)) => Ok(RouteStep::Forward {
+            next: next.clone(),
+            remaining: rest.to_vec(),
+            inner,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::direct::unpack;
+    use ed25519_dalek::SigningKey;
+    use rand_core::OsRng;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    struct Party {
+        vid: String,
+        sign_sk: [u8; 32],
+        sign_pk: [u8; 32],
+        enc_sk: [u8; 32],
+        enc_pk: [u8; 32],
+    }
+
+    fn party(vid: &str) -> Party {
+        let sign = SigningKey::generate(&mut OsRng);
+        let enc = StaticSecret::random_from_rng(OsRng);
+        Party {
+            vid: vid.to_string(),
+            sign_sk: sign.to_bytes(),
+            sign_pk: sign.verifying_key().to_bytes(),
+            enc_sk: enc.to_bytes(),
+            enc_pk: PublicKey::from(&enc).to_bytes(),
+        }
+    }
+
+    #[test]
+    fn encode_decode_route_roundtrip() {
+        let route = vec!["did:web:hop2".to_string(), "did:web:exit".to_string()];
+        let inner = b"opaque inner message".to_vec();
+        let encoded = encode_route(&route, &inner).unwrap();
+        let (decoded_route, decoded_inner) = decode_route(&encoded).unwrap();
+        assert_eq!(decoded_route, route);
+        assert_eq!(decoded_inner, inner);
+    }
+
+    #[test]
+    fn decode_route_rejects_truncation() {
+        assert!(decode_route(&[0x00]).is_err()); // not even a full hop_count
+        // hop_count = 1 but no hop follows
+        assert!(decode_route(&[0x00, 0x01]).is_err());
+    }
+
+    #[test]
+    fn encode_route_rejects_too_many_hops() {
+        let route: Vec<String> = (0..MAX_HOPS + 1).map(|i| format!("did:web:h{i}")).collect();
+        assert!(encode_route(&route, b"x").is_err());
+    }
+
+    #[test]
+    fn next_hop_forward_then_deliver() {
+        // route [hop2, exit]: first step forwards to hop2 leaving [exit];
+        // then [exit] forwards to exit leaving []; then [] delivers.
+        let inner = b"payload".to_vec();
+        let p1 = encode_route(&["hop2".into(), "exit".into()], &inner).unwrap();
+        match next_hop(&p1).unwrap() {
+            RouteStep::Forward {
+                next,
+                remaining,
+                inner: i,
+            } => {
+                assert_eq!(next, "hop2");
+                assert_eq!(remaining, vec!["exit".to_string()]);
+                assert_eq!(i, inner);
+            }
+            other => panic!("expected Forward, got {other:?}"),
+        }
+
+        let p_exit = encode_route(&[], &inner).unwrap();
+        assert_eq!(next_hop(&p_exit).unwrap(), RouteStep::Deliver { inner });
+    }
+
+    /// Full multi-hop crypto round-trip: alice → hop1 → hop2 (exit) carrying an
+    /// inner message sealed end-to-end alice → final. Proves (a) each hop can
+    /// open only its own routing layer, (b) the inner stays opaque until final,
+    /// (c) re-sealing at each hop re-authenticates the relaying party.
+    #[test]
+    fn routed_multihop_roundtrip() {
+        let alice = party("did:web:alice");
+        let hop1 = party("did:web:hop1");
+        let hop2 = party("did:web:hop2");
+        let final_p = party("did:web:final");
+
+        // 1. alice seals the inner message end-to-end to final (Direct).
+        let inner = direct::pack(
+            b"the secret",
+            MessageType::Direct,
+            &alice.vid,
+            &final_p.vid,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &final_p.enc_pk,
+        )
+        .unwrap();
+
+        // 2. alice packs a routed layer to hop1, route = [hop2, final].
+        //    (hop2 is the exit intermediary; final is the last hop it delivers to.)
+        let layer1 = pack_routed(
+            &inner.bytes,
+            &["did:web:hop2".into(), "did:web:final".into()],
+            &alice.vid,
+            &hop1.vid,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &hop1.enc_pk,
+        )
+        .unwrap();
+
+        // 3. hop1 opens its layer (it is the receiver), reads the route.
+        let at_hop1 = unpack(&layer1.bytes, &hop1.enc_sk, &alice.enc_pk, &alice.sign_pk).unwrap();
+        assert_eq!(at_hop1.message_type, MessageType::Routed);
+        let step1 = next_hop(&at_hop1.payload).unwrap();
+        let (next1, rest1, carried1) = match step1 {
+            RouteStep::Forward {
+                next,
+                remaining,
+                inner,
+            } => (next, remaining, inner),
+            other => panic!("hop1 expected Forward, got {other:?}"),
+        };
+        assert_eq!(next1, "did:web:hop2");
+        assert_eq!(rest1, vec!["did:web:final".to_string()]);
+        // The inner is still opaque (it equals alice's sealed bytes).
+        assert_eq!(carried1, inner.bytes);
+
+        // 4. hop1 re-seals to hop2 (authenticating as hop1).
+        let layer2 = pack_routed(
+            &carried1,
+            &rest1,
+            &hop1.vid,
+            &hop2.vid,
+            &hop1.sign_sk,
+            &hop1.enc_sk,
+            &hop2.enc_pk,
+        )
+        .unwrap();
+
+        // 5. hop2 opens its layer, sees route [final] → forward/deliver to final.
+        let at_hop2 = unpack(&layer2.bytes, &hop2.enc_sk, &hop1.enc_pk, &hop1.sign_pk).unwrap();
+        let step2 = next_hop(&at_hop2.payload).unwrap();
+        let (next2, rest2, carried2) = match step2 {
+            RouteStep::Forward {
+                next,
+                remaining,
+                inner,
+            } => (next, remaining, inner),
+            other => panic!("hop2 expected Forward, got {other:?}"),
+        };
+        assert_eq!(next2, "did:web:final");
+        assert!(rest2.is_empty());
+
+        // 6. hop2 forwards the opaque inner to final (no re-seal needed: the
+        //    inner is already a complete message sealed alice → final). final
+        //    unpacks it directly and recovers the plaintext.
+        let delivered = unpack(&carried2, &final_p.enc_sk, &alice.enc_pk, &alice.sign_pk).unwrap();
+        assert_eq!(delivered.payload, b"the secret");
+        assert_eq!(delivered.sender, "did:web:alice");
+        assert_eq!(delivered.receiver, "did:web:final");
+    }
+
+    /// A hop cannot open a routing layer addressed to a different hop.
+    #[test]
+    fn intermediary_cannot_open_wrong_layer() {
+        let alice = party("did:web:alice");
+        let hop1 = party("did:web:hop1");
+        let hop2 = party("did:web:hop2");
+
+        let layer = pack_routed(
+            b"inner",
+            &["did:web:hop2".into()],
+            &alice.vid,
+            &hop1.vid,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &hop1.enc_pk,
+        )
+        .unwrap();
+
+        // hop2 tries to open hop1's layer with its own key — must fail.
+        assert!(unpack(&layer.bytes, &hop2.enc_sk, &alice.enc_pk, &alice.sign_pk).is_err());
+    }
+
+    /// Nested wrapper: an inner packed message carried opaquely to an intermediary.
+    #[test]
+    fn nested_wrapper_roundtrip() {
+        let alice = party("did:web:alice");
+        let mediator = party("did:web:mediator");
+        let bob = party("did:web:bob");
+
+        let inner = direct::pack(
+            b"for bob only",
+            MessageType::Direct,
+            &alice.vid,
+            &bob.vid,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .unwrap();
+
+        // alice nests the inner inside an outer to the mediator.
+        let nested = pack_nested(
+            &inner,
+            &alice.vid,
+            &mediator.vid,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &mediator.enc_pk,
+        )
+        .unwrap();
+
+        // mediator opens the outer, gets the opaque inner, cannot read bob's plaintext.
+        let at_mediator = unpack(
+            &nested.bytes,
+            &mediator.enc_sk,
+            &alice.enc_pk,
+            &alice.sign_pk,
+        )
+        .unwrap();
+        assert_eq!(at_mediator.message_type, MessageType::Nested);
+        assert_eq!(at_mediator.payload, inner.bytes);
+        assert!(
+            unpack(
+                &at_mediator.payload,
+                &mediator.enc_sk,
+                &alice.enc_pk,
+                &alice.sign_pk
+            )
+            .is_err(),
+            "mediator must not be able to open the inner sealed to bob"
+        );
+
+        // bob opens the inner.
+        let at_bob = unpack(&inner.bytes, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk).unwrap();
+        assert_eq!(at_bob.payload, b"for bob only");
+    }
+}


### PR DESCRIPTION
## Summary

SDD library PR-2: implement TSP **routed mode** (§5.3, multi-hop relay through intermediaries) and the **nested** metadata-privacy wrapper (§5.5), replacing the `MessageType::{Routed,Nested}` recognized-but-unimplemented stubs (`wrap_for_relay` was `NotSupported`).

## Design
- **Routed**: the remaining hop list travels inside each HPKE-sealed routing layer (`[hop_count][ (vid_len,vid)* ][inner_len][inner]`), so only the addressed intermediary can read it. Each hop opens its layer, takes the next hop, and **re-seals** the remaining route + opaque inner to that hop — re-authenticating as itself. The **inner message stays opaque to every intermediary** (sealed end-to-end to the recipient).
- **Nested**: an inner packed message carried as the opaque payload of an outer message to a single intermediary (metadata-privacy wrapper).
- Each hop is bounded by `MAX_HOPS` (loop/DoS guard); the routing parser is fully bounds-checked.

## API
- `message::routed`: `pack_routed`, `pack_nested`, `next_hop` → `RouteStep`, `MAX_HOPS`.
- `TspAgent`: `send_routed`, `send_nested`, `forward_routed` → `ForwardOutcome::{Relay, Deliver}` (resolves each hop's keys via the agent resolver).
- `TspAdapter::wrap_for_relay` (messaging-core) now implemented.

## Compatibility / version
Purely additive → **patch bump 0.1.4 → 0.1.5**.

## Tests / checks
84 tests pass (all-features), including:
- a **full multi-hop crypto round-trip** (alice → hop1 → hop2 → final) proving re-seal correctness and that intermediaries cannot open the inner or a wrong layer;
- a **two-intermediary agent-level relay** (`send_routed` → `forward_routed` → deliver) end to end;
- routing-payload encode/decode + truncation/over-hop negative cases.

`cargo clippy` clean across default / `--all-features` / `--no-default-features`.

Next in the SDD plan: PR-3 (sniff/parse helpers), then the mediator coexistence/ingress PRs.