### PR TITLE
feat: carry TSP Nested messages through the mediator + SDK send_nested

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 24th June 2026
 
+### 0.16.25 — TSP: Nested message relay
+
+- The TSP inbound handler now carries **`Nested`** messages (TSP §5.5, the
+  metadata-privacy wrapper), where previously only `Direct` and `Routed` were handled.
+  A `Nested` envelope addressed to **this mediator** is unwrapped (the outer layer is
+  sealed to us) to reveal the inner message — itself sealed end-to-end to its final
+  recipient — which is then routed by its own envelope, delivered to a local account or
+  forwarded to a remote mediator (and may be TSP or an opaque DIDComm bridge payload). A
+  `Nested` envelope addressed to a **local account** is delivered opaquely for that
+  account to unwrap. TSP `Control` relay remains unimplemented.
+
 ### 0.16.24 — Trust Tasks: acl/set non-admin self-service
 
 - `messaging/acl/set` now supports non-admin **self-service** (it was admin-only). A

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.24"
+version = "0.16.25"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -187,12 +187,62 @@ pub(crate) async fn handle_inbound_tsp(
         // store it opaquely for them to pick up and relay onward.
         TspMessageType::Routed => deliver_tsp_local(state, session, raw).await,
 
-        // Nested / Control relay are not handled yet.
+        // Nested addressed to *this mediator*: we are the intermediary of a
+        // metadata-privacy wrapper (TSP §5.5). Unwrap our outer layer (sealed to us)
+        // to reveal the inner message — which is itself a packed TSP message sealed
+        // end-to-end to its final recipient — then route the inner by its own
+        // envelope, delivering locally or forwarding to a remote mediator.
+        TspMessageType::Nested if meta.receiver == state.config.mediator_did => {
+            let identity = state.tsp_identity().await?;
+            let sender = resolve_tsp_vid(state, &meta.sender, &session.session_id).await?;
+            let unpacked = affinidi_tsp::message::direct::unpack(
+                raw,
+                &identity.decryption_key,
+                &sender.encryption_key,
+                &sender.signing_key,
+            )
+            .map_err(|e| {
+                tsp_problem(
+                    session,
+                    37,
+                    "message.tsp.unpack",
+                    format!("couldn't unpack nested TSP layer: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            // The unpacked payload IS the inner packed message. Route it by its own
+            // (sealed) envelope — its recipient may be local or on another mediator,
+            // and the inner may be TSP or an opaque DIDComm bridge payload.
+            let inner_meta = TspMetaEnvelope::parse(&unpacked.payload).map_err(|e| {
+                tsp_problem(
+                    session,
+                    37,
+                    "message.tsp.malformed",
+                    format!("malformed nested inner TSP envelope: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+            forward_to_next(
+                state,
+                session,
+                &inner_meta.receiver,
+                &meta.sender,
+                &unpacked.payload,
+            )
+            .await
+        }
+
+        // Nested addressed to a *local account*: that account is the intermediary —
+        // store it opaquely for them to unwrap and relay onward.
+        TspMessageType::Nested => deliver_tsp_local(state, session, raw).await,
+
+        // TSP Control-message relay is not handled yet.
         _ => Err(tsp_problem(
             session,
             37,
             "protocol.tsp.unsupported",
-            "Only TSP Direct and Routed messages are handled so far".to_string(),
+            "TSP Control messages are not handled yet".to_string(),
             StatusCode::NOT_IMPLEMENTED,
         )),
     }

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.33] - 2026-06-24
+
+New `atm.tsp().send_nested(profile, intermediary, to_did, payload)` and
+`send_nested_opaque(profile, intermediary, inner)`: send a TSP message wrapped in a
+**`Nested`** metadata-privacy envelope. The payload is sealed end-to-end to `to_did`,
+then wrapped in an outer `Nested` message sealed to `intermediary` (typically the
+recipient's mediator), which unwraps the outer layer and forwards the inner — so only
+the intermediary learns `to_did`. The `_opaque` form takes a pre-built inner (which may
+be a DIDComm message — the TSP↔DIDComm bridge). Additive; no existing API changed.
+
 ## [0.18.32] - 2026-06-24
 
 `atm.trust_tasks().acl_set` is no longer admin-only — a non-admin may set its own ACL

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.32"
+version = "0.18.33"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -169,6 +169,54 @@ impl TspOps<'_> {
         self.send_raw(profile, &routed.bytes).await
     }
 
+    /// Send a TSP message wrapped in a **Nested** metadata-privacy envelope.
+    ///
+    /// The payload is sealed end-to-end to `to_did` as an inner Direct message, then
+    /// wrapped in an outer Nested message sealed to `intermediary` — typically the
+    /// recipient's mediator, which unwraps the outer layer and forwards the inner
+    /// onward. On the wire the envelope is addressed to `intermediary`, so only it
+    /// learns `to_did`; the recipient still opens a plain Direct message.
+    pub async fn send_nested(
+        &self,
+        profile: &Arc<ATMProfile>,
+        intermediary: &str,
+        to_did: &str,
+        payload: &[u8],
+    ) -> Result<(), ATMError> {
+        // Inner Direct message sealed end-to-end to the final recipient.
+        let inner = self.pack(profile, to_did, payload).await?;
+        self.send_nested_opaque(profile, intermediary, &inner).await
+    }
+
+    /// Wrap an **already-packed** inner message in a Nested envelope to `intermediary`.
+    ///
+    /// Like [`send_nested`], but `inner` is a pre-built message sealed to its final
+    /// recipient — which may be a **DIDComm** message (the TSP↔DIDComm bridge): the
+    /// intermediary unwraps the Nested layer and forwards the opaque inner, blind to
+    /// its protocol.
+    pub async fn send_nested_opaque(
+        &self,
+        profile: &Arc<ATMProfile>,
+        intermediary: &str,
+        inner: &[u8],
+    ) -> Result<(), ATMError> {
+        let (from_did, _) = profile.dids()?;
+        let (signing_key, encryption_key) = self.profile_tsp_keys(from_did).await?;
+        let intermediary_vid = self.resolve_vid(intermediary).await?;
+        let nested = affinidi_tsp::message::direct::pack(
+            inner,
+            affinidi_tsp::MessageType::Nested,
+            from_did,
+            intermediary,
+            &signing_key,
+            &encryption_key,
+            &intermediary_vid.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack nested TSP message: {e}")))?;
+
+        self.send_raw(profile, &nested.bytes).await
+    }
+
     /// POST an already-packed TSP message (raw qb2 bytes) to the mediator
     /// `/inbound`, reusing the profile's existing (DIDComm) authenticated session
     /// for the bearer token. The mediator sniffs the TSP magic byte and routes it

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 24th June 2026
 
+### 0.2.29 — TSP: Nested relay e2e
+
+- New `tsp_nested_message_relays_through_the_mediator`: Alice wraps an inner Direct
+  (sealed to Bob) in a `Nested` envelope sealed to the mediator; the mediator unwraps
+  its layer and forwards the inner to Bob, who unpacks the original payload + sender.
+
 ### 0.2.28 — Trust Tasks: acl/set self-service e2e
 
 - New `acl_set_self_service_changes_a_self_manageable_flag` (alice changes her own

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.28"
+version = "0.2.29"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -122,6 +122,61 @@ async fn tsp_routed_message_relays_through_the_mediator() {
     assert_eq!(sender, alice.did, "original sender VID is recovered, not the relay");
 }
 
+/// End-to-end TSP **Nested** relay: Alice wraps an inner Direct message (sealed to
+/// Bob) in an outer **Nested** envelope sealed to the mediator — a metadata-privacy
+/// carriage where Bob's identity is hidden from anyone but the mediator. The
+/// mediator unwraps its outer layer and forwards the opaque inner to Bob (a local
+/// recipient). Proves the mediator's nested-relay path: derive its own TSP identity
+/// → unpack the layer sealed to it → route the inner by its own envelope → deliver.
+#[tokio::test]
+async fn tsp_nested_message_relays_through_the_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mediator_did = env.mediator.did().to_string();
+
+    let payload = b"nested hello over TSP";
+
+    // Alice nests an inner Direct (sealed to bob) inside a Nested envelope sealed to
+    // the mediator, which unwraps its layer and forwards the inner to bob.
+    env.atm
+        .tsp()
+        .send_nested(&alice.profile, &mediator_did, &bob.did, payload)
+        .await
+        .expect("alice sends a nested TSP message via the mediator");
+
+    // Bob fetches the forwarded (now opaque Direct) message and unpacks it.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one forwarded message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("forwarded message carries its body");
+
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the forwarded TSP message");
+
+    assert_eq!(recovered, payload, "payload survives the nested relay end to end");
+    assert_eq!(
+        sender, alice.did,
+        "original sender VID is recovered, not the intermediary"
+    );
+}
+
 /// End-to-end **TSP↔DIDComm bridge**: Alice sends a *DIDComm* message to Bob, but
 /// carried over TSP routing. She authcrypts a normal DIDComm message to Bob, then
 /// routes it through the mediator with `send_routed_opaque`. The mediator unwraps


### PR DESCRIPTION
## Summary

Adds **TSP `Nested`** carriage (the metadata-privacy wrapper, TSP §5.5) — previously the mediator handled only `Direct` and `Routed`. This is the first of the parked TSP-completeness enhancements.

## Changes
- **mediator** (0.16.24 → 0.16.25) — the TSP inbound handler now carries `Nested` messages:
  - addressed to **this mediator** → unwrap our outer layer (sealed to us), reveal the inner message (sealed end-to-end to its final recipient), and route it by its own envelope — delivering locally or forwarding to a remote mediator (the inner may be TSP or an opaque DIDComm bridge payload);
  - addressed to a **local account** → deliver opaquely for that account to unwrap.
  - Mirrors the existing Routed relay path. TSP `Control` relay remains unimplemented.
- **sdk** (0.18.32 → 0.18.33) — new `atm.tsp().send_nested(profile, intermediary, to_did, payload)` + `send_nested_opaque(profile, intermediary, inner)`. Seals an inner `Direct` to `to_did`, wraps it `Nested` to `intermediary`. Additive — no existing API changed.
- **test-mediator** (0.2.28 → 0.2.29) — new e2e `tsp_nested_message_relays_through_the_mediator` (Alice nests to Bob via the mediator; the mediator unwraps + forwards; Bob unpacks the original payload + sender).

## Tests
All 5 `tsp_delivery` e2e tests pass (Direct, Routed relay, Routed bridge, Routed remote-forward, **Nested**); dual-feature clippy (with + without `tsp`) clean on mediator + sdk.

## Related
The Trust Tasks TSP binding (`trust-tasks-tsp`) gets a matching producer-side `pack_trust_task_nested` in a companion PR in the trust-tasks repo.