### PR TITLE
feat: relay TSP Control messages through the mediator + SDK send_control

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 24th June 2026
 
+### 0.16.26 — TSP: Control message relay
+
+- The TSP inbound handler now relays **`Control`** messages (relationship invite /
+  accept / cancel) to their recipient, like a `Direct` message — the relay is
+  payload-agnostic, the mediator never inspects the control payload. This completes the
+  mediator's TSP message-type coverage: **Direct, Routed, Nested, and Control** are all
+  carried (the previous `NotImplemented` fallback is gone). A `Control` message addressed
+  to the mediator *itself* (the mediator as a relationship party) remains unsupported and
+  fails cleanly at delivery.
+
 ### 0.16.25 — TSP: Nested message relay
 
 - The TSP inbound handler now carries **`Nested`** messages (TSP §5.5, the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.25"
+version = "0.16.26"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -237,14 +237,13 @@ pub(crate) async fn handle_inbound_tsp(
         // store it opaquely for them to unwrap and relay onward.
         TspMessageType::Nested => deliver_tsp_local(state, session, raw).await,
 
-        // TSP Control-message relay is not handled yet.
-        _ => Err(tsp_problem(
-            session,
-            37,
-            "protocol.tsp.unsupported",
-            "TSP Control messages are not handled yet".to_string(),
-            StatusCode::NOT_IMPLEMENTED,
-        )),
+        // Control (relationship invite / accept / cancel) addressed to a local
+        // account: relay it to its recipient, who applies the relationship transition
+        // on pickup. The relay is payload-agnostic — the mediator never inspects the
+        // control payload. (A Control message addressed to the mediator *itself* —
+        // the mediator as a relationship party — is not supported and fails cleanly
+        // at delivery, since the mediator's own VID is not a deliverable account.)
+        TspMessageType::Control => deliver_tsp_local(state, session, raw).await,
     }
 }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.34] - 2026-06-24
+
+New `atm.tsp().send_control(profile, to_did, control)`: send a TSP **`Control`** message
+— a relationship-management message (invite / accept / cancel) to a peer. Build `control`
+with `affinidi_tsp::message::control::ControlMessage`'s `invite` / `accept` / `cancel`; it
+is sealed to `to_did` and carried with message type `Control`, which the mediator relays
+to the recipient like a Direct message. Additive; no existing API changed.
+
 ## [0.18.33] - 2026-06-24
 
 New `atm.tsp().send_nested(profile, intermediary, to_did, payload)` and

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.33"
+version = "0.18.34"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -217,6 +217,37 @@ impl TspOps<'_> {
         self.send_raw(profile, &nested.bytes).await
     }
 
+    /// Send a TSP **Control** message — a relationship-management message (invite /
+    /// accept / cancel) to a peer.
+    ///
+    /// Build `control` with [`affinidi_tsp::message::control::ControlMessage`]'s
+    /// `invite` / `accept` / `cancel`. It is sealed to `to_did` and carried with
+    /// message type `Control`; the mediator relays it to the recipient like a Direct
+    /// message (it never inspects the control payload), and the recipient applies the
+    /// relationship transition on receipt.
+    pub async fn send_control(
+        &self,
+        profile: &Arc<ATMProfile>,
+        to_did: &str,
+        control: &affinidi_tsp::message::control::ControlMessage,
+    ) -> Result<(), ATMError> {
+        let (from_did, _) = profile.dids()?;
+        let (signing_key, encryption_key) = self.profile_tsp_keys(from_did).await?;
+        let to_vid = self.resolve_vid(to_did).await?;
+        let packed = affinidi_tsp::message::direct::pack(
+            &control.encode(),
+            affinidi_tsp::MessageType::Control,
+            from_did,
+            to_did,
+            &signing_key,
+            &encryption_key,
+            &to_vid.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack control TSP message: {e}")))?;
+
+        self.send_raw(profile, &packed.bytes).await
+    }
+
     /// POST an already-packed TSP message (raw qb2 bytes) to the mediator
     /// `/inbound`, reusing the profile's existing (DIDComm) authenticated session
     /// for the bearer token. The mediator sniffs the TSP magic byte and routes it

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 24th June 2026
 
+### 0.2.30 — TSP: Control relay e2e
+
+- New `tsp_control_message_relays_through_the_mediator`: Alice sends a relationship-
+  forming invite (a `Control` message) to Bob via `atm.tsp().send_control`; the mediator
+  relays it, and Bob unpacks + decodes the invite. Adds `affinidi-tsp` as a dev-dep for
+  the `ControlMessage` types.
+
 ### 0.2.29 — TSP: Nested relay e2e
 
 - New `tsp_nested_message_relays_through_the_mediator`: Alice wraps an inner Direct

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.29"
+version = "0.2.30"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -84,6 +84,8 @@ affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-d
 ## Used by integration tests to hit the mediator's HTTP endpoints
 ## without going through the SDK.
 reqwest = { version = "0.13", features = ["rustls", "json"] }
+## TSP control-message types named by the TSP control-relay integration test.
+affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
 trust-tasks-rs = "0.2"
 ## Tracing subscriber for test diagnostics.

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -7,6 +7,7 @@
 
 use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_sdk::messages::MessageProtocol;
+use affinidi_tsp::message::control::{ControlMessage, ControlType};
 use affinidi_messaging_sdk::messages::fetch::FetchOptions;
 use affinidi_messaging_test_mediator::TestEnvironment;
 use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole, PeerService, PeerServiceEndpoint};
@@ -174,6 +175,62 @@ async fn tsp_nested_message_relays_through_the_mediator() {
     assert_eq!(
         sender, alice.did,
         "original sender VID is recovered, not the intermediary"
+    );
+}
+
+/// End-to-end TSP **Control** relay: Alice sends a relationship-forming *invite* (a
+/// `Control` message) to Bob through the mediator. The mediator relays it like a
+/// Direct message — payload-agnostic, never inspecting the control payload — and Bob
+/// unpacks it and decodes the invite. Completes the mediator's TSP message-type
+/// coverage (Direct / Routed / Nested / Control).
+#[tokio::test]
+async fn tsp_control_message_relays_through_the_mediator() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Alice sends a relationship-forming invite (a Control message) to Bob.
+    let invite = ControlMessage::invite();
+    env.atm
+        .tsp()
+        .send_control(&alice.profile, &bob.did, &invite)
+        .await
+        .expect("alice sends a TSP control message via the mediator");
+
+    // Bob fetches the relayed control message and unpacks it.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one control message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("control message carries its body");
+
+    let (payload, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the relayed control message");
+
+    assert_eq!(
+        sender, alice.did,
+        "control message is authenticated from alice"
+    );
+    let control = ControlMessage::decode(&payload).expect("payload decodes as a control message");
+    assert_eq!(
+        control.control_type,
+        ControlType::RelationshipFormingInvite,
+        "the relayed control message is the invite alice sent"
     );
 }
 


### PR DESCRIPTION
## Summary

Completes the mediator's **TSP message-type coverage**. `Control` (relationship invite / accept / cancel) was the last unhandled type — the mediator now carries all four: **Direct, Routed, Nested, Control**.

## Changes
- **mediator** (0.16.25 → 0.16.26) — the TSP inbound handler relays `Control` messages to their recipient via `deliver_tsp_local`, like a `Direct` message: **payload-agnostic**, the mediator never inspects the control payload. The `NotImplemented` fallback is gone (the match over the 4 `MessageType` variants is now exhaustive). A `Control` message addressed to the mediator *itself* stays unsupported and fails cleanly at delivery.
- **sdk** (0.18.33 → 0.18.34) — new `atm.tsp().send_control(profile, to_did, control)`. Seals a `ControlMessage` (`invite` / `accept` / `cancel`) to `to_did` with message type `Control`, via the already-public `affinidi_tsp::message::control`. Additive.
- **test-mediator** (0.2.29 → 0.2.30) — new e2e `tsp_control_message_relays_through_the_mediator` (Alice sends an invite to Bob; the mediator relays it; Bob unpacks + decodes the invite). Adds `affinidi-tsp` (in-tree path) as a dev-dep for the `ControlMessage` types.

## Tests
All 6 `tsp_delivery` e2e tests pass (Direct, Routed relay, Routed bridge, Routed remote-forward, Nested, **Control**); dual-feature clippy (with + without `tsp`) clean on mediator + sdk. No `affinidi-tsp` change was needed — its `message::control` module is already public.

## Note
This finishes the TSP **message-type** coverage. The remaining parked TSP enhancements are orthogonal: `trust-tasks-tsp` routed carriage, DID-doc TSP advertisement (discovery), pure-TSP auth, a typed live-stream consumer, and deeper test variants.