### PR TITLE
refactor: migrate helper example demos to atm.trust_tasks() (PR-T18)

### DIFF
--- a/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
@@ -1,12 +1,7 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Sends a message from Alice to Bob and then retrieves it.
 
 use affinidi_messaging_didcomm::message::Message;
-use affinidi_messaging_sdk::{
-    errors::ATMError,
-    profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
-};
+use affinidi_messaging_sdk::{errors::ATMError, profiles::ATMProfile};
 use affinidi_tdk::{TDK, common::config::TDKConfig};
 use clap::Parser;
 use serde_json::json;
@@ -16,6 +11,7 @@ use std::{
 };
 use tracing::{error, info};
 use tracing_subscriber::filter;
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -79,14 +75,12 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_alice).await?, true)
         .await?;
 
-    let Some(alice_info) = atm.mediator().account_get(&atm_alice, None).await? else {
+    let Ok(alice_info) = atm.trust_tasks().account_get(&atm_alice, None).await else {
         panic!("Alice account not found on mediator");
     };
 
     info!("Alice profile active: {:?}", alice_info);
-    let alice_acl_mode = MediatorACLSet::from_u64(alice_info.acls)
-        .get_access_list_mode()
-        .0;
+    let alice_acl_mode = alice_info.acl.access_list_mode;
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
@@ -102,43 +96,41 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_bob).await?, true)
         .await?;
 
-    let Some(bob_info) = atm.mediator().account_get(&atm_bob, None).await? else {
+    let Ok(bob_info) = atm.trust_tasks().account_get(&atm_bob, None).await else {
         panic!("Bob account not found on mediator");
     };
 
     info!("Bob profile active: {:?}", bob_info);
-    let bob_acl_mode = MediatorACLSet::from_u64(bob_info.acls)
-        .get_access_list_mode()
-        .0;
+    let bob_acl_mode = bob_info.acl.access_list_mode;
     info!("Bob ACL Mode Type: {:?}", bob_acl_mode);
 
     // Reset ACL's as examples can get mixed up with back to back testing
     info!("Resetting Access Lists");
 
     // Reset Alice ACL's
-    if let AccessListModeType::ExplicitAllow = alice_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob is added to Alice explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_alice, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Bob is removed from Alice explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_alice, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     }
     info!("Alice Access Lists reset");
 
     // Reset Bob ACL's
-    if let AccessListModeType::ExplicitAllow = bob_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Bob is added to Bob explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_bob, None, &[&alice_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Bob is removed from Bob explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_bob, None, &[&alice_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
             .await?;
     }
     info!("Bob Access Lists reset");

--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Cross-Mediator Forwarding Example
 //!
 //! Demonstrates DIDComm message forwarding between two *different* mediators.
@@ -38,12 +37,7 @@
 //! exchange with a compact round-trip latency measurement loop.
 
 use affinidi_messaging_didcomm::message::Message;
-use affinidi_messaging_sdk::{
-    ATM,
-    errors::ATMError,
-    profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
-};
+use affinidi_messaging_sdk::{ATM, errors::ATMError, profiles::ATMProfile};
 use affinidi_tdk::{
     TDK,
     common::{config::TDKConfig, profiles::TDKProfile},
@@ -58,6 +52,7 @@ use std::{
 };
 use tracing::info;
 use tracing_subscriber::filter;
+use trust_tasks_rs::specs::messaging::account::{self, get::v0_1::MediatorAclAccessListMode};
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -333,41 +328,64 @@ async fn setup_acls(alice: &Party, bob: &Party) -> Result<(), ATMError> {
 }
 
 /// Fetch the party's mediator account (creating it if the mediator allows
-/// self-registration). Returns (did_hash, acls).
-async fn ensure_account(party: &Party) -> Result<(String, u64), ATMError> {
-    match party
-        .atm
-        .mediator()
-        .account_get(&party.profile, None)
-        .await?
-    {
-        Some(account) => Ok((account.did_hash, account.acls)),
-        None => {
+/// self-registration). Returns (did_hash, access_list_mode).
+async fn ensure_account(
+    party: &Party,
+) -> Result<(String, Option<MediatorAclAccessListMode>), ATMError> {
+    // A missing account is an Err (not Ok(None)) under the Trust Tasks API.
+    match party.atm.trust_tasks().account_get(&party.profile, None).await {
+        Ok(account) => Ok((
+            account.did.as_str().to_string(),
+            account.acl.access_list_mode,
+        )),
+        Err(_) => {
             let hash = sha256::digest(party.profile.inner.did.as_str());
             let account = party
                 .atm
-                .mediator()
-                .account_add(&party.profile, &hash, None)
+                .trust_tasks()
+                .account_add(
+                    &party.profile,
+                    hash,
+                    account::add::v0_1::AccountType::Standard,
+                    None,
+                )
                 .await?;
-            Ok((account.did_hash, account.acls))
+            // The per-module `add` Account shares one schema with `get`; normalise
+            // it so the access_list_mode enum type matches across the helper.
+            let account = to_get_account(&account);
+            Ok((
+                account.did.as_str().to_string(),
+                account.acl.access_list_mode,
+            ))
         }
     }
 }
 
+/// All the `messaging/account/*` Trust Tasks return a per-module `Account`
+/// struct, but they share one schema. Converts any of them back to the
+/// canonical `account::get::v0_1::Account`.
+fn to_get_account<T: serde::Serialize>(a: &T) -> account::get::v0_1::Account {
+    serde_json::from_value(serde_json::to_value(a).expect("serialize"))
+        .expect("messaging Account types share one schema")
+}
+
 /// Allow `peer_hash` to reach `party` regardless of the mediator's ACL mode.
-async fn apply_access(party: &Party, acls: u64, peer_hash: &str) -> Result<(), ATMError> {
-    let mode = MediatorACLSet::from_u64(acls).get_access_list_mode().0;
-    if let AccessListModeType::ExplicitAllow = mode {
+async fn apply_access(
+    party: &Party,
+    mode: Option<MediatorAclAccessListMode>,
+    peer_hash: &str,
+) -> Result<(), ATMError> {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = mode {
         party
             .atm
-            .mediator()
-            .access_list_add(&party.profile, None, &[peer_hash])
+            .trust_tasks()
+            .access_list_add(&party.profile, None, vec![peer_hash.to_string()])
             .await?;
     } else {
         party
             .atm
-            .mediator()
-            .access_list_remove(&party.profile, None, &[peer_hash])
+            .trust_tasks()
+            .access_list_remove(&party.profile, None, vec![peer_hash.to_string()])
             .await?;
     }
     Ok(())

--- a/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
@@ -1,10 +1,8 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_sdk::{
     errors::ATMError,
     messages::{DeleteMessageRequest, FetchDeletePolicy, Folder, fetch::FetchOptions},
     profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
 };
 use affinidi_tdk::{TDK, common::config::TDKConfig};
 use clap::Parser;
@@ -12,6 +10,7 @@ use serde_json::json;
 use std::env;
 use tracing::info;
 use tracing_subscriber::filter;
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -73,14 +72,12 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_alice).await?, true)
         .await?;
 
-    let Some(alice_info) = atm.mediator().account_get(&atm_alice, None).await? else {
+    let Ok(alice_info) = atm.trust_tasks().account_get(&atm_alice, None).await else {
         panic!("Alice account not found on mediator");
     };
 
     info!("Alice profile active: {:?}", alice_info);
-    let alice_acl_mode = MediatorACLSet::from_u64(alice_info.acls)
-        .get_access_list_mode()
-        .0;
+    let alice_acl_mode = alice_info.acl.access_list_mode;
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
@@ -96,43 +93,41 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_bob).await?, true)
         .await?;
 
-    let Some(bob_info) = atm.mediator().account_get(&atm_bob, None).await? else {
+    let Ok(bob_info) = atm.trust_tasks().account_get(&atm_bob, None).await else {
         panic!("Bob account not found on mediator");
     };
 
     info!("Bob profile active: {:?}", bob_info);
-    let bob_acl_mode = MediatorACLSet::from_u64(bob_info.acls)
-        .get_access_list_mode()
-        .0;
+    let bob_acl_mode = bob_info.acl.access_list_mode;
     info!("Bob ACL Mode Type: {:?}", bob_acl_mode);
 
     // Reset ACL's as examples can get mixed up with back to back testing
     info!("Resetting Access Lists");
 
     // Reset Alice ACL's
-    if let AccessListModeType::ExplicitAllow = alice_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob is added to Alice explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_alice, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Bob is removed from Alice explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_alice, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     }
     info!("Alice Access Lists reset");
 
     // Reset Bob ACL's
-    if let AccessListModeType::ExplicitAllow = bob_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Bob is added to Bob explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_bob, None, &[&alice_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Bob is removed from Bob explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_bob, None, &[&alice_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
             .await?;
     }
     info!("Bob Access Lists reset");

--- a/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 /*! Reproducible attack vector to hijack an admin account
  *
  * This is a demonstration of a potential attack vector that can be used to hijack an admin account.
@@ -24,6 +23,7 @@ use sha256::digest;
 use std::{env, sync::Arc, time::SystemTime};
 use tracing::{info, warn};
 use tracing_subscriber::filter;
+use trust_tasks_rs::specs::messaging::account::get::v0_1::AccountType;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -88,19 +88,19 @@ async fn main() -> Result<(), ATMError> {
         .await?;
     info!("Admin profile active");
 
-    // Check if actually admin?
-    match atm.mediator().account_get(&atm_admin, None).await {
-        Ok(Some(account)) => {
-            if account._type.is_admin() {
+    // Check if actually admin? (a missing account is an Err under Trust Tasks)
+    match atm.trust_tasks().account_get(&atm_admin, None).await {
+        Ok(account) => {
+            if matches!(
+                account.account_type,
+                AccountType::Admin | AccountType::RootAdmin
+            ) {
                 info!("Verified Admin account - OK");
             } else {
                 return Err(ATMError::ConfigError(
                     "Admin account is actually not an ADMIN level account!!!".to_string(),
                 ));
             }
-        }
-        Ok(None) => {
-            return Err(ATMError::ConfigError("Admin account not found".to_string()));
         }
         Err(e) => {
             return Err(ATMError::ConfigError(
@@ -126,21 +126,19 @@ async fn main() -> Result<(), ATMError> {
         .await?;
     info!("Mallory profile active");
 
-    // Check if actually not-admin?
-    match atm.mediator().account_get(&atm_mallory, None).await {
-        Ok(Some(account)) => {
-            if !account._type.is_admin() {
+    // Check if actually not-admin? (a missing account is an Err under Trust Tasks)
+    match atm.trust_tasks().account_get(&atm_mallory, None).await {
+        Ok(account) => {
+            if !matches!(
+                account.account_type,
+                AccountType::Admin | AccountType::RootAdmin
+            ) {
                 info!("Verified Non-Admin account - OK");
             } else {
                 return Err(ATMError::ConfigError(
                     "Mallory is an ADMIN level account!!!".to_string(),
                 ));
             }
-        }
-        Ok(None) => {
-            return Err(ATMError::ConfigError(
-                "Mallory account not found".to_string(),
-            ));
         }
         Err(e) => {
             return Err(ATMError::ConfigError(
@@ -161,7 +159,7 @@ async fn main() -> Result<(), ATMError> {
 
     // Try and do an admin function with Mallory
     info!("Trying to access an admin function with Mallory");
-    match atm.mediator().accounts_list(&atm_mallory, None, None).await {
+    match atm.trust_tasks().account_list(&atm_mallory, None, None).await {
         Ok(_) => {
             warn!("Mallory was able to access an admin function - NOT OK");
         }
@@ -218,19 +216,17 @@ async fn main() -> Result<(), ATMError> {
     info!("Sending bad admin message to mediator");
     http_post(&tdk, &atm_mallory, &msg, &admin_tokens).await;
 
-    // Lets check if Mallory is an admin?
-    match atm.mediator().account_get(&atm_mallory, None).await {
-        Ok(Some(account)) => {
-            if account._type.is_admin() {
+    // Lets check if Mallory is an admin? (a missing account is an Err under Trust Tasks)
+    match atm.trust_tasks().account_get(&atm_mallory, None).await {
+        Ok(account) => {
+            if matches!(
+                account.account_type,
+                AccountType::Admin | AccountType::RootAdmin
+            ) {
                 warn!("Mallory is now an ADMIN level account - NOT OK!!!!");
             } else {
                 info!("Mallory is still a non admin... Phew....");
             }
-        }
-        Ok(None) => {
-            return Err(ATMError::ConfigError(
-                "Mallory account not found".to_string(),
-            ));
         }
         Err(e) => {
             return Err(ATMError::ConfigError(
@@ -278,19 +274,17 @@ async fn main() -> Result<(), ATMError> {
     info!("Sending bad admin message to mediator");
     http_post(&tdk, &atm_mallory, &msg, &admin_tokens).await;
 
-    // Lets check if Mallory is an admin?
-    match atm.mediator().account_get(&atm_mallory, None).await {
-        Ok(Some(account)) => {
-            if account._type.is_admin() {
+    // Lets check if Mallory is an admin? (a missing account is an Err under Trust Tasks)
+    match atm.trust_tasks().account_get(&atm_mallory, None).await {
+        Ok(account) => {
+            if matches!(
+                account.account_type,
+                AccountType::Admin | AccountType::RootAdmin
+            ) {
                 warn!("Mallory is now an ADMIN level account - NOT OK!!!!");
             } else {
                 info!("Mallory is still a non admin... Phew....");
             }
-        }
-        Ok(None) => {
-            return Err(ATMError::ConfigError(
-                "Mallory account not found".to_string(),
-            ));
         }
         Err(e) => {
             return Err(ATMError::ConfigError(
@@ -347,19 +341,17 @@ async fn main() -> Result<(), ATMError> {
         }
     }
 
-    // Lets check if Mallory is an admin?
-    match atm.mediator().account_get(&atm_mallory, None).await {
-        Ok(Some(account)) => {
-            if account._type.is_admin() {
+    // Lets check if Mallory is an admin? (a missing account is an Err under Trust Tasks)
+    match atm.trust_tasks().account_get(&atm_mallory, None).await {
+        Ok(account) => {
+            if matches!(
+                account.account_type,
+                AccountType::Admin | AccountType::RootAdmin
+            ) {
                 warn!("Mallory is now an ADMIN level account - NOT OK!!!!");
             } else {
                 info!("Mallory is still a non admin... Phew....");
             }
-        }
-        Ok(None) => {
-            return Err(ATMError::ConfigError(
-                "Mallory account not found".to_string(),
-            ));
         }
         Err(e) => {
             return Err(ATMError::ConfigError(

--- a/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
@@ -1,13 +1,8 @@
-#![allow(deprecated)] // legacy atm.mediator() methods deprecated for atm.trust_tasks(); migrate then drop
 //! Tries to Spoof a message from Mallory to Bob, but pretending to be Alice.
 //! Mallory send to Bob, but inner envelope pretends to be Alice
 
 use affinidi_messaging_didcomm::message::Message;
-use affinidi_messaging_sdk::{
-    errors::ATMError,
-    profiles::ATMProfile,
-    protocols::mediator::acls::{AccessListModeType, MediatorACLSet},
-};
+use affinidi_messaging_sdk::{errors::ATMError, profiles::ATMProfile};
 use affinidi_tdk::{TDK, common::config::TDKConfig};
 use clap::Parser;
 use serde_json::json;
@@ -17,6 +12,7 @@ use std::{
 };
 use tracing::{error, info};
 use tracing_subscriber::filter;
+use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -80,14 +76,12 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_alice).await?, true)
         .await?;
 
-    let Some(alice_info) = atm.mediator().account_get(&atm_alice, None).await? else {
+    let Ok(alice_info) = atm.trust_tasks().account_get(&atm_alice, None).await else {
         panic!("Alice account not found on mediator");
     };
 
     info!("Alice profile active: {:?}", alice_info);
-    let alice_acl_mode = MediatorACLSet::from_u64(alice_info.acls)
-        .get_access_list_mode()
-        .0;
+    let alice_acl_mode = alice_info.acl.access_list_mode;
     info!("Alice ACL Mode Type: {:?}", alice_acl_mode);
 
     // Activate Bob Profile
@@ -103,14 +97,12 @@ async fn main() -> Result<(), ATMError> {
         .profile_add(&ATMProfile::from_tdk_profile(&atm, tdk_bob).await?, true)
         .await?;
 
-    let Some(bob_info) = atm.mediator().account_get(&atm_bob, None).await? else {
+    let Ok(bob_info) = atm.trust_tasks().account_get(&atm_bob, None).await else {
         panic!("Bob account not found on mediator");
     };
 
     info!("Bob profile active: {:?}", bob_info);
-    let bob_acl_mode = MediatorACLSet::from_u64(bob_info.acls)
-        .get_access_list_mode()
-        .0;
+    let bob_acl_mode = bob_info.acl.access_list_mode;
     info!("Bob ACL Mode Type: {:?}", bob_acl_mode);
 
     // Activate Mallory Profile
@@ -130,61 +122,66 @@ async fn main() -> Result<(), ATMError> {
         )
         .await?;
 
-    let Some(mallory_info) = atm.mediator().account_get(&atm_mallory, None).await? else {
+    let Ok(mallory_info) = atm.trust_tasks().account_get(&atm_mallory, None).await else {
         panic!("Mallory account not found on mediator");
     };
 
     info!("Mallory profile active: {:?}", mallory_info);
-    let mallory_acl_mode = MediatorACLSet::from_u64(mallory_info.acls)
-        .get_access_list_mode()
-        .0;
+    let mallory_acl_mode = mallory_info.acl.access_list_mode;
     info!("Mallory ACL Mode Type: {:?}", mallory_acl_mode);
 
     // Reset ACL's as examples can get mixed up with back to back testing
     info!("Resetting Access Lists");
 
     // Reset Alice ACL's (who has no access to either Bob or Mallory)
-    if let AccessListModeType::ExplicitAllow = alice_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob and Mallory are removed from explicit allow list
-        atm.mediator()
-            .access_list_remove(&atm_alice, None, &[&mallory_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(
+                &atm_alice,
+                None,
+                vec![mallory_info.did.as_str().to_string()],
+            )
             .await?;
     } else {
         // Ensure Mallory is removed from Bob explicit deny list
-        atm.mediator()
+        atm.trust_tasks()
             .access_list_add(
                 &atm_alice,
                 None,
-                &[&bob_info.did_hash, &mallory_info.did_hash],
+                vec![
+                    bob_info.did.as_str().to_string(),
+                    mallory_info.did.as_str().to_string(),
+                ],
             )
             .await?;
     }
     info!("Alice Access Lists reset");
 
     // Reset Bob ACL's
-    if let AccessListModeType::ExplicitAllow = bob_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Mallory is added to Bob explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_bob, None, &[&mallory_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_bob, None, vec![mallory_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Mallory is removed from Bob explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_bob, None, &[&mallory_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_bob, None, vec![mallory_info.did.as_str().to_string()])
             .await?;
     }
     info!("Bob Access Lists reset");
 
     // Reset Mallory ACL's
-    if let AccessListModeType::ExplicitAllow = mallory_acl_mode {
+    if let Some(MediatorAclAccessListMode::ExplicitAllow) = mallory_acl_mode {
         // Ensure Bob is added to Mallory explicit allow list
-        atm.mediator()
-            .access_list_add(&atm_mallory, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_add(&atm_mallory, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     } else {
         // Ensure Bob is removed from Mallory explicit deny list
-        atm.mediator()
-            .access_list_remove(&atm_mallory, None, &[&bob_info.did_hash])
+        atm.trust_tasks()
+            .access_list_remove(&atm_mallory, None, vec![bob_info.did.as_str().to_string()])
             .await?;
     }
     info!("Mallory Access Lists reset");


### PR DESCRIPTION
## Summary

**Phase 5 consumer migration — final cleanup.** Migrates the 5 `affinidi-messaging-helpers` example demos off the deprecated `atm.mediator()` methods and removes their per-file `#![allow(deprecated)]`. **The entire `helpers` crate is now deprecation-allow-free.**

## Changes
- **spoof_test.rs / delete_test.rs / alice_bob.rs** — `account_get` (Option→Result) + the access-list-mode read (`MediatorACLSet::from_u64` → `account.acl.access_list_mode`) + `access_list_add`/`remove`.
- **hijack_admin.rs** — `account_get` + `accounts_list`→`account_list`; the admin checks become `matches!(account.account_type, Admin | RootAdmin)`. **Security-demo intent preserved** — Mallory still can't access admin functions or self-promote ("still a non admin… Phew").
- **cross_mediator_forwarding.rs** — `ensure_account`/`apply_access` carry the structured access-list mode instead of a raw `u64`.

## Verification
`cargo build -p affinidi-messaging-helpers --examples` clean under **`-D warnings`** (no deprecated calls remain) + clippy clean. These are untestable demos — compile/clippy plus preserved control-flow/messages are the verification. The bulk edit was done by a focused agent under precise rules, then reviewed + verified here. `publish = false`, no version bump.

## Phase 5 — consumer migration complete
text-client (#519), didcomm-service (#520), and the helpers admin tool bin (#521/#522) + examples (this PR) are all off `atm.mediator()`. The only remaining Phase 5 item is the eventual **removal** of the deprecated methods + the mediator's legacy DIDComm handlers (the breaking major, after a grace period).