### PR TITLE
feat: SDK TSP client support foundation (atm.tsp() + storage codec)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.13] - 2026-06-22
+
+TSP client support — foundation. New optional `tsp` feature and an `atm.tsp()`
+ops accessor (the TSP sibling of `atm.routing()` etc.). This first slice adds the
+**storage-format codec** a client needs on pickup: a mediator stores a TSP message
+`base64url(qb2)` (its CESR qb64 text form, `1AAF…`), so `atm.tsp().is_tsp()`
+distinguishes it from a DIDComm JSON envelope and `decode()`/`encode()` convert
+to/from the raw qb2 bytes. Purely additive (no `tsp` feature = no change); patch
+bump keeps the `0.18` pin valid. The pack/send and fetch/unpack paths land next.
+
 ## [0.18.12] - 2026-06-14
 
 `ATMError` is now `#[non_exhaustive]` (ADR-0003) so new variants land additively.

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.12"
+version = "0.18.13"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -12,11 +12,20 @@ readme = "README.md"
 rust-version.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+## Trust Spanning Protocol (TSP) client support — `atm.tsp()` ops, alongside the
+## always-on DIDComm support. EXPERIMENTAL: the message-construction (pack/send)
+## and receive (fetch/unpack) paths are still being built.
+tsp = ["dep:affinidi-tsp"]
+
 [dependencies]
 # Affinidi Crates
 affinidi-tdk-common = "0.6"
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
+## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
+affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Source of truth for the mediator protocol vocabulary (ACLs, accounts,
 ## message types, problem reports). The SDK re-exports these so existing
 ## call sites continue to resolve their old paths.

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -184,6 +184,8 @@ use crate::protocols::{
     message_pickup::MessagePickupOps, oob_discovery::OOBDiscoveryOps, routing::RoutingOps,
     trust_ping::TrustPingOps,
 };
+#[cfg(feature = "tsp")]
+use crate::protocols::tsp::TspOps;
 use affinidi_task_utils::CancellationToken;
 use affinidi_tdk_common::TDKSharedState;
 use config::ATMConfig;
@@ -336,5 +338,11 @@ impl ATM {
     /// Access Discover Features protocol methods
     pub fn discover_features(&self) -> DiscoverfeaturesOps<'_> {
         DiscoverfeaturesOps { atm: self }
+    }
+
+    /// Access Trust Spanning Protocol (TSP) client methods.
+    #[cfg(feature = "tsp")]
+    pub fn tsp(&self) -> TspOps<'_> {
+        TspOps { atm: self }
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
@@ -30,6 +30,8 @@ pub mod mediator;
 pub mod message_pickup;
 pub mod oob_discovery;
 pub mod routing;
+#[cfg(feature = "tsp")]
+pub mod tsp;
 pub mod trust_ping;
 
 // `String` implements `GenericDataStruct` via an impl in

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1,0 +1,113 @@
+//! Trust Spanning Protocol (TSP) client support.
+//!
+//! Accessed via [`crate::ATM::tsp`]. This is the SDK's TSP entry point, the
+//! sibling of `atm.routing()` etc. for the DIDComm protocols.
+//!
+//! This first slice provides the **storage-format codec** the SDK needs to
+//! recognise and decode TSP messages on pickup. A mediator stores a TSP message
+//! `base64url(qb2)` — which is its CESR **qb64** text form (`1AAF…`) — so it
+//! rides the same string store/pickup pipeline as a DIDComm JSON envelope (see
+//! `affinidi-messaging-mediator` 0.16.6). When a client fetches messages it gets
+//! a mix of DIDComm JSON (`{…}` / `ey…`) and TSP qb64 (`1AAF…`) strings;
+//! [`TspOps::is_tsp`] tells them apart and [`TspOps::decode`] recovers the qb2
+//! bytes for unpacking.
+//!
+//! The TSP message-construction (pack/send) and decrypt (unpack) paths build on
+//! this codec and land in a later change.
+
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+
+use crate::ATM;
+
+/// TSP protocol operations, obtained from [`crate::ATM::tsp`].
+pub struct TspOps<'a> {
+    #[allow(dead_code)]
+    pub(crate) atm: &'a ATM,
+}
+
+impl TspOps<'_> {
+    /// Whether a fetched/stored message is a TSP message.
+    ///
+    /// The mediator stores TSP messages base64url-encoded; this base64url-decodes
+    /// and checks for the TSP magic byte. A DIDComm JSON envelope (`{…}`) or
+    /// compact JWS/JWE (`ey…`) is not valid base64url of a TSP message, so it
+    /// returns `false`. Cheap and key-free — for routing a fetched message to the
+    /// TSP vs DIDComm unpack path.
+    pub fn is_tsp(&self, stored: &str) -> bool {
+        BASE64_URL_SAFE_NO_PAD
+            .decode(stored.as_bytes())
+            .map(|bytes| affinidi_tsp::is_tsp(&bytes))
+            .unwrap_or(false)
+    }
+
+    /// Decode a stored TSP message (`base64url(qb2)` / CESR qb64 text) back to its
+    /// raw qb2 bytes, ready to hand to a TSP unpack. Errors if the input is not
+    /// valid base64url of a TSP message.
+    pub fn decode(&self, stored: &str) -> Result<Vec<u8>, crate::errors::ATMError> {
+        let bytes = BASE64_URL_SAFE_NO_PAD
+            .decode(stored.as_bytes())
+            .map_err(|e| crate::errors::ATMError::MsgSendError(format!("not valid base64url: {e}")))?;
+        if !affinidi_tsp::is_tsp(&bytes) {
+            return Err(crate::errors::ATMError::MsgSendError(
+                "decoded bytes are not a TSP message".into(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    /// Encode raw qb2 TSP bytes to the stored/transit string form
+    /// (`base64url(qb2)` = CESR qb64 text), as the mediator stores them.
+    pub fn encode(&self, qb2: &[u8]) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode(qb2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use affinidi_tsp::message::direct;
+    use affinidi_tsp::{MessageType, PrivateVid};
+    use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+
+    // The codec functions are pure, so test them without an ATM instance.
+    fn is_tsp(stored: &str) -> bool {
+        BASE64_URL_SAFE_NO_PAD
+            .decode(stored.as_bytes())
+            .map(|b| affinidi_tsp::is_tsp(&b))
+            .unwrap_or(false)
+    }
+
+    fn packed_tsp() -> Vec<u8> {
+        let alice = PrivateVid::generate("did:example:alice");
+        let bob = PrivateVid::generate("did:example:bob");
+        direct::pack(
+            b"hi",
+            MessageType::Direct,
+            "did:example:alice",
+            "did:example:bob",
+            &alice.signing_key,
+            &alice.decryption_key,
+            &bob.encryption_key,
+        )
+        .unwrap()
+        .bytes
+    }
+
+    #[test]
+    fn recognises_and_roundtrips_tsp() {
+        let qb2 = packed_tsp();
+        let stored = BASE64_URL_SAFE_NO_PAD.encode(&qb2);
+
+        assert!(is_tsp(&stored), "a stored TSP message is recognised");
+        assert!(stored.starts_with("1AAF"), "stored form is CESR qb64 text");
+        // Decode round-trips back to the exact qb2 bytes.
+        let decoded = BASE64_URL_SAFE_NO_PAD.decode(stored.as_bytes()).unwrap();
+        assert_eq!(decoded, qb2);
+    }
+
+    #[test]
+    fn rejects_didcomm_and_garbage() {
+        assert!(!is_tsp("{\"protected\":\"...\"}"), "DIDComm JSON is not TSP");
+        assert!(!is_tsp("eyJhbGciOiJ..."), "compact JWS/JWE is not TSP");
+        assert!(!is_tsp(""), "empty is not TSP");
+    }
+}


### PR DESCRIPTION
## Summary

First slice of SDK TSP support: a new optional **`tsp` feature** and an **`atm.tsp()`** ops accessor (the TSP sibling of `atm.routing()` / `atm.message_pickup()` etc.).

This slice provides the **storage-format codec** a client needs on pickup. A mediator stores a TSP message `base64url(qb2)` — its CESR **qb64** text form (`1AAF…`) — so a fetched mailbox is a mix of DIDComm JSON (`{…}` / `ey…`) and TSP qb64 (`1AAF…`) strings:
- `atm.tsp().is_tsp(stored)` — distinguishes a stored TSP message from a DIDComm envelope (base64url-decode + magic-byte check; key-free, cheap).
- `atm.tsp().decode(stored)` — recover the raw qb2 bytes for unpacking.
- `atm.tsp().encode(qb2)` — the inverse, for the send path.

## Why a foundation slice
The TSP **pack/send** and **fetch/unpack** paths need the sender profile's raw Ed25519+X25519 keys (via the secrets resolver) and recipient resolution (`DidVidResolver`) — security-sensitive integration that deserves its own focused change. This codec is the piece both build on, and it's pure + fully tested, so it lands cleanly first.

## Compatibility
**Purely additive** — the SDK has no behaviour change without the `tsp` feature (it's the SDK's first `[features]` entry, default empty). Patch bump 0.18.12 → 0.18.13.

## Tests
- Codec recognises a **real packed TSP message** and round-trips it; rejects DIDComm JSON, compact JWS/JWE, and empty input.
- Default (no-`tsp`) build + clippy clean; `tsp` build + clippy clean.

Next: `atm.tsp().pack()/send()` (profile-key extraction → `PrivateVid` → pack → POST `/inbound`) and `unpack()` (fetch → recognise → decode → decrypt), which together unlock the end-to-end TSP test.