### PR TITLE
feat: Trust Tasks account/change-type (PR-T7)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 24th June 2026
 
+### 0.16.19 — Trust Tasks: account/change-type
+
+- The Trust Tasks consumer now handles `messaging/account/change-type` (admin-only).
+  Faithfully ports the legacy admin-set transitions (promote / demote / switch) and
+  the root-admin guards — only a root admin may assign the root-admin role or modify
+  a root-admin account. Records an audit entry; returns the account's realized view
+  after the change.
+
 ### 0.16.18 — Trust Tasks: account/remove
 
 - The Trust Tasks consumer now handles `messaging/account/remove` (self-or-admin).

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.18"
+version = "0.16.19"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -161,6 +161,9 @@ pub(crate) async fn process(
             now,
         )
         .await?
+    } else if doc.type_uri == type_uri_of::<account::change_type::v0_1::Payload>() {
+        consume_account_change_type(downcast(&doc, session)?, state, session, &mediator_did, now)
+            .await?
     } else {
         return Err(tt_problem(
             session,
@@ -517,6 +520,138 @@ async fn consume_account_remove(
     };
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
+}
+
+/// Handle `messaging/account/change-type`: admin-only, with root-admin guards —
+/// only a root admin may assign root-admin or modify a root-admin account. A
+/// faithful port of the legacy admin-set transitions (promote / demote / switch).
+/// Returns the account's realized view after the change.
+async fn consume_account_change_type(
+    typed: TrustTask<account::change_type::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use account::change_type::v0_1::AccountType as WireType;
+
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    let target_hash = typed.payload.did.to_string();
+    let new_type = match typed.payload.account_type {
+        WireType::Standard => AccountType::Standard,
+        WireType::Admin => AccountType::Admin,
+        WireType::RootAdmin => AccountType::RootAdmin,
+        WireType::Mediator => AccountType::Mediator,
+    };
+
+    let denied = |reason: &str| {
+        tt_problem(
+            session,
+            "authorization.permission",
+            reason.to_string(),
+            StatusCode::FORBIDDEN,
+        )
+    };
+
+    // Must be an admin to change types at all.
+    if !state.database.check_admin_account(&session.did_hash).await? {
+        return Err(denied("admin access is required to change account types"));
+    }
+    // Only a root admin may assign the root-admin role.
+    if new_type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin {
+        return Err(denied("root-admin access is required to assign the root-admin role"));
+    }
+
+    let current = state.database.account_get(&target_hash).await?;
+    if let Some(current) = &current {
+        if current._type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin
+        {
+            return Err(denied("root-admin access is required to modify a root-admin account"));
+        } else if current._type == new_type {
+            // No change — report the account as-is.
+            return change_type_response(&typed, current);
+        } else if current._type.is_admin() && new_type.is_admin() {
+            // Switching between admin roles is a plain set-role (below).
+        } else if current._type.is_admin() && !new_type.is_admin() {
+            // Demotion — strip admin rights first.
+            state
+                .database
+                .strip_admin_accounts(vec![target_hash.clone()])
+                .await?;
+        } else if !current._type.is_admin() && new_type.is_admin() {
+            // Promotion — add admin rights, carrying the existing ACL set.
+            state
+                .database
+                .setup_admin_account(&target_hash, new_type, &MediatorACLSet::from_u64(current.acls))
+                .await?;
+            record_audit(
+                state,
+                session,
+                &target_hash,
+                AuditAction::AccountChangeType,
+                format!("type -> {new_type}"),
+            )
+            .await;
+            return change_type_fetch_response(&typed, state, session, &target_hash).await;
+        }
+    }
+
+    state
+        .database
+        .account_set_role(&target_hash, &new_type)
+        .await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccountChangeType,
+        format!("type -> {new_type}"),
+    )
+    .await;
+    change_type_fetch_response(&typed, state, session, &target_hash).await
+}
+
+/// Build a `change-type` response from an account.
+fn change_type_response(
+    typed: &TrustTask<account::change_type::v0_1::Payload>,
+    account: &Account,
+) -> Result<Value, MediatorError> {
+    let response = account::change_type::v0_1::Response {
+        account: to_wire_account(account),
+        ext: None,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Re-read the account after a change and build the `change-type` response.
+async fn change_type_fetch_response(
+    typed: &TrustTask<account::change_type::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    target_hash: &str,
+) -> Result<Value, MediatorError> {
+    let account = state
+        .database
+        .account_get(target_hash)
+        .await?
+        .ok_or_else(|| {
+            tt_problem(
+                session,
+                "account.not_found",
+                format!("account {target_hash} not found after change"),
+                StatusCode::NOT_FOUND,
+            )
+        })?;
+    change_type_response(typed, &account)
 }
 
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.26] - 2026-06-24
+
+`atm.trust_tasks().account_change_type(profile, did_hash, account_type)` (admin only) —
+change an account's role and return its realized view. Only a root admin may assign the
+root-admin role or modify a root-admin account. Additive.
+
 ## [0.18.25] - 2026-06-24
 
 `atm.trust_tasks().account_remove(profile, did_hash)` — remove an account (self-or-admin;

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.25"
+version = "0.18.26"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -175,6 +175,36 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.removed)
     }
 
+    /// Send a `messaging/account/change-type` Trust Task (admin only) and return the
+    /// account's realized view after the role change. Only a root admin may assign the
+    /// root-admin role or modify a root-admin account. `account_type` is the
+    /// [`account::change_type::v0_1::AccountType`] to set.
+    pub async fn account_change_type(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: String,
+        account_type: account::change_type::v0_1::AccountType,
+    ) -> Result<account::change_type::v0_1::Account, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let did = account::change_type::v0_1::Vid::from_str(&did_hash)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::change_type::v0_1::Payload {
+                account_type,
+                did,
+                ext: None,
+            },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::change_type::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload.account)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## 24th June 2026
 
+### 0.2.23 — Trust Tasks: account/change-type denial e2e
+
+- New `account_change_type_denies_a_non_admin` test. Adds a `trust-tasks-rs` dev-dep so
+  tests can name Trust Task payload types (e.g. `AccountType`).
+
 ### 0.2.22 — Trust Tasks: account/remove e2e
 
 - New `account_remove_self_removes_the_account` test: alice removes her own account

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.22"
+version = "0.2.23"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -84,6 +84,8 @@ affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-d
 ## Used by integration tests to hit the mediator's HTTP endpoints
 ## without going through the SDK.
 reqwest = { version = "0.13", features = ["rustls", "json"] }
+## Trust Tasks payload types named by the Trust Tasks integration tests.
+trust-tasks-rs = "0.2"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -180,3 +180,31 @@ async fn account_remove_self_removes_the_account() {
         .expect("alice removes her own account");
     assert!(removed, "a record should have been removed");
 }
+
+#[tokio::test]
+async fn account_change_type_denies_a_non_admin() {
+    use trust_tasks_rs::specs::messaging::account::change_type::v0_1::AccountType;
+
+    // `account/change-type` is admin-only. A standard account must be refused.
+    // (The admin happy-path — promotion/demotion across the admin set — isn't driven
+    // here: an admin authenticates by DID resolution but isn't a streaming-registered
+    // account, so the synchronous WebSocket response can't be established on the
+    // in-memory harness. The handler is a faithful port of the legacy admin-set logic.)
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let denied = env
+        .atm
+        .trust_tasks()
+        .account_change_type(&alice.profile, bob.did_hash(), AccountType::Admin)
+        .await;
+    assert!(denied.is_err(), "a non-admin must not change account types");
+}


### PR DESCRIPTION
## Summary

Fifth of the **account family** — completes the account ops *except* `account/add` (which needs the reverse ACL mapping). The mediator consumes `messaging/account/change-type` and the SDK exposes `atm.trust_tasks().account_change_type`.

### Mediator (0.16.18 → 0.16.19)
- Routes `account/change-type` — **admin-only**. A **faithful 1:1 port** of the legacy logic:
  - **root-admin guards** — only a root admin may *assign* the root-admin role or *modify* a root-admin account;
  - the admin-set **transitions** — promote (`setup_admin_account`, carrying the existing ACL set), demote (`strip_admin_accounts`), switch / simple change (`account_set_role`);
  - same-type request is a no-op that still returns the account.
- Records an **audit** entry; returns the account's **realized view** after the change (the spec returns the full account, an improvement over the legacy's bare `true`).

### SDK (0.18.25 → 0.18.26)
- `atm.trust_tasks().account_change_type(profile, did_hash, account_type)` → the updated account view.

### test-mediator (0.2.22 → 0.2.23)
- `account_change_type_denies_a_non_admin` e2e. Adds a `trust-tasks-rs` dev-dep so tests can name payload types.
- **Note**: the admin happy path (promote/demote across the admin set) isn't e2e'd — admins aren't streaming-registered accounts, so admin-over-WS doesn't run on the in-memory harness. The handler is a faithful port of the working legacy logic; the denial path is tested.

## Tests
6 `trust_tasks` e2e green; clippy (mediator + SDK) clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
`account/add` + `acl/set` — the security-sensitive **reverse** ACL mapping (`spec MediatorAcl → u64`), built with a `u64 → spec → u64` round-trip test. Then `acl/get` and access-list.