### PR TITLE
fix: did:peer dropped non-DIDComm service types (unblocks TSP remote forwarding)

### DIFF
--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2026-06-23
+
+### Fixed
+
+- `did:peer` resolution dropped **non-DIDComm service types**:
+  `PeerService::to_did_service` hardcoded the resolved service type to
+  `DIDCommMessaging` regardless of the encoded `t` value, so a `did:peer` that
+  published e.g. a TSP transport endpoint resolved to a `DIDCommMessaging` service
+  and the original type was lost. The service type is now expanded properly: `dm`
+  → `DIDCommMessaging`, `tsp` → `TSPTransport`, and any other type is preserved
+  verbatim. Existing `dm` services are unchanged.
+
 ## [0.3.8] - 2026-06-22
 
 ### Fixed

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.8"
+version = "0.3.9"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-common/src/did_method/peer.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/peer.rs
@@ -367,9 +367,20 @@ impl PeerService {
             }
         };
 
+        // Expand the abbreviated did:peer service type. `dm` is the spec-defined
+        // abbreviation for `DIDCommMessaging`; we likewise treat `tsp` as
+        // `TSPTransport`. Any other value is preserved verbatim — previously every
+        // service type was silently rewritten to `DIDCommMessaging`, which dropped
+        // custom service entries (e.g. a TSP transport endpoint).
+        let type_ = match self.type_.as_str() {
+            "dm" => "DIDCommMessaging".to_string(),
+            "tsp" => "TSPTransport".to_string(),
+            other => other.to_string(),
+        };
+
         Ok(crate::service::Service {
             id: Some(id),
-            type_: vec!["DIDCommMessaging".to_string()],
+            type_: vec![type_],
             service_endpoint,
             property_set: HashMap::new(),
         })
@@ -605,6 +616,33 @@ mod tests {
         let did_svc = svc.to_did_service("did:peer:2abc", 0).unwrap();
         assert_eq!(did_svc.id.unwrap().as_str(), "did:peer:2abc#service");
         assert_eq!(did_svc.type_, vec!["DIDCommMessaging"]);
+    }
+
+    #[test]
+    fn to_did_service_expands_service_type() {
+        // `dm` → DIDCommMessaging, `tsp` → TSPTransport, and any other type is
+        // preserved verbatim (regression: every type was once forced to
+        // DIDCommMessaging, dropping custom service entries).
+        let svc = |t: &str| PeerService {
+            type_: t.to_string(),
+            endpoint: PeerServiceEndpoint::Uri("https://example.com".to_string()),
+            id: None,
+        };
+        assert_eq!(
+            svc("dm").to_did_service("did:peer:2abc", 0).unwrap().type_,
+            vec!["DIDCommMessaging"]
+        );
+        assert_eq!(
+            svc("tsp").to_did_service("did:peer:2abc", 0).unwrap().type_,
+            vec!["TSPTransport"]
+        );
+        assert_eq!(
+            svc("CustomType")
+                .to_did_service("did:peer:2abc", 0)
+                .unwrap()
+                .type_,
+            vec!["CustomType"]
+        );
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 23rd June 2026
 
+### 0.2.16 — TSP remote-forwarding e2e
+
+- New `tsp_routed_forwards_to_a_remote_recipients_mediator` test: the recipient
+  lives on another mediator (his `did:peer` advertises a `tsp` transport endpoint
+  elsewhere). The mediator resolves the remote endpoint and enqueues the message
+  for forwarding. Unblocked by the `affinidi-did-common` 0.3.9 fix to `did:peer`
+  custom-service-type resolution.
+
 ### 0.2.15 — TSP↔DIDComm bridge e2e
 
 - New `tsp_routed_bridges_a_didcomm_message_to_the_recipient` test: Alice authcrypts

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.15"
+version = "0.2.16"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -8,6 +8,7 @@
 use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_sdk::messages::fetch::FetchOptions;
 use affinidi_messaging_test_mediator::TestEnvironment;
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole, PeerService, PeerServiceEndpoint};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -190,4 +191,46 @@ async fn tsp_routed_bridges_a_didcomm_message_to_the_recipient() {
         Some(alice.did.as_str()),
         "DIDComm sender is recovered"
     );
+}
+
+/// End-to-end TSP **remote forwarding**: the final recipient lives on *another*
+/// mediator. Bob's `did:peer` advertises a TSP transport endpoint elsewhere (via
+/// a `tsp` service entry) and he is not a local account here. Alice routes a
+/// message through this mediator to Bob; the mediator resolves Bob's remote
+/// endpoint and enqueues the message for the forwarding processor to deliver over
+/// the wire (responding `Forwarded`). Exercises the did:peer `tsp` service
+/// resolution + the remote-forward enqueue path.
+#[tokio::test]
+async fn tsp_routed_forwards_to_a_remote_recipients_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let mediator_did = env.mediator.did().to_string();
+
+    // Bob lives on another mediator: his DID advertises a TSP transport endpoint
+    // there (a `tsp` service, which resolves to type `TSPTransport`), and he is
+    // not registered locally here.
+    let (bob_remote, _secrets) = DID::generate_did_peer_with_services(
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ],
+        Some(vec![PeerService {
+            type_: "tsp".into(),
+            endpoint: PeerServiceEndpoint::Uri("https://remote.example/".into()),
+            id: None,
+        }]),
+    )
+    .expect("generate bob's remote DID");
+
+    // Alice routes to Bob via this mediator → the mediator resolves Bob's remote
+    // TSP endpoint and enqueues the message for forwarding (HTTP 200 Forwarded).
+    let route = vec![mediator_did, bob_remote];
+    env.atm
+        .tsp()
+        .send_routed(&alice.profile, &route, b"forward me onward")
+        .await
+        .expect("mediator resolves the remote endpoint and enqueues the forward");
 }


### PR DESCRIPTION
## The bug

`did:peer` resolution silently rewrote **every** service type to `DIDCommMessaging`. `PeerService::decode` reads the encoded `t` value correctly, but `PeerService::to_did_service` then hardcoded the output:

```rust
type_: vec!["DIDCommMessaging".to_string()],   // ← ignored self.type_
```

So a `did:peer` publishing e.g. a TSP transport endpoint resolved to a `DIDCommMessaging` service and the original type was lost. This is exactly why, in #502, the resolver surfaced no `TSPTransport` endpoint and TSP **remote forwarding couldn't be tested end to end**.

## The fix

As you suspected: the `did:peer:2` spec only defines the `dm` abbreviation (`DIDCommMessaging`) — it says nothing about other service types. So expand the type properly and stop discarding it:

```rust
let type_ = match self.type_.as_str() {
    "dm"  => "DIDCommMessaging".to_string(),
    "tsp" => "TSPTransport".to_string(),   // short, consistent with `dm`
    other => other.to_string(),            // preserve any custom type
};
```

- `dm` → `DIDCommMessaging` (**unchanged** — existing services unaffected).
- `tsp` → `TSPTransport` (the short abbreviation, as you suggested).
- Any other type is **preserved verbatim** (the general fix — custom services were being dropped).

This flows through the whole resolver chain (`PeerResolver` → `DID` parse → `to_did_service`) to the SDK's `DidVidResolver`.

## Tests

- **`affinidi-did-common` 0.3.8 → 0.3.9**: new `to_did_service_expands_service_type` unit test (`dm`/`tsp`/custom); full lib suite (192) passes.
- **`affinidi-messaging-test-mediator` 0.2.15 → 0.2.16**: re-adds the **remote-forwarding e2e** test that #502 had to leave out — Bob's `did:peer` advertises a `tsp` endpoint elsewhere, and the mediator now resolves it and enqueues the forward. **All 4 TSP e2e tests pass.**
- **DIDComm regression intact**: `lifecycle` (22) + `cross_mediator_forwarding` (6) pass — `dm` services still resolve to `DIDCommMessaging`. Clippy clean.

This closes the one gap left in the TSP work: remote forwarding is now proven end to end, and a real general `did:peer` resolution bug is fixed along the way.