### PR TITLE
feat: derive the mediator's own TSP identity (routed-relay foundation)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## 22nd June 2026
 
+### 0.16.8 — Mediator TSP identity (relay foundation)
+
+- `SharedData::tsp_identity()` derives (and caches, lazily) the mediator's own TSP
+  keys — the Ed25519 signing key from its DID's `authentication` and the X25519
+  decryption key from its `keyAgreement` — from the configured DID document and
+  the operating secrets it already uses to decrypt inbound DIDComm. No new key
+  management.
+- This is the foundation for acting as a **routed relay hop** (unpack a `Routed`
+  message sealed to the mediator, re-seal it onward), landing next. TSP **Direct**
+  delivery is a blind store-and-forward and never touches this. Purely additive;
+  derived only on first use.
+
 ### 0.16.7 — TSP client authentication
 
 - New `POST /tsp/authenticate` endpoint (dual `didcomm,tsp` build) lets a TSP

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.7"
+version = "0.16.8"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -31,6 +31,8 @@ pub mod messages;
 pub mod server;
 pub mod store;
 pub mod tasks;
+#[cfg(feature = "tsp")]
+pub mod tsp_identity;
 
 /// Shared application state available to all request handlers via Axum's state extraction.
 #[derive(Clone)]
@@ -78,9 +80,34 @@ pub struct SharedData {
     /// tests can inject a `TestClock` (via `TestMediatorBuilder::clock`) and
     /// advance it to exercise expiry instantly.
     pub clock: Arc<dyn affinidi_messaging_mediator_common::types::clock::Clock>,
+    /// The mediator's own TSP identity (Ed25519 signing + X25519 decryption keys),
+    /// derived lazily on first use from the configured DID + operating secrets.
+    /// Only needed when the mediator acts as a routed TSP relay hop; Direct
+    /// delivery is a blind store-and-forward and never touches it.
+    #[cfg(feature = "tsp")]
+    pub tsp_identity: Arc<tokio::sync::OnceCell<tsp_identity::MediatorTspIdentity>>,
 }
 
 impl SharedData {
+    /// The mediator's TSP identity, derived (and cached) on first use from its
+    /// configured DID document and operating secrets.
+    #[cfg(feature = "tsp")]
+    pub async fn tsp_identity(
+        &self,
+    ) -> Result<
+        &tsp_identity::MediatorTspIdentity,
+        affinidi_messaging_mediator_common::errors::MediatorError,
+    > {
+        self.tsp_identity
+            .get_or_try_init(|| {
+                tsp_identity::MediatorTspIdentity::derive(
+                    &self.config.mediator_did,
+                    &self.did_resolver,
+                    &*self.config.security.mediator_secrets,
+                )
+            })
+            .await
+    }
     /// Bound for request-path storage calls made during admission/validation
     /// (see [`common::storage_timeout`]). Sourced from the existing
     /// `[database] database_timeout` (the same knob that caps Redis

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -588,6 +588,8 @@ pub async fn serve_internal(
         self_authorities: Arc::new(self_authorities),
         component_health: supervisor.registry(),
         clock,
+        #[cfg(feature = "tsp")]
+        tsp_identity: Arc::new(tokio::sync::OnceCell::new()),
     };
 
     let app: Router = application_routes(&api_prefix, &shared_state);

--- a/crates/messaging/affinidi-messaging-mediator/src/tsp_identity.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tsp_identity.rs
@@ -1,0 +1,160 @@
+//! The mediator's own TSP identity.
+//!
+//! For TSP **Direct** delivery the mediator is a blind store-and-forward and
+//! needs no keys. To act as a **routed relay hop**, though, it must unpack a
+//! `Routed` message *sealed to it* (its X25519 decryption key) and re-seal the
+//! onward message as the sender (its Ed25519 signing + X25519 encryption keys).
+//!
+//! The mediator already has a DID and operating secrets (the same ones it uses
+//! to decrypt inbound DIDComm). Its TSP identity is simply those keys viewed
+//! through a TSP lens: the Ed25519 key from `authentication` and the X25519 key
+//! from `keyAgreement`. No new key management — we derive it on first use from
+//! the configured DID document + secrets resolver.
+
+use affinidi_did_common::document::DocumentExt;
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_secrets_resolver::{SecretsResolver, secrets::KeyType};
+
+/// The mediator's TSP keys, derived from its DID document + operating secrets.
+pub struct MediatorTspIdentity {
+    /// The mediator's VID — its configured DID.
+    pub vid: String,
+    /// Ed25519 signing private key (from `authentication`).
+    pub signing_key: [u8; 32],
+    /// X25519 decryption/encryption private key (from `keyAgreement`).
+    pub decryption_key: [u8; 32],
+}
+
+impl MediatorTspIdentity {
+    /// Derive the mediator's TSP identity from its DID document and operating
+    /// secrets. Fails with a config error if the DID can't be resolved or its
+    /// document lacks an Ed25519 authentication / X25519 keyAgreement key whose
+    /// private half the mediator holds.
+    pub(crate) async fn derive(
+        did: &str,
+        did_resolver: &DIDCacheClient,
+        secrets: &impl SecretsResolver,
+    ) -> Result<Self, MediatorError> {
+        let doc = did_resolver
+            .resolve(did)
+            .await
+            .map_err(|e| {
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("couldn't resolve mediator DID {did} to derive its TSP identity: {e}"),
+                )
+            })?
+            .doc;
+
+        let signing_key = first_private_key(doc.find_authentication(None), secrets, KeyType::Ed25519)
+            .await
+            .ok_or_else(|| {
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("mediator DID {did} has no Ed25519 authentication key for TSP relay"),
+                )
+            })?;
+        let decryption_key =
+            first_private_key(doc.find_key_agreement(None), secrets, KeyType::X25519)
+                .await
+                .ok_or_else(|| {
+                    MediatorError::ConfigError(
+                        12,
+                        "NA".into(),
+                        format!("mediator DID {did} has no X25519 keyAgreement key for TSP relay"),
+                    )
+                })?;
+
+        Ok(Self {
+            vid: did.to_string(),
+            signing_key,
+            decryption_key,
+        })
+    }
+}
+
+/// First verification-method `kid` whose secret is of `want` type, as a raw
+/// 32-byte private key.
+async fn first_private_key(
+    kids: Vec<&str>,
+    secrets: &impl SecretsResolver,
+    want: KeyType,
+) -> Option<[u8; 32]> {
+    for kid in kids {
+        if let Some(secret) = secrets.get_secret(kid).await
+            && secret.get_key_type() == want
+            && let Ok(bytes) = <[u8; 32]>::try_from(secret.get_private_bytes())
+        {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+    use affinidi_secrets_resolver::{ThreadedSecretsResolver, secrets::Secret};
+
+    /// `derive` extracts the Ed25519 key from `authentication` and the X25519 key
+    /// from `keyAgreement`, keyed by the document's published verification-method
+    /// ids. Uses a `did:key` (resolved locally) and secrets keyed under its actual
+    /// kids — proving the extraction picks the right key per relationship + type.
+    #[tokio::test]
+    async fn derive_extracts_signing_and_decryption_keys() {
+        const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+        let doc = resolver.resolve(DID_KEY).await.unwrap().doc;
+        let auth_kid = doc
+            .find_authentication(None)
+            .first()
+            .copied()
+            .expect("did:key publishes an authentication key")
+            .to_string();
+        let ka_kid = doc
+            .find_key_agreement(None)
+            .first()
+            .copied()
+            .expect("did:key publishes a keyAgreement key")
+            .to_string();
+
+        let ed = Secret::generate_ed25519(Some(&auth_kid), Some(&[3u8; 32]));
+        let x = Secret::generate_x25519(Some(&ka_kid), Some(&[5u8; 32])).unwrap();
+        let expected_signing: [u8; 32] = ed.get_private_bytes().try_into().unwrap();
+        let expected_decryption: [u8; 32] = x.get_private_bytes().try_into().unwrap();
+
+        let (secrets, _h) = ThreadedSecretsResolver::new(None).await;
+        secrets.insert_vec(&[ed, x]).await;
+
+        let identity = MediatorTspIdentity::derive(DID_KEY, &resolver, &secrets)
+            .await
+            .expect("derive the mediator TSP identity");
+
+        assert_eq!(identity.vid, DID_KEY);
+        assert_eq!(identity.signing_key, expected_signing, "Ed25519 from authentication");
+        assert_eq!(identity.decryption_key, expected_decryption, "X25519 from keyAgreement");
+    }
+
+    /// A document whose keys the mediator doesn't hold yields a clear config error.
+    #[tokio::test]
+    async fn derive_errors_when_secrets_missing() {
+        const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+        let (secrets, _h) = ThreadedSecretsResolver::new(None).await;
+
+        assert!(
+            MediatorTspIdentity::derive(DID_KEY, &resolver, &secrets)
+                .await
+                .is_err(),
+            "no operating secrets → derivation fails"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First step toward **routed TSP relay** (PR-12a of the relay work): the mediator can now derive its **own TSP identity**.

`SharedData::tsp_identity()` lazily derives (and caches) the mediator's TSP keys:
- **Ed25519 signing** key — from its DID's `authentication` relationship.
- **X25519 decryption** key — from its `keyAgreement`.

…pulled from the **same operating secrets** the mediator already uses to decrypt inbound DIDComm (`config.security.mediator_secrets`) and its configured DID. **No new key management** — the mediator's TSP identity is just its existing keys viewed through a TSP lens, mirroring how `atm.tsp()` derives a profile's keys.

## Why
A relay hop is a full TSP participant: it must **unpack** a `Routed` message *sealed to it* (X25519 key) and **re-seal** the onward message as the sender (Ed25519 + X25519). So the mediator needs its own keys — but only for routing. TSP **Direct** delivery remains a blind store-and-forward and never touches this.

## Compatibility
Purely additive — a new lazily-derived field + accessor, gated on `tsp`; derived only on first use (no startup cost, no failure mode for non-routing operation). DIDComm and Direct delivery untouched.

## Tests
- `derive` extracts the correct key per relationship + type (resolves a `did:key`, secrets keyed under its actual VM ids).
- Errors clearly when the operating secrets don't cover the keys.
- Default (no-`tsp`) build + DIDComm regression (`lifecycle` 22) + clippy clean.

## Next
PR-12b: `handle_inbound_tsp` handles `Routed` — unpack (this identity) → `next_hop` → re-seal + forward to the next hop (local store or remote POST) → with an `alice → mediator-hop → bob` e2e test.

Patch bump 0.16.7 → 0.16.8.