### PR TITLE
feat: mediator consumes Trust Task documents (PR-T1: messaging/ping)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## 23rd June 2026
 
+### 0.16.13 — Trust Tasks consumer (ping)
+
+- The mediator now consumes **Trust Task** documents carried over the DIDComm
+  binding envelope (`https://trusttasks.org/binding/didcomm/0.1/envelope`), via
+  the `trust-tasks-rs` `consume_inbound` pipeline. This is the foundation of the
+  messaging Trust Tasks migration (single core; per-task handlers will delegate to
+  the same `state.database.*` methods the legacy DIDComm protocols use).
+- First task wired: **`messaging/ping`** — returns `server_time`, `ok` status, and
+  the supported `protocols`, echoing the request nonce. The response is packed back
+  through the existing outbound path (like the trust-ping pong). Account / ACL /
+  access-list follow. Existing DIDComm protocols are untouched.
+
 ### 0.16.12 — Tag message protocol on pickup
 
 - The fetch, list, and outbound pickup endpoints now tag each returned message

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.12"
+version = "0.16.13"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -39,7 +39,7 @@ memory-backend = []
 ## At least one of `didcomm` or `tsp` must be enabled (see the `compile_error!`
 ## in `lib.rs`); the two are NOT mutually exclusive — they are designed to run
 ## together (`--features didcomm,tsp`), which is the dual-protocol deployment.
-didcomm = ["dep:affinidi-messaging-didcomm", "dep:affinidi-encoding", "dep:affinidi-crypto"]
+didcomm = ["dep:affinidi-messaging-didcomm", "dep:affinidi-encoding", "dep:affinidi-crypto", "dep:trust-tasks-rs"]
 
 ## TSP (Trust Spanning Protocol) — additive alongside DIDComm.
 ## EXPERIMENTAL: TSP message handling is still being built; a `tsp`-only build
@@ -66,6 +66,9 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
+## Trust Tasks framework core — consumes Trust Task documents (the messaging
+## ping / account / acl / access-list tasks) carried over the binding envelope.
+trust-tasks-rs = { version = "0.2", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "didcomm")]
 use self::protocols::ping;
 #[cfg(feature = "didcomm")]
+use self::protocols::trust_tasks;
+#[cfg(feature = "didcomm")]
 use crate::didcomm_compat;
 #[cfg(feature = "didcomm")]
 use crate::messages::protocols::discover_features;
@@ -68,6 +70,9 @@ impl MessageType {
                 acls::process(message, state, session, metadata).await
             }
             SDKMessageType::TrustPing => ping::process(message, session, state.clock.unix_secs()),
+            SDKMessageType::TrustTaskEnvelope => {
+                trust_tasks::process(message, state, session, metadata).await
+            }
             SDKMessageType::MessagePickupStatusRequest => {
                 message_pickup::status_request(message, state, session).await
             }

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod mediator;
 pub mod message_pickup;
 pub mod ping;
 pub mod routing;
+pub mod trust_tasks;

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -1,0 +1,262 @@
+//! Trust Tasks framework consumer — handles inbound [Trust Task] documents
+//! carried over the DIDComm binding envelope.
+//!
+//! A Trust Task request arrives as a DIDComm message whose `type` is the binding
+//! envelope URI and whose `body` is the full `TrustTask<P>` document. This module
+//! is the *single core*: it runs the framework's `consume_inbound` pipeline and
+//! the per-task handlers (which delegate to the same `state.database.*` methods
+//! the legacy DIDComm protocols use). The response is a `TrustTask<R>` packed back
+//! through the mediator's existing outbound path — exactly like the trust-ping
+//! pong — so no separate binding/agent plumbing is needed here.
+//!
+//! This first cut handles `messaging/ping`; account / acl / access-list follow.
+//!
+//! [Trust Task]: https://trusttasks.org
+
+use affinidi_messaging_didcomm::message::Message;
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
+use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
+use http::StatusCode;
+use serde_json::Value;
+use std::str::FromStr;
+use trust_tasks_rs::specs::messaging::ping;
+use trust_tasks_rs::{
+    ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
+    TrustTask, TypeUri, VerificationError, consume_inbound,
+};
+use uuid::Uuid;
+
+use crate::SharedData;
+use crate::common::session::Session;
+use crate::messages::{ProcessMessageResponse, WrapperType};
+
+/// DIDComm `type` URI of a Trust Tasks binding envelope.
+pub const ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+/// Stable identifier for this transport binding.
+const BINDING_URI: &str = "https://trusttasks.org/binding/didcomm/0.1";
+
+/// The mediator's [`TransportHandler`] for one inbound exchange. The DIDComm
+/// layer already verified the sender, so the framework's transport-authenticated
+/// `issuer` is that DID and the `recipient` is the mediator.
+struct MediatorTransport {
+    mediator_did: String,
+    sender_did: String,
+}
+
+impl TransportHandler for MediatorTransport {
+    fn binding_uri(&self) -> &str {
+        BINDING_URI
+    }
+
+    fn derive_parties(&self) -> TransportContext {
+        TransportContext {
+            issuer: Some(self.sender_did.clone()),
+            recipient: Some(self.mediator_did.clone()),
+        }
+    }
+}
+
+/// No-op proof verifier — the management tasks are transport-authenticated, so
+/// the consume pipeline runs with [`ProofPolicy::AcceptUnverified`] and this is
+/// never invoked; it only satisfies the type parameter.
+struct NoProof;
+
+#[async_trait::async_trait]
+impl ProofVerifier for NoProof {
+    async fn verify<P>(&self, _doc: &TrustTask<P>) -> Result<(), VerificationError>
+    where
+        P: serde::Serialize + Send + Sync,
+    {
+        Ok(())
+    }
+}
+
+/// Consume an inbound Trust Tasks envelope and produce the response.
+pub(crate) async fn process(
+    message: &Message,
+    state: &SharedData,
+    session: &Session,
+    metadata: &UnpackMetadata,
+) -> Result<ProcessMessageResponse, MediatorError> {
+    let mediator_did = state.config.mediator_did.clone();
+
+    // The DIDComm-verified sender (prefer the JWS signer, fall back to the
+    // authcrypt sender), stripped of its key fragment → the framework VID.
+    let sender_kid = metadata
+        .sign_from
+        .clone()
+        .or_else(|| metadata.encrypted_from_kid.clone())
+        .ok_or_else(|| {
+            tt_problem(
+                session,
+                "message.trust_task.unauthenticated",
+                "Trust Task envelopes require an authenticated sender".into(),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+    let sender_did = sender_kid
+        .split('#')
+        .next()
+        .unwrap_or(&sender_kid)
+        .to_string();
+
+    // The body is the full TrustTask document.
+    let doc: TrustTask<Value> = serde_json::from_value(message.body.clone()).map_err(|e| {
+        tt_problem(
+            session,
+            "message.trust_task.malformed",
+            format!("body is not a Trust Task document: {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    let now_secs = state.clock.unix_secs();
+    let now = chrono::DateTime::from_timestamp(now_secs as i64, 0).unwrap_or_else(chrono::Utc::now);
+
+    // Route by task type. (PR-T1: ping only; the account/acl/access-list families
+    // extend this match.)
+    let ping_type =
+        TypeUri::from_str(<ping::v0_1::Payload as Payload>::TYPE_URI).expect("valid const type URI");
+
+    let response_value: Value = if doc.type_uri == ping_type {
+        let typed: TrustTask<ping::v0_1::Payload> =
+            serde_json::from_value(serde_json::to_value(&doc).map_err(serialize_err)?)
+                .map_err(|e| {
+                    tt_problem(
+                        session,
+                        "message.trust_task.malformed",
+                        format!("not a valid ping payload: {e}"),
+                        StatusCode::BAD_REQUEST,
+                    )
+                })?;
+
+        match consume_ping(typed, &mediator_did, &sender_did, now).await? {
+            Some(value) => value,
+            // identity_mismatch with no transport sender → emit nothing.
+            None => return Ok(ProcessMessageResponse::default()),
+        }
+    } else {
+        return Err(tt_problem(
+            session,
+            "protocol.trust_task.unsupported",
+            format!("unsupported Trust Task type: {}", doc.type_uri),
+            StatusCode::NOT_IMPLEMENTED,
+        ));
+    };
+
+    // Pack the response back through the mediator's existing outbound path.
+    let response_msg = Message::build(Uuid::new_v4().to_string(), ENVELOPE_TYPE.to_string(), response_value)
+        .to(sender_did)
+        .from(mediator_did)
+        .created_time(now_secs)
+        .expires_time(now_secs + 300)
+        .finalize();
+
+    Ok(ProcessMessageResponse {
+        store_message: true,
+        force_live_delivery: false,
+        data: WrapperType::Message(Box::new(response_msg)),
+        forward_message: false,
+    })
+}
+
+fn tt_problem(
+    session: &Session,
+    code: &str,
+    message: String,
+    status: StatusCode,
+) -> MediatorError {
+    MediatorError::problem(
+        37,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Protocol,
+        code,
+        &message,
+        vec![],
+        status,
+    )
+}
+
+fn serialize_err(e: serde_json::Error) -> MediatorError {
+    MediatorError::InternalError(
+        14,
+        "NA".to_string(),
+        format!("couldn't serialise Trust Task response: {e}"),
+    )
+}
+
+/// Run the `ping` task through the framework's consume pipeline, returning the
+/// response document as JSON (`None` when the framework suppresses the response).
+async fn consume_ping(
+    doc: TrustTask<ping::v0_1::Payload>,
+    mediator_did: &str,
+    sender_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<Value>, MediatorError> {
+    let transport = MediatorTransport {
+        mediator_did: mediator_did.to_string(),
+        sender_did: sender_did.to_string(),
+    };
+    let outcome = consume_inbound(
+        &transport,
+        ProofPolicy::<NoProof>::AcceptUnverified,
+        doc,
+        mediator_did,
+        now,
+        || Uuid::new_v4().to_string(),
+        |req, _parties| async move {
+            let response = ping::v0_1::Response {
+                ext: None,
+                nonce: req.payload.nonce.clone(),
+                protocols: vec!["didcomm".to_string(), "tsp".to_string()],
+                server_time: now,
+                status: ping::v0_1::ResponseStatus::Ok,
+            };
+            Ok(req.respond_with(Uuid::new_v4().to_string(), response))
+        },
+    )
+    .await;
+
+    Ok(match outcome {
+        ConsumeOutcome::Handled(resp) => Some(serde_json::to_value(&resp).map_err(serialize_err)?),
+        ConsumeOutcome::Rejected(err) => Some(serde_json::to_value(&err).map_err(serialize_err)?),
+        ConsumeOutcome::Suppressed => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trust_tasks_rs::TrustTask;
+
+    #[tokio::test]
+    async fn ping_consume_returns_ok_and_echoes_nonce() {
+        let mut doc = TrustTask::for_payload(
+            "urn:uuid:ping-1",
+            ping::v0_1::Payload {
+                nonce: Some("nonce-xyz".to_string()),
+                ext: None,
+            },
+        );
+        doc.issuer = Some("did:example:alice".to_string());
+        doc.recipient = Some("did:example:mediator".to_string());
+
+        let value =
+            consume_ping(doc, "did:example:mediator", "did:example:alice", chrono::Utc::now())
+                .await
+                .expect("consume ok")
+                .expect("a response, not suppressed");
+
+        let resp: TrustTask<ping::v0_1::Response> =
+            serde_json::from_value(value).expect("ping response document");
+        assert!(matches!(resp.payload.status, ping::v0_1::ResponseStatus::Ok));
+        assert_eq!(resp.payload.nonce.as_deref(), Some("nonce-xyz"));
+        assert!(resp.payload.protocols.iter().any(|p| p == "tsp"));
+        // respond_with swaps the parties: the mediator answers alice.
+        assert_eq!(resp.issuer.as_deref(), Some("did:example:mediator"));
+        assert_eq!(resp.recipient.as_deref(), Some("did:example:alice"));
+    }
+}

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.20] - 2026-06-23
+
+`MessageType` gains a `TrustTaskEnvelope` variant (the Trust Tasks DIDComm binding
+envelope `type`), so the mediator can route Trust Task documents. Additive
+scaffolding for the messaging Trust Tasks migration; no API change. The deliberate
+minor bump that signals the migration's breaking client changes lands with
+`atm.trust_tasks()` (next).
+
 ## [0.18.19] - 2026-06-23
 
 WebSocket live-stream is now TSP-safe. An inbound frame is sniffed (the frame is

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.19"
+version = "0.18.20"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/known.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/known.rs
@@ -17,6 +17,7 @@ pub enum MessageType {
     MessagePickupLiveDeliveryChange, // Message Pickup 3.0 Live-delivery-change (Streaming enabled)
     ProblemReport,                   // Problem Report Protocol
     TrustPing,                       // Trust Ping Protocol
+    TrustTaskEnvelope,               // Trust Tasks framework — DIDComm binding envelope
     DiscoverFeaturesQueries,         // Discover Features 2.0 Protocol - Queries
     DiscoverFeaturesDisclose,        // Discover Features 2.0 Protocol - Disclose
     Other(String),                   // Other message type
@@ -28,6 +29,7 @@ impl FromStr for MessageType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "https://didcomm.org/trust-ping/2.0/ping" => Ok(Self::TrustPing),
+            "https://trusttasks.org/binding/didcomm/0.1/envelope" => Ok(Self::TrustTaskEnvelope),
             "https://affinidi.com/atm/1.0/authenticate" => Ok(Self::AffinidiAuthenticate),
             "https://affinidi.com/atm/1.0/authenticate/refresh" => {
                 Ok(Self::AffinidiAuthenticateRefresh)


### PR DESCRIPTION
## Summary

The first step of wiring the messaging **Trust Tasks** into `affinidi-messaging` — the deferred "implement against the reference" half (the Trust Tasks were *defined* in #96/#97 but the SDK + mediator never used them). Per the reviewed [SDD](../blob/main/tasks/trust-tasks-messaging-sdd.md), this lands the **single consume core** the rest of the migration builds on.

The mediator now accepts a Trust Task document carried over the DIDComm binding envelope (`https://trusttasks.org/binding/didcomm/0.1/envelope`) and runs it through `trust-tasks-rs::consume_inbound`. First task wired: **`messaging/ping`**.

### Mediator (0.16.12 → 0.16.13)
- New `protocols/trust_tasks.rs`:
  - Builds its **own** tiny `TransportHandler` from the DIDComm-verified sender — so it does **not** depend on `trust-tasks-didcomm` and avoids a second `affinidi-messaging-didcomm` copy.
  - Parses the `TrustTask` from the message body, runs `consume_inbound` (with `ProofPolicy::AcceptUnverified` — transport-authenticated), and the ping handler returns `server_time` + `ok` status + `protocols` + nonce echo.
  - Packs the `TrustTask<Response>` back **through the existing outbound path** (a `Message` + `ProcessMessageResponse`, exactly like the trust-ping pong) — no new packing/agent machinery.
- Dispatch wired in `messages/mod.rs`. The type match extends to account / ACL / access-list next.

### SDK (0.18.19 → 0.18.20)
- `MessageType` gains `TrustTaskEnvelope` (the binding envelope `type`). Additive scaffolding; the deliberate **minor** bump that signals the breaking client API lands with `atm.trust_tasks()` + legacy routing (PR-T2).

## Dependency note
Depends on **`trust-tasks-rs 0.2.9`** — republished via trust-tasks **#98** because #96 added the messaging specs without a version bump, so the published 0.2.8 didn't contain them.

## Tests
- `ping_consume` unit test: `Ok` status, nonce echoed, party-swap on the response.
- Mediator lib + clippy clean; **DIDComm regression (`lifecycle` 22) green** — existing protocols untouched.

## Next
PR-T2: `atm.trust_tasks().ping()` SDK client + the full SDK→mediator→SDK e2e (the deliberate minor bump). Then account / acl / access-list (PR-T3/4/5), then the admin Trust Task specs + migration.