### PR TITLE
refactor: migrate didcomm-service to atm.trust_tasks() (PR-T15)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.8] - 2026-06-24
+
+Migrated `set_acl_mode` off the deprecated `atm.mediator()` methods onto
+`atm.trust_tasks().acl_set` (a non-admin self-service ACL change, now supported by the
+mediator). The Trust Tasks partial-update model replaces the previous read-modify-write
+(no `account_get` / `MediatorACLSet` decode needed). Dropped the `#![allow(deprecated)]`.
+
 ## [0.3.7] - 2026-06-24
 
 Allows the now-`#[deprecated]` legacy `atm.mediator()` methods it still calls

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.7"
+version = "0.3.8"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -16,6 +16,8 @@ rust-version.workspace = true
 affinidi-tdk-common = "0.6"
 affinidi-messaging-sdk = "0.18"
 affinidi-messaging-didcomm = "0.15"
+## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
+trust-tasks-rs = "0.2"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -1,10 +1,10 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use std::sync::Arc;
 use std::time::Duration;
 
 use affinidi_messaging_sdk::errors::ATMError;
-use affinidi_messaging_sdk::protocols::mediator::acls::{AccessListModeType, MediatorACLSet};
+use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
+use trust_tasks_rs::specs::messaging::acl;
 use sha256::digest;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -27,22 +27,24 @@ impl Listener {
         let atm = self.atm()?;
         let profile = self.profile()?;
 
-        let account_info = atm
-            .mediator()
-            .account_get(profile, None)
-            .await
-            .map_err(StartupError::AccountInfo)?
-            .ok_or(StartupError::NoAccountInfo)?;
-
-        let mut acls = MediatorACLSet::from_u64(account_info.acls);
-
         info!(acl_mode = ?acl_mode, "ACL mode configured");
 
-        acls.set_access_list_mode(acl_mode.clone(), true, false)
-            .map_err(|e| StartupError::AclMode(e.into()))?;
-
-        atm.mediator()
-            .acls_set(profile, &digest(&profile.inner.did), &acls)
+        // A partial ACL update setting only the access-list mode; the mediator's
+        // self-service gating applies it (the rest of the ACL is left unchanged).
+        let mode = match acl_mode {
+            AccessListModeType::ExplicitAllow => {
+                acl::set::v0_1::MediatorAclAccessListMode::ExplicitAllow
+            }
+            AccessListModeType::ExplicitDeny => {
+                acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny
+            }
+        };
+        let acl = acl::set::v0_1::MediatorAcl {
+            access_list_mode: Some(mode),
+            ..Default::default()
+        };
+        atm.trust_tasks()
+            .acl_set(profile, digest(&profile.inner.did), acl)
             .await
             .map_err(StartupError::AclApply)?;
 


### PR DESCRIPTION
## Summary

**Phase 5 consumer migration (2 of 3).** Moves `affinidi-messaging-didcomm-service` (a published lib) off the deprecated `atm.mediator()` methods.

## Changes
- `set_acl_mode` previously did a read-modify-write (`account_get` → `MediatorACLSet::from_u64` → `set_access_list_mode` → `acls_set`). It's now a single `atm.trust_tasks().acl_set` with a **partial** spec `MediatorAcl` (just `access_list_mode`). This is a **non-admin self-service** ACL change — now supported by the mediator (PR-T13 #518) — and the partial-update model means no current-ACL read is needed.
- Dropped `#![allow(deprecated)]`; added the `trust-tasks-rs` dep. **0.3.7 → 0.3.8**.

## Tests
Builds clean under **`-D warnings`** (no deprecated calls; the now-unconstructed `StartupError` variants are public API, so no dead-code warning); clippy clean.

## Next
The last consumer: `affinidi-messaging-helpers` admin tool (18 sites — the largest).