### PR TITLE
feat: TSP routed relay through the mediator (PR-12b)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+## 23rd June 2026
+
+### 0.16.9 — TSP routed relay
+
+- The mediator now acts as a **routed TSP relay hop**. A `Routed` message sealed
+  to the mediator is unwrapped using its own TSP identity (0.16.8), the next hop
+  is read (`next_hop`), and the onward message is forwarded — re-sealed as this
+  mediator for an intermediate hop, or forwarded opaquely when this is the last
+  hop (the inner is already sealed end-to-end to the final recipient).
+- Direct delivery and the final hop of a relay now share one `deliver_tsp_local`
+  path: check the recipient is local, apply its access-list against the envelope
+  sender, store for pickup.
+- A `Routed` message addressed to a *local account* (the account is itself a hop)
+  is stored opaquely for it. Remote next-hops (forwarding to another mediator) and
+  Nested/Control messages return a clear problem report — they land later.
+
 ## 22nd June 2026
 
 ### 0.16.8 — Mediator TSP identity (relay foundation)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.8"
+version = "0.16.9"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -95,37 +95,131 @@ pub(crate) async fn handle_inbound_tsp(
         )
     })?;
 
-    // Only Direct messages are delivered so far; Routed/Nested relay and Control
-    // handling land in later PRs.
-    if meta.message_type != TspMessageType::Direct {
-        return Err(MediatorError::problem(
-            37,
-            &session.session_id,
-            None,
-            ProblemReportSorter::Error,
-            ProblemReportScope::Protocol,
-            "protocol.tsp.unsupported",
-            "Only TSP Direct messages are handled so far (routing/relay not yet enabled)",
-            vec![],
-            StatusCode::NOT_IMPLEMENTED,
-        ));
-    }
+    use affinidi_tsp::message::routed::{RouteStep, next_hop, pack_routed};
 
-    let to_vid = &meta.receiver;
-    let from_vid = &meta.sender;
+    match meta.message_type {
+        // Direct: deliver to the (local) recipient named in the envelope.
+        TspMessageType::Direct => deliver_tsp_local(state, session, raw).await,
+
+        // Routed addressed to *this mediator*: we are a relay hop. Unwrap our
+        // routing layer (sealed to us) and forward the onward message to the next
+        // hop, re-sealing as this mediator unless we are the last hop (in which
+        // case the opaque inner is already sealed to the final recipient).
+        TspMessageType::Routed if meta.receiver == state.config.mediator_did => {
+            let identity = state.tsp_identity().await?;
+            let sender = resolve_tsp_vid(state, &meta.sender, &session.session_id).await?;
+            let unpacked = affinidi_tsp::message::direct::unpack(
+                raw,
+                &identity.decryption_key,
+                &sender.encryption_key,
+                &sender.signing_key,
+            )
+            .map_err(|e| {
+                tsp_problem(
+                    session,
+                    37,
+                    "message.tsp.unpack",
+                    format!("couldn't unpack routed TSP layer: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            let step = next_hop(&unpacked.payload).map_err(|e| {
+                tsp_problem(
+                    session,
+                    37,
+                    "message.tsp.route",
+                    format!("malformed TSP route: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            let forward_bytes = match step {
+                // Last relay hop: `next` is the final recipient and `inner` is
+                // already sealed end-to-end to them — forward it opaquely.
+                RouteStep::Forward {
+                    remaining, inner, ..
+                } if remaining.is_empty() => inner,
+                // Re-seal the onward route to the next hop, authenticating as this
+                // mediator.
+                RouteStep::Forward {
+                    next,
+                    remaining,
+                    inner,
+                } => {
+                    let next_vid = resolve_tsp_vid(state, &next, &session.session_id).await?;
+                    pack_routed(
+                        &inner,
+                        &remaining,
+                        &identity.vid,
+                        &next,
+                        &identity.signing_key,
+                        &identity.decryption_key,
+                        &next_vid.encryption_key,
+                    )
+                    .map_err(|e| {
+                        tsp_problem(
+                            session,
+                            37,
+                            "message.tsp.reseal",
+                            format!("couldn't re-seal routed TSP message: {e}"),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        )
+                    })?
+                    .bytes
+                }
+                // This hop is the exit: `inner` is sealed to its final recipient.
+                RouteStep::Deliver { inner } => inner,
+            };
+
+            deliver_tsp_local(state, session, &forward_bytes).await
+        }
+
+        // Routed addressed to a *local account* (that account is itself the hop):
+        // store it opaquely for them to pick up and relay onward.
+        TspMessageType::Routed => deliver_tsp_local(state, session, raw).await,
+
+        // Nested / Control relay are not handled yet.
+        _ => Err(tsp_problem(
+            session,
+            37,
+            "protocol.tsp.unsupported",
+            "Only TSP Direct and Routed messages are handled so far".to_string(),
+            StatusCode::NOT_IMPLEMENTED,
+        )),
+    }
+}
+
+/// Deliver a TSP message to the local recipient named in its envelope: check the
+/// recipient is a local account, apply the recipient's access-list against the
+/// (envelope) sender, then store it for pickup. Shared by Direct delivery and the
+/// final hop of a routed relay. Remote recipients (forwarding on to another
+/// mediator) are not yet handled.
+#[cfg(feature = "tsp")]
+async fn deliver_tsp_local(
+    state: &SharedData,
+    session: &Session,
+    bytes: &[u8],
+) -> Result<InboundMessageResponse, MediatorError> {
+    let meta = TspMetaEnvelope::parse(bytes).map_err(|e| {
+        tsp_problem(
+            session,
+            37,
+            "message.tsp.malformed",
+            format!("malformed TSP message: {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+    let to_vid = meta.receiver;
     let to_hash = digest(to_vid.as_bytes());
 
-    // The recipient must be a local account — there is no TSP routing/bridge yet.
     if !state.database.account_exists(&to_hash).await? {
-        return Err(MediatorError::problem(
+        return Err(tsp_problem(
+            session,
             58,
-            &session.session_id,
-            None,
-            ProblemReportSorter::Error,
-            ProblemReportScope::Protocol,
             "direct_delivery.recipient.unknown",
-            "TSP recipient is not local to this mediator (routing not yet enabled)",
-            vec![],
+            "TSP recipient is not local to this mediator (remote forwarding not yet enabled)"
+                .to_string(),
             StatusCode::NOT_FOUND,
         ));
     }
@@ -133,27 +227,21 @@ pub(crate) async fn handle_inbound_tsp(
     // Access-list check (sender → recipient), mirroring DIDComm direct delivery.
     // The sender VID is the cleartext envelope claim; like an opaque DIDComm
     // forward, the mediator routes on it and the recipient verifies end-to-end.
-    let from_hash = digest(from_vid.as_bytes());
+    let from_hash = digest(meta.sender.as_bytes());
     if authz::check_access_list(state.database.as_ref(), &to_hash, Some(&from_hash))
         .await
         .is_err()
     {
-        return Err(MediatorError::problem(
+        return Err(tsp_problem(
+            session,
             73,
-            &session.session_id,
-            None,
-            ProblemReportSorter::Error,
-            ProblemReportScope::Protocol,
             "authorization.access_list.denied",
-            "Delivery blocked due to ACLs (access_list denied)",
-            vec![],
+            "Delivery blocked due to ACLs (access_list denied)".to_string(),
             StatusCode::FORBIDDEN,
         ));
     }
 
-    // Store base64url(qb2) = the CESR qb64 text form, through the neutral store
-    // path. DIDComm storage is unchanged.
-    let encoded = BASE64_URL_SAFE_NO_PAD.encode(raw);
+    let encoded = BASE64_URL_SAFE_NO_PAD.encode(bytes);
     let data = ProcessMessageResponse {
         store_message: true,
         force_live_delivery: false,
@@ -165,13 +253,55 @@ pub(crate) async fn handle_inbound_tsp(
         ),
     };
 
-    tracing::debug!(
-        to_vid = %to_vid,
-        from_vid = %from_vid,
-        "TSP direct delivery stored for local recipient"
-    );
-
+    tracing::debug!(to_vid = %to_vid, from_vid = %meta.sender, "TSP message stored for local recipient");
     store_message(state, session, &data, &UnpackMetadata::default()).await
+}
+
+/// Resolve a DID-based TSP VID to its keys + endpoints.
+#[cfg(feature = "tsp")]
+async fn resolve_tsp_vid(
+    state: &SharedData,
+    did: &str,
+    session_id: &str,
+) -> Result<affinidi_tsp::ResolvedVid, MediatorError> {
+    affinidi_tsp::DidVidResolver::new(state.did_resolver.clone())
+        .resolve_did(did)
+        .await
+        .map_err(|e| {
+            MediatorError::problem(
+                58,
+                session_id,
+                None,
+                ProblemReportSorter::Error,
+                ProblemReportScope::Protocol,
+                "message.tsp.resolve",
+                "couldn't resolve TSP VID: {1}",
+                vec![format!("{did}: {e}")],
+                StatusCode::BAD_GATEWAY,
+            )
+        })
+}
+
+/// Build a TSP protocol problem report with a single human-readable message.
+#[cfg(feature = "tsp")]
+fn tsp_problem(
+    session: &Session,
+    code: u16,
+    code_str: &str,
+    message: String,
+    status: StatusCode,
+) -> MediatorError {
+    MediatorError::problem(
+        code,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Protocol,
+        code_str,
+        &message,
+        vec![],
+        status,
+    )
 }
 
 #[cfg(feature = "didcomm")]

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.18.16] - 2026-06-23
+
+`atm.tsp()` gains routed send:
+- `send_routed(profile, route, payload)` — send a TSP message through one or more
+  relay hops. The payload is sealed end-to-end to the final recipient
+  (`route.last()`), wrapped in a routing layer sealed to the first hop
+  (`route[0]`, a TSP-routing mediator); each hop unwraps and forwards onward.
+- `send_raw(profile, bytes)` — POST an already-packed TSP message to `/inbound`
+  (the shared transport `send()` now builds on this).
+
+Verified end to end against a live mediator relay in
+`affinidi-messaging-test-mediator`. Additive; patch bump.
+
 ## [0.18.15] - 2026-06-22
 
 Picks up the `affinidi-did-common` 0.3.8 fix for

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.15"
+version = "0.18.16"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -28,7 +28,6 @@ use affinidi_secrets_resolver::secrets::KeyType;
 use affinidi_tsp::message::direct;
 use affinidi_tsp::{DidVidResolver, MessageType, MetaEnvelope};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use tracing::debug;
 
 use crate::ATM;
 use crate::errors::ATMError;
@@ -110,7 +109,54 @@ impl TspOps<'_> {
         payload: &[u8],
     ) -> Result<(), ATMError> {
         let bytes = self.pack(profile, to_did, payload).await?;
+        self.send_raw(profile, &bytes).await
+    }
 
+    /// Send a TSP message **routed** through one or more relay hops.
+    ///
+    /// `route` is the ordered hop list ending at the final recipient, e.g.
+    /// `[mediator_did, bob_did]`. The payload is sealed end-to-end to the final
+    /// recipient (`route.last()`), then wrapped in a routing layer sealed to the
+    /// first hop (`route[0]`) — which must be a mediator that speaks TSP routing.
+    /// Each hop unwraps its layer and forwards onward; only the final recipient
+    /// can read the payload.
+    pub async fn send_routed(
+        &self,
+        profile: &Arc<ATMProfile>,
+        route: &[String],
+        payload: &[u8],
+    ) -> Result<(), ATMError> {
+        let final_did = route
+            .last()
+            .ok_or_else(|| ATMError::MsgSendError("route must not be empty".into()))?;
+        let first_hop = &route[0];
+
+        // End-to-end Direct message to the final recipient.
+        let inner = self.pack(profile, final_did, payload).await?;
+
+        // Routing layer to the first hop, carrying the hops after it.
+        let (from_did, _) = profile.dids()?;
+        let (signing_key, encryption_key) = self.profile_tsp_keys(from_did).await?;
+        let first_vid = self.resolve_vid(first_hop).await?;
+        let routed = affinidi_tsp::message::routed::pack_routed(
+            &inner,
+            &route[1..],
+            from_did,
+            first_hop,
+            &signing_key,
+            &encryption_key,
+            &first_vid.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack routed TSP message: {e}")))?;
+
+        self.send_raw(profile, &routed.bytes).await
+    }
+
+    /// POST an already-packed TSP message (raw qb2 bytes) to the mediator
+    /// `/inbound`, reusing the profile's existing (DIDComm) authenticated session
+    /// for the bearer token. The mediator sniffs the TSP magic byte and routes it
+    /// to its TSP handler.
+    pub async fn send_raw(&self, profile: &Arc<ATMProfile>, bytes: &[u8]) -> Result<(), ATMError> {
         let mediator_url = profile.get_mediator_rest_endpoint().ok_or_else(|| {
             ATMError::MsgSendError("Profile is missing a valid mediator URL".into())
         })?;
@@ -130,7 +176,7 @@ impl TspOps<'_> {
             .post([&mediator_url, "/inbound"].concat())
             .header("Content-Type", "application/tsp")
             .header("Authorization", format!("Bearer {}", tokens.access_token))
-            .body(bytes)
+            .body(bytes.to_vec())
             .send()
             .await
             .map_err(|e| ATMError::TransportError(format!("Could not send TSP message: {e:?}")))?;
@@ -142,7 +188,6 @@ impl TspOps<'_> {
                 "Mediator rejected TSP message: status({status}), body({body})"
             )));
         }
-        debug!("TSP message sent to {to_did}");
         Ok(())
     }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 23rd June 2026
+
+### 0.2.14 — TSP routed relay e2e
+
+- New `tsp_routed_message_relays_through_the_mediator` test: Alice sends a TSP
+  message routed through the mediator (as a relay hop) to Bob, asserting the
+  payload survives the relay and the original sender is recovered. Complements the
+  existing Direct delivery test.
+
 ## 22nd June 2026
 
 ### 0.2.13 — TSP end-to-end fixture

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.13"
+version = "0.2.14"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -58,3 +58,54 @@ async fn tsp_direct_message_round_trips_through_the_mediator() {
     assert_eq!(recovered, payload, "payload round-trips end to end");
     assert_eq!(sender, alice.did, "sender VID is recovered");
 }
+
+/// End-to-end TSP **Routed** relay: Alice sends through the mediator as a relay
+/// hop to Bob. The payload is sealed end-to-end to Bob; the outer routing layer
+/// is sealed to the mediator, which unwraps it and forwards the opaque inner to
+/// Bob (a local recipient). Proves the mediator's routed-relay path: derive its
+/// own TSP identity → unpack the layer sealed to it → `next_hop` → deliver.
+#[tokio::test]
+async fn tsp_routed_message_relays_through_the_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mediator_did = env.mediator.did().to_string();
+
+    let payload = b"routed hello over TSP";
+
+    // Route: alice -> mediator (relay hop) -> bob.
+    let route = vec![mediator_did, bob.did.clone()];
+    env.atm
+        .tsp()
+        .send_routed(&alice.profile, &route, payload)
+        .await
+        .expect("alice sends a routed TSP message via the mediator");
+
+    // Bob fetches the relayed (now opaque Direct) message and unpacks it.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one relayed message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("relayed message carries its body");
+
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the relayed TSP message");
+
+    assert_eq!(recovered, payload, "payload survives the relay end to end");
+    assert_eq!(sender, alice.did, "original sender VID is recovered, not the relay");
+}


### PR DESCRIPTION
## Summary

The mediator now acts as a **routed TSP relay hop** — completing routed delivery (PR-12b, building on the mediator TSP identity from #499). A sender can route a message through the mediator to a recipient, with the payload sealed end-to-end and the routing layer hiding the final recipient from the network.

### Mediator (`affinidi-messaging-mediator` 0.16.8 → 0.16.9)
`handle_inbound_tsp` gains a `Routed` branch:
- A `Routed` message **sealed to the mediator** is unwrapped with its own TSP identity → `next_hop()` reads the route → the onward message is forwarded:
  - **intermediate hop** → re-seal the remaining route as *this mediator* and forward to the next hop;
  - **last hop** → the inner is already sealed end-to-end to the final recipient, so forward it opaquely.
- Direct delivery and the relay's final hop now share one **`deliver_tsp_local`** path (recipient-is-local + access-list + store).
- A `Routed` message addressed to a **local account** (the account is itself a hop) is stored opaquely for it. **Remote next-hops** (forwarding to another mediator) and **Nested/Control** return clear problem reports — they land in later PRs.

### SDK (`affinidi-messaging-sdk` 0.18.15 → 0.18.16)
- **`atm.tsp().send_routed(profile, route, payload)`** — seals the payload end-to-end to `route.last()`, wraps a routing layer to `route[0]` (a TSP-routing mediator), and sends it.
- **`atm.tsp().send_raw(profile, bytes)`** — POST a pre-packed TSP message; the existing `send()` now builds on it.

## Tests
New **`tsp_routed_message_relays_through_the_mediator`** e2e: *alice → mediator (relay hop) → bob*, asserting the payload survives the relay and the **original sender** (not the relay) is recovered. Runs alongside the Direct delivery test.

Mediator lib (139) + DIDComm `lifecycle` e2e (22) pass; default builds + clippy clean across all three crates. Additive; patch bumps.

## Scope / next
This covers routed delivery to a **local** final recipient (the common single-mediator case) + re-sealing for intermediate hops. **Remote forwarding** (POST to another mediator's TSP endpoint) is the natural follow-up, then the TSP↔DIDComm **bridge**.