### PR TITLE
fix: find_authentication returned keyAgreement ids, breaking bare-DID JWS verify

### DIFF
--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-06-22
+
+### Fixed
+
+- `DocumentExt::find_authentication(None)` returned the document's **`keyAgreement`**
+  ids instead of its **`authentication`** ids (a copy-paste of `find_key_agreement`).
+  Callers asking for the default authentication keys got key-agreement (X25519)
+  keys. Fixed to return `authentication`, and the regression test now asserts the
+  returned ids rather than only their count (the old count-only assertion passed
+  coincidentally because the test document had equal numbers of each). This also
+  fixes `affinidi-messaging-sdk`'s DIDComm signed-message verification for the
+  bare-DID `kid` case, which depends on this method.
+
 ## [0.3.7] - 2026-06-14
 
 ### Changed

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.7"
+version = "0.3.8"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-common/src/document.rs
+++ b/crates/identity/affinidi-did-common/src/document.rs
@@ -59,7 +59,7 @@ impl DocumentExt for Document {
                 vec![]
             }
         } else {
-            self.key_agreement.iter().map(|ka| ka.get_id()).collect()
+            self.authentication.iter().map(|a| a.get_id()).collect()
         }
     }
 
@@ -244,7 +244,14 @@ mod tests {
         assert!(!doc.contains_authentication("did:test:1234#auth_missing"));
         assert!(doc.contains_authentication("did:test:1234#auth_vm"));
 
-        assert_eq!(doc.find_authentication(None).len(), 2);
+        // `None` returns the *authentication* ids — not keyAgreement (regression
+        // guard: this method was once a copy-paste of `find_key_agreement`).
+        let all = doc.find_authentication(None);
+        assert_eq!(all.len(), 2);
+        assert!(all.contains(&"did:test:1234#auth_ref"));
+        assert!(all.contains(&"did:test:1234#auth_vm"));
+        assert!(!all.contains(&"did:test:1234#key_ref"));
+        assert!(!all.contains(&"did:test:1234#key_vm"));
         assert_eq!(
             doc.find_authentication(Some("did:test:1234#auth_ref"))
                 .len(),

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.15] - 2026-06-22
+
+Picks up the `affinidi-did-common` 0.3.8 fix for
+`DocumentExt::find_authentication`, which **fixes DIDComm signed-message
+verification when the signer's `kid` is a bare DID** (no fragment): the unpack
+path looked up the first authentication key via that method and previously got a
+keyAgreement (X25519) key, so verification failed. Fragment-qualified kids were
+unaffected. Also drops the local workaround in `atm.tsp()` (now that
+`find_authentication` is correct). No API change; patch bump.
+
 ## [0.18.14] - 2026-06-22
 
 TSP send/receive — `atm.tsp()` can now pack, send, and unpack TSP **Direct**

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.14"
+version = "0.18.15"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -205,13 +205,8 @@ impl TspOps<'_> {
             .map_err(|e| ATMError::DIDError(format!("couldn't resolve own DID {did}: {e}")))?
             .doc;
 
-        // NB: read `doc.authentication` directly rather than via
-        // `DocumentExt::find_authentication(None)` — that method has a
-        // copy-paste bug and returns the `keyAgreement` ids instead of the
-        // `authentication` ids, which would yield X25519 keys here.
-        let auth_kids: Vec<&str> = doc.authentication.iter().map(|vr| vr.get_id()).collect();
         let signing_key = self
-            .first_private_key(auth_kids, KeyType::Ed25519)
+            .first_private_key(doc.find_authentication(None), KeyType::Ed25519)
             .await
             .ok_or_else(|| {
                 ATMError::SecretsError(format!("no Ed25519 authentication key for {did}"))


### PR DESCRIPTION
## The bug

`DocumentExt::find_authentication(None)` was a copy-paste of `find_key_agreement` — its `else` branch iterated **`self.key_agreement`** instead of `self.authentication`:

```rust
} else {
    self.key_agreement.iter().map(|ka| ka.get_id()).collect()  // ← should be self.authentication
}
```

So asking for a document's default authentication keys returned its **keyAgreement (X25519)** keys.

## Impact — a latent DIDComm verification bug

`affinidi-messaging-sdk`'s DIDComm signed-message path (`messages/unpack.rs:386`) uses `find_authentication(None).first()` to find the signing key **when the signer's `kid` is a bare DID** (no `#fragment`). It was getting an X25519 key, failing the `ED25519_PUB` codec check, and **silently failing to verify the signature**. Fragment-qualified kids (the common case) take a different branch, so this went unnoticed and tests stayed green.

I surfaced it while building `atm.tsp()` (PR #497), which needs the profile's Ed25519 signing key — and worked around it locally there. This PR fixes it at the source and removes that workaround.

## The fix

- **`affinidi-did-common` 0.3.7 → 0.3.8**: return `authentication`. The existing regression test only checked `.len() == 2` — which was 2 either way (the test doc had equal numbers of auth/keyAgreement entries), so it never caught the bug. The test now asserts the **actual returned ids** (`auth_ref`/`auth_vm`, and explicitly *not* `key_ref`/`key_vm`).
- **`affinidi-messaging-sdk` 0.18.14 → 0.18.15**: picks up the fix (so bare-DID JWS verification works) and drops the local `atm.tsp()` workaround.

`find_key_agreement` and `find_assertion_method` were checked and are correct.

## Verification
- `affinidi-did-common` lib suite (191) incl. the strengthened test.
- TSP e2e (`tsp_delivery`) still green using the now-correct `find_authentication`.
- SDK `unpack` tests (28) + `lifecycle` e2e (22) pass; clippy clean.

Semver-compatible bug fix → patch bumps. (The `0.3` / `0.18` pins downstream remain valid.)