### PR TITLE
feat: add Protocols config + TspHandler trait (AffinidiMessageService skeleton)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.9"
+version = "0.3.10"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/config.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/config.rs
@@ -1,9 +1,58 @@
 use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 use affinidi_tdk_common::{config::TDKConfig, profiles::TDKProfile};
 
+use crate::error::ConfigError;
+
 #[derive(Debug)]
 pub struct DIDCommServiceConfig {
     pub listeners: Vec<ListenerConfig>,
+}
+
+/// Which transport protocols a message service handles on its single per-DID
+/// websocket.
+///
+/// The mediator allows one websocket per DID, so a node speaking both protocols
+/// multiplexes them on the same socket rather than opening a second one. At
+/// least one protocol must be enabled — an empty set is rejected at
+/// construction ([`ConfigError::NoProtocolEnabled`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Protocols {
+    pub didcomm: bool,
+    pub tsp: bool,
+}
+
+impl Protocols {
+    /// DIDComm only — the historical `DIDCommService` behaviour (and the
+    /// [`Default`]).
+    pub const DIDCOMM_ONLY: Protocols = Protocols {
+        didcomm: true,
+        tsp: false,
+    };
+    /// TSP only — a node with no DIDComm pickup; the socket carries only TSP.
+    pub const TSP_ONLY: Protocols = Protocols {
+        didcomm: false,
+        tsp: true,
+    };
+    /// Both protocols multiplexed on one socket.
+    pub const BOTH: Protocols = Protocols {
+        didcomm: true,
+        tsp: true,
+    };
+
+    /// Construct from flags, rejecting the empty set.
+    pub fn new(didcomm: bool, tsp: bool) -> Result<Self, ConfigError> {
+        if !didcomm && !tsp {
+            return Err(ConfigError::NoProtocolEnabled);
+        }
+        Ok(Self { didcomm, tsp })
+    }
+}
+
+impl Default for Protocols {
+    /// DIDComm-only, so existing `ListenerConfig` consumers keep their behaviour.
+    fn default() -> Self {
+        Protocols::DIDCOMM_ONLY
+    }
 }
 
 pub struct ListenerConfig {
@@ -14,6 +63,9 @@ pub struct ListenerConfig {
     pub message_wait_duration_secs: u64,
     pub auto_delete: bool,
     pub tdk_config: Option<TDKConfig>,
+    /// Which protocols this listener handles on its socket. Defaults to
+    /// [`Protocols::DIDCOMM_ONLY`].
+    pub protocols: Protocols,
 }
 
 impl std::fmt::Debug for ListenerConfig {
@@ -28,6 +80,7 @@ impl std::fmt::Debug for ListenerConfig {
             )
             .field("auto_delete", &self.auto_delete)
             .field("tdk_config", &self.tdk_config.as_ref().map(|_| "..."))
+            .field("protocols", &self.protocols)
             .finish()
     }
 }
@@ -54,6 +107,7 @@ impl Default for ListenerConfig {
             message_wait_duration_secs: 5,
             auto_delete: true,
             tdk_config: None,
+            protocols: Protocols::default(),
         }
     }
 }
@@ -99,6 +153,31 @@ mod tests {
         assert!(lc.acl_mode.is_none());
         assert!(matches!(lc.restart_policy, RestartPolicy::Never));
         assert!(lc.tdk_config.is_none());
+        // Back-compat: a listener defaults to DIDComm-only.
+        assert_eq!(lc.protocols, Protocols::DIDCOMM_ONLY);
+    }
+
+    #[test]
+    fn protocols_default_is_didcomm_only() {
+        assert_eq!(Protocols::default(), Protocols::DIDCOMM_ONLY);
+        assert!(Protocols::default().didcomm);
+        assert!(!Protocols::default().tsp);
+    }
+
+    #[test]
+    fn protocols_new_rejects_empty_set() {
+        let err = Protocols::new(false, false).unwrap_err();
+        assert!(matches!(err, ConfigError::NoProtocolEnabled));
+    }
+
+    #[test]
+    fn protocols_new_accepts_each_non_empty_combination() {
+        assert_eq!(
+            Protocols::new(true, false).unwrap(),
+            Protocols::DIDCOMM_ONLY
+        );
+        assert_eq!(Protocols::new(false, true).unwrap(), Protocols::TSP_ONLY);
+        assert_eq!(Protocols::new(true, true).unwrap(), Protocols::BOTH);
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/error.rs
@@ -50,6 +50,18 @@ pub enum StartupError {
     AclApply(#[source] affinidi_messaging_sdk::errors::ATMError),
 }
 
+/// Errors constructing service configuration.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// A message service must handle at least one transport. An empty
+    /// `Protocols` (neither DIDComm nor TSP) is a no-op and almost certainly a
+    /// config bug — the service-level analogue of "advertise at least one
+    /// transport".
+    #[error("at least one protocol (DIDComm or TSP) must be enabled")]
+    NoProtocolEnabled,
+}
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum DIDCommServiceError {

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
@@ -35,6 +35,42 @@ pub trait DIDCommHandler: Send + Sync + 'static {
     ) -> Result<Option<DIDCommResponse>, DIDCommServiceError>;
 }
 
+/// Top-level handler for incoming **TSP** messages.
+///
+/// The message service unpacks the TSP frame off the shared websocket and
+/// invokes this with the cleartext `payload` and the cryptographically
+/// authenticated `sender_vid` (a DID). TSP inbound is one-way at this layer (no
+/// reply is packed here, mirroring how a TSP frame carries a Trust Task into the
+/// application spine), so the handler returns `Ok(())` on success.
+///
+/// Symmetric with [`DIDCommHandler`]: a multiplexing service routes DIDComm
+/// frames to the `DIDCommHandler` and TSP frames to the `TspHandler`.
+#[async_trait]
+pub trait TspHandler: Send + Sync + 'static {
+    async fn handle(
+        &self,
+        ctx: HandlerContext,
+        payload: Vec<u8>,
+        sender_vid: String,
+    ) -> Result<(), DIDCommServiceError>;
+}
+
+/// No-op [`TspHandler`] that silently drops TSP messages — the TSP analogue of
+/// [`ignore_handler`]. Directly usable as `Arc<dyn TspHandler>`.
+pub struct IgnoreTspHandler;
+
+#[async_trait]
+impl TspHandler for IgnoreTspHandler {
+    async fn handle(
+        &self,
+        _ctx: HandlerContext,
+        _payload: Vec<u8>,
+        _sender_vid: String,
+    ) -> Result<(), DIDCommServiceError> {
+        Ok(())
+    }
+}
+
 /// Handler invoked when a route handler returns an error.
 ///
 /// Return `Some(response)` to send a reply (e.g., a problem report) back to the

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
@@ -9,12 +9,12 @@ pub mod service;
 pub mod transport;
 pub mod utils;
 
-pub use config::{DIDCommServiceConfig, ListenerConfig, RestartPolicy, RetryConfig};
-pub use error::{DIDCommServiceError, PolicyViolation, StartupError, TransportError};
+pub use config::{DIDCommServiceConfig, ListenerConfig, Protocols, RestartPolicy, RetryConfig};
+pub use error::{ConfigError, DIDCommServiceError, PolicyViolation, StartupError, TransportError};
 pub use handler::{
     DIDCommHandler, DefaultErrorHandler, ErrorHandler, Extension, Extensions, FromMessageParts,
-    HandlerContext, MESSAGE_PICKUP_STATUS_TYPE, TRUST_PING_TYPE, TRUST_PONG_TYPE, ignore_handler,
-    trust_ping_handler,
+    HandlerContext, IgnoreTspHandler, MESSAGE_PICKUP_STATUS_TYPE, TRUST_PING_TYPE, TRUST_PONG_TYPE,
+    TspHandler, ignore_handler, trust_ping_handler,
 };
 pub use middleware::{
     MessagePolicy, MiddlewareHandler, MiddlewareResult, Next, RequestLogging, middleware_fn,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -344,7 +344,7 @@ impl DIDCommService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ListenerConfig, RestartPolicy};
+    use crate::config::{ListenerConfig, Protocols, RestartPolicy};
     use affinidi_messaging_didcomm::Message;
     use affinidi_tdk_common::profiles::TDKProfile;
     use serde_json::json;
@@ -458,6 +458,7 @@ mod tests {
             message_wait_duration_secs: 5,
             auto_delete: true,
             tdk_config: None,
+            protocols: Protocols::default(),
         };
 
         let result = service.add_listener(config).await;


### PR DESCRIPTION
**Stage 2a of ADR 0005** — the risk-free, fully-tested foundation for `AffinidiMessageService`. Existing DIDComm behaviour is untouched; no runtime path changes yet.

## Adds
- **`Protocols { didcomm, tsp }`** with `DIDCOMM_ONLY` / `TSP_ONLY` / `BOTH` constants and **`Protocols::new(didcomm, tsp)` that rejects the empty set** → `ConfigError::NoProtocolEnabled`. This is the service-level analogue of the "advertise at least one transport" brick-prevention rule. `Default` is `DIDCOMM_ONLY`, so existing consumers are unaffected.
- **`ListenerConfig.protocols`** field (defaults to `DIDCOMM_ONLY`).
- **`TspHandler`** trait — symmetric with `DIDCommHandler`: `handle(ctx, payload, sender_vid) -> Result<()>` (TSP inbound is one-way at this layer). Plus **`IgnoreTspHandler`** (the TSP analogue of `ignore_handler`).
- Exports: `Protocols`, `ConfigError`, `TspHandler`, `IgnoreTspHandler`.

## Notes
- **Unconditional — no `tsp` feature gate.** These types use no tsp-gated APIs. The feature gate arrives with the **listener routing (stage 2b)**, which calls `atm.tsp().unpack_bytes` (SDK-tsp-gated) to route a TSP frame to the `TspHandler`.
- **Tests:** 4 new/updated unit tests (the empty-set rejection, each non-empty combo, defaults); **76 lib tests pass**.
- `affinidi-messaging-didcomm-service` `0.3.9 → 0.3.10`.

Next — **stage 2b**: wire `process_next_message` to use `live_stream_next_frame` (stage 1) and route DIDComm → existing handler / TSP → `TspHandler` (behind a new `tsp` feature on this crate).
