### PR TITLE
feat: enable P-256 webvh rendering via vta-sdk 0.18 bump

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 26th June 2026
 
+### 0.16.32 — Bump vta-sdk to 0.18 (enables did:webvh P-256 rendering)
+
+- Bumped the `vta-sdk` dependency from `0.16` to `0.18`, whose embedded
+  `didcomm-mediator` template carries the optional P-256 verification-method slots
+  (`OpenVTC/verifiable-trust-infrastructure#587`). This is what lets
+  `mediator-setup --did-method webvh --key-suite p256` actually emit the P-256
+  signing/key-agreement keys; the renderer itself already shipped in #531. No
+  behavioural change to the mediator runtime — the default DID document is byte-for-byte
+  unchanged when the P-256 suite is not requested.
+
 ### 0.16.31 — TSP: raw-TSP WebSocket delivery mode
 
 - A WebSocket client may now opt into a **raw-TSP delivery mode** by adding a `tsp`

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -96,7 +96,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.16", features = ["integration"] }
+vta-sdk = { version = "0.18", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.31"
+version = "0.16.32"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -11,18 +11,14 @@ use crate::{
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{StreamingUpdate, StreamingUpdateState, WebSocketCommands},
 };
-#[cfg(feature = "tsp")]
-use affinidi_messaging_mediator_common::store::DeletionAuthority;
-#[cfg(feature = "tsp")]
-use affinidi_messaging_mediator_common::types::messages::FetchOptions;
-#[cfg(feature = "tsp")]
-use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-#[cfg(feature = "tsp")]
-use std::ops::ControlFlow;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
+#[cfg(feature = "tsp")]
+use affinidi_messaging_mediator_common::store::DeletionAuthority;
 use affinidi_messaging_mediator_common::store::StatCounter;
+#[cfg(feature = "tsp")]
+use affinidi_messaging_mediator_common::types::messages::FetchOptions;
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_sdk::messages::problem_report::ProblemReport;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
@@ -37,10 +33,14 @@ use axum_extra::{
     TypedHeader,
     headers::{Authorization, authorization::Bearer},
 };
+#[cfg(feature = "tsp")]
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use dashmap::DashMap;
 use http::{HeaderMap, HeaderValue, StatusCode, header::ORIGIN, header::SEC_WEBSOCKET_PROTOCOL};
 #[cfg(feature = "didcomm")]
 use serde_json::json;
+#[cfg(feature = "tsp")]
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -256,11 +256,9 @@ pub async fn websocket_handler(
 
     #[cfg(feature = "tsp")]
     {
-        async move {
-            ws.on_upgrade(move |socket| handle_socket(socket, state, session, tsp_mode))
-        }
-        .instrument(_span)
-        .await
+        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session, tsp_mode)) }
+            .instrument(_span)
+            .await
     }
     #[cfg(not(feature = "tsp"))]
     {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -87,7 +87,7 @@ didwebvh-rs = "0.5.4"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.16", features = ["provision-client"] }
+vta-sdk = { version = "0.18", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -146,7 +146,7 @@ tracing = "0.1"
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.16", features = ["test-support"] }
+vta-sdk = { version = "0.18", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -307,9 +307,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires a vta-sdk release carrying the didcomm-mediator P-256 template slots \
-                (OpenVTC/verifiable-trust-infrastructure#587). Un-ignore once the vta-sdk \
-                dependency is bumped to that release."]
     async fn webvh_p256_suite_adds_signing_and_key_agreement_keys() {
         let result = generate_did_webvh(
             "https://mediator.example.com",


### PR DESCRIPTION
## What

Enables P-256 (`ES256`/`ECDH-ES`) verification-method rendering for `did:webvh` mediator DID documents.

- Bumps `vta-sdk` `0.16` -> `0.18` in `affinidi-messaging-mediator` and `mediator-setup` (dep + `test-support` dev-dep).
- Un-ignores `webvh_p256_suite_adds_signing_and_key_agreement_keys`.

## Why

The opt-in P-256 key suite renderer already shipped in #531, but it feeds the `didcomm-mediator` template's optional P-256 slots — and those slots only exist in `vta-sdk >= 0.18` (`OpenVTC/verifiable-trust-infrastructure#587`). Until the dependency was bumped the webvh P-256 verification methods couldn't render, so the render test was left `#[ignore]`d. This is the enablement follow-up to #531.

## Effect

`mediator-setup --did-method webvh --key-suite p256` now emits P-256 signing (`#key-2`) + key-agreement (`#key-3`) verification methods. The `did:web` export inherits them (same document is rewritten). `did:peer` already rendered P-256 via #531.

## Validation

- `vta-sdk` `0.16` -> `0.18` surface is additive (no breaking commits).
- `cargo check` clean on both crates.
- All 11 `mediator-setup` generator tests pass, **0 ignored** (incl. the un-ignored webvh P-256 test).

## Note

This makes P-256 keys *appear* in DID docs. P-256 keyAgreement/authentication work; the advertised P-256 `assertionMethod` cannot yet produce ES256 signatures — that's a separate, pre-existing EdDSA-only DIDComm JWS limitation, untouched here.
