### PR TITLE
docs: add a TSP cookbook (SDK usage guide)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ docs/*
 !docs/migration/
 # Testing guide + composed-stack docs are tracked.
 !docs/testing/
+# TSP usage cookbook is tracked.
+!docs/tsp/
 
 # mediator-setup wizard generated artifacts (may land in any directory)
 **/conf/secrets.json

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -130,6 +130,9 @@ least one secret backend must be enabled. Defaults are
 >   `TSPTransport` service **when generating the DID**. The mediator logs a startup
 >   warning if TSP is enabled but no `TSPTransport` service is advertised.
 
+For end-to-end TSP usage (sending, receiving, relationships, WebSocket, auth), see
+the **[TSP cookbook](../../../docs/tsp/cookbook.md)**.
+
 ### Storage backend (pick one)
 
 | Feature | Default | Use case |

--- a/crates/messaging/affinidi-tsp/README.md
+++ b/crates/messaging/affinidi-tsp/README.md
@@ -11,7 +11,9 @@ Verifiable Identifiers (VIDs).
 > **Reference Implementation:** The official TSP reference implementation is
 > maintained at [github.com/trustoverip/tsp](https://github.com/trustoverip/tsp).
 > This crate provides an independent implementation tailored for the Affinidi TDK
-> ecosystem.
+> ecosystem. It does **not** currently wire-interoperate with the reference
+> (`tsp-sdk`) — see the [interop status](../../../docs/tsp/interop.md) for the
+> field-by-field comparison and why interop is deferred.
 
 > **Using TSP through the TDK?** This crate is the low-level protocol. For sending,
 > receiving, relationships, WebSocket delivery, and authentication via the

--- a/crates/messaging/affinidi-tsp/README.md
+++ b/crates/messaging/affinidi-tsp/README.md
@@ -13,6 +13,10 @@ Verifiable Identifiers (VIDs).
 > This crate provides an independent implementation tailored for the Affinidi TDK
 > ecosystem.
 
+> **Using TSP through the TDK?** This crate is the low-level protocol. For sending,
+> receiving, relationships, WebSocket delivery, and authentication via the
+> messaging SDK (`atm.tsp()`), see the **[TSP cookbook](../../../docs/tsp/cookbook.md)**.
+
 ## Feature Flags
 
 | Feature | Default | Description |

--- a/docs/tsp/cookbook.md
+++ b/docs/tsp/cookbook.md
@@ -1,0 +1,247 @@
+# TSP cookbook
+
+Copy-paste scenarios for using the **Trust Spanning Protocol (TSP)** through the
+Affinidi TDK — sending and receiving TSP messages, relationship forming,
+authentication, and running TSP over a WebSocket.
+
+TSP is **additive alongside DIDComm**: one mediator carries both, one socket can
+carry both, and the same accounts / ACLs / mailbox / pickup machinery is reused
+(an account is keyed on `sha256(vid)`). You opt into TSP per build with the
+`tsp` cargo feature; with it off, nothing here compiles in and DIDComm is
+unchanged.
+
+> The SDK snippets are marked `ignore` because they need an async runtime and a
+> running mediator; they follow the patterns covered by the
+> `affinidi-messaging-test-mediator` integration tests
+> (`tests/tsp_delivery.rs`, `tests/tsp_websocket.rs`, `tests/tsp_auth.rs`),
+> which are the runnable, CI-checked source of truth for these APIs.
+
+---
+
+## Contents
+
+- [Enabling TSP](#enabling-tsp)
+- [The carriage model](#the-carriage-model)
+- [Sending](#sending)
+- [Receiving](#receiving)
+- [WebSocket delivery](#websocket-delivery)
+- [Relationships](#relationships)
+- [Authentication](#authentication)
+- [Trust Tasks over TSP](#trust-tasks-over-tsp)
+
+---
+
+## Enabling TSP
+
+**Cargo features** — enable `tsp` on the SDK (and the mediator, if you run one):
+
+```toml
+affinidi-messaging-sdk = { version = "0.18", features = ["tsp"] }
+# Mediator deployments: run TSP alongside DIDComm (dual-protocol).
+affinidi-messaging-mediator = { version = "0.16", features = ["didcomm", "tsp"] }
+```
+
+A TSP client today reuses the profile's **DIDComm-authenticated session**, so a
+dual-protocol mediator (`didcomm,tsp`) is the normal deployment. For a *pure*-TSP
+client see [Authentication](#authentication).
+
+**Endpoint discovery** — for other mediators to route TSP to yours, your
+mediator's DID document must advertise a `TSPTransport` service. With the `tsp`
+feature on:
+
+- **did:web** — added automatically at startup, mirroring the `DIDCommMessaging`
+  endpoint (TSP and DIDComm share `/inbound`). No action needed.
+- **did:peer / did:webvh** — the document is bound to the DID, so add the
+  `TSPTransport` service **when you generate the DID**. The mediator logs a
+  startup warning if `tsp` is on but no `TSPTransport` service is advertised.
+
+---
+
+## The carriage model
+
+A TSP message is always sealed **end-to-end to its final recipient**. How it
+*travels* there is the carriage:
+
+| Carriage | What it is | API |
+|----------|-----------|-----|
+| **Direct** | sealed sender → recipient, no intermediary | `send` / `pack` |
+| **Nested** | a Direct message wrapped once for a single intermediary (metadata privacy — only that intermediary learns the recipient) | `send_nested` |
+| **Routed** | a Direct message relayed through one or more hops | `send_routed` |
+| **Control** | relationship management (invite / accept / cancel) | `send_control`, or the [relationship](#relationships) helpers |
+
+The crucial property: **the mediator strips the outer (Nested/Routed) layers; the
+recipient always opens the innermost Direct message.** So `unpack` works
+identically no matter how a message was carried — and a Nested/Routed inner can
+even be a **DIDComm** message (the TSP↔DIDComm bridge), which the recipient then
+opens with its native protocol.
+
+---
+
+## Sending
+
+`atm.tsp()` is the entry point; every call takes the sender's `profile`.
+
+**Direct** — seal straight to a recipient DID and POST it to the mediator:
+
+```rust,ignore
+atm.tsp().send(&alice.profile, &bob_did, b"hello over TSP").await?;
+```
+
+**Routed** — relay through hops; `route` is the ordered hop list ending at the
+final recipient (the inner is sealed to `route.last()`):
+
+```rust,ignore
+let route = vec![mediator_did.clone(), bob_did.clone()];
+atm.tsp().send_routed(&alice.profile, &route, b"routed hello").await?;
+```
+
+**Nested** — wrap a Direct (sealed to `to_did`) inside an outer envelope sealed to
+`intermediary`; only the intermediary learns `to_did`:
+
+```rust,ignore
+atm.tsp()
+    .send_nested(&alice.profile, &mediator_did, &bob_did, b"private hello")
+    .await?;
+```
+
+**Bridging DIDComm over TSP** — `send_routed_opaque` / `send_nested_opaque` take
+an *already-packed* inner (e.g. a DIDComm message from `atm.pack_encrypted`) and
+relay it opaquely; the recipient unpacks it natively.
+
+Lower-level building blocks: `pack(profile, to_did, payload)` returns the raw qb2
+bytes without sending; `send_raw(profile, bytes)` POSTs already-packed bytes.
+
+---
+
+## Receiving
+
+TSP messages land in the same mailbox as DIDComm. Fetched messages are
+**tagged** with their protocol so you can route without inspecting the body:
+
+```rust,ignore
+let fetched = atm.fetch_messages(&bob.profile, &FetchOptions::default()).await?;
+for el in fetched.success {
+    let stored = el.msg.as_ref().expect("body");
+    match el.protocol {
+        Some(MessageProtocol::Tsp) => {
+            let (payload, sender) = atm.tsp().unpack(&bob.profile, stored).await?;
+            // `sender` is the authenticated sender VID.
+        }
+        _ => { /* DIDComm: atm.unpack(...) */ }
+    }
+}
+```
+
+Helpers: `is_tsp(stored)` (sniff a stored message), `decode`/`encode` (stored
+`base64url(qb2)` ↔ raw qb2), and `unpack_bytes(profile, qb2)` to unpack raw qb2
+directly (what the [WebSocket](#websocket-delivery) consumer yields).
+
+---
+
+## WebSocket delivery
+
+For low-latency, opt a socket into **raw-TSP mode** with `connect_websocket`. It
+offers a `tsp` subprotocol on the upgrade, so the mediator uses a
+**flush-on-connect + delete-on-successful-send** contract: on connect it drains
+your inbox as raw-TSP `Binary` frames and deletes each once it's sent; new
+messages stream the same way. **You own failure handling** — a dropped socket
+leaves undelivered messages in the inbox for the next connection.
+
+```rust,ignore
+let mut ws = atm.tsp().connect_websocket(&bob.profile).await?;
+while let Some(qb2) = ws.recv().await? {            // next raw TSP message, None on close
+    let (payload, sender) = atm.tsp().unpack_bytes(&bob.profile, &qb2).await?;
+    // ... handle it ...
+}
+ws.close().await?;
+```
+
+`ws.send(&qb2)` sends a raw TSP message inbound over the same socket.
+
+---
+
+## Relationships
+
+TSP relationships follow a small state machine, driven through `atm.tsp()` and
+backed by a **pluggable store** (so where the state lives — memory, a database —
+is yours to choose):
+
+```text
+None ──form_relationship──► Pending ──(peer accepts)──► Bidirectional
+None ──(peer invites)─────► InviteReceived ──accept_relationship──► Bidirectional
+                              (cancel from any state → None)
+```
+
+```rust,ignore
+// Initiator
+atm.tsp().form_relationship(&alice.profile, &bob_did).await?;   // → Pending (sends an invite)
+
+// Responder, after receiving an invite control message:
+let control = ControlMessage::decode(&payload)?;               // payload from unpack
+atm.tsp().record_incoming_control(&bob.profile, &alice_did, &control).await?; // → InviteReceived
+atm.tsp().accept_relationship(&bob.profile, &alice_did, &invite_wire).await?; // → Bidirectional
+
+let state = atm.tsp().relationship_state(&alice.profile, &bob_did).await?;
+```
+
+Outbound calls **persist only after the control message is sent**.
+`record_incoming_control` advances the FSM for a received invite/accept/cancel.
+
+**Choosing a store** — the default is ephemeral (in-memory, wiped on restart).
+Implement `RelationshipStore` against durable storage and inject it:
+
+```rust,ignore
+let config = ATMConfig::builder()
+    .with_relationship_store(Arc::new(MyDurableStore::new(/* ... */)))
+    .build()?;
+```
+
+---
+
+## Authentication
+
+**Dual-protocol clients** (the common case) authenticate with DIDComm; TSP calls
+reuse that session automatically — nothing extra to do.
+
+**Pure-TSP clients** (no DIDComm) authenticate by signing the mediator's
+challenge with their VID's Ed25519 key. The SDK ships `TspAuthHandler`; register
+it on the TDK at construction and every profile then authenticates over
+`/tsp/authenticate`:
+
+```rust,ignore
+use affinidi_messaging_sdk::TspAuthHandler;
+use affinidi_tdk::did_authentication::CustomAuthHandlers;
+
+let handlers = CustomAuthHandlers::default()
+    .with_auth_handler(Arc::new(TspAuthHandler::new(secrets.clone())));
+
+let tdk_config = TDKConfig::builder()
+    .with_secrets_resolver(secrets)        // the SAME resolver your VID keys live in
+    .with_custom_auth_handlers(handlers)
+    .build()?;
+```
+
+The handler resolves the mediator's `#auth` service, fetches a challenge, signs
+it, and POSTs to `/tsp/authenticate` — minting the **same** JWT session the
+DIDComm path issues, so all downstream ACL / pickup / WS gates are reused
+unchanged.
+
+---
+
+## Trust Tasks over TSP
+
+Trust Tasks (`messaging/ping`, account/acl/access-list/admin, …) are
+transport-agnostic. The `trust-tasks-tsp` binding carries any Trust Task over
+TSP — so a "TSP ping", account ops, etc. are just the corresponding Trust Task
+sent over a TSP carriage:
+
+```rust,ignore
+use trust_tasks_tsp::{pack_trust_task, pack_trust_task_nested, pack_trust_task_routed};
+
+let wire = pack_trust_task(&doc, &sender_private_vid, &recipient_resolved_vid)?;
+// nested / routed variants mirror the carriage model above.
+atm.tsp().send_raw(&profile, &wire).await?;
+```
+
+The consumer always opens the innermost Direct via `unpack_trust_task`,
+regardless of carriage — the mediator strips the relay layers.

--- a/docs/tsp/interop.md
+++ b/docs/tsp/interop.md
@@ -1,0 +1,86 @@
+# TSP interop status: `affinidi-tsp` vs the ToIP reference
+
+**Question:** does `affinidi-tsp` (this repo) wire-interoperate with the official
+ToIP reference implementation, [`tsp-sdk`](https://github.com/openwallet-foundation-labs/tsp)?
+
+**Verdict (2026-06, `affinidi-tsp` 0.1.6 vs `tsp-sdk` 0.9.0-alpha2): NO — they do
+not interoperate, in either direction.** This was verified empirically with a
+two-binary round-trip (two standalone crates exchanging raw bytes through a file,
+so the dependency graphs never linked), feeding **both** libraries the same raw
+Ed25519 + X25519 keys, VIDs, and payload.
+
+| Direction | Result |
+|---|---|
+| `affinidi-tsp` `pack` → `tsp-sdk` `open` | **FAIL** — `Decode(VersionMismatch)` |
+| `tsp-sdk` `seal` → `affinidi-tsp` `unpack` | **FAIL** — `unknown code: -E` |
+| each library opening its own output | OK |
+
+Both failures happen at the **first parse step (outer framing)** — neither side
+even reaches the other's crypto. And even if framing matched, the AEAD differs, so
+decryption would still fail.
+
+## Where they agree, and where they don't
+
+| Aspect | `affinidi-tsp` | `tsp-sdk` 0.9.0-alpha2 | Match |
+|---|---|---|:---:|
+| KEM | DHKEM(X25519, HKDF-SHA256) | X25519HkdfSha256 | ✅ |
+| KDF | HKDF-SHA256 | HkdfSha256 | ✅ |
+| HPKE mode | Auth | Auth (default) | ✅ |
+| **AEAD** | **AES-128-GCM** | **ChaCha20Poly1305** | ❌ fundamental |
+| **CESR framing** | one `Matter`/Tag1 header (`D4 00 05`) + a bespoke, mostly non-CESR body | nested CESR count-code groups (`-E`/`-Z`/`-C`/`-K`), `YTSP` version marker, var-data crypto codes | ❌ fundamental |
+| **Payload encoding** | raw payload encrypted directly | payload **CESR-encoded** (`-Z … XSCS …`) *before* encryption | ❌ fundamental |
+| HPKE `info` | `b"TSP-v1-direct"` | empty | ❌ |
+| enc/tag placement, signature framing | `enc`-before-ct, raw 64-byte Ed25519 sig appended | tag+enc after ct, CESR-framed sig | ❌ (subsumed by framing) |
+| signature algorithm | Ed25519 | Ed25519 | ✅ (framing differs) |
+
+The two implementations share only the **KEM and KDF**. They disagree on the
+AEAD, the entire CESR envelope framing, the payload encoding, the HPKE info/AAD
+bytes, and the signature framing.
+
+## Effort to close
+
+There is **no small change** that yields a green round-trip. The smallest viable
+path is for `affinidi-tsp` to **adopt `tsp-sdk`'s wire format end-to-end**:
+ChaCha20Poly1305 AEAD + the nested-CESR envelope (`-E`/`-Z`/`-C`/`-K`) + CESR
+payload pre-encoding + empty HPKE info + CESR signature framing. That is a
+**large, wire-breaking change on the `affinidi-tsp` side** (rewrite
+`envelope.rs` + `direct.rs`). The reference is authoritative for the spec rev it
+targets, so the change belongs on our side.
+
+## Caveat: the reference is alpha and does not build as published
+
+Independent of interop, `tsp-sdk` 0.9.0-alpha2 **does not build from crates.io**:
+its `definitions` module unconditionally imports from a `resolve`-gated path
+(making `resolve` mandatory), `resolve` pulls `didwebvh-rs` into an
+`affinidi-secrets-resolver` version diamond (two incompatible `Secret` types), and
+it pins `serde = "=1.0.219"` exactly, which blocks bumping past the diamond. The
+experiment only built `tsp-sdk` by vendoring it locally with the serde pin relaxed
+and `didwebvh-rs` bumped. **Its wire format and dependency set are both unstable.**
+
+## Recommendation
+
+**Defer interop.** It is not achievable without a wire-breaking rewrite of
+`affinidi-tsp`, and it is premature to target an alpha whose wire format isn't
+frozen and whose published crate doesn't build. Revisit once `tsp-sdk` ships a
+**stable (non-alpha) release** with a frozen wire format and a clean dependency
+graph.
+
+If/when interop becomes a goal, two options:
+1. **Re-implement `tsp-sdk`'s wire format in `affinidi-tsp`** (large; keeps our
+   lean dependency tree).
+2. **Depend on `tsp-sdk` directly** for the wire layer (smaller code, but pulls
+   its heavyweight deps — askar, sqlx, reqwest, quinn — versus our lean stack).
+
+## Reproducing this verdict
+
+The check is a two-binary round-trip that keeps the dependency graphs isolated (so
+the alpha's deps don't have to co-resolve with this workspace):
+
+- crate A depends only on `affinidi-tsp` (via path) and `pack`/`unpack`s;
+- crate B depends only on `tsp-sdk` and `seal`/`open`s;
+- both are fed the **same** raw Ed25519 + X25519 key bytes and VIDs, and exchange
+  the packed bytes through a file.
+
+Round-tripping in both directions and asserting success is the interop test. Today
+it would assert **failure**, so it documents incompatibility rather than passing —
+it can become an `#[ignore]`d interop test once `tsp-sdk` stabilizes.

--- a/docs/tsp/interop.md
+++ b/docs/tsp/interop.md
@@ -37,6 +37,29 @@ The two implementations share only the **KEM and KDF**. They disagree on the
 AEAD, the entire CESR envelope framing, the payload encoding, the HPKE info/AAD
 bytes, and the signature framing.
 
+## Which side is spec-correct?
+
+Adjudicated against the **TSP specification, v1.0 Experimental Implementor's Draft
+Rev 2** ([trustoverip.github.io/tswg-tsp-specification](https://trustoverip.github.io/tswg-tsp-specification/))
+— the same revision `affinidi-tsp` claims to target. On every clear point, the
+reference (`tsp-sdk`) conforms and **`affinidi-tsp` diverges**:
+
+| Mismatch | Spec says | `affinidi-tsp` | `tsp-sdk` | Conformant |
+|---|---|---|---|---|
+| AEAD | **ChaCha20Poly1305** only (code 0x0003); AES-GCM is not mentioned, no negotiation | AES-128-GCM | ChaCha20Poly1305 | **tsp-sdk** |
+| HPKE `info` | **`NULL`** (empty) in `TSP_SEAL`/`TSP_OPEN` | `b"TSP-v1-direct"` | empty | **tsp-sdk** |
+| Envelope framing | **CESR**: `TSP_Tag` count code `-E##` + `TSP_Version` `YTSP-###` + `VID_sndr`/`VID_rcvr` var-data codes | one `Matter`/Tag1 (`D4 00 05`) + bespoke non-CESR body, no `YTSP` version | CESR `-E`/`YTSP`/VID codes | **tsp-sdk** |
+| Payload framing | CESR control codes incl. `XSCS` for the payload | raw payload, no CESR frame | `-Z … XSCS …` | **tsp-sdk** |
+| Version marker | mandatory `TSP_Version` (`YTSP-###`) | none (a byte in the Matter raw) | `YTSP` marker | **tsp-sdk** |
+| KEM / KDF | X25519 / HKDF-SHA256 | ✅ | ✅ | both |
+| Signature algorithm | Ed25519 | ✅ | ✅ | both (framing differs; spec's sig **framing** is incomplete in this draft) |
+
+**Conclusion: `affinidi-tsp` is the non-conformant side.** Its AEAD choice, HPKE
+`info`, and CESR envelope/version framing are not what the TSP Rev 2 spec mandates
+— they read as independent implementation choices, not spec-grounded ones. The
+reference implements the spec. So the interop failure isn't a "two valid dialects"
+situation: it's `affinidi-tsp` deviating from the standard it targets.
+
 ## Effort to close
 
 There is **no small change** that yields a green round-trip. The smallest viable
@@ -59,17 +82,38 @@ and `didwebvh-rs` bumped. **Its wire format and dependency set are both unstable
 
 ## Recommendation
 
-**Defer interop.** It is not achievable without a wire-breaking rewrite of
-`affinidi-tsp`, and it is premature to target an alpha whose wire format isn't
-frozen and whose published crate doesn't build. Revisit once `tsp-sdk` ships a
-**stable (non-alpha) release** with a frozen wire format and a clean dependency
-graph.
+Because `affinidi-tsp` is the **non-conformant** side, the fix and the interop are
+the same task: bring `affinidi-tsp` into line with the TSP Rev 2 spec, which the
+reference already implements. This is a **correctness** issue (we don't match the
+standard we claim to target), not merely a missing nice-to-have.
 
-If/when interop becomes a goal, two options:
-1. **Re-implement `tsp-sdk`'s wire format in `affinidi-tsp`** (large; keeps our
-   lean dependency tree).
-2. **Depend on `tsp-sdk` directly** for the wire layer (smaller code, but pulls
-   its heavyweight deps — askar, sqlx, reqwest, quinn — versus our lean stack).
+Sequence it by how stable each gap is:
+
+1. **Now — the unambiguous, low-risk crypto fixes.** Switch the HPKE AEAD to
+   **ChaCha20Poly1305** and set the HPKE `info` to **empty/NULL**. These are clear,
+   stable spec requirements unlikely to change, and they're small, self-contained
+   edits in `affinidi-tsp`'s `crypto`/`direct` layer. (Both are wire-breaking, but
+   `affinidi-tsp` is `0.1.x` and pre-adoption, so the break is cheap now and only
+   gets more expensive later.)
+2. **Later — the CESR envelope/payload/signature rewrite.** Replacing the
+   bespoke `Matter`/Tag1 framing with the spec's count-code groups (`-E`/`-Z`/
+   `-C`/`-K`) + `YTSP` version + var-data VID/payload/signature codes is the large
+   change. Do it once (a) the spec's **signature framing** is complete (it is
+   *incomplete* in Rev 2's current draft) and (b) `tsp-sdk` is **buildable +
+   stable** so the round-trip can be the conformance test. Rewriting the framing
+   now, against an incomplete draft with no working reference to test against,
+   risks doing it twice.
+
+Two ways to land step 2 when the time comes:
+- **Re-implement the spec's wire format in `affinidi-tsp`** — keeps our lean
+  dependency tree; we own the conformance.
+- **Depend on `tsp-sdk` directly** for the wire layer — guaranteed conformance and
+  interop, but pulls its heavyweight deps (askar, sqlx, reqwest, quinn) versus our
+  lean stack, and it must build cleanly first.
+
+Until step 2 lands, `affinidi-tsp` remains a **self-consistent but non-standard**
+TSP — fine for TDK-internal use, but it will not interoperate with spec-compliant
+TSP peers. That limitation should be stated wherever TSP support is advertised.
 
 ## Reproducing this verdict
 

--- a/docs/tsp/interop.md
+++ b/docs/tsp/interop.md
@@ -19,6 +19,14 @@ Both failures happen at the **first parse step (outer framing)** — neither sid
 even reaches the other's crypto. And even if framing matched, the AEAD differs, so
 decryption would still fail.
 
+> **Status update (as of `affinidi-tsp` 0.1.7).** The **crypto** mismatches below —
+> the AEAD and the HPKE `info` — are now **fixed** (the AEAD is ChaCha20Poly1305 and
+> `info` is empty, per the spec; see the changelog / #540). The **CESR framing**
+> mismatches remain, and a framing rewrite to the spec/reference format is in
+> progress. The headline "no interop" verdict therefore still holds until the
+> framing work lands; the field tables below describe the original 0.1.6 divergence,
+> with the crypto rows now resolved.
+
 ## Where they agree, and where they don't
 
 | Aspect | `affinidi-tsp` | `tsp-sdk` 0.9.0-alpha2 | Match |


### PR DESCRIPTION
## Summary

Adds **`docs/tsp/cookbook.md`** — a task-oriented guide for using TSP through the TDK, mirroring the style of `docs/testing/cookbook.md`. The TSP SDK surface grew a lot over the last few PRs; this is the missing developer-facing guide (only the `affinidi-tsp` crate README + the design SDD existed).

## Covers
- Enabling the `tsp` feature + the `TSPTransport` DID-doc advertisement (did:web auto / did:peer+webvh manual)
- The **carriage model** — Direct / Nested / Routed / Control, and the key property that the mediator strips outer layers so the recipient always opens the innermost Direct (incl. the DIDComm bridge)
- **Sending** — `send` / `send_routed` / `send_nested` (+ the `_opaque` bridge variants), `pack` / `send_raw`
- **Receiving** — `fetch_messages` + the `protocol` tag + `unpack` / `unpack_bytes`
- **WebSocket** — `connect_websocket` (the `tsp` subprotocol, flush-on-connect + delete-on-send)
- **Relationships** — the FSM + `form`/`accept`/`cancel`/`relationship_state`/`record_incoming_control` + the pluggable `RelationshipStore`
- **Authentication** — dual-client (reuse DIDComm) vs pure-TSP (`TspAuthHandler` registration)
- **Trust Tasks over TSP** — `trust-tasks-tsp`

## Notes
SDK snippets are marked `ignore` (need an async runtime + a running mediator) and follow the patterns in the `test-mediator` `tsp_delivery` / `tsp_websocket` / `tsp_auth` integration tests — the runnable source of truth. Linked from the mediator + `affinidi-tsp` READMEs. **Docs-only; no version bump.**

First of three TSP wrap-up items (then: interop with the ToIP reference, two-mediator e2e).