### PR TITLE
feat: Trust Tasks access-list family — handlers complete (PR-T10)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 24th June 2026
 
+### 0.16.22 — Trust Tasks: access-list family (handlers complete)
+
+- `messaging/access-list/{add,remove,clear,get,list}`: self-or-admin, with the
+  `self_manage_list` capability required for a standard account's writes. `add`
+  truncates at the mediator limit and reports the inserted entries; `remove` reports
+  which requested entries were present; `get` partitions queried entries into
+  present/absent; `list` is cursor-paged (both `None` and `Some(0)` are terminal);
+  `clear` empties the list. Writes record audit entries. This completes every
+  messaging Trust Task handler (ping + account + acl + access-list).
+
 ### 0.16.21 — Trust Tasks: account/add (account family complete)
 
 - `messaging/account/add`: in `ExplicitAllow` mode only an admin may add accounts; in

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.21"
+version = "0.16.22"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -27,7 +27,8 @@ use serde_json::Value;
 use sha256::digest;
 use std::str::FromStr;
 use subtle::ConstantTimeEq;
-use trust_tasks_rs::specs::messaging::{account, acl, ping};
+use std::collections::HashSet;
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
 use trust_tasks_rs::{
     ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
     TrustTask, TypeUri, VerificationError, consume_inbound,
@@ -123,8 +124,8 @@ pub(crate) async fn process(
     let now_secs = state.clock.unix_secs();
     let now = chrono::DateTime::from_timestamp(now_secs as i64, 0).unwrap_or_else(chrono::Utc::now);
 
-    // Route by task type. (ping + account/get so far; the rest of the
-    // account / acl / access-list families extend this chain.)
+    // Route by task type across the ping / account / acl / access-list families.
+    let sk = Some(sender_kid.clone());
     let response_value: Value = if doc.type_uri == type_uri_of::<ping::v0_1::Payload>() {
         match consume_ping(downcast(&doc, session)?, &mediator_did, &sender_did, now).await? {
             Some(value) => value,
@@ -180,6 +181,35 @@ pub(crate) async fn process(
         .await?
     } else if doc.type_uri == type_uri_of::<acl::set::v0_1::Payload>() {
         consume_acl_set(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<access_list::add::v0_1::Payload>() {
+        consume_access_list_add(downcast(&doc, session)?, state, session, &sk, &mediator_did, now)
+            .await?
+    } else if doc.type_uri == type_uri_of::<access_list::remove::v0_1::Payload>() {
+        consume_access_list_remove(
+            downcast(&doc, session)?,
+            state,
+            session,
+            &sk,
+            &mediator_did,
+            now,
+        )
+        .await?
+    } else if doc.type_uri == type_uri_of::<access_list::clear::v0_1::Payload>() {
+        consume_access_list_clear(
+            downcast(&doc, session)?,
+            state,
+            session,
+            &sk,
+            &mediator_did,
+            now,
+        )
+        .await?
+    } else if doc.type_uri == type_uri_of::<access_list::get::v0_1::Payload>() {
+        consume_access_list_get(downcast(&doc, session)?, state, session, &sk, &mediator_did, now)
+            .await?
+    } else if doc.type_uri == type_uri_of::<access_list::list::v0_1::Payload>() {
+        consume_access_list_list(downcast(&doc, session)?, state, session, &sk, &mediator_did, now)
+            .await?
     } else {
         return Err(tt_problem(
             session,
@@ -887,6 +917,263 @@ async fn consume_acl_set(
         .map_err(serialize_err)
 }
 
+/// Access-list authz: self-or-admin for the target, plus the `self_manage_list`
+/// capability for a standard account performing a write.
+fn authorize_access_list(
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    target_hash: &str,
+    write: bool,
+) -> Result<(), MediatorError> {
+    if !check_permissions(
+        session,
+        std::slice::from_ref(&target_hash.to_string()),
+        state.config.security.block_remote_admin_msgs,
+        sender_kid,
+    ) {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            format!("not permitted to access the access list for {target_hash}"),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+    if write
+        && session.account_type == AccountType::Standard
+        && !session.acls.get_self_manage_list()
+    {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            "this account may not self-manage its access list".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+    Ok(())
+}
+
+/// The current size of a DID's access list (0 if the account is unknown).
+async fn access_list_count(state: &SharedData, target_hash: &str) -> u64 {
+    state
+        .database
+        .account_get(target_hash)
+        .await
+        .ok()
+        .flatten()
+        .map(|a| a.access_list_count as u64)
+        .unwrap_or(0)
+}
+
+/// Handle `messaging/access-list/add`: self-or-admin (+ `self_manage_list` for a
+/// standard account). Adds entries (truncated at the mediator limit); reports those
+/// actually inserted and the new count.
+async fn consume_access_list_add(
+    typed: TrustTask<access_list::add::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use access_list::add::v0_1::{Response, Vid};
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    let target_hash = typed.payload.did.to_string();
+    authorize_access_list(state, session, sender_kid, &target_hash, true)?;
+
+    let hashes: Vec<String> = typed.payload.entries.iter().map(|v| v.to_string()).collect();
+    let result = state
+        .database
+        .access_list_add(state.config.limits.access_list_limit, &target_hash, &hashes)
+        .await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccessListAdd,
+        format!("added {} entries", result.did_hashes.len()),
+    )
+    .await;
+
+    let added = result
+        .did_hashes
+        .iter()
+        .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
+        .collect();
+    let response = Response {
+        access_list_count: access_list_count(state, &target_hash).await,
+        added,
+        did: typed.payload.did.clone(),
+        ext: None,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/access-list/remove`: self-or-admin (+ `self_manage_list`).
+/// Reports which of the requested entries were present (and thus removed).
+async fn consume_access_list_remove(
+    typed: TrustTask<access_list::remove::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use access_list::remove::v0_1::{Response, Vid};
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    let target_hash = typed.payload.did.to_string();
+    authorize_access_list(state, session, sender_kid, &target_hash, true)?;
+
+    let hashes: Vec<String> = typed.payload.entries.iter().map(|v| v.to_string()).collect();
+    // Those present before removal are exactly those removed.
+    let present = state.database.access_list_get(&target_hash, &hashes).await?.did_hashes;
+    state.database.access_list_remove(&target_hash, &hashes).await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccessListRemove,
+        format!("removed {} entries", present.len()),
+    )
+    .await;
+
+    let removed = present
+        .iter()
+        .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
+        .collect();
+    let response = Response {
+        access_list_count: access_list_count(state, &target_hash).await,
+        did: typed.payload.did.clone(),
+        ext: None,
+        removed,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/access-list/clear`: self-or-admin (+ `self_manage_list`).
+async fn consume_access_list_clear(
+    typed: TrustTask<access_list::clear::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    let target_hash = typed.payload.did.to_string();
+    authorize_access_list(state, session, sender_kid, &target_hash, true)?;
+
+    state.database.access_list_clear(&target_hash).await?;
+    record_audit(
+        state,
+        session,
+        &target_hash,
+        AuditAction::AccessListClear,
+        "access list cleared".to_string(),
+    )
+    .await;
+
+    let response = access_list::clear::v0_1::Response {
+        access_list_count: access_list_count(state, &target_hash).await,
+        did: typed.payload.did.clone(),
+        ext: None,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/access-list/get`: self-or-admin, read-only. Partitions the
+/// requested entries into those present in the list and those absent.
+async fn consume_access_list_get(
+    typed: TrustTask<access_list::get::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use access_list::get::v0_1::Response;
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    let target_hash = typed.payload.did.to_string();
+    authorize_access_list(state, session, sender_kid, &target_hash, false)?;
+
+    let hashes: Vec<String> = typed.payload.entries.iter().map(|v| v.to_string()).collect();
+    let present: HashSet<String> = state
+        .database
+        .access_list_get(&target_hash, &hashes)
+        .await?
+        .did_hashes
+        .into_iter()
+        .collect();
+
+    let mut present_vids = Vec::new();
+    let mut absent_vids = Vec::new();
+    for v in &typed.payload.entries {
+        if present.contains(v.as_str()) {
+            present_vids.push(v.clone());
+        } else {
+            absent_vids.push(v.clone());
+        }
+    }
+
+    let response = Response {
+        absent: absent_vids,
+        did: typed.payload.did.clone(),
+        ext: None,
+        present: present_vids,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/access-list/list`: self-or-admin, read-only, cursor-paged.
+async fn consume_access_list_list(
+    typed: TrustTask<access_list::list::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &Option<String>,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use access_list::list::v0_1::{Response, ResponseNextCursor, Vid};
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    let target_hash = typed.payload.did.to_string();
+    authorize_access_list(state, session, sender_kid, &target_hash, false)?;
+
+    let cursor: u64 = typed
+        .payload
+        .cursor
+        .as_ref()
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0);
+    let page = state.database.access_list_list(&target_hash, cursor).await?;
+    let entries = page
+        .did_hashes
+        .iter()
+        .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
+        .collect();
+    // Both `None` and `Some(0)` mean the listing is exhausted.
+    let next_cursor = match page.cursor {
+        None | Some(0) => None,
+        Some(c) => Some(
+            ResponseNextCursor::from_str(&c.to_string())
+                .map_err(|e| serialize_err_msg(format!("cursor: {e}")))?,
+        ),
+    };
+
+    let response = Response {
+        access_list_count: access_list_count(state, &target_hash).await,
+        did: typed.payload.did.clone(),
+        entries,
+        ext: None,
+        next_cursor,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.
 ///
 /// The DID is carried as the mediator's account hash — a valid `Vid` per the
@@ -1036,6 +1323,27 @@ fn tt_problem(
         vec![],
         status,
     )
+}
+
+/// Framework basics: the request is addressed to this mediator and not expired.
+fn validate_tt_basic<P>(
+    typed: &TrustTask<P>,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), MediatorError> {
+    typed.validate_basic(now, mediator_did).map_err(|reason| {
+        tt_problem(
+            session,
+            "message.trust_task.rejected",
+            format!("Trust Task failed basic validation: {reason:?}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })
+}
+
+fn serialize_err_msg(msg: String) -> MediatorError {
+    MediatorError::InternalError(14, "NA".to_string(), msg)
 }
 
 fn serialize_err(e: serde_json::Error) -> MediatorError {

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.29] - 2026-06-24
+
+`atm.trust_tasks()` gains the access-list family: `access_list_add` / `access_list_remove`
+/ `access_list_clear` / `access_list_get` / `access_list_list` (self-or-admin; `None` =
+own list). Completes the messaging Trust Tasks client surface. Additive.
+
 ## [0.18.28] - 2026-06-24
 
 `atm.trust_tasks().account_add(profile, did_hash, account_type, acl)` — create an

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.28"
+version = "0.18.29"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -22,7 +22,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use sha256::digest;
 use trust_tasks_rs::TrustTask;
-use trust_tasks_rs::specs::messaging::{account, acl, ping};
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
 use uuid::Uuid;
 
 use crate::{ATM, errors::ATMError, profiles::ATMProfile, transports::SendMessageResponse};
@@ -284,6 +284,141 @@ impl TrustTasksOps<'_> {
         let response: TrustTask<account::add::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload.account)
+    }
+
+    /// `messaging/access-list/add` — add entries to an account's access list (self-or-
+    /// admin; `None` = own list). Returns the inserted entries and the new count.
+    pub async fn access_list_add(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+        entries: Vec<String>,
+    ) -> Result<access_list::add::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+        let did = access_list::add::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let entries = entries
+            .iter()
+            .map(|e| access_list::add::v0_1::Vid::from_str(e))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            access_list::add::v0_1::Payload { did, entries, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<access_list::add::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/access-list/remove` — remove entries (self-or-admin; `None` = own
+    /// list). Returns which of the requested entries were present (and so removed).
+    pub async fn access_list_remove(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+        entries: Vec<String>,
+    ) -> Result<access_list::remove::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+        let did = access_list::remove::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let entries = entries
+            .iter()
+            .map(|e| access_list::remove::v0_1::Vid::from_str(e))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            access_list::remove::v0_1::Payload { did, entries, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<access_list::remove::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/access-list/clear` — drop the entire access list (self-or-admin;
+    /// `None` = own list).
+    pub async fn access_list_clear(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+    ) -> Result<access_list::clear::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+        let did = access_list::clear::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            access_list::clear::v0_1::Payload { did, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<access_list::clear::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/access-list/get` — partition the queried entries into those present
+    /// in the list and those absent (self-or-admin; `None` = own list).
+    pub async fn access_list_get(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+        entries: Vec<String>,
+    ) -> Result<access_list::get::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+        let did = access_list::get::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let entries = entries
+            .iter()
+            .map(|e| access_list::get::v0_1::Vid::from_str(e))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            access_list::get::v0_1::Payload { did, entries, ext: None },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<access_list::get::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/access-list/list` — page through an account's access list (self-or-
+    /// admin; `None` = own list). Returns entries plus an opaque `next_cursor`.
+    pub async fn access_list_list(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hash: Option<String>,
+        cursor: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<access_list::list::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
+        let did = access_list::list::v0_1::Vid::from_str(&target)
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let cursor = cursor
+            .map(|c| access_list::list::v0_1::PayloadCursor::from_str(&c))
+            .transpose()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
+        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            access_list::list::v0_1::Payload { cursor, did, ext: None, limit },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<access_list::list::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
     }
 
     /// Wrap a `TrustTask<P>` in the DIDComm binding envelope, authcrypt + send it

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## 24th June 2026
 
+### 0.2.26 — Trust Tasks: access-list lifecycle e2e
+
+- `access_list_self_lifecycle`: alice adds, queries, lists, removes, and clears entries
+  on her own access list, asserting counts and present/absent partitioning throughout.
+
 ### 0.2.25 — Trust Tasks: account/add e2e
 
 - `account_add_self_register_creates_a_standard_account` (a standard account adds a new

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.25"
+version = "0.2.26"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -319,3 +319,72 @@ async fn account_add_denies_a_non_admin_creating_an_admin() {
         .await;
     assert!(denied.is_err(), "a non-admin must not create an admin account");
 }
+
+#[tokio::test]
+async fn access_list_self_lifecycle() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let carol = env.add_user("carol").await.expect("add carol");
+
+    // Add bob + carol to alice's own access list (allow_all grants self-manage).
+    let added = env
+        .atm
+        .trust_tasks()
+        .access_list_add(&alice.profile, None, vec![bob.did_hash(), carol.did_hash()])
+        .await
+        .expect("add to access list");
+    assert_eq!(added.added.len(), 2);
+    assert_eq!(added.access_list_count, 2);
+
+    // Get: bob is present, an unknown hash is absent.
+    let got = env
+        .atm
+        .trust_tasks()
+        .access_list_get(
+            &alice.profile,
+            None,
+            vec![bob.did_hash(), "not-in-the-list".to_string()],
+        )
+        .await
+        .expect("query access list");
+    assert!(got.present.iter().any(|v| v.as_str() == bob.did_hash()));
+    assert!(got.absent.iter().any(|v| v.as_str() == "not-in-the-list"));
+
+    // List: both entries, single page.
+    let listed = env
+        .atm
+        .trust_tasks()
+        .access_list_list(&alice.profile, None, None, None)
+        .await
+        .expect("list access list");
+    assert_eq!(listed.access_list_count, 2);
+    assert_eq!(listed.entries.len(), 2);
+    assert!(listed.next_cursor.is_none());
+
+    // Remove bob.
+    let removed = env
+        .atm
+        .trust_tasks()
+        .access_list_remove(&alice.profile, None, vec![bob.did_hash()])
+        .await
+        .expect("remove from access list");
+    assert_eq!(removed.removed.len(), 1);
+    assert_eq!(removed.access_list_count, 1);
+
+    // Clear.
+    let cleared = env
+        .atm
+        .trust_tasks()
+        .access_list_clear(&alice.profile, None)
+        .await
+        .expect("clear access list");
+    assert_eq!(cleared.access_list_count, 0);
+}


### PR DESCRIPTION
## Summary

The **access-list family** (`add` / `remove` / `clear` / `get` / `list`) — and with it, **every messaging Trust Task handler is implemented**.

### Mediator (0.16.21 → 0.16.22)
- Routes all five access-list ops — **self-or-admin**, with the **`self_manage_list`** capability required for a standard account's writes:
  - `add` truncates at the mediator limit and reports the inserted entries;
  - `remove` reports which requested entries were present (and so removed);
  - `get` partitions queried entries into present / absent;
  - `list` is cursor-paged (both `None` and `Some(0)` are terminal — the documented backend split);
  - `clear` empties the list.
- Writes record audit entries. Adds `authorize_access_list` / `access_list_count` / `validate_tt_basic` helpers.

### SDK (0.18.28 → 0.18.29)
- `atm.trust_tasks().access_list_{add,remove,clear,get,list}` (`None` = own list).

### test-mediator (0.2.25 → 0.2.26)
- `access_list_self_lifecycle`: alice adds, queries, lists, removes, and clears entries on her own list — asserting counts and present/absent partitioning throughout. (Self-manageable, so the **full lifecycle is e2e-tested**.)

## Messaging Trust Task handlers — complete ✅
`ping` · account `{get,list,change-queue-limits,remove,change-type,add}` · acl `{get,set}` · access-list `{add,remove,clear,get,list}`.

## Tests
11 `trust_tasks` e2e + the reverse-map unit test green; clippy clean; **DIDComm regression (`lifecycle` 22) green**.

## Next (Phase 3–5)
Route the legacy `atm.mediator()` / `atm.trust_ping()` through the Trust Tasks core (the breaking change → SDK **minor** bump), then the admin Trust Task specs + migration.