### PR TITLE
feat: Trust Tasks account/remove (PR-T6)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 24th June 2026
 
+### 0.16.18 — Trust Tasks: account/remove
+
+- The Trust Tasks consumer now handles `messaging/account/remove` (self-or-admin).
+  Refuses to remove the mediator's own account or the root admin (both compared in
+  constant time), records an audit entry, and returns the target id plus whether a
+  record was removed.
+
 ### 0.16.17 — Trust Tasks: account/change-queue-limits
 
 - The Trust Tasks consumer now handles `messaging/account/change-queue-limits`

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.17"
+version = "0.16.18"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -22,7 +22,9 @@ use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use http::StatusCode;
 use serde_json::Value;
+use sha256::digest;
 use std::str::FromStr;
+use subtle::ConstantTimeEq;
 use trust_tasks_rs::specs::messaging::{account, ping};
 use trust_tasks_rs::{
     ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
@@ -141,6 +143,16 @@ pub(crate) async fn process(
         consume_account_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else if doc.type_uri == type_uri_of::<account::change_queue_limits::v0_1::Payload>() {
         consume_account_change_queue_limits(
+            downcast(&doc, session)?,
+            state,
+            session,
+            &Some(sender_kid.clone()),
+            &mediator_did,
+            now,
+        )
+        .await?
+    } else if doc.type_uri == type_uri_of::<account::remove::v0_1::Payload>() {
+        consume_account_remove(
             downcast(&doc, session)?,
             state,
             session,
@@ -426,6 +438,85 @@ fn gate_self_managed_limit(requested: Option<i32>, self_managed: bool, hard: i32
         Some(limit) if limit > hard => Some(hard),
         other => other,
     }
+}
+
+/// Handle `messaging/account/remove`: self-or-admin. Refuses to remove the
+/// mediator's own account or the root admin (both compared in constant time).
+/// Returns the target id and whether a record was removed.
+async fn consume_account_remove(
+    typed: TrustTask<account::remove::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    let target_hash = typed.payload.did.to_string();
+    if !check_permissions(
+        session,
+        std::slice::from_ref(&target_hash),
+        state.config.security.block_remote_admin_msgs,
+        sender_kid,
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            format!("not permitted to remove account {target_hash}"),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    // Never remove the mediator's own account or the root admin.
+    let protected = state
+        .config
+        .mediator_did_hash
+        .as_bytes()
+        .ct_eq(target_hash.as_bytes())
+        .unwrap_u8()
+        == 1
+        || digest(&state.config.admin_did)
+            .as_bytes()
+            .ct_eq(target_hash.as_bytes())
+            .unwrap_u8()
+            == 1;
+    if protected {
+        return Err(tt_problem(
+            session,
+            "account.remove.protected",
+            "the mediator and root-admin accounts cannot be removed".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    let removed = state
+        .database
+        .account_remove(&session.to_store_session(), &target_hash)
+        .await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccountRemove,
+        "account removed".to_string(),
+    )
+    .await;
+
+    let response = account::remove::v0_1::Response {
+        did: typed.payload.did.clone(),
+        ext: None,
+        removed,
+    };
+    let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
+    serde_json::to_value(&response_doc).map_err(serialize_err)
 }
 
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.25] - 2026-06-24
+
+`atm.trust_tasks().account_remove(profile, did_hash)` — remove an account (self-or-admin;
+`None` = self) and return whether a record was removed. The mediator's own and the
+root-admin accounts can't be removed. Additive.
+
 ## [0.18.24] - 2026-06-24
 
 `atm.trust_tasks().account_change_queue_limits(profile, did_hash, send, receive)` —

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.24"
+version = "0.18.25"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -150,6 +150,31 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.account)
     }
 
+    /// Send a `messaging/account/remove` Trust Task and return whether a record was
+    /// removed. `did_hash` names the target; `None` removes the caller's own account.
+    /// Self-or-admin; the mediator's own and the root-admin accounts can't be removed.
+    pub async fn account_remove(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+    ) -> Result<bool, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+
+        let did = account::remove::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::remove::v0_1::Payload { did, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::remove::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload.removed)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## 24th June 2026
 
+### 0.2.22 — Trust Tasks: account/remove e2e
+
+- New `account_remove_self_removes_the_account` test: alice removes her own account
+  and the store reports a record was removed.
+
 ### 0.2.21 — Trust Tasks: account/change-queue-limits e2e
 
 - New `account_change_queue_limits_self_applies_caps_and_persists` test: alice changes

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.21"
+version = "0.2.22"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -148,3 +148,35 @@ async fn account_change_queue_limits_self_applies_caps_and_persists() {
         "a standard account is capped at the hard maximum"
     );
 }
+
+#[tokio::test]
+async fn account_remove_self_removes_the_account() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    // Sanity: alice's account exists.
+    env.atm
+        .trust_tasks()
+        .account_get(&alice.profile, None)
+        .await
+        .expect("alice's account exists before removal");
+
+    // Alice removes her own account (self-authorized); the store reports a record
+    // was removed. (We don't assert a follow-up read fails: the mediator
+    // re-registers the sender's account on her next authenticated request, so alice
+    // sending anything else would re-create it — the removal itself is the contract.)
+    let removed = env
+        .atm
+        .trust_tasks()
+        .account_remove(&alice.profile, None)
+        .await
+        .expect("alice removes her own account");
+    assert!(removed, "a record should have been removed");
+}


### PR DESCRIPTION
## Summary

Fourth of the **account family**. The mediator consumes `messaging/account/remove` and the SDK exposes `atm.trust_tasks().account_remove`. Off main.

### Mediator (0.16.17 → 0.16.18)
- Routes `account/remove` — **self-or-admin**. Refuses to remove the **mediator's own** account or the **root admin** (both compared in **constant time**, matching the legacy), records an **audit** entry, and returns the target id plus whether a record was removed.

### SDK (0.18.24 → 0.18.25)
- `atm.trust_tasks().account_remove(profile, did_hash)` (`None` = self) → `bool` (removed).

### test-mediator (0.2.21 → 0.2.22)
- e2e: alice removes her own account and the store reports a record was removed.
- **Note**: no "account gone" re-read assertion — the mediator re-registers the sender's account on her next authenticated request, so alice sending anything else re-creates it. The removal (`removed == true`) is the verifiable contract. The mediator/root-admin **protections** aren't e2e'd (they're only reachable by an admin targeting those hashes, and admin-over-WS doesn't run on the in-memory harness); they're constant-time checks mirroring the legacy.

## Tests
5 `trust_tasks` e2e green; clippy (mediator + SDK) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
`account/change-type` (admin-only), then `account/add` + `acl/set` (the security-sensitive **reverse** ACL mapping), then access-list.