### PR TITLE
refactor: migrate admin tool's admin + config screens to atm.trust_tasks() (PR-T16)

### DIFF
--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -22,6 +22,8 @@ path = "src/mediator_administration/main.rs"
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
+## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
+trust-tasks-rs = "0.2"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
@@ -241,8 +241,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", style("Admin account connected...").green());
 
     println!("{}", style("Fetching Mediator Configuration...").blue());
-    let shared_config: HashMap<String, Value> =
-        serde_json::from_value(atm.mediator().get_config(&admin).await?)?;
+    let config_response = atm.trust_tasks().admin_config(&admin).await?;
+    let shared_config: HashMap<String, Value> = serde_json::from_value(serde_json::json!({
+        "version": config_response.version,
+        "config": config_response.config,
+    }))?;
     let mut mediator_config = SharedConfig::new(shared_config)?;
     println!(
         "{}{}{}{}{}",

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/ui.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/ui.rs
@@ -1,12 +1,11 @@
 //! UI Related functions
-use affinidi_messaging_sdk::{
-    ATM, profiles::ATMProfile, protocols::mediator::accounts::AccountType,
-};
+use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
+use trust_tasks_rs::specs::messaging::admin::list::v0_1::AccountType;
 use console::style;
 use dialoguer::{Confirm, Input, MultiSelect, Select, theme::ColorfulTheme};
 use regex::Regex;
 use sha256::digest;
-use std::{slice, sync::Arc};
+use std::sync::Arc;
 
 use crate::SharedConfig;
 
@@ -49,26 +48,26 @@ pub(crate) async fn administration_accounts_menu(
 
 /// List first 100 Administration DIDs
 pub(crate) async fn list_admins(atm: &ATM, profile: &Arc<ATMProfile>, config: &SharedConfig) {
-    match atm.mediator().list_admins(profile, None, None).await {
-        Ok(admins) => {
+    match atm.trust_tasks().admin_list(profile, None, None).await {
+        Ok(response) => {
             println!(
                 "{}",
                 style("Listing Administration DIDs (SHA256 Hashed DID's). NOTE: Will only list first 100 admin accounts!").green()
             );
 
-            for (idx, admin) in admins.accounts.iter().enumerate() {
+            for (idx, admin) in response.admins.iter().enumerate() {
                 print!(
                     "  {}",
-                    style(format!("{}: {}", idx, admin.did_hash)).yellow(),
+                    style(format!("{}: {}", idx, admin.did.as_str())).yellow(),
                 );
-                let (role, color) = match admin._type {
-                    AccountType::Mediator => (admin._type.to_string(), 27_u8),
-                    AccountType::RootAdmin => (admin._type.to_string(), 127_u8),
-                    AccountType::Admin => (admin._type.to_string(), 129_u8),
+                let (role, color) = match admin.account_type {
+                    AccountType::Mediator => (admin.account_type.to_string(), 27_u8),
+                    AccountType::RootAdmin => (admin.account_type.to_string(), 127_u8),
+                    AccountType::Admin => (admin.account_type.to_string(), 129_u8),
                     _ => ("Unknown".into(), 1_u8),
                 };
                 print!(" {}", style(format!("({role})")).color256(color));
-                if admin.did_hash.as_bytes() == config.our_admin_hash.as_bytes() {
+                if admin.did.as_str() == config.our_admin_hash.as_str() {
                     print!(" {}", style("(our Admin account)").color256(208));
                 }
 
@@ -108,27 +107,20 @@ pub(crate) async fn add_admin(atm: &ATM, profile: &Arc<ATMProfile>, theme: &Colo
         .unwrap()
     {
         match atm
-            .mediator()
-            .add_admins(profile, slice::from_ref(&input))
+            .trust_tasks()
+            .admin_add(profile, vec![input.clone()])
             .await
         {
-            Ok(result) => {
-                if result == 1 {
-                    println!(
-                        "{}",
-                        style(format!("Successfully added DID ({})", &input)).green()
-                    );
-                    println!(
-                        "  {}{}",
-                        style("DID Hash: ").green(),
-                        style(digest(&input)).yellow()
-                    );
-                } else {
-                    println!(
-                        "{}",
-                        style(format!("DID ({}) already exists", &input)).color256(208)
-                    );
-                }
+            Ok(_admins) => {
+                println!(
+                    "{}",
+                    style(format!("DID ({}) is now an administrator", &input)).green()
+                );
+                println!(
+                    "  {}{}",
+                    style("DID Hash: ").green(),
+                    style(digest(&input)).yellow()
+                );
             }
             Err(e) => {
                 println!("{}", style(format!("Error: {e}")).red());
@@ -143,17 +135,17 @@ pub(crate) async fn strip_admins(
     config: &SharedConfig,
     theme: &ColorfulTheme,
 ) {
-    match atm.mediator().list_admins(profile, None, None).await {
-        Ok(admins) => {
+    match atm.trust_tasks().admin_list(profile, None, None).await {
+        Ok(response) => {
             // remove the mediator administrator account from the list
-            let admins: Vec<String> = admins
-                .accounts
+            let admins: Vec<String> = response
+                .admins
                 .iter()
                 .filter_map(|x| {
-                    if x.did_hash.as_bytes() != config.our_admin_hash.as_bytes()
-                        && x.did_hash.as_bytes() != config.mediator_did_hash.as_bytes()
+                    if x.did.as_str() != config.our_admin_hash.as_str()
+                        && x.did.as_str() != config.mediator_did_hash.as_str()
                     {
-                        Some(x.did_hash.clone())
+                        Some(x.did.as_str().to_string())
                     } else {
                         None
                     }
@@ -195,11 +187,12 @@ pub(crate) async fn strip_admins(
                     .iter()
                     .map(|&idx| admins[idx].clone())
                     .collect::<Vec<_>>();
-                match atm.mediator().strip_admins(profile, &admins).await {
+                match atm.trust_tasks().admin_strip(profile, admins).await {
                     Ok(result) => {
                         println!(
                             "{}",
-                            style(format!("Stripped admin rights from {result} DIDs")).green()
+                            style(format!("Stripped admin rights from {} DIDs", result.len()))
+                                .green()
                         );
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary

**Phase 5 consumer migration (3 of 3, part 1).** Migrates the `mediator_administration` bin's **admin-family + config screens** off the deprecated `atm.mediator()` methods.

## Changes
- **ui.rs** — `list_admins` → `admin_list` (displays `response.admins` / `admin.did` / `admin.account_type` instead of `accounts` / `did_hash` / `_type`); `add_admins` → `admin_add` (echoes the requested set, so the new-vs-existing display distinction is dropped); `strip_admins` → `admin_strip`.
- **main.rs** — `get_config` → `admin_config` (reconstructs the `{version, config}` shape the tool expects from the typed response).
- Adds the `trust-tasks-rs` dep.

## What's deferred (and why)
`account_management.rs` + `acl_management.rs` (13 sites) **remain on the legacy methods** under the still-present crate-level `#![allow(deprecated)]`. They're a materially harder migration:
- they print the **raw `u64` ACL bitfield** (`{:064b}`), which the Trust Tasks types deliberately don't expose — migrating *changes the display*;
- they hold a **mutable account** across operations, but the spec `Account` is **per-module** (`account/get` vs `account/change-type` vs `account/change-queue-limits`), needing serde conversions;
- it's a **TUI** — no automated coverage.

Best done as a focused follow-up with the ability to run the tool. The deprecated methods still work via the grace period.

## Tests
helpers builds + clippy clean. `publish = false`, no version bump.