### PR TITLE
feat: TSP coexistence groundwork in the mediator

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+## 22nd June 2026
+
+### 0.16.4 — TSP coexistence groundwork
+
+- Groundwork for the dual-protocol (DIDComm + TSP) mediator. **No behavior
+  change** to the supported `didcomm` and `didcomm,tsp` builds.
+- The `didcomm` and `tsp` features are NOT mutually exclusive — corrected the
+  stale Cargo.toml comments. The dual build (`--features didcomm,tsp`) is the
+  intended dual-protocol deployment and compiles cleanly under `-D warnings`.
+- A `tsp`-only build (`--no-default-features --features tsp,<backend>`) now
+  compiles: DIDComm-only imports/helpers (the OOB encoders in `store::mod`,
+  problem-report/forward imports on the inbound/websocket paths) are gated to
+  `#[cfg(feature = "didcomm")]`. Such a build remains non-functional (no
+  auth/inbound) until the TSP message-handling path lands in later PRs; the
+  shared authz/store machinery it will reuse is intentionally left ungated.
+
 ## 14th June 2026
 
 ### 0.16.2 — bump vta-sdk to 0.13

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.3"
+version = "0.16.4"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -36,12 +36,15 @@ memory-backend = []
 
 ## DIDComm v2 — industry-standard DID-based secure messaging.
 ## Enables inbound/outbound message handling, authentication, and OOB discovery.
-## Mutually exclusive with `tsp` at runtime (only one protocol active).
+## At least one of `didcomm` or `tsp` must be enabled (see the `compile_error!`
+## in `lib.rs`); the two are NOT mutually exclusive — they are designed to run
+## together (`--features didcomm,tsp`), which is the dual-protocol deployment.
 didcomm = ["dep:affinidi-messaging-didcomm", "dep:affinidi-encoding", "dep:affinidi-crypto"]
 
-## TSP (Trust Spanning Protocol) — lightweight alternative to DIDComm.
-## EXPERIMENTAL: not all mediator features are supported yet.
-## Mutually exclusive with `didcomm` at runtime.
+## TSP (Trust Spanning Protocol) — additive alongside DIDComm.
+## EXPERIMENTAL: TSP message handling is still being built; a `tsp`-only build
+## compiles but is not yet functional (no auth/inbound). Run it together with
+## `didcomm` for a dual-protocol mediator.
 tsp = ["dep:affinidi-tsp"]
 
 ## Secret storage backends — forwarded to `mediator-common`'s `secrets-*`

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -28,6 +28,7 @@ pub mod websocket;
 pub mod well_known_did_fetch;
 
 pub fn application_routes(api_prefix: &str, shared_data: &SharedData) -> Router {
+    #[cfg_attr(not(feature = "didcomm"), allow(unused_mut))]
     let mut app = Router::new()
         // Outbound message handling to ATM clients
         .route(

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -13,9 +13,9 @@ use crate::{
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
 use affinidi_messaging_mediator_common::store::StatCounter;
-use affinidi_messaging_sdk::messages::problem_report::{
-    ProblemReport, ProblemReportScope, ProblemReportSorter,
-};
+#[cfg(feature = "didcomm")]
+use affinidi_messaging_sdk::messages::problem_report::ProblemReport;
+use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use axum::{
     extract::{
         State, WebSocketUpgrade,
@@ -29,6 +29,7 @@ use axum_extra::{
 };
 use dashmap::DashMap;
 use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN, header::SEC_WEBSOCKET_PROTOCOL};
+#[cfg(feature = "didcomm")]
 use serde_json::json;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -38,6 +39,7 @@ use tokio::{
     sync::mpsc::{self, Receiver, Sender},
 };
 use tracing::{Instrument, debug, info, span, warn};
+#[cfg(feature = "didcomm")]
 use uuid::Uuid;
 
 /// Subprotocol prefix used to carry the bearer JWT through the

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -4,10 +4,10 @@ use crate::didcomm_compat::MetaEnvelope;
 use crate::messages::MessageHandler;
 #[cfg(feature = "didcomm")]
 use crate::messages::protocols::routing::{relay_peer_trusted, rewrap_inner_attachment};
+use crate::{SharedData, common::session::Session};
+#[cfg(feature = "didcomm")]
 use crate::{
-    SharedData,
     common::authz::{self, Capability},
-    common::session::Session,
     messages::store::store_message,
 };
 use affinidi_messaging_mediator_common::errors::MediatorError;
@@ -22,14 +22,16 @@ use affinidi_messaging_sdk::messages::{
 use http::StatusCode;
 #[cfg(feature = "didcomm")]
 use sha256::digest;
+#[cfg(feature = "didcomm")]
 use tracing::{Instrument, debug, span};
 
+#[cfg(feature = "didcomm")]
 use super::{ProcessMessageResponse, WrapperType};
 
 pub(crate) async fn handle_inbound(
-    state: &SharedData,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused_variables))] state: &SharedData,
     session: &Session,
-    message: &str,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused_variables))] message: &str,
 ) -> Result<InboundMessageResponse, MediatorError> {
     // Try DIDComm first if enabled
     #[cfg(feature = "didcomm")]

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
@@ -4,6 +4,7 @@ use self::protocols::ping;
 use crate::didcomm_compat;
 #[cfg(feature = "didcomm")]
 use crate::messages::protocols::discover_features;
+#[cfg(feature = "didcomm")]
 use crate::{SharedData, common::session::Session};
 #[cfg(feature = "didcomm")]
 use affinidi_did_common::service::Endpoint;
@@ -11,9 +12,11 @@ use affinidi_did_common::service::Endpoint;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message;
+#[cfg(feature = "didcomm")]
 use affinidi_messaging_mediator_common::errors::MediatorError;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_sdk::messages::compat::{PackEncryptedMetadata, UnpackMetadata};
+#[cfg(feature = "didcomm")]
 use affinidi_messaging_sdk::messages::{
     known::MessageType as SDKMessageType,
     problem_report::{ProblemReport, ProblemReportScope, ProblemReportSorter},
@@ -22,6 +25,7 @@ use affinidi_messaging_sdk::messages::{
 use affinidi_secrets_resolver::SecretsResolver;
 #[cfg(feature = "didcomm")]
 use ahash::AHashSet as HashSet;
+#[cfg(feature = "didcomm")]
 use http::StatusCode;
 #[cfg(feature = "didcomm")]
 use protocols::{

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/store.rs
@@ -14,7 +14,9 @@ use affinidi_messaging_sdk::messages::sending::{InboundMessageList, InboundMessa
 use http::StatusCode;
 use sha256::digest;
 use std::sync::Arc;
-use tracing::{Instrument, debug, error, span, trace, warn};
+#[cfg(feature = "didcomm")]
+use tracing::trace;
+use tracing::{Instrument, debug, error, span, warn};
 
 use super::{ProcessMessageResponse, WrapperType};
 
@@ -66,7 +68,7 @@ pub(crate) async fn store_message(
     state: &SharedData,
     session: &Session,
     response: &ProcessMessageResponse,
-    metadata: &UnpackMetadata,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused_variables))] metadata: &UnpackMetadata,
 ) -> Result<InboundMessageResponse, MediatorError> {
     let _span = span!(tracing::Level::DEBUG, "store_message",);
 

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -35,8 +35,13 @@ pub use memory_store::MemoryStore;
 // in `redis_store.rs`) so non-Redis builds can still call them from
 // the OOB discovery handler.
 
+// These OOB helpers operate on the DIDComm `Message` type and are only called
+// from the (DIDComm-only) OOB discovery handler, so they are gated to `didcomm`.
+#[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message;
+#[cfg(feature = "didcomm")]
 use affinidi_messaging_mediator_common::errors::MediatorError;
+#[cfg(feature = "didcomm")]
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 
 /// Build the absolute `expires_at` for an OOB invitation given the
@@ -44,6 +49,7 @@ use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 /// the current time `now` (from the caller's injected clock). Mirrors the legacy
 /// computation so handlers can produce the same value before calling the trait
 /// method.
+#[cfg(feature = "didcomm")]
 pub fn oob_expires_at(invite: &Message, oob_invite_ttl: u64, now: u64) -> u64 {
     match invite.expires_time {
         Some(expiry) if expiry > now + oob_invite_ttl => now + oob_invite_ttl,
@@ -55,6 +61,7 @@ pub fn oob_expires_at(invite: &Message, oob_invite_ttl: u64, now: u64) -> u64 {
 /// Encode a DIDComm `Message` to the base64-url form the trait
 /// expects. Mirrors the legacy serialisation so callers don't have to
 /// know the encoding.
+#[cfg(feature = "didcomm")]
 pub fn encode_oob_invite(invite: &Message) -> Result<String, MediatorError> {
     let json = serde_json::to_string(invite).map_err(|err| {
         MediatorError::InternalError(


### PR DESCRIPTION
## Summary

SDD mediator PR-7: coexistence groundwork for the dual-protocol (DIDComm + TSP) mediator. **No behavior change** to the supported builds.

- **Corrected the stale "mutually exclusive" Cargo.toml comments.** `didcomm` and `tsp` are *not* mutually exclusive — the dual build (`--features didcomm,tsp`) is the intended dual-protocol deployment and was already compiling cleanly under `-D warnings`.
- **Made a `tsp`-only build compile.** DIDComm-only imports/helpers (the OOB invite encoders in `store::mod`, problem-report/forward imports on the inbound + websocket paths, the `mut app` in `application_routes`) are gated to `#[cfg(feature = "didcomm")]` / annotated. Such a build remains **non-functional** (no auth/inbound) until the TSP message-handling path lands in later PRs.
- The **shared authz/store machinery** the TSP path will reuse (`check_access_list`, `authentication_check`, `store_message`, …) is intentionally **left ungated** — it is dead in tsp-only today only because the TSP path doesn't exist yet, and will be un-dead when it does. (So tsp-only carries a few transitional dead-code warnings; it's not a CI-built config and the deployment model is `didcomm,tsp`.)

## Verification
- **Default (`didcomm`) build: clean under `-D warnings` + clippy** — the CI gate. Behavior byte-identical (only didcomm-off code paths and comments changed).
- **`didcomm,tsp` build: clean under `-D warnings` + clippy.**
- **`tsp`-only build: compiles** (`cargo check`).

## Decision recorded
Per discussion, pure-TSP was preserved as a buildable target (rather than making `tsp` imply `didcomm`). Reversible later.

## Version
Patch bump 0.16.3 → 0.16.4 (no behavior change to published builds).

Next in the SDD plan: PR-1 ingress dispatcher (`is_tsp`/`MetaEnvelope` sniff + `handle_inbound` fork) and the store base64url shim.