### PR TITLE
feat: Trust Tasks admin family — all messaging tasks complete (PR-T11)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 24th June 2026
 
+### 0.16.23 — Trust Tasks: admin family (all messaging tasks complete)
+
+- `messaging/admin/{add,strip,list,audit-log,config}`: admin-only. `add`/`strip` grant
+  and revoke admin rights (auditing each); `list` pages the admin accounts; `audit-log`
+  pages the privileged-change log (mapping the mediator's internal `AuditLogEntry` /
+  `AuditAction` to the wire shapes); `config` returns the mediator version + its
+  configuration object. Picks up the published `trust-tasks-rs` 0.2.11 (the admin
+  family specs). This completes every messaging Trust Task — the four legacy mediator
+  management protocols are now fully expressible as Trust Tasks.
+
 ### 0.16.22 — Trust Tasks: access-list family (handlers complete)
 
 - `messaging/access-list/{add,remove,clear,get,list}`: self-or-admin, with the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.22"
+version = "0.16.23"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -19,7 +19,8 @@ use affinidi_messaging_mediator_common::types::accounts::{Account, AccountType};
 use affinidi_messaging_mediator_common::types::acls::{
     ACLError, AccessListModeType, MediatorACLSet,
 };
-use affinidi_messaging_mediator_common::types::audit::AuditAction;
+use affinidi_messaging_mediator_common::types::administration::AdminAccount as MediatorAdminAccount;
+use affinidi_messaging_mediator_common::types::audit::{AuditAction, AuditLogEntry};
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
 use http::StatusCode;
@@ -28,7 +29,7 @@ use sha256::digest;
 use std::str::FromStr;
 use subtle::ConstantTimeEq;
 use std::collections::HashSet;
-use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, admin, ping};
 use trust_tasks_rs::{
     ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
     TrustTask, TypeUri, VerificationError, consume_inbound,
@@ -210,6 +211,16 @@ pub(crate) async fn process(
     } else if doc.type_uri == type_uri_of::<access_list::list::v0_1::Payload>() {
         consume_access_list_list(downcast(&doc, session)?, state, session, &sk, &mediator_did, now)
             .await?
+    } else if doc.type_uri == type_uri_of::<admin::add::v0_1::Payload>() {
+        consume_admin_add(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<admin::strip::v0_1::Payload>() {
+        consume_admin_strip(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<admin::list::v0_1::Payload>() {
+        consume_admin_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<admin::audit_log::v0_1::Payload>() {
+        consume_admin_audit_log(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<admin::config::v0_1::Payload>() {
+        consume_admin_config(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else {
         return Err(tt_problem(
             session,
@@ -1172,6 +1183,218 @@ async fn consume_access_list_list(
     };
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
+}
+
+/// Reject a non-admin caller of an admin-only task.
+fn require_admin(session: &Session, task: &str) -> Result<(), MediatorError> {
+    if matches!(
+        session.account_type,
+        AccountType::Admin | AccountType::RootAdmin
+    ) {
+        Ok(())
+    } else {
+        Err(tt_problem(
+            session,
+            "authorization.admin_required",
+            format!("{task} requires an admin account"),
+            StatusCode::FORBIDDEN,
+        ))
+    }
+}
+
+/// Handle `messaging/admin/add`: admin-only. Grants admin rights to the named
+/// accounts (with the mediator's default ACL) and echoes the now-admin set.
+async fn consume_admin_add(
+    typed: TrustTask<admin::add::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    require_admin(session, "admin/add")?;
+
+    let dids: Vec<String> = typed.payload.dids.iter().map(|v| v.to_string()).collect();
+    state
+        .database
+        .add_admin_accounts(dids.clone(), &state.config.security.global_acl_default)
+        .await?;
+    for did in &dids {
+        record_audit(state, session, did, AuditAction::AdminAdd, "promoted to admin".to_string()).await;
+    }
+
+    let response = admin::add::v0_1::Response {
+        admins: typed.payload.dids.clone(),
+        ext: None,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/admin/strip`: admin-only. Removes admin rights from the named
+/// accounts (demoting them to standard) and echoes the stripped set.
+async fn consume_admin_strip(
+    typed: TrustTask<admin::strip::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    require_admin(session, "admin/strip")?;
+
+    let dids: Vec<String> = typed.payload.dids.iter().map(|v| v.to_string()).collect();
+    state.database.strip_admin_accounts(dids.clone()).await?;
+    for did in &dids {
+        record_audit(state, session, did, AuditAction::AdminStrip, "admin rights stripped".to_string())
+            .await;
+    }
+
+    let response = admin::strip::v0_1::Response {
+        ext: None,
+        stripped: typed.payload.dids.clone(),
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/admin/list`: admin-only. Pages the mediator's admin accounts.
+async fn consume_admin_list(
+    typed: TrustTask<admin::list::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use admin::list::v0_1::{Response, ResponseNextCursor};
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    require_admin(session, "admin/list")?;
+
+    let cursor: u32 = typed
+        .payload
+        .cursor
+        .as_ref()
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0);
+    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
+
+    let page = state.database.list_admin_accounts(cursor, limit).await?;
+    let admins = page.accounts.iter().map(map_admin_account).collect();
+    let next_cursor = (page.cursor != 0)
+        .then(|| ResponseNextCursor::from_str(&page.cursor.to_string()))
+        .transpose()
+        .map_err(|e| serialize_err_msg(format!("cursor: {e}")))?;
+
+    let response = Response {
+        admins,
+        ext: None,
+        next_cursor,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/admin/audit-log`: admin-only. Pages the privileged-change log.
+async fn consume_admin_audit_log(
+    typed: TrustTask<admin::audit_log::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    use admin::audit_log::v0_1::{Response, ResponseNextCursor};
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    require_admin(session, "admin/audit-log")?;
+
+    let cursor: u32 = typed
+        .payload
+        .cursor
+        .as_ref()
+        .and_then(|c| c.parse().ok())
+        .unwrap_or(0);
+    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
+
+    let page = state.database.audit_log_list(cursor, limit).await?;
+    let entries = page.entries.iter().map(map_audit_entry).collect();
+    let next_cursor = (page.cursor != 0)
+        .then(|| ResponseNextCursor::from_str(&page.cursor.to_string()))
+        .transpose()
+        .map_err(|e| serialize_err_msg(format!("cursor: {e}")))?;
+
+    let response = Response {
+        entries,
+        ext: None,
+        next_cursor,
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+/// Handle `messaging/admin/config`: admin-only. Returns the mediator's software
+/// version and current configuration.
+async fn consume_admin_config(
+    typed: TrustTask<admin::config::v0_1::Payload>,
+    state: &SharedData,
+    session: &Session,
+    mediator_did: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, MediatorError> {
+    validate_tt_basic(&typed, session, mediator_did, now)?;
+    require_admin(session, "admin/config")?;
+
+    let config = serde_json::to_value(&state.config)
+        .map_err(serialize_err)?
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+    let response = admin::config::v0_1::Response {
+        config,
+        ext: None,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+        .map_err(serialize_err)
+}
+
+fn map_admin_account(a: &MediatorAdminAccount) -> admin::list::v0_1::AdminAccount {
+    use admin::list::v0_1::{AccountType as WireType, AdminAccount as Wire, Vid};
+    Wire {
+        account_type: match a._type {
+            AccountType::Standard => WireType::Standard,
+            AccountType::Admin => WireType::Admin,
+            AccountType::RootAdmin => WireType::RootAdmin,
+            AccountType::Mediator => WireType::Mediator,
+            AccountType::Unknown => WireType::Standard,
+        },
+        did: Vid::from_str(&a.did_hash).expect("an account hash is a valid Vid"),
+    }
+}
+
+fn map_audit_entry(e: &AuditLogEntry) -> admin::audit_log::v0_1::AuditEntry {
+    use admin::audit_log::v0_1::{AuditEntry as Wire, Vid};
+    Wire {
+        action: map_audit_action(e.action),
+        actor: Vid::from_str(&e.actor_did_hash).expect("an account hash is a valid Vid"),
+        detail: Some(e.detail.clone()),
+        target: Vid::from_str(&e.target_did_hash).expect("an account hash is a valid Vid"),
+        timestamp: e.timestamp,
+    }
+}
+
+fn map_audit_action(a: AuditAction) -> admin::audit_log::v0_1::AuditAction {
+    use admin::audit_log::v0_1::AuditAction as W;
+    match a {
+        AuditAction::SetAcl => W::SetAcl,
+        AuditAction::AccessListAdd => W::AccessListAdd,
+        AuditAction::AccessListRemove => W::AccessListRemove,
+        AuditAction::AccessListClear => W::AccessListClear,
+        AuditAction::AccountAdd => W::AccountAdd,
+        AuditAction::AccountRemove => W::AccountRemove,
+        AuditAction::AccountChangeType => W::AccountChangeType,
+        AuditAction::AccountChangeQueueLimits => W::AccountChangeQueueLimits,
+        AuditAction::AdminAdd => W::AdminAdd,
+        AuditAction::AdminStrip => W::AdminStrip,
+    }
 }
 
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.30] - 2026-06-24
+
+`atm.trust_tasks()` gains the admin family: `admin_add` / `admin_strip` / `admin_list` /
+`admin_audit_log` / `admin_config` (all admin only). Completes the messaging Trust Tasks
+client surface. Additive.
+
 ## [0.18.29] - 2026-06-24
 
 `atm.trust_tasks()` gains the access-list family: `access_list_add` / `access_list_remove`

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.29"
+version = "0.18.30"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -22,7 +22,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use sha256::digest;
 use trust_tasks_rs::TrustTask;
-use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, admin, ping};
 use uuid::Uuid;
 
 use crate::{ATM, errors::ATMError, profiles::ATMProfile, transports::SendMessageResponse};
@@ -417,6 +417,110 @@ impl TrustTasksOps<'_> {
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
         let response: TrustTask<access_list::list::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/admin/add` (admin only) — grant admin rights to the named accounts.
+    /// Returns the now-admin account identifiers.
+    pub async fn admin_add(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hashes: Vec<String>,
+    ) -> Result<Vec<String>, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let dids = did_hashes
+            .iter()
+            .map(|d| admin::add::v0_1::Vid::from_str(d))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task = TrustTask::for_payload(new_id(), admin::add::v0_1::Payload { dids, ext: None });
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<admin::add::v0_1::Response> = self.exchange(profile, &task).await?;
+        Ok(response.payload.admins.iter().map(|v| v.to_string()).collect())
+    }
+
+    /// `messaging/admin/strip` (admin only) — revoke admin rights from the named
+    /// accounts. Returns the stripped account identifiers.
+    pub async fn admin_strip(
+        &self,
+        profile: &Arc<ATMProfile>,
+        did_hashes: Vec<String>,
+    ) -> Result<Vec<String>, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let dids = did_hashes
+            .iter()
+            .map(|d| admin::strip::v0_1::Vid::from_str(d))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
+        let mut task =
+            TrustTask::for_payload(new_id(), admin::strip::v0_1::Payload { dids, ext: None });
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<admin::strip::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload.stripped.iter().map(|v| v.to_string()).collect())
+    }
+
+    /// `messaging/admin/list` (admin only) — page the mediator's admin accounts.
+    pub async fn admin_list(
+        &self,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<admin::list::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let cursor = cursor
+            .map(|c| admin::list::v0_1::PayloadCursor::from_str(&c))
+            .transpose()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
+        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            admin::list::v0_1::Payload { cursor, ext: None, limit },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<admin::list::v0_1::Response> = self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/admin/audit-log` (admin only) — page the privileged-change log,
+    /// newest first.
+    pub async fn admin_audit_log(
+        &self,
+        profile: &Arc<ATMProfile>,
+        cursor: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<admin::audit_log::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let cursor = cursor
+            .map(|c| admin::audit_log::v0_1::PayloadCursor::from_str(&c))
+            .transpose()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
+        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+        let mut task = TrustTask::for_payload(
+            new_id(),
+            admin::audit_log::v0_1::Payload { cursor, ext: None, limit },
+        );
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<admin::audit_log::v0_1::Response> =
+            self.exchange(profile, &task).await?;
+        Ok(response.payload)
+    }
+
+    /// `messaging/admin/config` (admin only) — read the mediator's version + config.
+    pub async fn admin_config(
+        &self,
+        profile: &Arc<ATMProfile>,
+    ) -> Result<admin::config::v0_1::Response, ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+        let mut task = TrustTask::for_payload(new_id(), admin::config::v0_1::Payload { ext: None });
+        task.issuer = Some(profile_did.to_string());
+        task.recipient = Some(mediator_did.to_string());
+        let response: TrustTask<admin::config::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload)
     }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## 24th June 2026
 
+### 0.2.27 — Trust Tasks: admin family denial e2e
+
+- `admin_family_denies_a_non_admin`: a standard account is refused all five
+  `messaging/admin/*` tasks.
+
 ### 0.2.26 — Trust Tasks: access-list lifecycle e2e
 
 - `access_list_self_lifecycle`: alice adds, queries, lists, removes, and clears entries

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.26"
+version = "0.2.27"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -388,3 +388,42 @@ async fn access_list_self_lifecycle() {
         .expect("clear access list");
     assert_eq!(cleared.access_list_count, 0);
 }
+
+#[tokio::test]
+async fn admin_family_denies_a_non_admin() {
+    // Every messaging/admin/* task is admin-only. A standard account must be refused
+    // for all of them. (The admin happy paths aren't exercised: an add_admin identity
+    // isn't a streaming-registered account, so admin-over-WS doesn't run on the
+    // in-memory harness — the handlers mirror the legacy admin-management protocol.)
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    assert!(
+        env.atm.trust_tasks().admin_add(&alice.profile, vec![bob.did_hash()]).await.is_err(),
+        "non-admin admin/add must be refused"
+    );
+    assert!(
+        env.atm.trust_tasks().admin_strip(&alice.profile, vec![bob.did_hash()]).await.is_err(),
+        "non-admin admin/strip must be refused"
+    );
+    assert!(
+        env.atm.trust_tasks().admin_list(&alice.profile, None, None).await.is_err(),
+        "non-admin admin/list must be refused"
+    );
+    assert!(
+        env.atm.trust_tasks().admin_audit_log(&alice.profile, None, None).await.is_err(),
+        "non-admin admin/audit-log must be refused"
+    );
+    assert!(
+        env.atm.trust_tasks().admin_config(&alice.profile).await.is_err(),
+        "non-admin admin/config must be refused"
+    );
+}


### PR DESCRIPTION
## Summary

The **`messaging/admin/*`** family — implementing the admin Trust Task specs (trust-tasks #101, published as `trust-tasks-rs 0.2.11`). This is the **last** of the four legacy mediator management protocols to become Trust Tasks.

### Mediator (0.16.22 → 0.16.23)
- Routes all five admin ops — **admin-only** (`require_admin`):
  - `admin/add` / `admin/strip` — grant / revoke admin rights (`add_admin_accounts` / `strip_admin_accounts`), auditing each change;
  - `admin/list` — pages `list_admin_accounts`;
  - `admin/audit-log` — pages `audit_log_list`, mapping the mediator's internal `AuditLogEntry` / `AuditAction` to the wire shapes (snake_case → the spec's camelCase enum);
  - `admin/config` — returns the mediator `version` (`CARGO_PKG_VERSION`) + `state.config` as a JSON object.

### SDK (0.18.29 → 0.18.30)
- `atm.trust_tasks().admin_{add,strip,list,audit_log,config}` (all admin only).

### test-mediator (0.2.26 → 0.2.27)
- `admin_family_denies_a_non_admin`: a standard account is refused all five `admin/*` tasks. (The admin happy paths aren't WS-testable on the in-memory harness — same as the other admin-only ops.)

## Messaging Trust Tasks — fully complete ✅
`ping` · account `{get,list,change-queue-limits,remove,change-type,add}` · acl `{get,set}` · access-list `{add,remove,clear,get,list}` · **admin `{add,strip,list,audit-log,config}`** — all four legacy management protocols (trust-ping, account-management, acl-management, admin-management) now expressible as Trust Tasks.

## Tests
12 `trust_tasks` e2e + the reverse-map unit test green; clippy clean; **DIDComm regression (`lifecycle` 22) green**.

## Next (Phase 5)
Route the legacy `atm.mediator()` / `atm.trust_ping()` SDK methods through the Trust Tasks core (the breaking change → SDK **minor** bump), then deprecate.