### PR TITLE
refactor: migrate admin tool's account/acl screens to atm.trust_tasks() (PR-T17)

### DIFF
--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
@@ -1,17 +1,19 @@
 use crate::{SharedConfig, account_management::acl_management::manage_account_acls};
 use affinidi_messaging_helpers::common::did::manually_enter_did_or_hash;
-use affinidi_messaging_sdk::{
-    ATM,
-    profiles::ATMProfile,
-    protocols::mediator::{
-        accounts::{Account, AccountChangeQueueLimitsResponse, AccountType},
-        acls::MediatorACLSet,
-    },
-};
+use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use console::style;
 use dialoguer::{Input, Select, theme::ColorfulTheme};
 use regex::Regex;
 use std::sync::Arc;
+use trust_tasks_rs::specs::messaging::account;
+
+/// All the `messaging/account/*` Trust Tasks return a per-module `Account` struct,
+/// but they share one schema. This converts any of them back to the canonical
+/// `account::get::v0_1::Account` we hold across the screen.
+fn to_get_account<T: serde::Serialize>(a: &T) -> account::get::v0_1::Account {
+    serde_json::from_value(serde_json::to_value(a).expect("serialize"))
+        .expect("messaging Account types share one schema")
+}
 
 pub(crate) async fn account_management_menu(
     atm: &ATM,
@@ -58,12 +60,12 @@ pub(crate) async fn create_account_menu(
         return Ok(());
     };
 
-    // Does this account exist?
+    // Does this account exist? A missing account is an Err, so existence is is_ok().
     if atm
-        .mediator()
+        .trust_tasks()
         .account_get(profile, Some(new_did_hash.clone()))
-        .await?
-        .is_some()
+        .await
+        .is_ok()
     {
         println!(
             "{}",
@@ -74,13 +76,18 @@ pub(crate) async fn create_account_menu(
 
     // Create the account
     let account = atm
-        .mediator()
-        .account_add(profile, &new_did_hash, None)
+        .trust_tasks()
+        .account_add(
+            profile,
+            new_did_hash.clone(),
+            account::add::v0_1::AccountType::Standard,
+            None,
+        )
         .await?;
 
     println!("{}", style("Created account successfully").green());
 
-    manage_account_menu(atm, profile, theme, mediator_config, &account).await
+    manage_account_menu(atm, profile, theme, mediator_config, &to_get_account(&account)).await
 }
 
 pub(crate) async fn manage_account_menu(
@@ -88,7 +95,7 @@ pub(crate) async fn manage_account_menu(
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
     mediator_config: &SharedConfig,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let selections = &[
         "Modify ACLs",
@@ -102,19 +109,19 @@ pub(crate) async fn manage_account_menu(
     loop {
         println!();
         println!(
-            "{} {}  {} {:064b} {} {}",
+            "{} {}  {} {} {} {}",
             style("Selected DID: ").yellow(),
-            style(&account.did_hash).color256(208),
+            style(account.did.as_str()).color256(208),
             style("ACL:").yellow(),
-            style(account.acls).blue().bold(),
+            style(format!("{:?}", account.acl)).blue().bold(),
             style("Access List Count:").yellow(),
-            style(account.access_list_count).blue().bold()
+            style(account.access_list_count.unwrap_or(0)).blue().bold()
         );
 
         println!(
             "{} {:<12} {} {} {} {}",
             style("Selected DID Account Type:").yellow(),
-            style(&account._type.to_string()).blue().bold(),
+            style(account.account_type.to_string()).blue().bold(),
             style("Mediator ACL Mode:").yellow(),
             style(&mediator_config.acl_mode).blue().bold(),
             style("Default ACL:").yellow(),
@@ -126,30 +133,37 @@ pub(crate) async fn manage_account_menu(
             .bold()
         );
 
+        let queue_send_limit = account
+            .queue_limits
+            .as_ref()
+            .and_then(|q| q.send_queue_limit);
+        let queue_receive_limit = account
+            .queue_limits
+            .as_ref()
+            .and_then(|q| q.receive_queue_limit);
+
         println!(
             "{} {} {} {} {} {} {} {} {} {} {} {} {}",
             style("Stats").yellow(),
             style("INBOX Count:").yellow(),
-            style(&account.receive_queue_count).blue().bold(),
+            style(account.receive_queue_count.unwrap_or(0)).blue().bold(),
             style("INBOX bytes").yellow(),
-            style(&account.receive_queue_bytes).blue().bold(),
+            style(account.receive_queue_bytes.unwrap_or(0)).blue().bold(),
             style("OUTBOX Count:").yellow(),
-            style(&account.receive_queue_count).blue().bold(),
+            style(account.receive_queue_count.unwrap_or(0)).blue().bold(),
             style("OUTBOX bytes").yellow(),
-            style(&account.receive_queue_bytes).blue().bold(),
+            style(account.receive_queue_bytes.unwrap_or(0)).blue().bold(),
             style("Send Q Limit:").yellow(),
             style(
-                &account
-                    .queue_send_limit
-                    .unwrap_or(mediator_config.queued_send_messages_soft)
+                queue_send_limit
+                    .unwrap_or(mediator_config.queued_send_messages_soft as i64)
             )
             .blue()
             .bold(),
             style("Receive Q Limit:").yellow(),
             style(
-                &account
-                    .queue_receive_limit
-                    .unwrap_or(mediator_config.queued_receive_messages_soft)
+                queue_receive_limit
+                    .unwrap_or(mediator_config.queued_receive_messages_soft as i64)
             )
             .blue()
             .bold()
@@ -178,8 +192,8 @@ pub(crate) async fn manage_account_menu(
             1 => {
                 // Change Account Type
                 match _change_account_type(atm, profile, theme, &account).await {
-                    Ok(_type) => {
-                        account._type = _type;
+                    Ok(updated) => {
+                        account = updated;
                     }
                     Err(err) => println!(
                         "{}",
@@ -190,24 +204,10 @@ pub(crate) async fn manage_account_menu(
             2 => {
                 // Change Queue Limits
                 match _change_account_queue_limit(atm, profile, theme, &account).await {
-                    Ok(response) => {
-                        if let Some(response) = response {
-                            if let Some(limit) = response.send_queue_limit {
-                                if limit == -2 {
-                                    account.queue_send_limit = None;
-                                } else {
-                                    account.queue_send_limit = response.send_queue_limit;
-                                }
-                            }
-                            if let Some(limit) = response.receive_queue_limit {
-                                if limit == -2 {
-                                    account.queue_receive_limit = None;
-                                } else {
-                                    account.queue_receive_limit = response.receive_queue_limit;
-                                }
-                            }
-                        }
+                    Ok(Some(updated)) => {
+                        account = updated;
                     }
+                    Ok(None) => {}
                     Err(err) => println!(
                         "{}",
                         style(format!("Error changing account queue_limit: {err}")).red()
@@ -217,8 +217,8 @@ pub(crate) async fn manage_account_menu(
             3 => {
                 // Delete Account
                 match atm
-                    .mediator()
-                    .account_remove(profile, Some(account.did_hash.clone()))
+                    .trust_tasks()
+                    .account_remove(profile, Some(account.did.as_str().to_string()))
                     .await
                 {
                     Ok(_) => {
@@ -245,9 +245,17 @@ async fn _change_account_type(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
-) -> Result<AccountType, Box<dyn std::error::Error>> {
-    let mut selections = AccountType::iterator()
+    account: &account::get::v0_1::Account,
+) -> Result<account::get::v0_1::Account, Box<dyn std::error::Error>> {
+    let options = [
+        account::change_type::v0_1::AccountType::Standard,
+        account::change_type::v0_1::AccountType::Admin,
+        account::change_type::v0_1::AccountType::RootAdmin,
+        account::change_type::v0_1::AccountType::Mediator,
+    ];
+
+    let mut selections = options
+        .iter()
         .map(|t| t.to_string())
         .collect::<Vec<String>>();
 
@@ -262,22 +270,25 @@ async fn _change_account_type(
 
     if selection == selections.len() - 1 {
         // No change, exit gracefully
-        return Ok(account._type);
+        return Ok(account.clone());
     }
 
-    let new_type = AccountType::from(selection as u32);
+    let new_type = options[selection];
     println!("Changing account type to: {new_type}");
 
-    if new_type == account._type {
+    // Compare current account type to the requested one (variants are equivalent
+    // across modules, so compare via their string representation).
+    if new_type.to_string() == account.account_type.to_string() {
         // No change, exit gracefully
-        Ok(account._type)
+        Ok(account.clone())
     } else {
-        atm.mediator()
-            .account_change_type(profile, &account.did_hash, new_type)
+        let updated = atm
+            .trust_tasks()
+            .account_change_type(profile, account.did.as_str().to_string(), new_type)
             .await
             .map_err(|e| e.to_string())?;
         println!("{}", style("Account type changed successfully").green());
-        Ok(new_type)
+        Ok(to_get_account(&updated))
     }
 }
 
@@ -285,8 +296,8 @@ async fn _change_account_queue_limit(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
-) -> Result<Option<AccountChangeQueueLimitsResponse>, Box<dyn std::error::Error>> {
+    account: &account::get::v0_1::Account,
+) -> Result<Option<account::get::v0_1::Account>, Box<dyn std::error::Error>> {
     let send_input = Input::with_theme(theme)
         .with_prompt("New Send Queue Limit? (-2 = Reset, -1 = Unlimited, n = limit, blank = no change, exit = cancel")
         .validate_with(|input: &String| -> Result<(), &str> {
@@ -294,7 +305,7 @@ async fn _change_account_queue_limit(
             if input == "exit" || input.is_empty() {
                 Ok(())
             } else if re.is_match(input) {
-                match input.parse::<i32>() {
+                match input.parse::<i64>() {
                     Ok(limit) => {
                         if limit < -2 {
                             Err("Invalid queue limit")
@@ -318,10 +329,10 @@ async fn _change_account_queue_limit(
     }
 
     println!("Changing account send queue_limit to: {send_input}");
-    let send_queue_limit: Option<i32> = if send_input.is_empty() {
+    let send_queue_limit: Option<i64> = if send_input.is_empty() {
         None
     } else {
-        match send_input.parse::<i32>() {
+        match send_input.parse::<i64>() {
             Ok(limit) => Some(limit),
             Err(e) => {
                 println!("{}", style(format!("Couldn't parse number: {e}")).red());
@@ -337,7 +348,7 @@ async fn _change_account_queue_limit(
             if input == "exit" || input.is_empty() {
                 Ok(())
             } else if re.is_match(input) {
-                match input.parse::<i32>() {
+                match input.parse::<i64>() {
                     Ok(limit) => {
                         if limit < -2 {
                             Err("Invalid queue limit")
@@ -361,10 +372,10 @@ async fn _change_account_queue_limit(
     }
 
     println!("Changing account receive queue_limit to: {receive_input}");
-    let receive_queue_limit: Option<i32> = if receive_input.is_empty() {
+    let receive_queue_limit: Option<i64> = if receive_input.is_empty() {
         None
     } else {
-        match receive_input.parse::<i32>() {
+        match receive_input.parse::<i64>() {
             Ok(limit) => Some(limit),
             Err(e) => {
                 println!("{}", style(format!("Couldn't parse number: {e}")).red());
@@ -373,11 +384,11 @@ async fn _change_account_queue_limit(
         }
     };
 
-    let response = atm
-        .mediator()
+    let updated = atm
+        .trust_tasks()
         .account_change_queue_limits(
             profile,
-            &account.did_hash,
+            Some(account.did.as_str().to_string()),
             send_queue_limit,
             receive_queue_limit,
         )
@@ -386,11 +397,11 @@ async fn _change_account_queue_limit(
     println!(
         "{}",
         style(format!(
-            "Account queue_limits changed successfully {response:#?}"
+            "Account queue_limits changed successfully {updated:#?}"
         ))
         .green()
     );
-    Ok(Some(response))
+    Ok(Some(to_get_account(&updated)))
 }
 
 /// Picks the target DID
@@ -426,9 +437,10 @@ pub(crate) async fn select_did(
             }
             1 => {
                 if let Some(did_hash) = manually_enter_did_or_hash(theme) {
-                    // Look up the Account for this DID
-                    let account = atm.mediator().account_get(profile, Some(did_hash)).await?;
-                    if let Some(account) = account {
+                    // Look up the Account for this DID (a missing account is an Err)
+                    if let Ok(account) =
+                        atm.trust_tasks().account_get(profile, Some(did_hash)).await
+                    {
                         manage_account_menu(atm, profile, theme, mediator_config, &account).await?;
                     }
                 }
@@ -445,12 +457,12 @@ async fn _select_from_existing_dids(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    cursor: Option<u32>,
+    cursor: Option<String>,
     mediator_config: &SharedConfig,
-) -> Result<Option<Account>, Box<dyn std::error::Error>> {
+) -> Result<Option<account::get::v0_1::Account>, Box<dyn std::error::Error>> {
     let dids = atm
-        .mediator()
-        .accounts_list(profile, cursor, Some(2))
+        .trust_tasks()
+        .account_list(profile, cursor, Some(2))
         .await?;
 
     if dids.accounts.is_empty() {
@@ -461,37 +473,29 @@ async fn _select_from_existing_dids(
 
     let mut did_list: Vec<String> = Vec::new();
     for account in &dids.accounts {
-        let acls = MediatorACLSet::from_u64(account.acls);
-        let acl_default_flag = account.acls == mediator_config.global_acl_default.to_u64();
+        let blocked = account.acl.blocked.unwrap_or(false);
+        let local = account.acl.local.unwrap_or(false);
 
         did_list.push(format!(
-            "{} {} {:^8} {:^6} {:064b} {}",
-            account.did_hash,
-            style(format!("{:^12}", account._type.to_string())).blue(),
-            if acls.get_blocked() {
+            "{} {} {:^8} {:^6} {:?}",
+            account.did.as_str(),
+            style(format!("{:^12}", account.account_type.to_string())).blue(),
+            if blocked {
                 style("Yes").red().bold()
             } else {
                 style("No").green()
             },
-            if acls.get_local() {
+            if local {
                 style("Yes").green().bold()
             } else {
                 style("No").red()
             },
-            if acl_default_flag {
-                style(account.acls).green()
-            } else {
-                style(account.acls).cyan()
-            },
-            if acl_default_flag {
-                style("Default").green()
-            } else {
-                style("Custom").cyan()
-            }
+            style(format!("{:?}", account.acl)).cyan(),
         ));
     }
     let mut load_more_flag = false;
-    if dids.cursor > 0 {
+    let next_cursor = dids.next_cursor.as_ref().map(|c| c.to_string());
+    if next_cursor.is_some() {
         did_list.push("Load more DIDs...".to_string());
         load_more_flag = true;
     }
@@ -512,7 +516,7 @@ async fn _select_from_existing_dids(
             atm,
             profile,
             theme,
-            Some(dids.cursor),
+            next_cursor,
             mediator_config,
         ))
         .await
@@ -520,6 +524,6 @@ async fn _select_from_existing_dids(
         // Exit gracefully
         Ok(None)
     } else {
-        Ok(Some(dids.accounts[selected].clone()))
+        Ok(Some(to_get_account(&dids.accounts[selected])))
     }
 }

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
@@ -4,25 +4,26 @@
 
 use crate::SharedConfig;
 use affinidi_messaging_helpers::common::did::manually_enter_did_or_hash;
-use affinidi_messaging_sdk::{
-    ATM,
-    profiles::ATMProfile,
-    protocols::mediator::{
-        accounts::Account,
-        acls::{AccessListModeType, MediatorACLSet},
-    },
-};
+use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use console::style;
 use dialoguer::{MultiSelect, Select, theme::ColorfulTheme};
 use std::sync::Arc;
+use trust_tasks_rs::specs::messaging::{account, acl};
+
+/// Convert a partial / per-module `MediatorAcl` into the canonical
+/// `account::get::v0_1::MediatorAcl` we hold on the account across the screen.
+fn to_get_acl<T: serde::Serialize>(acl: &T) -> account::get::v0_1::MediatorAcl {
+    serde_json::from_value(serde_json::to_value(acl).expect("serialize"))
+        .expect("messaging MediatorAcl types share one schema")
+}
 
 pub(crate) async fn manage_account_acls(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
     mediator_config: &SharedConfig,
-    account: &Account,
-) -> Result<Account, Box<dyn std::error::Error>> {
+    account: &account::get::v0_1::Account,
+) -> Result<account::get::v0_1::Account, Box<dyn std::error::Error>> {
     let selections = &[
         "Modify ACL Flags",
         "Access List - List",
@@ -37,19 +38,19 @@ pub(crate) async fn manage_account_acls(
     loop {
         println!();
         println!(
-            "{} {}  {} {:064b} {} {}",
+            "{} {}  {} {} {} {}",
             style("Selected DID: ").yellow(),
-            style(&account.did_hash).color256(208),
+            style(account.did.as_str()).color256(208),
             style("ACL:").yellow(),
-            style(account.acls).blue().bold(),
+            style(format!("{:?}", account.acl)).blue().bold(),
             style("Access List Count:").yellow(),
-            style(account.access_list_count).blue().bold()
+            style(account.access_list_count.unwrap_or(0)).blue().bold()
         );
 
         println!(
             "{} {:<12} {} {} {} {}",
             style("Selected DID Account Type:").yellow(),
-            style(&account._type.to_string()).blue().bold(),
+            style(account.account_type.to_string()).blue().bold(),
             style("Mediator ACL Mode:").yellow(),
             style(&mediator_config.acl_mode).blue().bold(),
             style("Default ACL:").yellow(),
@@ -73,9 +74,7 @@ pub(crate) async fn manage_account_acls(
         match selection {
             0 => {
                 // Modify ACL Flags
-                account.acls = _modify_acl_flags(atm, profile, theme, &account)
-                    .await?
-                    .to_u64();
+                account.acl = _modify_acl_flags(atm, profile, theme, &account).await?;
             }
             1 => {
                 // Access List - List
@@ -87,13 +86,14 @@ pub(crate) async fn manage_account_acls(
                     .await?
                     .is_some()
                 {
-                    account.access_list_count += 1;
+                    account.access_list_count = Some(account.access_list_count.unwrap_or(0) + 1);
                 }
             }
             3 => {
                 // Access List - Remove
-                account.access_list_count -=
-                    _access_list_remove(atm, profile, theme, &account).await? as u32;
+                let removed = _access_list_remove(atm, profile, theme, &account).await? as u64;
+                account.access_list_count =
+                    Some(account.access_list_count.unwrap_or(0).saturating_sub(removed));
             }
             4 => {
                 // Access List - Search
@@ -102,7 +102,7 @@ pub(crate) async fn manage_account_acls(
             5 => {
                 // Access List - Clear
                 _access_list_clear(atm, profile, &account).await?;
-                account.access_list_count = 0;
+                account.access_list_count = Some(0);
             }
             6 => break,
             _ => println!("Invalid selection"),
@@ -115,63 +115,51 @@ async fn _modify_acl_flags(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
-) -> Result<MediatorACLSet, Box<dyn std::error::Error>> {
+    account: &account::get::v0_1::Account,
+) -> Result<account::get::v0_1::MediatorAcl, Box<dyn std::error::Error>> {
     println!("self-change? : If set, allows the DID to change its own ACL flag");
 
-    let acls = MediatorACLSet::from_u64(account.acls);
+    let acl = &account.acl;
     let selections = [
         (
             "Access List Mode: explicit_deny if set, explicit_allow if not",
-            acls.get_access_list_mode().0 == AccessListModeType::ExplicitDeny,
-        ),
-        (
-            "Access List Mode self-change?",
-            acls.get_access_list_mode().1,
+            acl.access_list_mode
+                == Some(account::get::v0_1::MediatorAclAccessListMode::ExplicitDeny),
         ),
         (
             "blocked - DID is blocked from authentication?",
-            acls.get_blocked(),
+            acl.blocked.unwrap_or(false),
         ),
         (
             "local - DID is able to store messages locally?",
-            acls.get_local(),
+            acl.local.unwrap_or(false),
         ),
-        ("send_messages?", acls.get_send_messages().0),
-        ("send_messages self-change?", acls.get_send_messages().1),
-        ("receive_messages?", acls.get_receive_messages().0),
+        ("send_messages?", acl.send_messages.unwrap_or(false)),
+        ("receive_messages?", acl.receive_messages.unwrap_or(false)),
         (
-            "receive_messages self-change?",
-            acls.get_receive_messages().1,
-        ),
-        ("send_forwarded_messages?", acls.get_send_forwarded().0),
-        (
-            "send_forwarded_messages self-change?",
-            acls.get_send_forwarded().1,
+            "send_forwarded_messages?",
+            acl.send_forwarded.unwrap_or(false),
         ),
         (
             "receive_forwarded_messages?",
-            acls.get_receive_forwarded().0,
+            acl.receive_forwarded.unwrap_or(false),
+        ),
+        ("create_invites?", acl.create_invites.unwrap_or(false)),
+        (
+            "anon_receive_messages?",
+            acl.anon_receive.unwrap_or(false),
         ),
         (
-            "receive_forwarded_messages self-change?",
-            acls.get_receive_forwarded().1,
+            "access_list self-change?",
+            acl.self_manage_list.unwrap_or(false),
         ),
-        ("create_invites?", acls.get_create_invites().0),
-        ("create_invites self-change?", acls.get_create_invites().1),
-        ("anon_receive_messages?", acls.get_anon_receive().0),
-        (
-            "anon_receive_messages self-change?",
-            acls.get_anon_receive().1,
-        ),
-        ("access_list self-change?", acls.get_self_manage_list()),
         (
             "queue send limits self-change?",
-            acls.get_self_manage_send_queue_limit(),
+            acl.self_manage_send_queue_limit.unwrap_or(false),
         ),
         (
             "queue receive limits self-change?",
-            acls.get_self_manage_receive_queue_limit(),
+            acl.self_manage_receive_queue_limit.unwrap_or(false),
         ),
     ];
 
@@ -184,74 +172,76 @@ async fn _modify_acl_flags(
         .unwrap();
 
     // convert the selection to an array of bools
-    let mut flags = [false; 19];
+    let mut flags = [false; 12];
     for s in selection {
         flags[s] = true;
     }
 
-    // Create a new ACL set from the values
-    let mut new_acls = MediatorACLSet::default();
-    let _ = new_acls.set_access_list_mode(
-        if flags[0] {
-            AccessListModeType::ExplicitDeny
+    // Build a full ACL set from the chosen flags.
+    let new_acl = acl::set::v0_1::MediatorAcl {
+        access_list_mode: Some(if flags[0] {
+            acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny
         } else {
-            AccessListModeType::ExplicitAllow
-        },
-        flags[1],
-        true,
-    );
-    new_acls.set_blocked(flags[2]);
-    new_acls.set_local(flags[3]);
-    let _ = new_acls.set_send_messages(flags[4], flags[5], true);
-    let _ = new_acls.set_receive_messages(flags[6], flags[7], true);
-    let _ = new_acls.set_send_forwarded(flags[8], flags[9], true);
-    let _ = new_acls.set_receive_forwarded(flags[10], flags[11], true);
-    let _ = new_acls.set_create_invites(flags[12], flags[13], true);
-    let _ = new_acls.set_anon_receive(flags[14], flags[15], true);
-    new_acls.set_self_manage_list(flags[16]);
-    new_acls.set_self_manage_send_queue_limit(flags[17]);
-    new_acls.set_self_manage_receive_queue_limit(flags[18]);
+            acl::set::v0_1::MediatorAclAccessListMode::ExplicitAllow
+        }),
+        blocked: Some(flags[1]),
+        local: Some(flags[2]),
+        send_messages: Some(flags[3]),
+        receive_messages: Some(flags[4]),
+        send_forwarded: Some(flags[5]),
+        receive_forwarded: Some(flags[6]),
+        create_invites: Some(flags[7]),
+        anon_receive: Some(flags[8]),
+        self_manage_list: Some(flags[9]),
+        self_manage_send_queue_limit: Some(flags[10]),
+        self_manage_receive_queue_limit: Some(flags[11]),
+        ..Default::default()
+    };
 
-    if new_acls == acls {
+    // Compare against the current ACL (both normalised to JSON; MediatorAcl
+    // does not derive PartialEq).
+    if serde_json::to_value(to_get_acl(&new_acl)).ok()
+        == serde_json::to_value(&account.acl).ok()
+    {
         println!("{}", style("No changes made").yellow());
-        return Ok(acls);
+        return Ok(account.acl.clone());
     }
-    println!("New ACLs: {:064b}", new_acls.to_u64());
+    println!("New ACLs: {new_acl:?}");
 
     match atm
-        .mediator()
-        .acls_set(profile, &account.did_hash, &new_acls)
+        .trust_tasks()
+        .acl_set(profile, account.did.as_str().to_string(), new_acl.clone())
         .await
     {
-        Ok(_) => println!("{}", style("ACLs updated").green()),
-        Err(e) => println!("{}", style(format!("Error updating ACLs: {e}")).red()),
+        Ok(updated) => {
+            println!("{}", style("ACLs updated").green());
+            Ok(to_get_acl(&updated))
+        }
+        Err(e) => {
+            println!("{}", style(format!("Error updating ACLs: {e}")).red());
+            Ok(to_get_acl(&new_acl))
+        }
     }
-
-    Ok(new_acls)
 }
 
 async fn _access_list_list(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut cursor: Option<u64> = None;
+    let mut cursor: Option<String> = None;
     loop {
         let list = atm
-            .mediator()
-            .access_list_list(profile, Some(&account.did_hash), cursor)
+            .trust_tasks()
+            .access_list_list(profile, Some(account.did.as_str().to_string()), cursor, None)
             .await?;
 
-        for hash in list.did_hashes {
-            println!("{}", style(hash).blue());
+        for hash in &list.entries {
+            println!("{}", style(hash.as_str()).blue());
         }
 
-        if let Some(_cursor) = list.cursor {
-            if _cursor == 0 {
-                break;
-            } else {
-                cursor = Some(_cursor);
-            }
+        if let Some(next_cursor) = list.next_cursor {
+            cursor = Some(next_cursor.to_string());
         } else {
             break;
         }
@@ -263,11 +253,15 @@ async fn _access_list_add(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     if let Some(hash) = manually_enter_did_or_hash(theme) {
-        atm.mediator()
-            .access_list_add(profile, Some(&account.did_hash), &[hash.as_str()])
+        atm.trust_tasks()
+            .access_list_add(
+                profile,
+                Some(account.did.as_str().to_string()),
+                vec![hash.clone()],
+            )
             .await?;
         Ok(Some(hash))
     } else {
@@ -279,13 +273,18 @@ async fn _access_list_remove(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<usize, Box<dyn std::error::Error>> {
     if let Some(hash) = manually_enter_did_or_hash(theme) {
-        Ok(atm
-            .mediator()
-            .access_list_remove(profile, Some(&account.did_hash), &[hash.as_str()])
-            .await?)
+        let response = atm
+            .trust_tasks()
+            .access_list_remove(
+                profile,
+                Some(account.did.as_str().to_string()),
+                vec![hash],
+            )
+            .await?;
+        Ok(response.removed.len())
     } else {
         Ok(0)
     }
@@ -295,19 +294,23 @@ async fn _access_list_get(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
     theme: &ColorfulTheme,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(hash) = manually_enter_did_or_hash(theme) {
         let result = atm
-            .mediator()
-            .access_list_get(profile, Some(&account.did_hash), &[hash.as_str()])
+            .trust_tasks()
+            .access_list_get(
+                profile,
+                Some(account.did.as_str().to_string()),
+                vec![hash],
+            )
             .await?;
 
         println!("{}", style("DID Hashes Found:").blue());
-        for hash in &result.did_hashes {
-            println!("  {}", style(hash).blue());
+        for hash in &result.present {
+            println!("  {}", style(hash.as_str()).blue());
         }
-        if result.did_hashes.is_empty() {
+        if result.present.is_empty() {
             println!("{}", style("No DID Hashes found").yellow());
         }
     }
@@ -317,10 +320,10 @@ async fn _access_list_get(
 async fn _access_list_clear(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
-    account: &Account,
+    account: &account::get::v0_1::Account,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    Ok(atm
-        .mediator()
-        .access_list_clear(profile, Some(&account.did_hash))
-        .await?)
+    atm.trust_tasks()
+        .access_list_clear(profile, Some(account.did.as_str().to_string()))
+        .await?;
+    Ok(())
 }

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Example of how to manage administration accounts for the mediator
 use account_management::account_management::account_management_menu;
 use affinidi_messaging_helpers::common::{affinidi_logo::print_logo, check_path};


### PR DESCRIPTION
## Summary

**Phase 5 consumer migration (3 of 3, part 2)** — completes the `mediator_administration` **bin**. The account-management + acl-management screens move off the deprecated `atm.mediator()` methods, and the crate-level `#![allow(deprecated)]` is **removed**. The admin tool is now fully on the Trust Tasks core.

## Changes
- **account_management.rs** (7 sites): `account_get` (Option→Result existence check), `account_add`, `account_remove`, `account_change_type`, `account_change_queue_limits`, `account_list`. Holds `account::get::v0_1::Account`; the change ops return per-module `Account` types, normalised back via a `to_get_account` serde round-trip. Account-type selection hard-codes the spec variants.
- **acl_management.rs** (6 sites): `acls_set` → `acl_set` (partial spec `MediatorAcl`), `acls_get` → `acl_get`, `access_list_{list,add,remove,clear,get}`.

## Faithful (cosmetic) display changes
- The raw `u64` ACL bitfield (`{:064b}`) → the structured spec `MediatorAcl` (`{:?}`) — there's no bitfield in the spec types.
- The per-capability **self-change** checkboxes (no spec equivalent) reduce to the 12 flags the spec models.
- "Account already exists" folds into the `account_get` error path (Option→Result).

## Verification
helpers builds clean under **`-D warnings`** (no deprecated calls remain) + `clippy --all-targets` clean. It's an **untestable TUI** — compile/clippy is the only check; behaviour is preserved by faithful conversion. (The bulk edit was done by a focused agent under precise rules, then reviewed + verified here.) `publish = false`, no version bump.

## Remaining
The 5 helper **examples** keep their own `#![allow(deprecated)]` (demos — a separate, low-priority follow-up), and the eventual **removal** of the deprecated methods + the mediator's legacy DIDComm handlers (the breaking major).