### PR TITLE
feat: Trust Tasks account/get (PR-T3)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 24th June 2026
 
+### 0.16.16 — Trust Tasks: account/list
+
+- The Trust Tasks consumer now handles `messaging/account/list` (admin-only): it
+  pages `state.database.account_list`, maps each `Account` to the wire shape (reusing
+  the `account/get` mapping), and encodes the store's numeric cursor as the spec's
+  opaque `next_cursor` (omitted when the listing is exhausted). Non-admins are
+  refused.
+
 ### 0.16.15 — Trust Tasks: account/get
 
 - The Trust Tasks consumer now handles `messaging/account/get` (self-or-admin,

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 24th June 2026
+
+### 0.16.15 — Trust Tasks: account/get
+
+- The Trust Tasks consumer now handles `messaging/account/get` (self-or-admin,
+  read-only): it authorizes via the existing `check_permissions`, reads
+  `state.database.account_get`, and maps the mediator's internal `Account` to the
+  wire shape — the account hash as the `Vid` (per the messaging spec's privacy
+  note) and the `u64` ACL bitfield decoded into the spec's named booleans
+  (`didcommEnabled`/`tspEnabled` have no bitfield slot, reported as `null`). Adds
+  a reusable `type_uri_of` / `downcast` routing pair. Existing protocols untouched.
+
 ## 23rd June 2026
 
 ### 0.16.14 — Trust Tasks response threading

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.15"
+version = "0.16.16"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.14"
+version = "0.16.15"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -15,12 +15,14 @@
 
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::types::accounts::{Account, AccountType};
+use affinidi_messaging_mediator_common::types::acls::{AccessListModeType, MediatorACLSet};
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use http::StatusCode;
 use serde_json::Value;
 use std::str::FromStr;
-use trust_tasks_rs::specs::messaging::ping;
+use trust_tasks_rs::specs::messaging::{account, ping};
 use trust_tasks_rs::{
     ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
     TrustTask, TypeUri, VerificationError, consume_inbound,
@@ -29,6 +31,7 @@ use uuid::Uuid;
 
 use crate::SharedData;
 use crate::common::session::Session;
+use crate::messages::protocols::mediator::acls::check_permissions;
 use crate::messages::{ProcessMessageResponse, WrapperType};
 
 /// DIDComm `type` URI of a Trust Tasks binding envelope.
@@ -114,28 +117,24 @@ pub(crate) async fn process(
     let now_secs = state.clock.unix_secs();
     let now = chrono::DateTime::from_timestamp(now_secs as i64, 0).unwrap_or_else(chrono::Utc::now);
 
-    // Route by task type. (PR-T1: ping only; the account/acl/access-list families
-    // extend this match.)
-    let ping_type =
-        TypeUri::from_str(<ping::v0_1::Payload as Payload>::TYPE_URI).expect("valid const type URI");
-
-    let response_value: Value = if doc.type_uri == ping_type {
-        let typed: TrustTask<ping::v0_1::Payload> =
-            serde_json::from_value(serde_json::to_value(&doc).map_err(serialize_err)?)
-                .map_err(|e| {
-                    tt_problem(
-                        session,
-                        "message.trust_task.malformed",
-                        format!("not a valid ping payload: {e}"),
-                        StatusCode::BAD_REQUEST,
-                    )
-                })?;
-
-        match consume_ping(typed, &mediator_did, &sender_did, now).await? {
+    // Route by task type. (ping + account/get so far; the rest of the
+    // account / acl / access-list families extend this chain.)
+    let response_value: Value = if doc.type_uri == type_uri_of::<ping::v0_1::Payload>() {
+        match consume_ping(downcast(&doc, session)?, &mediator_did, &sender_did, now).await? {
             Some(value) => value,
             // identity_mismatch with no transport sender → emit nothing.
             None => return Ok(ProcessMessageResponse::default()),
         }
+    } else if doc.type_uri == type_uri_of::<account::get::v0_1::Payload>() {
+        consume_account_get(
+            downcast(&doc, session)?,
+            state,
+            session,
+            &Some(sender_kid.clone()),
+            &mediator_did,
+            now,
+        )
+        .await?
     } else {
         return Err(tt_problem(
             session,
@@ -162,6 +161,138 @@ pub(crate) async fn process(
         data: WrapperType::Message(Box::new(response_msg)),
         forward_message: false,
     })
+}
+
+/// The canonical request type URI of a generated payload `P`.
+fn type_uri_of<P: Payload>() -> TypeUri {
+    TypeUri::from_str(P::TYPE_URI).expect("generated payload has a valid type URI")
+}
+
+/// Re-deserialise a type-erased document into the typed payload `P`.
+fn downcast<P: serde::de::DeserializeOwned>(
+    doc: &TrustTask<Value>,
+    session: &Session,
+) -> Result<TrustTask<P>, MediatorError> {
+    serde_json::from_value(serde_json::to_value(doc).map_err(serialize_err)?).map_err(|e| {
+        tt_problem(
+            session,
+            "message.trust_task.malformed",
+            format!("payload does not match the task type: {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })
+}
+
+/// Handle `messaging/account/get`: read-only, self-or-admin. Returns the
+/// mediator's view of the named account as a `TrustTask<Response>` JSON value.
+async fn consume_account_get(
+    typed: TrustTask<account::get::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    // Framework basics: addressed to this mediator and not expired.
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    // Authz: the caller must be the target account itself, or an admin.
+    let target_hash = typed.payload.did.to_string();
+    if !check_permissions(
+        session,
+        std::slice::from_ref(&target_hash),
+        state.config.security.block_remote_admin_msgs,
+        sender_kid,
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            format!("not permitted to read account {target_hash}"),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    let account = state
+        .database
+        .account_get(&target_hash)
+        .await?
+        .ok_or_else(|| {
+            tt_problem(
+                session,
+                "account.not_found",
+                format!("account {target_hash} not found"),
+                StatusCode::NOT_FOUND,
+            )
+        })?;
+
+    let response = account::get::v0_1::Response {
+        account: map_account(&account),
+        ext: None,
+    };
+    let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
+    serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// Map the mediator's internal [`Account`] to the wire `account/get` shape.
+///
+/// The DID is carried as the mediator's account hash — a valid `Vid` per the
+/// messaging spec's privacy note (the mediator never holds the full DID). The
+/// `u64` ACL bitfield is decoded into the spec's named booleans; `didcommEnabled`
+/// / `tspEnabled` have no bitfield slot and are reported as `None`.
+fn map_account(acc: &Account) -> account::get::v0_1::Account {
+    use account::get::v0_1::{
+        Account as WireAccount, AccountType as WireType, MediatorAcl, MediatorAclAccessListMode,
+        QueueLimits, Vid,
+    };
+
+    let acl = MediatorACLSet::from_u64(acc.acls);
+    let access_list_mode = match acl.get_access_list_mode().0 {
+        AccessListModeType::ExplicitAllow => MediatorAclAccessListMode::ExplicitAllow,
+        AccessListModeType::ExplicitDeny => MediatorAclAccessListMode::ExplicitDeny,
+    };
+
+    WireAccount {
+        did: Vid::from_str(&acc.did_hash).expect("an account hash is a non-empty Vid string"),
+        account_type: match acc._type {
+            AccountType::Standard => WireType::Standard,
+            AccountType::Admin => WireType::Admin,
+            AccountType::RootAdmin => WireType::RootAdmin,
+            AccountType::Mediator => WireType::Mediator,
+            AccountType::Unknown => WireType::Standard,
+        },
+        acl: MediatorAcl {
+            access_list_mode: Some(access_list_mode),
+            blocked: Some(acl.get_blocked()),
+            local: Some(acl.get_local()),
+            send_messages: Some(acl.get_send_messages().0),
+            receive_messages: Some(acl.get_receive_messages().0),
+            send_forwarded: Some(acl.get_send_forwarded().0),
+            receive_forwarded: Some(acl.get_receive_forwarded().0),
+            create_invites: Some(acl.get_create_invites().0),
+            anon_receive: Some(acl.get_anon_receive().0),
+            self_manage_list: Some(acl.get_self_manage_list()),
+            self_manage_send_queue_limit: Some(acl.get_self_manage_send_queue_limit()),
+            self_manage_receive_queue_limit: Some(acl.get_self_manage_receive_queue_limit()),
+            didcomm_enabled: None,
+            tsp_enabled: None,
+        },
+        access_list_count: Some(acc.access_list_count as u64),
+        queue_limits: Some(QueueLimits {
+            send_queue_limit: acc.queue_send_limit.map(|v| v as i64),
+            receive_queue_limit: acc.queue_receive_limit.map(|v| v as i64),
+        }),
+        send_queue_count: Some(acc.send_queue_count as u64),
+        send_queue_bytes: Some(acc.send_queue_bytes),
+        receive_queue_count: Some(acc.receive_queue_count as u64),
+        receive_queue_bytes: Some(acc.receive_queue_bytes),
+    }
 }
 
 fn tt_problem(

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -135,6 +135,8 @@ pub(crate) async fn process(
             now,
         )
         .await?
+    } else if doc.type_uri == type_uri_of::<account::list::v0_1::Payload>() {
+        consume_account_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else {
         return Err(tt_problem(
             session,
@@ -233,7 +235,71 @@ async fn consume_account_get(
         })?;
 
     let response = account::get::v0_1::Response {
-        account: map_account(&account),
+        account: map_account_get(&account),
+        ext: None,
+    };
+    let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
+    serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// Handle `messaging/account/list`: admin-only, read-only. Returns one page of the
+/// mediator's accounts (with an opaque continuation cursor) as a `TrustTask<Response>`.
+async fn consume_account_list(
+    typed: TrustTask<account::list::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    // Authz: admin-only (listing every account is an administrative action).
+    if !matches!(
+        session.account_type,
+        AccountType::Admin | AccountType::RootAdmin
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.admin_required",
+            "account/list requires an admin account".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    // The wire cursor is an opaque string over the store's numeric cursor.
+    let cursor: u32 = typed
+        .payload
+        .cursor
+        .as_ref()
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0);
+    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
+
+    let page = state.database.account_list(cursor, limit).await?;
+    let accounts = page.accounts.iter().map(map_account_list).collect();
+    // The store returns cursor 0 when the listing is exhausted.
+    let next_cursor = (page.cursor != 0)
+        .then(|| account::list::v0_1::ResponseNextCursor::from_str(&page.cursor.to_string()))
+        .transpose()
+        .map_err(|e| {
+            tt_problem(
+                session,
+                "account.list.cursor",
+                format!("couldn't encode the continuation cursor: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        })?;
+
+    let response = account::list::v0_1::Response {
+        accounts,
+        next_cursor,
         ext: None,
     };
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
@@ -246,7 +312,7 @@ async fn consume_account_get(
 /// messaging spec's privacy note (the mediator never holds the full DID). The
 /// `u64` ACL bitfield is decoded into the spec's named booleans; `didcommEnabled`
 /// / `tspEnabled` have no bitfield slot and are reported as `None`.
-fn map_account(acc: &Account) -> account::get::v0_1::Account {
+fn map_account_get(acc: &Account) -> account::get::v0_1::Account {
     use account::get::v0_1::{
         Account as WireAccount, AccountType as WireType, MediatorAcl, MediatorAclAccessListMode,
         QueueLimits, Vid,
@@ -293,6 +359,17 @@ fn map_account(acc: &Account) -> account::get::v0_1::Account {
         receive_queue_count: Some(acc.receive_queue_count as u64),
         receive_queue_bytes: Some(acc.receive_queue_bytes),
     }
+}
+
+/// Same mapping as [`map_account_get`] but for the `account/list` module's copy of
+/// the shared `Account` type. The two are generated from the one shared schema and
+/// are structurally identical, so we reuse the get mapping via a JSON round-trip
+/// rather than duplicate the bitfield decode.
+fn map_account_list(acc: &Account) -> account::list::v0_1::Account {
+    serde_json::from_value(
+        serde_json::to_value(map_account_get(acc)).expect("get Account serialises"),
+    )
+    .expect("get and list Account share the one shared schema")
 }
 
 fn tt_problem(

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.23] - 2026-06-24
+
+`atm.trust_tasks().account_list(profile, cursor, limit)` (admin only) — returns one
+page of accounts plus an opaque `next_cursor` (present only when more remain); pass
+it back to continue. Additive.
+
 ## [0.18.22] - 2026-06-24
 
 `atm.trust_tasks().account_get(profile, did_hash)` — fetch the mediator's view of an

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.22] - 2026-06-24
+
+`atm.trust_tasks().account_get(profile, did_hash)` — fetch the mediator's view of an
+account as a typed `account/get` response. `None` requests the caller's own account
+(self; no admin rights needed). Shares the binding-envelope send path with `ping`
+(refactored into an internal `exchange` helper). Additive.
+
 ## [0.18.21] - 2026-06-23
 
 New `atm.trust_tasks()` accessor with `.ping(profile, nonce)` — sends a

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.22"
+version = "0.18.23"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.21"
+version = "0.18.22"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -81,6 +81,39 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.account)
     }
 
+    /// Send a `messaging/account/list` Trust Task (admin only) and return one page
+    /// of accounts plus an opaque `next_cursor` (present only when more remain).
+    /// Pass the previous page's cursor to continue; `None` starts from the top.
+    pub async fn account_list(
+        &self,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<account::list::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let cursor = cursor
+            .map(|c| account::list::v0_1::PayloadCursor::from_str(&c))
+            .transpose()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
+        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::list::v0_1::Payload {
+                cursor,
+                ext: None,
+                limit,
+            },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::list::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -6,18 +6,23 @@
 //! `type` is the [`ENVELOPE_TYPE`] and whose `body` is the document). The mediator
 //! consumes it through the Trust Tasks framework and returns a `TrustTask<R>`.
 //!
-//! This first cut exposes `ping`; account / acl / access-list follow, and the
-//! legacy `atm.mediator()` / `atm.trust_ping()` methods will route through this
-//! same core.
+//! This exposes `ping` and `account_get`; the rest of the account / acl /
+//! access-list families follow, and the legacy `atm.mediator()` / `atm.trust_ping()`
+//! methods will route through this same core.
 //!
 //! [Trust Tasks]: https://trusttasks.org
 
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use affinidi_messaging_didcomm::message::Message;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use sha256::digest;
 use trust_tasks_rs::TrustTask;
-use trust_tasks_rs::specs::messaging::ping;
+use trust_tasks_rs::specs::messaging::{account, ping};
 use uuid::Uuid;
 
 use crate::{ATM, errors::ATMError, profiles::ATMProfile, transports::SendMessageResponse};
@@ -39,27 +44,66 @@ impl TrustTasksOps<'_> {
         profile: &Arc<ATMProfile>,
         nonce: Option<String>,
     ) -> Result<ping::v0_1::Response, ATMError> {
-        let atm = self.atm;
         let (profile_did, mediator_did) = profile.dids()?;
-
-        // Build the Trust Task document (in-band parties: me → the mediator).
         let mut task = TrustTask::for_payload(
-            format!("urn:uuid:{}", Uuid::new_v4()),
+            new_id(),
             ping::v0_1::Payload { ext: None, nonce },
         );
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
-        let body = serde_json::to_value(&task)
-            .map_err(|e| ATMError::MsgSendError(format!("couldn't serialise ping Trust Task: {e}")))?;
+        let response: TrustTask<ping::v0_1::Response> = self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// Send a `messaging/account/get` Trust Task and return the mediator's view of
+    /// the account. `did_hash` names the target account; `None` requests the
+    /// caller's own account (self). Self requests need no admin rights; fetching
+    /// another account requires an admin profile.
+    pub async fn account_get(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+    ) -> Result<account::get::v0_1::Account, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+
+        let did = account::get::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::get::v0_1::Payload { did, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::get::v0_1::Response> = self.exchange(profile, &task).await?;
+        Ok(response.payload.account)
+    }
+
+    /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
+    /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
+    async fn exchange<P, R>(
+        &self,
+        profile: &Arc<ATMProfile>,
+        task: &TrustTask<P>,
+    ) -> Result<TrustTask<R>, ATMError>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        let atm = self.atm;
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let body = serde_json::to_value(task)
+            .map_err(|e| ATMError::MsgSendError(format!("couldn't serialise Trust Task: {e}")))?;
 
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        // Wrap it in the DIDComm binding envelope and authcrypt it to the mediator.
-        let msg = Message::build(Uuid::new_v4().to_string(), ENVELOPE_TYPE.to_string(), body)
+        let msg = Message::build(new_id(), ENVELOPE_TYPE.to_string(), body)
             .to(mediator_did.into())
             .from(profile_did.into())
             .created_time(now)
@@ -71,21 +115,22 @@ impl TrustTasksOps<'_> {
             .inner
             .pack_encrypted(&msg, mediator_did, Some(profile_did))
             .await
-            .map_err(|e| ATMError::MsgSendError(format!("couldn't pack ping Trust Task: {e}")))?;
+            .map_err(|e| ATMError::MsgSendError(format!("couldn't pack Trust Task: {e}")))?;
 
         match atm.send_message(profile, &packed, &msg_id, true, true).await? {
-            SendMessageResponse::Message(response) => {
-                let doc: TrustTask<ping::v0_1::Response> =
-                    serde_json::from_value(response.body.clone()).map_err(|e| {
-                        ATMError::MsgReceiveError(format!(
-                            "ping response is not a Trust Task document: {e}"
-                        ))
-                    })?;
-                Ok(doc.payload)
-            }
+            SendMessageResponse::Message(response) => decode_body(&response.body),
             _ => Err(ATMError::MsgReceiveError(
-                "no response from mediator for the ping Trust Task".to_owned(),
+                "no response from mediator for the Trust Task".to_owned(),
             )),
         }
     }
+}
+
+fn new_id() -> String {
+    format!("urn:uuid:{}", Uuid::new_v4())
+}
+
+fn decode_body<R: DeserializeOwned>(body: &Value) -> Result<TrustTask<R>, ATMError> {
+    serde_json::from_value(body.clone())
+        .map_err(|e| ATMError::MsgReceiveError(format!("response is not a Trust Task document: {e}")))
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 24th June 2026
 
+### 0.2.20 — Trust Tasks: account/list authz e2e
+
+- New `account_list_denies_a_non_admin` test: a standard account is refused
+  `account/list`. (The admin happy-path listing isn't exercised end-to-end — an
+  `add_admin` identity isn't a streaming-registered account, so the synchronous
+  WebSocket response can't be established on the in-memory harness; the account view
+  itself round-trips via the `account/get` test, which `account/list` reuses.)
+
 ### 0.2.19 — Trust Tasks: account/get e2e
 
 - New `account_get_self_returns_the_callers_account` test: alice fetches her own

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 24th June 2026
+
+### 0.2.19 — Trust Tasks: account/get e2e
+
+- New `account_get_self_returns_the_callers_account` test: alice fetches her own
+  account via `atm.trust_tasks().account_get(.., None)` and asserts the identity
+  (hash as `Vid`), account type, and decoded ACL booleans round-trip through a live
+  mediator.
+
 ## 23rd June 2026
 
 ### 0.2.18 — Trust Tasks ping e2e

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.18"
+version = "0.2.19"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.19"
+version = "0.2.20"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -44,3 +44,32 @@ async fn ping_trust_task_round_trips_through_the_mediator() {
         response.protocols
     );
 }
+
+#[tokio::test]
+async fn account_get_self_returns_the_callers_account() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    // Alice fetches her OWN account — self-authorized, no admin rights needed.
+    let account = env
+        .atm
+        .trust_tasks()
+        .account_get(&alice.profile, None)
+        .await
+        .expect("alice reads her own account");
+
+    // Identity is carried as the mediator's account hash (a valid Vid per the
+    // messaging spec's privacy note), and the decoded view matches a standard
+    // allow-all account as minted by `add_user`.
+    assert_eq!(account.did.as_str(), alice.did_hash().as_str());
+    assert_eq!(account.account_type.to_string(), "standard");
+    assert_eq!(account.acl.send_messages, Some(true));
+    assert_eq!(account.acl.receive_messages, Some(true));
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -73,3 +73,31 @@ async fn account_get_self_returns_the_callers_account() {
     assert_eq!(account.acl.send_messages, Some(true));
     assert_eq!(account.acl.receive_messages, Some(true));
 }
+
+#[tokio::test]
+async fn account_list_denies_a_non_admin() {
+    // `account/list` is admin-only. A standard account must be refused — the
+    // mediator returns an error rather than leaking the account listing.
+    //
+    // (The admin happy-path listing isn't exercised here: an `add_admin` identity
+    // authenticates by DID resolution but isn't a streaming-registered account, so
+    // the synchronous WebSocket response path can't be established on the in-memory
+    // harness. The account view itself round-trips end-to-end via the `account/get`
+    // test above — `account/list` reuses the very same mapping.)
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    let denied = env
+        .atm
+        .trust_tasks()
+        .account_list(&alice.profile, None, None)
+        .await;
+    assert!(denied.is_err(), "a non-admin must not list accounts");
+}


### PR DESCRIPTION
## Summary

First of the **account family** — the mediator consumes `messaging/account/get` and the SDK exposes `atm.trust_tasks().account_get`. Builds on the ping round-trip (PR-T1 #506 / PR-T2 #507) and the identity clarification (trust-tasks #99).

### Mediator (0.16.14 → 0.16.15)
- `trust_tasks::process` routes `account/get` — **read-only, self-or-admin**. Authorizes via the existing `check_permissions`, reads `state.database.account_get`, and maps the internal `Account` to the wire shape:
  - the account **hash** as the `Vid` (a valid identifier per the messaging spec's privacy note, #99 — the mediator never holds the full DID);
  - the `u64` **ACL bitfield decoded** into the spec's named booleans (`didcommEnabled`/`tspEnabled` have no bitfield slot → `null`).
- Adds reusable `type_uri_of` / `downcast` routing helpers for the rest of the family.
- The **security-sensitive reverse** ACL mapping (`acl/set`, `account/add`) is intentionally deferred to its own PRs.

### SDK (0.18.21 → 0.18.22)
- `atm.trust_tasks().account_get(profile, did_hash)`; `None` = the caller's own account (self, no admin). Shares the binding-envelope send path with `ping` via an internal `exchange` helper.

### test-mediator (0.2.18 → 0.2.19)
- `account_get_self` e2e: alice reads her own account through a live mediator and asserts the identity (hash as `Vid`), account type, and decoded ACL booleans round-trip.

## Tests
`account_get` + `ping` e2e green; mediator ping unit test; clippy (3 crates) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
`account/list` (admin-only, reuses the mapping + pagination), then the account writes, then `acl/set` (the reverse ACL mapping), then access-list.