### PR TITLE
fix(mediator): treat empty sender hash as anonymous in store_message

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/store.rs
@@ -42,7 +42,7 @@ impl Database {
         async move {
             let message_hash = digest(message.as_bytes());
 
-            let from_hash = from_hash.unwrap_or("ANONYMOUS");
+            let from_hash = from_hash.filter(|s| !s.is_empty()).unwrap_or("ANONYMOUS");
             debug!(
                 "trying to store msg_id({}), from_hash({:?}) to_hash({}), bytes({})",
                 message_hash,

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -685,7 +685,7 @@ impl MediatorStore for FjallStore {
     ) -> Result<String, MediatorError> {
         let msg_id = digest(message.as_bytes());
         let bytes = message.len();
-        let from = from_hash.unwrap_or("ANONYMOUS").to_string();
+        let from = from_hash.filter(|s| !s.is_empty()).unwrap_or("ANONYMOUS").to_string();
 
         let _guard = self.write_lock.lock().await;
 
@@ -3349,6 +3349,21 @@ mod tests {
         let stats = store.get_global_stats().await.expect("stats");
         assert_eq!(stats.websocket_open, 3);
         assert_eq!(stats.sent_bytes, 100);
+    }
+
+    #[tokio::test]
+    async fn store_message_empty_from_treated_as_anonymous() {
+        // Regression: an anonymous routing/2.0/forward reaches store_message with
+        // an EMPTY from_hash (`Some("")`) rather than `None`. Before the fix the
+        // empty string built an empty store key and fjall asserted `!k.is_empty()`
+        // → panic. The guard now maps an empty hash to ANONYMOUS, so the write
+        // succeeds (redis/memory tolerated the empty key but stored it malformed).
+        let dir = TempDir::new().expect("tempdir");
+        let store = FjallStore::open(dir.path()).expect("open");
+        store
+            .store_message("sess", "ciphertext", &hash("recipient"), Some(""), 0, 0)
+            .await
+            .expect("empty from_hash must not panic — treated as anonymous");
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -380,7 +380,7 @@ impl MediatorStore for MemoryStore {
         let msg_id = digest(message.as_bytes());
         let bytes = message.len();
         let ts_ms = now_ms() as u128;
-        let from = from_hash.unwrap_or("ANONYMOUS").to_string();
+        let from = from_hash.filter(|s| !s.is_empty()).unwrap_or("ANONYMOUS").to_string();
 
         let mut state = self.state.lock().await;
 


### PR DESCRIPTION
An anonymous routing/2.0/forward (no `from`) reaches store_message with an empty sender hash instead of the ANONYMOUS sentinel. The shared from_hash.unwrap_or("ANONYMOUS") normalization only catches None, so the empty string builds an empty store key: the fjall backend asserts non-empty keys and panics; redis/memory silently store a malformed empty-keyed entry. Guard all three backends (fjall, memory, redis) to treat an empty hash as anonymous, plus a fjall regression test. Unblocks block_anonymous_outer_envelope=false (spec-standard anonymous forwards).