### PR TITLE
feat: Trust Tasks account/list (PR-T4)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 24th June 2026
 
+### 0.16.16 — Trust Tasks: account/list
+
+- The Trust Tasks consumer now handles `messaging/account/list` (admin-only): it
+  pages `state.database.account_list`, maps each `Account` to the wire shape (reusing
+  the `account/get` mapping), and encodes the store's numeric cursor as the spec's
+  opaque `next_cursor` (omitted when the listing is exhausted). Non-admins are
+  refused.
+
 ### 0.16.15 — Trust Tasks: account/get
 
 - The Trust Tasks consumer now handles `messaging/account/get` (self-or-admin,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.15"
+version = "0.16.16"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -135,6 +135,8 @@ pub(crate) async fn process(
             now,
         )
         .await?
+    } else if doc.type_uri == type_uri_of::<account::list::v0_1::Payload>() {
+        consume_account_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else {
         return Err(tt_problem(
             session,
@@ -233,7 +235,71 @@ async fn consume_account_get(
         })?;
 
     let response = account::get::v0_1::Response {
-        account: map_account(&account),
+        account: map_account_get(&account),
+        ext: None,
+    };
+    let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
+    serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// Handle `messaging/account/list`: admin-only, read-only. Returns one page of the
+/// mediator's accounts (with an opaque continuation cursor) as a `TrustTask<Response>`.
+async fn consume_account_list(
+    typed: TrustTask<account::list::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    // Authz: admin-only (listing every account is an administrative action).
+    if !matches!(
+        session.account_type,
+        AccountType::Admin | AccountType::RootAdmin
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.admin_required",
+            "account/list requires an admin account".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    // The wire cursor is an opaque string over the store's numeric cursor.
+    let cursor: u32 = typed
+        .payload
+        .cursor
+        .as_ref()
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0);
+    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
+
+    let page = state.database.account_list(cursor, limit).await?;
+    let accounts = page.accounts.iter().map(map_account_list).collect();
+    // The store returns cursor 0 when the listing is exhausted.
+    let next_cursor = (page.cursor != 0)
+        .then(|| account::list::v0_1::ResponseNextCursor::from_str(&page.cursor.to_string()))
+        .transpose()
+        .map_err(|e| {
+            tt_problem(
+                session,
+                "account.list.cursor",
+                format!("couldn't encode the continuation cursor: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        })?;
+
+    let response = account::list::v0_1::Response {
+        accounts,
+        next_cursor,
         ext: None,
     };
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
@@ -246,7 +312,7 @@ async fn consume_account_get(
 /// messaging spec's privacy note (the mediator never holds the full DID). The
 /// `u64` ACL bitfield is decoded into the spec's named booleans; `didcommEnabled`
 /// / `tspEnabled` have no bitfield slot and are reported as `None`.
-fn map_account(acc: &Account) -> account::get::v0_1::Account {
+fn map_account_get(acc: &Account) -> account::get::v0_1::Account {
     use account::get::v0_1::{
         Account as WireAccount, AccountType as WireType, MediatorAcl, MediatorAclAccessListMode,
         QueueLimits, Vid,
@@ -293,6 +359,17 @@ fn map_account(acc: &Account) -> account::get::v0_1::Account {
         receive_queue_count: Some(acc.receive_queue_count as u64),
         receive_queue_bytes: Some(acc.receive_queue_bytes),
     }
+}
+
+/// Same mapping as [`map_account_get`] but for the `account/list` module's copy of
+/// the shared `Account` type. The two are generated from the one shared schema and
+/// are structurally identical, so we reuse the get mapping via a JSON round-trip
+/// rather than duplicate the bitfield decode.
+fn map_account_list(acc: &Account) -> account::list::v0_1::Account {
+    serde_json::from_value(
+        serde_json::to_value(map_account_get(acc)).expect("get Account serialises"),
+    )
+    .expect("get and list Account share the one shared schema")
 }
 
 fn tt_problem(

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.23] - 2026-06-24
+
+`atm.trust_tasks().account_list(profile, cursor, limit)` (admin only) — returns one
+page of accounts plus an opaque `next_cursor` (present only when more remain); pass
+it back to continue. Additive.
+
 ## [0.18.22] - 2026-06-24
 
 `atm.trust_tasks().account_get(profile, did_hash)` — fetch the mediator's view of an

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.22"
+version = "0.18.23"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -81,6 +81,39 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.account)
     }
 
+    /// Send a `messaging/account/list` Trust Task (admin only) and return one page
+    /// of accounts plus an opaque `next_cursor` (present only when more remain).
+    /// Pass the previous page's cursor to continue; `None` starts from the top.
+    pub async fn account_list(
+        &self,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<account::list::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let cursor = cursor
+            .map(|c| account::list::v0_1::PayloadCursor::from_str(&c))
+            .transpose()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
+        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::list::v0_1::Payload {
+                cursor,
+                ext: None,
+                limit,
+            },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::list::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 24th June 2026
 
+### 0.2.20 — Trust Tasks: account/list authz e2e
+
+- New `account_list_denies_a_non_admin` test: a standard account is refused
+  `account/list`. (The admin happy-path listing isn't exercised end-to-end — an
+  `add_admin` identity isn't a streaming-registered account, so the synchronous
+  WebSocket response can't be established on the in-memory harness; the account view
+  itself round-trips via the `account/get` test, which `account/list` reuses.)
+
 ### 0.2.19 — Trust Tasks: account/get e2e
 
 - New `account_get_self_returns_the_callers_account` test: alice fetches her own

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.19"
+version = "0.2.20"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -73,3 +73,31 @@ async fn account_get_self_returns_the_callers_account() {
     assert_eq!(account.acl.send_messages, Some(true));
     assert_eq!(account.acl.receive_messages, Some(true));
 }
+
+#[tokio::test]
+async fn account_list_denies_a_non_admin() {
+    // `account/list` is admin-only. A standard account must be refused — the
+    // mediator returns an error rather than leaking the account listing.
+    //
+    // (The admin happy-path listing isn't exercised here: an `add_admin` identity
+    // authenticates by DID resolution but isn't a streaming-registered account, so
+    // the synchronous WebSocket response path can't be established on the in-memory
+    // harness. The account view itself round-trips end-to-end via the `account/get`
+    // test above — `account/list` reuses the very same mapping.)
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    let denied = env
+        .atm
+        .trust_tasks()
+        .account_list(&alice.profile, None, None)
+        .await;
+    assert!(denied.is_err(), "a non-admin must not list accounts");
+}


### PR DESCRIPTION
## Summary

Second of the **account family** — the mediator consumes `messaging/account/list` and the SDK exposes `atm.trust_tasks().account_list`. Stacked on PR-T3 (#508).

### Mediator (0.16.15 → 0.16.16)
- `trust_tasks::process` routes `account/list` — **admin-only, read-only**. Pages `state.database.account_list`, maps each `Account` to the wire shape (reusing the `account/get` mapping via the shared schema), and encodes the store's numeric cursor as the spec's opaque `next_cursor` (omitted when the listing is exhausted). Non-admins are refused.

### SDK (0.18.22 → 0.18.23)
- `atm.trust_tasks().account_list(profile, cursor, limit)` (admin only) — returns a page of accounts + an opaque `next_cursor`; pass it back to continue.

### test-mediator (0.2.19 → 0.2.20)
- `account_list_denies_a_non_admin` e2e: a standard account is refused.
- **Note**: the admin happy-path listing isn't exercised end-to-end — an `add_admin` identity authenticates by DID resolution but isn't a streaming-registered account, so the synchronous WebSocket response can't be established on the in-memory harness (the lifecycle admin tests gate on Redis for the same reason). The account view itself round-trips via the `account/get` test, which `account/list` reuses.

## Tests
3 `trust_tasks` e2e green; clippy (mediator + SDK) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
The account **writes** (add / remove / change-type / change-queue-limits), then `acl/set` (the security-sensitive reverse ACL mapping), then access-list.