### PR TITLE
test: end-to-end pure-TSP client authentication

### DIFF
--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 27th June 2026
 
+### 0.2.33 — TSP: pure-TSP authentication e2e
+
+- New `TestEnvironment::spawn_with_tsp_auth()` (tsp-gated): builds the TDK with a shared
+  secrets resolver + a registered `TspAuthHandler`, so every profile authenticates over
+  TSP (`/tsp/authenticate`) instead of DIDComm. `new()` was refactored to delegate to a
+  private `new_with_config` — `spawn()` behaviour is unchanged.
+- New `tsp_auth` e2e (`pure_tsp_authentication_round_trips_a_direct_message`): a pure-TSP
+  client sends + fetches a TSP Direct message; both legs require a JWT minted by the
+  `TspAuthHandler` (challenge → Ed25519-sign → `/tsp/authenticate`), so a green round-trip
+  proves the full pure-TSP auth chain.
+
 ### 0.2.32 — TSP: WebSocket SDK-consumer e2e
 
 - New `tsp_websocket_sdk_consumer_flushes_and_deletes`: drives the SDK's

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.32"
+version = "0.2.33"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -123,12 +123,67 @@ impl TestEnvironment {
         Self::new(TestMediator::spawn().await?).await
     }
 
+    /// Spawn the default mediator (with the `tsp` feature) and wire up
+    /// the SDK to authenticate every profile over **pure TSP** instead
+    /// of the built-in DIDComm flow.
+    ///
+    /// The shared [`ThreadedSecretsResolver`] is constructed up front and
+    /// handed BOTH to the TDK (via
+    /// [`with_secrets_resolver`](affinidi_tdk::common::config::TDKConfigBuilder::with_secrets_resolver))
+    /// and to the [`TspAuthHandler`](affinidi_messaging_sdk::TspAuthHandler).
+    /// This is the load-bearing difference from [`spawn`](Self::spawn):
+    /// the handler must hold the *same* resolver instance that
+    /// [`add_user`](Self::add_user) later populates, otherwise it can't
+    /// load each user's Ed25519 VID key to sign the auth challenge.
+    ///
+    /// With a [`CustomAuthHandlers`] bundle set, the TDK's
+    /// `AuthenticationCache` routes every profile authentication through
+    /// the custom handler, so the whole environment authenticates over
+    /// `POST /tsp/authenticate`.
+    #[cfg(feature = "tsp")]
+    pub async fn spawn_with_tsp_auth() -> Result<Self, TestEnvironmentError> {
+        use affinidi_secrets_resolver::ThreadedSecretsResolver;
+        use affinidi_tdk::did_authentication::CustomAuthHandlers;
+
+        let mediator = TestMediator::spawn().await?;
+
+        // Build the shared resolver exactly as `TDKSharedState::new`
+        // does when the config doesn't supply one. We need a handle to
+        // it up front so the `TspAuthHandler` and the TDK share the same
+        // instance — that's where `add_user` later inserts user keys.
+        let (secrets, _task) = ThreadedSecretsResolver::new(None).await;
+
+        let handlers = CustomAuthHandlers::default().with_auth_handler(Arc::new(
+            affinidi_messaging_sdk::TspAuthHandler::new(secrets.clone()),
+        ));
+        let tdk_config = TDKConfig::builder()
+            .with_load_environment(false)
+            .with_use_atm(false)
+            .with_secrets_resolver(secrets)
+            .with_custom_auth_handlers(handlers)
+            .build()
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+
+        Self::new_with_config(mediator, tdk_config).await
+    }
+
     /// Use an existing [`TestMediatorHandle`] — for tests that want
     /// custom mediator config (e.g. enable forwarding, override the
     /// Redis URL) via [`TestMediator::builder`].
     pub async fn new(mediator: TestMediatorHandle) -> Result<Self, TestEnvironmentError> {
         let tdk_config =
             TDKConfig::headless().map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        Self::new_with_config(mediator, tdk_config).await
+    }
+
+    /// Shared constructor: wire the SDK + TDK against `mediator` using
+    /// the supplied `tdk_config`. The only difference between
+    /// [`new`](Self::new) and [`spawn_with_tsp_auth`](Self::spawn_with_tsp_auth)
+    /// is which config is passed here.
+    async fn new_with_config(
+        mediator: TestMediatorHandle,
+        tdk_config: TDKConfig,
+    ) -> Result<Self, TestEnvironmentError> {
         let tdk = Arc::new(
             TDKSharedState::new(tdk_config)
                 .await

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_auth.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_auth.rs
@@ -1,0 +1,90 @@
+//! End-to-end **pure-TSP client authentication** through the mediator.
+//!
+//! Unlike `tsp_delivery.rs` (which lets the SDK authenticate over the built-in
+//! DIDComm flow), this environment registers a `TspAuthHandler` as the *only*
+//! authentication path: every profile authenticates by signing the mediator's
+//! `/authenticate/challenge` with its Ed25519 VID key and POSTing the signature
+//! to `POST /tsp/authenticate`, minting the JWT used for the REST send/fetch.
+//!
+//! Driving a flow that *requires* authentication (Alice sends a TSP Direct
+//! message to Bob; Bob fetches and unpacks it) proves the whole pure-TSP auth
+//! chain end to end:
+//!
+//! ```text
+//! challenge → Ed25519-sign-with-VID → /tsp/authenticate → JWT → REST send/fetch
+//! ```
+//!
+//! Both the send and the fetch require a valid token the `TspAuthHandler`
+//! produced, so a green round-trip is only possible if pure-TSP auth works.
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_sdk::messages::MessageProtocol;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+#[tokio::test]
+async fn pure_tsp_authentication_round_trips_a_direct_message() {
+    // The environment's only auth handler is the `TspAuthHandler`, so every
+    // profile below authenticates over `/tsp/authenticate`.
+    let env = TestEnvironment::spawn_with_tsp_auth()
+        .await
+        .expect("spawn TSP-auth test environment");
+
+    // Alice + Bob: their secrets land in the SAME resolver the `TspAuthHandler`
+    // holds, so it can load each one's Ed25519 VID key to sign the challenge.
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"hello over pure-TSP auth";
+
+    // Alice sends a TSP Direct message to Bob. This first authenticates Alice's
+    // profile (challenge → sign → /tsp/authenticate → JWT) and then POSTs the
+    // packed message to `/inbound` with that token.
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice authenticates over TSP and sends a message to bob");
+
+    // Bob fetches his mailbox — which likewise authenticates Bob's profile over
+    // TSP before the authenticated `/fetch` REST call.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob authenticates over TSP and fetches messages");
+
+    let element = fetched
+        .success
+        .first()
+        .expect("bob has one fetched message");
+    let stored = element
+        .msg
+        .as_ref()
+        .expect("fetched message carries its body");
+
+    assert!(
+        env.atm.tsp().is_tsp(stored),
+        "the stored message is recognised as TSP"
+    );
+    assert_eq!(
+        element.protocol,
+        Some(MessageProtocol::Tsp),
+        "fetch tags the message as TSP"
+    );
+
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the TSP message");
+
+    assert_eq!(
+        recovered, payload,
+        "payload round-trips end to end under pure-TSP auth"
+    );
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+
+    env.shutdown().await.expect("shut down the environment");
+}


### PR DESCRIPTION
## Summary

Closes the **last TSP follow-up**: the pure-TSP auth path — `TspAuthHandler` (sdk 0.18.37) + the mediator's `/tsp/authenticate` — is now exercised **end-to-end**. Previously it had only unit coverage because the test harness couldn't inject a custom auth handler.

## Changes (test-mediator only, `0.2.32 → 0.2.33`)
- **`TestEnvironment::spawn_with_tsp_auth()`** (tsp-gated): builds the TDK with a shared `ThreadedSecretsResolver` + a registered `TspAuthHandler` (via `TDKConfig::with_secrets_resolver` + `with_custom_auth_handlers`), so every profile authenticates over **TSP** instead of DIDComm. The handler holds the same resolver `add_user` populates, so it can sign each user's challenge with their Ed25519 VID key. `new()` was refactored to delegate to a private `new_with_config`; **`spawn()` is unchanged**.
- **`tsp_auth` e2e** (`pure_tsp_authentication_round_trips_a_direct_message`): a pure-TSP client sends + fetches a TSP Direct message; both legs require a JWT the `TspAuthHandler` minted (challenge → Ed25519-sign → `/tsp/authenticate`), so a green round-trip proves the full chain. The test mediator already advertises the `#auth` service the handler resolves.

## Tests
Builds + clippy clean (tsp); the `tsp_auth` e2e passes; `tsp_delivery` (6 tests) still passes, confirming `spawn()` is unchanged.

## TSP track
This was the final documented follow-up. With it, **every TSP feature is implemented, published, and e2e-tested** — dual-protocol mediator + bridge, all four message types, DID-doc advertisement, `trust-tasks-tsp` (Direct/Nested/Routed), graduation-to-supported, relationship management, pure-TSP auth (+ e2e now), and WebSocket TSP (mediator + SDK consumer).