### PR TITLE
feat: affinidi-tsp ingress sniff and keys-free envelope metadata

### DIFF
--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 22nd June 2026
 
+### 0.1.6 — ingress sniff + keys-free envelope metadata
+
+- New `message::meta` module for relays/mediators that must route a message
+  without holding keys: `is_tsp` (cheap first-byte classifier — every TSP
+  message starts with the CESR `1AAF` magic byte `0xD4`, vs DIDComm's `{`/`ey`),
+  the `TSP_MAGIC_BYTE` constant, and `MetaEnvelope::parse` which reads the
+  cleartext sender/receiver VIDs + message type and computes the SHA-256 message
+  id without decrypting the payload.
+- Re-exported at the crate root (`is_tsp`, `MetaEnvelope`, `TSP_MAGIC_BYTE`).
+- Purely additive; patch bump 0.1.5 → 0.1.6.
+
 ### 0.1.5 — routed & nested message modes (§5.3 / §5.5)
 
 - New `message::routed` module implementing TSP routed mode (multi-hop relay

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/lib.rs
+++ b/crates/messaging/affinidi-tsp/src/lib.rs
@@ -38,6 +38,7 @@ pub mod vid;
 
 pub use error::TspError;
 pub use message::MessageType;
+pub use message::meta::{MetaEnvelope, TSP_MAGIC_BYTE, is_tsp};
 pub use message::routed::{MAX_HOPS, RouteStep};
 pub use relationship::RelationshipState;
 pub use vid::resolver::VidResolver;

--- a/crates/messaging/affinidi-tsp/src/message/meta.rs
+++ b/crates/messaging/affinidi-tsp/src/message/meta.rs
@@ -1,0 +1,147 @@
+//! Ingress sniffing and keys-free envelope metadata.
+//!
+//! A mediator (or any relay) receiving raw bytes needs to decide *what* a
+//! message is and *who* it is for **without** holding any keys — to route it,
+//! enforce ACLs, and store it. These helpers provide exactly that:
+//!
+//! - [`is_tsp`] — a cheap first-byte classifier distinguishing a TSP message
+//!   from other wire formats (e.g. JSON-based DIDComm).
+//! - [`MetaEnvelope`] — the cleartext envelope (sender VID, receiver VID,
+//!   message type) plus the message id, parsed without decrypting the payload.
+
+use sha2::{Digest, Sha256};
+
+use crate::error::TspError;
+use crate::message::MessageType;
+use crate::message::envelope::Envelope;
+
+/// The leading byte of every TSP message: the CESR Tag1 qb2 magic for code
+/// `1AAF` (the full 3-byte magic is `D4 00 05`). DIDComm — being JSON or
+/// compact-JWS — starts with `{` (`0x7B`) or `ey…` instead, so this byte is an
+/// unambiguous discriminator.
+pub const TSP_MAGIC_BYTE: u8 = 0xD4;
+
+/// Cheap classifier: does `bytes` look like a TSP message?
+///
+/// This is a pre-classifier for ingress routing, not a validator — it inspects
+/// only the leading byte. A caller routes `is_tsp(bytes)` input to the TSP
+/// handler, which then calls [`MetaEnvelope::parse`] (or a full unpack) to
+/// validate and reject anything malformed. Anything not starting with the TSP
+/// magic byte is definitely not a TSP message.
+pub fn is_tsp(bytes: &[u8]) -> bool {
+    bytes.first() == Some(&TSP_MAGIC_BYTE)
+}
+
+/// Cleartext metadata of a TSP message, parsed without any keys.
+///
+/// The TSP envelope carries the sender VID, receiver VID, version, and message
+/// type in the clear (they are HPKE additional-authenticated data, bound to the
+/// ciphertext but readable). This lets a relay route and account for a message
+/// without being able to decrypt its payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaEnvelope {
+    /// The sender VID.
+    pub sender: String,
+    /// The receiver VID (the next hop / addressee).
+    pub receiver: String,
+    /// The message type (Direct / Nested / Routed / Control).
+    pub message_type: MessageType,
+    /// SHA-256 of the full wire bytes — the message id used for storage and
+    /// idempotency (matches the convention of DIDComm-based mediators).
+    pub sha256: [u8; 32],
+}
+
+impl MetaEnvelope {
+    /// Parse the cleartext envelope of a TSP message and compute its id.
+    ///
+    /// Does **not** decrypt or verify the payload — it only reads the envelope
+    /// and hashes the wire bytes. Returns an error if the bytes are not a
+    /// well-formed TSP envelope.
+    pub fn parse(wire: &[u8]) -> Result<Self, TspError> {
+        let (envelope, _consumed) = Envelope::decode(wire)?;
+        let sha256: [u8; 32] = Sha256::digest(wire).into();
+        Ok(Self {
+            sender: envelope.sender,
+            receiver: envelope.receiver,
+            message_type: envelope.message_type,
+            sha256,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::direct;
+    use ed25519_dalek::SigningKey;
+    use rand_core::OsRng;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    fn packed() -> direct::PackedMessage {
+        let sign = SigningKey::generate(&mut OsRng);
+        let sender_enc = StaticSecret::random_from_rng(OsRng);
+        let recv_enc = StaticSecret::random_from_rng(OsRng);
+        direct::pack(
+            b"payload",
+            MessageType::Direct,
+            "did:web:alice",
+            "did:web:bob",
+            &sign.to_bytes(),
+            &sender_enc.to_bytes(),
+            &PublicKey::from(&recv_enc).to_bytes(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn is_tsp_detects_magic_byte() {
+        let msg = packed();
+        assert_eq!(msg.bytes[0], TSP_MAGIC_BYTE);
+        assert!(is_tsp(&msg.bytes));
+    }
+
+    #[test]
+    fn is_tsp_rejects_didcomm_and_empty() {
+        assert!(!is_tsp(b"{\"protected\":\"...\"}")); // DIDComm JSON
+        assert!(!is_tsp(b"eyJhbGciOiJ...")); // compact JWS/JWE
+        assert!(!is_tsp(&[])); // empty
+    }
+
+    #[test]
+    fn meta_envelope_parse_reads_addressing_without_keys() {
+        let msg = packed();
+        let meta = MetaEnvelope::parse(&msg.bytes).unwrap();
+        assert_eq!(meta.sender, "did:web:alice");
+        assert_eq!(meta.receiver, "did:web:bob");
+        assert_eq!(meta.message_type, MessageType::Direct);
+        // id is the sha256 of the full wire bytes, and is deterministic.
+        let expected: [u8; 32] = Sha256::digest(&msg.bytes).into();
+        assert_eq!(meta.sha256, expected);
+    }
+
+    #[test]
+    fn meta_envelope_parse_rejects_garbage() {
+        assert!(MetaEnvelope::parse(b"not a tsp message").is_err());
+        assert!(MetaEnvelope::parse(&[TSP_MAGIC_BYTE, 0x00]).is_err());
+    }
+
+    #[test]
+    fn meta_envelope_reads_routed_type() {
+        let sign = SigningKey::generate(&mut OsRng);
+        let sender_enc = StaticSecret::random_from_rng(OsRng);
+        let recv_enc = StaticSecret::random_from_rng(OsRng);
+        let msg = direct::pack(
+            b"routing-layer",
+            MessageType::Routed,
+            "did:web:alice",
+            "did:web:mediator",
+            &sign.to_bytes(),
+            &sender_enc.to_bytes(),
+            &PublicKey::from(&recv_enc).to_bytes(),
+        )
+        .unwrap();
+        let meta = MetaEnvelope::parse(&msg.bytes).unwrap();
+        assert_eq!(meta.message_type, MessageType::Routed);
+        assert_eq!(meta.receiver, "did:web:mediator");
+    }
+}

--- a/crates/messaging/affinidi-tsp/src/message/mod.rs
+++ b/crates/messaging/affinidi-tsp/src/message/mod.rs
@@ -3,6 +3,7 @@
 pub mod control;
 pub mod direct;
 pub mod envelope;
+pub mod meta;
 pub mod routed;
 
 use crate::error::TspError;


### PR DESCRIPTION
## Summary

SDD library PR-3: the ingress helpers the mediator's protocol dispatcher consumes — classify a raw message as TSP and read its addressing without holding keys.

New `message::meta` module:
- **`is_tsp(bytes)`** — cheap first-byte classifier. Every TSP message starts with the CESR `1AAF` qb2 magic byte `0xD4`; DIDComm (JSON / compact-JWS) starts with `{` or `ey…`, so it's an unambiguous discriminator. A pre-classifier for routing, not a validator.
- **`TSP_MAGIC_BYTE`** constant.
- **`MetaEnvelope::parse(wire)`** — reads the cleartext sender VID, receiver VID, and message type, and computes the **SHA-256 message id** (matching DIDComm-mediator storage/idempotency convention) — all **without decrypting** the payload.

Re-exported at the crate root.

## Compatibility / version
Purely additive → **patch bump 0.1.5 → 0.1.6**.

## Tests / checks
89 tests pass (all-features), including: magic-byte detection, DIDComm/empty rejection, keys-free addressing parse with deterministic id, and garbage/truncation rejection. `cargo clippy` clean across default / `--all-features` / `--no-default-features`.

This completes the `affinidi-tsp` library layer (PR-1 resolver, PR-2 routed/nested, PR-3 sniff/meta). Next in the SDD plan: the mediator coexistence + ingress-dispatcher PRs, which consume `is_tsp` + `MetaEnvelope`.