### PR TITLE
fix: don't drop TSP messages on the WebSocket live-stream

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.19] - 2026-06-23
+
+WebSocket live-stream is now TSP-safe. An inbound frame is sniffed (the frame is
+self-describing CESR qb64); a TSP message is delivered **packed** — so the
+consumer unpacks it via `atm.tsp()` — instead of being routed into the DIDComm
+`unpack`, where it previously failed and was silently dropped. DIDComm frames are
+unchanged, and the sniff is gated on the `tsp` feature (no-op without it).
+
 ## [0.18.18] - 2026-06-23
 
 Re-exports `MessageProtocol` (from `affinidi-messaging-mediator-common`).

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.18"
+version = "0.18.19"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -455,8 +455,17 @@ impl WebSocketTransport {
     async fn process_inbound_didcomm_message(&mut self, atm: &ATM, message: String) {
         debug!("Received text message ({})", message);
 
+        // A TSP message can't be DIDComm-unpacked. The live-stream frame is
+        // self-describing (CESR qb64), so sniff it and deliver TSP frames packed
+        // — the consumer unpacks them via `atm.tsp()`. Without this a TSP frame
+        // would fail the DIDComm `unpack` below and be silently dropped.
+        #[cfg(feature = "tsp")]
+        let force_packed = atm.tsp().is_tsp(&message);
+        #[cfg(not(feature = "tsp"))]
+        let force_packed = false;
+
         // If skip_unpack_messages is true, send the packed message directly
-        if self.skip_unpack_messages {
+        if self.skip_unpack_messages || force_packed {
             // for packed messages skip cache lookup
             if let Some(next_request) = self.next_requests_list.pop_front() {
                 debug!("Next message found, sending to requestor packed");


### PR DESCRIPTION
## Summary

Makes the SDK's WebSocket live-stream **TSP-safe**, the compat-safe way (no frame-format change, no breaking the existing DIDComm WS protocol).

**The bug:** every inbound WS frame was fed straight into `atm.unpack` (DIDComm). A TSP message — stored/delivered as CESR qb64, which can't be DIDComm-unpacked — failed that call and was **silently dropped** (just a logged error).

**The fix:** the frame is self-describing, so sniff it (`atm.tsp().is_tsp`). A TSP frame is delivered **packed** — routed to the same `PackedMessageReceived` path that `skip_unpack` mode already uses — so the consumer unpacks it via `atm.tsp()`. No more drops.

```rust
#[cfg(feature = "tsp")]
let force_packed = atm.tsp().is_tsp(&message);
// …
if self.skip_unpack_messages || force_packed { /* deliver packed */ }
```

## Why this shape
This is the "SDK sniffs the frame" approach: deterministic, **no mediator change, no WS frame-format change, no break to existing DIDComm WS clients**. (A server-side frame envelope would break every existing client for no functional gain, since the message is already self-describing.)

## Scope / follow-up
`live_stream_next`/`live_stream_get` return a DIDComm-typed `Message`, so a *typed* TSP live-stream consumer API is a larger future enhancement. This fix is the essential correctness piece: TSP frames now **survive** the WS path and reach packed/direct-channel consumers instead of being lost. Fetch-based pickup remains the primary, fully-tagged TSP delivery path.

## Tests
- SDK default + `tsp` builds + clippy clean.
- DIDComm WS regression (`local_did_websocket`) passes — the sniff is gated on `tsp` and is a **no-op** for non-`tsp` builds, so the DIDComm WS path is byte-identical.

Patch bump 0.18.18 → 0.18.19.