### PR TITLE
feat: TSP↔DIDComm bridge (PR-13)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 23rd June 2026
 
+### 0.16.10 — TSP↔DIDComm bridge
+
+- A routed TSP relay now bridges protocols. At the exit hop the mediator delivers
+  the **opaque inner** to the recipient *named in the route* (not parsed from the
+  inner's envelope), so the inner may be a TSP **or** a DIDComm message — the
+  recipient recognises and unpacks it natively. The mediator never reads it.
+- `deliver_opaque` is the bridge primitive: known recipient + authenticated
+  routing-layer sender for the access-list, store for pickup. It stores a TSP
+  inner as base64url(qb2) (`1AAF…` qb64) and a DIDComm inner as its plain JWE/JWS
+  text, so a pickup client sniffs the prefix and decodes correctly.
+  `deliver_tsp_local` (Direct + empty-route `Deliver`) now parses the envelope and
+  delegates to it.
+
 ### 0.16.9 — TSP routed relay
 
 - The mediator now acts as a **routed TSP relay hop**. A `Routed` message sealed

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.9"
+version = "0.16.10"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -134,21 +134,29 @@ pub(crate) async fn handle_inbound_tsp(
                 )
             })?;
 
-            let forward_bytes = match step {
-                // Last relay hop: `next` is the final recipient and `inner` is
-                // already sealed end-to-end to them — forward it opaquely.
+            match step {
+                // Last relay hop: `next` is the final recipient named in the route
+                // and `inner` is already sealed end-to-end to them. Deliver the
+                // opaque inner — which may be a TSP *or* a DIDComm message — to that
+                // recipient, who handles it natively on pickup. This is the
+                // TSP↔DIDComm bridge point: the mediator forwards on the route, not
+                // on the inner's (possibly non-TSP) envelope.
                 RouteStep::Forward {
-                    remaining, inner, ..
-                } if remaining.is_empty() => inner,
-                // Re-seal the onward route to the next hop, authenticating as this
-                // mediator.
+                    next,
+                    remaining,
+                    inner,
+                } if remaining.is_empty() => {
+                    deliver_opaque(state, session, &next, &meta.sender, &inner).await
+                }
+                // Intermediate hop: re-seal the onward route to the next hop,
+                // authenticating as this mediator, and forward.
                 RouteStep::Forward {
                     next,
                     remaining,
                     inner,
                 } => {
                     let next_vid = resolve_tsp_vid(state, &next, &session.session_id).await?;
-                    pack_routed(
+                    let resealed = pack_routed(
                         &inner,
                         &remaining,
                         &identity.vid,
@@ -166,13 +174,13 @@ pub(crate) async fn handle_inbound_tsp(
                             StatusCode::INTERNAL_SERVER_ERROR,
                         )
                     })?
-                    .bytes
+                    .bytes;
+                    deliver_opaque(state, session, &next, &identity.vid, &resealed).await
                 }
-                // This hop is the exit: `inner` is sealed to its final recipient.
-                RouteStep::Deliver { inner } => inner,
-            };
-
-            deliver_tsp_local(state, session, &forward_bytes).await
+                // Empty route: `inner` is sealed to its own final recipient —
+                // deliver by its (TSP) envelope.
+                RouteStep::Deliver { inner } => deliver_tsp_local(state, session, &inner).await,
+            }
         }
 
         // Routed addressed to a *local account* (that account is itself the hop):
@@ -190,11 +198,10 @@ pub(crate) async fn handle_inbound_tsp(
     }
 }
 
-/// Deliver a TSP message to the local recipient named in its envelope: check the
-/// recipient is a local account, apply the recipient's access-list against the
-/// (envelope) sender, then store it for pickup. Shared by Direct delivery and the
-/// final hop of a routed relay. Remote recipients (forwarding on to another
-/// mediator) are not yet handled.
+/// Deliver a TSP message to the local recipient named in *its own envelope*:
+/// parse the envelope and hand off to [`deliver_opaque`]. Used for Direct
+/// delivery and the empty-route (`Deliver`) relay case, where the recipient is
+/// the TSP receiver rather than a route hop.
 #[cfg(feature = "tsp")]
 async fn deliver_tsp_local(
     state: &SharedData,
@@ -210,7 +217,27 @@ async fn deliver_tsp_local(
             StatusCode::BAD_REQUEST,
         )
     })?;
-    let to_vid = meta.receiver;
+    deliver_opaque(state, session, &meta.receiver, &meta.sender, bytes).await
+}
+
+/// Deliver an opaque message to a known local recipient: check the recipient is a
+/// local account, apply its access-list against `from_vid`, then store the bytes
+/// for pickup. The bytes are **not** parsed — this is the TSP↔DIDComm bridge
+/// primitive. A routed relay carries an opaque inner (which may be a DIDComm
+/// message) and delivers it to the route's named recipient, who recognises and
+/// handles it natively on pickup; the mediator never reads it. `from_vid` is the
+/// authenticated sender the mediator routes on (the routing-layer sender for a
+/// relayed message, or the envelope sender for Direct), against which the
+/// recipient's access-list is applied. Remote recipients (forwarding on to
+/// another mediator) are not yet handled.
+#[cfg(feature = "tsp")]
+async fn deliver_opaque(
+    state: &SharedData,
+    session: &Session,
+    to_vid: &str,
+    from_vid: &str,
+    bytes: &[u8],
+) -> Result<InboundMessageResponse, MediatorError> {
     let to_hash = digest(to_vid.as_bytes());
 
     if !state.database.account_exists(&to_hash).await? {
@@ -225,9 +252,9 @@ async fn deliver_tsp_local(
     }
 
     // Access-list check (sender → recipient), mirroring DIDComm direct delivery.
-    // The sender VID is the cleartext envelope claim; like an opaque DIDComm
-    // forward, the mediator routes on it and the recipient verifies end-to-end.
-    let from_hash = digest(meta.sender.as_bytes());
+    // The mediator routes on the authenticated sender and the recipient verifies
+    // the (opaque) message end-to-end on pickup.
+    let from_hash = digest(from_vid.as_bytes());
     if authz::check_access_list(state.database.as_ref(), &to_hash, Some(&from_hash))
         .await
         .is_err()
@@ -241,19 +268,38 @@ async fn deliver_tsp_local(
         ));
     }
 
-    let encoded = BASE64_URL_SAFE_NO_PAD.encode(bytes);
+    // Store in the form the recipient's protocol expects, so a pickup client can
+    // recognise and decode it. A TSP message is stored as base64url(qb2) = its
+    // CESR qb64 text (`1AAF…`); a bridged DIDComm message is stored as its plain
+    // JWE/JWS text. Both ride the same UTF-8 string store; the client sniffs the
+    // prefix (qb64 vs `{`/`ey`) on pickup.
+    let encoded = if affinidi_tsp::is_tsp(bytes) {
+        BASE64_URL_SAFE_NO_PAD.encode(bytes)
+    } else {
+        std::str::from_utf8(bytes)
+            .map_err(|e| {
+                tsp_problem(
+                    session,
+                    37,
+                    "message.bridge.malformed",
+                    format!("bridged inner is neither a TSP message nor valid UTF-8 text: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?
+            .to_string()
+    };
     let data = ProcessMessageResponse {
         store_message: true,
         force_live_delivery: false,
         forward_message: false,
         data: WrapperType::Envelope(
-            to_vid.clone(),
+            to_vid.to_string(),
             encoded,
             state.clock.unix_secs() + state.config.limits.message_expiry_seconds,
         ),
     };
 
-    tracing::debug!(to_vid = %to_vid, from_vid = %meta.sender, "TSP message stored for local recipient");
+    tracing::debug!(%to_vid, %from_vid, "TSP/bridged message stored for local recipient");
     store_message(state, session, &data, &UnpackMetadata::default()).await
 }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.17] - 2026-06-23
+
+`atm.tsp().send_routed_opaque(profile, route, inner)` — route an **already-packed**
+inner message through TSP relay hops. The inner may be a **DIDComm** message (the
+TSP↔DIDComm bridge): pack it with `atm.pack_encrypted`, then route it over TSP to a
+recipient who unpacks it natively. `send_routed` now builds on this. Additive;
+patch bump.
+
 ## [0.18.16] - 2026-06-23
 
 `atm.tsp()` gains routed send:

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.16"
+version = "0.18.17"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -129,17 +129,34 @@ impl TspOps<'_> {
         let final_did = route
             .last()
             .ok_or_else(|| ATMError::MsgSendError("route must not be empty".into()))?;
+        // End-to-end Direct TSP message to the final recipient, carried opaquely.
+        let inner = self.pack(profile, final_did, payload).await?;
+        self.send_routed_opaque(profile, route, &inner).await
+    }
+
+    /// Route an **already-packed** inner message through one or more relay hops.
+    ///
+    /// Like [`send_routed`], but `inner` is a pre-built message sealed to the final
+    /// recipient — which may be a **DIDComm** message (the TSP↔DIDComm bridge): a
+    /// TSP-routing mediator carries it opaquely to the recipient, who unpacks it
+    /// with their native protocol. `route` is the hop list ending at that
+    /// recipient (`route.last()`); the routing layer is sealed to `route[0]`.
+    pub async fn send_routed_opaque(
+        &self,
+        profile: &Arc<ATMProfile>,
+        route: &[String],
+        inner: &[u8],
+    ) -> Result<(), ATMError> {
+        if route.is_empty() {
+            return Err(ATMError::MsgSendError("route must not be empty".into()));
+        }
         let first_hop = &route[0];
 
-        // End-to-end Direct message to the final recipient.
-        let inner = self.pack(profile, final_did, payload).await?;
-
-        // Routing layer to the first hop, carrying the hops after it.
         let (from_did, _) = profile.dids()?;
         let (signing_key, encryption_key) = self.profile_tsp_keys(from_did).await?;
         let first_vid = self.resolve_vid(first_hop).await?;
         let routed = affinidi_tsp::message::routed::pack_routed(
-            &inner,
+            inner,
             &route[1..],
             from_did,
             first_hop,

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 23rd June 2026
 
+### 0.2.15 — TSP↔DIDComm bridge e2e
+
+- New `tsp_routed_bridges_a_didcomm_message_to_the_recipient` test: Alice authcrypts
+  a DIDComm message to Bob and routes it over TSP through the mediator; the mediator
+  delivers the opaque DIDComm inner and Bob unpacks it natively. Proves protocol
+  bridging end to end.
+
 ### 0.2.14 — TSP routed relay e2e
 
 - New `tsp_routed_message_relays_through_the_mediator` test: Alice sends a TSP

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.14"
+version = "0.2.15"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -5,8 +5,11 @@
 //! across the SDK + mediator (memory backend, no Redis needed).
 #![cfg(feature = "tsp")]
 
+use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_sdk::messages::fetch::FetchOptions;
 use affinidi_messaging_test_mediator::TestEnvironment;
+use serde_json::json;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn tsp_direct_message_round_trips_through_the_mediator() {
@@ -108,4 +111,83 @@ async fn tsp_routed_message_relays_through_the_mediator() {
 
     assert_eq!(recovered, payload, "payload survives the relay end to end");
     assert_eq!(sender, alice.did, "original sender VID is recovered, not the relay");
+}
+
+/// End-to-end **TSP↔DIDComm bridge**: Alice sends a *DIDComm* message to Bob, but
+/// carried over TSP routing. She authcrypts a normal DIDComm message to Bob, then
+/// routes it through the mediator with `send_routed_opaque`. The mediator unwraps
+/// the TSP routing layer and delivers the opaque inner to Bob, who recognises it
+/// as DIDComm (not TSP) and unpacks it natively. Proves the mediator bridges
+/// protocols by forwarding on the route, blind to the inner's protocol.
+#[tokio::test]
+async fn tsp_routed_bridges_a_didcomm_message_to_the_recipient() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mediator_did = env.mediator.did().to_string();
+
+    let text = "hello bob — DIDComm carried over TSP";
+
+    // Alice builds and authcrypts a DIDComm message to Bob — the bridged inner.
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(bob.did.clone())
+    .from(alice.did.clone())
+    .finalize();
+    let (jwe, _) = env
+        .atm
+        .pack_encrypted(&msg, &bob.did, Some(&alice.did), Some(&alice.did))
+        .await
+        .expect("authcrypt the DIDComm message for bob");
+
+    // Alice routes that DIDComm message through the mediator to Bob.
+    let route = vec![mediator_did, bob.did.clone()];
+    env.atm
+        .tsp()
+        .send_routed_opaque(&alice.profile, &route, jwe.as_bytes())
+        .await
+        .expect("route the DIDComm message over TSP to bob");
+
+    // Bob fetches it — stored as a plain DIDComm JWE, not a TSP message — and
+    // unpacks it with the DIDComm stack.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one bridged message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("bridged message carries its body");
+
+    assert!(
+        !env.atm.tsp().is_tsp(stored),
+        "the bridged inner is a DIDComm message, not TSP"
+    );
+
+    let (received, _meta) = env
+        .atm
+        .unpack(stored)
+        .await
+        .expect("bob unpacks the bridged DIDComm message");
+    assert_eq!(
+        received.body.get("content").and_then(|c| c.as_str()),
+        Some(text),
+        "DIDComm payload survives the TSP bridge"
+    );
+    assert_eq!(
+        received.from.as_deref(),
+        Some(alice.did.as_str()),
+        "DIDComm sender is recovered"
+    );
 }


### PR DESCRIPTION
## Summary

**The headline feature: the mediator now bridges TSP and DIDComm.** A message can be sent over TSP routing and delivered to a DIDComm recipient (and vice versa), with the mediator forwarding **on the route, blind to the inner's protocol**.

The key idea (opaque-forward model): at a routed relay's exit hop, the mediator delivers the opaque inner to the recipient **named in the route** — *not* parsed from the inner's own envelope. So the inner can be a TSP **or** a DIDComm message; the recipient recognises and unpacks it natively, and the mediator never reads it.

### Mediator (`affinidi-messaging-mediator` 0.16.9 → 0.16.10)
- New **`deliver_opaque`** bridge primitive: known recipient + the **authenticated routing-layer sender** for the access-list, then store for pickup.
- It stores in the form the recipient's protocol expects, so a pickup client decodes correctly: a **TSP** inner as `base64url(qb2)` (`1AAF…` qb64), a **DIDComm** inner as its **plain JWE/JWS** text. (Without this, a DIDComm inner would be base64url'd and fail to unpack.)
- `deliver_tsp_local` (Direct + empty-route `Deliver`) now parses the envelope and delegates to `deliver_opaque`; the relay exit hop calls `deliver_opaque` with the route's recipient.

### SDK (`affinidi-messaging-sdk` 0.18.16 → 0.18.17)
- **`atm.tsp().send_routed_opaque(profile, route, inner)`** — route an already-packed inner (which may be a DIDComm message) over TSP. Pack a DIDComm message with `atm.pack_encrypted`, then route it. `send_routed` now builds on this.

## Tests — the bridge, proven end to end
New **`tsp_routed_bridges_a_didcomm_message_to_the_recipient`**: Alice authcrypts a normal **DIDComm** message to Bob, routes it over TSP through the mediator, and Bob — seeing it's *not* TSP (`!is_tsp`) — **unpacks it with the DIDComm stack**. Payload and sender recovered. Runs alongside the Direct and Routed tests (3 TSP e2e, all green).

Mediator lib (139), DIDComm `lifecycle` (22) + `cross_mediator_forwarding` (6) e2e pass; default builds + clippy clean. Additive; patch bumps.

## Where this leaves the effort
With this, the mediator + SDK do TSP **Direct**, **client auth**, **routed relay**, and the **TSP↔DIDComm bridge** — all end to end, all driven from the SDK, DIDComm provably untouched throughout. The remaining routing item is **remote forwarding** (relaying to *another* mediator's TSP endpoint over the wire).