### PR TITLE
feat: route inbound TSP frames on the shared websocket (listener multiplex)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.10"
+version = "0.3.11"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -11,6 +11,13 @@ repository.workspace = true
 publish.workspace = true
 readme = "README.md"
 rust-version.workspace = true
+
+[features]
+## Multiplex TSP alongside DIDComm on the listener's single websocket.
+## Enables the SDK's TSP surface (`atm.tsp().unpack_bytes`) used to route
+## inbound TSP frames to a `TspHandler`. Off by default — a DIDComm-only build
+## is unaffected.
+tsp = ["affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 affinidi-tdk-common = "0.6"

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -12,10 +12,12 @@ use tracing::{error, info, warn};
 
 use crate::config::ListenerConfig;
 use crate::error::{DIDCommServiceError, StartupError};
-use crate::handler::{DIDCommHandler, HandlerContext};
+use crate::handler::{DIDCommHandler, HandlerContext, TspHandler};
 use crate::response::DIDCommResponse;
 use crate::service::ListenerEvent;
 use crate::transport;
+#[cfg(feature = "tsp")]
+use crate::utils::new_message_id;
 use crate::utils::{get_parent_thread_id, get_thread_id};
 
 /// Convert SDK compat UnpackMetadata to didcomm crate UnpackMetadata
@@ -49,6 +51,10 @@ pub(crate) struct ConnectionHandle {
 pub(crate) struct Listener {
     pub config: ListenerConfig,
     pub handler: Arc<dyn DIDCommHandler>,
+    /// Optional TSP handler. When set and `config.protocols.tsp` is on, inbound
+    /// TSP frames off the shared socket are routed here. `None` → TSP frames are
+    /// dropped with a warning.
+    pub tsp_handler: Option<Arc<dyn TspHandler>>,
     pub shutdown: CancellationToken,
     atm: Option<ATM>,
     profile: Option<Arc<ATMProfile>>,
@@ -62,6 +68,7 @@ impl Listener {
     pub fn new(
         config: ListenerConfig,
         handler: Arc<dyn DIDCommHandler>,
+        tsp_handler: Option<Arc<dyn TspHandler>>,
         shutdown: CancellationToken,
         connection_tx: watch::Sender<Option<ConnectionHandle>>,
         events_tx: broadcast::Sender<ListenerEvent>,
@@ -69,6 +76,7 @@ impl Listener {
         Self {
             config,
             handler,
+            tsp_handler,
             shutdown,
             atm: None,
             profile: None,
@@ -236,6 +244,14 @@ impl Listener {
         &self,
         tasks: &mut JoinSet<()>,
     ) -> Result<(), DIDCommServiceError> {
+        // When TSP is enabled, pull frames of *either* protocol off the one
+        // socket and route by transport (a node speaks both over a single
+        // per-DID websocket — opening a second would be evicted as a duplicate).
+        #[cfg(feature = "tsp")]
+        if self.config.protocols.tsp {
+            return self.process_next_frame(tasks).await;
+        }
+
         let wait_duration = Duration::from_secs(self.config.message_wait_duration_secs);
         let auto_delete = self.config.auto_delete;
         let atm = self.atm()?;
@@ -259,6 +275,104 @@ impl Listener {
         }
 
         Ok(())
+    }
+
+    /// Multiplexed receive: pull the next inbound frame (DIDComm *or* TSP) off
+    /// the shared websocket and dispatch by transport.
+    #[cfg(feature = "tsp")]
+    async fn process_next_frame(&self, tasks: &mut JoinSet<()>) -> Result<(), DIDCommServiceError> {
+        use affinidi_messaging_sdk::protocols::message_pickup::InboundFrame;
+
+        let wait_duration = Duration::from_secs(self.config.message_wait_duration_secs);
+        let auto_delete = self.config.auto_delete;
+        let atm = self.atm()?;
+        let profile = self.profile()?;
+
+        let next = atm
+            .message_pickup()
+            .live_stream_next_frame(profile, Some(wait_duration), auto_delete)
+            .await
+            .map_err(DIDCommServiceError::ATM)?;
+
+        match next {
+            Some(InboundFrame::DidComm(message, meta)) => {
+                let meta = convert_meta(*meta);
+                let listener_id = self.config.id.clone();
+                let atm = atm.clone();
+                let profile = profile.clone();
+                let handler = self.handler.clone();
+                tasks.spawn(async move {
+                    Self::dispatch_message(&listener_id, &atm, &profile, &handler, *message, meta)
+                        .await;
+                });
+            }
+            Some(InboundFrame::Tsp(packed)) => {
+                if let Some(tsp_handler) = self.tsp_handler.clone() {
+                    let listener_id = self.config.id.clone();
+                    let atm = atm.clone();
+                    let profile = profile.clone();
+                    tasks.spawn(async move {
+                        Self::dispatch_tsp(&listener_id, &atm, &profile, &tsp_handler, *packed)
+                            .await;
+                    });
+                } else {
+                    warn!(
+                        profile = %profile.inner.alias,
+                        "received TSP frame but no TspHandler configured — dropping"
+                    );
+                }
+            }
+            // `InboundFrame` is `#[non_exhaustive]`; tolerate a future frame
+            // kind this build doesn't yet route.
+            Some(_) => {
+                warn!(
+                    profile = %profile.inner.alias,
+                    "received unrecognised inbound frame kind — dropping"
+                );
+            }
+            None => {}
+        }
+
+        Ok(())
+    }
+
+    /// Unpack a TSP frame (yielding cleartext payload + authenticated sender VID)
+    /// and hand it to the configured [`TspHandler`].
+    #[cfg(feature = "tsp")]
+    pub(crate) async fn dispatch_tsp(
+        listener_id: &str,
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        handler: &Arc<dyn TspHandler>,
+        packed: String,
+    ) {
+        // NOTE: the packed frame surfaces as a String off the pickup socket; the
+        // exact qb2/qb64 encoding handed to `unpack_bytes` is confirmed by the
+        // live VTA↔mediator run.
+        let (payload, sender_vid) = match atm.tsp().unpack_bytes(profile, packed.as_bytes()).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(profile = %profile.inner.alias, error = %e, "Failed to unpack TSP frame");
+                return;
+            }
+        };
+
+        let ctx = HandlerContext {
+            listener_id: listener_id.to_string(),
+            atm: atm.clone(),
+            profile: profile.clone(),
+            sender_did: Some(sender_vid.clone()),
+            // A TSP frame carries no DIDComm thread/message id; synthesize one so
+            // handlers and logs have a stable id.
+            message_id: new_message_id(),
+            thread_id: String::new(),
+            parent_thread_id: None,
+        };
+
+        let profile_alias = profile.inner.alias.clone();
+        if let Err(e) = handler.handle(ctx, payload, sender_vid).await {
+            warn!(profile = %profile_alias, error = %e, "Unhandled TSP handler error");
+        }
     }
 
     pub(crate) async fn dispatch_message(

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mod.rs
@@ -15,7 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::{DIDCommServiceConfig, ListenerConfig};
 use crate::error::DIDCommServiceError;
-use crate::handler::DIDCommHandler;
+use crate::handler::{DIDCommHandler, TspHandler};
 
 use listener::ConnectionHandle;
 
@@ -44,6 +44,10 @@ pub enum ListenerEvent {
 pub struct DIDCommService {
     listeners: Arc<RwLock<HashMap<String, ListenerHandle>>>,
     handler: Arc<dyn DIDCommHandler>,
+    /// Optional TSP handler, attached via [`DIDCommService::with_tsp_handler`].
+    /// Used by listeners whose `protocols.tsp` is enabled to route inbound TSP
+    /// frames off the shared websocket.
+    tsp_handler: Option<Arc<dyn TspHandler>>,
     shutdown: CancellationToken,
     events_tx: broadcast::Sender<ListenerEvent>,
 }
@@ -79,13 +83,48 @@ impl DIDCommService {
         handler: impl DIDCommHandler,
         shutdown: CancellationToken,
     ) -> Result<DIDCommService, DIDCommServiceError> {
-        let handler = Arc::new(handler) as Arc<dyn DIDCommHandler>;
+        Self::start_inner(
+            config,
+            Arc::new(handler) as Arc<dyn DIDCommHandler>,
+            None,
+            shutdown,
+        )
+        .await
+    }
+
+    /// Like [`start`](Self::start), but also routes inbound **TSP** frames to
+    /// `tsp_handler` on listeners whose `protocols.tsp` is enabled. The TSP
+    /// frames ride the same single per-DID websocket as DIDComm (no second
+    /// socket). Routing only takes effect when this crate is built with the
+    /// `tsp` feature; without it the handler is stored but never invoked.
+    pub async fn start_with_tsp(
+        config: DIDCommServiceConfig,
+        handler: impl DIDCommHandler,
+        tsp_handler: impl TspHandler,
+        shutdown: CancellationToken,
+    ) -> Result<DIDCommService, DIDCommServiceError> {
+        Self::start_inner(
+            config,
+            Arc::new(handler) as Arc<dyn DIDCommHandler>,
+            Some(Arc::new(tsp_handler) as Arc<dyn TspHandler>),
+            shutdown,
+        )
+        .await
+    }
+
+    async fn start_inner(
+        config: DIDCommServiceConfig,
+        handler: Arc<dyn DIDCommHandler>,
+        tsp_handler: Option<Arc<dyn TspHandler>>,
+        shutdown: CancellationToken,
+    ) -> Result<DIDCommService, DIDCommServiceError> {
         let listeners = Arc::new(RwLock::new(HashMap::new()));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
 
         let service = DIDCommService {
             listeners: listeners.clone(),
             handler: handler.clone(),
+            tsp_handler,
             shutdown: shutdown.clone(),
             events_tx,
         };
@@ -313,6 +352,7 @@ impl DIDCommService {
         let listener_did = config.profile.did.clone();
         let listener_token = self.shutdown.child_token();
         let handler = self.handler.clone();
+        let tsp_handler = self.tsp_handler.clone();
         let restart_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let restart_count_clone = restart_count.clone();
         let token_clone = listener_token.clone();
@@ -321,8 +361,14 @@ impl DIDCommService {
         let (connection_tx, connection_rx) = watch::channel(None);
 
         let task = tokio::spawn(async move {
-            let mut listener =
-                listener::Listener::new(config, handler, token_clone, connection_tx, events_tx);
+            let mut listener = listener::Listener::new(
+                config,
+                handler,
+                tsp_handler,
+                token_clone,
+                connection_tx,
+                events_tx,
+            );
             listener.run_with_restart(restart_count_clone).await;
         });
 
@@ -360,6 +406,7 @@ mod tests {
         DIDCommService {
             listeners: Arc::new(RwLock::new(HashMap::new())),
             handler: Arc::new(handler),
+            tsp_handler: None,
             shutdown: CancellationToken::new(),
             events_tx,
         }


### PR DESCRIPTION
**Stage 2b of ADR 0005** — the behavioural half of the service skeleton: the listener now multiplexes DIDComm + TSP off its **single** websocket.

## What it does
When a listener's `protocols.tsp` is on (and the crate is built with the new `tsp` feature), `process_next_message` pulls via **`live_stream_next_frame`** (stage 1) and routes by transport off the one per-DID socket:
- `InboundFrame::DidComm` → the existing `DIDCommHandler` chain (unchanged)
- `InboundFrame::Tsp` → unpack via `atm.tsp().unpack_bytes` → the `TspHandler`

**No second socket** — that's precisely what the mediator evicts as `duplicate-channel`. This is the core fix the ADR exists for.

## Shape
- **New `tsp` feature** = `["affinidi-messaging-sdk/tsp"]`; *all* TSP routing/unpack is behind it. The default (DIDComm-only) build and behaviour are **byte-identical** to before — the `tsp` branch is `#[cfg(feature = "tsp")]`.
- **`DIDCommService::start_with_tsp(config, handler, tsp_handler, shutdown)`** — a non-breaking sibling of `start()` that attaches the `TspHandler` before listeners spawn. Existing `start()` callers are untouched.
- Threads `tsp_handler: Option<Arc<dyn TspHandler>>` through `DIDCommService → spawn_listener → Listener::new`. No handler → TSP frames dropped with a warning. Tolerates future `InboundFrame` variants (it's `#[non_exhaustive]`).
- A TSP frame carries no DIDComm thread/message id, so `dispatch_tsp` synthesizes a `message_id` and sets `sender_did` from the authenticated sender VID.

## Verification
- **76 lib tests pass in BOTH feature configs** (default + `--features tsp`); clippy clean on the tsp build.
- **Honest boundary:** the routing structure is type-checked and compiles both ways, but the live unpack (and the exact qb2/qb64 encoding of the pickup-socket frame handed to `unpack_bytes`) is confirmed by the **live VTA↔mediator run** — flagged in a code comment. No live mediator in CI.
- `affinidi-messaging-didcomm-service` `0.3.10 → 0.3.11`.

Next — **stage 3** (unified outbound send) and **stage 4** (the `AffinidiMessageService` public face / `DIDCommService` shim). Then **stage 5** in VTI swaps the #595 second-socket loop for `start_with_tsp` + a `TspHandler`.
