### PR TITLE
feat: ingress protocol dispatcher in the mediator (sniff DIDComm vs TSP)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ## 22nd June 2026
 
+### 0.16.5 — ingress protocol dispatcher (sniff DIDComm vs TSP)
+
+- Inbound messages are now sniffed at ingress: a TSP message (CESR `1AAF` magic
+  byte `0xD4`) is routed to the TSP handler, everything else to DIDComm. Active
+  only in a dual `didcomm,tsp` build.
+- `POST /inbound` now takes the raw request body (`Bytes`) and sniffs it. **The
+  DIDComm path is byte-identical**: the JWE envelope is parsed and re-serialised
+  to the same canonical string as before, so the stored blob and its sha256
+  message-id are unchanged for existing clients (regression-tested, and verified
+  by the full end-to-end integration suite). The only behavior change is that a
+  malformed request body returns the mediator's own problem-report 400 instead of
+  the axum `Json`-extractor 400; the success path is unchanged.
+- The WebSocket frame loop routes a `Binary` frame leading with `0xD4` to the TSP
+  handler; all other frames are handled as DIDComm exactly as before.
+- TSP ingress is the **seam only**: a sniffed TSP message is parsed (cleartext
+  envelope, no keys) and then rejected with a clear problem report — TSP message
+  delivery (store / relay / bridge) lands in later PRs.
+
 ### 0.16.4 — TSP coexistence groundwork
 
 - Groundwork for the dual-protocol (DIDComm + TSP) mediator. **No behavior

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.4"
+version = "0.16.5"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -4,12 +4,14 @@ use crate::{
     common::jwt_auth::MaybeSession,
     messages::inbound::handle_inbound,
 };
+#[cfg(feature = "tsp")]
+use crate::messages::inbound::handle_inbound_tsp;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::messages::{
     problem_report::{ProblemReportScope, ProblemReportSorter},
     sending::InboundMessageResponse,
 };
-use axum::{Json, extract::State};
+use axum::{Json, body::Bytes, extract::State};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level, span};
@@ -52,7 +54,7 @@ pub struct InboundMessage {
 pub async fn message_inbound_handler(
     MaybeSession(session): MaybeSession,
     State(state): State<SharedData>,
-    Json(body): Json<InboundMessage>,
+    body: Bytes,
 ) -> Result<(StatusCode, Json<SuccessResponse<InboundMessageResponse>>), AppError> {
     let _span = span!(
         Level::DEBUG,
@@ -60,7 +62,7 @@ pub async fn message_inbound_handler(
         session = session.session_id
     );
     async move {
-        // ACL Check
+        // ACL Check — applies to both protocols.
         if authz::require_capability(&session.acls, Capability::SendMessages).is_err() {
             metrics::counter!(names::ACL_DENIALS_TOTAL, "action" => "send").increment(1);
             return Err(MediatorError::problem(
@@ -76,6 +78,45 @@ pub async fn message_inbound_handler(
             )
             .into());
         }
+
+        // Protocol sniff: a TSP message leads with the CESR `1AAF` magic byte
+        // (0xD4); a DIDComm JWE/JWS is JSON (`{` / `ey…`). Only compiled into a
+        // dual didcomm+tsp build. DIDComm bytes fall through to the unchanged path.
+        #[cfg(feature = "tsp")]
+        if affinidi_tsp::is_tsp(&body) {
+            let response = handle_inbound_tsp(&state, &session, &body).await?;
+            return Ok((
+                StatusCode::OK,
+                Json(SuccessResponse {
+                    session_id: session.session_id,
+                    http_code: StatusCode::OK.as_u16(),
+                    error_code: 0,
+                    error_code_str: "NA".to_string(),
+                    message: "Success".to_string(),
+                    data: Some(response),
+                }),
+            ));
+        }
+
+        // DIDComm: parse the JWE envelope, then re-serialise it to the exact
+        // canonical string used historically (the `Json<InboundMessage>`
+        // extractor parsed then the handler `to_string`'d it). Re-creating that
+        // canonical form here keeps the stored blob and its sha256 message-id
+        // byte-identical for existing DIDComm clients.
+        let body: InboundMessage = serde_json::from_slice(&body).map_err(|e| {
+            MediatorError::problem_with_log(
+                19,
+                session.session_id.clone(),
+                None,
+                ProblemReportSorter::Warning,
+                ProblemReportScope::Message,
+                "message.deserialize",
+                "Couldn't parse DIDComm message envelope. Reason: {1}",
+                vec![e.to_string()],
+                StatusCode::BAD_REQUEST,
+                "Couldn't parse DIDComm message envelope",
+            )
+        })?;
 
         let s = match serde_json::to_string(&body) {
             Ok(s) => s,
@@ -115,4 +156,67 @@ pub async fn message_inbound_handler(
     }
     .instrument(_span)
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha256::digest;
+
+    fn sample() -> InboundMessage {
+        InboundMessage {
+            protected: "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIn0".to_string(),
+            recipients: vec![Recipient {
+                header: RecipientHeader {
+                    kid: "did:example:bob#key-1".to_string(),
+                },
+                encrypted_key: "encrypted-key-value".to_string(),
+            }],
+            iv: "iv-value".to_string(),
+            ciphertext: "ciphertext-value".to_string(),
+            tag: "tag-value".to_string(),
+        }
+    }
+
+    /// Regression guard for the `/inbound` switch from `Json<InboundMessage>` to
+    /// raw `Bytes`. The DIDComm branch now does `from_slice` + `to_string`; this
+    /// MUST yield the exact canonical string the old extractor + `to_string`
+    /// produced, so the stored blob and its sha256 message-id are byte-identical
+    /// for existing DIDComm clients — independent of how the client formatted the
+    /// JSON on the wire (compact, pretty, or with surrounding whitespace).
+    #[test]
+    fn didcomm_canonicalization_is_stable_and_format_independent() {
+        let msg = sample();
+        // The canonical stored form: `to_string` of the parsed envelope, exactly
+        // as the historical handler produced from the `Json`-extracted body.
+        let canonical = serde_json::to_string(&msg).unwrap();
+        let canonical_id = digest(canonical.as_bytes());
+
+        for wire in [
+            serde_json::to_string(&msg).unwrap(),        // compact
+            serde_json::to_string_pretty(&msg).unwrap(), // pretty-printed
+            format!("  {}\n", serde_json::to_string(&msg).unwrap()), // surrounding whitespace
+        ] {
+            // Exactly what the handler now does for the DIDComm branch.
+            let parsed: InboundMessage = serde_json::from_slice(wire.as_bytes()).unwrap();
+            let stored = serde_json::to_string(&parsed).unwrap();
+
+            assert_eq!(
+                stored, canonical,
+                "stored blob must be the canonical form regardless of wire formatting"
+            );
+            // The store keys the message by sha256(stored_bytes); it must not move.
+            assert_eq!(digest(stored.as_bytes()), canonical_id);
+        }
+    }
+
+    /// `InboundMessage` round-trips through serde without altering field order,
+    /// so re-serialisation is idempotent (a second store of the same message is
+    /// deduplicated by id).
+    #[test]
+    fn inbound_message_serialisation_is_idempotent() {
+        let s = serde_json::to_string(&sample()).unwrap();
+        let back: InboundMessage = serde_json::from_str(&s).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), s);
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -9,6 +9,8 @@ use crate::{
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{StreamingUpdate, StreamingUpdateState, WebSocketCommands},
 };
+#[cfg(feature = "tsp")]
+use crate::messages::inbound::handle_inbound_tsp;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
@@ -454,6 +456,17 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
                                 Message::Binary(msg) => {
                                     if msg.len() > state.config.limits.ws_size {
                                         warn!("Error processing message, the size is too big. limit is {}, message size is {}", state.config.limits.ws_size, msg.len());
+                                        continue;
+                                    }
+
+                                    // A binary frame leading with the TSP magic byte (0xD4) is a
+                                    // TSP message; route it to the TSP handler. Other binary frames
+                                    // are UTF-8-decoded and handled as DIDComm exactly as before.
+                                    #[cfg(feature = "tsp")]
+                                    if affinidi_tsp::is_tsp(&msg) {
+                                        if let Err(e) = handle_inbound_tsp(&state, &session, &msg).await {
+                                            warn!("WebSocket TSP inbound error: {}", e);
+                                        }
                                         continue;
                                     }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -10,6 +10,8 @@ use crate::{
     common::authz::{self, Capability},
     messages::store::store_message,
 };
+#[cfg(feature = "tsp")]
+use affinidi_tsp::MetaEnvelope as TspMetaEnvelope;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
@@ -54,6 +56,53 @@ pub(crate) async fn handle_inbound(
             StatusCode::BAD_REQUEST,
         ))
     }
+}
+
+/// Handle an inbound TSP message, sniffed at ingress by its CESR magic byte.
+///
+/// This is the ingress *seam*: it parses the cleartext envelope (no keys) to
+/// validate the message and surface its addressing. TSP message **delivery**
+/// (local store / routed relay / bridge) is not yet wired — it lands in a later
+/// PR — so for now a well-formed TSP message is rejected with a clear problem
+/// report and a malformed one with a parse error.
+#[cfg(feature = "tsp")]
+pub(crate) async fn handle_inbound_tsp(
+    _state: &SharedData,
+    session: &Session,
+    raw: &[u8],
+) -> Result<InboundMessageResponse, MediatorError> {
+    let meta = TspMetaEnvelope::parse(raw).map_err(|e| {
+        MediatorError::problem(
+            37,
+            &session.session_id,
+            None,
+            ProblemReportSorter::Error,
+            ProblemReportScope::Message,
+            "message.tsp.malformed",
+            "Malformed TSP message envelope: {1}",
+            vec![e.to_string()],
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    tracing::debug!(
+        to_vid = %meta.receiver,
+        from_vid = %meta.sender,
+        tsp_msg_type = ?meta.message_type,
+        "Received TSP message (handling not yet enabled)"
+    );
+
+    Err(MediatorError::problem(
+        37,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Protocol,
+        "protocol.tsp.unsupported",
+        "TSP message handling is not yet enabled on this mediator",
+        vec![],
+        StatusCode::NOT_IMPLEMENTED,
+    ))
 }
 
 #[cfg(feature = "didcomm")]


### PR DESCRIPTION
## Summary

SDD mediator ingress PR: sniff inbound messages and fork DIDComm vs TSP at the `handle_inbound` seam. **The DIDComm hot path is preserved byte-identical.**

- **Sniff**: a TSP message leads with the CESR `1AAF` magic byte `0xD4`; a DIDComm JWE/JWS is JSON (`{`/`ey…`). Active only in a dual `didcomm,tsp` build.
- **`POST /inbound`**: now takes the raw body (`Bytes`) and sniffs. The **DIDComm branch parses the JWE envelope and re-serialises to the same canonical string** as the old `Json<InboundMessage>` extractor path, so the **stored blob and its sha256 message-id are unchanged** for existing clients, independent of wire formatting.
- **WebSocket**: a `Binary` frame leading with `0xD4` routes to the TSP handler; all other frames are handled as DIDComm exactly as before.
- **TSP ingress = seam only**: a sniffed TSP message is parsed (cleartext `MetaEnvelope`, no keys) then rejected with a clear problem report. TSP message *delivery* (store / relay / bridge) lands in later PRs.

## "Existing DIDComm doesn't break" — evidence
- **Unit regression test** locking the canonical form + sha256 id stable across compact / pretty / whitespace-wrapped input.
- **Full end-to-end integration suite passes** (in-process mediator, real `/inbound` HTTP POST + WS): `cross_mediator_forwarding` (6), `lifecycle` (22), `streaming_forwarding_acl` (6), `relay_rewrap` (2), `topology`, `local_did_websocket`, `websocket_per_did_cap`, `health`, `test_sender_authentication` (9) — all green.
- Default build `-D warnings` clean; default / dual / tsp-only build + clippy clean; 135 lib tests pass in both default and dual configs.

## Behavior change (one, flagged)
A **malformed** `/inbound` body now returns the mediator's own problem-report `400` instead of the axum `Json`-extractor `400`. The DIDComm **success** path is byte-identical. (Also: the `Bytes` extractor no longer enforces `Content-Type`, so it's slightly more lenient — a valid body with a wrong content-type now succeeds instead of `415`.)

## Version
Patch bump 0.16.4 → 0.16.5.

Next: TSP Direct local delivery (PR-9) — wire `handle_inbound_tsp` to store via the neutral path (with the base64url shim, H1).