### PR TITLE
feat: Trust Tasks account/change-queue-limits (PR-T5)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 24th June 2026
 
+### 0.16.17 — Trust Tasks: account/change-queue-limits
+
+- The Trust Tasks consumer now handles `messaging/account/change-queue-limits`
+  (self-or-admin). A standard account may only change a limit it self-manages, and
+  its values are capped at the mediator's hard maximum (the `-1`/`-2` sentinels pass
+  through); an admin sets any value. Records an audit entry and returns the updated
+  account view. Adds a reusable generic `to_wire_account` (replacing the list-only
+  helper).
+
 ### 0.16.16 — Trust Tasks: account/list
 
 - The Trust Tasks consumer now handles `messaging/account/list` (admin-only): it

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.16"
+version = "0.16.17"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -17,6 +17,7 @@ use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_mediator_common::types::accounts::{Account, AccountType};
 use affinidi_messaging_mediator_common::types::acls::{AccessListModeType, MediatorACLSet};
+use affinidi_messaging_mediator_common::types::audit::AuditAction;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use http::StatusCode;
@@ -32,6 +33,7 @@ use uuid::Uuid;
 use crate::SharedData;
 use crate::common::session::Session;
 use crate::messages::protocols::mediator::acls::check_permissions;
+use crate::messages::protocols::mediator::record_audit;
 use crate::messages::{ProcessMessageResponse, WrapperType};
 
 /// DIDComm `type` URI of a Trust Tasks binding envelope.
@@ -137,6 +139,16 @@ pub(crate) async fn process(
         .await?
     } else if doc.type_uri == type_uri_of::<account::list::v0_1::Payload>() {
         consume_account_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<account::change_queue_limits::v0_1::Payload>() {
+        consume_account_change_queue_limits(
+            downcast(&doc, session)?,
+            state,
+            session,
+            &Some(sender_kid.clone()),
+            &mediator_did,
+            now,
+        )
+        .await?
     } else {
         return Err(tt_problem(
             session,
@@ -283,7 +295,11 @@ async fn consume_account_list(
     let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
 
     let page = state.database.account_list(cursor, limit).await?;
-    let accounts = page.accounts.iter().map(map_account_list).collect();
+    let accounts = page
+        .accounts
+        .iter()
+        .map(to_wire_account::<account::list::v0_1::Account>)
+        .collect();
     // The store returns cursor 0 when the listing is exhausted.
     let next_cursor = (page.cursor != 0)
         .then(|| account::list::v0_1::ResponseNextCursor::from_str(&page.cursor.to_string()))
@@ -304,6 +320,112 @@ async fn consume_account_list(
     };
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// Handle `messaging/account/change-queue-limits`: self-or-admin. A standard account
+/// may only change a limit it is permitted to self-manage, and its values are capped
+/// at the mediator's hard maximum; an admin sets any value. Returns the updated view.
+async fn consume_account_change_queue_limits(
+    typed: TrustTask<account::change_queue_limits::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    let target_hash = typed.payload.did.to_string();
+    if !check_permissions(
+        session,
+        std::slice::from_ref(&target_hash),
+        state.config.security.block_remote_admin_msgs,
+        sender_kid,
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            format!("not permitted to change queue limits for account {target_hash}"),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    // The wire carries i64; the store works in i32. A member omitted is unchanged.
+    let req_send = typed.payload.queue_limits.send_queue_limit.map(|v| v as i32);
+    let req_receive = typed.payload.queue_limits.receive_queue_limit.map(|v| v as i32);
+
+    // A standard account may only touch limits it self-manages, capped at the hard
+    // maximum; an admin sets any value.
+    let (send_queue_limit, receive_queue_limit) =
+        if session.account_type == AccountType::Standard {
+            (
+                gate_self_managed_limit(
+                    req_send,
+                    session.acls.get_self_manage_send_queue_limit(),
+                    state.config.limits.queued_send_messages_hard,
+                ),
+                gate_self_managed_limit(
+                    req_receive,
+                    session.acls.get_self_manage_receive_queue_limit(),
+                    state.config.limits.queued_receive_messages_hard,
+                ),
+            )
+        } else {
+            (req_send, req_receive)
+        };
+
+    state
+        .database
+        .account_change_queue_limits(&target_hash, send_queue_limit, receive_queue_limit)
+        .await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccountChangeQueueLimits,
+        format!("send={send_queue_limit:?} receive={receive_queue_limit:?}"),
+    )
+    .await;
+
+    let account = state
+        .database
+        .account_get(&target_hash)
+        .await?
+        .ok_or_else(|| {
+            tt_problem(
+                session,
+                "account.not_found",
+                format!("account {target_hash} not found"),
+                StatusCode::NOT_FOUND,
+            )
+        })?;
+    let response = account::change_queue_limits::v0_1::Response {
+        account: to_wire_account(&account),
+        ext: None,
+    };
+    let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
+    serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// A standard account may change a queue limit only if it self-manages that limit;
+/// the value is capped at the mediator's hard maximum. The `-1` (unlimited) and `-2`
+/// sentinels pass through unchanged. Not self-managed → leave the limit unchanged.
+fn gate_self_managed_limit(requested: Option<i32>, self_managed: bool, hard: i32) -> Option<i32> {
+    if !self_managed {
+        return None;
+    }
+    match requested {
+        Some(-1) | Some(-2) => requested,
+        Some(limit) if limit > hard => Some(hard),
+        other => other,
+    }
 }
 
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.
@@ -361,15 +483,13 @@ fn map_account_get(acc: &Account) -> account::get::v0_1::Account {
     }
 }
 
-/// Same mapping as [`map_account_get`] but for the `account/list` module's copy of
-/// the shared `Account` type. The two are generated from the one shared schema and
-/// are structurally identical, so we reuse the get mapping via a JSON round-trip
-/// rather than duplicate the bitfield decode.
-fn map_account_list(acc: &Account) -> account::list::v0_1::Account {
-    serde_json::from_value(
-        serde_json::to_value(map_account_get(acc)).expect("get Account serialises"),
-    )
-    .expect("get and list Account share the one shared schema")
+/// Re-shape [`map_account_get`]'s output into another `messaging/*` module's copy of
+/// the shared `Account` type. typify generates a structurally-identical `Account`
+/// per spec module; they all derive from the one shared schema, so a JSON round-trip
+/// converts between them without re-implementing the bitfield decode.
+fn to_wire_account<T: serde::de::DeserializeOwned>(acc: &Account) -> T {
+    serde_json::from_value(serde_json::to_value(map_account_get(acc)).expect("get Account serialises"))
+        .expect("messaging Account types share the one shared schema")
 }
 
 fn tt_problem(

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.24] - 2026-06-24
+
+`atm.trust_tasks().account_change_queue_limits(profile, did_hash, send, receive)` —
+change an account's queued-message limits and return the updated view. `None` target
+= self; each limit is `Some(-1)` (unlimited) / `Some(n)` / `None` (unchanged). Additive.
+
 ## [0.18.23] - 2026-06-24
 
 `atm.trust_tasks().account_list(profile, cursor, limit)` (admin only) — returns one

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.23"
+version = "0.18.24"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -114,6 +114,42 @@ impl TrustTasksOps<'_> {
         Ok(response.payload)
     }
 
+    /// Send a `messaging/account/change-queue-limits` Trust Task and return the
+    /// updated account view. `did_hash` names the target; `None` is the caller's own
+    /// account. Each limit is an `Option`: `Some(-1)` = unlimited, `Some(n)` = a cap,
+    /// `None` = leave that limit unchanged. A standard account may only change limits
+    /// it self-manages (others are silently left unchanged).
+    pub async fn account_change_queue_limits(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+        send_queue_limit: Option<i64>,
+        receive_queue_limit: Option<i64>,
+    ) -> Result<account::change_queue_limits::v0_1::Account, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+
+        let did = account::change_queue_limits::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::change_queue_limits::v0_1::Payload {
+                did,
+                ext: None,
+                queue_limits: account::change_queue_limits::v0_1::QueueLimits {
+                    receive_queue_limit,
+                    send_queue_limit,
+                },
+            },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::change_queue_limits::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload.account)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 24th June 2026
 
+### 0.2.21 — Trust Tasks: account/change-queue-limits e2e
+
+- New `account_change_queue_limits_self_applies_caps_and_persists` test: alice changes
+  her own limits (a value, and `-1` = unlimited), the change persists across a fresh
+  read, and an over-limit request from a standard account is capped at the hard maximum.
+
 ### 0.2.20 — Trust Tasks: account/list authz e2e
 
 - New `account_list_denies_a_non_admin` test: a standard account is refused

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.20"
+version = "0.2.21"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -101,3 +101,50 @@ async fn account_list_denies_a_non_admin() {
         .await;
     assert!(denied.is_err(), "a non-admin must not list accounts");
 }
+
+#[tokio::test]
+async fn account_change_queue_limits_self_applies_caps_and_persists() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    // Alice self-manages her queue limits (allow_all). A normal value is applied;
+    // `-1` means unlimited.
+    let updated = env
+        .atm
+        .trust_tasks()
+        .account_change_queue_limits(&alice.profile, None, Some(42), Some(-1))
+        .await
+        .expect("alice changes her own queue limits");
+    let q = updated.queue_limits.expect("queue limits present");
+    assert_eq!(q.send_queue_limit, Some(42));
+    assert_eq!(q.receive_queue_limit, Some(-1));
+
+    // Persisted across a fresh read.
+    let account = env
+        .atm
+        .trust_tasks()
+        .account_get(&alice.profile, None)
+        .await
+        .expect("re-read alice's account");
+    assert_eq!(account.queue_limits.and_then(|q| q.send_queue_limit), Some(42));
+
+    // A standard account's request above the hard maximum (1000) is capped.
+    let capped = env
+        .atm
+        .trust_tasks()
+        .account_change_queue_limits(&alice.profile, None, Some(5000), None)
+        .await
+        .expect("over-limit request is accepted but capped");
+    assert_eq!(
+        capped.queue_limits.and_then(|q| q.send_queue_limit),
+        Some(1000),
+        "a standard account is capped at the hard maximum"
+    );
+}


### PR DESCRIPTION
## Summary

Third of the **account family** — the first *write*. The mediator consumes `messaging/account/change-queue-limits` and the SDK exposes `atm.trust_tasks().account_change_queue_limits`. Off main (the reads — #508/#509 — have merged).

### Mediator (0.16.16 → 0.16.17)
- Routes `account/change-queue-limits` — **self-or-admin**, faithfully replicating the legacy authz:
  - a **standard** account may only change a limit it **self-manages** (others are left unchanged), and its values are **capped at the mediator's hard maximum** (the `-1` unlimited / `-2` sentinels pass through);
  - an **admin** sets any value.
- Records an **audit** entry (parity with the legacy) and returns the **updated account view**.
- Generalised the list-only mapping into a reusable generic `to_wire_account<T>` (every account-returning op reuses it).

### SDK (0.18.23 → 0.18.24)
- `atm.trust_tasks().account_change_queue_limits(profile, did_hash, send, receive)`; `None` target = self; each limit `Some(-1)` = unlimited / `Some(n)` = cap / `None` = unchanged.

### test-mediator (0.2.20 → 0.2.21)
- e2e: alice changes her own limits (a value + `-1` unlimited), the change **persists** across a fresh read, and an **over-limit request is capped** at the hard maximum (1000) — exercising the security bound.

## Tests
4 `trust_tasks` e2e green; clippy (mediator + SDK) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
`account/remove` + `account/change-type`, then `account/add` and `acl/set` (the security-sensitive **reverse** ACL mapping), then access-list.