### PR TITLE
feat: spec-compliant TSP Routed/Nested payloads + reference-aligned size cap

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 29th June 2026 (later)
+
+### 0.16.34 — follow affinidi-tsp's new routed `next_hop` signature
+
+- The TSP relay now calls `routed::next_hop(&unpacked)` (affinidi-tsp 0.1.9 moved the route
+  into the CESR hop list, so the next hop is derived from the unpacked message rather than
+  re-parsing the payload bytes). No change to the receiver-based dispatch or relay behaviour.
+
 ## 29th June 2026
 
 ### 0.16.33 — TSP routed-by-receiver + new `-E` framing detection

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.33"
+version = "0.16.34"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -131,7 +131,7 @@ pub(crate) async fn handle_inbound_tsp(
         // message, re-sealing as this mediator unless we are the last hop (the
         // opaque inner is already sealed to the final recipient).
         TspMessageType::Routed => {
-            let step = next_hop(&unpacked.payload).map_err(|e| {
+            let step = next_hop(&unpacked).map_err(|e| {
                 tsp_problem(
                     session,
                     37,

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Affinidi TSP Changelog
 
+## 29th June 2026 (later)
+
+### 0.1.9 — spec-compliant Routed/Nested payloads + reference-aligned size cap
+
+- **Routed and Nested payloads now match the ToIP reference (`tsp_sdk`) and interoperate
+  both directions.** The payload frame inside `-Z` is now kind-encoded per the spec:
+  Direct=`XSCS`+`B(body)`, Nested=`XHOP`+empty-hop-list+`B(body)`, Routed=`XHOP`+hop-list+
+  `B(body)` (hops as `-J<count>` + a `B` field per VID). Replaces the previous
+  affinidi-private `ANS`/`ART` markers and the bespoke `encode_route` (the route is now the
+  CESR hop list, not baked into the plaintext). `UnpackedMessage` gains `hops`. New
+  `direct::pack_with_hops`; `routed::next_hop(&UnpackedMessage)` (was `next_hop(&[u8])`).
+  Control stays on its `ACT` marker (relationship interop is a separate follow-up).
+- **Size cap aligned with the reference:** `MAX_FIELD_SIZE` is now `3 * (1 << 24)` (~48 MiB,
+  the reference's `DATA_LIMIT`) instead of 1 MiB, so affinidi accepts any field the reference
+  can validly send; `MAX_MESSAGE_SIZE` (the ciphertext guard) tracks it. `decode_hops` is
+  bounded by `MAX_HOPS` so the larger cap can't let a hostile hop count over-allocate.
+  Verified by a 2 MiB Direct round-trip in the interop harness (exercises the large CESR
+  variable-data code).
+- Wire-breaking for Routed/Nested (Direct unchanged/byte-exact); API: `next_hop` signature
+  changed, `pack_with_hops` added, `pack_routed`/`pack_nested` public signatures unchanged.
+
 ## 29th June 2026
 
 ### 0.1.8 — spec conformance (2/2): CESR wire framing + RFC-9180 HPKE (tsp-sdk interop)

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/lib.rs
+++ b/crates/messaging/affinidi-tsp/src/lib.rs
@@ -331,7 +331,7 @@ impl TspAgent {
             )));
         }
 
-        match message::routed::next_hop(&unpacked.payload)? {
+        match message::routed::next_hop(&unpacked)? {
             // Last intermediary: deliver the opaque inner to the final recipient.
             message::routed::RouteStep::Forward {
                 next,

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -30,9 +30,10 @@ use crate::message::MessageType;
 use crate::message::envelope::Envelope;
 use crate::message::wire;
 
-/// Maximum allowed message size (1 MB) to prevent memory exhaustion from
-/// maliciously crafted length fields on the wire.
-const MAX_MESSAGE_SIZE: usize = 1_048_576;
+/// Maximum allowed ciphertext size, kept in lock-step with the variable-data
+/// field cap (which mirrors the ToIP reference's `DATA_LIMIT`). The ciphertext is
+/// itself a `G` variable-data field, so this matches what the wire layer accepts.
+const MAX_MESSAGE_SIZE: usize = crate::message::wire::MAX_FIELD_SIZE;
 
 /// X25519 encapsulated-key length appended to the ciphertext.
 const ENC_LEN: usize = 32;

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -51,71 +51,82 @@ pub struct PackedMessage {
 /// Result of unpacking a TSP message.
 #[derive(Debug, Clone)]
 pub struct UnpackedMessage {
-    /// The decrypted payload.
+    /// The decrypted payload. For Direct/Control this is the message body; for
+    /// Nested it is the opaque inner packed message; for Routed it is the opaque
+    /// inner message (the route travels in [`UnpackedMessage::hops`]).
     pub payload: Vec<u8>,
+    /// The remaining hop list for a Routed message (empty for Direct, Nested and
+    /// Control).
+    pub hops: Vec<String>,
     /// The sender's VID.
     pub sender: String,
     /// The receiver's VID.
     pub receiver: String,
-    /// The message type (currently always [`MessageType::Direct`] for the
-    /// interop-format Direct payload; other kinds are a follow-up).
+    /// The message type, recovered from the encrypted payload frame.
     pub message_type: MessageType,
 }
 
-/// Affinidi-internal payload-type markers for the message kinds that are not yet
-/// interop-framed. Direct uses the reference's `XSCS` marker verbatim (so a
-/// Direct message is byte-compatible with `tsp-sdk`). The other kinds are
-/// affinidi-private 3-byte markers so [`unpack`] can recover the kind; bringing
-/// them to the reference's `XHOP`/`XRFI`/… framing is a tracked follow-up.
+/// Payload-type markers. Direct/Nested/Routed use the reference `tsp-sdk`
+/// framing verbatim (so they are byte-compatible with `tsp-sdk`):
+///
+///   * Direct → `XSCS`
+///   * Nested → `XHOP` + empty hop list
+///   * Routed → `XHOP` + non-empty hop list
+///
+/// Control stays on an affinidi-private `ACT` marker (the reference's
+/// relationship/control payloads — `XRFI`/`XRFA`/`XRFD` — are out of scope).
 mod payload_marker {
     /// Generic message (Direct) — the reference `XSCS` marker, byte-exact.
     pub const DIRECT: [u8; 3] = crate::message::wire::XSCS;
-    /// Affinidi-private marker for a Nested wrapper payload.
-    pub const NESTED: [u8; 3] = *b"ANS";
-    /// Affinidi-private marker for a Routed-layer payload.
-    pub const ROUTED: [u8; 3] = *b"ART";
-    /// Affinidi-private marker for a Control payload.
+    /// Hop-carrying payload (Nested or Routed) — the reference `XHOP` marker.
+    pub const HOP: [u8; 3] = crate::message::wire::XHOP;
+    /// Affinidi-private marker for a Control payload (out of interop scope).
     pub const CONTROL: [u8; 3] = *b"ACT";
-}
-
-fn marker_for(kind: MessageType) -> [u8; 3] {
-    match kind {
-        MessageType::Direct => payload_marker::DIRECT,
-        MessageType::Nested => payload_marker::NESTED,
-        MessageType::Routed => payload_marker::ROUTED,
-        MessageType::Control => payload_marker::CONTROL,
-    }
-}
-
-fn kind_for(marker: &[u8]) -> Option<MessageType> {
-    match marker {
-        m if m == payload_marker::DIRECT => Some(MessageType::Direct),
-        m if m == payload_marker::NESTED => Some(MessageType::Nested),
-        m if m == payload_marker::ROUTED => Some(MessageType::Routed),
-        m if m == payload_marker::CONTROL => Some(MessageType::Control),
-        _ => None,
-    }
 }
 
 /// Build the CESR payload frame that is encrypted (the HPKE plaintext).
 ///
-/// `-Z<count> <marker> <var-data B> plaintext`. For [`MessageType::Direct`] the
-/// marker is `XSCS`, making the whole frame byte-compatible with `tsp-sdk`'s
-/// generic-message payload.
-fn encode_payload_frame(plaintext: &[u8], kind: MessageType) -> Vec<u8> {
-    let mut body = Vec::with_capacity(3 + plaintext.len() + 3);
-    body.extend_from_slice(&marker_for(kind));
-    wire::encode_variable_data(wire::TSP_PLAINTEXT, plaintext, &mut body);
+/// Layout matches the `tsp_sdk` reference's `encode_payload`:
+///   * Direct  → `-Z<count> XSCS <var-data B> body`
+///   * Nested  → `-Z<count> XHOP -J0 <var-data B> body`
+///   * Routed  → `-Z<count> XHOP -J<n> (B hop)* <var-data B> body`
+///   * Control → `-Z<count> ACT <var-data B> body` (affinidi-private)
+fn encode_payload_frame(body: &[u8], kind: MessageType, hops: &[String]) -> Vec<u8> {
+    let mut frame_body = Vec::with_capacity(3 + body.len() + 3);
+    match kind {
+        MessageType::Direct => {
+            frame_body.extend_from_slice(&payload_marker::DIRECT);
+        }
+        MessageType::Nested => {
+            frame_body.extend_from_slice(&payload_marker::HOP);
+            let no_hops: [&[u8]; 0] = [];
+            wire::encode_hops(&no_hops, &mut frame_body);
+        }
+        MessageType::Routed => {
+            frame_body.extend_from_slice(&payload_marker::HOP);
+            wire::encode_hops(hops, &mut frame_body);
+        }
+        MessageType::Control => {
+            frame_body.extend_from_slice(&payload_marker::CONTROL);
+        }
+    }
+    wire::encode_variable_data(wire::TSP_PLAINTEXT, body, &mut frame_body);
 
-    debug_assert!(body.len().is_multiple_of(3));
-    let mut out = Vec::with_capacity(3 + body.len());
-    wire::encode_count(wire::TSP_PAYLOAD, (body.len() / 3) as u32, &mut out);
-    out.extend_from_slice(&body);
+    debug_assert!(frame_body.len().is_multiple_of(3));
+    let mut out = Vec::with_capacity(3 + frame_body.len());
+    wire::encode_count(wire::TSP_PAYLOAD, (frame_body.len() / 3) as u32, &mut out);
+    out.extend_from_slice(&frame_body);
     out
 }
 
-/// Decode a CESR payload frame, returning the plaintext and message kind.
-fn decode_payload_frame(frame: &[u8]) -> Result<(Vec<u8>, MessageType), TspError> {
+/// Decode a CESR payload frame, returning `(kind, hops, body)`.
+///
+/// `XSCS` → `(Direct, [], body)`; `XHOP` → decode the hop list, an empty list is
+/// `(Nested, [], body)` and a non-empty one is `(Routed, hops, body)`; `ACT` →
+/// `(Control, [], body)`.
+fn decode_payload_frame(
+    frame: &[u8],
+) -> Result<(MessageType, Vec<String>, Vec<u8>), TspError> {
     let mut pos = 0usize;
     wire::decode_count(wire::TSP_PAYLOAD, frame, &mut pos)
         .ok_or_else(|| TspError::InvalidMessage("missing -Z payload frame".into()))?;
@@ -127,14 +138,37 @@ fn decode_payload_frame(frame: &[u8]) -> Result<(Vec<u8>, MessageType), TspError
     let marker = frame
         .get(pos..pos + 3)
         .ok_or_else(|| TspError::InvalidMessage("missing payload type marker".into()))?;
-    let kind = kind_for(marker).ok_or_else(|| {
-        TspError::InvalidMessage("unsupported TSP payload type marker".into())
-    })?;
-    pos += 3;
 
-    let plaintext = wire::decode_variable_data(wire::TSP_PLAINTEXT, frame, &mut pos)
+    let (kind, hops) = if marker == payload_marker::DIRECT {
+        pos += 3;
+        (MessageType::Direct, Vec::new())
+    } else if marker == payload_marker::HOP {
+        pos += 3;
+        let hop_bytes = wire::decode_hops(frame, &mut pos)?;
+        let hops = hop_bytes
+            .into_iter()
+            .map(|h| {
+                String::from_utf8(h)
+                    .map_err(|_| TspError::InvalidMessage("hop VID not UTF-8".into()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if hops.is_empty() {
+            (MessageType::Nested, hops)
+        } else {
+            (MessageType::Routed, hops)
+        }
+    } else if marker == payload_marker::CONTROL {
+        pos += 3;
+        (MessageType::Control, Vec::new())
+    } else {
+        return Err(TspError::InvalidMessage(
+            "unsupported TSP payload type marker".into(),
+        ));
+    };
+
+    let body = wire::decode_variable_data(wire::TSP_PLAINTEXT, frame, &mut pos)
         .ok_or_else(|| TspError::InvalidMessage("missing payload plaintext".into()))?;
-    Ok((plaintext, kind))
+    Ok((kind, hops, body))
 }
 
 /// Encode the signature frame: `-C<n> -K<n> <fixed B> sig`.
@@ -178,12 +212,38 @@ pub fn pack(
     sender_encryption_key: &[u8; 32],
     receiver_encryption_key: &[u8; 32],
 ) -> Result<PackedMessage, TspError> {
+    pack_with_hops(
+        payload,
+        message_type,
+        &[],
+        sender_vid,
+        receiver_vid,
+        sender_signing_key,
+        sender_encryption_key,
+        receiver_encryption_key,
+    )
+}
+
+/// Like [`pack`] but carries a routing `hops` list in the payload frame (used by
+/// [`crate::message::routed::pack_routed`] for [`MessageType::Routed`]). For all
+/// other kinds `hops` must be empty.
+#[allow(clippy::too_many_arguments)]
+pub fn pack_with_hops(
+    body: &[u8],
+    message_type: MessageType,
+    hops: &[String],
+    sender_vid: &str,
+    receiver_vid: &str,
+    sender_signing_key: &[u8; 32],
+    sender_encryption_key: &[u8; 32],
+    receiver_encryption_key: &[u8; 32],
+) -> Result<PackedMessage, TspError> {
     // 1. Envelope frame = HPKE info.
     let envelope = Envelope::new(message_type, sender_vid, receiver_vid);
     let envelope_bytes = envelope.encode()?;
 
     // 2. CESR payload frame, then HPKE-Auth seal it.
-    let payload_frame = encode_payload_frame(payload, message_type);
+    let payload_frame = encode_payload_frame(body, message_type, hops);
     let sealed = hpke::seal(
         &payload_frame,
         b"", // AAD is empty in the reference
@@ -272,10 +332,11 @@ pub fn unpack(
     )?;
 
     // 5. Decode the CESR payload frame.
-    let (payload, message_type) = decode_payload_frame(&payload_frame)?;
+    let (message_type, hops, payload) = decode_payload_frame(&payload_frame)?;
 
     Ok(UnpackedMessage {
         payload,
+        hops,
         sender: envelope.sender,
         receiver: envelope.receiver,
         message_type,

--- a/crates/messaging/affinidi-tsp/src/message/routed.rs
+++ b/crates/messaging/affinidi-tsp/src/message/routed.rs
@@ -8,9 +8,12 @@
 //! itself. The **inner** message is opaque to every intermediary: it is sealed
 //! end-to-end to the exit/recipient and merely carried.
 //!
-//! Routing-layer wire layout (the plaintext sealed to each hop):
+//! Routing-layer wire layout: the remaining hop list and the opaque inner
+//! message are carried as separate fields of the CESR payload frame (see
+//! [`crate::message::direct`]), byte-compatible with the `tsp_sdk` reference's
+//! `Payload::RoutedMessage(hops, inner)`:
 //! ```text
-//! [hop_count:u16] ( [vid_len:u16][vid utf8] )*  [inner_len:u32][inner bytes]
+//! -Z<count> XHOP -J<n> (B hop)*  <var-data B> inner
 //! ```
 //!
 //! **Nested mode** is the degenerate metadata-privacy wrapper: an inner packed
@@ -25,106 +28,17 @@
 
 use crate::error::TspError;
 use crate::message::MessageType;
-use crate::message::direct::{self, PackedMessage};
+use crate::message::direct::{self, PackedMessage, UnpackedMessage};
 
 /// Maximum number of hops in a route, bounding both memory and forwarding loops.
 pub const MAX_HOPS: usize = 16;
-
-/// Maximum inner-message size carried in a routing layer (mirrors direct mode).
-const MAX_INNER_SIZE: usize = 1_048_576;
-
-/// Encode a routing payload: the remaining hop list followed by the opaque inner
-/// message. This is the plaintext that gets HPKE-sealed to the addressed hop.
-pub(crate) fn encode_route(remaining: &[String], inner: &[u8]) -> Result<Vec<u8>, TspError> {
-    if remaining.len() > MAX_HOPS {
-        return Err(TspError::InvalidMessage(format!(
-            "route has {} hops, exceeds maximum of {MAX_HOPS}",
-            remaining.len()
-        )));
-    }
-    if inner.len() > MAX_INNER_SIZE {
-        return Err(TspError::InvalidMessage(format!(
-            "inner message {} bytes exceeds maximum of {MAX_INNER_SIZE}",
-            inner.len()
-        )));
-    }
-
-    let mut buf = Vec::new();
-    buf.extend_from_slice(&(remaining.len() as u16).to_be_bytes());
-    for vid in remaining {
-        let bytes = vid.as_bytes();
-        let len = u16::try_from(bytes.len())
-            .map_err(|_| TspError::InvalidMessage("hop VID too long".into()))?;
-        buf.extend_from_slice(&len.to_be_bytes());
-        buf.extend_from_slice(bytes);
-    }
-    buf.extend_from_slice(&(inner.len() as u32).to_be_bytes());
-    buf.extend_from_slice(inner);
-    Ok(buf)
-}
-
-/// Decode a routing payload into `(remaining_route, inner)`.
-pub(crate) fn decode_route(bytes: &[u8]) -> Result<(Vec<String>, Vec<u8>), TspError> {
-    let mut pos = 0usize;
-    let hop_count = read_u16(bytes, &mut pos)? as usize;
-    if hop_count > MAX_HOPS {
-        return Err(TspError::InvalidMessage(format!(
-            "routing header claims {hop_count} hops, exceeds maximum of {MAX_HOPS}"
-        )));
-    }
-
-    let mut route = Vec::with_capacity(hop_count);
-    for _ in 0..hop_count {
-        let len = read_u16(bytes, &mut pos)? as usize;
-        let end = pos
-            .checked_add(len)
-            .filter(|e| *e <= bytes.len())
-            .ok_or_else(|| TspError::InvalidMessage("routing hop VID truncated".into()))?;
-        let vid = std::str::from_utf8(&bytes[pos..end])
-            .map_err(|_| TspError::InvalidMessage("routing hop VID not UTF-8".into()))?
-            .to_string();
-        route.push(vid);
-        pos = end;
-    }
-
-    let inner_len = read_u32(bytes, &mut pos)? as usize;
-    if inner_len > MAX_INNER_SIZE {
-        return Err(TspError::InvalidMessage(format!(
-            "inner message length {inner_len} exceeds maximum of {MAX_INNER_SIZE}"
-        )));
-    }
-    let end = pos
-        .checked_add(inner_len)
-        .filter(|e| *e <= bytes.len())
-        .ok_or_else(|| TspError::InvalidMessage("inner message truncated".into()))?;
-    let inner = bytes[pos..end].to_vec();
-    Ok((route, inner))
-}
-
-fn read_u16(bytes: &[u8], pos: &mut usize) -> Result<u16, TspError> {
-    let end = pos
-        .checked_add(2)
-        .filter(|e| *e <= bytes.len())
-        .ok_or_else(|| TspError::InvalidMessage("routing payload truncated (u16)".into()))?;
-    let v = u16::from_be_bytes(bytes[*pos..end].try_into().unwrap());
-    *pos = end;
-    Ok(v)
-}
-
-fn read_u32(bytes: &[u8], pos: &mut usize) -> Result<u32, TspError> {
-    let end = pos
-        .checked_add(4)
-        .filter(|e| *e <= bytes.len())
-        .ok_or_else(|| TspError::InvalidMessage("routing payload truncated (u32)".into()))?;
-    let v = u32::from_be_bytes(bytes[*pos..end].try_into().unwrap());
-    *pos = end;
-    Ok(v)
-}
 
 /// Pack a routed message addressed to `first_hop`, carrying `remaining_route`
 /// (the hops to visit after `first_hop`, in order) and the opaque `inner`
 /// message (already sealed end-to-end to the exit/recipient).
 ///
+/// The route + inner travel as separate CESR fields of the payload frame (the
+/// `tsp_sdk` `RoutedMessage(hops, inner)` framing), not baked into the plaintext.
 /// The full path is `[first_hop] ++ remaining_route`; when an intermediary's
 /// remaining route is empty it is the exit and consumes `inner`.
 #[allow(clippy::too_many_arguments)]
@@ -137,10 +51,21 @@ pub fn pack_routed(
     sender_encryption_key: &[u8; 32],
     first_hop_encryption_key: &[u8; 32],
 ) -> Result<PackedMessage, TspError> {
-    let routing = encode_route(remaining_route, inner)?;
-    direct::pack(
-        &routing,
+    if remaining_route.is_empty() {
+        return Err(TspError::InvalidMessage(
+            "a routed message requires at least one onward hop".into(),
+        ));
+    }
+    if remaining_route.len() > MAX_HOPS {
+        return Err(TspError::InvalidMessage(format!(
+            "route has {} hops, exceeds maximum of {MAX_HOPS}",
+            remaining_route.len()
+        )));
+    }
+    direct::pack_with_hops(
+        inner,
         MessageType::Routed,
+        remaining_route,
         sender_vid,
         first_hop_vid,
         sender_signing_key,
@@ -190,16 +115,24 @@ pub enum RouteStep {
     },
 }
 
-/// Determine the next routing step from a decrypted routed payload (the
-/// `payload` returned by unpacking a [`MessageType::Routed`] message).
-pub fn next_hop(routing_payload: &[u8]) -> Result<RouteStep, TspError> {
-    let (route, inner) = decode_route(routing_payload)?;
-    match route.split_first() {
-        None => Ok(RouteStep::Deliver { inner }),
+/// Determine the next routing step from an unpacked [`MessageType::Routed`]
+/// message: its `hops` are the remaining route and its `payload` is the opaque
+/// inner message.
+pub fn next_hop(unpacked: &UnpackedMessage) -> Result<RouteStep, TspError> {
+    next_hop_parts(&unpacked.hops, &unpacked.payload)
+}
+
+/// Variant of [`next_hop`] that takes the remaining route and inner message
+/// directly (the route VIDs and the opaque inner bytes).
+pub fn next_hop_parts(hops: &[String], inner: &[u8]) -> Result<RouteStep, TspError> {
+    match hops.split_first() {
+        None => Ok(RouteStep::Deliver {
+            inner: inner.to_vec(),
+        }),
         Some((next, rest)) => Ok(RouteStep::Forward {
             next: next.clone(),
             remaining: rest.to_vec(),
-            inner,
+            inner: inner.to_vec(),
         }),
     }
 }
@@ -233,26 +166,40 @@ mod tests {
     }
 
     #[test]
-    fn encode_decode_route_roundtrip() {
-        let route = vec!["did:web:hop2".to_string(), "did:web:exit".to_string()];
-        let inner = b"opaque inner message".to_vec();
-        let encoded = encode_route(&route, &inner).unwrap();
-        let (decoded_route, decoded_inner) = decode_route(&encoded).unwrap();
-        assert_eq!(decoded_route, route);
-        assert_eq!(decoded_inner, inner);
+    fn pack_routed_rejects_empty_route() {
+        let alice = party("did:web:alice");
+        let hop1 = party("did:web:hop1");
+        assert!(
+            pack_routed(
+                b"inner",
+                &[],
+                &alice.vid,
+                &hop1.vid,
+                &alice.sign_sk,
+                &alice.enc_sk,
+                &hop1.enc_pk,
+            )
+            .is_err()
+        );
     }
 
     #[test]
-    fn decode_route_rejects_truncation() {
-        assert!(decode_route(&[0x00]).is_err()); // not even a full hop_count
-        // hop_count = 1 but no hop follows
-        assert!(decode_route(&[0x00, 0x01]).is_err());
-    }
-
-    #[test]
-    fn encode_route_rejects_too_many_hops() {
+    fn pack_routed_rejects_too_many_hops() {
+        let alice = party("did:web:alice");
+        let hop1 = party("did:web:hop1");
         let route: Vec<String> = (0..MAX_HOPS + 1).map(|i| format!("did:web:h{i}")).collect();
-        assert!(encode_route(&route, b"x").is_err());
+        assert!(
+            pack_routed(
+                b"x",
+                &route,
+                &alice.vid,
+                &hop1.vid,
+                &alice.sign_sk,
+                &alice.enc_sk,
+                &hop1.enc_pk,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -260,8 +207,7 @@ mod tests {
         // route [hop2, exit]: first step forwards to hop2 leaving [exit];
         // then [exit] forwards to exit leaving []; then [] delivers.
         let inner = b"payload".to_vec();
-        let p1 = encode_route(&["hop2".into(), "exit".into()], &inner).unwrap();
-        match next_hop(&p1).unwrap() {
+        match next_hop_parts(&["hop2".into(), "exit".into()], &inner).unwrap() {
             RouteStep::Forward {
                 next,
                 remaining,
@@ -274,8 +220,10 @@ mod tests {
             other => panic!("expected Forward, got {other:?}"),
         }
 
-        let p_exit = encode_route(&[], &inner).unwrap();
-        assert_eq!(next_hop(&p_exit).unwrap(), RouteStep::Deliver { inner });
+        assert_eq!(
+            next_hop_parts(&[], &inner).unwrap(),
+            RouteStep::Deliver { inner }
+        );
     }
 
     /// Full multi-hop crypto round-trip: alice → hop1 → hop2 (exit) carrying an
@@ -317,7 +265,7 @@ mod tests {
         // 3. hop1 opens its layer (it is the receiver), reads the route.
         let at_hop1 = unpack(&layer1.bytes, &hop1.enc_sk, &alice.enc_pk, &alice.sign_pk).unwrap();
         assert_eq!(at_hop1.message_type, MessageType::Routed);
-        let step1 = next_hop(&at_hop1.payload).unwrap();
+        let step1 = next_hop(&at_hop1).unwrap();
         let (next1, rest1, carried1) = match step1 {
             RouteStep::Forward {
                 next,
@@ -345,7 +293,7 @@ mod tests {
 
         // 5. hop2 opens its layer, sees route [final] → forward/deliver to final.
         let at_hop2 = unpack(&layer2.bytes, &hop2.enc_sk, &hop1.enc_pk, &hop1.sign_pk).unwrap();
-        let step2 = next_hop(&at_hop2.payload).unwrap();
+        let step2 = next_hop(&at_hop2).unwrap();
         let (next2, rest2, carried2) = match step2 {
             RouteStep::Forward {
                 next,

--- a/crates/messaging/affinidi-tsp/src/message/wire.rs
+++ b/crates/messaging/affinidi-tsp/src/message/wire.rs
@@ -35,9 +35,10 @@ const D8: u32 = D0 + 8;
 const D9: u32 = D0 + 9;
 const DASH: u32 = 62;
 
-/// Maximum size we will allocate / accept for a single variable-data field
-/// (1 MiB), guarding against hostile size headers.
-pub const MAX_FIELD_SIZE: usize = 1_048_576;
+/// Maximum size we accept for a single variable-data field, mirroring the ToIP
+/// reference (`tsp_sdk`'s `DATA_LIMIT = 3 * (1 << 24)`, ~48 MiB) so we accept any
+/// field the reference can validly produce. Guards against hostile size headers.
+pub const MAX_FIELD_SIZE: usize = 3 * (1 << 24);
 
 /// Interpret a base64url string as a big-endian integer of its 6-bit symbols.
 /// Used to derive the numeric identifier of single/short CESR codes (e.g. the
@@ -207,7 +208,9 @@ pub fn encode_hops(hops: &[impl AsRef<[u8]>], out: &mut Vec<u8>) {
 pub fn decode_hops(stream: &[u8], pos: &mut usize) -> Result<Vec<Vec<u8>>, TspError> {
     let count = decode_count(TSP_HOP_LIST, stream, pos)
         .ok_or_else(|| TspError::InvalidMessage("missing -J hop list".into()))?;
-    if count as usize > MAX_FIELD_SIZE {
+    // The hop list is a route; bound the count by the route limit (not the much
+    // larger field-size cap) so a hostile count can't pre-allocate gigabytes.
+    if count as usize > crate::message::routed::MAX_HOPS {
         return Err(TspError::InvalidMessage("hop list too long".into()));
     }
     let mut hops = Vec::with_capacity(count as usize);

--- a/crates/messaging/affinidi-tsp/src/message/wire.rs
+++ b/crates/messaging/affinidi-tsp/src/message/wire.rs
@@ -113,13 +113,18 @@ pub const TSP_TMP: u32 = cesr_int("X") as u32;
 pub const TSP_ETS_WRAPPER: u16 = cesr_int("E") as u16;
 /// `-Z`: count-code wrapper for the (to-be-encrypted) CESR payload frame.
 pub const TSP_PAYLOAD: u16 = cesr_int("Z") as u16;
+/// `-J`: count-code group for a hop (routing) list.
+pub const TSP_HOP_LIST: u16 = cesr_int("J") as u16;
 /// `-C`: count-code attach group for the signature.
 pub const TSP_ATTACH_GRP: u16 = cesr_int("C") as u16;
 /// `-K`: count-code indexed-signature group for the signature.
 pub const TSP_INDEX_SIG_GRP: u16 = cesr_int("K") as u16;
 
-/// 3-byte payload-type marker for a generic (GenericMessage) payload.
+/// 3-byte payload-type marker for a generic (GenericMessage / Content) payload.
 pub const XSCS: [u8; 3] = cesr_data("XSCS");
+/// 3-byte payload-type marker for a hop-carrying payload (Nested when the hop
+/// list is empty, Routed otherwise).
+pub const XHOP: [u8; 3] = cesr_data("XHOP");
 /// 3-byte TSP version genus marker.
 pub const YTSP: [u8; 3] = cesr_data("YTSP");
 
@@ -184,6 +189,34 @@ pub fn encode_count(identifier: u16, count: u32, out: &mut Vec<u8>) {
 pub fn encode_version(out: &mut Vec<u8>) {
     out.extend_from_slice(&YTSP);
     encode_count(TSP_VERSION.0, encoded_version() as u32, out);
+}
+
+/// Encode a hop (routing) list: a `-J<count>` group header followed by one
+/// `B` var-data field per hop VID. Byte-compatible with `tsp_sdk`'s
+/// `encode_hops`. An empty list encodes to just the `-J0` header (this is how
+/// a Nested payload is distinguished from a Routed one).
+pub fn encode_hops(hops: &[impl AsRef<[u8]>], out: &mut Vec<u8>) {
+    encode_count(TSP_HOP_LIST, hops.len() as u32, out);
+    for hop in hops {
+        encode_variable_data(TSP_VID, hop.as_ref(), out);
+    }
+}
+
+/// Decode a hop (routing) list at `*pos`. On success advances `*pos` past the
+/// `-J` group + every hop field and returns the hop VID byte vectors.
+pub fn decode_hops(stream: &[u8], pos: &mut usize) -> Result<Vec<Vec<u8>>, TspError> {
+    let count = decode_count(TSP_HOP_LIST, stream, pos)
+        .ok_or_else(|| TspError::InvalidMessage("missing -J hop list".into()))?;
+    if count as usize > MAX_FIELD_SIZE {
+        return Err(TspError::InvalidMessage("hop list too long".into()));
+    }
+    let mut hops = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let hop = decode_variable_data(TSP_VID, stream, pos)
+            .ok_or_else(|| TspError::InvalidMessage("malformed hop VID".into()))?;
+        hops.push(hop);
+    }
+    Ok(hops)
 }
 
 // ---- Decoding ----
@@ -389,6 +422,29 @@ mod tests {
         let got = decode_fixed_data::<2>(TSP_TMP, &buf, &mut pos).unwrap();
         assert_eq!(got, [0, 0]);
         assert_eq!(pos, 3);
+    }
+
+    #[test]
+    fn hops_empty_roundtrip() {
+        let mut buf = Vec::new();
+        let no_hops: [&[u8]; 0] = [];
+        encode_hops(&no_hops, &mut buf);
+        // Just the -J0 count header.
+        let mut pos = 0;
+        let got = decode_hops(&buf, &mut pos).unwrap();
+        assert!(got.is_empty());
+        assert_eq!(pos, buf.len());
+    }
+
+    #[test]
+    fn hops_roundtrip() {
+        let hops = [b"did:web:hop1".as_slice(), b"did:web:exit".as_slice()];
+        let mut buf = Vec::new();
+        encode_hops(&hops, &mut buf);
+        let mut pos = 0;
+        let got = decode_hops(&buf, &mut pos).unwrap();
+        assert_eq!(got, vec![b"did:web:hop1".to_vec(), b"did:web:exit".to_vec()]);
+        assert_eq!(pos, buf.len());
     }
 
     #[test]

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -171,6 +171,42 @@ fn main() {
         results.push(("Direct R->A", ok));
     }
 
+    // Large-payload Direct: 2 MiB exercises the *large* CESR variable-data code
+    // (>12 KiB) AND proves the raised MAX_FIELD_SIZE accepts what the old 1 MiB
+    // cap would have rejected. Confirms the size-cap alignment interoperates.
+    {
+        let big = vec![0x5au8; 2 * 1024 * 1024];
+        let packed = atsp::pack(
+            &big,
+            MessageType::Direct,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack 2MiB");
+        let mut buf = packed.bytes.clone();
+        let ar = matches!(
+            tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf),
+            Ok((_, Payload::Content(c), _, _)) if c == big.as_slice()
+        );
+        results.push(("Direct(2MiB) A->R", ar));
+
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::Content(big.as_slice()),
+        )
+        .expect("tsp_sdk seal 2MiB");
+        let ra = matches!(
+            atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk),
+            Ok(u) if u.payload == big
+        );
+        results.push(("Direct(2MiB) R->A", ra));
+    }
+
     // The route hops carried inside the payload frame. They are arbitrary VID
     // byte strings as far as the framing is concerned.
     let route_strs = vec!["did:web:hop2.example".to_string(), bob_id.to_string()];

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -5,6 +5,7 @@
 //! directions.
 
 use affinidi_tsp::message::direct as atsp;
+use affinidi_tsp::message::routed as artd;
 use affinidi_tsp::message::MessageType;
 use base64ct::{Base64UrlUnpadded, Encoding};
 use ed25519_dalek::SigningKey;
@@ -142,8 +143,198 @@ fn main() {
     }
     println!();
 
+    // A running PASS/FAIL tally for the four interop gate cases (Routed/Nested
+    // both directions). Direct is exercised above and re-checked here.
+    let mut results: Vec<(&str, bool)> = Vec::new();
+
+    // Re-run the two Direct cases into the tally so the gate report is complete.
+    {
+        let mut buf = a_packed.bytes.clone();
+        let ok = matches!(
+            tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf),
+            Ok((_, Payload::Content(c), _, _)) if c == payload
+        );
+        results.push(("Direct A->R", ok));
+    }
+    {
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::Content(payload.as_slice()),
+        )
+        .expect("tsp_sdk seal");
+        let ok = matches!(
+            atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk),
+            Ok(u) if u.payload == payload
+        );
+        results.push(("Direct R->A", ok));
+    }
+
+    // The route hops carried inside the payload frame. They are arbitrary VID
+    // byte strings as far as the framing is concerned.
+    let route_strs = vec!["did:web:hop2.example".to_string(), bob_id.to_string()];
+    let route_bytes: Vec<&[u8]> = route_strs.iter().map(|s| s.as_bytes()).collect();
+    let inner = b"opaque inner message";
+
+    // ================= ROUTED =================
+    println!("\n========== ROUTED ==========");
+
+    // ---- A->R: affinidi pack_routed -> tsp_sdk open (expect RoutedMessage) ----
+    println!("--- A->R: affinidi pack_routed -> tsp_sdk open ---");
+    {
+        let packed = artd::pack_routed(
+            inner,
+            &route_strs,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack_routed");
+        let mut buf = packed.bytes.clone();
+        let ok = match tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf) {
+            Ok((_ncd, Payload::RoutedMessage(hops, body), ct, st)) => {
+                let hops_match = hops == route_bytes;
+                let body_match = body == inner;
+                println!(
+                    "  RESULT: OK crypto={ct:?} sig={st:?} hops_match={hops_match} body_match={body_match}"
+                );
+                hops_match && body_match
+            }
+            Ok((_, other, _, _)) => {
+                println!("  RESULT: FAIL -> unexpected payload kind: {other:?}");
+                false
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Routed A->R", ok));
+    }
+
+    // ---- R->A: tsp_sdk seal RoutedMessage -> affinidi unpack ----
+    println!("--- R->A: tsp_sdk seal RoutedMessage -> affinidi unpack ---");
+    {
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::RoutedMessage(route_bytes.clone(), inner.as_slice()),
+        )
+        .expect("tsp_sdk seal routed");
+        let ok = match atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk) {
+            Ok(u) => {
+                let kind_ok = u.message_type == MessageType::Routed;
+                let hops_match = u.hops == route_strs;
+                let body_match = u.payload == inner;
+                println!(
+                    "  RESULT: OK kind={:?} hops_match={hops_match} body_match={body_match}",
+                    u.message_type
+                );
+                kind_ok && hops_match && body_match
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Routed R->A", ok));
+    }
+
+    // ================= NESTED =================
+    println!("\n========== NESTED ==========");
+
+    // ---- A->R: affinidi pack_nested -> tsp_sdk open (expect NestedMessage) ----
+    println!("--- A->R: affinidi pack_nested -> tsp_sdk open ---");
+    {
+        // pack_nested wraps an already-packed PackedMessage; for a framing test we
+        // can wrap any opaque bytes by constructing a PackedMessage via a Direct
+        // pack so the inner is a real TSP message.
+        let inner_packed = atsp::pack(
+            b"for bob only",
+            MessageType::Direct,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("inner pack");
+        let packed = artd::pack_nested(
+            &inner_packed,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack_nested");
+        let mut buf = packed.bytes.clone();
+        let ok = match tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf) {
+            Ok((_ncd, Payload::NestedMessage(body), ct, st)) => {
+                let body_match = body.as_ref() == inner_packed.bytes.as_slice();
+                println!("  RESULT: OK crypto={ct:?} sig={st:?} body_match={body_match}");
+                body_match
+            }
+            Ok((_, other, _, _)) => {
+                println!("  RESULT: FAIL -> unexpected payload kind: {other:?}");
+                false
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Nested A->R", ok));
+    }
+
+    // ---- R->A: tsp_sdk seal NestedMessage -> affinidi unpack ----
+    println!("--- R->A: tsp_sdk seal NestedMessage -> affinidi unpack ---");
+    {
+        let nested_inner = b"nested inner bytes";
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::NestedMessage(nested_inner.as_slice()),
+        )
+        .expect("tsp_sdk seal nested");
+        let ok = match atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk) {
+            Ok(u) => {
+                let kind_ok = u.message_type == MessageType::Nested;
+                let body_match = u.payload == nested_inner;
+                let hops_empty = u.hops.is_empty();
+                println!(
+                    "  RESULT: OK kind={:?} body_match={body_match} hops_empty={hops_empty}",
+                    u.message_type
+                );
+                kind_ok && body_match && hops_empty
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Nested R->A", ok));
+    }
+
+    // ================= SUMMARY =================
+    println!("\n========== INTEROP GATE SUMMARY ==========");
+    let mut all_ok = true;
+    for (name, ok) in &results {
+        println!("  {:<14} {}", name, if *ok { "PASS" } else { "FAIL" });
+        all_ok &= ok;
+    }
+    println!(
+        "  ----\n  OVERALL: {}",
+        if all_ok { "PASS" } else { "FAIL" }
+    );
+
     // ---- Diagnostic: does tsp_sdk round-trip with itself using these keys? ----
-    println!("--- Sanity: tsp_sdk self round-trip with the same raw keys ---");
+    println!("\n--- Sanity: tsp_sdk self round-trip with the same raw keys ---");
     {
         let mut sealed = tsp_sdk::crypto::seal(
             &alice_vid,


### PR DESCRIPTION
## Summary

Follow-up to #542 (which made **Direct** messages interoperate with the ToIP reference `tsp_sdk`). This makes **Routed** and **Nested** payloads spec-compliant too, so they interoperate both directions, and aligns affinidi's max message-size cap with the reference.

## What changed

**Routed/Nested payload encoding (`affinidi-tsp` 0.1.8 → 0.1.9)**
- The payload frame inside `-Z` is now kind-encoded exactly as the reference (`tsp_sdk/src/cesr/packet.rs`):
  - Direct → `XSCS` + `B(body)` (unchanged, byte-exact)
  - **Nested** → `XHOP` + *empty* hop-list + `B(body)`
  - **Routed** → `XHOP` + hop-list + `B(body)`, hops = `-J<count>` + a `B` field per VID
- Replaces the affinidi-private `ANS`/`ART` markers and the bespoke `encode_route` (the route is now the CESR hop list, not baked into the plaintext). `UnpackedMessage` gains `hops`. New `direct::pack_with_hops`; `routed::next_hop(&UnpackedMessage)` (was `next_hop(&[u8])`). **Control stays on its `ACT` marker** — relationship-payload (`XRFI`/`XRFA`/`XRFD`) interop is a separate follow-up.

**Size cap aligned with the reference**
- `MAX_FIELD_SIZE` raised from 1 MiB to `3 * (1 << 24)` (~48 MiB — the reference's `DATA_LIMIT`), so affinidi accepts any field the reference can validly send; `MAX_MESSAGE_SIZE` (ciphertext guard) now tracks it. `decode_hops` is bounded by `MAX_HOPS` so the larger cap can't let a hostile hop count over-allocate.
- This caught a **latent bug**: affinidi rejected its own valid >1 MiB ciphertext via a separate guard. Now fixed.

**Mediator (0.16.33 → 0.16.34)** — the TSP relay follows the new `next_hop` signature; dispatch/relay behaviour unchanged.

## Message-size behaviour (no per-hop growth)
Routed mode re-seals per hop (not cumulative onion layering): the opaque inner is constant and the hop list shrinks by one VID per hop, so size is constant-to-decreasing across hops. The CESR hop encoding adds only small, bounded per-hop overhead.

## Tests / interop
- `interop/` harness: **all 8 cases PASS** — Direct, Routed, Nested (each both directions) + a **2 MiB Direct** round-trip (exercises the large CESR variable-data code and the raised cap).
- `affinidi-tsp`: 91/91. `tsp_delivery` e2e: 6/6 (direct, routed, routed-remote, nested, control, didcomm-bridge). Clippy clean.