### PR TITLE
fix: accept sender-authenticated nested DIDComm envelopes again

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 30th June 2026
 
+### 0.16.36 — fix: accept sender-authenticated nested DIDComm envelopes again
+
+- The DIDComm unpack (`didcomm_compat`) only inspected the outermost layer, so it never
+  populated `sign_from` and never recursed — making `anoncrypt(signed(..))`,
+  `anoncrypt(authcrypt(..))`, and top-level signed messages look anonymous and get rejected
+  by the `block_anonymous_outer_envelope` check (only single-layer `authcrypt` survived).
+  This was a regression from the full recursive unpack the mediator previously used.
+- Fix: after decrypting a JWE, recurse into a nested envelope — verify a nested/top-level
+  JWS against the signer's resolved Ed25519 key (from the signer DID's `authentication`
+  relationship) and set `sign_from`; decrypt a nested authcrypt and set `authenticated`.
+  Signatures are **verified** (a forged signature errors, never passes), and recursion is
+  bounded (`MAX_NEST_DEPTH = 8`). The `block_anonymous_outer_envelope` check and its default
+  are unchanged — only the metadata feeding it is now correct, so genuinely-anonymous
+  `anoncrypt(plaintext)` is still blocked.
+- Adds `tests/test_sender_authentication.rs` covering all four wrappings + a forged-signature
+  case.
+
 ### 0.16.35 — store conformance: OOB discovery round-trip; rustfmt
 
 - `tests/store_conformance.rs` gains an `oob_discovery_roundtrip` check (store → get →

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.35"
+version = "0.16.36"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -16,6 +16,7 @@ use affinidi_did_common::{document::DocumentExt, verification_method::Verificati
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_didcomm::{
     jwe::decrypt::decrypt,
+    jws::verify::verify_ed25519,
     message::{
         Message,
         pack::{pack_encrypted_anoncrypt, pack_encrypted_authcrypt},
@@ -184,7 +185,7 @@ impl MetaEnvelope {
         if self.parsed.get("ciphertext").is_some() && self.parsed.get("recipients").is_some() {
             self.unpack_jwe(did_resolver, secrets_resolver).await
         } else if self.parsed.get("payload").is_some() && self.parsed.get("signatures").is_some() {
-            unpack_jws(&self.raw, &self.sha256_hash)
+            unpack_jws(&self.raw, &self.sha256_hash, did_resolver).await
         } else if self.parsed.get("type").is_some() {
             let msg = Message::from_json(self.raw.as_bytes())
                 .map_err(|e| format!("Cannot parse plaintext message: {e}"))?;
@@ -255,10 +256,11 @@ impl MetaEnvelope {
         )
         .map_err(|e| format!("Couldn't decrypt message: {e}"))?;
 
-        let msg = Message::from_json(&decrypted.plaintext)
-            .map_err(|e| format!("Cannot parse decrypted message: {e}"))?;
-
-        let metadata = UnpackMetadata {
+        // Seed metadata from the OUTER JWE layer. `authenticated`/`sign_from`
+        // may be promoted below if the decrypted plaintext is itself a signed
+        // JWS or a nested authcrypt JWE (the regression this fixes: the old
+        // shim stopped here and mis-classified those as anonymous).
+        let mut metadata = UnpackMetadata {
             encrypted: true,
             authenticated: decrypted.authenticated,
             anonymous_sender: !decrypted.authenticated,
@@ -268,7 +270,167 @@ impl MetaEnvelope {
             ..Default::default()
         };
 
+        let msg = recurse_decrypted_plaintext(
+            &decrypted.plaintext,
+            &recipient_kid_str,
+            &recipient_private,
+            did_resolver,
+            &mut metadata,
+            0,
+        )
+        .await?;
+
         Ok((msg, metadata))
+    }
+}
+
+/// Maximum nested-envelope depth we will peel, bounding decrypt/verify work
+/// against a maliciously deeply-nested message.
+const MAX_NEST_DEPTH: u8 = 8;
+
+/// Interpret a decrypted JWE plaintext and recurse into any nested envelope,
+/// promoting `metadata` as authentication/signature evidence is recovered.
+///
+/// Three shapes can appear inside a decrypted JWE:
+/// - a plaintext DIDComm `Message` (has `type`),
+/// - a JWS (sign-then-encrypt — has `payload`+`signatures`), or
+/// - another JWE (anoncrypt(authcrypt(..)) — has `ciphertext`+`recipients`).
+///
+/// `recipient_private`/`recipient_kid` are the SAME local recipient key used
+/// for the outer layer, reused to peel a nested JWE addressed to us.
+async fn recurse_decrypted_plaintext(
+    plaintext: &[u8],
+    recipient_kid: &str,
+    recipient_private: &PrivateKeyAgreement,
+    did_resolver: &DIDCacheClient,
+    metadata: &mut UnpackMetadata,
+    depth: u8,
+) -> Result<Message, String> {
+    if depth >= MAX_NEST_DEPTH {
+        return Err(format!(
+            "nested DIDComm envelope exceeds max depth {MAX_NEST_DEPTH}"
+        ));
+    }
+    // Anything that isn't valid JSON can only be a bare Message attempt.
+    let value: serde_json::Value = match serde_json::from_slice(plaintext) {
+        Ok(v) => v,
+        Err(_) => {
+            return Message::from_json(plaintext)
+                .map_err(|e| format!("Cannot parse decrypted message: {e}"));
+        }
+    };
+
+    if value.get("payload").is_some() && value.get("signatures").is_some() {
+        // Nested JWS: sign-then-encrypt. Verify the inner signature with the
+        // signer's resolved Ed25519 key and attribute non-repudiation. Never
+        // trust the kid without verifying — a bad signature must error.
+        let jws_str = std::str::from_utf8(plaintext)
+            .map_err(|e| format!("Inner JWS is not valid UTF-8: {e}"))?;
+        let signer_kid = extract_jws_signer_kid(&value)
+            .ok_or("Inner JWS has no signer kid to resolve a verification key")?;
+        let signer_did = did_part(&signer_kid);
+        let pubkey = resolve_did_ed25519_verification(&signer_did, Some(&signer_kid), did_resolver)
+            .await
+            .ok_or_else(|| {
+                format!("Could not resolve Ed25519 verification key for signer {signer_kid}")
+            })?;
+        let verified = verify_ed25519(jws_str, &pubkey)
+            .map_err(|e| format!("Inner JWS signature verification failed: {e}"))?;
+        metadata.non_repudiation = true;
+        metadata.sign_from = verified.signer_kid.or(Some(signer_kid));
+        return Message::from_json(&verified.payload)
+            .map_err(|e| format!("Cannot parse verified JWS payload: {e}"));
+    }
+
+    if value.get("ciphertext").is_some() && value.get("recipients").is_some() {
+        // Nested JWE: anoncrypt(authcrypt(..)). Decrypt the inner layer with
+        // the same local recipient key, resolving the inner sender's
+        // key-agreement key (from skid/apu) so ECDH-1PU authcrypt is recovered.
+        let inner_str = std::str::from_utf8(plaintext)
+            .map_err(|e| format!("Inner JWE is not valid UTF-8: {e}"))?;
+        let inner_sender_did = inner_jwe_sender_did(&value);
+        let inner_sender_public = if let Some(did) = &inner_sender_did {
+            resolve_did_key_agreement(did, did_resolver).await
+        } else {
+            None
+        };
+        let inner = decrypt(
+            inner_str,
+            recipient_kid,
+            recipient_private,
+            inner_sender_public.as_ref(),
+        )
+        .map_err(|e| format!("Couldn't decrypt nested JWE: {e}"))?;
+
+        if inner.authenticated {
+            metadata.authenticated = true;
+            metadata.anonymous_sender = false;
+            metadata.encrypted_from_kid = inner.sender_kid.clone();
+        }
+
+        // The inner plaintext may itself be a Message or a JWS — recurse.
+        return Box::pin(recurse_decrypted_plaintext(
+            &inner.plaintext,
+            recipient_kid,
+            recipient_private,
+            did_resolver,
+            metadata,
+            depth + 1,
+        ))
+        .await;
+    }
+
+    // Plaintext DIDComm message (`type`), or a best-effort parse otherwise.
+    Message::from_json(plaintext).map_err(|e| format!("Cannot parse decrypted message: {e}"))
+}
+
+/// Extract the signer kid from a parsed JWS (General JSON Serialization).
+/// Prefers the integrity-protected header, falling back to the per-signature
+/// unprotected header (where credo-ts / didcomm-python place the kid).
+fn extract_jws_signer_kid(jws: &serde_json::Value) -> Option<String> {
+    let sig = jws.get("signatures")?.as_array()?.first()?;
+
+    // Protected header (base64url-encoded JSON) takes precedence.
+    if let Some(protected_b64) = sig.get("protected").and_then(|p| p.as_str())
+        && let Ok(bytes) = BASE64_URL_SAFE_NO_PAD.decode(protected_b64)
+        && let Ok(header) = serde_json::from_slice::<serde_json::Value>(&bytes)
+        && let Some(kid) = header.get("kid").and_then(|k| k.as_str())
+    {
+        return Some(kid.to_string());
+    }
+
+    // Fall back to the unprotected per-signature header.
+    sig.get("header")
+        .and_then(|h| h.get("kid"))
+        .and_then(|k| k.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Extract the inner JWE's sender DID from its protected header (`skid`, or
+/// `apu` fallback), mirroring the outer-layer logic in `MetaEnvelope::new`.
+fn inner_jwe_sender_did(jwe: &serde_json::Value) -> Option<String> {
+    let protected_b64 = jwe.get("protected").and_then(|p| p.as_str())?;
+    let bytes = BASE64_URL_SAFE_NO_PAD.decode(protected_b64).ok()?;
+    let header: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+
+    if let Some(skid) = header.get("skid").and_then(|s| s.as_str()) {
+        return Some(did_part(skid));
+    }
+    if let Some(apu) = header.get("apu").and_then(|a| a.as_str())
+        && let Ok(apu_bytes) = BASE64_URL_SAFE_NO_PAD.decode(apu)
+        && let Ok(apu_str) = String::from_utf8(apu_bytes)
+        && apu_str.contains('#')
+    {
+        return Some(did_part(&apu_str));
+    }
+    None
+}
+
+/// Strip the `#fragment` from a DID URL, yielding the bare DID.
+fn did_part(kid: &str) -> String {
+    match kid.find('#') {
+        Some(pos) => kid[..pos].to_string(),
+        None => kid.to_string(),
     }
 }
 
@@ -282,28 +444,87 @@ pub async fn unpack<S: SecretsResolver>(
     envelope.unpack(did_resolver, secrets_resolver).await
 }
 
-fn unpack_jws(msg_string: &str, sha256_hash: &str) -> Result<(Message, UnpackMetadata), String> {
+/// Unpack a top-level (unencrypted) JWS. Resolves the signer's Ed25519 key,
+/// verifies the signature, and records `sign_from` — without this the message
+/// is sender-authenticated but `sign_from` stays `None`, so the inbound
+/// anonymous-envelope check wrongly rejects it.
+async fn unpack_jws(
+    msg_string: &str,
+    sha256_hash: &str,
+    did_resolver: &DIDCacheClient,
+) -> Result<(Message, UnpackMetadata), String> {
     let value: serde_json::Value =
         serde_json::from_str(msg_string).map_err(|e| format!("Cannot parse JWS: {e}"))?;
 
-    let payload_b64 = value["payload"]
-        .as_str()
-        .ok_or("Invalid JWS: missing payload")?;
+    let signer_kid =
+        extract_jws_signer_kid(&value).ok_or("JWS has no signer kid to resolve a key")?;
+    let signer_did = did_part(&signer_kid);
+    let pubkey = resolve_did_ed25519_verification(&signer_did, Some(&signer_kid), did_resolver)
+        .await
+        .ok_or_else(|| {
+            format!("Could not resolve Ed25519 verification key for signer {signer_kid}")
+        })?;
 
-    let payload_bytes = BASE64_URL_SAFE_NO_PAD
-        .decode(payload_b64)
-        .map_err(|e| format!("Invalid JWS payload base64: {e}"))?;
+    let verified = verify_ed25519(msg_string, &pubkey)
+        .map_err(|e| format!("JWS signature verification failed: {e}"))?;
 
-    let msg =
-        Message::from_json(&payload_bytes).map_err(|e| format!("Cannot parse JWS payload: {e}"))?;
+    let msg = Message::from_json(&verified.payload)
+        .map_err(|e| format!("Cannot parse JWS payload: {e}"))?;
 
     let metadata = UnpackMetadata {
         non_repudiation: true,
+        sign_from: verified.signer_kid.or(Some(signer_kid)),
         sha256_hash: sha256_hash.to_string(),
         ..Default::default()
     };
 
     Ok((msg, metadata))
+}
+
+/// Resolve a DID's Ed25519 verification (signing) public key as raw 32 bytes.
+///
+/// Picks the verification method named by `prefer_kid` when present in the
+/// authentication relationship, otherwise the DID's first authentication key.
+/// Supports `publicKeyMultibase` (multikey, `ed25519-pub` codec) and
+/// `publicKeyJwk` (`OKP`/`Ed25519`).
+async fn resolve_did_ed25519_verification(
+    did: &str,
+    prefer_kid: Option<&str>,
+    did_resolver: &DIDCacheClient,
+) -> Option<[u8; 32]> {
+    let doc = did_resolver.resolve(did).await.ok()?;
+
+    // Prefer the exact authentication kid the signer claimed; fall back to the
+    // DID's first authentication key.
+    let auth = doc.doc.find_authentication(None);
+    let kid = prefer_kid
+        .filter(|k| auth.iter().any(|a| a == k))
+        .map(|k| k.to_string())
+        .or_else(|| auth.first().map(|k| k.to_string()))?;
+
+    let vm = doc.doc.get_verification_method(&kid)?;
+
+    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
+        && let Some(multibase_str) = multibase_value.as_str()
+        && let Ok((codec, key_bytes)) =
+            affinidi_encoding::decode_multikey_with_codec(multibase_str)
+        && codec == affinidi_encoding::ED25519_PUB
+        && key_bytes.len() == 32
+    {
+        return key_bytes.try_into().ok();
+    }
+
+    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk")
+        && jwk_value.get("kty").and_then(|v| v.as_str()) == Some("OKP")
+        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some("Ed25519")
+        && let Some(x_b64) = jwk_value.get("x").and_then(|v| v.as_str())
+        && let Ok(x_bytes) = BASE64_URL_SAFE_NO_PAD.decode(x_b64)
+        && x_bytes.len() == 32
+    {
+        return x_bytes.try_into().ok();
+    }
+
+    None
 }
 
 /// Resolve a DID's first key agreement public key.

--- a/crates/messaging/affinidi-messaging-mediator/tests/test_sender_authentication.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/test_sender_authentication.rs
@@ -378,3 +378,152 @@ async fn meta_envelope_detects_anoncrypt_no_sender() {
         "anoncrypt envelope should not have from_did"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression: nested-envelope classification.
+//
+// The compat unpack used to decrypt only ONE outer JWE layer and never
+// populate `sign_from` / never recurse, so it mis-classified several valid
+// sender-authenticated wrappings as anonymous (rejected by inbound.rs).
+//
+// For the SAME Alice→Bob DIDs/keys, pack all four wrappings and assert that
+// unpack now populates `authenticated`/`sign_from` correctly, so the inbound.rs
+// anonymous-block decision accepts the first three and blocks only the fourth.
+// ---------------------------------------------------------------------------
+
+use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
+use affinidi_did_common::document::DocumentExt;
+use affinidi_messaging_didcomm::{jwe::encrypt, jws::sign::sign_ed25519};
+use base64::Engine;
+
+/// Resolve a DID's first key-agreement public key (mirrors what the compat
+/// layer does internally) so the test can build inner JWE layers.
+async fn resolve_ka_public(did: &str, resolver: &DIDCacheClient) -> (String, PublicKeyAgreement) {
+    let doc = resolver.resolve(did).await.unwrap();
+    let kids = doc.doc.find_key_agreement(None);
+    let kid = kids.first().unwrap().to_string();
+    let vm = doc.doc.get_verification_method(&kid).unwrap();
+    let multibase = vm.property_set["publicKeyMultibase"].as_str().unwrap();
+    let (codec, bytes) = affinidi_encoding::decode_multikey_with_codec(multibase).unwrap();
+    let curve = match codec {
+        affinidi_encoding::X25519_PUB => Curve::X25519,
+        affinidi_encoding::P256_PUB => Curve::P256,
+        affinidi_encoding::SECP256K1_PUB => Curve::K256,
+        affinidi_encoding::P384_PUB => Curve::P384,
+        affinidi_encoding::P521_PUB => Curve::P521,
+        other => panic!("unexpected KA codec {other:#x}"),
+    };
+    (kid, PublicKeyAgreement::from_raw_bytes(curve, &bytes).unwrap())
+}
+
+/// Decode the 32-byte `d` of an OKP/EC JWK (the JWKs here use url-safe base64).
+fn jwk_d_bytes(jwk: &serde_json::Value) -> Vec<u8> {
+    let d = jwk["d"].as_str().unwrap();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(d)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn nested_wrappings_classified_correctly() {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+
+    let alice_ka_kid = format!("{ALICE_DID}#key-2");
+    let alice_sign_kid = format!("{ALICE_DID}#key-1");
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    // Alice's sender keys: key-agreement (secp256k1, ALICE_E1) for authcrypt,
+    // Ed25519 (ALICE_V1) for signing.
+    let alice_ka_priv =
+        PrivateKeyAgreement::from_raw_bytes(Curve::K256, &jwk_d_bytes(&ALICE_E1)).unwrap();
+    let alice_ed: [u8; 32] = jwk_d_bytes(&ALICE_V1).try_into().unwrap();
+
+    let msg = build_test_message(ALICE_DID, BOB_DID, "https://example.com/test");
+    let plaintext = msg.to_json().unwrap();
+
+    // 1. authcrypt(plaintext)
+    let authcrypt = encrypt::authcrypt(
+        &plaintext,
+        &alice_ka_kid,
+        &alice_ka_priv,
+        &[(&bob_ka_kid, &bob_ka_pub)],
+    )
+    .unwrap();
+
+    // 2. anoncrypt(signed(plaintext))
+    let inner_jws = sign_ed25519(&plaintext, &alice_sign_kid, &alice_ed).unwrap();
+    let anon_signed =
+        encrypt::anoncrypt(inner_jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    // 3. anoncrypt(authcrypt(plaintext))
+    let anon_auth = encrypt::anoncrypt(authcrypt.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    // 4. anoncrypt(plaintext)
+    let anon_plain = encrypt::anoncrypt(&plaintext, &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let (_, m_authcrypt) = didcomm_compat::unpack(&authcrypt, &resolver, &bob_secrets)
+        .await
+        .expect("authcrypt(plaintext) must unpack");
+    let (_, m_anon_signed) = didcomm_compat::unpack(&anon_signed, &resolver, &bob_secrets)
+        .await
+        .expect("anoncrypt(signed(plaintext)) must unpack");
+    let (_, m_anon_auth) = didcomm_compat::unpack(&anon_auth, &resolver, &bob_secrets)
+        .await
+        .expect("anoncrypt(authcrypt(plaintext)) must unpack");
+    let (_, m_anon_plain) = didcomm_compat::unpack(&anon_plain, &resolver, &bob_secrets)
+        .await
+        .expect("anoncrypt(plaintext) must unpack");
+
+    // Metadata assertions per wrapping.
+    assert!(
+        m_authcrypt.authenticated,
+        "authcrypt(plaintext) must be authenticated"
+    );
+    assert!(
+        m_anon_signed.sign_from.is_some(),
+        "anoncrypt(signed) must surface a verified signer (sign_from)"
+    );
+    assert!(
+        m_anon_auth.authenticated,
+        "anoncrypt(authcrypt) must recover inner authentication"
+    );
+    assert!(
+        !m_anon_plain.authenticated && m_anon_plain.sign_from.is_none(),
+        "pure anoncrypt must remain anonymous"
+    );
+
+    // The exact inbound.rs anonymous-block decision.
+    let blocked =
+        |m: &affinidi_messaging_sdk::messages::compat::UnpackMetadata| {
+            !m.authenticated && m.sign_from.is_none()
+        };
+    assert!(!blocked(&m_authcrypt), "authcrypt must be accepted");
+    assert!(!blocked(&m_anon_signed), "anoncrypt(signed) must be accepted");
+    assert!(!blocked(&m_anon_auth), "anoncrypt(authcrypt) must be accepted");
+    assert!(blocked(&m_anon_plain), "pure anoncrypt must be blocked");
+}
+
+/// A nested signed JWS with a BAD signature must NOT be accepted — verification
+/// must fail (we never trust an unverified signer kid).
+#[tokio::test]
+async fn nested_signed_with_bad_signature_is_rejected() {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+
+    let alice_sign_kid = format!("{ALICE_DID}#key-1");
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    // Sign with a DIFFERENT key (arbitrary 32-byte seed) but claim Alice's
+    // kid — the resolver will fetch Alice's REAL Ed25519 key, so verification
+    // against this forged signature must fail.
+    let wrong_key: [u8; 32] = [7u8; 32];
+    let msg = build_test_message(ALICE_DID, BOB_DID, "https://example.com/test");
+    let forged_jws = sign_ed25519(&msg.to_json().unwrap(), &alice_sign_kid, &wrong_key).unwrap();
+    let anon_forged =
+        encrypt::anoncrypt(forged_jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let result = didcomm_compat::unpack(&anon_forged, &resolver, &bob_secrets).await;
+    assert!(
+        result.is_err(),
+        "a forged inner signature must be rejected, not pass as authenticated"
+    );
+}


### PR DESCRIPTION
## Problem

The mediator's DIDComm unpack (`didcomm_compat.rs`) only inspected the **outermost** envelope layer — never populating `sign_from`, never recursing. So `anoncrypt(signed(plaintext))`, `anoncrypt(authcrypt(plaintext))`, and top-level signed messages all came back `authenticated=false, sign_from=None` and were rejected as anonymous by `inbound.rs:577` (`block_anonymous_outer_envelope`, default `true`). **Only single-layer `authcrypt(plaintext)` survived** — a regression from the recursive unpack the mediator previously used.

## Fix

After decrypting a JWE, recurse into the decrypted plaintext:
- **nested JWS** → resolve the signer's Ed25519 key from the signer DID's **`authentication`** relationship (validating the `ed25519-pub` multicodec), `verify_ed25519`, set `sign_from`. A forged/failed signature **errors** — never trusted on kid alone.
- **nested JWE** (`anoncrypt(authcrypt)`) → resolve the inner sender's key-agreement key, decrypt the inner layer, set `authenticated` + `encrypted_from_kid`, recurse.
- **top-level JWS** (`unpack_jws`) → now resolves + verifies + sets `sign_from`.

Recursion bounded by `MAX_NEST_DEPTH = 8`. The `block_anonymous_outer_envelope` check + default are unchanged — only the metadata feeding it is now correct, so genuinely-anonymous `anoncrypt(plaintext)` is still blocked (no posture weakened, no flag flip).

## Tests
`tests/test_sender_authentication.rs`: all four wrappings + a forged-inner-signature case (must error) — 11 pass. Full `cargo test -p affinidi-messaging-mediator` (139 lib + integration), `cross_mediator_forwarding`, `tsp_delivery` pass; clippy clean. mediator `0.16.34 → 0.16.35`.

## Security
Fails closed: signer key only from the DID's `authentication` methods, signature actually verified, bad signature/missing key → error not pass. Attributed `sign_from` is the DID whose auth key verified.