### PR TITLE
feat: SDK consumer for the raw-TSP WebSocket mode (atm.tsp().connect_websocket)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.18.39] - 2026-06-27
+
+SDK consumer for the mediator's raw-TSP WebSocket mode.
+
+- New `atm.tsp().connect_websocket(profile)` → `TspWebSocket`: opens a WebSocket to the
+  mediator offering the `tsp` subprotocol (alongside the bearer token), so the socket runs
+  in raw-TSP mode (flush-on-connect + delete-on-successful-send, server-side). `TspWebSocket`
+  has `recv()` (next raw qb2 TSP message, `None` on close — skips ping/pong), `send(&[u8])`
+  (send a raw TSP message inbound), and `close()`.
+- New `atm.tsp().unpack_bytes(profile, qb2)` — unpack a raw qb2 TSP message (what `recv`
+  returns) without the base64 round-trip; `unpack(stored)` now decodes then delegates to it
+  (its signature + behaviour are unchanged).
+- Re-exports `TspWebSocket`. Additive; no existing API changed.
+
 ## [0.18.38] - 2026-06-26
 
 Formatting only (`cargo fmt --all`); no functional or API change. Patch bump

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.38"
+version = "0.18.39"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -184,7 +184,7 @@ use crate::protocols::tsp::TspOps;
 /// Re-exports of the TSP relationship-store API so consumers can implement a
 /// durable store or select one via the config builder.
 #[cfg(feature = "tsp")]
-pub use crate::protocols::tsp::{InMemoryRelationshipStore, RelationshipStore};
+pub use crate::protocols::tsp::{InMemoryRelationshipStore, RelationshipStore, TspWebSocket};
 /// Re-export of the pure-TSP authentication handler so a TSP-only client can
 /// register it on the TDK in place of the built-in DIDComm auth flow.
 #[cfg(feature = "tsp")]

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -524,7 +524,21 @@ impl TspOps<'_> {
         stored: &str,
     ) -> Result<(Vec<u8>, String), ATMError> {
         let qb2 = self.decode(stored)?;
-        let meta = MetaEnvelope::parse(&qb2)
+        self.unpack_bytes(profile, &qb2).await
+    }
+
+    /// Unpack a raw qb2 TSP message (the bytes a [`TspWebSocket::recv`] yields, or
+    /// the result of [`TspOps::decode`]): resolve the sender's keys, then decrypt +
+    /// verify with the profile's decryption key. Returns `(payload, sender_vid)`.
+    ///
+    /// This is the shared core of [`TspOps::unpack`]; WS consumers that already hold
+    /// raw qb2 bytes call this directly instead of re-encoding to base64url.
+    pub async fn unpack_bytes(
+        &self,
+        profile: &Arc<ATMProfile>,
+        qb2: &[u8],
+    ) -> Result<(Vec<u8>, String), ATMError> {
+        let meta = MetaEnvelope::parse(qb2)
             .map_err(|e| ATMError::MsgReceiveError(format!("couldn't parse TSP envelope: {e}")))?;
 
         let (profile_did, _) = profile.dids()?;
@@ -539,7 +553,7 @@ impl TspOps<'_> {
         let sender = self.resolve_vid(&meta.sender).await?;
 
         let unpacked = direct::unpack(
-            &qb2,
+            qb2,
             &decryption_key,
             &sender.encryption_key,
             &sender.signing_key,
@@ -547,6 +561,99 @@ impl TspOps<'_> {
         .map_err(|e| ATMError::MsgReceiveError(format!("couldn't unpack TSP message: {e}")))?;
 
         Ok((unpacked.payload, unpacked.sender))
+    }
+
+    // ── WebSocket (raw-TSP) delivery ──────────────────────────────────────────
+
+    /// Open the mediator's **raw-TSP WebSocket** for `profile`.
+    ///
+    /// Authenticates the profile, upgrades the mediator `/ws` endpoint offering
+    /// the `tsp` subprotocol (alongside the `bearer.<jwt>` auth subprotocol), and
+    /// returns a [`TspWebSocket`] for reading/writing raw qb2 TSP frames.
+    ///
+    /// The mediator's raw-TSP mode is *flush-on-connect + delete-on-send*: any
+    /// queued TSP messages for `profile` are flushed onto the socket the instant
+    /// it connects, and each is deleted server-side once it has been sent. This
+    /// is distinct from the DIDComm message-pickup delete-to-ack contract.
+    ///
+    /// Frames are raw qb2 TSP bytes; unpack a received frame with
+    /// [`TspOps::unpack_bytes`].
+    pub async fn connect_websocket(
+        &self,
+        profile: &Arc<ATMProfile>,
+    ) -> Result<TspWebSocket, ATMError> {
+        use tokio_tungstenite::tungstenite::{ClientRequestBuilder, http::Uri};
+
+        let (profile_did, mediator_did) = profile.dids()?;
+        let tokens = self
+            .atm
+            .get_tdk()
+            .authentication()
+            .authenticate(profile_did.to_string(), mediator_did.to_string(), 3, None)
+            .await?;
+        let access_token = tokens.access_token;
+
+        // Resolve the WS endpoint from the profile's mediator config (mirrors
+        // the DIDComm transport's two checks).
+        let Some(mediator) = &*profile.inner.mediator else {
+            return Err(ATMError::ConfigError(format!(
+                "Profile ({}) is missing a valid mediator configuration!",
+                profile.inner.alias
+            )));
+        };
+        let Some(address) = &mediator.websocket_endpoint else {
+            return Err(ATMError::ConfigError(format!(
+                "Profile ({}) is missing a valid websocket endpoint!",
+                profile.inner.alias
+            )));
+        };
+
+        let uri: Uri = address.parse().map_err(|e| {
+            ATMError::TransportError(format!(
+                "Mediator {}: Invalid websocket endpoint {address}: {e}",
+                mediator.did
+            ))
+        })?;
+        let host = uri.host().unwrap_or_default().to_string();
+        let port = uri
+            .port_u16()
+            .unwrap_or(if uri.scheme_str() == Some("wss") {
+                443
+            } else {
+                80
+            });
+
+        // Offer `bearer.<jwt>` (auth) + `tsp` (raw-TSP mode) subprotocols.
+        let builder = ClientRequestBuilder::new(uri)
+            .with_sub_protocol(format!("bearer.{access_token}"))
+            .with_sub_protocol("tsp");
+
+        let (ws, response) =
+            crate::transports::websockets::proxy::connect_websocket(builder, &host, port)
+                .await
+                .map_err(|e| {
+                    ATMError::TransportError(format!(
+                        "Profile '{}' → mediator {} TSP websocket {address} ({host}:{port}): {e}",
+                        profile.inner.alias, mediator.did
+                    ))
+                })?;
+
+        // The 101 should echo `tsp`, confirming the mode was accepted.
+        // tokio-tungstenite already enforces subprotocol agreement, so a
+        // mismatch here is informational only — warn, don't hard-fail.
+        match response
+            .headers()
+            .get("sec-websocket-protocol")
+            .and_then(|v| v.to_str().ok())
+        {
+            Some("tsp") => {}
+            other => tracing::warn!(
+                "TSP websocket did not echo the `tsp` subprotocol (got {other:?}); \
+                 raw-TSP mode may not be active"
+            ),
+        }
+
+        Ok(TspWebSocket { ws })
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────
@@ -607,6 +714,71 @@ impl TspOps<'_> {
             }
         }
         None
+    }
+}
+
+/// An open **raw-TSP WebSocket** to the mediator, obtained from
+/// [`TspOps::connect_websocket`].
+///
+/// Frames are raw qb2 TSP bytes (the same wire form [`TspOps::decode`] yields).
+/// Receive the next message with [`recv`](TspWebSocket::recv) and unpack it with
+/// [`TspOps::unpack_bytes`]; send a raw TSP message with
+/// [`send`](TspWebSocket::send).
+///
+/// Delivery is *flush-on-connect + delete-on-send* (server-side): queued
+/// messages are flushed onto the socket on connect and deleted once sent. The
+/// client therefore owns its own failure handling — a dropped socket after a
+/// frame was sent means that message is already gone from the mailbox.
+pub struct TspWebSocket {
+    ws: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+}
+
+impl TspWebSocket {
+    /// Receive the next raw qb2 TSP frame.
+    ///
+    /// Returns `Ok(Some(bytes))` for a delivered message (unpack it with
+    /// [`TspOps::unpack_bytes`]), or `Ok(None)` when the socket closes / the
+    /// stream ends. Control frames (`Ping`/`Pong`) and any `Text` frames are
+    /// skipped transparently.
+    pub async fn recv(&mut self) -> Result<Option<Vec<u8>>, ATMError> {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        loop {
+            match self.ws.next().await {
+                Some(Ok(Message::Binary(bytes))) => return Ok(Some(bytes.to_vec())),
+                Some(Ok(Message::Close(_))) | None => return Ok(None),
+                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Text(_))) => continue,
+                Some(Ok(Message::Frame(_))) => continue,
+                Some(Err(e)) => {
+                    return Err(ATMError::TransportError(format!(
+                        "TSP websocket receive error: {e}"
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Send a raw qb2 TSP message inbound. The mediator routes it via its TSP
+    /// inbound handler (the same path as [`TspOps::send_raw`], over the socket).
+    pub async fn send(&mut self, tsp_message: &[u8]) -> Result<(), ATMError> {
+        use futures_util::SinkExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        self.ws
+            .send(Message::Binary(tsp_message.to_vec().into()))
+            .await
+            .map_err(|e| ATMError::TransportError(format!("TSP websocket send error: {e}")))
+    }
+
+    /// Close the socket gracefully.
+    pub async fn close(mut self) -> Result<(), ATMError> {
+        self.ws
+            .close(None)
+            .await
+            .map_err(|e| ATMError::TransportError(format!("TSP websocket close error: {e}")))
     }
 }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 27th June 2026
+
+### 0.2.32 — TSP: WebSocket SDK-consumer e2e
+
+- New `tsp_websocket_sdk_consumer_flushes_and_deletes`: drives the SDK's
+  `atm.tsp().connect_websocket` + `recv` + `unpack_bytes` (rather than a raw tungstenite
+  client) against the embedded mediator — asserts the queued TSP is flushed, unpacks to the
+  payload + sender, and is deleted afterwards. The raw-wire test is retained alongside it.
+
 ## 26th June 2026
 
 ### 0.2.31 — TSP: WebSocket delivery e2e

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.31"
+version = "0.2.32"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
@@ -153,3 +153,68 @@ async fn tsp_websocket_flushes_and_deletes_queued_message() {
     drop(stream);
     env.shutdown().await.expect("shutdown");
 }
+
+/// The same flush-on-connect + delete-on-send contract, but driven through the
+/// SDK's ergonomic `atm.tsp().connect_websocket()` consumer instead of a raw
+/// tungstenite client. This covers the public SDK API surface (the test above
+/// covers the wire contract directly).
+#[tokio::test]
+async fn tsp_websocket_sdk_consumer_flushes_and_deletes() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"hello over the SDK TSP websocket";
+
+    // Alice queues a TSP Direct message to Bob (no socket open yet).
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    // Bob opens the raw-TSP websocket via the SDK consumer.
+    let mut ws = env
+        .atm
+        .tsp()
+        .connect_websocket(&bob.profile)
+        .await
+        .expect("bob opens the TSP websocket");
+
+    // Flush-on-connect: the queued message arrives as the next frame.
+    let qb2 = timeout(Duration::from_secs(5), ws.recv())
+        .await
+        .expect("a frame arrives within the timeout")
+        .expect("recv succeeds")
+        .expect("a flushed frame");
+
+    // Unpack the raw qb2 directly (no re-encode to base64url needed).
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack_bytes(&bob.profile, &qb2)
+        .await
+        .expect("bob unpacks the flushed TSP message");
+    assert_eq!(recovered, payload, "payload round-trips over the websocket");
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+
+    // Delete-on-send: Bob's mailbox is empty after the flush.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    assert!(
+        fetched.success.is_empty(),
+        "the delivered TSP message must be deleted on send (inbox is empty), got {} message(s)",
+        fetched.success.len()
+    );
+
+    ws.close().await.ok();
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
## Summary

Adds an ergonomic SDK client for the mediator's **raw-TSP WebSocket mode** (the mediator side shipped in #534 / mediator 0.16.31). This was the documented follow-up after the roadmap.

## API
- **`atm.tsp().connect_websocket(profile)` → `TspWebSocket`**: authenticates, then opens a WebSocket offering the **`tsp`** subprotocol (alongside `bearer.<jwt>`), putting the socket in raw-TSP mode (**flush-on-connect + delete-on-successful-send**, server-side). Reuses the existing proxy/TLS-aware connect helper.
- **`TspWebSocket`**: `recv()` (next raw qb2 TSP message; `None` on close; skips ping/pong), `send(&[u8])` (send raw TSP inbound → `handle_inbound_tsp`), `close()`.
- **`atm.tsp().unpack_bytes(profile, qb2)`**: unpack a raw qb2 message (what `recv` returns) without the base64 round-trip. `unpack(stored)` now decodes then delegates to it — **signature + behaviour unchanged**.
- Re-exports `TspWebSocket`. `sdk 0.18.38 → 0.18.39`.

## Tests
**test-mediator** (0.2.31 → 0.2.32): new `tsp_websocket_sdk_consumer_flushes_and_deletes` — drives the SDK consumer against the embedded mediator end-to-end (Alice sends → Bob `connect_websocket` → `recv` → `unpack_bytes` → asserts payload + sender, then the mailbox is empty). The raw-tungstenite wire test is retained.

Builds with + without `tsp`; dual-feature clippy clean; both `tsp_websocket` e2e tests pass; SDK tsp unit tests pass.

## Closes the TSP follow-ups
This was one of the two documented follow-ups; the only remaining one is the pure-TSP-auth e2e (needs a small `TestEnvironment` custom-handler-injection enhancement).