### PR TITLE
feat: TSP Direct send/receive end to end (atm.tsp() pack/send/unpack + e2e)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.18.14] - 2026-06-22
+
+TSP send/receive — `atm.tsp()` can now pack, send, and unpack TSP **Direct**
+messages end to end:
+
+- `pack(profile, to_did, payload)` builds a TSP Direct message — extracting the
+  profile's Ed25519 signing key (from its `authentication`) and X25519 encryption
+  key (from its `keyAgreement`) via the secrets resolver, and resolving the
+  recipient's keys from its DID document.
+- `send(profile, to_did, payload)` packs and POSTs to the mediator `/inbound`,
+  reusing the profile's existing (DIDComm) authenticated session for the bearer
+  token; the mediator sniffs the TSP magic byte and stores it for pickup.
+- `unpack(profile, stored)` decodes a fetched message, resolves the sender, and
+  decrypts + verifies with the profile's key, returning `(payload, sender_vid)`.
+
+Verified end to end against a live mediator in
+`affinidi-messaging-test-mediator` (alice packs → mediator stores → bob unpacks).
+Additive (no `tsp` feature = no change); patch bump keeps the `0.18` pin valid.
+
+NB: works around a copy-paste bug in `affinidi-did-common`'s
+`DocumentExt::find_authentication(None)` (it returns `keyAgreement` ids) by
+reading `doc.authentication` directly.
+
 ## [0.18.13] - 2026-06-22
 
 TSP client support — foundation. New optional `tsp` feature and an `atm.tsp()`

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.13"
+version = "0.18.14"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1,38 +1,50 @@
 //! Trust Spanning Protocol (TSP) client support.
 //!
-//! Accessed via [`crate::ATM::tsp`]. This is the SDK's TSP entry point, the
-//! sibling of `atm.routing()` etc. for the DIDComm protocols.
+//! Accessed via [`crate::ATM::tsp`]. The TSP sibling of `atm.routing()` etc.
 //!
-//! This first slice provides the **storage-format codec** the SDK needs to
-//! recognise and decode TSP messages on pickup. A mediator stores a TSP message
-//! `base64url(qb2)` — which is its CESR **qb64** text form (`1AAF…`) — so it
-//! rides the same string store/pickup pipeline as a DIDComm JSON envelope (see
-//! `affinidi-messaging-mediator` 0.16.6). When a client fetches messages it gets
-//! a mix of DIDComm JSON (`{…}` / `ey…`) and TSP qb64 (`1AAF…`) strings;
-//! [`TspOps::is_tsp`] tells them apart and [`TspOps::decode`] recovers the qb2
-//! bytes for unpacking.
+//! ## Storage-format codec
 //!
-//! The TSP message-construction (pack/send) and decrypt (unpack) paths build on
-//! this codec and land in a later change.
+//! A mediator stores a TSP message `base64url(qb2)` — its CESR **qb64** text form
+//! (`1AAF…`) — so it rides the same string store/pickup pipeline as a DIDComm
+//! JSON envelope. [`TspOps::is_tsp`] / [`TspOps::decode`] / [`TspOps::encode`]
+//! convert a fetched message to/from raw qb2 bytes.
+//!
+//! ## Send / receive
+//!
+//! [`TspOps::pack`] builds a TSP **Direct** message from a profile to a recipient
+//! DID (extracting the profile's Ed25519 signing + X25519 encryption keys from
+//! the secrets resolver, and resolving the recipient's keys from its DID
+//! document). [`TspOps::send`] packs and POSTs it to the mediator `/inbound`
+//! (reusing the existing DIDComm-authenticated session — the mediator sniffs the
+//! `0xD4` magic byte and routes it to its TSP handler). [`TspOps::unpack`]
+//! reverses a fetched message: decode → resolve the sender → decrypt + verify
+//! with the profile's key.
 
+use std::sync::Arc;
+
+use affinidi_did_common::DocumentExt;
+use affinidi_secrets_resolver::SecretsResolver;
+use affinidi_secrets_resolver::secrets::KeyType;
+use affinidi_tsp::message::direct;
+use affinidi_tsp::{DidVidResolver, MessageType, MetaEnvelope};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use tracing::debug;
 
 use crate::ATM;
+use crate::errors::ATMError;
+use crate::profiles::ATMProfile;
 
 /// TSP protocol operations, obtained from [`crate::ATM::tsp`].
 pub struct TspOps<'a> {
-    #[allow(dead_code)]
     pub(crate) atm: &'a ATM,
 }
 
 impl TspOps<'_> {
-    /// Whether a fetched/stored message is a TSP message.
-    ///
-    /// The mediator stores TSP messages base64url-encoded; this base64url-decodes
-    /// and checks for the TSP magic byte. A DIDComm JSON envelope (`{…}`) or
-    /// compact JWS/JWE (`ey…`) is not valid base64url of a TSP message, so it
-    /// returns `false`. Cheap and key-free — for routing a fetched message to the
-    /// TSP vs DIDComm unpack path.
+    // ── Storage-format codec ────────────────────────────────────────────────
+
+    /// Whether a fetched/stored message is a TSP message (base64url-decode +
+    /// magic-byte check). DIDComm JSON / compact JWS is not valid base64url of a
+    /// TSP message, so it returns `false`.
     pub fn is_tsp(&self, stored: &str) -> bool {
         BASE64_URL_SAFE_NO_PAD
             .decode(stored.as_bytes())
@@ -40,25 +52,191 @@ impl TspOps<'_> {
             .unwrap_or(false)
     }
 
-    /// Decode a stored TSP message (`base64url(qb2)` / CESR qb64 text) back to its
-    /// raw qb2 bytes, ready to hand to a TSP unpack. Errors if the input is not
-    /// valid base64url of a TSP message.
-    pub fn decode(&self, stored: &str) -> Result<Vec<u8>, crate::errors::ATMError> {
+    /// Decode a stored TSP message (`base64url(qb2)`) back to its raw qb2 bytes.
+    pub fn decode(&self, stored: &str) -> Result<Vec<u8>, ATMError> {
         let bytes = BASE64_URL_SAFE_NO_PAD
             .decode(stored.as_bytes())
-            .map_err(|e| crate::errors::ATMError::MsgSendError(format!("not valid base64url: {e}")))?;
+            .map_err(|e| ATMError::MsgReceiveError(format!("not valid base64url: {e}")))?;
         if !affinidi_tsp::is_tsp(&bytes) {
-            return Err(crate::errors::ATMError::MsgSendError(
+            return Err(ATMError::MsgReceiveError(
                 "decoded bytes are not a TSP message".into(),
             ));
         }
         Ok(bytes)
     }
 
-    /// Encode raw qb2 TSP bytes to the stored/transit string form
-    /// (`base64url(qb2)` = CESR qb64 text), as the mediator stores them.
+    /// Encode raw qb2 TSP bytes to the stored/transit string form.
     pub fn encode(&self, qb2: &[u8]) -> String {
         BASE64_URL_SAFE_NO_PAD.encode(qb2)
+    }
+
+    // ── Send / receive ──────────────────────────────────────────────────────
+
+    /// Build a TSP **Direct** message from `profile` to `to_did` carrying
+    /// `payload`, returning the raw qb2 bytes.
+    pub async fn pack(
+        &self,
+        profile: &Arc<ATMProfile>,
+        to_did: &str,
+        payload: &[u8],
+    ) -> Result<Vec<u8>, ATMError> {
+        let (from_did, _) = profile.dids()?;
+        let (signing_key, decryption_key) = self.profile_tsp_keys(from_did).await?;
+        let recipient = self.resolve_vid(to_did).await?;
+
+        let packed = direct::pack(
+            payload,
+            MessageType::Direct,
+            from_did,
+            to_did,
+            &signing_key,
+            &decryption_key,
+            &recipient.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack TSP message: {e}")))?;
+
+        Ok(packed.bytes)
+    }
+
+    /// Pack a TSP Direct message and send it to the mediator `/inbound`.
+    ///
+    /// Reuses the profile's existing (DIDComm) authenticated session for the
+    /// bearer token; the mediator sniffs the TSP magic byte and routes it to its
+    /// TSP handler.
+    pub async fn send(
+        &self,
+        profile: &Arc<ATMProfile>,
+        to_did: &str,
+        payload: &[u8],
+    ) -> Result<(), ATMError> {
+        let bytes = self.pack(profile, to_did, payload).await?;
+
+        let mediator_url = profile.get_mediator_rest_endpoint().ok_or_else(|| {
+            ATMError::MsgSendError("Profile is missing a valid mediator URL".into())
+        })?;
+        let (profile_did, mediator_did) = profile.dids()?;
+        let tokens = self
+            .atm
+            .get_tdk()
+            .authentication()
+            .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
+            .await?;
+
+        let res = self
+            .atm
+            .inner
+            .tdk_common
+            .client()
+            .post([&mediator_url, "/inbound"].concat())
+            .header("Content-Type", "application/tsp")
+            .header("Authorization", format!("Bearer {}", tokens.access_token))
+            .body(bytes)
+            .send()
+            .await
+            .map_err(|e| ATMError::TransportError(format!("Could not send TSP message: {e:?}")))?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(ATMError::TransportError(format!(
+                "Mediator rejected TSP message: status({status}), body({body})"
+            )));
+        }
+        debug!("TSP message sent to {to_did}");
+        Ok(())
+    }
+
+    /// Unpack a fetched TSP message (stored `base64url(qb2)`): decode, resolve the
+    /// sender's keys, then decrypt + verify with the profile's decryption key.
+    /// Returns `(payload, sender_vid)`.
+    pub async fn unpack(
+        &self,
+        profile: &Arc<ATMProfile>,
+        stored: &str,
+    ) -> Result<(Vec<u8>, String), ATMError> {
+        let qb2 = self.decode(stored)?;
+        let meta = MetaEnvelope::parse(&qb2)
+            .map_err(|e| ATMError::MsgReceiveError(format!("couldn't parse TSP envelope: {e}")))?;
+
+        let (profile_did, _) = profile.dids()?;
+        if meta.receiver != profile_did {
+            return Err(ATMError::MsgReceiveError(format!(
+                "TSP message addressed to {}, not this profile ({profile_did})",
+                meta.receiver
+            )));
+        }
+
+        let (_signing_key, decryption_key) = self.profile_tsp_keys(profile_did).await?;
+        let sender = self.resolve_vid(&meta.sender).await?;
+
+        let unpacked = direct::unpack(
+            &qb2,
+            &decryption_key,
+            &sender.encryption_key,
+            &sender.signing_key,
+        )
+        .map_err(|e| ATMError::MsgReceiveError(format!("couldn't unpack TSP message: {e}")))?;
+
+        Ok((unpacked.payload, unpacked.sender))
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────────────
+
+    /// Resolve a DID-based VID to its TSP public keys + endpoints.
+    async fn resolve_vid(&self, did: &str) -> Result<affinidi_tsp::ResolvedVid, ATMError> {
+        let resolver = DidVidResolver::new(self.atm.inner.tdk_common.did_resolver().clone());
+        resolver
+            .resolve_did(did)
+            .await
+            .map_err(|e| ATMError::DIDError(format!("couldn't resolve TSP VID {did}: {e}")))
+    }
+
+    /// Extract this profile's TSP private keys `(signing_key, decryption_key)`:
+    /// the Ed25519 key from its `authentication` relationship and the X25519 key
+    /// from its `keyAgreement`, pulled from the secrets resolver.
+    async fn profile_tsp_keys(&self, did: &str) -> Result<([u8; 32], [u8; 32]), ATMError> {
+        let doc = self
+            .atm
+            .inner
+            .tdk_common
+            .did_resolver()
+            .resolve(did)
+            .await
+            .map_err(|e| ATMError::DIDError(format!("couldn't resolve own DID {did}: {e}")))?
+            .doc;
+
+        // NB: read `doc.authentication` directly rather than via
+        // `DocumentExt::find_authentication(None)` — that method has a
+        // copy-paste bug and returns the `keyAgreement` ids instead of the
+        // `authentication` ids, which would yield X25519 keys here.
+        let auth_kids: Vec<&str> = doc.authentication.iter().map(|vr| vr.get_id()).collect();
+        let signing_key = self
+            .first_private_key(auth_kids, KeyType::Ed25519)
+            .await
+            .ok_or_else(|| {
+                ATMError::SecretsError(format!("no Ed25519 authentication key for {did}"))
+            })?;
+        let decryption_key = self
+            .first_private_key(doc.find_key_agreement(None), KeyType::X25519)
+            .await
+            .ok_or_else(|| {
+                ATMError::SecretsError(format!("no X25519 keyAgreement key for {did}"))
+            })?;
+        Ok((signing_key, decryption_key))
+    }
+
+    /// First verification-method `kid` whose secret is of `want` type, as a raw
+    /// 32-byte private key.
+    async fn first_private_key(&self, kids: Vec<&str>, want: KeyType) -> Option<[u8; 32]> {
+        for kid in kids {
+            if let Some(secret) = self.atm.inner.tdk_common.secrets_resolver().get_secret(kid).await
+                && secret.get_key_type() == want
+                && let Ok(bytes) = <[u8; 32]>::try_from(secret.get_private_bytes())
+            {
+                return Some(bytes);
+            }
+        }
+        None
     }
 }
 
@@ -68,7 +246,6 @@ mod tests {
     use affinidi_tsp::{MessageType, PrivateVid};
     use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 
-    // The codec functions are pure, so test them without an ATM instance.
     fn is_tsp(stored: &str) -> bool {
         BASE64_URL_SAFE_NO_PAD
             .decode(stored.as_bytes())
@@ -76,11 +253,18 @@ mod tests {
             .unwrap_or(false)
     }
 
-    fn packed_tsp() -> Vec<u8> {
+    /// Codec + a pack/unpack round-trip using `direct::pack`/`unpack` with the
+    /// same keys the `TspOps` pack/unpack drive through the secrets resolver and
+    /// DID resolution. (The full profile/mediator path is exercised by the
+    /// end-to-end test in `affinidi-messaging-test-mediator`.)
+    #[test]
+    fn pack_unpack_roundtrip_via_codec() {
         let alice = PrivateVid::generate("did:example:alice");
         let bob = PrivateVid::generate("did:example:bob");
-        direct::pack(
-            b"hi",
+
+        // alice packs to bob (as TspOps::pack does, with direct::pack).
+        let packed = direct::pack(
+            b"secret payload",
             MessageType::Direct,
             "did:example:alice",
             "did:example:bob",
@@ -88,26 +272,26 @@ mod tests {
             &alice.decryption_key,
             &bob.encryption_key,
         )
-        .unwrap()
-        .bytes
-    }
+        .unwrap();
 
-    #[test]
-    fn recognises_and_roundtrips_tsp() {
-        let qb2 = packed_tsp();
-        let stored = BASE64_URL_SAFE_NO_PAD.encode(&qb2);
+        // Stored/transit form, recognised on pickup.
+        let stored = BASE64_URL_SAFE_NO_PAD.encode(&packed.bytes);
+        assert!(is_tsp(&stored));
+        let qb2 = BASE64_URL_SAFE_NO_PAD.decode(stored.as_bytes()).unwrap();
 
-        assert!(is_tsp(&stored), "a stored TSP message is recognised");
-        assert!(stored.starts_with("1AAF"), "stored form is CESR qb64 text");
-        // Decode round-trips back to the exact qb2 bytes.
-        let decoded = BASE64_URL_SAFE_NO_PAD.decode(stored.as_bytes()).unwrap();
-        assert_eq!(decoded, qb2);
+        // bob unpacks (as TspOps::unpack does, with direct::unpack).
+        let unpacked =
+            direct::unpack(&qb2, &bob.decryption_key, &alice.encryption_key, &alice.verifying_key)
+                .unwrap();
+        assert_eq!(unpacked.payload, b"secret payload");
+        assert_eq!(unpacked.sender, "did:example:alice");
+        assert_eq!(unpacked.receiver, "did:example:bob");
     }
 
     #[test]
     fn rejects_didcomm_and_garbage() {
-        assert!(!is_tsp("{\"protected\":\"...\"}"), "DIDComm JSON is not TSP");
-        assert!(!is_tsp("eyJhbGciOiJ..."), "compact JWS/JWE is not TSP");
-        assert!(!is_tsp(""), "empty is not TSP");
+        assert!(!is_tsp("{\"protected\":\"...\"}"));
+        assert!(!is_tsp("eyJhbGciOiJ..."));
+        assert!(!is_tsp(""));
     }
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog history
 
+## 22nd June 2026
+
+### 0.2.13 — TSP end-to-end fixture
+
+- New opt-in `tsp` feature spawns the mediator with TSP support and enables the
+  SDK's `atm.tsp()`, so the suite can exercise dual-protocol (DIDComm + TSP)
+  flows.
+- New `tsp_delivery` integration test: a full TSP Direct round-trip through the
+  mediator driven by the SDK (alice packs → `/inbound` sniff + store → bob fetches
+  + unpacks), asserting payload and sender are recovered. DIDComm suite unchanged.
+
 ## 14th June 2026
 
 ### 0.2.12 — non_exhaustive error enums (W7 sweep)

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.12"
+version = "0.2.13"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -19,6 +19,9 @@ default = []
 ## available). Adds a few hundred ms to test-binary build time and
 ## pulls in fjall + tempfile, so it's opt-in.
 fjall-backend = ["affinidi-messaging-mediator/fjall-backend", "dep:tempfile"]
+## Spawn the mediator with TSP support and expose `atm.tsp()` so the e2e suite
+## can exercise the dual-protocol (DIDComm + TSP) flows.
+tsp = ["affinidi-messaging-mediator/tsp", "affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 # ── Mediator: the thing we're spawning ───────────────────────────────────

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -1,0 +1,60 @@
+//! End-to-end TSP Direct delivery through the mediator, driven entirely by the
+//! SDK's `atm.tsp()`: Alice packs a TSP Direct message and POSTs it to
+//! `/inbound`; the mediator sniffs the TSP magic byte and stores it for Bob; Bob
+//! fetches and unpacks it. Exercises the full sniff → store → fetch → unpack path
+//! across the SDK + mediator (memory backend, no Redis needed).
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+#[tokio::test]
+async fn tsp_direct_message_round_trips_through_the_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    // Two locally-served, authenticated users (did:peer profiles).
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"hello over TSP";
+
+    // Alice packs a TSP Direct message to Bob and sends it to the mediator.
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    // Bob fetches his mailbox; the message is the stored TSP (CESR qb64) string.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one fetched message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("fetched message carries its body");
+
+    // It is recognised as TSP and unpacks to the original payload + sender.
+    assert!(
+        env.atm.tsp().is_tsp(stored),
+        "the stored message is recognised as TSP"
+    );
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the TSP message");
+
+    assert_eq!(recovered, payload, "payload round-trips end to end");
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+}


### PR DESCRIPTION
## Summary

TSP now works **end to end** through the stack. `atm.tsp()` can pack, send, and unpack TSP **Direct** messages, and a new e2e test proves the whole flow against a live mediator.

### SDK (`affinidi-messaging-sdk` 0.18.13 → 0.18.14)
- **`pack(profile, to_did, payload)`** — builds a TSP Direct message: extracts the profile's **Ed25519 signing** key (from its `authentication`) and **X25519 encryption** key (from its `keyAgreement`) via the secrets resolver, and resolves the recipient's keys from its DID document.
- **`send(profile, to_did, payload)`** — packs and POSTs to the mediator `/inbound`, **reusing the profile's existing DIDComm-authenticated session** for the bearer token. The mediator sniffs the `0xD4` magic byte and stores it for pickup. (A dual-capable client doesn't need separate TSP auth.)
- **`unpack(profile, stored)`** — decodes a fetched message, resolves the sender, decrypts + verifies with the profile's key, returns `(payload, sender_vid)`.

### test-mediator (`affinidi-messaging-test-mediator` 0.2.12 → 0.2.13)
- New opt-in **`tsp` feature** (spawns the mediator with TSP + enables `atm.tsp()`).
- New **`tsp_delivery` e2e test**: a full TSP Direct round-trip through a live mediator, driven entirely by the SDK — *alice packs → `/inbound` sniff + store → bob fetches + unpacks* — asserting payload and sender are recovered. **This closes the end-to-end test gap** flagged across the mediator-side TSP PRs (#492/#493/#495).

## Compatibility
Both additive — **no behaviour change without the `tsp` feature**. DIDComm regression intact: `lifecycle` (22) e2e pass on **both** default and dual builds; SDK + test-mediator clippy clean in both configs.

## Found a library bug (left for a separate fix)
`affinidi-did-common`'s `DocumentExt::find_authentication(None)` is a copy-paste of `find_key_agreement` and returns the **`keyAgreement`** ids instead of `authentication`. I work around it here by reading `doc.authentication` directly. The bug **also affects `affinidi-messaging-sdk/src/messages/unpack.rs:386`** (DIDComm signed-message path), so fixing the shared method has blast radius and deserves its own focused PR rather than being bundled here.

## Versions
SDK 0.18.13 → 0.18.14 (patch, additive); test-mediator 0.2.12 → 0.2.13.