### PR TITLE
feat: Trust Tasks account/add — account family complete (PR-T9)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 24th June 2026
 
+### 0.16.21 — Trust Tasks: account/add (account family complete)
+
+- `messaging/account/add`: in `ExplicitAllow` mode only an admin may add accounts; in
+  `ExplicitDeny` mode any authenticated account may. An admin may supply the new
+  account's ACL (applied onto the mediator default via the reverse map); a non-admin
+  gets the default. Creating an admin / root-admin account requires the matching
+  privilege. Records an audit entry; returns the created account's realized view.
+  Initial queue limits use the mediator default (adjust via change-queue-limits).
+  This completes the messaging account family (get / list / change-queue-limits /
+  remove / change-type / add).
+
 ### 0.16.20 — Trust Tasks: acl/get + acl/set
 
 - `messaging/acl/get` (self-or-admin, batched): returns the decoded `MediatorAcl` per

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.20"
+version = "0.16.21"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -166,6 +166,8 @@ pub(crate) async fn process(
     } else if doc.type_uri == type_uri_of::<account::change_type::v0_1::Payload>() {
         consume_account_change_type(downcast(&doc, session)?, state, session, &mediator_did, now)
             .await?
+    } else if doc.type_uri == type_uri_of::<account::add::v0_1::Payload>() {
+        consume_account_add(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else if doc.type_uri == type_uri_of::<acl::get::v0_1::Payload>() {
         consume_acl_get(
             downcast(&doc, session)?,
@@ -666,6 +668,105 @@ async fn change_type_fetch_response(
             )
         })?;
     change_type_response(typed, &account)
+}
+
+/// Handle `messaging/account/add`. In `ExplicitAllow` mode only an admin may add
+/// accounts; in `ExplicitDeny` mode any authenticated account may. An admin may
+/// supply the new account's ACL (applied onto the mediator default); a non-admin
+/// gets the default. Creating an admin / root-admin account requires admin /
+/// root-admin rights. Returns the created account's realized view.
+async fn consume_account_add(
+    typed: TrustTask<account::add::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use account::add::v0_1::AccountType as WireType;
+
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    let target_hash = typed.payload.did.to_string();
+    let new_type = match typed.payload.account_type {
+        WireType::Standard => AccountType::Standard,
+        WireType::Admin => AccountType::Admin,
+        WireType::RootAdmin => AccountType::RootAdmin,
+        WireType::Mediator => AccountType::Mediator,
+    };
+    let is_admin = matches!(
+        session.account_type,
+        AccountType::Admin | AccountType::RootAdmin
+    );
+
+    let denied = |reason: &str| {
+        tt_problem(
+            session,
+            "authorization.permission",
+            reason.to_string(),
+            StatusCode::FORBIDDEN,
+        )
+    };
+
+    // In allowlist mode only admins may add accounts.
+    if state.config.security.mediator_acl_mode == AccessListModeType::ExplicitAllow && !is_admin {
+        return Err(denied("admin access is required to add accounts"));
+    }
+    // Creating a privileged account requires the matching privilege.
+    if new_type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin {
+        return Err(denied("root-admin access is required to create a root-admin account"));
+    }
+    if new_type.is_admin() && !is_admin {
+        return Err(denied("admin access is required to create an admin account"));
+    }
+
+    // ACLs: an admin may supply them (applied onto the mediator default); a non-admin
+    // always gets the default.
+    let acls = match (is_admin, &typed.payload.acl) {
+        (true, Some(acl)) => merge_wire_acl(
+            serde_json::to_value(acl).map_err(serialize_err)?,
+            state.config.security.global_acl_default.clone(),
+        )?,
+        _ => state.config.security.global_acl_default.clone(),
+    };
+
+    let account = state.database.account_add(&target_hash, &acls, None).await?;
+    // Apply a non-standard role if requested (the guards above already authorized it).
+    let account = if new_type != AccountType::Standard {
+        state
+            .database
+            .account_set_role(&target_hash, &new_type)
+            .await?;
+        state
+            .database
+            .account_get(&target_hash)
+            .await?
+            .unwrap_or(account)
+    } else {
+        account
+    };
+
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccountAdd,
+        "account created".to_string(),
+    )
+    .await;
+
+    let response = account::add::v0_1::Response {
+        account: to_wire_account(&account),
+        ext: None,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
 }
 
 /// Handle `messaging/acl/get`: self-or-admin, read-only, batched. Returns one entry

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.28] - 2026-06-24
+
+`atm.trust_tasks().account_add(profile, did_hash, account_type, acl)` — create an
+account and return its realized view. Completes the account-family client surface.
+Additive.
+
 ## [0.18.27] - 2026-06-24
 
 `atm.trust_tasks()` gains `acl_get(profile, did_hashes)` (self-or-admin; batched ACL

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.27"
+version = "0.18.28"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -250,6 +250,42 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.acl)
     }
 
+    /// Send a `messaging/account/add` Trust Task and return the created account's view.
+    /// In allowlist mode only an admin may add accounts; in denylist mode any
+    /// authenticated account may. `acl` is optional — an admin's is applied onto the
+    /// mediator default, a non-admin's is ignored (the default is used). Creating an
+    /// admin / root-admin account requires the matching privilege.
+    pub async fn account_add(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: String,
+        account_type: account::add::v0_1::AccountType,
+        acl: Option<account::add::v0_1::MediatorAcl>,
+    ) -> Result<account::add::v0_1::Account, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let did = account::add::v0_1::Vid::from_str(&did_hash)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            account::add::v0_1::Payload {
+                account_type,
+                acl,
+                did,
+                ext: None,
+                // Initial queue limits use the mediator default; adjust with
+                // `account_change_queue_limits` after creation.
+                queue_limits: None,
+            },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+
+        let response: TrustTask<account::add::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload.account)
+    }
+
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it
     /// to the mediator, and decode the reply's body as a `TrustTask<R>`.
     async fn exchange<P, R>(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 24th June 2026
 
+### 0.2.25 — Trust Tasks: account/add e2e
+
+- `account_add_self_register_creates_a_standard_account` (a standard account adds a new
+  account under the default `ExplicitDeny` mode) and
+  `account_add_denies_a_non_admin_creating_an_admin`.
+
 ### 0.2.24 — Trust Tasks: acl/get + acl/set e2e
 
 - `acl_get_self_returns_the_decoded_acl` (alice reads her own ACL) and

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.24"
+version = "0.2.25"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -265,3 +265,57 @@ async fn acl_set_denies_a_non_admin() {
         .await;
     assert!(denied.is_err(), "a non-admin must not set ACLs");
 }
+
+#[tokio::test]
+async fn account_add_self_register_creates_a_standard_account() {
+    use trust_tasks_rs::specs::messaging::account::add::v0_1::AccountType;
+
+    // The fixture defaults to `ExplicitDeny`, so a standard account may add accounts.
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    let new_hash = "tt-add-standard-account".to_string();
+    let account = env
+        .atm
+        .trust_tasks()
+        .account_add(&alice.profile, new_hash.clone(), AccountType::Standard, None)
+        .await
+        .expect("alice adds a new standard account");
+
+    assert_eq!(account.did.as_str(), new_hash);
+    assert_eq!(account.account_type.to_string(), "standard");
+}
+
+#[tokio::test]
+async fn account_add_denies_a_non_admin_creating_an_admin() {
+    use trust_tasks_rs::specs::messaging::account::add::v0_1::AccountType;
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    let denied = env
+        .atm
+        .trust_tasks()
+        .account_add(
+            &alice.profile,
+            "tt-add-admin-attempt".to_string(),
+            AccountType::Admin,
+            None,
+        )
+        .await;
+    assert!(denied.is_err(), "a non-admin must not create an admin account");
+}


### PR DESCRIPTION
## Summary

The last **account-family** op. The mediator consumes `messaging/account/add` and the SDK exposes `atm.trust_tasks().account_add` — **completing the messaging account family**.

### Mediator (0.16.20 → 0.16.21)
- Routes `account/add`:
  - **`ExplicitAllow`** mode requires admin; **`ExplicitDeny`** (the production default) lets any authenticated account add.
  - An admin may supply the new account's ACL (applied onto the mediator default via the **reverse map**, `merge_wire_acl`); a non-admin gets the default.
  - Creating an **admin / root-admin** account requires the matching privilege (the role is applied via `account_set_role`).
  - Records an audit entry; returns the created account's realized view. Initial queue limits use the mediator default (adjust via `change-queue-limits`).

### SDK (0.18.27 → 0.18.28)
- `atm.trust_tasks().account_add(profile, did_hash, account_type, acl)` → the created account.

### test-mediator (0.2.24 → 0.2.25)
- `account_add_self_register_creates_a_standard_account` (a standard account self-registers under the default `ExplicitDeny` mode — the **happy path is e2e-testable** here, unlike the admin-only ops) + `account_add_denies_a_non_admin_creating_an_admin`.

## Account family — complete ✅
`get` · `list` · `change-queue-limits` · `remove` · `change-type` · `add`, plus `acl/get` · `acl/set`.

## Tests
10 `trust_tasks` e2e + the reverse-map unit test green; clippy clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
The **access-list** family (5: add / get / list / remove / clear), then legacy-method routing through the core (the minor bump), then the admin Trust Task specs + migration.