### PR TITLE
feat: advertise a TSPTransport service in the mediator DID document

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 25th June 2026
+
+### 0.16.27 — TSP: advertise a TSPTransport service in the DID document
+
+- When TSP is enabled, the mediator now advertises a `TSPTransport` service in its DID
+  document so other mediators can **discover its TSP endpoint** — remote routed/nested
+  forwarding resolves the next hop's endpoint from its DID document, and previously
+  failed with "publishes no TSP transport endpoint" against a mediator that didn't
+  advertise one.
+- For **did:web** the service is added automatically at startup, mirroring the
+  `DIDCommMessaging` endpoint (TSP and DIDComm share the mediator's `/inbound`). Applied
+  on the owned config in `serve_internal`, so it covers both the config-file and builder
+  startup paths.
+- **did:peer** and **did:webvh** bind the document to the DID (peer encodes it; webvh
+  hashes it), so their `TSPTransport` service must be baked in at DID generation. When
+  TSP is enabled but no `TSPTransport` service is advertised, the mediator logs an
+  actionable warning at startup instead of failing silently at the first remote forward.
+
 ## 24th June 2026
 
 ### 0.16.26 — TSP: Control message relay

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.26"
+version = "0.16.27"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -121,6 +121,15 @@ least one secret backend must be enabled. Defaults are
 | `didcomm` | Yes | DIDComm v2 — production protocol |
 | `tsp` | No | Trust Spanning Protocol — experimental |
 
+> **TSP endpoint advertisement.** For other mediators to route/forward TSP messages
+> to this one, this mediator's DID document must advertise a `TSPTransport` service
+> pointing at its inbound endpoint. With the `tsp` feature enabled:
+> - **did:web** — added automatically at startup, mirroring the `DIDCommMessaging`
+>   service endpoint (TSP and DIDComm share `/inbound`). No action needed.
+> - **did:peer / did:webvh** — the document is bound to the DID, so add the
+>   `TSPTransport` service **when generating the DID**. The mediator logs a startup
+>   warning if TSP is enabled but no `TSPTransport` service is advertised.
+
 ### Storage backend (pick one)
 
 | Feature | Default | Use case |

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -893,6 +893,98 @@ impl TryFrom<ConfigRaw> for Config {
     }
 }
 
+/// Ensure the mediator's DID document advertises a `TSPTransport` service so peers can
+/// discover its TSP endpoint (remote routed/nested forwarding resolves it from the DID
+/// document). For **did:web** the service is added automatically, mirroring the
+/// `DIDCommMessaging` endpoint (TSP and DIDComm share `/inbound`); **did:peer** and
+/// **did:webvh** bind the document to the DID, so their service must be baked in at DID
+/// generation — there we only warn. A no-op unless the `tsp` feature is on.
+///
+/// Called once at startup ([`crate::server::serve_internal`]) so it covers both the
+/// config-file path (typed `mediator_did_document`) and the builder path (served JSON
+/// only).
+#[cfg(feature = "tsp")]
+pub(crate) fn apply_tsp_did_advertisement(config: &mut Config) {
+    // Work from the typed document if we have it (config-file path), else parse the
+    // served JSON (builder path). No self-hosted document (e.g. a network-published
+    // did:peer) → nothing to advertise here.
+    let mut doc = match config.mediator_did_document.clone() {
+        Some(doc) => doc,
+        None => match config
+            .mediator_did_doc
+            .as_ref()
+            .and_then(|json| serde_json::from_str::<Document>(json).ok())
+        {
+            Some(doc) => doc,
+            None => return,
+        },
+    };
+
+    // did:web (no webvh log) is the only form we may safely mutate in place.
+    if config.mediator_did_log.is_none() {
+        if let Some(augmented) = augment_did_web_doc_with_tsp_service(&mut doc, &config.mediator_did)
+        {
+            config.mediator_did_doc = Some(augmented);
+            config.mediator_did_document = Some(doc.clone());
+        }
+    }
+
+    if !doc
+        .service
+        .iter()
+        .any(|s| s.type_.iter().any(|t| t == affinidi_tsp::TSP_SERVICE_TYPE))
+    {
+        warn!(
+            "TSP is enabled but the mediator DID document advertises no '{}' service; \
+             other mediators cannot discover this mediator's TSP endpoint for routed/nested \
+             forwarding. For did:web it is added automatically from the DIDCommMessaging \
+             endpoint (is one present?); for did:peer / did:webvh add the service at DID \
+             generation.",
+            affinidi_tsp::TSP_SERVICE_TYPE
+        );
+    }
+}
+
+/// Ensure a self-hosted **did:web** document advertises a `TSPTransport` service,
+/// mirroring the `DIDCommMessaging` endpoint (TSP and DIDComm share the mediator's
+/// `/inbound`). Returns the re-serialised document JSON when a service was added, or
+/// `None` if the document already advertises TSP or has no DIDComm endpoint to mirror.
+///
+/// Only safe for did:web, where the served document is authoritative — did:peer and
+/// did:webvh bind the document to the DID, so their service must be set at generation.
+#[cfg(feature = "tsp")]
+fn augment_did_web_doc_with_tsp_service(doc: &mut Document, did: &str) -> Option<String> {
+    use affinidi_did_common::ServiceBuilder;
+    use affinidi_did_common::service::Endpoint;
+
+    let tsp_type = affinidi_tsp::TSP_SERVICE_TYPE;
+
+    // Already advertised — nothing to do.
+    if doc
+        .service
+        .iter()
+        .any(|s| s.type_.iter().any(|t| t == tsp_type))
+    {
+        return None;
+    }
+
+    // Mirror the first DIDCommMessaging endpoint URI — TSP lands on the same `/inbound`.
+    let uri = doc
+        .service
+        .iter()
+        .find(|s| s.type_.iter().any(|t| t == "DIDCommMessaging"))
+        .and_then(|s| s.service_endpoint.get_uri())?;
+    let endpoint = url::Url::parse(uri.trim_matches('"')).ok()?;
+
+    let service = ServiceBuilder::new(tsp_type, Endpoint::Url(endpoint))
+        .id(&format!("{did}#tsp"))
+        .ok()?
+        .build();
+    doc.service.push(service);
+
+    serde_json::to_string(doc).ok()
+}
+
 pub async fn init(config_file: &str, with_ansi: bool) -> Result<Config, MediatorError> {
     // Read configuration file parameters. `read_config_file` lives in the config
     // crate now (returns its lean `ConfigError`); map it back to MediatorError.
@@ -958,5 +1050,69 @@ pub async fn init(config_file: &str, with_ansi: bool) -> Result<Config, Mediator
             Ok(config)
         }
         Err(err) => Err(err),
+    }
+}
+
+#[cfg(all(test, feature = "tsp"))]
+mod tsp_advertise_tests {
+    use super::*;
+
+    fn did_doc(services: &str) -> Document {
+        let json = format!(
+            r#"{{ "id": "did:web:mediator.example.com", "service": [{services}] }}"#
+        );
+        serde_json::from_str(&json).expect("valid DID document")
+    }
+
+    const DIDCOMM: &str = r#"{
+        "id": "did:web:mediator.example.com#didcomm",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": "https://mediator.example.com/inbound"
+    }"#;
+
+    #[test]
+    fn adds_tsp_service_mirroring_the_didcomm_endpoint() {
+        let mut doc = did_doc(DIDCOMM);
+        let out = augment_did_web_doc_with_tsp_service(&mut doc, "did:web:mediator.example.com");
+        assert!(out.is_some(), "a TSPTransport service should have been added");
+
+        let tsp: Vec<_> = doc
+            .service
+            .iter()
+            .filter(|s| s.type_.iter().any(|t| t == affinidi_tsp::TSP_SERVICE_TYPE))
+            .collect();
+        assert_eq!(tsp.len(), 1, "exactly one TSPTransport service");
+        assert_eq!(
+            tsp[0].service_endpoint.get_uri().as_deref(),
+            Some("https://mediator.example.com/inbound"),
+            "the TSP endpoint mirrors the DIDCommMessaging endpoint"
+        );
+        // The re-serialised JSON carries the new service.
+        assert!(out.unwrap().contains(affinidi_tsp::TSP_SERVICE_TYPE));
+    }
+
+    #[test]
+    fn no_change_when_tsp_already_advertised() {
+        let tsp = r#"{
+            "id": "did:web:mediator.example.com#tsp",
+            "type": "TSPTransport",
+            "serviceEndpoint": "https://mediator.example.com/inbound"
+        }"#;
+        let mut doc = did_doc(&format!("{DIDCOMM},{tsp}"));
+        let out = augment_did_web_doc_with_tsp_service(&mut doc, "did:web:mediator.example.com");
+        assert!(out.is_none(), "already advertised — no mutation");
+        assert_eq!(doc.service.len(), 2, "no extra service appended");
+    }
+
+    #[test]
+    fn no_change_without_a_didcomm_endpoint_to_mirror() {
+        let other = r#"{
+            "id": "did:web:mediator.example.com#other",
+            "type": "SomeOtherService",
+            "serviceEndpoint": "https://mediator.example.com/other"
+        }"#;
+        let mut doc = did_doc(other);
+        let out = augment_did_web_doc_with_tsp_service(&mut doc, "did:web:mediator.example.com");
+        assert!(out.is_none(), "no DIDComm endpoint to mirror — no mutation");
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -203,7 +203,7 @@ pub async fn start(config_path: &str) -> Result<(), MediatorError> {
 /// Returns once the listener is bound. The actual server runs in a
 /// `tokio::spawn`-ed task whose handle lives on [`MediatorHandle`].
 pub async fn serve_internal(
-    config: Config,
+    #[cfg_attr(not(feature = "tsp"), allow(unused_mut))] mut config: Config,
     opts: StartOpts,
     shutdown_token: CancellationToken,
     pre_built_store: Option<Arc<dyn affinidi_messaging_mediator_common::store::MediatorStore>>,
@@ -494,6 +494,13 @@ pub async fn serve_internal(
                 format!("Failed to create DID resolver: {e}"),
             )
         })?;
+
+    // If TSP is enabled, make sure our served DID document advertises a
+    // `TSPTransport` service so peers can discover our TSP endpoint. Runs here, on the
+    // owned `config`, so it covers both the config-file and builder paths before the
+    // document is preloaded + served below.
+    #[cfg(feature = "tsp")]
+    crate::common::config::apply_tsp_did_advertisement(&mut config);
 
     // Preload the mediator's own DID document so it can pack/unpack DIDComm
     // messages without hitting the network (did:web/did:webvh self-resolution


### PR DESCRIPTION
## Summary

Makes the mediator **discoverable as a TSP endpoint**. The *consuming* side was already built and in use — `forward_tsp_remote` resolves the next hop's `TSPTransport` service from its DID document and errors `publishes no TSP transport endpoint` when it's absent — so **inter-mediator TSP forwarding required the destination to advertise `TSPTransport`**, which nothing did. This adds the advertising side.

## Changes
- **did:web (auto):** when `tsp` is enabled, a `TSPTransport` service is added to the served DID document automatically at startup, mirroring the `DIDCommMessaging` endpoint (TSP and DIDComm share `/inbound`). Applied on the owned `config` in `serve_internal`, so it covers **both** the config-file and builder startup paths.
- **did:peer / did:webvh (warn):** these bind the document to the DID (peer encodes it, webvh hashes it), so their `TSPTransport` service must be baked in at DID generation. The mediator logs an **actionable startup warning** when TSP is enabled but no `TSPTransport` service is advertised — instead of silently failing at the first remote forward.
- New `apply_tsp_did_advertisement(&mut Config)` (cfg `tsp`) wraps the did:web augmenter (`augment_did_web_doc_with_tsp_service`, built via `ServiceBuilder`) + the warning.
- `mediator` 0.16.26 → 0.16.27.

## Tests
3 new unit tests (adds the service mirroring DIDComm; no-op when already present; no-op without a DIDComm endpoint). Both feature builds compile; all 6 `tsp_delivery` e2e tests still pass; dual-feature clippy clean.

> Note: the e2e harness mediator is `did:peer` (self-describing, no served doc), so the did:web auto-inject path isn't exercised end-to-end there — the unit tests cover the augment logic, and `apply_tsp_did_advertisement` correctly no-ops for did:peer.

## Docs
README (Protocol section) + CHANGELOG document the did:peer/webvh operator step.