### PR TITLE
feat: TSP remote forwarding to another mediator (PR-12c)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## 23rd June 2026
 
+### 0.16.11 — TSP remote forwarding
+
+- A routed TSP relay now forwards to a **remote** next hop. When the next hop is
+  not a local account, the mediator reads its `TSPTransport` endpoint from its DID
+  document and enqueues the message on the shared forwarding queue; the forwarding
+  processor (mediator-common 0.15.16) POSTs the raw qb2 to the remote mediator's
+  `/inbound`. A next hop that resolves back to this mediator is rejected as a loop.
+- The relay's hop delivery now dispatches via `forward_to_next`: local recipient →
+  store (`deliver_opaque`); remote → enqueue (`forward_tsp_remote`).
+- Note: the wire path is exercised by the existing DIDComm cross-mediator suite
+  (same processor); a TSP-specific two-mediator e2e awaits `did:web` TSP-endpoint
+  test fixtures (a `did:peer` does not surface a custom `TSPTransport` service to
+  the resolver).
+
 ### 0.16.10 — TSP↔DIDComm bridge
 
 - A routed TSP relay now bridges protocols. At the exit hop the mediator delivers

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.10"
+version = "0.16.11"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog history
 
+## 23rd June 2026
+
+### 0.15.16 — Forwarding processor: TSP-aware delivery
+
+- The forwarding processor now delivers **TSP** forwards correctly. A TSP forward
+  is queued as `base64url(qb2)` text; `deliver_via_rest` decodes it back to the raw
+  qb2 bytes and POSTs with `Content-Type: application/tsp` so the remote mediator's
+  ingress recognises the TSP magic byte. TSP forwards always use REST (the WebSocket
+  relay path is DIDComm-text oriented). DIDComm forwarding is unchanged — a DIDComm
+  message is not valid base64url of a TSP message, so it is sent verbatim as before.
+
 ## 14th June 2026
 
 ### 0.15.15 — non_exhaustive ProcessorError + SecretStoreError (W7 sweep)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.15"
+version = "0.15.16"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
@@ -110,6 +110,24 @@ fn now_epoch_secs() -> u64 {
         .as_secs()
 }
 
+/// A forward whose `message` is a TSP message decodes back to raw qb2 bytes for
+/// the wire; a DIDComm message does not (and is sent as text, unchanged).
+///
+/// TSP forwards are queued as `base64url(qb2)` — the CESR qb64 text form, which
+/// begins `1AAF` (the TSP envelope code) and decodes to bytes leading with the
+/// `0xD4` magic byte. A DIDComm JWE/JWS is not valid base64url of such bytes, so
+/// this returns `None` and the message is sent verbatim.
+fn decode_tsp_forward(message: &str) -> Option<Vec<u8>> {
+    use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+    if !message.starts_with("1AAF") {
+        return None;
+    }
+    BASE64_URL_SAFE_NO_PAD
+        .decode(message)
+        .ok()
+        .filter(|bytes| bytes.first() == Some(&0xD4))
+}
+
 /// State for a connection to a remote mediator endpoint
 struct EndpointState {
     rate_tracker: EndpointRateTracker,
@@ -613,6 +631,10 @@ impl ForwardingProcessor {
         msg: &ForwardQueueEntry,
         use_websocket: bool,
     ) -> Result<(), String> {
+        // TSP forwards go over REST: they carry raw qb2 binary which the remote
+        // mediator's ingress sniffs by its magic byte, whereas the WebSocket relay
+        // path is DIDComm-text oriented.
+        let use_websocket = use_websocket && decode_tsp_forward(&msg.message).is_none();
         if use_websocket {
             match self.deliver_via_websocket(endpoint_url, msg).await {
                 Ok(()) => Ok(()),
@@ -642,12 +664,23 @@ impl ForwardingProcessor {
             format!("{endpoint_url}/inbound")
         };
 
+        // A TSP forward is queued as base64url(qb2) text; send the decoded raw qb2
+        // so the remote mediator's ingress recognises the TSP magic byte. A DIDComm
+        // message is sent as-is. (DIDComm forwarding is unchanged.)
+        let (content_type, body): (&str, Vec<u8>) = match decode_tsp_forward(&msg.message) {
+            Some(qb2) => ("application/tsp", qb2),
+            None => (
+                "application/didcomm-encrypted+json",
+                msg.message.clone().into_bytes(),
+            ),
+        };
+
         let response = self
             .http_pool
             .client
             .post(&inbound_url)
-            .header("Content-Type", "application/didcomm-encrypted+json")
-            .body(msg.message.clone())
+            .header("Content-Type", content_type)
+            .body(body)
             .send()
             .await
             .map_err(|e| format!("Connection error to {inbound_url}: {e}"))?;
@@ -759,6 +792,28 @@ impl ForwardingProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- decode_tsp_forward tests ---
+
+    #[test]
+    fn decode_tsp_forward_recovers_qb2_and_passes_didcomm_through() {
+        use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+
+        // A TSP message (leads with the 0xD4 magic byte) queued as base64url(qb2).
+        let qb2 = [0xD4u8, 0x00, 0x05, 1, 2, 3, 4];
+        let queued = BASE64_URL_SAFE_NO_PAD.encode(qb2);
+        assert!(queued.starts_with("1AAF"), "qb64 envelope-code prefix");
+        assert_eq!(
+            decode_tsp_forward(&queued).as_deref(),
+            Some(&qb2[..]),
+            "a TSP forward decodes back to the exact qb2 bytes"
+        );
+
+        // DIDComm messages (JSON or compact) are not TSP — sent verbatim.
+        assert!(decode_tsp_forward("{\"protected\":\"...\"}").is_none());
+        assert!(decode_tsp_forward("eyJhbGciOiJ...").is_none());
+        assert!(decode_tsp_forward("").is_none());
+    }
 
     // --- http_to_ws_url tests ---
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -146,7 +146,7 @@ pub(crate) async fn handle_inbound_tsp(
                     remaining,
                     inner,
                 } if remaining.is_empty() => {
-                    deliver_opaque(state, session, &next, &meta.sender, &inner).await
+                    forward_to_next(state, session, &next, &meta.sender, &inner).await
                 }
                 // Intermediate hop: re-seal the onward route to the next hop,
                 // authenticating as this mediator, and forward.
@@ -175,7 +175,7 @@ pub(crate) async fn handle_inbound_tsp(
                         )
                     })?
                     .bytes;
-                    deliver_opaque(state, session, &next, &identity.vid, &resealed).await
+                    forward_to_next(state, session, &next, &identity.vid, &resealed).await
                 }
                 // Empty route: `inner` is sealed to its own final recipient —
                 // deliver by its (TSP) envelope.
@@ -301,6 +301,115 @@ async fn deliver_opaque(
 
     tracing::debug!(%to_vid, %from_vid, "TSP/bridged message stored for local recipient");
     store_message(state, session, &data, &UnpackMetadata::default()).await
+}
+
+/// Forward a relayed message to the next hop named in the route: deliver locally
+/// if it is a local account, otherwise enqueue it for delivery to the next hop's
+/// remote TSP endpoint.
+#[cfg(feature = "tsp")]
+async fn forward_to_next(
+    state: &SharedData,
+    session: &Session,
+    next: &str,
+    from_vid: &str,
+    bytes: &[u8],
+) -> Result<InboundMessageResponse, MediatorError> {
+    if state.database.account_exists(&digest(next.as_bytes())).await? {
+        deliver_opaque(state, session, next, from_vid, bytes).await
+    } else {
+        forward_tsp_remote(state, session, next, from_vid, bytes).await
+    }
+}
+
+/// Enqueue a relayed message for delivery to the next hop's **remote** TSP
+/// endpoint. The next hop's transport endpoint is read from its DID document
+/// (`TSPTransport` service); the message is queued (as base64url(qb2)) on the
+/// shared forwarding queue, and the forwarding processor POSTs the raw qb2 to the
+/// remote mediator's `/inbound`. A next hop that resolves back to this mediator is
+/// rejected as a loop.
+#[cfg(feature = "tsp")]
+async fn forward_tsp_remote(
+    state: &SharedData,
+    session: &Session,
+    next: &str,
+    from_vid: &str,
+    bytes: &[u8],
+) -> Result<InboundMessageResponse, MediatorError> {
+    use affinidi_messaging_mediator_common::store::types::ForwardQueueEntry;
+
+    let resolved = resolve_tsp_vid(state, next, &session.session_id).await?;
+    let endpoint_url = resolved
+        .endpoints
+        .first()
+        .map(|u| u.to_string())
+        .ok_or_else(|| {
+            tsp_problem(
+                session,
+                58,
+                "message.tsp.no_endpoint",
+                format!("next hop {next} publishes no TSP transport endpoint"),
+                StatusCode::NOT_FOUND,
+            )
+        })?;
+
+    // Loop guard: the next hop must not resolve back to this mediator.
+    if tsp_endpoint_is_self(&endpoint_url, &state.self_authorities) {
+        return Err(tsp_problem(
+            session,
+            94,
+            "protocol.forwarding.loop_detected",
+            format!("TSP next hop {next} resolves back to this mediator"),
+            StatusCode::LOOP_DETECTED,
+        ));
+    }
+
+    let entry = ForwardQueueEntry {
+        stream_id: String::new(),
+        message: BASE64_URL_SAFE_NO_PAD.encode(bytes),
+        to_did_hash: digest(next.as_bytes()),
+        from_did_hash: digest(from_vid.as_bytes()),
+        from_did: from_vid.to_string(),
+        to_did: next.to_string(),
+        endpoint_url: endpoint_url.clone(),
+        received_at_ms: state.clock.unix_millis(),
+        delay_milli: 0,
+        expires_at: state.clock.unix_secs() + state.config.limits.message_expiry_seconds,
+        retry_count: 0,
+        hop_count: 1,
+    };
+
+    state
+        .database
+        .forward_queue_enqueue(&entry, state.config.limits.forward_task_queue)
+        .await
+        .map_err(|e| {
+            tsp_problem(
+                session,
+                90,
+                "message.tsp.forward.enqueue",
+                format!("couldn't enqueue TSP message for remote forwarding: {e}"),
+                StatusCode::SERVICE_UNAVAILABLE,
+            )
+        })?;
+
+    tracing::info!(%next, %endpoint_url, "TSP message enqueued for remote forwarding");
+    Ok(InboundMessageResponse::Forwarded)
+}
+
+/// Whether `endpoint` resolves back to this mediator — the loop guard for remote
+/// TSP forwarding, mirroring the DIDComm forward path's self-detection.
+#[cfg(feature = "tsp")]
+fn tsp_endpoint_is_self(
+    endpoint: &str,
+    self_authorities: &std::collections::HashSet<(String, u16)>,
+) -> bool {
+    let Ok(url) = url::Url::parse(endpoint) else {
+        return false;
+    };
+    let (Some(host), Some(port)) = (url.host_str(), url.port_or_known_default()) else {
+        return false;
+    };
+    self_authorities.contains(&(host.to_lowercase(), port))
 }
 
 /// Resolve a DID-based TSP VID to its keys + endpoints.


### PR DESCRIPTION
## Summary

Completes TSP routing: a routed relay now forwards to a **remote** next hop on another mediator, integrated with the existing outbound forwarding queue/processor (the robust path you asked for).

### Mediator (`affinidi-messaging-mediator` 0.16.10 → 0.16.11)
- The relay's hop delivery now dispatches via **`forward_to_next`**: a **local** recipient is stored (`deliver_opaque`); a **remote** one is enqueued (`forward_tsp_remote`).
- `forward_tsp_remote` reads the next hop's **`TSPTransport`** endpoint from its DID document, **rejects a hop that resolves back to this mediator** (loop guard, mirroring the DIDComm forward path), and enqueues the message (`base64url(qb2)`) on the shared forwarding queue — returning `Forwarded`.

### mediator-common (`0.15.16`)
- The forwarding **processor** now delivers TSP forwards: `deliver_via_rest` decodes the queued `base64url(qb2)` back to **raw qb2** and POSTs with `Content-Type: application/tsp` so the remote mediator's ingress recognises the magic byte. TSP forwards always use REST (the WS relay path is DIDComm-text oriented).
- **DIDComm forwarding is unchanged** — a DIDComm message is not valid base64url of a TSP message, so it's sent verbatim.

## Tests
- **Processor unit test** (`decode_tsp_forward`): qb2 round-trip + DIDComm pass-through.
- The `forward_to_next` refactor is **regression-covered** by the 3 TSP e2e tests (Direct / Routed / Bridge — all exercise the local branch).
- **DIDComm `cross_mediator_forwarding` (6) passes** — confirms the processor change is safe for DIDComm.
- Default builds + clippy clean.

## Honest gap
A TSP-specific **two-mediator wire e2e** awaits `did:web` TSP-endpoint test fixtures: a `did:peer` doesn't surface a custom `TSPTransport` service to the resolver (a separate resolver/test-infra concern, not a forwarding-logic issue). The endpoint extraction itself is unit-tested in `affinidi-tsp` (for `did:web` docs), and the wire transport is the same processor proven by the DIDComm cross-mediator suite.

## This completes the TSP vision
TSP **Direct** + **client auth** + **routed relay** + **TSP↔DIDComm bridge** + **remote forwarding** — all implemented, DIDComm provably untouched.