### PR TITLE
refactor: migrate text-client to atm.trust_tasks() (PR-T14)

### DIFF
--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -17,6 +17,8 @@ repository.workspace = true
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
+## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
+trust-tasks-rs = "0.2"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/messaging/affinidi-messaging-text-client/src/main.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use affinidi_tdk::common::TDKSharedState;
 use log::LevelFilter;
 use state_store::StateStore;

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
@@ -1,10 +1,7 @@
 use affinidi_messaging_didcomm::message::{Attachment, Message};
-use affinidi_messaging_sdk::{
-    ATM,
-    messages::SuccessResponse,
-    profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
-};
+use affinidi_messaging_sdk::{ATM, messages::SuccessResponse, profiles::ATMProfile};
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
+use trust_tasks_rs::specs::messaging::acl;
 use affinidi_tdk::dids::{DID as DIDKey, KeyType};
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
@@ -197,32 +194,34 @@ pub async fn send_invitation_accept(
     let accept_temp_profile = atm.profile_add(&accept_temp_profile, true).await?;
 
     // Set up the ACL for the temporary profile. Allow the invite DID to send messages to this DID
-    let Some(accept_temp_profile_info) = atm
-        .mediator()
+    let accept_temp_profile_info = match atm
+        .trust_tasks()
         .account_get(&accept_temp_profile, None)
-        .await?
-    else {
-        state.invite_popup.messages.push(Line::from(Span::styled(
-            "Failed to get temp invite response profile info from mediator",
-            Style::default().fg(Color::Red),
-        )));
-        state_tx.send(state.clone())?;
+        .await
+    {
+        Ok(info) => info,
+        Err(e) => {
+            state.invite_popup.messages.push(Line::from(Span::styled(
+                "Failed to get temp invite response profile info from mediator",
+                Style::default().fg(Color::Red),
+            )));
+            state_tx.send(state.clone())?;
 
-        warn!("Failed to get temp invite response profile info from mediator");
-        return Err(anyhow::anyhow!(
-            "Failed to get temp invite response profile info from mediator"
-        ));
+            warn!("Failed to get temp invite response profile info from mediator: {e}");
+            return Err(anyhow::anyhow!(
+                "Failed to get temp invite response profile info from mediator"
+            ));
+        }
     };
 
     info!("temp invite response profile info: {accept_temp_profile_info:?}");
-    let accept_temp_profile_acl_flags = MediatorACLSet::from_u64(accept_temp_profile_info.acls);
-    if let AccessListModeType::ExplicitAllow =
-        accept_temp_profile_acl_flags.get_access_list_mode().0
+    if accept_temp_profile_info.acl.access_list_mode
+        == Some(MediatorAclAccessListMode::ExplicitAllow)
     {
         // Add the invite DID to this profile's ACL
         match atm
-            .mediator()
-            .access_list_add(&accept_temp_profile, None, &[&digest(&invite_did)])
+            .trust_tasks()
+            .access_list_add(&accept_temp_profile, None, vec![digest(&invite_did)])
             .await
         {
             Ok(_) => {}
@@ -473,42 +472,50 @@ pub async fn create_invitation(
                         state_tx.send(state.clone())?;
 
                         // Ensure Mediator ACL set up is correctly setup
-                        let Some(profile_info) = atm.mediator().account_get(&profile, None).await?
-                        else {
-                            state.invite_popup.messages.push(Line::from(Span::styled(
-                                "Failed to get profile info from mediator",
-                                Style::default().fg(Color::Red),
-                            )));
-                            state_tx.send(state.clone())?;
+                        let profile_info = match atm
+                            .trust_tasks()
+                            .account_get(&profile, None)
+                            .await
+                        {
+                            Ok(info) => info,
+                            Err(e) => {
+                                state.invite_popup.messages.push(Line::from(Span::styled(
+                                    "Failed to get profile info from mediator",
+                                    Style::default().fg(Color::Red),
+                                )));
+                                state_tx.send(state.clone())?;
 
-                            warn!("Failed to get profile info from mediator");
-                            return Err(anyhow::anyhow!(
-                                "Failed to get profile info from mediator"
-                            ));
+                                warn!("Failed to get profile info from mediator: {e}");
+                                return Err(anyhow::anyhow!(
+                                    "Failed to get profile info from mediator"
+                                ));
+                            }
                         };
                         info!("Profile info: {profile_info:?}");
 
-                        let profile_acl_flags = MediatorACLSet::from_u64(profile_info.acls);
-                        if let AccessListModeType::ExplicitAllow =
-                            profile_acl_flags.get_access_list_mode().0
+                        if profile_info.acl.access_list_mode
+                            == Some(MediatorAclAccessListMode::ExplicitAllow)
                         {
-                            // Need to set invitation DID to explicit_deny
-                            if profile_acl_flags.get_access_list_mode_admin_change() {
-                                let mut new_acl = profile_acl_flags;
-                                new_acl.set_access_list_mode(
-                                    AccessListModeType::ExplicitDeny,
-                                    true,
-                                    false,
-                                )?;
-                                atm.mediator()
-                                    .acls_set(&profile, &digest(&profile.inner.did), &new_acl)
-                                    .await?;
-                            } else {
+                            // Flip the access-list mode to explicit_deny. This is a
+                            // self-service change; the mediator refuses it if this account
+                            // may not self-manage its access-list mode.
+                            let new_acl = acl::set::v0_1::MediatorAcl {
+                                access_list_mode: Some(
+                                    acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny,
+                                ),
+                                ..Default::default()
+                            };
+                            if let Err(e) = atm
+                                .trust_tasks()
+                                .acl_set(&profile, digest(&profile.inner.did), new_acl)
+                                .await
+                            {
                                 state.invite_popup.messages.push(Line::from(Span::styled(
                                     "Mediator is not allowing DID owners to change their Access List Mode! Contact support.",
                                     Style::default().fg(Color::Red),
                                 )));
                                 state_tx.send(state.clone())?;
+                                warn!("Failed to set access-list mode: {e}");
                                 return Err(anyhow::anyhow!(
                                     "Mediator is not allowing DID owners to change their Access List Mode! Contact support."
                                 ));

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
@@ -1,10 +1,7 @@
 use super::chat_list::ChatStatus;
 use crate::state_store::State;
-use affinidi_messaging_sdk::{
-    ATM,
-    profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
-};
+use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
 use affinidi_tdk::{
     dids::{DID, KeyType, PeerKeyRole},
     secrets_resolver::SecretsResolver,
@@ -48,36 +45,28 @@ pub async fn manual_connect_setup(
 
     // Setup Access List Setup
     // Add the remote secure DID to the our new secure profile
-    let profile_info = match atm.mediator().account_get(&profile, None).await {
-        Ok(Some(info)) => info,
-        Ok(None) => {
-            warn!("No profile info found ({})", &profile.inner.did);
-            return Err(anyhow!("No profile info found"));
-        }
+    let profile_info = match atm.trust_tasks().account_get(&profile, None).await {
+        Ok(info) => info,
         Err(e) => {
             warn!("Failed to get profile info from mediator: {}", e);
             return Err(anyhow!("Failed to get profile info from mediator: {e}"));
         }
     };
 
-    let profile_acl_flags = MediatorACLSet::from_u64(profile_info.acls);
-    if let AccessListModeType::ExplicitAllow = profile_acl_flags.get_access_list_mode().0 {
+    if profile_info.acl.access_list_mode == Some(MediatorAclAccessListMode::ExplicitAllow) {
         // Add the remote secure DID to our secure DID
-        match atm
-            .mediator()
-            .access_list_add(&profile, None, &[&digest(remote_did)])
+        if let Err(e) = atm
+            .trust_tasks()
+            .access_list_add(&profile, None, vec![digest(remote_did)])
             .await
         {
-            Ok(_) => {}
-            Err(e) => {
-                warn!(
-                    "Failed to add {} to ACL of our secure profile: {}",
-                    remote_did, e
-                );
-                return Err(anyhow!(
-                    "Failed to add {remote_did} to ACL of our secure profile: {e}"
-                ));
-            }
+            warn!(
+                "Failed to add {} to ACL of our secure profile: {}",
+                remote_did, e
+            );
+            return Err(anyhow!(
+                "Failed to add {remote_did} to ACL of our secure profile: {e}"
+            ));
         }
     }
 

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/inbound_messages.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/inbound_messages.rs
@@ -7,7 +7,7 @@ use affinidi_messaging_didcomm::message::{Attachment, Message};
 use affinidi_messaging_sdk::ATM;
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::ProblemReport;
-use affinidi_messaging_sdk::protocols::mediator::acls::{AccessListModeType, MediatorACLSet};
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
 use affinidi_messaging_sdk::protocols::message_pickup::{MessagePickup, MessagePickupStatusReply};
 use base64::prelude::*;
 use rand::RngExt;
@@ -194,15 +194,8 @@ async fn _handle_connection_setup(
     info!("Added new profile to ATM");
 
     // Add the remote secure DID to the our new secure profile
-    let our_new_profile_info = match atm.mediator().account_get(&our_new_profile, None).await {
-        Ok(Some(info)) => info,
-        Ok(None) => {
-            warn!(
-                "No profile info found for local secure DID ({})",
-                &our_new_profile.inner.did
-            );
-            return;
-        }
+    let our_new_profile_info = match atm.trust_tasks().account_get(&our_new_profile, None).await {
+        Ok(info) => info,
         Err(e) => {
             warn!(
                 "Failed to get temp invite response profile info from mediator: {}",
@@ -212,12 +205,11 @@ async fn _handle_connection_setup(
         }
     };
 
-    let our_new_profile_acl_flags = MediatorACLSet::from_u64(our_new_profile_info.acls);
-    if let AccessListModeType::ExplicitAllow = our_new_profile_acl_flags.get_access_list_mode().0 {
+    if our_new_profile_info.acl.access_list_mode == Some(MediatorAclAccessListMode::ExplicitAllow) {
         // Add the new remote secure DID to our new secure DID
         match atm
-            .mediator()
-            .access_list_add(&our_new_profile, None, &[&digest(&remote_secure_did)])
+            .trust_tasks()
+            .access_list_add(&our_new_profile, None, vec![digest(&remote_secure_did)])
             .await
         {
             Ok(_) => {}
@@ -679,15 +671,8 @@ pub async fn handle_message(
 
             // Set up the ACL for the remote secure DID.
             let local_secure_profile_info =
-                match atm.mediator().account_get(&our_secure_profile, None).await {
-                    Ok(Some(info)) => info,
-                    Ok(None) => {
-                        warn!(
-                            "No profile info found for local secure DID ({})",
-                            &profile.inner.did
-                        );
-                        return;
-                    }
+                match atm.trust_tasks().account_get(&our_secure_profile, None).await {
+                    Ok(info) => info,
                     Err(e) => {
                         warn!(
                             "Failed to get local secure profile info from mediator: {}",
@@ -697,15 +682,13 @@ pub async fn handle_message(
                     }
                 };
 
-            let local_secure_profile_acl_flags =
-                MediatorACLSet::from_u64(local_secure_profile_info.acls);
-            if let AccessListModeType::ExplicitAllow =
-                local_secure_profile_acl_flags.get_access_list_mode().0
+            if local_secure_profile_info.acl.access_list_mode
+                == Some(MediatorAclAccessListMode::ExplicitAllow)
             {
                 // Add the remote secure DID to this profile's ACL
                 match atm
-                    .mediator()
-                    .access_list_add(&our_secure_profile, None, &[&digest(&remote_secure_did)])
+                    .trust_tasks()
+                    .access_list_add(&our_secure_profile, None, vec![digest(&remote_secure_did)])
                     .await
                 {
                     Ok(_) => {


### PR DESCRIPTION
## Summary

**Phase 5 consumer migration (1 of 3).** Moves `affinidi-messaging-text-client` off the deprecated `atm.mediator()` methods onto the `atm.trust_tasks()` core, and drops its `#![allow(deprecated)]`.

## Changes
- **`account_get`** → `atm.trust_tasks().account_get`: returns `Result<Account>` (not `Option`), so the not-found case folds into the `Err` arm; reads `info.acl.access_list_mode` (the spec `MediatorAcl`) instead of decoding `info.acls` (the `u64` bitfield).
- **`access_list_add`** → `atm.trust_tasks().access_list_add`: `Vec<String>` entries.
- **`acls_set`** → `atm.trust_tasks().acl_set`: builds a partial spec `MediatorAcl` (`access_list_mode = explicitDeny`). The client's prior self-change-permission check is **folded into the mediator's server-side self-service gating** (PR-T13 #518) + error handling — same outcome, server is authoritative.
- Adds the `trust-tasks-rs` dep (to name the spec types); drops the legacy `MediatorACLSet` / `AccessListModeType` imports.

## Tests
Builds clean under **`-D warnings`** (no deprecated calls remain); clippy clean. It's a TUI, so not e2e-tested — behaviour is preserved by faithful conversion. `publish = false`, so no version bump.

## Next
Migrate `affinidi-messaging-helpers` (admin tool) and `affinidi-messaging-didcomm-service`.