### PR TITLE
feat: deprecate legacy atm.mediator() methods for atm.trust_tasks() (PR-T12)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.7] - 2026-06-24
+
+Allows the now-`#[deprecated]` legacy `atm.mediator()` methods it still calls
+(`#![allow(deprecated)]` in `service/mediator.rs`) so the build stays clean under
+`-D warnings`. No behaviour change; migration to `atm.trust_tasks()` is a follow-up.
+
 ## [0.3.6] - 2026-06-14
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.6"
+version = "0.3.7"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Sends a message from Alice to Bob and then retrieves it.
 
 use affinidi_messaging_didcomm::message::Message;

--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Cross-Mediator Forwarding Example
 //!
 //! Demonstrates DIDComm message forwarding between two *different* mediators.

--- a/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_sdk::{
     errors::ATMError,

--- a/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 /*! Reproducible attack vector to hijack an admin account
  *
  * This is a demonstration of a potential attack vector that can be used to hijack an admin account.

--- a/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Tries to Spoof a message from Mallory to Bob, but pretending to be Alice.
 //! Mallory send to Bob, but inner envelope pretends to be Alice
 

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Example of how to manage administration accounts for the mediator
 use account_management::account_management::account_management_menu;
 use affinidi_messaging_helpers::common::{affinidi_logo::print_logo, check_path};

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.18.31] - 2026-06-24
+
+The legacy `atm.mediator()` management methods are now `#[deprecated]` in favour of the
+`atm.trust_tasks()` core: `account_get`/`account_add`/`account_remove`/`accounts_list`/
+`account_change_type`/`account_change_queue_limits`, `acls_get`/`acls_set`,
+`access_list_{list,add,remove,clear,get}`, and `get_config`/`add_admins`/`strip_admins`/
+`list_admins`/`list_audit_log` — each points to its `atm.trust_tasks().*` replacement.
+The methods still work (legacy DIDComm wire); they will be removed in a future major
+release (the breaking change). **Additive — patch bump, `0.18` pin stays valid.** (The
+deliberately-louder minor/major bump is reserved for the removal, per the workspace's
+patch-not-minor convention.)
+
 ## [0.18.30] - 2026-06-24
 
 `atm.trust_tasks()` gains the admin family: `admin_add` / `admin_strip` / `admin_list` /

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.30"
+version = "0.18.31"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/accounts.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/accounts.rs
@@ -453,6 +453,7 @@ impl Mediator {
 impl<'a> MediatorOps<'a> {
     /// Fetch an account information from the mediator
     /// See [`Mediator::account_get`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_get()` instead")]
     pub async fn account_get(
         &self,
         profile: &Arc<ATMProfile>,
@@ -465,6 +466,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Create a new account on the Mediator for a given DID
     /// See [`Mediator::account_add`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_add()` instead")]
     pub async fn account_add(
         &self,
         profile: &Arc<ATMProfile>,
@@ -478,6 +480,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Removes an account from the mediator
     /// See [`Mediator::account_remove`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_remove()` instead")]
     pub async fn account_remove(
         &self,
         profile: &Arc<ATMProfile>,
@@ -490,6 +493,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Lists known DID accounts in the mediator
     /// See [`Mediator::accounts_list`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_list()` instead")]
     pub async fn accounts_list(
         &self,
         profile: &Arc<ATMProfile>,
@@ -503,6 +507,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Change the Account Type for a DID
     /// See [`Mediator::account_change_type`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_change_type()` instead")]
     pub async fn account_change_type(
         &self,
         profile: &Arc<ATMProfile>,
@@ -516,6 +521,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Change the Queue Limits for a DID
     /// See [`Mediator::account_change_queue_limits`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().account_change_queue_limits()` instead")]
     pub async fn account_change_queue_limits(
         &self,
         profile: &Arc<ATMProfile>,

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/acls_handler.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/acls_handler.rs
@@ -578,6 +578,7 @@ impl Mediator {
 impl<'a> MediatorOps<'a> {
     /// Get the ACL's set for a list of DIDs
     /// See [`Mediator::acls_get`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().acl_get()` instead")]
     pub async fn acls_get(
         &self,
         profile: &Arc<ATMProfile>,
@@ -588,6 +589,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Set the ACL's for a DID
     /// See [`Mediator::acls_set`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().acl_set()` instead")]
     pub async fn acls_set(
         &self,
         profile: &Arc<ATMProfile>,
@@ -601,6 +603,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Access List List: Lists hash of DID's in the Access Control List for a given DID
     /// See [`Mediator::access_list_list`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().access_list_list()` instead")]
     pub async fn access_list_list(
         &self,
         profile: &Arc<ATMProfile>,
@@ -614,6 +617,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Access List Add: Adds one or more DIDs to a Access Control List for a given DID
     /// See [`Mediator::access_list_add`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().access_list_add()` instead")]
     pub async fn access_list_add(
         &self,
         profile: &Arc<ATMProfile>,
@@ -627,6 +631,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Access List Remove: Removes one or more DIDs from a Access Control List for a given DID
     /// See [`Mediator::access_list_remove`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().access_list_remove()` instead")]
     pub async fn access_list_remove(
         &self,
         profile: &Arc<ATMProfile>,
@@ -640,6 +645,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Access List Clear: Clears Access Control List for a given DID
     /// See [`Mediator::access_list_clear`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().access_list_clear()` instead")]
     pub async fn access_list_clear(
         &self,
         profile: &Arc<ATMProfile>,
@@ -652,6 +658,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Access List Get: Searches for one or more DID's in the Access Control List for a given DID
     /// See [`Mediator::access_list_get`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().access_list_get()` instead")]
     pub async fn access_list_get(
         &self,
         profile: &Arc<ATMProfile>,

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/administration.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mediator/administration.rs
@@ -407,12 +407,14 @@ pub struct MediatorOps<'a> {
 impl<'a> MediatorOps<'a> {
     /// Get mediator configuration
     /// See [`Mediator::get_config`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().admin_config()` instead")]
     pub async fn get_config(&self, profile: &Arc<ATMProfile>) -> Result<Value, ATMError> {
         Mediator::default().get_config(self.atm, profile).await
     }
 
     /// Adds a number of admins to the mediator
     /// See [`Mediator::add_admins`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().admin_add()` instead")]
     pub async fn add_admins(
         &self,
         profile: &Arc<ATMProfile>,
@@ -425,6 +427,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Strips admin rights from a number of accounts from the mediator
     /// See [`Mediator::strip_admins`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().admin_strip()` instead")]
     pub async fn strip_admins(
         &self,
         profile: &Arc<ATMProfile>,
@@ -437,6 +440,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Lists all the admins in the mediator
     /// See [`Mediator::list_admins`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().admin_list()` instead")]
     pub async fn list_admins(
         &self,
         profile: &Arc<ATMProfile>,
@@ -450,6 +454,7 @@ impl<'a> MediatorOps<'a> {
 
     /// Pages through the mediator's privileged-change audit log
     /// See [`Mediator::list_audit_log`] for full documentation
+    #[deprecated(since = "0.18.31", note = "use `atm.trust_tasks().admin_audit_log()` instead")]
     pub async fn list_audit_log(
         &self,
         profile: &Arc<ATMProfile>,

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/mod.rs
@@ -7,7 +7,7 @@
 //! ```rust,ignore
 //! atm.trust_ping().send_ping(&profile, &did, true, true, false).await?;
 //! atm.message_pickup().live_stream_get(&profile, &msg_id, dur, true).await?;
-//! atm.mediator().get_config(&profile).await?;
+//! atm.trust_tasks().admin_config(&profile).await?;
 //! ```
 
 use mediator::administration::Mediator;

--- a/crates/messaging/affinidi-messaging-text-client/src/main.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use affinidi_tdk::common::TDKSharedState;
 use log::LevelFilter;
 use state_store::StateStore;


### PR DESCRIPTION
## Summary

**Phase 5, step 1** — the chosen approach was *deprecate now, remove later*. The legacy `atm.mediator()` management methods now carry `#[deprecated]` attributes pointing to their `atm.trust_tasks()` equivalents (the single Trust Tasks core).

### SDK (0.18.30 → 0.18.31)
- `#[deprecated]` on the **18** `atm.mediator()` management wrappers:
  - account: `account_get` / `account_add` / `account_remove` / `accounts_list` / `account_change_type` / `account_change_queue_limits`
  - acl: `acls_get` / `acls_set`
  - access-list: `access_list_{list,add,remove,clear,get}`
  - admin: `get_config` / `add_admins` / `strip_admins` / `list_admins` / `list_audit_log`
- Each `note` points to the `atm.trust_tasks().*` replacement. The methods **still work** (legacy DIDComm wire); **removal** (the breaking change) is a future major.

### Versioning — patch, not minor
Adding `#[deprecated]` is **additive (non-breaking)**, so this is a **patch** (`0.18.31`) — the `affinidi-messaging-sdk = "0.18"` pins stay valid. A **minor** bump (`0.19.0`) would cascade pin updates across ~6 dependent crates, against the workspace's patch-not-minor convention (ADR-0003). The deliberately-louder **minor/major** bump is reserved for the **removal** (the real break) — which is where your "minor bump signals breaking" principle properly applies.

### Consumer grace period
First-party callers keep the legacy API (which still works) under `#![allow(deprecated)]` for now; migrating them to `atm.trust_tasks()` is a follow-up:
- `affinidi-messaging-helpers` (admin tool + examples) — `publish = false`.
- `affinidi-messaging-text-client` — `publish = false`.
- `affinidi-messaging-didcomm-service` (0.3.6 → 0.3.7) — published.

## Tests
SDK + all consumers build clean under **`-D warnings`** (matching CI); clippy clean. No behaviour change.

## Next
Migrate the first-party consumers (helpers admin tool, text-client, didcomm-service) to `atm.trust_tasks()`, then schedule the legacy removal (the breaking major).