### PR TITLE
feat(mediator-setup): opt-in P-256 key suite (--key-suite p256)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -361,6 +361,12 @@ pub struct WizardConfig {
     /// of the DID document to `did-web.json`. Collected via the
     /// `DidPhase::SaveDidWebChoice` prompt or the `--save-did-web` flag.
     pub save_did_web: bool,
+    /// Extra key suites (beyond the mandatory Ed25519 + X25519 pair) to mint
+    /// for the mediator identity. Empty by default. Only consulted by the
+    /// local generators (`did:peer`, `did:webvh`); VTA-managed DIDs derive
+    /// their key set from the VTA template. Populated from the `--key-suite`
+    /// flag or the recipe's `[identity] extra_key_suites`.
+    pub key_suite: Vec<crate::cli::KeySuite>,
     pub secret_storage: String,
     // Per-backend config fields. Only the set relevant to `secret_storage`
     // is meaningful; others stay at defaults. Storing them as flat strings
@@ -527,6 +533,7 @@ impl Default for WizardConfig {
             did_method: String::new(),
             public_url: String::new(),
             save_did_web: false,
+            key_suite: Vec::new(),
             secret_storage: String::new(),
             secret_file_path: DEFAULT_SECRET_FILE_PATH.into(),
             secret_keyring_service: DEFAULT_KEYRING_SERVICE.into(),

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
@@ -39,6 +39,15 @@ pub struct Args {
     #[arg(long)]
     pub save_did_web: bool,
 
+    /// Extra cryptographic key suite(s) to provision *in addition to* the
+    /// mandatory Ed25519 (signing) + X25519 (key-agreement) pair.
+    /// Repeatable: `--key-suite p256`. Counterparties that can't speak
+    /// Curve25519 (JOSE-first stacks, hardware wallets, ES256 issuers) need
+    /// these. Applies to the locally-generated did:peer / did:webvh methods;
+    /// VTA-managed DIDs take their key set from the VTA's template.
+    #[arg(long, value_enum, value_name = "SUITE")]
+    pub key_suite: Vec<KeySuite>,
+
     /// Secret storage backend
     #[arg(long, value_enum)]
     pub secret_storage: Option<SecretStorage>,
@@ -199,6 +208,24 @@ impl std::fmt::Display for DidMethod {
             Self::Peer => write!(f, "did:peer"),
             Self::Webvh => write!(f, "did:webvh"),
             Self::Vta => write!(f, "VTA managed"),
+        }
+    }
+}
+
+/// Optional extra key suites layered on top of the always-present Ed25519 +
+/// X25519 mediator identity keys. Each suite contributes a signing key plus a
+/// key-agreement key so the mediator can both authenticate and receive
+/// authcrypt traffic on that curve family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum KeySuite {
+    /// NIST P-256 — ES256 signing + ECDH-ES (P-256) key agreement.
+    P256,
+}
+
+impl std::fmt::Display for KeySuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::P256 => write!(f, "p256"),
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
@@ -3,13 +3,24 @@ use affinidi_tdk::dids::{
     DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
 };
 
+use crate::cli::KeySuite;
+
 /// Generate a did:peer for the mediator with Ed25519 (signing) + X25519 (encryption) keys,
-/// plus an optional DIDComm service endpoint.
-pub fn generate_did_peer(service_uri: Option<String>) -> anyhow::Result<(String, Vec<Secret>)> {
-    let keys = vec![
+/// plus an optional DIDComm service endpoint. Any opt-in `key_suites` append
+/// extra key pairs after the mandatory Curve25519 pair — e.g. `p256` adds a
+/// P-256 verification key and a P-256 encryption key.
+pub fn generate_did_peer(
+    service_uri: Option<String>,
+    key_suites: &[KeySuite],
+) -> anyhow::Result<(String, Vec<Secret>)> {
+    let mut keys = vec![
         (PeerKeyRole::Verification, KeyType::Ed25519),
         (PeerKeyRole::Encryption, KeyType::X25519),
     ];
+    if key_suites.contains(&KeySuite::P256) {
+        keys.push((PeerKeyRole::Verification, KeyType::P256));
+        keys.push((PeerKeyRole::Encryption, KeyType::P256));
+    }
 
     let services = service_uri.as_deref().map(mediator_services).transpose()?;
 
@@ -91,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_generate_did_peer() {
-        let (did, secrets) = generate_did_peer(None).unwrap();
+        let (did, secrets) = generate_did_peer(None, &[]).unwrap();
         assert!(did.starts_with("did:peer:2.V"));
         assert_eq!(secrets.len(), 2);
         assert!(secrets[0].id.contains("#key-1"));
@@ -99,9 +110,25 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_did_peer_with_p256_suite() {
+        // P-256 appends a verification key (`#key-3`) and an encryption key
+        // (`#key-4`) after the mandatory Ed25519 + X25519 pair.
+        let (did, secrets) = generate_did_peer(None, &[KeySuite::P256]).unwrap();
+        // Two verification segments (Ed25519, P-256) and two encryption.
+        assert_eq!(did.matches(".V").count(), 2);
+        assert_eq!(did.matches(".E").count(), 2);
+        assert_eq!(secrets.len(), 4);
+        assert!(secrets[2].id.contains("#key-3"));
+        assert!(secrets[3].id.contains("#key-4"));
+        use affinidi_secrets_resolver::secrets::KeyType;
+        assert!(matches!(secrets[2].get_key_type(), KeyType::P256));
+        assert!(matches!(secrets[3].get_key_type(), KeyType::P256));
+    }
+
+    #[test]
     fn test_generate_did_peer_with_service() {
         let (did, secrets) =
-            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into())).unwrap();
+            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[]).unwrap();
         assert!(did.starts_with("did:peer:2.V"));
         assert_eq!(did.matches(".S").count(), 2);
         assert_eq!(secrets.len(), 2);

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -21,13 +21,17 @@ use didwebvh_rs::{
     create::{CreateDIDConfig, create_did},
     parameters::Parameters,
 };
+use serde_json::json;
 use vta_sdk::did_templates::{TemplateVars, load_embedded};
+
+use crate::cli::KeySuite;
 
 pub struct DidWebvhResult {
     /// The final DID string (resolved from the WebVH log entry).
     pub did: String,
     /// Private keys the mediator needs at runtime — Ed25519 signing, X25519
-    /// key-agreement.
+    /// key-agreement, plus any opt-in extra-suite keys (e.g. P-256 signing +
+    /// P-256 key-agreement when `p256` is requested).
     pub secrets: Vec<Secret>,
     /// The DID document log entry in JSONL form, ready for the operator to
     /// host at the webvh URL.
@@ -51,6 +55,7 @@ pub struct DidWebvhResult {
 pub async fn generate_did_webvh(
     address: &str,
     service_url: &str,
+    key_suites: &[KeySuite],
 ) -> anyhow::Result<DidWebvhResult> {
     let address = if address.starts_with("http://") || address.starts_with("https://") {
         address.to_string()
@@ -72,6 +77,30 @@ pub async fn generate_did_webvh(
         .get_public_keymultibase()
         .map_err(|e| anyhow::anyhow!("Failed to get X25519 public key: {e}"))?;
 
+    // ── Opt-in extra key suites ────────────────────────────────────
+    // Each requested suite contributes a signing key (`#key-2`) + a
+    // key-agreement key (`#key-3`) advertised through the template's
+    // optional P-256 slots. Only P-256 is supported today. When no suite
+    // is requested the slots stay pruned, so the default document is
+    // byte-identical to before.
+    let include_p256 = key_suites.contains(&KeySuite::P256);
+    let mut p256_signing = if include_p256 {
+        Some(
+            Secret::generate_p256(None, None)
+                .map_err(|e| anyhow::anyhow!("Failed to generate P-256 signing key: {e}"))?,
+        )
+    } else {
+        None
+    };
+    let mut p256_key_agreement = if include_p256 {
+        Some(
+            Secret::generate_p256(None, None)
+                .map_err(|e| anyhow::anyhow!("Failed to generate P-256 key-agreement key: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     // ── Render template ─────────────────────────────────────────────
     let template = load_embedded("didcomm-mediator")
         .map_err(|e| anyhow::anyhow!("Failed to load mediator template: {e}"))?;
@@ -84,6 +113,41 @@ pub async fn generate_did_webvh(
     vars.insert_string("URL", service_url);
     vars.insert_string("SIGNING_KEY_MB", &signing_mb);
     vars.insert_string("KA_KEY_MB", &ka_mb);
+    // Opt-in P-256 verification methods. The supplied objects keep the
+    // `{DID}` sentinel — didwebvh-rs resolves it across the whole document
+    // after SCID computation, including these var-injected methods (they
+    // are not recursively re-substituted by the template renderer). When no
+    // P-256 suite is requested these vars stay unset and the renderer prunes
+    // the corresponding null slots.
+    if let (Some(p256_sign), Some(p256_ka)) = (p256_signing.as_ref(), p256_key_agreement.as_ref()) {
+        let p256_sign_mb = p256_sign
+            .get_public_keymultibase()
+            .map_err(|e| anyhow::anyhow!("Failed to get P-256 signing public key: {e}"))?;
+        let p256_ka_mb = p256_ka
+            .get_public_keymultibase()
+            .map_err(|e| anyhow::anyhow!("Failed to get P-256 key-agreement public key: {e}"))?;
+        vars.insert(
+            "VM_P256_SIGNING",
+            json!({
+                "id": "{DID}#key-2",
+                "type": "Multikey",
+                "controller": "{DID}",
+                "publicKeyMultibase": p256_sign_mb,
+            }),
+        );
+        vars.insert(
+            "VM_P256_KA",
+            json!({
+                "id": "{DID}#key-3",
+                "type": "Multikey",
+                "controller": "{DID}",
+                "publicKeyMultibase": p256_ka_mb,
+            }),
+        );
+        vars.insert_string("AUTH_P256", "{DID}#key-2");
+        vars.insert_string("ASSERTION_P256", "{DID}#key-2");
+        vars.insert_string("KEYAGREEMENT_P256", "{DID}#key-3");
+    }
     // `{DID}` is a sentinel — we declare it as "provided" so the renderer
     // doesn't flag it as unresolved; `didwebvh-rs` substitutes the actual
     // DID string after SCID computation.
@@ -131,11 +195,24 @@ pub async fn generate_did_webvh(
     signing.id = format!("{final_did}#key-0");
     key_agreement.id = format!("{final_did}#key-1");
 
+    // Opt-in P-256 keys occupy `#key-2` (signing / assertion) and `#key-3`
+    // (key agreement), matching the slots advertised in the rendered DID
+    // document above.
+    let mut secrets = vec![signing, key_agreement];
+    if let Some(mut p256_sign) = p256_signing.take() {
+        p256_sign.id = format!("{final_did}#key-2");
+        secrets.push(p256_sign);
+    }
+    if let Some(mut p256_ka) = p256_key_agreement.take() {
+        p256_ka.id = format!("{final_did}#key-3");
+        secrets.push(p256_ka);
+    }
+
     let did_doc = serde_json::to_string(result.log_entry())?;
 
     Ok(DidWebvhResult {
         did: final_did,
-        secrets: vec![signing, key_agreement],
+        secrets,
         did_doc,
     })
 }
@@ -163,6 +240,7 @@ mod tests {
         let result = generate_did_webvh(
             "https://mediator.example.com",
             "https://mediator.example.com/mediator/v1",
+            &[],
         )
         .await
         .unwrap();
@@ -189,13 +267,19 @@ mod tests {
         assert_eq!(doc["authentication"].as_array().unwrap().len(), 1);
         assert_eq!(doc["keyAgreement"].as_array().unwrap().len(), 1);
 
+        // Locate services by `type` rather than position — the template may
+        // advertise additional transports (e.g. a `#tsp` TSPTransport entry)
+        // ahead of the DIDComm one, and the canonical preference order is not
+        // this test's concern.
         let services = doc["service"].as_array().unwrap();
-        assert_eq!(services.len(), 2);
-        // `type` is now an array (`["DIDCommMessaging"]`) per the
-        // multi-transport template, and the id is `#service`.
-        assert_eq!(services[0]["type"][0], "DIDCommMessaging");
-        assert!(services[0]["id"].as_str().unwrap().ends_with("#service"));
-        let endpoints = services[0]["serviceEndpoint"].as_array().unwrap();
+        let service_type_is =
+            |svc: &Value, want: &str| svc["type"] == json!([want]) || svc["type"] == json!(want);
+        let didcomm = services
+            .iter()
+            .find(|svc| service_type_is(svc, "DIDCommMessaging"))
+            .expect("DIDCommMessaging service present");
+        assert!(didcomm["id"].as_str().unwrap().ends_with("#service"));
+        let endpoints = didcomm["serviceEndpoint"].as_array().unwrap();
         assert_eq!(endpoints.len(), 2);
         assert_eq!(
             endpoints[0]["uri"].as_str().unwrap(),
@@ -211,19 +295,85 @@ mod tests {
         assert_eq!(accept.len(), 1);
         assert_eq!(accept[0], "didcomm/v2");
 
-        assert_eq!(services[1]["type"][0], "Authentication");
-        assert!(services[1]["id"].as_str().unwrap().ends_with("#auth"));
+        let auth = services
+            .iter()
+            .find(|svc| service_type_is(svc, "Authentication"))
+            .expect("Authentication service present");
+        assert!(auth["id"].as_str().unwrap().ends_with("#auth"));
         assert_eq!(
-            services[1]["serviceEndpoint"].as_str().unwrap(),
+            auth["serviceEndpoint"].as_str().unwrap(),
             "https://mediator.example.com/mediator/v1/authenticate"
         );
     }
 
     #[tokio::test]
+    #[ignore = "requires a vta-sdk release carrying the didcomm-mediator P-256 template slots \
+                (OpenVTC/verifiable-trust-infrastructure#587). Un-ignore once the vta-sdk \
+                dependency is bumped to that release."]
+    async fn webvh_p256_suite_adds_signing_and_key_agreement_keys() {
+        let result = generate_did_webvh(
+            "https://mediator.example.com",
+            "https://mediator.example.com/mediator/v1",
+            &[KeySuite::P256],
+        )
+        .await
+        .unwrap();
+
+        // Four runtime secrets now: Ed25519 + X25519 + P-256 signing + P-256 KA.
+        assert_eq!(result.secrets.len(), 4);
+        assert!(result.secrets[0].id.ends_with("#key-0"));
+        assert!(result.secrets[1].id.ends_with("#key-1"));
+        assert!(result.secrets[2].id.ends_with("#key-2"));
+        assert!(result.secrets[3].id.ends_with("#key-3"));
+        use affinidi_secrets_resolver::secrets::KeyType;
+        assert!(matches!(result.secrets[2].get_key_type(), KeyType::P256));
+        assert!(matches!(result.secrets[3].get_key_type(), KeyType::P256));
+
+        let entry: Value = serde_json::from_str(&result.did_doc).unwrap();
+        let doc = &entry["state"];
+
+        // Four verification methods; the P-256 pair are `#key-2` / `#key-3`,
+        // both `Multikey`, and the relationship arrays grew to two entries.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert_eq!(vms.len(), 4);
+        assert!(vms.iter().all(|vm| vm["type"] == "Multikey"));
+        assert!(vms[2]["id"].as_str().unwrap().ends_with("#key-2"));
+        assert!(vms[3]["id"].as_str().unwrap().ends_with("#key-3"));
+        // P-256 Multikey multibase uses the `zDna…` (0x1200) prefix.
+        assert!(
+            vms[2]["publicKeyMultibase"]
+                .as_str()
+                .unwrap()
+                .starts_with("zDn")
+        );
+        assert!(
+            vms[3]["publicKeyMultibase"]
+                .as_str()
+                .unwrap()
+                .starts_with("zDn")
+        );
+
+        let auth = doc["authentication"].as_array().unwrap();
+        assert_eq!(auth.len(), 2);
+        assert!(auth[1].as_str().unwrap().ends_with("#key-2"));
+        let assertion = doc["assertionMethod"].as_array().unwrap();
+        assert_eq!(assertion.len(), 2);
+        assert!(assertion[1].as_str().unwrap().ends_with("#key-2"));
+        let ka = doc["keyAgreement"].as_array().unwrap();
+        assert_eq!(ka.len(), 2);
+        assert!(ka[1].as_str().unwrap().ends_with("#key-3"));
+
+        // The webvh SCID sentinel must be fully resolved — no `{DID}` token
+        // survives in the var-injected P-256 methods.
+        assert!(!result.did_doc.contains("{DID}"));
+    }
+
+    #[tokio::test]
     async fn webvh_key_ids_match_final_did() {
-        let result = generate_did_webvh("mediator.example.com", "https://mediator.example.com")
-            .await
-            .unwrap();
+        let result =
+            generate_did_webvh("mediator.example.com", "https://mediator.example.com", &[])
+                .await
+                .unwrap();
         for secret in &result.secrets {
             assert!(secret.id.starts_with(&result.did));
         }
@@ -236,6 +386,7 @@ mod tests {
         let result = generate_did_webvh(
             "https://mediator.example.com",
             "https://mediator.example.com/mediator/v1",
+            &[],
         )
         .await
         .unwrap();

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -233,6 +233,9 @@ fn apply_cli_args(args: &Args, config: &mut WizardConfig) {
     if args.save_did_web {
         config.save_did_web = true;
     }
+    if !args.key_suite.is_empty() {
+        config.key_suite = args.key_suite.clone();
+    }
     if let Some(ref secret_storage) = args.secret_storage {
         config.secret_storage = secret_storage.to_string();
     }
@@ -1229,7 +1232,8 @@ async fn mint_did_material(
     let (did, secrets, did_log, authorization_vc) = match config.did_method.as_str() {
         DID_PEER => {
             let service_uri = did_peer_service_url(&config.public_url, &config.api_prefix);
-            let (did, secrets) = generators::did_peer::generate_did_peer(service_uri)?;
+            let (did, secrets) =
+                generators::did_peer::generate_did_peer(service_uri, &config.key_suite)?;
             (did, secrets, None, None)
         }
         DID_WEBVH => {
@@ -1246,7 +1250,12 @@ async fn mint_did_material(
             };
             let address = strip_url_path_owned(&raw_url);
             let service_url = combine_url_prefix(&address, &config.api_prefix);
-            let result = generators::did_webvh::generate_did_webvh(&address, &service_url).await?;
+            let result = generators::did_webvh::generate_did_webvh(
+                &address,
+                &service_url,
+                &config.key_suite,
+            )
+            .await?;
             (result.did, result.secrets, Some(result.did_doc), None)
         }
         DID_VTA => {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -122,10 +122,30 @@ pub struct IdentitySection {
     /// DIDs; ignored otherwise.
     #[serde(default)]
     pub save_did_web: bool,
+    /// Extra key suites to mint alongside the mandatory Ed25519 + X25519
+    /// pair, e.g. `["p256"]`. Empty by default (Curve25519 only). Applies
+    /// to the local `did:peer` / `did:webvh` generators.
+    #[serde(default)]
+    pub extra_key_suites: Vec<String>,
 }
 
 fn default_did_method() -> String {
     "vta".into()
+}
+
+/// Map recipe `extra_key_suites` strings (e.g. `["p256"]`) to typed
+/// [`crate::cli::KeySuite`] values, mirroring the `--key-suite` CLI flag.
+/// Case-insensitive; unknown suites are a hard error so a typo in a recipe
+/// fails fast instead of silently provisioning Curve25519-only keys.
+fn parse_extra_key_suites(raw: &[String]) -> anyhow::Result<Vec<crate::cli::KeySuite>> {
+    raw.iter()
+        .map(|s| match s.trim().to_ascii_lowercase().as_str() {
+            "p256" | "p-256" | "es256" => Ok(crate::cli::KeySuite::P256),
+            other => anyhow::bail!(
+                "Invalid identity.extra_key_suites entry '{other}': supported suites are 'p256'"
+            ),
+        })
+        .collect()
 }
 
 impl Default for IdentitySection {
@@ -134,6 +154,7 @@ impl Default for IdentitySection {
             did_method: default_did_method(),
             public_url: None,
             save_did_web: false,
+            extra_key_suites: Vec::new(),
         }
     }
 }
@@ -490,6 +511,7 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
         config.public_url = url.clone();
     }
     config.save_did_web = recipe.identity.save_did_web;
+    config.key_suite = parse_extra_key_suites(&recipe.identity.extra_key_suites)?;
 
     // Secrets — accept either the bare scheme (backward compat with
     // pre-cloud-config recipes) or a fully-formed URL. A full URL gets


### PR DESCRIPTION
> **Draft — blocked on a `vta-sdk` release.** The did:webvh path needs the P-256 template slots added in OpenVTC/verifiable-trust-infrastructure#587. Once that ships, bump the `vta-sdk` dependency and un-ignore `webvh_p256_suite_adds_*`.

## What

Adds an opt-in **`--key-suite p256`** flag to `mediator-setup` so the mediator is provisioned with extra **P-256 (ES256 / ECDH-ES)** identity + key-agreement keys alongside the mandatory Ed25519 + X25519 pair. Off by default — existing setups are byte-identical. Tracked in `kb/50`.

Counterparties that can't speak Curve25519 (JOSE-first stacks, hardware-backed wallets, ES256 / W3C VC issuers) need a P-256 key to interoperate with the mediator.

## Changes

- **`cli.rs`** — `--key-suite` flag + `KeySuite` enum (`p256`).
- **`app.rs` / `recipe.rs` / `main.rs`** — thread `key_suite` through `WizardConfig`; recipe support via `[identity] extra_key_suites = ["p256"]`.
- **`generators/did_webvh.rs`** — mint P-256 signing (`#key-2`) + P-256 key-agreement (`#key-3`), feed the `didcomm-mediator` template's optional P-256 slots, align secret ids to the SCID-resolved DID.
- **`generators/did_peer.rs`** — append `(Verification, P256)` + `(Encryption, P256)` inline keys.
- **tests** — both generators. The did:peer P-256 test runs today; the did:webvh P-256 render test is `#[ignore]`d until the `vta-sdk` template slots land (see below).

## Dependency / sequencing

The did:webvh path renders the `didcomm-mediator` template from `vta-sdk`. The P-256 slots are added in **OpenVTC/verifiable-trust-infrastructure#587**. This PR keeps `vta-sdk = "0.16"` so it compiles against the current published SDK; the did:webvh P-256 behaviour only activates once that change is released and the dependency is bumped. Follow-up after release: bump `vta-sdk`, remove the `#[ignore]`.

## Validation

- `cargo check -p affinidi-messaging-mediator-setup --tests` against published `vta-sdk 0.16.1` — clean.
- Full validation against a local `vta-sdk` build with the #587 template: `cargo test -p affinidi-messaging-mediator-setup` → **362 passed** (incl. the now-`#[ignore]`d webvh P-256 test), clippy clean, `cargo fmt` applied.
- End-to-end in the `vta-e2e-local` harness (new `vta-webvh_mediator-webvh-p256_didcomm-rest` profile): mediator DID document advertises 4 verification methods (2 P-256) with the P-256 keys wired into authentication/assertionMethod/keyAgreement, and the full DIDComm+REST flow still passes (**19/19 assertions**).
