### PR TITLE
feat: Trust Tasks acl/set non-admin self-service (PR-T13)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 24th June 2026
 
+### 0.16.24 — Trust Tasks: acl/set non-admin self-service
+
+- `messaging/acl/set` now supports non-admin **self-service** (it was admin-only). A
+  standard account may set its **own** ACL, but only the capabilities it is permitted
+  to self-manage (per the per-capability self-change bits); the admin-only flags
+  (`blocked`, `local`, the `selfManage*` bits) are refused, as is setting any other
+  account's ACL. Faithful to the legacy `acls_set` rules — making `acl/set` a full
+  replacement for the legacy method (unblocks migrating self-service consumers).
+
 ### 0.16.23 — Trust Tasks: admin family (all messaging tasks complete)
 
 - `messaging/admin/{add,strip,list,audit-log,config}`: admin-only. `add`/`strip` grant

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.23"
+version = "0.16.24"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -181,7 +181,7 @@ pub(crate) async fn process(
         )
         .await?
     } else if doc.type_uri == type_uri_of::<acl::set::v0_1::Payload>() {
-        consume_acl_set(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+        consume_acl_set(downcast(&doc, session)?, state, session, &sk, &mediator_did, now).await?
     } else if doc.type_uri == type_uri_of::<access_list::add::v0_1::Payload>() {
         consume_access_list_add(downcast(&doc, session)?, state, session, &sk, &mediator_did, now)
             .await?
@@ -876,37 +876,45 @@ async fn consume_acl_set(
     typed: TrustTask<acl::set::v0_1::Payload>,
     state: &SharedData,
     session: &Session,
+    sender_kid: &Option<String>,
     mediator_did: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, MediatorError> {
-    typed.validate_basic(now, mediator_did).map_err(|reason| {
-        tt_problem(
-            session,
-            "message.trust_task.rejected",
-            format!("Trust Task failed basic validation: {reason:?}"),
-            StatusCode::BAD_REQUEST,
-        )
-    })?;
+    validate_tt_basic(&typed, session, mediator_did, now)?;
 
-    if !matches!(
+    let target_hash = typed.payload.did.to_string();
+    let is_admin = matches!(
         session.account_type,
         AccountType::Admin | AccountType::RootAdmin
+    );
+
+    // Self-or-admin: a non-admin may only set its own ACL.
+    if !check_permissions(
+        session,
+        std::slice::from_ref(&target_hash),
+        state.config.security.block_remote_admin_msgs,
+        sender_kid,
     ) {
         return Err(tt_problem(
             session,
-            "authorization.admin_required",
-            "acl/set requires an admin account".to_string(),
+            "authorization.account.denied",
+            format!("not permitted to set the ACL for {target_hash}"),
             StatusCode::FORBIDDEN,
         ));
     }
 
-    let target_hash = typed.payload.did.to_string();
     let base = state
         .database
         .get_did_acl(&target_hash)
         .await?
         .unwrap_or_default();
     let acl_value = serde_json::to_value(&typed.payload.acl).map_err(serialize_err)?;
+
+    // A non-admin may only change flags it is permitted to self-manage.
+    if !is_admin {
+        ensure_self_manageable(&acl_value, &base, session)?;
+    }
+
     let merged = merge_wire_acl(acl_value, base)?;
 
     let stored = state.database.set_did_acl(&target_hash, &merged).await?;
@@ -974,6 +982,96 @@ async fn access_list_count(state: &SharedData, target_hash: &str) -> u64 {
         .flatten()
         .map(|a| a.access_list_count as u64)
         .unwrap_or(0)
+}
+
+/// Gate a non-admin `acl/set`: a standard account may change a capability only when
+/// its per-capability self-change bit is set, and may never touch the admin-only flags
+/// (`blocked`, `local`, the `selfManage*` bits). A flag whose requested value equals
+/// the current value is not a change. Faithful to the legacy `acls_set` self-service
+/// rules.
+fn ensure_self_manageable(
+    acl_value: &Value,
+    base: &MediatorACLSet,
+    session: &Session,
+) -> Result<(), MediatorError> {
+    let req: account::get::v0_1::MediatorAcl = serde_json::from_value(acl_value.clone())
+        .map_err(|e| serialize_err_msg(format!("invalid ACL payload: {e}")))?;
+    let cur = decode_acl_canonical(base);
+    let deny = |flag: &str| -> Result<(), MediatorError> {
+        Err(tt_problem(
+            session,
+            "authorization.acl.not_self_manageable",
+            format!("this account may not change `{flag}`"),
+            StatusCode::FORBIDDEN,
+        ))
+    };
+
+    // Capabilities self-manageable when the account's self-change bit is set.
+    if req.access_list_mode.is_some()
+        && req.access_list_mode != cur.access_list_mode
+        && !base.get_access_list_mode().1
+    {
+        return deny("accessListMode");
+    }
+    if req.send_messages.is_some()
+        && req.send_messages != cur.send_messages
+        && !base.get_send_messages().1
+    {
+        return deny("sendMessages");
+    }
+    if req.receive_messages.is_some()
+        && req.receive_messages != cur.receive_messages
+        && !base.get_receive_messages().1
+    {
+        return deny("receiveMessages");
+    }
+    if req.send_forwarded.is_some()
+        && req.send_forwarded != cur.send_forwarded
+        && !base.get_send_forwarded().1
+    {
+        return deny("sendForwarded");
+    }
+    if req.receive_forwarded.is_some()
+        && req.receive_forwarded != cur.receive_forwarded
+        && !base.get_receive_forwarded().1
+    {
+        return deny("receiveForwarded");
+    }
+    if req.create_invites.is_some()
+        && req.create_invites != cur.create_invites
+        && !base.get_create_invites().1
+    {
+        return deny("createInvites");
+    }
+    if req.anon_receive.is_some()
+        && req.anon_receive != cur.anon_receive
+        && !base.get_anon_receive().1
+    {
+        return deny("anonReceive");
+    }
+
+    // Admin-only flags: a non-admin may never change these.
+    if req.blocked.is_some() && req.blocked != cur.blocked {
+        return deny("blocked");
+    }
+    if req.local.is_some() && req.local != cur.local {
+        return deny("local");
+    }
+    if req.self_manage_list.is_some() && req.self_manage_list != cur.self_manage_list {
+        return deny("selfManageList");
+    }
+    if req.self_manage_send_queue_limit.is_some()
+        && req.self_manage_send_queue_limit != cur.self_manage_send_queue_limit
+    {
+        return deny("selfManageSendQueueLimit");
+    }
+    if req.self_manage_receive_queue_limit.is_some()
+        && req.self_manage_receive_queue_limit != cur.self_manage_receive_queue_limit
+    {
+        return deny("selfManageReceiveQueueLimit");
+    }
+
+    Ok(())
 }
 
 /// Handle `messaging/access-list/add`: self-or-admin (+ `self_manage_list` for a

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.32] - 2026-06-24
+
+`atm.trust_tasks().acl_set` is no longer admin-only — a non-admin may set its own ACL
+(the self-manageable capabilities); docs updated. (Server-side change in the mediator;
+the SDK call is unchanged.)
+
 ## [0.18.31] - 2026-06-24
 
 The legacy `atm.mediator()` management methods are now `#[deprecated]` in favour of the

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.31"
+version = "0.18.32"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -228,9 +228,11 @@ impl TrustTasksOps<'_> {
         Ok(response.payload)
     }
 
-    /// Send a `messaging/acl/set` Trust Task (admin only). The `acl` is applied as a
-    /// partial update — flags present are set, flags absent are left unchanged — and
-    /// the realized ACL is returned.
+    /// Send a `messaging/acl/set` Trust Task. The `acl` is applied as a partial update
+    /// — flags present are set, flags absent are left unchanged — and the realized ACL
+    /// is returned. An admin may set any account's ACL; a non-admin may set its own,
+    /// but only the capabilities it is permitted to self-manage (the admin-only flags
+    /// `blocked` / `local` / `selfManage*` are refused).
     pub async fn acl_set(
         &self,
         profile: &Arc<ATMProfile>,

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 24th June 2026
 
+### 0.2.28 — Trust Tasks: acl/set self-service e2e
+
+- New `acl_set_self_service_changes_a_self_manageable_flag` (alice changes her own
+  `anonReceive`) and `acl_set_self_service_refuses_an_admin_only_flag` (alice can't set
+  `blocked`); the cross-account denial test is reframed accordingly.
+
 ### 0.2.27 — Trust Tasks: admin family denial e2e
 
 - `admin_family_denies_a_non_admin`: a standard account is refused all five

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.27"
+version = "0.2.28"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -240,9 +240,9 @@ async fn acl_get_self_returns_the_decoded_acl() {
 async fn acl_set_denies_a_non_admin() {
     use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
 
-    // `acl/set` is admin-only here (non-admin self-service ACL changes aren't
-    // supported). The reverse mapping itself is covered by the mediator's
-    // `acl_reverse_map_round_trips` unit test.
+    // A non-admin may set its *own* ACL (self-service, covered below), but never
+    // another account's. (The reverse mapping is covered by the mediator's
+    // `acl_reverse_map_round_trips` unit test.)
     let env = TestEnvironment::spawn()
         .await
         .expect("spawn test environment");
@@ -426,4 +426,69 @@ async fn admin_family_denies_a_non_admin() {
         env.atm.trust_tasks().admin_config(&alice.profile).await.is_err(),
         "non-admin admin/config must be refused"
     );
+}
+
+#[tokio::test]
+async fn acl_set_self_service_changes_a_self_manageable_flag() {
+    use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    // allow_all grants alice the self-change bits, so she may change her own
+    // `anonReceive` (a self-manageable capability) from true to false.
+    let acl = MediatorAcl {
+        anon_receive: Some(false),
+        ..Default::default()
+    };
+    let updated = env
+        .atm
+        .trust_tasks()
+        .acl_set(&alice.profile, alice.did_hash(), acl)
+        .await
+        .expect("alice self-manages her own ACL");
+    assert_eq!(updated.anon_receive, Some(false));
+
+    // Persisted across a fresh read.
+    let got = env
+        .atm
+        .trust_tasks()
+        .acl_get(&alice.profile, vec![alice.did_hash()])
+        .await
+        .expect("re-read alice's ACL");
+    assert_eq!(got.entries[0].acl.anon_receive, Some(false));
+}
+
+#[tokio::test]
+async fn acl_set_self_service_refuses_an_admin_only_flag() {
+    use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    env.atm
+        .profile_add(&alice.profile, true)
+        .await
+        .expect("enable websocket for alice");
+
+    // `blocked` is admin-only — alice may not set it even on her own account.
+    let acl = MediatorAcl {
+        blocked: Some(true),
+        ..Default::default()
+    };
+    let denied = env
+        .atm
+        .trust_tasks()
+        .acl_set(&alice.profile, alice.did_hash(), acl)
+        .await;
+    assert!(denied.is_err(), "a non-admin may not change an admin-only flag");
 }


### PR DESCRIPTION
## Summary

Completes `messaging/acl/set` so it **fully replaces** the legacy `acls_set` — which supports non-admin **self-service** ACL changes. Surfaced while migrating `text-client` (a non-admin self-managing its own ACL), this unblocks moving consumers off the deprecated methods.

### Mediator (0.16.23 → 0.16.24)
- `acl/set` is now **self-or-admin** (was admin-only). A non-admin may set its **own** ACL (`check_permissions`), gated by the new `ensure_self_manageable`:
  - a capability may be changed only if its **self-change bit** is set;
  - the **admin-only** flags (`blocked`, `local`, the `selfManage*` bits) are always refused for a non-admin;
  - a flag whose requested value equals the current value isn't a change.
- A faithful port of the legacy `acls_set` self-service rules.

### SDK (0.18.31 → 0.18.32)
- `acl_set` doc updated (no longer admin-only). The call itself is unchanged — the gating is server-side.

### test-mediator (0.2.27 → 0.2.28)
- `acl_set_self_service_changes_a_self_manageable_flag` (alice changes her own `anonReceive`, persists) + `acl_set_self_service_refuses_an_admin_only_flag` (alice refused `blocked`); the cross-account denial test is reframed.

## Tests
14 `trust_tasks` e2e (incl. the new self-service cases) + the reverse-map unit test green; clippy clean; **DIDComm regression (`lifecycle` 22) green**.

## Next
Resume the consumer migration — `text-client` can now move its `acls_set` to `atm.trust_tasks().acl_set`.