### PR TITLE
feat: raw-TSP WebSocket delivery mode (flush-on-connect, delete-on-send)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Changelog history
 
+## 26th June 2026
+
+### 0.16.31 — TSP: raw-TSP WebSocket delivery mode
+
+- A WebSocket client may now opt into a **raw-TSP delivery mode** by adding a `tsp`
+  entry to `Sec-WebSocket-Protocol` (alongside `bearer.<jwt>`). In this mode the socket
+  uses a **flush-on-connect + delete-on-successful-send** contract instead of the DIDComm
+  message-pickup delete-to-ack: on connect the mediator drains the inbox, sending each
+  message as a raw-TSP `Binary` frame and deleting it once the send succeeds; a live
+  notification re-drains the same way. The client owns its own failure handling (a send
+  error leaves the message in the inbox for the next connection). Inbound raw TSP over the
+  socket (`Binary` → the TSP handler) is unchanged. DIDComm sockets are byte-for-byte
+  unchanged; the whole path is gated on the `tsp` feature.
+
 ## 25th June 2026
 
 ### 0.16.29 — TSP graduated from experimental to supported

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.30"
+version = "0.16.31"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -11,6 +11,14 @@ use crate::{
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{StreamingUpdate, StreamingUpdateState, WebSocketCommands},
 };
+#[cfg(feature = "tsp")]
+use affinidi_messaging_mediator_common::store::DeletionAuthority;
+#[cfg(feature = "tsp")]
+use affinidi_messaging_mediator_common::types::messages::FetchOptions;
+#[cfg(feature = "tsp")]
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+#[cfg(feature = "tsp")]
+use std::ops::ControlFlow;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
@@ -225,6 +233,15 @@ pub async fn websocket_handler(
     //    carries no `Sec-WebSocket-Protocol` header (RFC 6455 permits
     //    this; browsers accept it).
     let app_protocols = app_subprotocols(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter());
+
+    // A client opts into raw-TSP WebSocket delivery by offering a `tsp`
+    // subprotocol alongside `bearer.<jwt>`. The `tsp` marker is echoed back to
+    // the client via the `app_protocols` path below (it's a genuine app
+    // subprotocol, not the bearer entry), so the client learns the mode was
+    // accepted from the 101 response's `Sec-WebSocket-Protocol` header.
+    #[cfg(feature = "tsp")]
+    let tsp_mode = app_protocols.iter().any(|p| p == "tsp");
+
     let ws = if app_protocols.is_empty() {
         ws
     } else {
@@ -237,9 +254,20 @@ pub async fn websocket_handler(
     let ws_size = state.config.limits.ws_size;
     let ws = ws.max_message_size(ws_size).max_frame_size(ws_size);
 
-    async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
+    #[cfg(feature = "tsp")]
+    {
+        async move {
+            ws.on_upgrade(move |socket| handle_socket(socket, state, session, tsp_mode))
+        }
         .instrument(_span)
         .await
+    }
+    #[cfg(not(feature = "tsp"))]
+    {
+        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
+            .instrument(_span)
+            .await
+    }
 }
 
 /// Releases a DID's reserved per-DID WebSocket slot on drop, so the count is
@@ -285,7 +313,12 @@ fn close_with(code: u16, reason: &'static str) -> Message {
 }
 
 /// WebSocket state machine. This is spawned per connection.
-async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Session) {
+async fn handle_socket(
+    mut socket: WebSocket,
+    state: SharedData,
+    session: Session,
+    #[cfg(feature = "tsp")] tsp_mode: bool,
+) {
     let _span = span!(
         tracing::Level::INFO,
         "handle_socket",
@@ -388,6 +421,28 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
         // Periodic ping to detect dead connections
         let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
         ping_interval.reset(); // Skip the immediate first tick
+
+        // Flush-on-connect for raw-TSP delivery: drain whatever is already queued
+        // for this DID straight onto the socket (delete-on-send) before entering
+        // the live-delivery loop. If the socket is already gone, exit cleanly.
+        #[cfg(feature = "tsp")]
+        if tsp_mode && drain_tsp_inbox(&state, &session, &mut socket).await.is_break() {
+            if let Some(streaming) = &state.streaming_task {
+                let stop = StreamingUpdate {
+                    did_hash: session.did_hash.clone(),
+                    state: StreamingUpdateState::Deregister,
+                };
+                let _ = streaming.channel.send(stop).await;
+            }
+            state.active_websocket_count.fetch_sub(1, Ordering::Relaxed);
+            metrics::gauge!(ACTIVE_WEBSOCKET_CONNECTIONS).decrement(1.0);
+            let _ = state
+                .database
+                .stats_increment(StatCounter::WebsocketClose, 1)
+                .await;
+            info!("Websocket connection closed during TSP flush-on-connect");
+            return;
+        }
 
         // Flag to prevent double deregistration
         // This can occur because in some situations the streaming-task will send a close message
@@ -510,6 +565,19 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
                         match msg {
                             WebSocketCommands::Message(msg) => {
                                 debug!("ws: Received message from streaming task");
+                                // In raw-TSP mode the notification body carries no id we can
+                                // delete by, so it's just a wake-up: re-drain the inbox (which
+                                // re-fetches with ids, sends Binary, and deletes-on-send). The
+                                // DIDComm path is unchanged — send the body as Text.
+                                #[cfg(feature = "tsp")]
+                                if tsp_mode {
+                                    let _ = &msg; // body intentionally ignored in TSP mode
+                                    if drain_tsp_inbox(&state, &session, &mut socket).await.is_break() {
+                                        close_reason = (close_code::GOING_AWAY, "client disconnected");
+                                        break;
+                                    }
+                                    continue;
+                                }
                                 if let Err(e) = socket.send(Message::Text(msg.into())).await {
                                     warn!("Failed to send message to WebSocket client: {e}");
                                 }
@@ -566,6 +634,138 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData, session: Sessio
     }
     .instrument(_span)
     .await
+}
+
+/// Page size for the TSP inbox drain — reuses the same shape as
+/// [`crate::tasks::websocket_streaming`]'s redelivery drain.
+#[cfg(feature = "tsp")]
+const TSP_DRAIN_PAGE: usize = 50;
+
+/// Safety bound on how many messages a single TSP drain will push, so a
+/// pathologically large inbox can't pin the socket loop. If hit, the
+/// remainder is left for the next drain (the next live-delivery wake-up
+/// re-fetches from the head of the inbox).
+#[cfg(feature = "tsp")]
+const TSP_DRAIN_MAX: usize = 1000;
+
+/// Drain the recipient's undelivered inbox to a **raw TSP** WebSocket,
+/// inline on the connection, with a *delete-on-successful-send* contract.
+///
+/// This is the outbound (delivery) half of the TSP WebSocket mode. Unlike
+/// the DIDComm message-pickup path (delete-to-ack) or the streaming
+/// redelivery (notification re-cover with `DoNotDelete`), here the socket
+/// itself is the ack: each stored TSP message is decoded to its raw qb2
+/// bytes, sent as a `Binary` frame, and only then deleted. If the send
+/// fails the socket is gone — the message (and the rest of the inbox) is
+/// left intact for the next connection, so delivery is at-least-once.
+///
+/// Returns:
+/// - [`ControlFlow::Break`] when the socket send failed (caller should
+///   tear the connection down).
+/// - [`ControlFlow::Continue`] when the inbox is drained (or the safety
+///   cap was hit) and the connection should keep running.
+#[cfg(feature = "tsp")]
+async fn drain_tsp_inbox(
+    state: &SharedData,
+    session: &Session,
+    socket: &mut WebSocket,
+) -> ControlFlow<(), ()> {
+    let mut start_id: Option<String> = None;
+    let mut total: usize = 0;
+
+    loop {
+        let options = FetchOptions {
+            limit: TSP_DRAIN_PAGE,
+            start_id: start_id.clone(),
+            ..Default::default() // delete_policy defaults to DoNotDelete; we delete explicitly.
+        };
+        let page = match state
+            .database
+            .fetch_messages(&session.session_id, &session.did_hash, &options)
+            .await
+        {
+            Ok(page) => page,
+            Err(err) => {
+                warn!(
+                    did_hash = %session.did_hash,
+                    "TSP inbox drain fetch failed, aborting drain: {err}"
+                );
+                return ControlFlow::Continue(());
+            }
+        };
+        if page.success.is_empty() {
+            break;
+        }
+
+        for element in page.success {
+            // Advance the cursor regardless of body presence so a missing body
+            // can't pin the drain on the same page forever. `receive_id` is the
+            // inbox stream id, used as the exclusive fetch cursor.
+            start_id = element.receive_id.clone();
+
+            let Some(body) = element.msg else { continue };
+            // Deletion keys on `msg_id` (the message hash) — the same key the
+            // optimistic-delete fetch path uses; `receive_id` is only the stream
+            // cursor, not a valid delete key.
+            let id = element.msg_id;
+
+            // Stored body is base64url(qb2). Decode back to raw qb2 bytes for
+            // the wire. A malformed entry is skipped (not deleted) so it can be
+            // inspected rather than silently dropped.
+            let qb2 = match BASE64_URL_SAFE_NO_PAD.decode(&body) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    warn!(
+                        did_hash = %session.did_hash,
+                        message_id = %id,
+                        "Skipping inbox entry that isn't valid base64url: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            if let Err(e) = socket.send(Message::Binary(qb2.into())).await {
+                // The socket is gone — leave this message and the rest of the
+                // inbox in place for the next connection (do NOT delete).
+                warn!("Failed to send TSP message to WebSocket client: {e}");
+                return ControlFlow::Break(());
+            }
+
+            // Delivered — delete it. A delete error is logged but not fatal: the
+            // message was already delivered, so we continue.
+            if let Err(err) = state
+                .database
+                .delete_message(
+                    &id,
+                    DeletionAuthority::Owner {
+                        did_hash: session.did_hash.clone(),
+                    },
+                )
+                .await
+            {
+                warn!(
+                    did_hash = %session.did_hash,
+                    message_id = %id,
+                    "Failed to delete delivered TSP message: {err}"
+                );
+            }
+
+            total += 1;
+            if total >= TSP_DRAIN_MAX {
+                warn!(
+                    did_hash = %session.did_hash,
+                    max = TSP_DRAIN_MAX,
+                    "TSP inbox drain hit its safety cap; remaining messages left for the next drain"
+                );
+                return ControlFlow::Continue(());
+            }
+        }
+    }
+
+    if total > 0 {
+        debug!(did_hash = %session.did_hash, total, "TSP inbox drain complete");
+    }
+    ControlFlow::Continue(())
 }
 
 /// Generates a problem report for a duplicate websocket connection

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Changelog history
 
+## 26th June 2026
+
+### 0.2.31 — TSP: WebSocket delivery e2e
+
+- New `tsp_websocket` test: Alice sends a TSP Direct message to Bob, Bob opens a raw
+  WebSocket with the `tsp` subprotocol, and the test asserts the queued message is flushed
+  on connect as a raw-TSP `Binary` frame (decodes to the original payload + sender) and is
+  deleted afterwards (a subsequent fetch is empty). Adds `base64` as a dev-dep to re-encode
+  the raw frame for `atm.tsp().unpack`.
+
 ## 24th June 2026
 
 ### 0.2.30 — TSP: Control relay e2e

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.30"
+version = "0.2.31"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -86,6 +86,9 @@ affinidi-messaging-didcomm = { version = "0.15", path = "../affinidi-messaging-d
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 ## TSP control-message types named by the TSP control-relay integration test.
 affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
+## Re-encode raw qb2 bytes from a flushed TSP websocket Binary frame back to
+## the stored base64url form so the SDK can unpack it (tsp_websocket test).
+base64 = "0.22"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
 trust-tasks-rs = "0.2"
 ## Tracing subscriber for test diagnostics.

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
@@ -1,0 +1,155 @@
+//! End-to-end TSP **WebSocket delivery** through the mediator.
+//!
+//! A client opts into raw-TSP WebSocket delivery by offering a `tsp`
+//! subprotocol alongside `bearer.<jwt>` on the upgrade. In that mode the
+//! socket carries raw TSP (`Message::Binary`) and uses a
+//! *flush-on-connect + delete-on-successful-send* delivery contract — not
+//! the DIDComm message-pickup delete-to-ack.
+//!
+//! This test drives a raw `tokio-tungstenite` client (so it controls the
+//! `Sec-WebSocket-Protocol` header directly, like
+//! `websocket_subprotocol_auth.rs`) against the embedded fixture and asserts:
+//!
+//! 1. Alice's queued TSP Direct message to Bob is flushed onto the socket as
+//!    a `Binary` frame the instant Bob connects in TSP mode.
+//! 2. The frame bytes are recognised as a TSP message and unpack to Alice's
+//!    original payload + sender VID.
+//! 3. The message is *deleted on send*: a subsequent fetch of Bob's mailbox
+//!    is empty.
+#![cfg(feature = "tsp")]
+
+mod common;
+
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::{TestEnvironment, TestUser};
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use common::init_tracing;
+use futures_util::StreamExt;
+use std::time::Duration;
+use tokio::time::timeout;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{ClientRequestBuilder, Message, http::Uri},
+};
+
+/// Authenticate `user` against the environment's mediator and return a
+/// fresh access token plus the mediator's `ws://…/ws` upgrade URI.
+///
+/// Mirrors `websocket_subprotocol_auth.rs`: we mint the token through the
+/// SDK's auth task so the test doesn't reimplement the challenge/response
+/// handshake.
+async fn token_and_ws_uri(env: &TestEnvironment, user: &TestUser) -> (String, Uri) {
+    let mediator_did = env.mediator.did().to_string();
+    let tokens = env
+        .tdk
+        .authentication()
+        .authenticate(user.did.clone(), mediator_did, 3, None)
+        .await
+        .expect("authenticate user");
+
+    let ws_uri: Uri = env
+        .mediator
+        .ws_endpoint()
+        .as_str()
+        .parse()
+        .expect("parse ws endpoint");
+
+    (tokens.access_token, ws_uri)
+}
+
+#[tokio::test]
+async fn tsp_websocket_flushes_and_deletes_queued_message() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"hello over the TSP websocket";
+
+    // Alice sends a TSP Direct message to Bob; it is stored for Bob's mailbox
+    // (no socket is open yet, so it sits in the inbox awaiting delivery).
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    // Bob authenticates and opens a raw WS in TSP mode: `["bearer.<jwt>",
+    // "tsp"]`. The server echoes `tsp` (a genuine app subprotocol, never the
+    // bearer entry), which both confirms the mode was accepted and lets
+    // tokio-tungstenite's strict client complete the handshake.
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &bob).await;
+    let request = ClientRequestBuilder::new(ws_uri)
+        .with_sub_protocol(format!("bearer.{access_token}"))
+        .with_sub_protocol("tsp");
+
+    let (mut stream, response) = connect_async(request)
+        .await
+        .expect("tsp websocket upgrade must succeed");
+    assert_eq!(
+        response.status().as_u16(),
+        101,
+        "expected 101 Switching Protocols"
+    );
+    // The 101 echoes `tsp`, confirming the mode was accepted.
+    let echoed = response
+        .headers()
+        .get("sec-websocket-protocol")
+        .expect("server should echo the tsp subprotocol")
+        .to_str()
+        .expect("subprotocol is ASCII");
+    assert_eq!(echoed, "tsp", "server must echo the tsp subprotocol");
+
+    // Flush-on-connect: the queued TSP message arrives as a Binary frame.
+    // (Skip any control frames like Ping the server may interleave.)
+    let qb2 = loop {
+        let frame = timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("a frame arrives within the timeout")
+            .expect("stream not closed")
+            .expect("frame is not an error");
+        match frame {
+            Message::Binary(bytes) => break bytes.to_vec(),
+            Message::Ping(_) | Message::Pong(_) => continue,
+            other => panic!("expected a Binary TSP frame, got: {other:?}"),
+        }
+    };
+
+    assert!(!qb2.is_empty(), "the flushed TSP frame must be non-empty");
+    assert!(
+        affinidi_tsp::is_tsp(&qb2),
+        "the flushed frame must be recognised as a TSP message"
+    );
+
+    // The raw qb2 bytes re-encode to the stored base64url form, which Bob can
+    // unpack to recover Alice's payload + sender VID.
+    let stored = BASE64_URL_SAFE_NO_PAD.encode(&qb2);
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, &stored)
+        .await
+        .expect("bob unpacks the flushed TSP message");
+    assert_eq!(recovered, payload, "payload round-trips over the websocket");
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+
+    // Delete-on-send: the message was deleted after a successful send, so Bob's
+    // mailbox is now empty.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    assert!(
+        fetched.success.is_empty(),
+        "the delivered TSP message must be deleted on send (inbox is empty), got {} message(s)",
+        fetched.success.len()
+    );
+
+    drop(stream);
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
## Summary

Adds a **raw-TSP WebSocket delivery mode** — the last item on the post-graduation TSP roadmap (task 4). A client opts in by adding a **`tsp`** entry to `Sec-WebSocket-Protocol` (alongside `bearer.<jwt>`).

In TSP mode the socket uses a **flush-on-connect + delete-on-successful-send** contract (not the DIDComm message-pickup delete-to-ack):
- **On connect** the mediator drains the inbox: each message is sent as a raw-TSP **`Binary`** frame and deleted once the send succeeds. A send error aborts the drain, leaving the message + remainder for the next connection — **the client owns its own failure handling**.
- A **live** delivery notification re-drains the same way (the notification is a wake-up; the drain re-fetches with ids so it can delete). Mirrors the existing inbox-redelivery drain, inline with delete-on-send.
- **Inbound** raw TSP (`Binary` → `handle_inbound_tsp`) is unchanged. **DIDComm sockets are byte-for-byte unchanged.** All new code is `#[cfg(feature = "tsp")]`.

## Changes
- **mediator** (0.16.29 → 0.16.30): `tsp_mode` detection + `drain_tsp_inbox` + the two drain call sites (flush-on-connect, live re-drain).
- **test-mediator** (0.2.30 → 0.2.31): new `tsp_websocket` e2e (Alice → Bob; Bob connects with the `tsp` subprotocol; asserts the queued TSP is flushed as a `Binary` frame decoding to the payload + sender, then deleted). Adds `base64` dev-dep.

## Tests
Builds with + without `tsp`; dual-feature clippy clean; the `tsp_websocket` e2e passes. The e2e caught a real bug during development — deletion must key on `msg_id`, not the stream `receive_id` — now fixed.

## Roadmap complete
This finishes the post-graduation TSP roadmap: flip-to-supported (#528), relationship management (#529), pure-TSP auth (#533), and WebSocket TSP (this).