### PR TITLE
fix: make TSP HPKE spec-conformant (ChaCha20Poly1305 + empty info)

### DIFF
--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Affinidi TSP Changelog
 
+## 28th June 2026
+
+### 0.1.7 — spec conformance (1/2): ChaCha20Poly1305 HPKE AEAD + empty HPKE info
+
+- The HPKE AEAD is now **ChaCha20Poly1305** (was AES-128-GCM) and the HPKE `info` is
+  now empty/`NULL` (was `"TSP-v1-direct"`), matching the TSP spec (v1.0 Implementor's
+  Draft Rev 2), which mandates ChaCha20Poly1305 and `info = NULL`. The HPKE suite ID's
+  AEAD code is updated `0x0001 → 0x0003` accordingly.
+- **Wire-breaking:** the ciphertext format changed; messages packed by 0.1.6 (or any
+  AES-GCM build) will not decrypt under 0.1.7. TSP is pre-adoption / experimental, so
+  no migration is provided. The public API is unchanged (`seal`/`open`/`pack`/`unpack`
+  signatures identical), so consumers need no code changes.
+- This is the first of two spec-conformance steps. The CESR envelope / payload /
+  signature **framing** is still being brought to spec (a follow-up); full interop with
+  the reference (`tsp-sdk`) lands once both are done. See
+  [`docs/tsp/interop.md`](../../../docs/tsp/interop.md).
+
 ## 22nd June 2026
 
 ### 0.1.6 — ingress sniff + keys-free envelope metadata

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -37,7 +37,8 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 hkdf = "0.12"
 sha2 = "0.10"
-aes-gcm = "0.10"
+## TSP mandates ChaCha20Poly1305 as the HPKE AEAD (spec Rev 2); see docs/tsp/interop.md.
+chacha20poly1305 = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
 zeroize = { version = "1", features = ["derive"] }
 blake2 = "0.10"

--- a/crates/messaging/affinidi-tsp/README.md
+++ b/crates/messaging/affinidi-tsp/README.md
@@ -24,7 +24,7 @@ Verifiable Identifiers (VIDs).
 
 | Operation | Algorithm |
 |---|---|
-| Authenticated encryption | HPKE-Auth (DHKEM(X25519) + HKDF-SHA256 + AES-128-GCM) per [RFC 9180](https://www.rfc-editor.org/rfc/rfc9180) |
+| Authenticated encryption | HPKE-Auth (DHKEM(X25519) + HKDF-SHA256 + ChaCha20Poly1305) per [RFC 9180](https://www.rfc-editor.org/rfc/rfc9180) |
 | Signing | Ed25519 |
 | Message digest | BLAKE2s-256 |
 | Encoding | CESR (Composable Event Streaming Representation) |

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -1,11 +1,12 @@
 //! HPKE-Auth (RFC 9180) implementation using primitives.
 //!
-//! Suite: DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM, Auth mode.
+//! Suite: DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305, Auth mode —
+//! the cipher suite the TSP spec (v1.0 Implementor's Draft Rev 2) mandates.
 //!
 //! This implements only the specific HPKE suite required by TSP, built from
 //! standard cryptographic primitives rather than a generic HPKE library.
 
-use aes_gcm::{AeadInPlace, Aes128Gcm, KeyInit, aead::generic_array::GenericArray};
+use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, KeyInit, aead::generic_array::GenericArray};
 use hkdf::Hkdf;
 use rand_core::OsRng;
 use sha2::Sha256;
@@ -18,15 +19,15 @@ use crate::error::TspError;
 const MODE_AUTH: u8 = 0x02;
 
 const N_SECRET: usize = 32; // KEM shared secret size
-const N_K: usize = 16; // AES-128-GCM key size
-const N_N: usize = 12; // AES-128-GCM nonce size
+const N_K: usize = 32; // ChaCha20Poly1305 key size
+const N_N: usize = 12; // ChaCha20Poly1305 nonce size
 const N_H: usize = 32; // HKDF-SHA256 hash output size
 
 /// Result of HPKE-Auth sealing (encryption + sender authentication).
 pub struct SealResult {
     /// The encapsulated key (32 bytes, X25519 ephemeral public key).
     pub enc: [u8; 32],
-    /// The ciphertext (plaintext + 16-byte AES-GCM tag).
+    /// The ciphertext (plaintext + 16-byte Poly1305 tag).
     pub ciphertext: Vec<u8>,
 }
 
@@ -64,12 +65,12 @@ pub fn seal(
     let (key, base_nonce) = key_schedule(&shared_secret, info)?;
 
     let mut ciphertext = plaintext.to_vec();
-    let cipher = Aes128Gcm::new_from_slice(&key)
-        .map_err(|e| TspError::Hpke(format!("AES-GCM invalid key: {e}")))?;
+    let cipher = ChaCha20Poly1305::new_from_slice(&key)
+        .map_err(|e| TspError::Hpke(format!("ChaCha20Poly1305 invalid key: {e}")))?;
     let nonce = GenericArray::from(base_nonce);
     cipher
         .encrypt_in_place(&nonce, aad, &mut ciphertext)
-        .map_err(|e| TspError::Hpke(format!("AES-GCM seal failed: {e}")))?;
+        .map_err(|e| TspError::Hpke(format!("ChaCha20Poly1305 seal failed: {e}")))?;
 
     Ok(SealResult { enc, ciphertext })
 }
@@ -84,7 +85,7 @@ pub fn seal(
 /// equally unique and used only once.
 ///
 /// # Arguments
-/// * `ciphertext` - The encrypted data (including 16-byte AES-GCM tag)
+/// * `ciphertext` - The encrypted data (including 16-byte Poly1305 tag)
 /// * `aad` - Additional authenticated data (must match what was used in seal)
 /// * `enc` - The encapsulated key from the sender
 /// * `recipient_sk` - Recipient's X25519 private key (32 bytes)
@@ -105,12 +106,14 @@ pub fn open(
     let (key, base_nonce) = key_schedule(&shared_secret, info)?;
 
     let mut plaintext = ciphertext.to_vec();
-    let cipher = Aes128Gcm::new_from_slice(&key)
-        .map_err(|e| TspError::Hpke(format!("AES-GCM invalid key: {e}")))?;
+    let cipher = ChaCha20Poly1305::new_from_slice(&key)
+        .map_err(|e| TspError::Hpke(format!("ChaCha20Poly1305 invalid key: {e}")))?;
     let nonce = GenericArray::from(base_nonce);
     cipher
         .decrypt_in_place(&nonce, aad, &mut plaintext)
-        .map_err(|_| TspError::Hpke("AES-GCM open failed: authentication tag mismatch".into()))?;
+        .map_err(|_| {
+            TspError::Hpke("ChaCha20Poly1305 open failed: authentication tag mismatch".into())
+        })?;
 
     Ok(plaintext)
 }
@@ -299,7 +302,8 @@ fn labeled_expand(
 const KEM_SUITE_ID: &[u8] = b"KEM\x00\x20";
 
 /// HPKE suite ID: "HPKE" || I2OSP(kem_id, 2) || I2OSP(kdf_id, 2) || I2OSP(aead_id, 2)
-const HPKE_SUITE_ID: &[u8] = b"HPKE\x00\x20\x00\x01\x00\x01";
+/// = HPKE || 0x0020 (DHKEM X25519) || 0x0001 (HKDF-SHA256) || 0x0003 (ChaCha20Poly1305).
+const HPKE_SUITE_ID: &[u8] = b"HPKE\x00\x20\x00\x01\x00\x03";
 
 #[cfg(test)]
 mod tests {
@@ -325,7 +329,7 @@ mod tests {
         )
         .unwrap();
 
-        // Ciphertext should be plaintext + 16-byte AES-GCM tag
+        // Ciphertext should be plaintext + 16-byte Poly1305 tag
         assert_eq!(sealed.ciphertext.len(), plaintext.len() + 16);
 
         let opened = open(

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -56,13 +56,14 @@ pub fn pack(
     let envelope = Envelope::new(message_type, sender_vid, receiver_vid);
     let envelope_bytes = envelope.encode()?;
 
-    // 2. HPKE-Auth seal: encrypt payload with envelope as AAD
+    // 2. HPKE-Auth seal: encrypt payload with envelope as AAD. The TSP spec sets
+    // the HPKE `info` to NULL (empty), so pass no context string.
     let sealed = hpke::seal(
         payload,
         &envelope_bytes,
         sender_encryption_key,
         receiver_encryption_key,
-        b"TSP-v1-direct",
+        b"",
     )?;
 
     // 3. Build wire format: envelope || enc || ciphertext_len || ciphertext || signature
@@ -155,7 +156,7 @@ pub fn unpack(
         &enc,
         receiver_decryption_key,
         sender_encryption_key,
-        b"TSP-v1-direct",
+        b"",
     )?;
 
     Ok(UnpackedMessage {


### PR DESCRIPTION
## Summary

**Spec-conformance step 1 of 2.** The TSP spec (v1.0 Implementor's Draft Rev 2 — the rev `affinidi-tsp` targets) mandates the HPKE AEAD be **ChaCha20Poly1305** and the HPKE `info` be **NULL**. `affinidi-tsp` used **AES-128-GCM** and `info = "TSP-v1-direct"` — both non-conformant (see [`docs/tsp/interop.md`](https://github.com/affinidi/affinidi-tdk-rs/blob/main/docs/tsp/interop.md), which adjudicated this against the spec).

## Changes
- **AEAD** AES-128-GCM → **ChaCha20Poly1305** (`crypto/hpke.rs`): swap the cipher, `N_K` 16 → 32, and the HPKE suite-ID AEAD code `0x0001 → 0x0003`. Dep `aes-gcm` → `chacha20poly1305` (already in the workspace lock).
- **HPKE `info`** `"TSP-v1-direct"` → empty (`message/direct.rs` seal + open).
- README crypto-suite table updated.

## Compatibility
**Wire-breaking** — the ciphertext format changed; messages packed by 0.1.6 (any AES-GCM build) won't decrypt under 0.1.7. TSP is pre-adoption / experimental, so no migration. The **public API is unchanged** (`seal`/`open`/`pack`/`unpack` signatures identical), so consumers (mediator/SDK via the `0.1` path pin) need **no code changes**. `affinidi-tsp 0.1.6 → 0.1.7` (patch, per the workspace's pin-stability convention).

## Tests
All 84 `affinidi-tsp` tests pass; the SDK `tsp` unit tests and the test-mediator `tsp_delivery` / `tsp_websocket` / `tsp_auth` e2e suites all pass — internal consistency holds because `pack` and `unpack` both use the new suite. Clippy clean.

## Next
Step 2/2 — the CESR **envelope / payload / signature framing** rewrite (the `Matter`/Tag1 `D4 00 05` + bespoke body → the spec's `-E`/`YTSP`/var-data codes), which is what unlocks actual interop with the reference `tsp-sdk`. That's the larger change and ripples into the mediator/SDK TSP sniff.