### PR TITLE
feat: graduate TSP from experimental to supported

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 25th June 2026
 
+### 0.16.29 — TSP graduated from experimental to supported
+
+- The `tsp` feature is no longer marked **experimental**. The dual-protocol mediator
+  carries TSP Direct / Routed / Nested / Control messages, bridges TSP↔DIDComm, runs
+  Trust Tasks over TSP, and advertises a `TSPTransport` service for discovery — the
+  feature set is complete and exercised by the e2e suite. Documentation/labelling only;
+  no behaviour change.
+- Caveat carried in the feature docs: TSP currently reuses the DIDComm-authenticated
+  session, so run `tsp` together with `didcomm`. A pure-TSP auth path
+  (`/tsp/authenticate`) and SDK relationship management are tracked follow-ups.
+
 ### 0.16.28 — did:web self-hosting: serve a valid did:web document
 
 - A self-hosted `did:webvh` mediator (`did_web_self_hosted = file://.../did.jsonl`)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.28"
+version = "0.16.29"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -41,10 +41,11 @@ memory-backend = []
 ## together (`--features didcomm,tsp`), which is the dual-protocol deployment.
 didcomm = ["dep:affinidi-messaging-didcomm", "dep:affinidi-encoding", "dep:affinidi-crypto", "dep:trust-tasks-rs"]
 
-## TSP (Trust Spanning Protocol) — additive alongside DIDComm.
-## EXPERIMENTAL: TSP message handling is still being built; a `tsp`-only build
-## compiles but is not yet functional (no auth/inbound). Run it together with
-## `didcomm` for a dual-protocol mediator.
+## TSP (Trust Spanning Protocol) — supported, additive alongside DIDComm. Carries TSP
+## Direct / Routed / Nested / Control messages, the TSP↔DIDComm bridge, Trust Tasks over
+## TSP, and advertises a TSPTransport service for discovery. Run together with `didcomm`:
+## TSP currently reuses the DIDComm-authenticated session, so a `tsp`-only build has no
+## auth path yet (pure-TSP `/tsp/authenticate` is pending).
 tsp = ["dep:affinidi-tsp"]
 
 ## Secret storage backends — forwarded to `mediator-common`'s `secrets-*`

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -32,7 +32,7 @@ cargo run --bin mediator-setup
 The interactive TUI guides you through:
 
 1. **Deployment type** — local dev, headless server, or container
-2. **Protocol** — DIDComm v2 (recommended) or TSP (experimental)
+2. **Protocol** — DIDComm v2, TSP, or both (dual-protocol)
 3. **DID configuration** — did:peer, did:webvh, or VTA-managed
 4. **Key storage** — file (`?encrypt=1` opt-in), OS keyring, AWS
    Secrets Manager, GCP Secret Manager, Azure Key Vault, or
@@ -119,7 +119,7 @@ least one secret backend must be enabled. Defaults are
 | Feature | Default | Description |
 |---|---|---|
 | `didcomm` | Yes | DIDComm v2 — production protocol |
-| `tsp` | No | Trust Spanning Protocol — experimental |
+| `tsp` | No | Trust Spanning Protocol — supported; run with `didcomm` (dual-protocol) |
 
 > **TSP endpoint advertisement.** For other mediators to route/forward TSP messages
 > to this one, this mediator's DID document must advertise a `TSPTransport` service

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.35] - 2026-06-25
+
+The `tsp` feature is no longer marked **experimental** — `atm.tsp()` (pack / send /
+send_routed / send_nested / send_control / unpack) is supported. Documentation/labelling
+only; no behaviour change. Caveat: pure-TSP client auth (`/tsp/authenticate`) is still
+pending, so `atm.tsp()` reuses the profile's DIDComm-authenticated session for now.
+
 ## [0.18.34] - 2026-06-24
 
 New `atm.tsp().send_control(profile, to_did, control)`: send a TSP **`Control`** message

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.34"
+version = "0.18.35"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -14,9 +14,10 @@ repository.workspace = true
 
 [features]
 default = []
-## Trust Spanning Protocol (TSP) client support — `atm.tsp()` ops, alongside the
-## always-on DIDComm support. EXPERIMENTAL: the message-construction (pack/send)
-## and receive (fetch/unpack) paths are still being built.
+## Trust Spanning Protocol (TSP) client support — the `atm.tsp()` ops (pack / send /
+## send_routed / send_nested / send_control / unpack), alongside the always-on DIDComm
+## support. Supported; pure-TSP client auth (`/tsp/authenticate`) is still pending, so
+## today `atm.tsp()` reuses the profile's DIDComm-authenticated session.
 tsp = ["dep:affinidi-tsp"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Flips the `tsp` feature from **experimental** to **supported**. The dual-protocol feature set is complete and exercised end-to-end:
- TSP **Direct / Routed / Nested / Control** messages
- the **TSP↔DIDComm bridge**
- **Trust Tasks over TSP** (`trust-tasks-tsp`)
- **`TSPTransport`** DID-document advertisement for discovery

## Changes
- **mediator** (0.16.28 → 0.16.29): the `tsp` feature comment + README no longer say "experimental".
- **sdk** (0.18.34 → 0.18.35): the `tsp` feature comment no longer says "experimental".

Documentation/labelling only — **no behaviour change**, no runtime gate existed.

## Caveat (carried in the feature docs)
TSP currently reuses the **DIDComm-authenticated session**, so run `tsp` together with `didcomm`. A pure-TSP auth path (`/tsp/authenticate`) and SDK **relationship management** are tracked follow-ups (next on the TSP roadmap).