### PR TITLE
fix: serve did:web-native document at /.well-known/did.json for self-hosted did:webvh mediators

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 24th June 2026
 
+### 0.16.27 — did:web self-hosting: serve a valid did:web document
+
+- A self-hosted `did:webvh` mediator (`did_web_self_hosted = file://.../did.jsonl`)
+  now serves a **did:web-native** document at `/.well-known/did.json`: its identifier
+  (and every verification-method and service self-reference) is rewritten from
+  `did:webvh:{scid}:{domain}` to `did:web:{domain}`. Previously the extracted log
+  `state` was served verbatim, so a `did:web:{domain}` resolver received a document
+  whose `id` didn't match the DID it resolved and whose `#key-…` references couldn't
+  be dereferenced. The `/.well-known/did.jsonl` log stream and the mediator's internal
+  `did:webvh` identity are unchanged. Automatic — no new config key.
+
+## 24th June 2026
+
 ### 0.16.26 — TSP: Control message relay
 
 - The TSP inbound handler now relays **`Control`** messages (relationship invite /

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.26"
+version = "0.16.27"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog history
 
+## 24th June 2026
+
+### 0.15.18 — did:webvh → did:web document rewriting
+
+- New always-built `did_web` module: `webvh_did_to_web`, `rewrite_did_document_to_web`,
+  and `webvh_log_to_did_web` convert a `did:webvh:{scid}:{domain}` DID document into its
+  wire-compatible `did:web:{domain}` form (id, controller, key and service
+  self-references rewritten). Pure (`serde_json` only), shared by the mediator runtime
+  (serving `/.well-known/did.json`) and the `mediator-setup` wizard (writing the
+  `did-web.json` operator artefact) so both use one tested implementation.
+
 ## 23rd June 2026
 
 ### 0.15.17 — Message protocol metadata

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 - New always-built `did_web` module: `webvh_did_to_web`, `rewrite_did_document_to_web`,
   and `webvh_log_to_did_web` convert a `did:webvh:{scid}:{domain}` DID document into its
-  wire-compatible `did:web:{domain}` form (id, controller, key and service
-  self-references rewritten). Pure (`serde_json` only), shared by the mediator runtime
-  (serving `/.well-known/did.json`) and the `mediator-setup` wizard (writing the
+  wire-compatible `did:web:{domain}` form. The rewrite is structured: only DID-URL
+  *self-references* of the document's own DID (the bare DID and `{did}#frag` / `{did}?query`
+  / `{did}/path` forms — id, controller, key and service references) are rewritten. Foreign
+  DIDs, longer DIDs sharing the prefix (`{did}:tenant`), and values that merely embed the
+  DID as a substring (e.g. a `serviceEndpoint` URL) are left verbatim. `webvh_did_to_web`
+  also rejects an empty SCID segment. Pure (`serde_json` only), shared by the mediator
+  runtime (serving `/.well-known/did.json`) and the `mediator-setup` wizard (writing the
   `did-web.json` operator artefact) so both use one tested implementation.
 
 ## 23rd June 2026

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.17"
+version = "0.15.18"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/did_web.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/did_web.rs
@@ -4,7 +4,11 @@
 //! `did:webvh` and `did:web` are wire-compatible by design: a
 //! `did:webvh:{scid}:{domain}` DID resolves to the same document as
 //! `did:web:{domain}` once the self-certifying identifier (SCID) is
-//! dropped and every self-reference in the document is rewritten.
+//! dropped and every *self-reference* in the document is rewritten. Only
+//! the document's own DID (and DID URLs derived from it — `{did}#frag`,
+//! `{did}?query`, `{did}/path`) is rewritten; foreign DIDs, longer DIDs
+//! that merely share the prefix, and values that merely embed the DID as a
+//! substring (e.g. a `serviceEndpoint` URL) are left verbatim.
 //!
 //! Two consumers share this logic:
 //! - the mediator runtime, which rewrites the DID document it serves at
@@ -23,6 +27,9 @@ pub enum DidWebRewriteError {
     /// The supplied identifier is not a `did:webvh` DID.
     #[error("not a did:webvh DID: {0}")]
     NotWebvh(String),
+    /// The `did:webvh` identifier has an empty SCID segment.
+    #[error("did:webvh DID has an empty SCID: {0}")]
+    EmptyScid(String),
     /// The `did:webvh` identifier is missing its domain segment.
     #[error("malformed did:webvh DID (missing domain): {0}")]
     MissingDomain(String),
@@ -44,9 +51,12 @@ pub fn webvh_did_to_web(webvh_did: &str) -> Result<String, DidWebRewriteError> {
     let rest = webvh_did
         .strip_prefix("did:webvh:")
         .ok_or_else(|| DidWebRewriteError::NotWebvh(webvh_did.to_string()))?;
-    let (_scid, domain_and_path) = rest
+    let (scid, domain_and_path) = rest
         .split_once(':')
         .ok_or_else(|| DidWebRewriteError::MissingDomain(webvh_did.to_string()))?;
+    if scid.is_empty() {
+        return Err(DidWebRewriteError::EmptyScid(webvh_did.to_string()));
+    }
     if domain_and_path.is_empty() {
         return Err(DidWebRewriteError::EmptyDomain(webvh_did.to_string()));
     }
@@ -57,19 +67,59 @@ pub fn webvh_did_to_web(webvh_did: &str) -> Result<String, DidWebRewriteError> {
 /// from its `did:webvh` identifier into the equivalent `did:web` form,
 /// returning `(did:web identifier, rewritten document)`.
 ///
-/// In the resolved state the DID always appears in full (`id`,
-/// `controller`, `{did}#key-0`, service ids …), so a whole-string swap of
-/// the webvh DID for its did:web form rewrites them all without touching
-/// unrelated values. `web_did` never contains `webvh_did`, so the
-/// replacement can't recurse.
+/// Every string in the document that is a *DID URL of `webvh_did`* — the
+/// bare DID, or the DID followed by a `#fragment`, `?query`, or `/path`
+/// component — is rewritten to its `did:web` form (`id`, `controller`,
+/// `{did}#key-0`, service ids, verification-relationship references …).
+/// Strings that merely contain the DID as a substring are left verbatim:
+/// a foreign `did:webvh:` DID, a longer DID sharing the prefix
+/// (`{did}:tenant`), and a `serviceEndpoint` URL embedding the DID in a
+/// query parameter are all untouched.
 pub fn rewrite_did_document_to_web(
     state: &Value,
     webvh_did: &str,
 ) -> Result<(String, Value), DidWebRewriteError> {
     let web_did = webvh_did_to_web(webvh_did)?;
-    let rewritten = serde_json::to_string(state)?.replace(webvh_did, &web_did);
-    let doc: Value = serde_json::from_str(&rewritten)?;
+    let mut doc = state.clone();
+    rewrite_self_references(&mut doc, webvh_did, &web_did);
     Ok((web_did, doc))
+}
+
+/// Recursively walk a JSON value, rewriting every DID-URL self-reference of
+/// `webvh_did` (see [`rewrite_did_url`]) to its `web_did` form.
+fn rewrite_self_references(value: &mut Value, webvh_did: &str, web_did: &str) {
+    match value {
+        Value::String(s) => {
+            if let Some(rewritten) = rewrite_did_url(s, webvh_did, web_did) {
+                *s = rewritten;
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                rewrite_self_references(item, webvh_did, web_did);
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values_mut() {
+                rewrite_self_references(value, webvh_did, web_did);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// If `s` is a DID URL of `webvh_did` — exactly the DID, or the DID followed
+/// by a DID-URL delimiter (`#`, `?`, `/`) — return it rewritten onto
+/// `web_did` with the trailing component preserved. Otherwise (a different
+/// DID, a longer DID sharing the prefix such as `{did}:tenant`, or the DID
+/// embedded mid-string) return `None` so the value is left verbatim.
+fn rewrite_did_url(s: &str, webvh_did: &str, web_did: &str) -> Option<String> {
+    let rest = s.strip_prefix(webvh_did)?;
+    if rest.is_empty() || rest.starts_with(['#', '?', '/']) {
+        Some(format!("{web_did}{rest}"))
+    } else {
+        None
+    }
 }
 
 /// Convert a full `did:webvh` log entry (the envelope carrying `state`)
@@ -125,6 +175,10 @@ mod tests {
             webvh_did_to_web("did:webvh:QmScId:"),
             Err(DidWebRewriteError::EmptyDomain(_))
         ));
+        assert!(matches!(
+            webvh_did_to_web("did:webvh::example.com"),
+            Err(DidWebRewriteError::EmptyScid(_))
+        ));
     }
 
     #[test]
@@ -158,6 +212,41 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .starts_with("did:web:")
+        );
+    }
+
+    #[test]
+    fn rewrite_leaves_foreign_and_substring_references_verbatim() {
+        let webvh_did = "did:webvh:QmScId:mediator.example.com";
+        let foreign = "did:webvh:QmOther:org.example.com";
+        let sub_did = format!("{webvh_did}:tenant1");
+        let state = json!({
+            "id": webvh_did,
+            // A delegated controller owned by another entity — not ours to rewrite.
+            "controller": foreign,
+            // A longer DID that merely shares our DID as a prefix.
+            "alsoKnownAs": [sub_did],
+            "service": [
+                {
+                    "id": format!("{webvh_did}#relay"),
+                    "type": ["DIDCommMessaging"],
+                    // The DID embedded inside an endpoint URL's query string.
+                    "serviceEndpoint": format!("https://gw.example/resolve?did={webvh_did}")
+                }
+            ]
+        });
+
+        let (web_did, doc) = rewrite_did_document_to_web(&state, webvh_did).unwrap();
+
+        // Our own self-references are rewritten…
+        assert_eq!(doc["id"], web_did);
+        assert_eq!(doc["service"][0]["id"], format!("{web_did}#relay"));
+        // …but foreign DIDs, prefix-sharing DIDs, and embedded substrings are not.
+        assert_eq!(doc["controller"], foreign);
+        assert_eq!(doc["alsoKnownAs"][0], sub_did);
+        assert_eq!(
+            doc["service"][0]["serviceEndpoint"],
+            format!("https://gw.example/resolve?did={webvh_did}")
         );
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/did_web.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/did_web.rs
@@ -1,0 +1,186 @@
+//! Convert a `did:webvh` DID document into its wire-compatible `did:web`
+//! form.
+//!
+//! `did:webvh` and `did:web` are wire-compatible by design: a
+//! `did:webvh:{scid}:{domain}` DID resolves to the same document as
+//! `did:web:{domain}` once the self-certifying identifier (SCID) is
+//! dropped and every self-reference in the document is rewritten.
+//!
+//! Two consumers share this logic:
+//! - the mediator runtime, which rewrites the DID document it serves at
+//!   `/.well-known/did.json` so `did:web` resolvers receive a document
+//!   whose `id` (and every key / service self-reference) matches
+//!   `did:web:{domain}` (the `did.jsonl` log stream stays verbatim);
+//! - the `mediator-setup` wizard, which writes a standalone `did-web.json`
+//!   operator artefact via [`webvh_log_to_did_web`].
+
+use serde_json::Value;
+use thiserror::Error;
+
+/// Errors raised while rewriting a `did:webvh` document to `did:web`.
+#[derive(Debug, Error)]
+pub enum DidWebRewriteError {
+    /// The supplied identifier is not a `did:webvh` DID.
+    #[error("not a did:webvh DID: {0}")]
+    NotWebvh(String),
+    /// The `did:webvh` identifier is missing its domain segment.
+    #[error("malformed did:webvh DID (missing domain): {0}")]
+    MissingDomain(String),
+    /// The `did:webvh` identifier has an empty domain segment.
+    #[error("did:webvh DID has an empty domain: {0}")]
+    EmptyDomain(String),
+    /// The log entry envelope had no `state` (DID document) field.
+    #[error("did:webvh log entry has no `state` (DID document)")]
+    MissingState,
+    /// (De)serialising the DID document failed.
+    #[error("DID document JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Map a `did:webvh:{scid}:{domain}[:path…]` identifier to its
+/// `did:web:{domain}[:path…]` equivalent by dropping the SCID segment.
+/// Path segments (`:`-separated, did:web style) are preserved verbatim.
+pub fn webvh_did_to_web(webvh_did: &str) -> Result<String, DidWebRewriteError> {
+    let rest = webvh_did
+        .strip_prefix("did:webvh:")
+        .ok_or_else(|| DidWebRewriteError::NotWebvh(webvh_did.to_string()))?;
+    let (_scid, domain_and_path) = rest
+        .split_once(':')
+        .ok_or_else(|| DidWebRewriteError::MissingDomain(webvh_did.to_string()))?;
+    if domain_and_path.is_empty() {
+        return Err(DidWebRewriteError::EmptyDomain(webvh_did.to_string()));
+    }
+    Ok(format!("did:web:{domain_and_path}"))
+}
+
+/// Rewrite an already-resolved DID document (a webvh log entry's `state`)
+/// from its `did:webvh` identifier into the equivalent `did:web` form,
+/// returning `(did:web identifier, rewritten document)`.
+///
+/// In the resolved state the DID always appears in full (`id`,
+/// `controller`, `{did}#key-0`, service ids …), so a whole-string swap of
+/// the webvh DID for its did:web form rewrites them all without touching
+/// unrelated values. `web_did` never contains `webvh_did`, so the
+/// replacement can't recurse.
+pub fn rewrite_did_document_to_web(
+    state: &Value,
+    webvh_did: &str,
+) -> Result<(String, Value), DidWebRewriteError> {
+    let web_did = webvh_did_to_web(webvh_did)?;
+    let rewritten = serde_json::to_string(state)?.replace(webvh_did, &web_did);
+    let doc: Value = serde_json::from_str(&rewritten)?;
+    Ok((web_did, doc))
+}
+
+/// Convert a full `did:webvh` log entry (the envelope carrying `state`)
+/// into the equivalent `did:web` DID document, returning the `did:web`
+/// identifier and the pretty-printed document.
+///
+/// Used by `mediator-setup` to write the standalone `did-web.json`
+/// operator artefact. The runtime, which already holds the extracted
+/// `state`, calls [`rewrite_did_document_to_web`] directly.
+pub fn webvh_log_to_did_web(
+    log_entry_json: &str,
+    webvh_did: &str,
+) -> Result<(String, String), DidWebRewriteError> {
+    let entry: Value = serde_json::from_str(log_entry_json)?;
+    let state = entry.get("state").ok_or(DidWebRewriteError::MissingState)?;
+    let (web_did, doc) = rewrite_did_document_to_web(state, webvh_did)?;
+    let pretty = serde_json::to_string_pretty(&doc)?;
+    Ok((web_did, pretty))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn webvh_did_to_web_drops_scid() {
+        assert_eq!(
+            webvh_did_to_web("did:webvh:QmScId:mediator.example.com").unwrap(),
+            "did:web:mediator.example.com"
+        );
+    }
+
+    #[test]
+    fn webvh_did_to_web_preserves_path_segments() {
+        assert_eq!(
+            webvh_did_to_web("did:webvh:QmScId:example.com:mediators:m1").unwrap(),
+            "did:web:example.com:mediators:m1"
+        );
+    }
+
+    #[test]
+    fn webvh_did_to_web_rejects_non_webvh_and_malformed() {
+        assert!(matches!(
+            webvh_did_to_web("did:web:example.com"),
+            Err(DidWebRewriteError::NotWebvh(_))
+        ));
+        assert!(matches!(
+            webvh_did_to_web("did:webvh:QmScId"),
+            Err(DidWebRewriteError::MissingDomain(_))
+        ));
+        assert!(matches!(
+            webvh_did_to_web("did:webvh:QmScId:"),
+            Err(DidWebRewriteError::EmptyDomain(_))
+        ));
+    }
+
+    #[test]
+    fn rewrite_document_rewrites_every_self_reference() {
+        let webvh_did = "did:webvh:QmScId:mediator.example.com";
+        let state = json!({
+            "id": webvh_did,
+            "controller": webvh_did,
+            "verificationMethod": [
+                { "id": format!("{webvh_did}#key-0"), "controller": webvh_did, "type": "Multikey" },
+                { "id": format!("{webvh_did}#key-1"), "controller": webvh_did, "type": "Multikey" }
+            ],
+            "service": [
+                { "id": format!("{webvh_did}#service"), "type": ["DIDCommMessaging"] }
+            ]
+        });
+
+        let (web_did, doc) = rewrite_did_document_to_web(&state, webvh_did).unwrap();
+        assert_eq!(web_did, "did:web:mediator.example.com");
+
+        let doc_str = serde_json::to_string(&doc).unwrap();
+        assert!(!doc_str.contains("did:webvh:"));
+        assert_eq!(doc["id"], web_did);
+        assert_eq!(doc["controller"], web_did);
+        for vm in doc["verificationMethod"].as_array().unwrap() {
+            assert!(vm["id"].as_str().unwrap().starts_with("did:web:"));
+            assert_eq!(vm["controller"], web_did);
+        }
+        assert!(
+            doc["service"][0]["id"]
+                .as_str()
+                .unwrap()
+                .starts_with("did:web:")
+        );
+    }
+
+    #[test]
+    fn log_to_did_web_extracts_state() {
+        let webvh_did = "did:webvh:QmScId:example.com";
+        let log = json!({
+            "versionId": "1-abc",
+            "state": { "id": webvh_did }
+        })
+        .to_string();
+
+        let (web_did, pretty) = webvh_log_to_did_web(&log, webvh_did).unwrap();
+        assert_eq!(web_did, "did:web:example.com");
+        let doc: Value = serde_json::from_str(&pretty).unwrap();
+        assert_eq!(doc["id"], "did:web:example.com");
+    }
+
+    #[test]
+    fn log_to_did_web_errors_without_state() {
+        let err = webvh_log_to_did_web(r#"{"versionId":"1-abc"}"#, "did:webvh:QmScId:example.com")
+            .unwrap_err();
+        assert!(matches!(err, DidWebRewriteError::MissingState));
+        assert!(err.to_string().contains("state"));
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -22,6 +22,11 @@
 
 pub mod types;
 
+/// `did:webvh` → `did:web` document rewriting. Pure (`serde_json` only),
+/// always built: shared by the mediator runtime (serving `did.json`) and
+/// the `mediator-setup` wizard (writing the `did-web.json` artefact).
+pub mod did_web;
+
 #[cfg(feature = "server")]
 pub mod circuit_breaker;
 /// Database wiring: the lean `DatabaseConfig` serde struct is always

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -29,7 +29,8 @@ use affinidi_did_resolver_cache_sdk::{
     config::{DIDCacheConfig, DIDCacheConfigBuilder},
 };
 use affinidi_messaging_mediator_common::{
-    MediatorSecrets, database::config::DatabaseConfig, errors::MediatorError, secrets::open_store,
+    MediatorSecrets, database::config::DatabaseConfig, did_web::rewrite_did_document_to_web,
+    errors::MediatorError, secrets::open_store,
 };
 use affinidi_secrets_resolver::ThreadedSecretsResolver;
 use async_convert::{TryFrom, async_trait};
@@ -738,69 +739,10 @@ impl TryFrom<ConfigRaw> for Config {
         if let Some(path) = raw.server.did_web_self_hosted {
             let document_json = read_document(&path, &aws_config).await?;
 
-            // Validate and parse as LogEntry (webvh format) first, then fall back to direct
-            // Document. We split the canonical DID Document (served at `did.json`) from the
-            // raw log entry stream (served at `did.jsonl`) so each well-known route returns
-            // the correct shape — the previous version served the raw input verbatim at both
-            // routes, which meant `did.jsonl` returned a DID Document for did:web sources and
-            // `did.json` returned a log envelope for did:webvh sources.
-            let parsed_document = match LogEntry::deserialize_string(&document_json, None) {
-                Ok(log_entry) => {
-                    // did:webvh source — extract the DID document for `did.json`, keep the
-                    // raw log entry for `did.jsonl`.
-                    let did_doc_value = log_entry.get_did_document().map_err(|err| {
-                        error!("Couldn't extract DID Document from LogEntry: {err}");
-                        MediatorError::ConfigError(
-                            12,
-                            "NA".into(),
-                            format!("Couldn't extract DID Document from LogEntry: {err}"),
-                        )
-                    })?;
-
-                    // Serialise the extracted DID document for the did.json handler. The
-                    // resolver receives the typed `Document` below (parsed from the same
-                    // value) so we don't pay double parse costs at request time.
-                    let extracted_json = serde_json::to_string(&did_doc_value).map_err(|err| {
-                        error!("Couldn't serialise extracted DID Document as JSON. Reason: {err}");
-                        MediatorError::ConfigError(
-                            12,
-                            "NA".into(),
-                            format!(
-                                "Couldn't serialise extracted DID Document as JSON. Reason: {err}"
-                            ),
-                        )
-                    })?;
-
-                    config.mediator_did_doc = Some(extracted_json);
-                    config.mediator_did_log = Some(document_json);
-
-                    serde_json::from_value(did_doc_value).map_err(|err| {
-                        error!("Couldn't convert DID Document value to Document struct. Reason: {err}");
-                        MediatorError::ConfigError(
-                            12,
-                            "NA".into(),
-                            format!("Couldn't convert DID Document value to Document struct. Reason: {err}"),
-                        )
-                    })?
-                }
-                Err(_log_entry_err) => {
-                    // did:web source — the raw input is the DID document; no log entry to serve.
-                    let parsed =
-                        serde_json::from_str::<Document>(&document_json).map_err(|err| {
-                            error!("Couldn't parse content as LogEntry or Document. Reason: {err}");
-                            MediatorError::ConfigError(
-                                12,
-                                "NA".into(),
-                                format!(
-                                    "Couldn't parse content as LogEntry or Document. Reason: {err}"
-                                ),
-                            )
-                        })?;
-                    config.mediator_did_doc = Some(document_json);
-                    config.mediator_did_log = None;
-                    parsed
-                }
-            };
+            let (did_json, did_jsonl, parsed_document) =
+                split_self_hosted_did_source(document_json)?;
+            config.mediator_did_doc = Some(did_json);
+            config.mediator_did_log = did_jsonl;
 
             // Store the parsed Document for later use
             did_document = Some(parsed_document);
@@ -893,6 +835,109 @@ impl TryFrom<ConfigRaw> for Config {
     }
 }
 
+/// Split a self-hosted DID source into the bodies served at the well-known
+/// routes, returning `(did.json body, did.jsonl body, typed Document)`.
+///
+/// We split the canonical DID Document (served at `did.json`) from the raw
+/// log entry stream (served at `did.jsonl`) so each well-known route returns
+/// the correct shape — an earlier version served the raw input verbatim at
+/// both routes, which meant `did.jsonl` returned a DID Document for did:web
+/// sources and `did.json` returned a log envelope for did:webvh sources.
+///
+/// For did:webvh sources the `did.json` body's identifier is additionally
+/// rewritten from `did:webvh:{scid}:{domain}` to `did:web:{domain}` (id,
+/// controller, key and service self-references). `did.json` is the did:web
+/// resolution surface; without the rewrite a `did:web:{domain}` resolver
+/// receives a document whose id and `#key-…` references all live under
+/// `did:webvh:`, so they can't be dereferenced. The `did.jsonl` body
+/// (`Some` only for did:webvh sources) and the typed Document both stay
+/// verbatim (real did:webvh) for did:webvh resolvers and the mediator's own
+/// DID.
+fn split_self_hosted_did_source(
+    document_json: String,
+) -> Result<(String, Option<String>, Document), MediatorError> {
+    // Validate and parse as LogEntry (webvh format) first, then fall back to
+    // a direct DID Document (did:web source).
+    match LogEntry::deserialize_string(&document_json, None) {
+        Ok(log_entry) => {
+            // did:webvh source — extract the DID document for `did.json`, keep the
+            // raw log entry for `did.jsonl`.
+            let did_doc_value = log_entry.get_did_document().map_err(|err| {
+                error!("Couldn't extract DID Document from LogEntry: {err}");
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Couldn't extract DID Document from LogEntry: {err}"),
+                )
+            })?;
+
+            // The extracted state's `id` is the did:webvh DID; rewrite it (and every
+            // self-reference) to the did:web form for the `did.json` handler. The
+            // typed `Document` below is parsed from the original `did:webvh` value so
+            // the resolver preload keeps the mediator's real DID.
+            let webvh_did = did_doc_value
+                .get("id")
+                .and_then(|id| id.as_str())
+                .ok_or_else(|| {
+                    error!("Extracted DID Document from LogEntry is missing an `id`");
+                    MediatorError::ConfigError(
+                        12,
+                        "NA".into(),
+                        "Extracted DID Document from LogEntry is missing an `id`".into(),
+                    )
+                })?
+                .to_string();
+
+            let (_web_did, web_doc_value) = rewrite_did_document_to_web(&did_doc_value, &webvh_did)
+                .map_err(|err| {
+                    error!("Couldn't rewrite did:webvh document to did:web. Reason: {err}");
+                    MediatorError::ConfigError(
+                        12,
+                        "NA".into(),
+                        format!("Couldn't rewrite did:webvh document to did:web. Reason: {err}"),
+                    )
+                })?;
+
+            // Serialise the rewritten did:web document for the did.json handler. The
+            // resolver receives the typed `Document` below (parsed from the original
+            // did:webvh value) so we don't pay double parse costs at request time.
+            let did_json = serde_json::to_string(&web_doc_value).map_err(|err| {
+                error!("Couldn't serialise extracted DID Document as JSON. Reason: {err}");
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Couldn't serialise extracted DID Document as JSON. Reason: {err}"),
+                )
+            })?;
+
+            let typed = serde_json::from_value(did_doc_value).map_err(|err| {
+                error!("Couldn't convert DID Document value to Document struct. Reason: {err}");
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!(
+                        "Couldn't convert DID Document value to Document struct. Reason: {err}"
+                    ),
+                )
+            })?;
+
+            Ok((did_json, Some(document_json), typed))
+        }
+        Err(_log_entry_err) => {
+            // did:web source — the raw input is the DID document; no log entry to serve.
+            let typed = serde_json::from_str::<Document>(&document_json).map_err(|err| {
+                error!("Couldn't parse content as LogEntry or Document. Reason: {err}");
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!("Couldn't parse content as LogEntry or Document. Reason: {err}"),
+                )
+            })?;
+            Ok((document_json, None, typed))
+        }
+    }
+}
+
 pub async fn init(config_file: &str, with_ansi: bool) -> Result<Config, MediatorError> {
     // Read configuration file parameters. `read_config_file` lives in the config
     // crate now (returns its lean `ConfigError`); map it back to MediatorError.
@@ -958,5 +1003,61 @@ pub async fn init(config_file: &str, with_ansi: bool) -> Result<Config, Mediator
             Ok(config)
         }
         Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod self_hosted_did_tests {
+    use super::*;
+
+    // A real did:webvh log entry (didwebvh-rs `basic-create` test vector).
+    // `state.id` is `did:webvh:{scid}:example.com`.
+    const WEBVH_LOG: &str = r#"{"versionId":"1-QmPFhMuZH9gjY2JZgyyrgRuFTywQ4mDhoKGVoGE8uy7hFD","versionTime":"2000-01-01T00:00:00Z","parameters":{"method":"did:webvh:1.0","scid":"Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg","updateKeys":["z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"],"portable":false,"nextKeyHashes":[],"watchers":[],"witness":{},"deactivated":false},"state":{"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1"],"id":"did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com","controller":"did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com","verificationMethod":[{"type":"Multikey","controller":"did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com","publicKeyMultibase":"z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG","id":"did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com#P5RDjVJG"}],"authentication":["did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com#P5RDjVJG"],"assertionMethod":[],"keyAgreement":[],"capabilityDelegation":[],"capabilityInvocation":[]},"proof":[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","verificationMethod":"did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG#z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG","created":"2000-01-01T00:00:00Z","proofPurpose":"assertionMethod","proofValue":"z3gfipj528cwTsP7aSSWMsPzA5uqSUGSN7WNzJQFf1WTvjpHf9Ftjk6StQmqqzjyjQT9xyqTjEsRp2jw4DBjcyqac"}]}"#;
+
+    // A plain did:web DID document (no webvh log envelope).
+    const WEB_DOC: &str = r#"{"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1"],"id":"did:web:example.com","controller":"did:web:example.com","verificationMethod":[{"type":"Multikey","controller":"did:web:example.com","publicKeyMultibase":"z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG","id":"did:web:example.com#P5RDjVJG"}],"authentication":["did:web:example.com#P5RDjVJG"]}"#;
+
+    /// did:webvh source: the did.json body must have its id (and every
+    /// self-reference) rewritten to did:web, while the did.jsonl body stays
+    /// the verbatim webvh log and the typed Document keeps the real did:webvh
+    /// id.
+    #[test]
+    fn webvh_source_rewrites_did_json_only() {
+        let (did_json, did_jsonl, typed) =
+            split_self_hosted_did_source(WEBVH_LOG.to_string()).unwrap();
+
+        // did.json: rewritten to did:web, no webvh traces anywhere.
+        let doc: serde_json::Value = serde_json::from_str(&did_json).unwrap();
+        assert_eq!(doc["id"], "did:web:example.com");
+        assert_eq!(doc["controller"], "did:web:example.com");
+        assert!(!did_json.contains("did:webvh:"));
+        for vm in doc["verificationMethod"].as_array().unwrap() {
+            assert!(
+                vm["id"]
+                    .as_str()
+                    .unwrap()
+                    .starts_with("did:web:example.com#")
+            );
+        }
+
+        // did.jsonl: verbatim webvh log, unchanged.
+        assert_eq!(did_jsonl.as_deref(), Some(WEBVH_LOG));
+
+        // typed Document: the mediator's real did:webvh identity.
+        assert_eq!(
+            typed.id.as_str(),
+            "did:webvh:Qmdxt11AjZewCNXX69bpEDobgjySeZ7eFwjf4tgpF6p2Dg:example.com"
+        );
+    }
+
+    /// did:web source: served verbatim at did.json, no did.jsonl log.
+    #[test]
+    fn web_source_served_verbatim_without_log() {
+        let (did_json, did_jsonl, typed) =
+            split_self_hosted_did_source(WEB_DOC.to_string()).unwrap();
+
+        assert_eq!(did_json, WEB_DOC);
+        assert!(did_jsonl.is_none());
+        assert_eq!(typed.id.as_str(), "did:web:example.com");
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/well_known_did_fetch.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/well_known_did_fetch.rs
@@ -31,9 +31,12 @@ pub async fn well_known_did_fetch_handler(
 }
 
 /// Serve the canonical mediator DID Document at `/.well-known/did.json`
-/// for did:web-style resolution. The body is the DID Document only —
-/// for did:webvh sources the loader extracts `state` from the original
-/// log entry so this handler returns the same shape for either source.
+/// for did:web-style resolution. The body is the DID Document only — for
+/// did:webvh sources the loader extracts `state` from the original log
+/// entry and rewrites its identifier from `did:webvh:{scid}:{domain}` to
+/// `did:web:{domain}` (id + every key / service self-reference), so a
+/// `did:web:{domain}` resolver receives a document whose `id` matches the
+/// DID it asked for. The verbatim webvh log stays at `did.jsonl`.
 pub async fn well_known_did_json_handler(
     State(state): State<SharedData>,
 ) -> Result<impl IntoResponse, AppError> {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -142,57 +142,16 @@ pub async fn generate_did_webvh(
 
 /// Convert a did:webvh log entry into the equivalent did:web DID document.
 ///
-/// `did:webvh` and `did:web` are wire-compatible by design: a
-/// `did:webvh:{scid}:{domain}` DID resolves to the same document as
-/// `did:web:{domain}` once the self-certifying identifier (SCID) is
-/// dropped and every self-reference in the document is rewritten. This
-/// takes the resolved DID document — the log entry's `state` — and
-/// rewrites every reference to the webvh DID into its did:web form,
-/// returning `(did:web identifier, pretty-printed did.json document)`.
+/// Re-exported from `affinidi-messaging-mediator-common` so the wizard's
+/// `did-web.json` operator artefact and the mediator runtime's
+/// `/.well-known/did.json` body share one tested rewrite implementation.
+/// Returns `(did:web identifier, pretty-printed did.json document)`.
 ///
 /// The returned document is an operator artefact for hosting the DID
 /// under did:web (e.g. at a web server's `/.well-known/did.json`). It is
 /// **not** consumed by the mediator runtime, which serves its own DID
 /// document from the webvh log (`did_web_self_hosted` → `did.jsonl`).
-pub fn webvh_log_to_did_web(
-    log_entry_json: &str,
-    webvh_did: &str,
-) -> anyhow::Result<(String, String)> {
-    let web_did = webvh_did_to_web(webvh_did)?;
-
-    let entry: serde_json::Value = serde_json::from_str(log_entry_json)
-        .map_err(|e| anyhow::anyhow!("Failed to parse did:webvh log entry: {e}"))?;
-    let state = entry
-        .get("state")
-        .ok_or_else(|| anyhow::anyhow!("did:webvh log entry has no `state` (DID document)"))?;
-
-    // Rewrite every self-reference. In the resolved state the DID always
-    // appears in full (`id`, `controller`, `{did}#key-0`, service ids …),
-    // so a whole-string swap of the webvh DID for its did:web form
-    // rewrites them all without touching unrelated values. `web_did`
-    // never contains `webvh_did`, so the replacement can't recurse.
-    let rewritten = serde_json::to_string(state)?.replace(webvh_did, &web_did);
-    let doc: serde_json::Value = serde_json::from_str(&rewritten)?;
-    let pretty = serde_json::to_string_pretty(&doc)?;
-
-    Ok((web_did, pretty))
-}
-
-/// Map a `did:webvh:{scid}:{domain}[:path…]` identifier to its
-/// `did:web:{domain}[:path…]` equivalent by dropping the SCID segment.
-/// Path segments (`:`-separated, did:web style) are preserved verbatim.
-fn webvh_did_to_web(webvh_did: &str) -> anyhow::Result<String> {
-    let rest = webvh_did
-        .strip_prefix("did:webvh:")
-        .ok_or_else(|| anyhow::anyhow!("not a did:webvh DID: {webvh_did}"))?;
-    let (_scid, domain_and_path) = rest
-        .split_once(':')
-        .ok_or_else(|| anyhow::anyhow!("malformed did:webvh DID (missing domain): {webvh_did}"))?;
-    if domain_and_path.is_empty() {
-        anyhow::bail!("did:webvh DID has an empty domain: {webvh_did}");
-    }
-    Ok(format!("did:web:{domain_and_path}"))
-}
+pub use affinidi_messaging_mediator_common::did_web::webvh_log_to_did_web;
 
 #[cfg(test)]
 mod tests {
@@ -270,30 +229,6 @@ mod tests {
         }
         assert!(result.secrets[0].id.ends_with("#key-0"));
         assert!(result.secrets[1].id.ends_with("#key-1"));
-    }
-
-    #[test]
-    fn webvh_did_to_web_drops_scid() {
-        assert_eq!(
-            webvh_did_to_web("did:webvh:QmScId:mediator.example.com").unwrap(),
-            "did:web:mediator.example.com"
-        );
-    }
-
-    #[test]
-    fn webvh_did_to_web_preserves_path_segments() {
-        // did:web path style: `:`-separated segments after the domain.
-        assert_eq!(
-            webvh_did_to_web("did:webvh:QmScId:example.com:mediators:m1").unwrap(),
-            "did:web:example.com:mediators:m1"
-        );
-    }
-
-    #[test]
-    fn webvh_did_to_web_rejects_non_webvh_and_malformed() {
-        assert!(webvh_did_to_web("did:web:example.com").is_err());
-        assert!(webvh_did_to_web("did:webvh:QmScId").is_err()); // no domain
-        assert!(webvh_did_to_web("did:webvh:QmScId:").is_err()); // empty domain
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A mediator configured with `did_web_self_hosted = file://.../did.jsonl` (the default when set up via `mediator-setup --did-method webvh --save-did-web`) serves the DID Document extracted from its **did:webvh** log at `/.well-known/did.json`. That document's `id` — and every verification-method and service self-reference — stays under `did:webvh:{scid}:{domain}`.

`/.well-known/did.json` is the **did:web** resolution surface (did:webvh resolvers fetch `/.well-known/did.jsonl`, per spec). So a resolver looking up `did:web:{domain}` receives a document whose `id` does **not** match the DID it resolved, and whose keys are published as `did:webvh:{scid}:{domain}#key-0` — meaning `did:web:{domain}#key-0` cannot be dereferenced. The Affinidi did:web resolver does not reject the mismatched `id`, but downstream key/service dereferencing breaks.

Observed live:
```
curl -sf https://<mediator>/.well-known/did.json | jq .id
# -> "did:webvh:Qm...:<domain>"   (should be "did:web:<domain>")
```

## Fix

When the self-hosted source is a did:webvh log, rewrite the **`did.json`** body's identifier `did:webvh:{scid}:{domain}` -> `did:web:{domain}` (id, controller, key ids, service ids). Left verbatim:
- `/.well-known/did.jsonl` — the did:webvh log stream
- the internal typed `Document` (`mediator_did_document`) — the mediator's real `did:webvh` identity, used for resolver preload

| Surface | `id` | Consumer |
|---------|------|----------|
| `/.well-known/did.json`  | `did:web:{domain}` (fixed) | did:web resolvers |
| `/.well-known/did.jsonl` | `did:webvh:{scid}:{domain}` | did:webvh resolvers |
| internal `Document` | `did:webvh:{scid}:{domain}` | mediator self / resolver cache |

### Implementation
- Hoist the canonical rewrite (`webvh_did_to_web`, `webvh_log_to_did_web`) out of the `mediator-setup` binary into `affinidi-messaging-mediator-common::did_web` (pure, `serde_json`-only, always-built) so the runtime and the wizard share **one tested implementation**. `mediator-setup` now re-exports it.
- Add `rewrite_did_document_to_web(state, webvh_did)` for the runtime, which already holds the extracted `state`.
- `config/mod.rs`: extract the self-hosted load path into a pure, unit-tested `split_self_hosted_did_source(...)` and build `mediator_did_doc` from the rewritten document.
- Doc comment on `well_known_did_json_handler` updated.

Automatic — no new config key, no operator action — and non-breaking for did:webvh resolvers.

## Testing

- **Unit** (`mediator-common::did_web`, 6): scid drop, path preservation, malformed rejection, full-document rewrite (id/controller/VM/service), log-envelope extraction, missing-`state` error.
- **Config** (`affinidi-messaging-mediator`, 2): feeds a real `didwebvh-rs` log vector through `split_self_hosted_did_source` and asserts `did.json` `id == did:web:example.com` (no `did:webvh:` traces), `did.jsonl` unchanged, typed `Document` keeps `did:webvh`; plus the plain did:web passthrough case.
- **mediator-setup**: existing did:web-export tests still pass.
- **End-to-end**: built the mediator from this branch, ran a self-hosted did:webvh mediator (`--save-did-web`), and confirmed:
  ```
  /.well-known/did.json  -> id       = did:web:mediator              (all VM/service ids did:web:)
  /.well-known/did.jsonl -> state.id = did:webvh:QmZde...:mediator    (verbatim)
  ```

`cargo build -p affinidi-messaging-mediator` + clippy clean.
