### PR TITLE
chore: ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ CLAUDE.md
 
 # Local agent state (Claude Code, etc.)
 .claude/
+
+# Secrets and credentials
+.env
+.env.*


### PR DESCRIPTION
Add .env and .env.* to .gitignore so operator-local secrets and credentials from downstream build pipelines are never accidentally checked in.