### PR TITLE
feat: SDK trust_tasks().ping() + full e2e (PR-T2)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 23rd June 2026
 
+### 0.16.14 — Trust Tasks response threading
+
+- The Trust Tasks consumer now threads its response to the request (`thid`), so a
+  caller's live-stream correlates the reply by thread id — the round-trip the SDK's
+  `atm.trust_tasks().ping()` relies on.
+
 ### 0.16.13 — Trust Tasks consumer (ping)
 
 - The mediator now consumes **Trust Task** documents carried over the DIDComm

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.13"
+version = "0.16.14"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -146,12 +146,15 @@ pub(crate) async fn process(
     };
 
     // Pack the response back through the mediator's existing outbound path.
-    let response_msg = Message::build(Uuid::new_v4().to_string(), ENVELOPE_TYPE.to_string(), response_value)
-        .to(sender_did)
-        .from(mediator_did)
-        .created_time(now_secs)
-        .expires_time(now_secs + 300)
-        .finalize();
+    // `thid` threads it to the request so the caller's live-stream correlates it.
+    let response_msg =
+        Message::build(Uuid::new_v4().to_string(), ENVELOPE_TYPE.to_string(), response_value)
+            .thid(message.id.clone())
+            .to(sender_did)
+            .from(mediator_did)
+            .created_time(now_secs)
+            .expires_time(now_secs + 300)
+            .finalize();
 
     Ok(ProcessMessageResponse {
         store_message: true,

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.21] - 2026-06-23
+
+New `atm.trust_tasks()` accessor with `.ping(profile, nonce)` — sends a
+`messaging/ping` Trust Task to the mediator (over the DIDComm binding envelope) and
+returns the typed `ping` response (server time, status, supported protocols, echoed
+nonce). Additive — the first of the messaging Trust Tasks client surface; account /
+acl / access-list follow, and the legacy `atm.mediator()` / `atm.trust_ping()`
+methods will route through this core (the breaking change that lands then is
+signalled by a minor bump).
+
 ## [0.18.20] - 2026-06-23
 
 `MessageType` gains a `TrustTaskEnvelope` variant (the Trust Tasks DIDComm binding

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.20"
+version = "0.18.21"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -24,6 +24,9 @@ tsp = ["dep:affinidi-tsp"]
 affinidi-tdk-common = "0.6"
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
+## Trust Tasks framework — typed request/response documents for the messaging
+## tasks (ping / account / acl / access-list), carried over the binding envelope.
+trust-tasks-rs = "0.2"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Source of truth for the mediator protocol vocabulary (ACLs, accounts,

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -182,7 +182,7 @@
 use crate::protocols::{
     discover_features::DiscoverfeaturesOps, mediator::administration::MediatorOps,
     message_pickup::MessagePickupOps, oob_discovery::OOBDiscoveryOps, routing::RoutingOps,
-    trust_ping::TrustPingOps,
+    trust_ping::TrustPingOps, trust_tasks::TrustTasksOps,
 };
 #[cfg(feature = "tsp")]
 use crate::protocols::tsp::TspOps;
@@ -313,6 +313,12 @@ impl ATM {
     /// Access Trust Ping protocol methods
     pub fn trust_ping(&self) -> TrustPingOps<'_> {
         TrustPingOps { atm: self }
+    }
+
+    /// Access Trust Tasks protocol methods (the messaging tasks: ping, account,
+    /// acl, access-list — carried over the framework binding envelope).
+    pub fn trust_tasks(&self) -> TrustTasksOps<'_> {
+        TrustTasksOps { atm: self }
     }
 
     /// Access Message Pickup 3.0 protocol methods

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
@@ -33,6 +33,7 @@ pub mod routing;
 #[cfg(feature = "tsp")]
 pub mod tsp;
 pub mod trust_ping;
+pub mod trust_tasks;
 
 // `String` implements `GenericDataStruct` via an impl in
 // `affinidi-messaging-mediator-common::types::messages` — the orphan

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -1,0 +1,91 @@
+//! Trust Tasks client — send the messaging [Trust Tasks] to a mediator and get
+//! the typed response.
+//!
+//! Accessed via [`crate::ATM::trust_tasks`]. Each task is a typed `TrustTask<P>`
+//! document carried over the DIDComm binding envelope (a DIDComm message whose
+//! `type` is the [`ENVELOPE_TYPE`] and whose `body` is the document). The mediator
+//! consumes it through the Trust Tasks framework and returns a `TrustTask<R>`.
+//!
+//! This first cut exposes `ping`; account / acl / access-list follow, and the
+//! legacy `atm.mediator()` / `atm.trust_ping()` methods will route through this
+//! same core.
+//!
+//! [Trust Tasks]: https://trusttasks.org
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use affinidi_messaging_didcomm::message::Message;
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::messaging::ping;
+use uuid::Uuid;
+
+use crate::{ATM, errors::ATMError, profiles::ATMProfile, transports::SendMessageResponse};
+
+/// DIDComm `type` URI of a Trust Tasks binding envelope.
+pub const ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
+/// Trust Tasks client operations, obtained from [`crate::ATM::trust_tasks`].
+pub struct TrustTasksOps<'a> {
+    pub(crate) atm: &'a ATM,
+}
+
+impl TrustTasksOps<'_> {
+    /// Send a `messaging/ping` Trust Task to the mediator and return its response
+    /// (server time, status, and the protocols the mediator supports). An optional
+    /// `nonce` is echoed back, letting the caller correlate the reply.
+    pub async fn ping(
+        &self,
+        profile: &Arc<ATMProfile>,
+        nonce: Option<String>,
+    ) -> Result<ping::v0_1::Response, ATMError> {
+        let atm = self.atm;
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        // Build the Trust Task document (in-band parties: me → the mediator).
+        let mut task = TrustTask::for_payload(
+            format!("urn:uuid:{}", Uuid::new_v4()),
+            ping::v0_1::Payload { ext: None, nonce },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let body = serde_json::to_value(&task)
+            .map_err(|e| ATMError::MsgSendError(format!("couldn't serialise ping Trust Task: {e}")))?;
+
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        // Wrap it in the DIDComm binding envelope and authcrypt it to the mediator.
+        let msg = Message::build(Uuid::new_v4().to_string(), ENVELOPE_TYPE.to_string(), body)
+            .to(mediator_did.into())
+            .from(profile_did.into())
+            .created_time(now)
+            .expires_time(now + 10)
+            .finalize();
+        let msg_id = msg.id.clone();
+
+        let (packed, _) = atm
+            .inner
+            .pack_encrypted(&msg, mediator_did, Some(profile_did))
+            .await
+            .map_err(|e| ATMError::MsgSendError(format!("couldn't pack ping Trust Task: {e}")))?;
+
+        match atm.send_message(profile, &packed, &msg_id, true, true).await? {
+            SendMessageResponse::Message(response) => {
+                let doc: TrustTask<ping::v0_1::Response> =
+                    serde_json::from_value(response.body.clone()).map_err(|e| {
+                        ATMError::MsgReceiveError(format!(
+                            "ping response is not a Trust Task document: {e}"
+                        ))
+                    })?;
+                Ok(doc.payload)
+            }
+            _ => Err(ATMError::MsgReceiveError(
+                "no response from mediator for the ping Trust Task".to_owned(),
+            )),
+        }
+    }
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 23rd June 2026
 
+### 0.2.18 — Trust Tasks ping e2e
+
+- New `trust_tasks` integration test: `atm.trust_tasks().ping()` round-trips through
+  a live mediator (SDK → DIDComm binding envelope → the mediator's Trust Tasks
+  consumer → typed response), asserting status, nonce echo, and advertised protocols.
+
 ### 0.2.17 — Assert message-protocol tagging
 
 - The Direct and bridge e2e tests now assert the fetched message's `protocol`

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.17"
+version = "0.2.18"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -1,0 +1,46 @@
+//! End-to-end Trust Tasks round-trip: the SDK sends a `messaging/ping` Trust Task
+//! to a live mediator over the DIDComm binding envelope; the mediator consumes it
+//! through the Trust Tasks framework and returns a typed `ping` response.
+//!
+//! Exercises the whole path — `atm.trust_tasks().ping()` → pack + `/inbound` →
+//! the mediator's `trust_tasks` consumer → response → the SDK's typed reply — over
+//! a real in-process HTTP mediator (memory backend, no Redis).
+
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+#[tokio::test]
+async fn ping_trust_task_round_trips_through_the_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    // Enable the WebSocket live-stream so the synchronous request/response
+    // (`send_message` with wait) can correlate the reply by thread id.
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    let response = env
+        .atm
+        .trust_tasks()
+        .ping(&alice.profile, Some("nonce-42".to_string()))
+        .await
+        .expect("alice pings the mediator via a Trust Task");
+
+    // The mediator reports healthy, echoes the nonce, and advertises the protocols
+    // it speaks — all from the typed response, no message inspection by the caller.
+    assert_eq!(response.status.to_string(), "ok");
+    assert_eq!(response.nonce.as_deref(), Some("nonce-42"));
+    assert!(
+        response.protocols.iter().any(|p| p == "didcomm"),
+        "advertises DIDComm: {:?}",
+        response.protocols
+    );
+    assert!(
+        response.protocols.iter().any(|p| p == "tsp"),
+        "advertises TSP: {:?}",
+        response.protocols
+    );
+}


### PR DESCRIPTION
## Summary

Proves the messaging **Trust Tasks** round-trip end to end: the SDK sends a `ping` Trust Task to a live mediator and gets the **typed response** back. This builds on the mediator consumer from PR-T1 (#506).

### SDK (0.18.20 → 0.18.21)
- New **`atm.trust_tasks()`** accessor + **`.ping(profile, nonce)`**. It builds a `TrustTask<ping::Payload>`, wraps it in the DIDComm binding envelope (a `Message` typed as the envelope, `body` = the document), authcrypts + sends it to the mediator, and returns the typed `ping::Response` (server time, `ok` status, supported protocols, echoed nonce) from the reply.
- Additive — the first of the messaging Trust Tasks client surface. account / acl / access-list follow, and the legacy `atm.mediator()` / `atm.trust_ping()` methods will route through this core (the breaking change that lands then gets the minor bump).

### Mediator (0.16.13 → 0.16.14)
- The Trust Tasks response now threads to the request (**`thid`**), so the caller's live-stream correlates the reply by thread id — a gap the e2e surfaced in PR-T1's response packing.

### test-mediator (0.2.17 → 0.2.18)
- New **`trust_tasks` e2e**: alice pings a live mediator and asserts `status = ok`, the nonce echo, and the advertised protocols (`didcomm` + `tsp`). (Uses a WebSocket-connected profile — the supported synchronous request/response path.)

## Tests
- Ping e2e green (SDK → real mediator → typed response).
- Mediator ping unit test + clippy (mediator + SDK) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
PR-T3/4/5: the **account / acl / access-list** families (mediator handlers delegating to the existing `state.database.*`; SDK methods), then routing the legacy `atm.mediator()` through the Trust Tasks core (the minor bump), then the admin Trust Task specs + migration.