### PR TITLE
feat: spec-compliant TSP relationship Control — full tsp_sdk wire parity

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.41] - 2026-06-29
+
+- TSP relationship methods follow affinidi-tsp 0.1.10's spec-compliant Control encoding:
+  `accept_relationship` / `cancel_relationship` now take the invite's thread digest (the
+  SHA-256 of the invite's payload frame) for cross-impl correlation, and a new
+  `TspOps::unpack_control` returns `(ControlMessage, sender, thread_digest)`.
+
 ## [0.18.40] - 2026-06-29
 
 - Doc/comment updates for affinidi-tsp 0.1.8's new `-E` CESR wire framing. No functional

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.40"
+version = "0.18.41"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -27,7 +27,7 @@ use affinidi_did_common::DocumentExt;
 use affinidi_secrets_resolver::SecretsResolver;
 use affinidi_secrets_resolver::secrets::KeyType;
 use affinidi_tsp::message::control::{ControlMessage, ControlType};
-use affinidi_tsp::message::direct::{self, PackedMessage};
+use affinidi_tsp::message::direct;
 use affinidi_tsp::relationship::{InvalidTransition, RelationshipEvent, RelationshipState};
 use affinidi_tsp::{DidVidResolver, MessageType, MetaEnvelope};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
@@ -389,28 +389,29 @@ impl TspOps<'_> {
     /// [`Bidirectional`]), send a Relationship Forming Accept referencing the
     /// invite, then persist.
     ///
-    /// `invite_wire` is the raw qb2 bytes of the received invite message (as
-    /// returned by [`TspOps::decode`]); its BLAKE2s-256 digest is carried in the
-    /// accept as the thread reference. State is only persisted after the accept
-    /// is successfully sent. Returns the new state ([`Bidirectional`]).
+    /// `invite_thread_digest` is the received invite's TSP **thread digest** —
+    /// the `SHA256` of its plaintext payload frame, which the recipient obtains
+    /// by unpacking the invite (see [`TspOps::unpack_control`]). It is carried in
+    /// the accept as the `reply` digest, byte-compatible with the reference's
+    /// `AcceptRelationship { thread_id }`. State is only persisted after the
+    /// accept is successfully sent. Returns the new state ([`Bidirectional`]).
     ///
     /// [`Bidirectional`]: RelationshipState::Bidirectional
     pub async fn accept_relationship(
         &self,
         profile: &Arc<ATMProfile>,
         their_did: &str,
-        invite_wire: &[u8],
+        invite_thread_digest: [u8; 32],
     ) -> Result<RelationshipState, ATMError> {
         let (our_did, _) = profile.dids()?;
         let store = self.relationship_store();
         let next = next_state(store, our_did, their_did, RelationshipEvent::SendAccept).await?;
-        // `direct::message_digest` takes a `PackedMessage`; wrap the wire bytes.
-        let digest = direct::message_digest(&PackedMessage {
-            bytes: invite_wire.to_vec(),
-        })
-        .to_vec();
-        self.send_control(profile, their_did, &ControlMessage::accept(digest))
-            .await?;
+        self.send_control(
+            profile,
+            their_did,
+            &ControlMessage::accept(invite_thread_digest),
+        )
+        .await?;
         store.set(our_did, their_did, next).await?;
         Ok(next)
     }
@@ -420,8 +421,11 @@ impl TspOps<'_> {
     /// [`Bidirectional`] → [`RelationshipState::None`]), send a Relationship
     /// Cancel control message, then persist.
     ///
-    /// State is only persisted after the cancel is successfully sent. Returns
-    /// the new state ([`RelationshipState::None`]).
+    /// `thread_digest` is the relationship-forming message's thread digest (the
+    /// invite's `SHA256` plaintext-frame digest) referenced as the cancel
+    /// `reply`, byte-compatible with the reference's `CancelRelationship {
+    /// thread_id }`. State is only persisted after the cancel is successfully
+    /// sent. Returns the new state ([`RelationshipState::None`]).
     ///
     /// [`Pending`]: RelationshipState::Pending
     /// [`InviteReceived`]: RelationshipState::InviteReceived
@@ -430,11 +434,12 @@ impl TspOps<'_> {
         &self,
         profile: &Arc<ATMProfile>,
         their_did: &str,
+        thread_digest: [u8; 32],
     ) -> Result<RelationshipState, ATMError> {
         let (our_did, _) = profile.dids()?;
         let store = self.relationship_store();
         let next = next_state(store, our_did, their_did, RelationshipEvent::SendCancel).await?;
-        self.send_control(profile, their_did, &ControlMessage::cancel())
+        self.send_control(profile, their_did, &ControlMessage::cancel(thread_digest))
             .await?;
         store.set(our_did, their_did, next).await?;
         Ok(next)
@@ -561,6 +566,45 @@ impl TspOps<'_> {
         .map_err(|e| ATMError::MsgReceiveError(format!("couldn't unpack TSP message: {e}")))?;
 
         Ok((unpacked.payload, unpacked.sender))
+    }
+
+    /// Unpack a fetched TSP **control** message (raw qb2 bytes), returning the
+    /// decoded [`ControlMessage`], the sender VID, and the message's TSP
+    /// **thread digest** (`SHA256` of its plaintext frame).
+    ///
+    /// For an invite, the returned `thread_digest` is the value to pass to
+    /// [`TspOps::accept_relationship`] (and, later,
+    /// [`TspOps::cancel_relationship`]) as the relationship reference.
+    pub async fn unpack_control(
+        &self,
+        profile: &Arc<ATMProfile>,
+        qb2: &[u8],
+    ) -> Result<(ControlMessage, String, [u8; 32]), ATMError> {
+        let meta = MetaEnvelope::parse(qb2)
+            .map_err(|e| ATMError::MsgReceiveError(format!("couldn't parse TSP envelope: {e}")))?;
+
+        let (profile_did, _) = profile.dids()?;
+        if meta.receiver != profile_did {
+            return Err(ATMError::MsgReceiveError(format!(
+                "TSP message addressed to {}, not this profile ({profile_did})",
+                meta.receiver
+            )));
+        }
+
+        let (_signing_key, decryption_key) = self.profile_tsp_keys(profile_did).await?;
+        let sender = self.resolve_vid(&meta.sender).await?;
+        let unpacked = direct::unpack(
+            qb2,
+            &decryption_key,
+            &sender.encryption_key,
+            &sender.signing_key,
+        )
+        .map_err(|e| ATMError::MsgReceiveError(format!("couldn't unpack TSP message: {e}")))?;
+
+        let control = unpacked.control.ok_or_else(|| {
+            ATMError::MsgReceiveError("TSP message is not a control message".into())
+        })?;
+        Ok((control, unpacked.sender, unpacked.thread_digest))
     }
 
     // ── WebSocket (raw-TSP) delivery ──────────────────────────────────────────

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Affinidi TSP Changelog
 
+## 29th June 2026 (control)
+
+### 0.1.10 — spec-compliant relationship Control (full tsp_sdk wire parity)
+
+- **Relationship Control (invite / accept / cancel) now matches the ToIP reference and
+  interoperates both directions** — completing full TSP wire parity (Direct/Routed/Nested/
+  Control all interop with `tsp_sdk`). Control payloads are now CESR-coded per the spec:
+  invite → `XRFI` + hop list + 32-byte `TSP_NONCE` + empty VID; accept → `XRFA` + 32-byte
+  SHA-256 `reply`; cancel → `XRFD` + 32-byte SHA-256 `reply`. Replaces the previous
+  serde-serialized `ACT` marker and 16-byte nonce.
+- **Correlation digest = `SHA256(plaintext payload frame)`** (`thread_digest`), computed at
+  `pack` (before sealing) and `unpack` (after decrypt), byte-identical to the reference's
+  `thread_id`. The accept/cancel `reply` references the invite's `thread_digest`. (BLAKE2s
+  `message_digest` is retained only as an opaque message id.)
+- `ControlMessage` is now `{ control_type, nonce: Option<[u8;32]>, reply: Option<[u8;32]>,
+  route }`; `PackedMessage`/`UnpackedMessage` expose `thread_digest`. The relationship FSM
+  records the invite digest per `(our, their)` and verifies an accept's `reply` against the
+  invite it sent. States/transitions unchanged.
+- Wire-breaking for Control (Direct/Routed/Nested unchanged); accept/cancel APIs now take the
+  thread digest.
+
 ## 29th June 2026 (later)
 
 ### 0.1.9 — spec-compliant Routed/Nested payloads + reference-aligned size cap

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/examples/alice_and_bob.rs
+++ b/crates/messaging/affinidi-tsp/examples/alice_and_bob.rs
@@ -37,7 +37,7 @@
 
 use affinidi_tsp::{
     TspAgent,
-    message::{MessageType, direct},
+    message::MessageType,
     relationship::RelationshipState,
     vid::PrivateVid,
 };
@@ -141,11 +141,11 @@ fn main() {
     );
 
     // Bob accepts the invite by sending a Relationship Forming Accept (RFA).
-    // The accept references the invite via its cryptographic digest (BLAKE2s-256),
-    // binding the accept to the specific invite it responds to.
-    let rfi_digest = direct::message_digest(&rfi_packed).to_vec();
+    // The accept references the invite via its TSP thread digest (SHA-256 of the
+    // invite's plaintext frame), which the agent recorded when Bob received the
+    // invite — so it binds the accept to the specific invite it responds to.
     let rfa_packed = bob_agent
-        .send_relationship_accept("did:example:bob", "did:example:alice", rfi_digest)
+        .send_relationship_accept("did:example:bob", "did:example:alice")
         .expect("Failed to create relationship accept");
 
     println!(

--- a/crates/messaging/affinidi-tsp/src/adapter.rs
+++ b/crates/messaging/affinidi-tsp/src/adapter.rs
@@ -88,9 +88,7 @@ impl MessagingProtocol for TspAdapter {
             .map_err(|e| MessagingError::Unpack(e.to_string()))?;
 
         Ok(ReceivedMessage {
-            id: hex::encode(direct::message_digest(&direct::PackedMessage {
-                bytes: packed.to_vec(),
-            })),
+            id: hex::encode(direct::message_digest_bytes(packed)),
             sender: Some(received.sender),
             recipient: received.receiver,
             payload: received.payload,
@@ -172,10 +170,12 @@ impl RelationshipManager for TspAdapter {
         &self,
         my_id: &str,
         their_id: &str,
-        request_id: &[u8],
+        _request_id: &[u8],
     ) -> Result<RelationshipState, MessagingError> {
+        // The TSP agent correlates the accept to the received invite via the
+        // thread digest it recorded on receipt, so `request_id` is unused here.
         self.agent
-            .send_relationship_accept(my_id, their_id, request_id.to_vec())
+            .send_relationship_accept(my_id, their_id)
             .map_err(|e| MessagingError::Relationship(e.to_string()))?;
 
         Ok(RelationshipState::Bidirectional)
@@ -267,27 +267,26 @@ mod tests {
             .unwrap();
         assert_eq!(state, RelationshipState::None);
 
-        // Alice requests relationship (sends RFI)
-        let state = alice
-            .request_relationship("did:example:alice", "did:example:bob")
-            .await
+        // Alice sends the RFI (via the agent so we can transport the wire bytes).
+        let rfi = alice
+            .agent()
+            .send_relationship_invite("did:example:alice", "did:example:bob")
             .unwrap();
-        assert_eq!(state, RelationshipState::Pending);
+        assert_eq!(
+            alice
+                .relationship_state("did:example:alice", "did:example:bob")
+                .await
+                .unwrap(),
+            RelationshipState::Pending
+        );
 
-        // Bob receives the invite via the agent to update his state
-        // (In real usage, the RFI wire bytes would be transported and received)
-        bob.agent()
-            .store
-            .transition_relationship(
-                "did:example:bob",
-                "did:example:alice",
-                crate::relationship::RelationshipEvent::ReceiveInvite,
-            )
-            .unwrap();
+        // Bob receives the invite — this records the invite's thread digest so
+        // his accept can reference it.
+        bob.agent().receive("did:example:bob", &rfi.bytes).unwrap();
 
-        // Now Bob can accept
+        // Now Bob can accept (the agent looks up the recorded invite digest).
         let state = bob
-            .accept_relationship("did:example:bob", "did:example:alice", b"digest")
+            .accept_relationship("did:example:bob", "did:example:alice", b"unused")
             .await
             .unwrap();
         assert_eq!(state, RelationshipState::Bidirectional);

--- a/crates/messaging/affinidi-tsp/src/lib.rs
+++ b/crates/messaging/affinidi-tsp/src/lib.rs
@@ -114,7 +114,9 @@ impl TspAgent {
 
     /// Build and pack a Relationship Forming Invite (RFI).
     ///
-    /// This sends a control message to initiate a relationship.
+    /// This sends a control message to initiate a relationship. The invite's
+    /// thread digest (`SHA256` of its plaintext frame) is remembered so a later
+    /// accept can be correlated, and is used as the cancel reference.
     pub fn send_relationship_invite(
         &self,
         our_vid: &str,
@@ -125,19 +127,31 @@ impl TspAgent {
 
         self.store
             .transition_relationship(our_vid, their_vid, RelationshipEvent::SendInvite)?;
+        // Remember the invite's thread digest to correlate the accept and to
+        // reference on cancel.
+        self.store
+            .set_thread_digest(our_vid, their_vid, packed.thread_digest);
 
         Ok(packed)
     }
 
     /// Build and pack a Relationship Forming Accept (RFA).
     ///
-    /// `invite_digest` is the BLAKE2s-256 digest of the received invite message.
+    /// The accept's `reply` is the thread digest of the invite being accepted
+    /// — the `thread_digest` of the received invite (see
+    /// [`ReceivedMessage::thread_digest`]), which the FSM remembers when it
+    /// transitions to [`RelationshipState::InviteReceived`]. The accept's own
+    /// thread digest then becomes the relationship reference for cancel.
     pub fn send_relationship_accept(
         &self,
         our_vid: &str,
         their_vid: &str,
-        invite_digest: Vec<u8>,
     ) -> Result<PackedMessage, TspError> {
+        let invite_digest = self.store.thread_digest(our_vid, their_vid).ok_or_else(|| {
+            TspError::Relationship(format!(
+                "no invite on record from {their_vid} to accept"
+            ))
+        })?;
         let control = ControlMessage::accept(invite_digest);
         let packed = self.pack_control(our_vid, their_vid, &control)?;
 
@@ -148,16 +162,25 @@ impl TspAgent {
     }
 
     /// Build and pack a Relationship Cancel (RFD).
+    ///
+    /// The cancel's `reply` references the relationship-forming message's thread
+    /// digest (the remembered invite digest); if none is on record (e.g. a
+    /// degenerate teardown) a zero digest is used.
     pub fn send_relationship_cancel(
         &self,
         our_vid: &str,
         their_vid: &str,
     ) -> Result<PackedMessage, TspError> {
-        let control = ControlMessage::cancel();
+        let reply = self
+            .store
+            .thread_digest(our_vid, their_vid)
+            .unwrap_or([0u8; 32]);
+        let control = ControlMessage::cancel(reply);
         let packed = self.pack_control(our_vid, their_vid, &control)?;
 
         self.store
             .transition_relationship(our_vid, their_vid, RelationshipEvent::SendCancel)?;
+        self.store.clear_thread_digest(our_vid, their_vid);
 
         Ok(packed)
     }
@@ -213,14 +236,18 @@ impl TspAgent {
 
         // Handle control messages
         if unpacked.message_type == MessageType::Control {
-            let control = ControlMessage::decode(&unpacked.payload)?;
-            self.handle_control(our_vid, &unpacked.sender, &control, wire)?;
+            let control = unpacked
+                .control
+                .clone()
+                .ok_or_else(|| TspError::InvalidMessage("control message has no payload".into()))?;
+            self.handle_control(our_vid, &unpacked.sender, &control, unpacked.thread_digest)?;
 
             return Ok(ReceivedMessage {
                 payload: unpacked.payload,
                 sender: unpacked.sender,
                 receiver: unpacked.receiver,
                 message_type: unpacked.message_type,
+                thread_digest: unpacked.thread_digest,
                 control: Some(control),
             });
         }
@@ -230,6 +257,7 @@ impl TspAgent {
             sender: unpacked.sender,
             receiver: unpacked.receiver,
             message_type: unpacked.message_type,
+            thread_digest: unpacked.thread_digest,
             control: None,
         })
     }
@@ -403,12 +431,17 @@ impl TspAgent {
         self.pack_message(our_vid, their_vid, &payload, MessageType::Control)
     }
 
+    /// Apply a received control message to the relationship FSM, correlating it
+    /// to the relationship-forming message via the thread digest.
+    ///
+    /// `thread_digest` is the `SHA256` of the received message's plaintext frame
+    /// (for an invite it is the value the accepter must echo back as `reply`).
     fn handle_control(
         &self,
         our_vid: &str,
         their_vid: &str,
         control: &ControlMessage,
-        _wire: &[u8],
+        thread_digest: [u8; 32],
     ) -> Result<(), TspError> {
         use message::control::ControlType;
 
@@ -419,8 +452,21 @@ impl TspAgent {
                     their_vid,
                     RelationshipEvent::ReceiveInvite,
                 )?;
+                // Remember the invite's thread digest so our accept can echo it
+                // back as `reply`, and so it serves as the cancel reference.
+                self.store
+                    .set_thread_digest(our_vid, their_vid, thread_digest);
             }
             ControlType::RelationshipFormingAccept => {
+                // The accept's `reply` must match the invite we sent.
+                let reply = control.require_reply()?;
+                if let Some(expected) = self.store.thread_digest(our_vid, their_vid)
+                    && reply != &expected
+                {
+                    return Err(TspError::Relationship(format!(
+                        "accept from {their_vid} references an unknown invite (reply mismatch)"
+                    )));
+                }
                 self.store.transition_relationship(
                     our_vid,
                     their_vid,
@@ -433,6 +479,7 @@ impl TspAgent {
                     their_vid,
                     RelationshipEvent::ReceiveCancel,
                 )?;
+                self.store.clear_thread_digest(our_vid, their_vid);
             }
         }
 
@@ -457,6 +504,9 @@ pub struct ReceivedMessage {
     pub receiver: String,
     /// The message type.
     pub message_type: MessageType,
+    /// `SHA256` of the decrypted plaintext payload frame — the TSP thread
+    /// digest. For an invite this is the value an accept must echo as `reply`.
+    pub thread_digest: [u8; 32],
     /// If this is a control message, the parsed control payload.
     pub control: Option<ControlMessage>,
 }
@@ -599,9 +649,8 @@ mod tests {
         );
 
         // Bob sends RFA back to Alice
-        let digest = direct::message_digest(&rfi).to_vec();
         let rfa = bob
-            .send_relationship_accept(&bob_id, &alice_id, digest)
+            .send_relationship_accept(&bob_id, &alice_id)
             .unwrap();
         assert_eq!(
             bob.relationship_state(&bob_id, &alice_id),
@@ -623,9 +672,8 @@ mod tests {
         // Establish relationship
         let rfi = alice.send_relationship_invite(&alice_id, &bob_id).unwrap();
         bob.receive(&bob_id, &rfi.bytes).unwrap();
-        let digest = direct::message_digest(&rfi).to_vec();
         let rfa = bob
-            .send_relationship_accept(&bob_id, &alice_id, digest)
+            .send_relationship_accept(&bob_id, &alice_id)
             .unwrap();
         alice.receive(&alice_id, &rfa.bytes).unwrap();
 
@@ -653,9 +701,8 @@ mod tests {
         // Establish relationship
         let rfi = alice.send_relationship_invite(&alice_id, &bob_id).unwrap();
         bob.receive(&bob_id, &rfi.bytes).unwrap();
-        let digest = direct::message_digest(&rfi).to_vec();
         let rfa = bob
-            .send_relationship_accept(&bob_id, &alice_id, digest)
+            .send_relationship_accept(&bob_id, &alice_id)
             .unwrap();
         alice.receive(&alice_id, &rfa.bytes).unwrap();
 

--- a/crates/messaging/affinidi-tsp/src/message/control.rs
+++ b/crates/messaging/affinidi-tsp/src/message/control.rs
@@ -1,16 +1,39 @@
 //! TSP control messages for relationship management.
 //!
-//! Control messages are sent as TSP message payloads with message type `Control`.
-//! They manage the explicit relationship lifecycle that distinguishes TSP from DIDComm.
+//! Control messages drive the explicit relationship lifecycle that distinguishes
+//! TSP from DIDComm. On the wire they are **not** a serialized body inside a
+//! generic payload — each is its own CESR payload-frame variant, byte-compatible
+//! with the ToIP `tsp_sdk` reference (v0.9.0-alpha2):
+//!
+//!   * **Invite** (`DirectRelationProposal`) → `XRFI` + hops + `A` nonce(32) +
+//!     empty `B` VID.
+//!   * **Accept** (`DirectRelationAffirm`) → `XRFA` + `I` SHA-256 reply(32).
+//!   * **Cancel** (`RelationshipCancel`) → `XRFD` + `I` SHA-256 reply(32).
+//!
+//! The CESR encode/decode of these frames lives in [`crate::message::direct`]
+//! (see `encode_payload_frame` / `decode_payload_frame`). This module owns the
+//! semantic [`ControlMessage`] type and a compact self-describing
+//! `encode`/`decode` used to carry a recovered control across the SDK's
+//! `payload` field (the SDK unpacks to bytes, then re-decodes a control).
+//!
+//! Replay correlation rides on the **thread digest**: `SHA256` of the plaintext
+//! payload frame (the `-Z…` bytes before sealing / after decrypt). The accept's
+//! `reply` is the invite's thread digest; the cancel's `reply` is the
+//! relationship-forming message's thread digest. See
+//! [`crate::message::direct::thread_digest`].
 
 use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::error::TspError;
 
-/// Generate a cryptographically random 16-byte nonce.
-pub fn generate_nonce() -> [u8; 16] {
-    let mut nonce = [0u8; 16];
+/// Length of a relationship nonce and of a SHA-256 thread digest, in bytes.
+pub const DIGEST_LEN: usize = 32;
+
+/// Generate a cryptographically random 32-byte nonce (matching the reference's
+/// `Nonce`, which is 32 bytes for 256 bits of security).
+pub fn generate_nonce() -> [u8; DIGEST_LEN] {
+    let mut nonce = [0u8; DIGEST_LEN];
     rand_core::OsRng.fill_bytes(&mut nonce);
     nonce
 }
@@ -19,11 +42,11 @@ pub fn generate_nonce() -> [u8; 16] {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ControlType {
-    /// Relationship Forming Invite — initiates a relationship.
+    /// Relationship Forming Invite (`XRFI` / `DirectRelationProposal`).
     RelationshipFormingInvite = 0x00,
-    /// Relationship Forming Accept — accepts an invite.
+    /// Relationship Forming Accept (`XRFA` / `DirectRelationAffirm`).
     RelationshipFormingAccept = 0x01,
-    /// Relationship Cancel — terminates a relationship.
+    /// Relationship Cancel (`XRFD` / `RelationshipCancel`).
     RelationshipCancel = 0x02,
 }
 
@@ -41,138 +64,176 @@ impl ControlType {
 }
 
 /// A TSP control message payload.
+///
+/// The fields used depend on [`ControlType`]:
+///   * **invite** carries a 32-byte `nonce` (and an optional `route` of hop
+///     VIDs, normally empty for a direct relationship); `reply` is `None`.
+///   * **accept** / **cancel** carry a 32-byte SHA-256 `reply` (the thread
+///     digest they respond to); `nonce` is `None` and `route` is empty.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlMessage {
     /// The control message type.
     pub control_type: ControlType,
-    /// Optional thread reference (digest of the message being responded to).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub thread_id: Option<Vec<u8>>,
-    /// Optional 16-byte nonce for replay protection (present in RFI and RFA messages).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nonce: Option<[u8; 16]>,
+    /// The 32-byte nonce (invite only).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub nonce: Option<[u8; DIGEST_LEN]>,
+    /// The 32-byte SHA-256 thread reference (accept / cancel only).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reply: Option<[u8; DIGEST_LEN]>,
+    /// Hop VIDs carried in an invite (empty for a direct relationship).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub route: Vec<String>,
 }
 
 impl ControlMessage {
-    /// Create a Relationship Forming Invite (with a random nonce).
+    /// Create a Relationship Forming Invite (with a fresh random 32-byte nonce
+    /// and no route).
     pub fn invite() -> Self {
         Self {
             control_type: ControlType::RelationshipFormingInvite,
-            thread_id: None,
             nonce: Some(generate_nonce()),
+            reply: None,
+            route: Vec::new(),
         }
     }
 
-    /// Create a Relationship Forming Accept referencing the invite (with a random nonce).
-    pub fn accept(invite_digest: Vec<u8>) -> Self {
+    /// Create a Relationship Forming Invite carrying a `route` of hop VIDs.
+    pub fn invite_routed(route: Vec<String>) -> Self {
+        Self {
+            control_type: ControlType::RelationshipFormingInvite,
+            nonce: Some(generate_nonce()),
+            reply: None,
+            route,
+        }
+    }
+
+    /// Create a Relationship Forming Accept referencing the invite's thread
+    /// digest (`reply` = `SHA256` of the invite's plaintext payload frame).
+    pub fn accept(reply: [u8; DIGEST_LEN]) -> Self {
         Self {
             control_type: ControlType::RelationshipFormingAccept,
-            thread_id: Some(invite_digest),
-            nonce: Some(generate_nonce()),
+            nonce: None,
+            reply: Some(reply),
+            route: Vec::new(),
         }
     }
 
-    /// Create a Relationship Cancel.
-    pub fn cancel() -> Self {
+    /// Create a Relationship Cancel referencing the relationship-forming
+    /// message's thread digest (`reply` = `SHA256` of that plaintext frame).
+    pub fn cancel(reply: [u8; DIGEST_LEN]) -> Self {
         Self {
             control_type: ControlType::RelationshipCancel,
-            thread_id: None,
             nonce: None,
+            reply: Some(reply),
+            route: Vec::new(),
         }
     }
 
-    /// Encode the control message to bytes.
-    pub fn encode(&self) -> Vec<u8> {
-        let mut cap = 2; // type + thread_id flag
-        if let Some(digest) = &self.thread_id {
-            cap += 2 + digest.len(); // len + data
-        }
-        cap += 1; // nonce presence flag
-        if self.nonce.is_some() {
-            cap += 16;
-        }
+    /// The nonce, erroring if absent (invariant: present iff invite).
+    pub fn require_nonce(&self) -> Result<&[u8; DIGEST_LEN], TspError> {
+        self.nonce
+            .as_ref()
+            .ok_or_else(|| TspError::InvalidMessage("invite is missing its nonce".into()))
+    }
 
-        let mut buf = Vec::with_capacity(cap);
+    /// The reply digest, erroring if absent (invariant: present iff accept/cancel).
+    pub fn require_reply(&self) -> Result<&[u8; DIGEST_LEN], TspError> {
+        self.reply
+            .as_ref()
+            .ok_or_else(|| TspError::InvalidMessage("control is missing its reply digest".into()))
+    }
+
+    /// Encode this control message to a compact self-describing byte form.
+    ///
+    /// This is **not** the TSP wire form (that is the CESR payload frame built in
+    /// [`crate::message::direct`]); it is a local encoding so the SDK — which
+    /// unpacks a message down to a `payload: Vec<u8>` — can recover a
+    /// [`ControlMessage`] via [`ControlMessage::decode`].
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
         buf.push(self.control_type as u8);
 
-        match &self.thread_id {
-            Some(digest) => {
-                buf.push(1); // has thread_id
-                let len = digest.len() as u16;
-                buf.extend_from_slice(&len.to_be_bytes());
-                buf.extend_from_slice(digest);
+        match self.control_type {
+            ControlType::RelationshipFormingInvite => {
+                buf.extend_from_slice(self.nonce.as_ref().unwrap_or(&[0u8; DIGEST_LEN]));
+                buf.extend_from_slice(&(self.route.len() as u16).to_be_bytes());
+                for hop in &self.route {
+                    let bytes = hop.as_bytes();
+                    buf.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+                    buf.extend_from_slice(bytes);
+                }
             }
-            None => {
-                buf.push(0); // no thread_id
-            }
-        }
-
-        // Nonce: 1-byte presence flag + 16 bytes if present
-        match &self.nonce {
-            Some(nonce) => {
-                buf.push(1);
-                buf.extend_from_slice(nonce);
-            }
-            None => {
-                buf.push(0);
+            ControlType::RelationshipFormingAccept | ControlType::RelationshipCancel => {
+                buf.extend_from_slice(self.reply.as_ref().unwrap_or(&[0u8; DIGEST_LEN]));
             }
         }
-
         buf
     }
 
-    /// Decode a control message from bytes.
+    /// Decode a control message from its compact self-describing byte form
+    /// (the inverse of [`ControlMessage::encode`]).
     pub fn decode(data: &[u8]) -> Result<Self, TspError> {
-        if data.len() < 2 {
-            return Err(TspError::InvalidMessage("control message too short".into()));
-        }
+        let control_type = data
+            .first()
+            .ok_or_else(|| TspError::InvalidMessage("control message empty".into()))
+            .and_then(|b| ControlType::from_byte(*b))?;
+        let mut pos = 1;
 
-        let control_type = ControlType::from_byte(data[0])?;
-        let has_thread = data[1] != 0;
-
-        let mut offset = 2;
-        let thread_id = if has_thread {
-            if data.len() < offset + 2 {
-                return Err(TspError::InvalidMessage(
-                    "thread_id length truncated".into(),
-                ));
-            }
-            let len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
-            offset += 2;
-            if data.len() < offset + len {
-                return Err(TspError::InvalidMessage("thread_id data truncated".into()));
-            }
-            let tid = Some(data[offset..offset + len].to_vec());
-            offset += len;
-            tid
-        } else {
-            None
-        };
-
-        // Nonce: 1-byte presence flag + 16 bytes if present
-        let nonce = if offset < data.len() {
-            let has_nonce = data[offset] != 0;
-            offset += 1;
-            if has_nonce {
-                if data.len() < offset + 16 {
-                    return Err(TspError::InvalidMessage("nonce data truncated".into()));
+        match control_type {
+            ControlType::RelationshipFormingInvite => {
+                let nonce = read_digest(data, &mut pos, "invite nonce")?;
+                let hop_count = read_u16(data, &mut pos, "route length")? as usize;
+                let mut route = Vec::with_capacity(hop_count);
+                for _ in 0..hop_count {
+                    let len = read_u16(data, &mut pos, "hop length")? as usize;
+                    let end = pos
+                        .checked_add(len)
+                        .filter(|e| *e <= data.len())
+                        .ok_or_else(|| TspError::InvalidMessage("hop VID truncated".into()))?;
+                    let hop = String::from_utf8(data[pos..end].to_vec())
+                        .map_err(|_| TspError::InvalidMessage("hop VID not UTF-8".into()))?;
+                    pos = end;
+                    route.push(hop);
                 }
-                let mut n = [0u8; 16];
-                n.copy_from_slice(&data[offset..offset + 16]);
-                Some(n)
-            } else {
-                None
+                Ok(Self {
+                    control_type,
+                    nonce: Some(nonce),
+                    reply: None,
+                    route,
+                })
             }
-        } else {
-            None
-        };
-
-        Ok(Self {
-            control_type,
-            thread_id,
-            nonce,
-        })
+            ControlType::RelationshipFormingAccept | ControlType::RelationshipCancel => {
+                let reply = read_digest(data, &mut pos, "reply digest")?;
+                Ok(Self {
+                    control_type,
+                    nonce: None,
+                    reply: Some(reply),
+                    route: Vec::new(),
+                })
+            }
+        }
     }
+}
+
+fn read_u16(data: &[u8], pos: &mut usize, what: &str) -> Result<u16, TspError> {
+    let end = *pos + 2;
+    if end > data.len() {
+        return Err(TspError::InvalidMessage(format!("{what} truncated")));
+    }
+    let v = u16::from_be_bytes([data[*pos], data[*pos + 1]]);
+    *pos = end;
+    Ok(v)
+}
+
+fn read_digest(data: &[u8], pos: &mut usize, what: &str) -> Result<[u8; DIGEST_LEN], TspError> {
+    let end = *pos + DIGEST_LEN;
+    if end > data.len() {
+        return Err(TspError::InvalidMessage(format!("{what} truncated")));
+    }
+    let mut out = [0u8; DIGEST_LEN];
+    out.copy_from_slice(&data[*pos..end]);
+    *pos = end;
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -182,35 +243,41 @@ mod tests {
     #[test]
     fn invite_roundtrip() {
         let msg = ControlMessage::invite();
-        let encoded = msg.encode();
-        let decoded = ControlMessage::decode(&encoded).unwrap();
+        let decoded = ControlMessage::decode(&msg.encode()).unwrap();
         assert_eq!(decoded, msg);
         assert_eq!(decoded.control_type, ControlType::RelationshipFormingInvite);
-        assert!(decoded.thread_id.is_none());
-        assert!(decoded.nonce.is_some());
-        assert_eq!(decoded.nonce.unwrap().len(), 16);
+        assert_eq!(decoded.nonce.unwrap().len(), 32);
+        assert!(decoded.reply.is_none());
+        assert!(decoded.route.is_empty());
+    }
+
+    #[test]
+    fn invite_routed_roundtrip() {
+        let route = vec!["did:web:hop1".to_string(), "did:web:hop2".to_string()];
+        let msg = ControlMessage::invite_routed(route.clone());
+        let decoded = ControlMessage::decode(&msg.encode()).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(decoded.route, route);
     }
 
     #[test]
     fn accept_roundtrip() {
-        let digest = vec![0xAA; 32];
-        let msg = ControlMessage::accept(digest.clone());
-        let encoded = msg.encode();
-        let decoded = ControlMessage::decode(&encoded).unwrap();
+        let reply = [0xAA; 32];
+        let msg = ControlMessage::accept(reply);
+        let decoded = ControlMessage::decode(&msg.encode()).unwrap();
         assert_eq!(decoded, msg);
         assert_eq!(decoded.control_type, ControlType::RelationshipFormingAccept);
-        assert_eq!(decoded.thread_id.unwrap(), digest);
-        assert!(decoded.nonce.is_some());
-        assert_eq!(decoded.nonce.unwrap().len(), 16);
+        assert_eq!(decoded.reply.unwrap(), reply);
+        assert!(decoded.nonce.is_none());
     }
 
     #[test]
     fn cancel_roundtrip() {
-        let msg = ControlMessage::cancel();
-        let encoded = msg.encode();
-        let decoded = ControlMessage::decode(&encoded).unwrap();
+        let reply = [0x55; 32];
+        let msg = ControlMessage::cancel(reply);
+        let decoded = ControlMessage::decode(&msg.encode()).unwrap();
         assert_eq!(decoded.control_type, ControlType::RelationshipCancel);
-        assert!(decoded.nonce.is_none());
+        assert_eq!(decoded.reply.unwrap(), reply);
     }
 
     #[test]
@@ -221,45 +288,12 @@ mod tests {
     #[test]
     fn truncated_control_message() {
         assert!(ControlMessage::decode(&[]).is_err());
-        assert!(ControlMessage::decode(&[0x00]).is_err());
+        assert!(ControlMessage::decode(&[0x00]).is_err()); // invite w/o nonce
+        assert!(ControlMessage::decode(&[0x01]).is_err()); // accept w/o reply
     }
 
     #[test]
     fn generate_nonce_uniqueness() {
-        let n1 = generate_nonce();
-        let n2 = generate_nonce();
-        assert_ne!(n1, n2, "two consecutive nonces should differ");
-    }
-
-    #[test]
-    fn nonce_truncated_in_decode() {
-        // Build a message with nonce presence flag = 1, but only 5 bytes of nonce data
-        let mut buf = vec![0x00, 0x00]; // invite, no thread_id
-        buf.push(1); // has nonce
-        buf.extend_from_slice(&[0u8; 5]); // only 5 bytes instead of 16
-        assert!(ControlMessage::decode(&buf).is_err());
-    }
-
-    #[test]
-    fn backward_compat_no_nonce_field() {
-        // Simulate a legacy message that lacks the nonce byte entirely
-        let buf = vec![0x02, 0x00]; // cancel, no thread_id, no nonce field
-        let decoded = ControlMessage::decode(&buf).unwrap();
-        assert_eq!(decoded.control_type, ControlType::RelationshipCancel);
-        assert!(decoded.nonce.is_none());
-    }
-
-    #[test]
-    fn explicit_nonce_none_roundtrip() {
-        // A message that has the nonce presence flag set to 0
-        let msg = ControlMessage {
-            control_type: ControlType::RelationshipCancel,
-            thread_id: None,
-            nonce: None,
-        };
-        let encoded = msg.encode();
-        let decoded = ControlMessage::decode(&encoded).unwrap();
-        assert_eq!(decoded, msg);
-        assert!(decoded.nonce.is_none());
+        assert_ne!(generate_nonce(), generate_nonce());
     }
 }

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -27,6 +27,7 @@
 use crate::crypto::{hpke, signing};
 use crate::error::TspError;
 use crate::message::MessageType;
+use crate::message::control::{ControlMessage, ControlType, DIGEST_LEN};
 use crate::message::envelope::Envelope;
 use crate::message::wire;
 
@@ -47,6 +48,13 @@ const SIG_LEN: usize = 64;
 pub struct PackedMessage {
     /// The raw wire-format bytes.
     pub bytes: Vec<u8>,
+    /// `SHA256` of the plaintext CESR payload frame (the `-Z…` bytes before
+    /// sealing). This is the TSP **thread digest** used to correlate
+    /// relationship control messages: an accept's `reply` is the invite's
+    /// `thread_digest`, and a cancel's `reply` is the relationship-forming
+    /// message's `thread_digest`. The reference (`tsp_sdk`) computes the same
+    /// value (`sha256` of the decrypted payload frame) on open.
+    pub thread_digest: [u8; DIGEST_LEN],
 }
 
 /// Result of unpacking a TSP message.
@@ -65,24 +73,48 @@ pub struct UnpackedMessage {
     pub receiver: String,
     /// The message type, recovered from the encrypted payload frame.
     pub message_type: MessageType,
+    /// `SHA256` of the decrypted plaintext CESR payload frame — the TSP
+    /// **thread digest** (see [`PackedMessage::thread_digest`]). Always present;
+    /// the FSM uses it to correlate a received accept/cancel back to the
+    /// relationship-forming message it replies to.
+    pub thread_digest: [u8; DIGEST_LEN],
+    /// For a [`MessageType::Control`] message, the decoded control payload
+    /// (invite / accept / cancel). `None` for all other message types.
+    pub control: Option<ControlMessage>,
 }
 
-/// Payload-type markers. Direct/Nested/Routed use the reference `tsp-sdk`
-/// framing verbatim (so they are byte-compatible with `tsp-sdk`):
+/// Payload-type markers, all using the reference `tsp-sdk` framing verbatim so
+/// they are byte-compatible with `tsp-sdk`:
 ///
 ///   * Direct → `XSCS`
 ///   * Nested → `XHOP` + empty hop list
 ///   * Routed → `XHOP` + non-empty hop list
-///
-/// Control stays on an affinidi-private `ACT` marker (the reference's
-/// relationship/control payloads — `XRFI`/`XRFA`/`XRFD` — are out of scope).
+///   * Control(invite) → `XRFI` + hops + `A` nonce(32) + empty `B` VID
+///   * Control(accept) → `XRFA` + `I` SHA-256 reply(32)
+///   * Control(cancel) → `XRFD` + `I` SHA-256 reply(32)
 mod payload_marker {
     /// Generic message (Direct) — the reference `XSCS` marker, byte-exact.
     pub const DIRECT: [u8; 3] = crate::message::wire::XSCS;
     /// Hop-carrying payload (Nested or Routed) — the reference `XHOP` marker.
     pub const HOP: [u8; 3] = crate::message::wire::XHOP;
-    /// Affinidi-private marker for a Control payload (out of interop scope).
-    pub const CONTROL: [u8; 3] = *b"ACT";
+    /// Relationship-forming invite (`DirectRelationProposal`).
+    pub const INVITE: [u8; 3] = crate::message::wire::XRFI;
+    /// Relationship-forming accept (`DirectRelationAffirm`).
+    pub const ACCEPT: [u8; 3] = crate::message::wire::XRFA;
+    /// Relationship cancel (`RelationshipCancel`).
+    pub const CANCEL: [u8; 3] = crate::message::wire::XRFD;
+}
+
+/// Encode a SHA-256 digest as the reference's `encode_digest` does: a fixed-data
+/// field under the `I` (SHA-256) id.
+fn encode_sha256_digest(digest: &[u8; DIGEST_LEN], out: &mut Vec<u8>) {
+    wire::encode_fixed_data(wire::TSP_SHA256, digest, out);
+}
+
+/// Decode a SHA-256 digest (`I`-coded 32-byte fixed-data field).
+fn decode_sha256_digest(frame: &[u8], pos: &mut usize) -> Result<[u8; DIGEST_LEN], TspError> {
+    wire::decode_fixed_data::<DIGEST_LEN>(wire::TSP_SHA256, frame, pos)
+        .ok_or_else(|| TspError::InvalidMessage("missing or non-SHA256 reply digest".into()))
 }
 
 /// Build the CESR payload frame that is encrypted (the HPKE plaintext).
@@ -91,43 +123,94 @@ mod payload_marker {
 ///   * Direct  → `-Z<count> XSCS <var-data B> body`
 ///   * Nested  → `-Z<count> XHOP -J0 <var-data B> body`
 ///   * Routed  → `-Z<count> XHOP -J<n> (B hop)* <var-data B> body`
-///   * Control → `-Z<count> ACT <var-data B> body` (affinidi-private)
-fn encode_payload_frame(body: &[u8], kind: MessageType, hops: &[String]) -> Vec<u8> {
+///   * Control(invite) → `-Z<count> XRFI -J<n> (B hop)* A nonce(32) B(empty)`
+///   * Control(accept) → `-Z<count> XRFA I reply(32)`
+///   * Control(cancel) → `-Z<count> XRFD I reply(32)`
+///
+/// For Control, `body` is a [`ControlMessage::encode`] blob; it is decoded back
+/// to the structured control so the spec CESR fields can be emitted.
+fn encode_payload_frame(
+    body: &[u8],
+    kind: MessageType,
+    hops: &[String],
+) -> Result<Vec<u8>, TspError> {
     let mut frame_body = Vec::with_capacity(3 + body.len() + 3);
     match kind {
         MessageType::Direct => {
             frame_body.extend_from_slice(&payload_marker::DIRECT);
+            wire::encode_variable_data(wire::TSP_PLAINTEXT, body, &mut frame_body);
         }
         MessageType::Nested => {
             frame_body.extend_from_slice(&payload_marker::HOP);
             let no_hops: [&[u8]; 0] = [];
             wire::encode_hops(&no_hops, &mut frame_body);
+            wire::encode_variable_data(wire::TSP_PLAINTEXT, body, &mut frame_body);
         }
         MessageType::Routed => {
             frame_body.extend_from_slice(&payload_marker::HOP);
             wire::encode_hops(hops, &mut frame_body);
+            wire::encode_variable_data(wire::TSP_PLAINTEXT, body, &mut frame_body);
         }
         MessageType::Control => {
-            frame_body.extend_from_slice(&payload_marker::CONTROL);
+            let control = ControlMessage::decode(body)?;
+            match control.control_type {
+                ControlType::RelationshipFormingInvite => {
+                    frame_body.extend_from_slice(&payload_marker::INVITE);
+                    wire::encode_hops(&control.route, &mut frame_body);
+                    wire::encode_fixed_data(
+                        wire::TSP_NONCE,
+                        control.require_nonce()?,
+                        &mut frame_body,
+                    );
+                    // empty VID (a direct-relationship invite carries no new VID)
+                    wire::encode_variable_data(wire::TSP_VID, &[], &mut frame_body);
+                }
+                ControlType::RelationshipFormingAccept => {
+                    frame_body.extend_from_slice(&payload_marker::ACCEPT);
+                    encode_sha256_digest(control.require_reply()?, &mut frame_body);
+                }
+                ControlType::RelationshipCancel => {
+                    frame_body.extend_from_slice(&payload_marker::CANCEL);
+                    encode_sha256_digest(control.require_reply()?, &mut frame_body);
+                }
+            }
         }
     }
-    wire::encode_variable_data(wire::TSP_PLAINTEXT, body, &mut frame_body);
 
     debug_assert!(frame_body.len().is_multiple_of(3));
     let mut out = Vec::with_capacity(3 + frame_body.len());
     wire::encode_count(wire::TSP_PAYLOAD, (frame_body.len() / 3) as u32, &mut out);
     out.extend_from_slice(&frame_body);
-    out
+    Ok(out)
 }
 
-/// Decode a CESR payload frame, returning `(kind, hops, body)`.
+/// A decoded payload frame: its message kind, the remaining hop list (Routed
+/// only), the plaintext body, and — for Control — the structured control.
+struct DecodedFrame {
+    kind: MessageType,
+    hops: Vec<String>,
+    body: Vec<u8>,
+    control: Option<ControlMessage>,
+}
+
+/// Decode hop VID byte vectors into UTF-8 VID strings.
+fn hops_to_strings(hop_bytes: Vec<Vec<u8>>) -> Result<Vec<String>, TspError> {
+    hop_bytes
+        .into_iter()
+        .map(|h| {
+            String::from_utf8(h).map_err(|_| TspError::InvalidMessage("hop VID not UTF-8".into()))
+        })
+        .collect()
+}
+
+/// Decode a CESR payload frame into a [`DecodedFrame`].
 ///
-/// `XSCS` → `(Direct, [], body)`; `XHOP` → decode the hop list, an empty list is
-/// `(Nested, [], body)` and a non-empty one is `(Routed, hops, body)`; `ACT` →
-/// `(Control, [], body)`.
-fn decode_payload_frame(
-    frame: &[u8],
-) -> Result<(MessageType, Vec<String>, Vec<u8>), TspError> {
+/// `XSCS` → Direct; `XHOP` → Nested (empty hops) or Routed (non-empty);
+/// `XRFI`/`XRFA`/`XRFD` → Control (invite / accept / cancel). For Control the
+/// `body` is set to the control's [`ControlMessage::encode`] form (so the SDK,
+/// which only sees the `payload` bytes, can recover it) and `control` carries
+/// the structured message.
+fn decode_payload_frame(frame: &[u8]) -> Result<DecodedFrame, TspError> {
     let mut pos = 0usize;
     wire::decode_count(wire::TSP_PAYLOAD, frame, &mut pos)
         .ok_or_else(|| TspError::InvalidMessage("missing -Z payload frame".into()))?;
@@ -140,36 +223,78 @@ fn decode_payload_frame(
         .get(pos..pos + 3)
         .ok_or_else(|| TspError::InvalidMessage("missing payload type marker".into()))?;
 
-    let (kind, hops) = if marker == payload_marker::DIRECT {
+    if marker == payload_marker::DIRECT {
         pos += 3;
-        (MessageType::Direct, Vec::new())
+        let body = wire::decode_variable_data(wire::TSP_PLAINTEXT, frame, &mut pos)
+            .ok_or_else(|| TspError::InvalidMessage("missing payload plaintext".into()))?;
+        Ok(DecodedFrame {
+            kind: MessageType::Direct,
+            hops: Vec::new(),
+            body,
+            control: None,
+        })
     } else if marker == payload_marker::HOP {
         pos += 3;
-        let hop_bytes = wire::decode_hops(frame, &mut pos)?;
-        let hops = hop_bytes
-            .into_iter()
-            .map(|h| {
-                String::from_utf8(h)
-                    .map_err(|_| TspError::InvalidMessage("hop VID not UTF-8".into()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        if hops.is_empty() {
-            (MessageType::Nested, hops)
+        let hops = hops_to_strings(wire::decode_hops(frame, &mut pos)?)?;
+        let body = wire::decode_variable_data(wire::TSP_PLAINTEXT, frame, &mut pos)
+            .ok_or_else(|| TspError::InvalidMessage("missing payload plaintext".into()))?;
+        let kind = if hops.is_empty() {
+            MessageType::Nested
         } else {
-            (MessageType::Routed, hops)
-        }
-    } else if marker == payload_marker::CONTROL {
+            MessageType::Routed
+        };
+        Ok(DecodedFrame {
+            kind,
+            hops,
+            body,
+            control: None,
+        })
+    } else if marker == payload_marker::INVITE {
         pos += 3;
-        (MessageType::Control, Vec::new())
+        let route = hops_to_strings(wire::decode_hops(frame, &mut pos)?)?;
+        let nonce = wire::decode_fixed_data::<DIGEST_LEN>(wire::TSP_NONCE, frame, &mut pos)
+            .ok_or_else(|| TspError::InvalidMessage("missing or malformed invite nonce".into()))?;
+        // empty (or new-VID) `B` field; we only support the direct-relationship
+        // form, so the VID is expected to be empty.
+        let _new_vid = wire::decode_variable_data(wire::TSP_VID, frame, &mut pos)
+            .ok_or_else(|| TspError::InvalidMessage("missing invite VID field".into()))?;
+        let control = ControlMessage {
+            control_type: ControlType::RelationshipFormingInvite,
+            nonce: Some(nonce),
+            reply: None,
+            route,
+        };
+        Ok(DecodedFrame {
+            kind: MessageType::Control,
+            hops: Vec::new(),
+            body: control.encode(),
+            control: Some(control),
+        })
+    } else if marker == payload_marker::ACCEPT || marker == payload_marker::CANCEL {
+        let control_type = if marker == payload_marker::ACCEPT {
+            ControlType::RelationshipFormingAccept
+        } else {
+            ControlType::RelationshipCancel
+        };
+        pos += 3;
+        let reply = decode_sha256_digest(frame, &mut pos)?;
+        let control = ControlMessage {
+            control_type,
+            nonce: None,
+            reply: Some(reply),
+            route: Vec::new(),
+        };
+        Ok(DecodedFrame {
+            kind: MessageType::Control,
+            hops: Vec::new(),
+            body: control.encode(),
+            control: Some(control),
+        })
     } else {
-        return Err(TspError::InvalidMessage(
+        Err(TspError::InvalidMessage(
             "unsupported TSP payload type marker".into(),
-        ));
-    };
-
-    let body = wire::decode_variable_data(wire::TSP_PLAINTEXT, frame, &mut pos)
-        .ok_or_else(|| TspError::InvalidMessage("missing payload plaintext".into()))?;
-    Ok((kind, hops, body))
+        ))
+    }
 }
 
 /// Encode the signature frame: `-C<n> -K<n> <fixed B> sig`.
@@ -243,8 +368,11 @@ pub fn pack_with_hops(
     let envelope = Envelope::new(message_type, sender_vid, receiver_vid);
     let envelope_bytes = envelope.encode()?;
 
-    // 2. CESR payload frame, then HPKE-Auth seal it.
-    let payload_frame = encode_payload_frame(body, message_type, hops);
+    // 2. CESR payload frame, then HPKE-Auth seal it. The thread digest is
+    //    SHA256 of this plaintext frame (computed before sealing, matching the
+    //    reference's seal-time hash).
+    let payload_frame = encode_payload_frame(body, message_type, hops)?;
+    let thread_digest = sha256(&payload_frame);
     let sealed = hpke::seal(
         &payload_frame,
         b"", // AAD is empty in the reference
@@ -266,7 +394,10 @@ pub fn pack_with_hops(
     let signature = signing::sign(&wire_bytes, sender_signing_key)?;
     encode_signature_frame(&signature, &mut wire_bytes);
 
-    Ok(PackedMessage { bytes: wire_bytes })
+    Ok(PackedMessage {
+        bytes: wire_bytes,
+        thread_digest,
+    })
 }
 
 /// Unpack a direct TSP message.
@@ -332,8 +463,18 @@ pub fn unpack(
         envelope_bytes, // envelope frame is the HPKE `info`
     )?;
 
-    // 5. Decode the CESR payload frame.
-    let (message_type, hops, payload) = decode_payload_frame(&payload_frame)?;
+    // 5. The thread digest is SHA256 of the decrypted plaintext frame (computed
+    //    here, after decrypt — identical to the reference's open-time hash and
+    //    to the sender's seal-time `PackedMessage::thread_digest`).
+    let thread_digest = sha256(&payload_frame);
+
+    // 6. Decode the CESR payload frame.
+    let DecodedFrame {
+        kind: message_type,
+        hops,
+        body: payload,
+        control,
+    } = decode_payload_frame(&payload_frame)?;
 
     Ok(UnpackedMessage {
         payload,
@@ -341,15 +482,35 @@ pub fn unpack(
         sender: envelope.sender,
         receiver: envelope.receiver,
         message_type,
+        thread_digest,
+        control,
     })
 }
 
-/// Compute a BLAKE2s-256 digest of a packed message (used as message ID).
-pub fn message_digest(packed: &PackedMessage) -> [u8; 32] {
+/// Compute a SHA-256 digest (the TSP thread-digest hash).
+pub fn sha256(data: &[u8]) -> [u8; DIGEST_LEN] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// Compute a BLAKE2s-256 digest of raw wire bytes (used as an opaque message ID,
+/// e.g. for the mediator adapter). This is **not** the TSP thread digest — use
+/// [`PackedMessage::thread_digest`] / [`UnpackedMessage::thread_digest`] for
+/// relationship correlation.
+pub fn message_digest_bytes(bytes: &[u8]) -> [u8; 32] {
     use blake2::{Blake2s256, Digest};
     let mut hasher = Blake2s256::new();
-    hasher.update(&packed.bytes);
+    hasher.update(bytes);
     hasher.finalize().into()
+}
+
+/// Compute a BLAKE2s-256 digest of a packed message (used as an opaque message
+/// ID). For relationship correlation use the TSP thread digest instead
+/// ([`PackedMessage::thread_digest`]).
+pub fn message_digest(packed: &PackedMessage) -> [u8; 32] {
+    message_digest_bytes(&packed.bytes)
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-tsp/src/message/wire.rs
+++ b/crates/messaging/affinidi-tsp/src/message/wire.rs
@@ -109,6 +109,11 @@ pub const TSP_HPKEAUTH_CIPHERTEXT: u32 = cesr_int("G") as u32;
 pub const ED25519_SIGNATURE: u32 = cesr_int("B") as u32;
 /// `X`: a 2-byte fixed-data marker emitted after the envelope VIDs.
 pub const TSP_TMP: u32 = cesr_int("X") as u32;
+/// `A`: fixed-data id for a relationship nonce (32 bytes).
+pub const TSP_NONCE: u32 = cesr_int("A") as u32;
+/// `I`: fixed-data id for a SHA-256 digest (32 bytes) — the relationship
+/// thread reference (`reply`) carried by accept / cancel.
+pub const TSP_SHA256: u32 = cesr_int("I") as u32;
 
 /// `-E`: outer count-code wrapper for an encrypted-then-signed (ETS) envelope.
 pub const TSP_ETS_WRAPPER: u16 = cesr_int("E") as u16;
@@ -126,6 +131,15 @@ pub const XSCS: [u8; 3] = cesr_data("XSCS");
 /// 3-byte payload-type marker for a hop-carrying payload (Nested when the hop
 /// list is empty, Routed otherwise).
 pub const XHOP: [u8; 3] = cesr_data("XHOP");
+/// 3-byte payload-type marker for a relationship-forming invite
+/// (`DirectRelationProposal`).
+pub const XRFI: [u8; 3] = cesr_data("XRFI");
+/// 3-byte payload-type marker for a relationship-forming accept
+/// (`DirectRelationAffirm`).
+pub const XRFA: [u8; 3] = cesr_data("XRFA");
+/// 3-byte payload-type marker for a relationship cancel
+/// (`RelationshipCancel`).
+pub const XRFD: [u8; 3] = cesr_data("XRFD");
 /// 3-byte TSP version genus marker.
 pub const YTSP: [u8; 3] = cesr_data("YTSP");
 
@@ -353,6 +367,17 @@ mod tests {
         assert_eq!(TSP_PAYLOAD, 25);
         assert_eq!(TSP_ATTACH_GRP, 2);
         assert_eq!(TSP_INDEX_SIG_GRP, 10);
+        // cesr!("A")=0, cesr!("I")=8.
+        assert_eq!(TSP_NONCE, 0);
+        assert_eq!(TSP_SHA256, 8);
+    }
+
+    #[test]
+    fn relationship_markers_match_reference() {
+        // cesr_data("XRFI"/"XRFA"/"XRFD") — relationship payload-type markers.
+        assert_eq!(XRFI, cesr_data::<3>("XRFI"));
+        assert_eq!(XRFA, cesr_data::<3>("XRFA"));
+        assert_eq!(XRFD, cesr_data::<3>("XRFD"));
     }
 
     #[test]

--- a/crates/messaging/affinidi-tsp/src/store.rs
+++ b/crates/messaging/affinidi-tsp/src/store.rs
@@ -38,6 +38,12 @@ pub struct TspStore {
     remote_vids: RwLock<HashMap<String, ResolvedVid>>,
     /// Relationship states between VID pairs. Key format: "{our_vid}\0{their_vid}".
     relationships: RwLock<HashMap<String, RelationshipState>>,
+    /// The thread digest (`SHA256` of the relationship-forming message's
+    /// plaintext frame) outstanding for each VID pair. The inviter stores its
+    /// invite digest here; the accepter stores the received invite's digest.
+    /// Used to correlate a later accept/cancel back to the forming message.
+    /// Key format: "{our_vid}\0{their_vid}".
+    thread_digests: RwLock<HashMap<String, [u8; 32]>>,
 }
 
 impl TspStore {
@@ -46,7 +52,28 @@ impl TspStore {
             private_vids: RwLock::new(HashMap::new()),
             remote_vids: RwLock::new(HashMap::new()),
             relationships: RwLock::new(HashMap::new()),
+            thread_digests: RwLock::new(HashMap::new()),
         }
+    }
+
+    // --- Thread-digest correlation ---
+
+    /// Remember the thread digest of the relationship-forming message for a pair.
+    pub fn set_thread_digest(&self, our_vid: &str, their_vid: &str, digest: [u8; 32]) {
+        let key = relationship_key(our_vid, their_vid);
+        self.thread_digests.write().unwrap().insert(key, digest);
+    }
+
+    /// Get the remembered thread digest for a pair, if any.
+    pub fn thread_digest(&self, our_vid: &str, their_vid: &str) -> Option<[u8; 32]> {
+        let key = relationship_key(our_vid, their_vid);
+        self.thread_digests.read().unwrap().get(&key).copied()
+    }
+
+    /// Forget the remembered thread digest for a pair (on cancel / teardown).
+    pub fn clear_thread_digest(&self, our_vid: &str, their_vid: &str) {
+        let key = relationship_key(our_vid, their_vid);
+        self.thread_digests.write().unwrap().remove(&key);
     }
 
     // --- Private VID management ---

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -4,6 +4,7 @@
 //! bytes to both libraries, then attempts a Direct-message round-trip both
 //! directions.
 
+use affinidi_tsp::message::control::ControlMessage;
 use affinidi_tsp::message::direct as atsp;
 use affinidi_tsp::message::routed as artd;
 use affinidi_tsp::message::MessageType;
@@ -355,6 +356,227 @@ fn main() {
             }
         };
         results.push(("Nested R->A", ok));
+    }
+
+    // ================= RELATIONSHIP CONTROL =================
+    // Invite (XRFI / RequestRelationship), Accept (XRFA / AcceptRelationship),
+    // Cancel (XRFD / CancelRelationship). The correlation key is the TSP thread
+    // digest: SHA256 of the plaintext payload frame. affinidi exposes it as
+    // `PackedMessage::thread_digest` / `UnpackedMessage::thread_digest`; the
+    // reference exposes it as `seal_and_hash`'s `digest` out-param and as the
+    // `thread_id` it derives when opening a proposal.
+    println!("\n========== RELATIONSHIP CONTROL ==========");
+
+    // ---- INVITE A->R: affinidi invite -> tsp_sdk open (RequestRelationship) ----
+    println!("--- Invite A->R: affinidi pack -> tsp_sdk open ---");
+    {
+        let invite = ControlMessage::invite();
+        let packed = atsp::pack(
+            &invite.encode(),
+            MessageType::Control,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack invite");
+        let mut buf = packed.bytes.clone();
+        let ok = match tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf) {
+            Ok((_ncd, Payload::RequestRelationship { route, thread_id }, ct, st)) => {
+                let route_empty = route.is_none();
+                // The reference's derived thread_id must equal affinidi's
+                // thread_digest for the same invite message.
+                let digest_match = thread_id == packed.thread_digest;
+                println!(
+                    "  RESULT: OK crypto={ct:?} sig={st:?} route_empty={route_empty} thread_id_match={digest_match}"
+                );
+                route_empty && digest_match
+            }
+            Ok((_, other, _, _)) => {
+                println!("  RESULT: FAIL -> unexpected payload kind: {other:?}");
+                false
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Invite A->R", ok));
+    }
+
+    // ---- INVITE R->A: tsp_sdk seal RequestRelationship -> affinidi unpack ----
+    println!("--- Invite R->A: tsp_sdk seal -> affinidi unpack ---");
+    {
+        let mut ref_digest = [0u8; 32];
+        let sealed = tsp_sdk::crypto::seal_and_hash(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::RequestRelationship {
+                route: None,
+                thread_id: [0u8; 32],
+            },
+            Some(&mut ref_digest),
+        )
+        .expect("tsp_sdk seal invite");
+        let ok = match atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk) {
+            Ok(u) => {
+                let is_control = u.message_type == MessageType::Control;
+                let control = u.control.as_ref();
+                let nonce_ok = control
+                    .and_then(|c| c.nonce.as_ref())
+                    .map(|n| n.len() == 32)
+                    .unwrap_or(false);
+                // affinidi's thread_digest must equal the reference's seal-time
+                // digest of the same message.
+                let digest_match = u.thread_digest == ref_digest;
+                println!(
+                    "  RESULT: OK kind={:?} nonce_32={nonce_ok} thread_digest_match={digest_match}",
+                    u.message_type
+                );
+                is_control && nonce_ok && digest_match
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Invite R->A", ok));
+    }
+
+    // A fixed 32-byte digest used as the accept/cancel `reply` (thread_id) so we
+    // can assert the value survives the round-trip in both directions.
+    let reply_digest: [u8; 32] = {
+        let mut d = [0u8; 32];
+        for (i, b) in d.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        d
+    };
+
+    // ---- ACCEPT A->R: affinidi accept -> tsp_sdk open (AcceptRelationship) ----
+    println!("--- Accept A->R: affinidi pack -> tsp_sdk open ---");
+    {
+        let accept = ControlMessage::accept(reply_digest);
+        let packed = atsp::pack(
+            &accept.encode(),
+            MessageType::Control,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack accept");
+        let mut buf = packed.bytes.clone();
+        let ok = match tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf) {
+            Ok((_ncd, Payload::AcceptRelationship { thread_id }, ct, st)) => {
+                let digest_match = thread_id == reply_digest;
+                println!("  RESULT: OK crypto={ct:?} sig={st:?} reply_match={digest_match}");
+                digest_match
+            }
+            Ok((_, other, _, _)) => {
+                println!("  RESULT: FAIL -> unexpected payload kind: {other:?}");
+                false
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Accept A->R", ok));
+    }
+
+    // ---- ACCEPT R->A: tsp_sdk seal AcceptRelationship -> affinidi unpack ----
+    println!("--- Accept R->A: tsp_sdk seal -> affinidi unpack ---");
+    {
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::AcceptRelationship {
+                thread_id: reply_digest,
+            },
+        )
+        .expect("tsp_sdk seal accept");
+        let ok = match atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk) {
+            Ok(u) => {
+                let reply_match = u.control.as_ref().and_then(|c| c.reply) == Some(reply_digest);
+                println!(
+                    "  RESULT: OK kind={:?} reply_match={reply_match}",
+                    u.message_type
+                );
+                u.message_type == MessageType::Control && reply_match
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Accept R->A", ok));
+    }
+
+    // ---- CANCEL A->R: affinidi cancel -> tsp_sdk open (CancelRelationship) ----
+    println!("--- Cancel A->R: affinidi pack -> tsp_sdk open ---");
+    {
+        let cancel = ControlMessage::cancel(reply_digest);
+        let packed = atsp::pack(
+            &cancel.encode(),
+            MessageType::Control,
+            alice_id,
+            bob_id,
+            &alice.sign_sk,
+            &alice.enc_sk,
+            &bob.enc_pk,
+        )
+        .expect("affinidi pack cancel");
+        let mut buf = packed.bytes.clone();
+        let ok = match tsp_sdk::crypto::open(&bob_vid, alice_vid.vid(), &mut buf) {
+            Ok((_ncd, Payload::CancelRelationship { thread_id }, ct, st)) => {
+                let digest_match = thread_id == reply_digest;
+                println!("  RESULT: OK crypto={ct:?} sig={st:?} reply_match={digest_match}");
+                digest_match
+            }
+            Ok((_, other, _, _)) => {
+                println!("  RESULT: FAIL -> unexpected payload kind: {other:?}");
+                false
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Cancel A->R", ok));
+    }
+
+    // ---- CANCEL R->A: tsp_sdk seal CancelRelationship -> affinidi unpack ----
+    println!("--- Cancel R->A: tsp_sdk seal -> affinidi unpack ---");
+    {
+        let sealed = tsp_sdk::crypto::seal(
+            &alice_vid,
+            bob_vid.vid(),
+            None,
+            Payload::CancelRelationship {
+                thread_id: reply_digest,
+            },
+        )
+        .expect("tsp_sdk seal cancel");
+        let ok = match atsp::unpack(&sealed, &bob.enc_sk, &alice.enc_pk, &alice.sign_pk) {
+            Ok(u) => {
+                let reply_match = u.control.as_ref().and_then(|c| c.reply) == Some(reply_digest);
+                println!(
+                    "  RESULT: OK kind={:?} reply_match={reply_match}",
+                    u.message_type
+                );
+                u.message_type == MessageType::Control && reply_match
+            }
+            Err(e) => {
+                println!("  RESULT: FAIL -> {e:?}");
+                false
+            }
+        };
+        results.push(("Cancel R->A", ok));
     }
 
     // ================= SUMMARY =================


### PR DESCRIPTION
## Summary

Final piece of TSP cross-impl interop: **relationship Control (invite / accept / cancel) now matches the ToIP reference `tsp_sdk` and interoperates both directions.** With #542 (Direct) and #543 (Routed/Nested + size cap), this completes **full TSP wire parity** — every message type round-trips with the reference.

## What changed

**Control encoding (`affinidi-tsp` 0.1.9 → 0.1.10)** — Control payloads are now CESR-coded per the spec (`tsp_sdk/src/cesr/packet.rs`), replacing the old serde-serialized `ACT` marker:
- **invite** → `XRFI` + hop list + 32-byte `TSP_NONCE` + empty VID
- **accept** → `XRFA` + 32-byte SHA-256 `reply`
- **cancel** → `XRFD` + 32-byte SHA-256 `reply`

(nonce widened 16 → 32 bytes to match.)

**Correlation digest** — the accept/cancel `reply` is `SHA256(plaintext payload frame)` (the `thread_digest`), computed at `pack` before sealing and at `unpack` after decrypt — byte-identical to the reference's `thread_id` (`tsp_hpke.rs` hashes the plaintext before encryption / after in-place decrypt). The previous BLAKE2s `message_digest` (over the full wire) is kept only as an opaque message id.

**FSM** — `ControlMessage` is now `{ control_type, nonce, reply, route }`; `PackedMessage`/`UnpackedMessage` expose `thread_digest`. The relationship store records the invite digest per `(our, their)`; an accept's `reply` is verified against the invite that was sent. States/transitions (`None→Pending/InviteReceived→Bidirectional→None`) unchanged.

**SDK (0.18.40 → 0.18.41)** — `accept_relationship`/`cancel_relationship` take the thread digest; new `TspOps::unpack_control`. The mediator is untouched (it relays Control opaquely by receiver).

## Tests / interop
- `interop/` harness: **14/14 PASS** — Direct, Routed, Nested, **Invite, Accept, Cancel** (each both directions) + a 2 MiB Direct case. Digest agreement confirmed (`thread_id_match` / `thread_digest_match`).
- `affinidi-tsp`: 95/95 (all-features). `tsp_delivery` 6/6 + `tsp_auth` 1/1 e2e. Clippy clean (all-features, no-default-features, sdk).