### PR TITLE
feat: tag message wire-protocol on pickup (unified, transparent fetch)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 23rd June 2026
 
+### 0.16.12 — Tag message protocol on pickup
+
+- The fetch, list, and outbound pickup endpoints now tag each returned message
+  with its wire `protocol` (DIDComm / TSP / …), detected server-side. A client can
+  just fetch its messages and route each one natively from the metadata, without
+  inspecting the body or caring which protocols exist over time. Unified,
+  transparent, future-proof. No change to which messages are returned (no
+  filtering, no Lua/store-schema change).
+
 ### 0.16.11 — TSP remote forwarding
 
 - A routed TSP relay now forwards to a **remote** next hop. When the next hop is

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.11"
+version = "0.16.12"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 23rd June 2026
 
+### 0.15.17 — Message protocol metadata
+
+- New `MessageProtocol` enum (`DidComm` / `Tsp` / `Other`, `#[non_exhaustive]`)
+  with `MessageProtocol::detect(&str)`, and a `protocol: Option<MessageProtocol>`
+  field on `MessageListElement` (with `MessageListElement::detect_protocol_in_place`).
+  Lets pickup responses carry each message's wire protocol so clients can fetch
+  their messages and route each natively without inspecting it — additive and
+  future-proof (new protocols don't break consumers).
+
+## 23rd June 2026
+
 ### 0.15.16 — Forwarding processor: TSP-aware delivery
 
 - The forwarding processor now delivers **TSP** forwards correctly. A TSP forward

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.16"
+version = "0.15.17"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/messages.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/messages.rs
@@ -10,6 +10,40 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+/// The wire protocol of a stored message.
+///
+/// Surfaced in fetch/pickup responses so a client can hand each message to the
+/// right handler without inspecting it itself — fetch your messages and let the
+/// metadata tell you what each one is. New protocols can be added over time
+/// without breaking consumers: it is `#[non_exhaustive]`, so match with a
+/// wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum MessageProtocol {
+    /// A DIDComm message (JWE / JWS).
+    DidComm,
+    /// A Trust Spanning Protocol message (CESR qb64).
+    Tsp,
+    /// An unrecognised or future protocol.
+    Other,
+}
+
+impl MessageProtocol {
+    /// Detect the protocol of a stored message from its on-the-wire form. TSP is
+    /// stored as CESR qb64 text (begins `1AAF`); a DIDComm JWE/JWS is JSON (`{`)
+    /// or compact (`ey`). Anything else is [`MessageProtocol::Other`].
+    pub fn detect(message: &str) -> Self {
+        if message.starts_with("1AAF") {
+            MessageProtocol::Tsp
+        } else if message.starts_with('{') || message.starts_with("ey") {
+            MessageProtocol::DidComm
+        } else {
+            MessageProtocol::Other
+        }
+    }
+}
+
 /// A list of messages stored for a given DID.
 ///
 /// - `msg_id`        : The unique identifier of the message
@@ -20,6 +54,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 /// - `to_address`    : Address the message was sent to
 /// - `from_address`  : Address the message was sent from (if applicable)
 /// - `msg`           : The message itself
+/// - `protocol`      : The detected wire protocol of `msg` (DIDComm, TSP, …)
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MessageListElement {
@@ -36,6 +71,16 @@ pub struct MessageListElement {
     pub from_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub msg: Option<String>,
+    /// The detected wire protocol of `msg`, set server-side on pickup so clients
+    /// don't have to inspect the message. `None` when there is no body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<MessageProtocol>,
+}
+impl MessageListElement {
+    /// Populate [`protocol`](Self::protocol) by detecting it from the message body.
+    pub fn detect_protocol_in_place(&mut self) {
+        self.protocol = self.msg.as_deref().map(MessageProtocol::detect);
+    }
 }
 impl GenericDataStruct for MessageListElement {}
 
@@ -119,5 +164,25 @@ impl Default for FetchOptions {
             start_id: None,
             delete_policy: FetchDeletePolicy::DoNotDelete,
         }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::MessageProtocol;
+
+    #[test]
+    fn detect_classifies_the_wire_protocol() {
+        // TSP is stored as CESR qb64 text (begins `1AAF`).
+        assert_eq!(MessageProtocol::detect("1AAFsomeqb64"), MessageProtocol::Tsp);
+        // DIDComm: JSON JWE or compact JWS/JWE.
+        assert_eq!(
+            MessageProtocol::detect(r#"{"protected":"..."}"#),
+            MessageProtocol::DidComm
+        );
+        assert_eq!(MessageProtocol::detect("eyJhbGciOiJ"), MessageProtocol::DidComm);
+        // Anything else is Other.
+        assert_eq!(MessageProtocol::detect("not a message"), MessageProtocol::Other);
+        assert_eq!(MessageProtocol::detect(""), MessageProtocol::Other);
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/inbox_fetch.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/inbox_fetch.rs
@@ -76,7 +76,7 @@ pub async fn inbox_fetch_handler(
             }
 
         // Fetch messages if possible
-        let results = state.database.fetch_messages(&session.session_id, &session.did_hash, &body).await.map_err(|e| {MediatorError::problem_with_log(
+        let mut results = state.database.fetch_messages(&session.session_id, &session.did_hash, &body).await.map_err(|e| {MediatorError::problem_with_log(
             14, session.session_id.clone(), None,
             ProblemReportSorter::Error, ProblemReportScope::Protocol,
             "me.res.storage.error",
@@ -84,6 +84,13 @@ pub async fn inbox_fetch_handler(
             vec![e.to_string()], StatusCode::SERVICE_UNAVAILABLE,
             format!("Database transaction error: {e}"),
         )})?;
+
+        // Tag each message's wire protocol (DIDComm / TSP / …) so the client can
+        // route it without inspecting the body itself.
+        results
+            .success
+            .iter_mut()
+            .for_each(|m| m.detect_protocol_in_place());
 
         Ok((
             StatusCode::OK,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_list.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_list.rs
@@ -83,7 +83,7 @@ pub async fn message_list_handler(
             .into());
         }
 
-        let messages = state
+        let mut messages = state
             .database
             .list_messages(
                 &did_hash,
@@ -92,6 +92,11 @@ pub async fn message_list_handler(
                 state.config.limits.listed_messages as u32,
             )
             .await?;
+
+        // Tag each message's wire protocol so the client can route it natively.
+        messages
+            .iter_mut()
+            .for_each(|m| m.detect_protocol_in_place());
 
         debug!("List contains ({}) messages", messages.len());
         Ok((

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
@@ -75,8 +75,10 @@ pub async fn message_outbound_handler(
         for msg_id in &body.message_ids {
             debug!("getting message with id: {}", msg_id);
             match state.database.get_message(&session.did_hash, msg_id).await {
-                Ok(Some(msg)) => {
+                Ok(Some(mut msg)) => {
                     debug!("Got message: {:?}", msg);
+                    // Tag the message's wire protocol so the client can route it.
+                    msg.detect_protocol_in_place();
                     messages.success.push(msg);
 
                     if body.delete {

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -550,6 +550,11 @@ impl MediatorStore for MemoryStore {
             to_address: Some(record.to_did_hash.clone()),
             from_address: record.from_did_hash.clone(),
             msg: Some(record.body.clone()),
+            protocol: Some(
+                affinidi_messaging_mediator_common::types::messages::MessageProtocol::detect(
+                    &record.body,
+                ),
+            ),
         }))
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.18] - 2026-06-23
+
+Re-exports `MessageProtocol` (from `affinidi-messaging-mediator-common`).
+Fetched messages now carry a `protocol` field (`Some(MessageProtocol::DidComm |
+Tsp | …)`), tagged server-side, so a client can route each message natively
+without inspecting it. Additive; patch bump.
+
 ## [0.18.17] - 2026-06-23
 
 `atm.tsp().send_routed_opaque(profile, route, inner)` — route an **already-packed**

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.17"
+version = "0.18.18"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/mod.rs
@@ -20,7 +20,7 @@ pub mod unpack;
 // paths working unchanged.
 pub use affinidi_messaging_mediator_common::types::messages::{
     FetchDeletePolicy, Folder, GenericDataStruct, GetMessagesResponse, MessageList,
-    MessageListElement,
+    MessageListElement, MessageProtocol,
 };
 
 pub trait MessageDelete<T> {

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 23rd June 2026
 
+### 0.2.17 — Assert message-protocol tagging
+
+- The Direct and bridge e2e tests now assert the fetched message's `protocol`
+  field (TSP and DIDComm respectively) — proving the mediator tags the wire
+  protocol on pickup transparently.
+
 ### 0.2.16 — TSP remote-forwarding e2e
 
 - New `tsp_routed_forwards_to_a_remote_recipients_mediator` test: the recipient

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.16"
+version = "0.2.17"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -6,6 +6,7 @@
 #![cfg(feature = "tsp")]
 
 use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::messages::MessageProtocol;
 use affinidi_messaging_sdk::messages::fetch::FetchOptions;
 use affinidi_messaging_test_mediator::TestEnvironment;
 use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole, PeerService, PeerServiceEndpoint};
@@ -51,6 +52,13 @@ async fn tsp_direct_message_round_trips_through_the_mediator() {
     assert!(
         env.atm.tsp().is_tsp(stored),
         "the stored message is recognised as TSP"
+    );
+    // The mediator tags the wire protocol on pickup, so the client doesn't have
+    // to inspect the body itself.
+    assert_eq!(
+        element.protocol,
+        Some(MessageProtocol::Tsp),
+        "fetch tags the message as TSP"
     );
     let (recovered, sender) = env
         .atm
@@ -174,6 +182,13 @@ async fn tsp_routed_bridges_a_didcomm_message_to_the_recipient() {
     assert!(
         !env.atm.tsp().is_tsp(stored),
         "the bridged inner is a DIDComm message, not TSP"
+    );
+    // And the mediator tags it as DIDComm on pickup — a unified fetch, with the
+    // protocol surfaced transparently in the metadata.
+    assert_eq!(
+        element.protocol,
+        Some(MessageProtocol::DidComm),
+        "fetch tags the bridged message as DIDComm"
     );
 
     let (received, _meta) = env


### PR DESCRIPTION
## Summary

"Just get me my messages." A client fetches its mailbox and gets every message — DIDComm *and* TSP — with each one's wire **protocol tagged in the metadata**, so it can route each natively without inspecting the body or caring which protocols come and go over time.

This is the per-protocol pickup work (L5), done the way you asked: **server-side, transparent, future-proof** — and notably it does **not** touch the delicate message store (no Lua change, no filtering, no change to which messages return).

### mediator-common (0.15.16 → 0.15.17)
- New **`MessageProtocol`** enum — `DidComm` / `Tsp` / `Other`, **`#[non_exhaustive]`** so new protocols never break consumers — with **`MessageProtocol::detect(&str)`** (sniffs the stored form: TSP qb64 `1AAF`, DIDComm JWE/JWS `{`/`ey`).
- New **`protocol: Option<MessageProtocol>`** field on `MessageListElement` (serde-default, additive) + `detect_protocol_in_place()`.

### mediator (0.16.11 → 0.16.12)
- The **fetch**, **list**, and **outbound** pickup endpoints tag each returned message's protocol server-side. No filtering — the unified fetch still returns everything; it's just labelled now.

### sdk (0.18.17 → 0.18.18)
- Re-exports `MessageProtocol`; fetched messages carry `.protocol`.

## Why server-side + sniff (not a filter, not separate queues)
Protocol is cheaply derivable from the stored bytes, so tagging needs **no schema change, no Redis Lua change, no migration, and no change to delete-on-pickup semantics** — exactly the production-store sensitivity we've protected all along. And `#[non_exhaustive]` + a sniff means adding a future protocol is a one-line `detect` change with zero consumer breakage.

## Tests
- `MessageProtocol::detect` unit test (TSP / DIDComm / Other).
- The Direct e2e asserts the fetched `protocol == Tsp`; the bridge e2e asserts `protocol == DidComm` — proving the server tags both transparently through a normal fetch (4 TSP e2e green).
- DIDComm regression (`lifecycle` 22) intact; clippy clean.

Note: the WebSocket live-stream delivers raw message strings (a client sniffs there via `atm.tsp().is_tsp`); tagging that push path would change the WS frame format and is a separate follow-up. The explicit "fetch my messages" endpoints are all covered.