### PR TITLE
fix: unblock publish-verify for affinidi-messaging-didcomm-service (dead-code tsp_handler)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.12] - 2026-06-30
+
+Fixes the publish-verify failure that has blocked the release pipeline since the listener
+multiplex landed. The `Listener::tsp_handler` field is only read by `process_next_frame`,
+which is `#[cfg(feature = "tsp")]`; `cargo publish` verifies the packaged tarball with
+**default features** under `-D warnings`, where the field is set but never read, so the
+`dead_code` lint became a hard error (`field tsp_handler is never read`). Gated the lint
+with `#[cfg_attr(not(feature = "tsp"), allow(dead_code))]`. No behaviour change; the `tsp`
+build is unaffected.
+
 ## [0.3.8] - 2026-06-24
 
 Migrated `set_acl_mode` off the deprecated `atm.mediator()` methods onto

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.11"
+version = "0.3.12"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -54,6 +54,12 @@ pub(crate) struct Listener {
     /// Optional TSP handler. When set and `config.protocols.tsp` is on, inbound
     /// TSP frames off the shared socket are routed here. `None` → TSP frames are
     /// dropped with a warning.
+    ///
+    /// Only read by `process_next_frame`, which is `#[cfg(feature = "tsp")]`.
+    /// In a default (non-`tsp`) build the field is still set by `new()` but
+    /// never read, so silence the dead-code lint there — otherwise the
+    /// default-feature publish-verify build fails under `-D warnings`.
+    #[cfg_attr(not(feature = "tsp"), allow(dead_code))]
     pub tsp_handler: Option<Arc<dyn TspHandler>>,
     pub shutdown: CancellationToken,
     atm: Option<ATM>,


### PR DESCRIPTION
## Problem

The `release` pipeline on `main` has been **failing to publish since the listener-multiplex work (#551)**. Every merge re-hits it (it surfaced again on the #547 release run, where the three messaging crates published fine but this one blocked the job):

```
error: field `tsp_handler` is never read
  --> src/service/listener.rs:57:9
error: could not compile `affinidi-messaging-didcomm-service` (lib) due to 1 previous error
error: failed to verify package tarball
::error::failed to publish after N attempt(s): affinidi-messaging-didcomm-service
```

## Root cause

`cargo publish` verifies the packaged tarball built with **default features** under `-D warnings`. `Listener::tsp_handler` (listener.rs:57) is set unconditionally by `new()`, but its only **read** is in `process_next_frame` (listener.rs:283), which is `#[cfg(feature = "tsp")]`. The `tsp` feature is off by default, so in the verify build the field is written-but-never-read → `dead_code` → hard error. Normal workspace CI doesn't catch it because the feature is enabled in the workspace build.

## Fix

Gate the lint on the field:

```rust
#[cfg_attr(not(feature = "tsp"), allow(dead_code))]
pub tsp_handler: Option<Arc<dyn TspHandler>>,
```

No behaviour change. The `tsp` build still reads the field; the default build no longer trips the lint. Bumps `affinidi-messaging-didcomm-service` 0.3.11 → 0.3.12.

## Verified locally

- `RUSTFLAGS="-D warnings" cargo build -p affinidi-messaging-didcomm-service` (default) — **was failing, now passes**
- `RUSTFLAGS="-D warnings" cargo build … --features tsp` — passes
- `cargo publish -p affinidi-messaging-didcomm-service --dry-run` — **tarball verify passes** (the exact CI step that was failing)
- `cargo fmt --check` and the version-bump release guard — pass

Follow-up to #547; independent of it (different crate).