### PR TITLE
feat: p256 signature verification and alg Ed25519

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -39,6 +39,7 @@ jobs:
     env:
       # Override the repo's stable rust-toolchain.toml for this job.
       RUSTUP_TOOLCHAIN: nightly
+      CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi Crypto Changelog
 
+## 30th June 2026 (0.2.3)
+
+Adds `jose::signing::verify_p256` — ECDSA P-256 signature verification over
+SHA-256 (JWS `alg: ES256`), accepting compressed or uncompressed SEC1 public
+points. Additive (verify-only); locked by a deterministic RFC 6979 golden
+vector in `jose::kat`. Patch bump (additive) keeps the `[patch.crates-io]`
+redirect valid — see [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md).
+
 ## 13th June 2026 (0.2.2)
 
 Semver wave (W7/W8 — release W11). `CryptoError` and `Params` are now

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -14,6 +14,8 @@
 //! - `ecdh_1pu_x25519_kek_golden` — the full ECDH-1PU + Concat-KDF KEK,
 //!   asserting the **same** `f3cc56…` golden as didcomm #336 (closes the
 //!   vector 5b deferred until key agreement landed).
+//! - `es256_p256_golden` — deterministic (RFC 6979) ECDSA P-256 sign +
+//!   `verify_p256` roundtrip, pinning the ES256 signature/public-key bytes.
 
 #![cfg(test)]
 
@@ -23,6 +25,9 @@ use super::ecdh::{
 use super::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
 use super::{A256CbcHs512, A256Kw, ContentEncryption, Ed25519, JwsSigner, JwsVerifier, KeyWrap};
 use super::{aes_kw, concat_kdf, content_encryption, signing};
+// ECDSA P-256 signing lives in the `p256` dev-dependency (this crate is
+// verify-only for ES256), used by the P-256 KAT(s) below to produce vectors.
+use p256::ecdsa::{SigningKey as P256SigningKey, signature::Signer as P256Signer};
 
 fn hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -329,4 +334,93 @@ fn ed25519_eddsa_golden() {
     let sig_t = Ed25519.sign(msg, &seed).unwrap();
     assert_eq!(hex(&sig_t), EXPECTED_SIG);
     assert!(Ed25519.verify(msg, &sig_t, &pk).is_ok());
+}
+
+// ─── ES256 (ECDSA P-256) — deterministic RFC 6979 golden ────────────────────
+
+#[test]
+fn es256_p256_golden() {
+    const EXPECTED_PK: &str = "0457e977f6db7e33c3fe7acf2842ed987009caf56d458682fca447b7d3d762ab34c5ab3770ba573bdff5414065640ffb5b346dfa84dec4db4d68e5f59cc471c2ec";
+    const EXPECTED_SIG: &str = "db8c58825274a5559cefa68f7b724f1a9039350f7c833b17e9e81d024fe15ae3df31fa3296816af83f24c18bac256f2a2b38fafa23f9c88a9b48629911702027";
+
+    let sk = P256SigningKey::from_slice(&[0x55u8; 32]).expect("valid P-256 scalar");
+    let msg = b"DIDComm KAT message";
+
+    let pk = sk.verifying_key().to_encoded_point(false);
+    assert_eq!(hex(pk.as_bytes()), EXPECTED_PK, "P-256 public key drifted");
+
+    // RustCrypto ECDSA `sign` is deterministic (RFC 6979), so these bytes pin.
+    let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert_eq!(
+        hex(&sig_bytes),
+        EXPECTED_SIG,
+        "ES256 signature drifted (RFC 6979 determinism broken)"
+    );
+
+    assert!(signing::verify_p256(msg, &sig_bytes, pk.as_bytes()).is_ok());
+    assert!(signing::verify_p256(b"tampered", &sig_bytes, pk.as_bytes()).is_err());
+}
+
+/// A P-256 signing key's public point as uncompressed SEC1 bytes (65 bytes).
+fn p256_sec1_uncompressed(sk: &P256SigningKey) -> Vec<u8> {
+    sk.verifying_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec()
+}
+
+#[test]
+fn p256_sign_verify_roundtrip() {
+    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"affinidi es256 roundtrip";
+    let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(signing::verify_p256(msg, &sig_bytes, &p256_sec1_uncompressed(&sk)).is_ok());
+}
+
+#[test]
+fn p256_wrong_key_fails() {
+    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let other = P256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"affinidi es256";
+    let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(signing::verify_p256(msg, &sig_bytes, &p256_sec1_uncompressed(&other)).is_err());
+}
+
+#[test]
+fn p256_tampered_message_fails() {
+    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, b"original");
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(signing::verify_p256(b"tampered", &sig_bytes, &p256_sec1_uncompressed(&sk)).is_err());
+}
+
+/// `verify_p256` accepts both SEC1 encodings of the public point
+/// (compressed 33-byte and uncompressed 65-byte).
+#[test]
+fn p256_compressed_and_uncompressed_pubkey_agree() {
+    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"sec1 encodings";
+    let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    let uncompressed = sk
+        .verifying_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    let compressed = sk
+        .verifying_key()
+        .to_encoded_point(true)
+        .as_bytes()
+        .to_vec();
+    assert!(signing::verify_p256(msg, &sig_bytes, &uncompressed).is_ok());
+    assert!(signing::verify_p256(msg, &sig_bytes, &compressed).is_ok());
+}
+
+#[test]
+fn p256_invalid_public_key_errors() {
+    let sig_bytes = [0u8; 64];
+    assert!(signing::verify_p256(b"x", &sig_bytes, b"not-a-key").is_err());
 }

--- a/crates/core/affinidi-crypto/src/jose/signing.rs
+++ b/crates/core/affinidi-crypto/src/jose/signing.rs
@@ -1,7 +1,9 @@
-//! Ed25519 signing and verification (EdDSA / JWS `alg: EdDSA`).
+//! Ed25519 signing/verification (EdDSA / JWS `alg: EdDSA`) and ECDSA P-256
+//! verification (JWS `alg: ES256`).
 //!
 //! Ported verbatim from `affinidi-messaging-didcomm` for the #327
-//! centralization; byte-level output is locked by [`super::kat`].
+//! centralization; byte-level output is locked by [`super::kat`] (both the
+//! Ed25519 and the deterministic-ECDSA P-256 golden vectors).
 
 use ed25519_dalek::{Signer, Verifier};
 
@@ -28,4 +30,21 @@ pub fn verify(data: &[u8], signature: &[u8; 64], public_key: &[u8; 32]) -> Resul
 pub fn public_key_from_private(private_key: &[u8; 32]) -> [u8; 32] {
     let signing_key = ed25519_dalek::SigningKey::from_bytes(private_key);
     signing_key.verifying_key().to_bytes()
+}
+
+/// Verify an ECDSA P-256 signature (JWS `alg: ES256`).
+pub fn verify_p256(
+    data: &[u8],
+    signature: &[u8; 64],
+    public_key_sec1: &[u8],
+) -> Result<(), CryptoError> {
+    use p256::ecdsa::signature::Verifier as _;
+
+    let verifying_key = p256::ecdsa::VerifyingKey::from_sec1_bytes(public_key_sec1)
+        .map_err(|e| CryptoError::Verification(format!("invalid P-256 public key: {e}")))?;
+    let sig = p256::ecdsa::Signature::from_slice(signature)
+        .map_err(|e| CryptoError::Verification(format!("invalid P-256 signature: {e}")))?;
+    verifying_key
+        .verify(data, &sig)
+        .map_err(|e| CryptoError::Verification(format!("signature verification failed: {e}")))
 }

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.4] - 2026-06-30
+
+### Added
+
+- **ES256 (ECDSA P-256) JWS verification.** `jws::verify::verify_p256` verifies
+  DIDComm signed messages whose protected header declares `alg: ES256`,
+  alongside the existing `EdDSA` path. The signer `kid` is attributed from the
+  protected header, falling back to the per-signature unprotected header
+  (#323 semantics). Signer-key resolution and the inner/top-level JWS dispatch
+  live in the mediator's `didcomm_compat` shim. Verify-only — this crate does
+  not sign ES256.
+- **Fully-specified `Ed25519` alg accepted on verification.** `verify_ed25519`
+  now accepts a protected-header `alg` of either `EdDSA` (polymorphic, RFC 8037)
+  or `Ed25519` (fully-specified, draft-ietf-jose-fully-specified-algorithms) —
+  both denote Ed25519 signatures. Signing still emits `EdDSA` for broad interop.
+
 ## [0.15.3] - 2026-06-14
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -24,7 +24,7 @@ arbitrary = ["dep:arbitrary"]
 # JOSE crypto primitives (#327) — this crate owns only the DIDComm/JOSE
 # envelope layer; all key agreement, KDF, key-wrap, content-encryption,
 # and signing live in affinidi-crypto's `jose` module.
-affinidi-crypto = { version = "0.2.3", features = ["jose"] }
+affinidi-crypto = { version = "0.2", features = ["jose"] }
 
 # Curve crates — still used directly by the adapter for SEC1 point
 # encoding (`ToEncodedPoint`) on resolved public keys.

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -24,7 +24,7 @@ arbitrary = ["dep:arbitrary"]
 # JOSE crypto primitives (#327) — this crate owns only the DIDComm/JOSE
 # envelope layer; all key agreement, KDF, key-wrap, content-encryption,
 # and signing live in affinidi-crypto's `jose` module.
-affinidi-crypto = { version = "0.2", features = ["jose"] }
+affinidi-crypto = { version = "0.2.3", features = ["jose"] }
 
 # Curve crates — still used directly by the adapter for SEC1 point
 # encoding (`ToEncodedPoint`) on resolved public keys.

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.3"
+version = "0.15.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -55,6 +55,10 @@ arbitrary = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# ECDSA signing for ES256 JWS verification tests (the runtime dep only needs
+# `ecdh`/`jwk`; tests additionally sign with P-256). Cargo unifies the feature
+# set so this enables `ecdsa` for test builds only.
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/envelope.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/envelope.rs
@@ -44,7 +44,7 @@ pub struct JwsProtectedHeader {
     /// Media type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typ: Option<String>,
-    /// Signing algorithm: "EdDSA"
+    /// Signing algorithm: "EdDSA"/"Ed25519" (Ed25519) or "ES256" (P-256)
     pub alg: String,
     /// Signer KID (DID URL)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -11,11 +11,15 @@ pub struct VerifiedJws {
     /// The raw payload bytes.
     pub payload: Vec<u8>,
     /// The signer KID, taken from the protected header if present,
-    /// otherwise from the per-signature unprotected header (issue #323).
+    /// otherwise from the per-signature unprotected header.
     pub signer_kid: Option<String>,
 }
 
 /// Verify a JWS string using an Ed25519 public key.
+///
+/// Accepts either the polymorphic `EdDSA` alg (RFC 8037) or the fully-specified
+/// `Ed25519` alg (draft-ietf-jose-fully-specified-algorithms) — both denote
+/// Ed25519 signatures.
 ///
 /// # Arguments
 /// * `jws_str` - The JWS JSON string
@@ -37,9 +41,9 @@ pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJw
     let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
 
-    if header.alg != "EdDSA" {
+    if header.alg != "EdDSA" && header.alg != "Ed25519" {
         return Err(DIDCommError::UnsupportedAlgorithm(format!(
-            "expected EdDSA, got {}",
+            "expected EdDSA or Ed25519, got {}",
             header.alg
         )));
     }
@@ -63,6 +67,62 @@ pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJw
     // per-signature unprotected header (where DIDComm / credo-ts /
     // didcomm-python place it). Verification itself doesn't depend on
     // kid — the caller supplies the key — but attribution does.
+    let signer_kid = header
+        .kid
+        .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
+
+    Ok(VerifiedJws {
+        payload,
+        signer_kid,
+    })
+}
+
+/// Verify a JWS string using an ECDSA P-256 (ES256) public key.
+///
+/// # Arguments
+/// * `jws_str` - The JWS JSON string
+/// * `public_key` - The signer's SEC1-encoded P-256 public key (compressed 33 bytes or uncompressed 65 bytes)
+pub fn verify_p256(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDCommError> {
+    let jws: Jws = serde_json::from_str(jws_str)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid JWS JSON: {e}")))?;
+
+    if jws.signatures.is_empty() {
+        return Err(DIDCommError::InvalidMessage("no signatures in JWS".into()));
+    }
+
+    // Verify the first signature
+    let sig_entry = &jws.signatures[0];
+
+    // Parse protected header
+    let header_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.protected)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid protected header: {e}")))?;
+    let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
+
+    if header.alg != "ES256" {
+        return Err(DIDCommError::UnsupportedAlgorithm(format!(
+            "expected ES256, got {}",
+            header.alg
+        )));
+    }
+
+    // Decode signature (raw r || s, 64 bytes)
+    let sig_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.signature)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid signature base64: {e}")))?;
+    let sig: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| DIDCommError::InvalidMessage("ES256 signature must be 64 bytes".into()))?;
+
+    // Reconstruct signing input
+    let signing_input = format!("{}.{}", sig_entry.protected, jws.payload);
+    signing::verify_p256(signing_input.as_bytes(), &sig, public_key)?;
+
+    // Decode payload
+    let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid payload base64: {e}")))?;
+
+    // Signer kid: prefer the protected header, fall back to the
+    // per-signature unprotected header.
     let signer_kid = header
         .kid
         .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
@@ -108,7 +168,7 @@ mod tests {
         assert!(verify_ed25519(&jws_str, &wrong_pk).is_err());
     }
 
-    /// #323: a credo-ts / didcomm-python style JWS carries `kid` in the
+    /// A credo-ts / didcomm-python style JWS carries `kid` in the
     /// per-signature *unprotected* header (the protected header has only
     /// `typ`/`alg`). Verification must succeed AND attribute the signer
     /// from the unprotected header.
@@ -173,6 +233,169 @@ mod tests {
         assert_eq!(
             result.signer_kid.as_deref(),
             Some("did:example:alice#protected")
+        );
+    }
+
+    // ─── ES256 / ECDSA P-256 ────────────────────────────────────────────────
+    use p256::ecdsa::{SigningKey as P256SigningKey, signature::Signer as _};
+
+    /// Build an ES256 JWS (General JSON Serialization) over `payload`, placing
+    /// `kid` in the protected header (or omitting it when `None`).
+    fn build_es256_jws(payload: &[u8], kid: Option<&str>, sk: &P256SigningKey) -> String {
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "ES256".into(),
+            kid: kid.map(|k| k.to_string()),
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig: p256::ecdsa::Signature = sk.sign(signing_input.as_bytes());
+        let sig_bytes: [u8; 64] = sig.to_bytes().into();
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: None,
+                signature: Base64UrlUnpadded::encode_string(&sig_bytes),
+            }],
+        };
+        serde_json::to_string(&jws).unwrap()
+    }
+
+    fn p256_pub_sec1(sk: &P256SigningKey) -> Vec<u8> {
+        sk.verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn es256_sign_verify_roundtrip() {
+        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let payload = b"{\"type\":\"test\",\"body\":{}}";
+        let jws_str = build_es256_jws(payload, Some("did:example:alice#p256-1"), &sk);
+
+        let result = verify_p256(&jws_str, &p256_pub_sec1(&sk)).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#p256-1")
+        );
+    }
+
+    #[test]
+    fn es256_wrong_key_fails() {
+        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let other = P256SigningKey::random(&mut rand_core::OsRng);
+        let jws_str = build_es256_jws(b"test", Some("did:example:alice#p256-1"), &sk);
+
+        assert!(verify_p256(&jws_str, &p256_pub_sec1(&other)).is_err());
+    }
+
+    /// The ES256 verifier must reject a JWS that declares a different `alg`
+    /// (here EdDSA) before touching the signature — guards against an
+    /// algorithm-confusion attempt.
+    #[test]
+    fn es256_rejects_eddsa_alg() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let jws_str = sign::sign_ed25519(b"x", "did:example:alice#key-1", &sk.to_bytes()).unwrap();
+
+        let dummy_pub = [0x04u8; 65];
+        let result = verify_p256(&jws_str, &dummy_pub);
+        assert!(matches!(result, Err(DIDCommError::UnsupportedAlgorithm(_))));
+    }
+
+    /// Symmetric guard: the Ed25519 verifier must reject an ES256 JWS.
+    #[test]
+    fn ed25519_rejects_es256_alg() {
+        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let jws_str = build_es256_jws(b"x", Some("did:example:alice#p256-1"), &sk);
+
+        let dummy_pub = [0u8; 32];
+        let result = verify_ed25519(&jws_str, &dummy_pub);
+        assert!(matches!(result, Err(DIDCommError::UnsupportedAlgorithm(_))));
+    }
+
+    /// ES256 counterpart of `signer_kid_from_unprotected_header`: when the
+    /// signer `kid` lives only in the per-signature unprotected header, it
+    /// must still be attributed.
+    #[test]
+    fn es256_signer_kid_from_unprotected_header() {
+        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let payload = b"{\"type\":\"test\"}";
+
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "ES256".into(),
+            kid: None,
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig: p256::ecdsa::Signature = sk.sign(signing_input.as_bytes());
+        let sig_bytes: [u8; 64] = sig.to_bytes().into();
+
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: Some(JwsUnprotectedHeader {
+                    kid: Some("did:example:alice#p256-1".into()),
+                }),
+                signature: Base64UrlUnpadded::encode_string(&sig_bytes),
+            }],
+        };
+        let jws_str = serde_json::to_string(&jws).unwrap();
+
+        let result = verify_p256(&jws_str, &p256_pub_sec1(&sk)).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#p256-1")
+        );
+    }
+
+    /// The fully-specified `Ed25519` alg
+    /// (draft-ietf-jose-fully-specified-algorithms) must verify identically to
+    /// the polymorphic `EdDSA`.
+    #[test]
+    fn ed25519_alg_accepted_alongside_eddsa() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let pk = sk.verifying_key().to_bytes();
+        let payload = b"{\"type\":\"test\"}";
+
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "Ed25519".into(),
+            kid: Some("did:example:alice#key-1".into()),
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig = signing::sign(signing_input.as_bytes(), &sk.to_bytes()).unwrap();
+
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: None,
+                signature: Base64UrlUnpadded::encode_string(&sig),
+            }],
+        };
+        let jws_str = serde_json::to_string(&jws).unwrap();
+
+        let result = verify_ed25519(&jws_str, &pk).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#key-1")
         );
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -11,7 +11,7 @@ pub struct VerifiedJws {
     /// The raw payload bytes.
     pub payload: Vec<u8>,
     /// The signer KID, taken from the protected header if present,
-    /// otherwise from the per-signature unprotected header.
+    /// otherwise from the per-signature unprotected header (issue #323).
     pub signer_kid: Option<String>,
 }
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/lib.rs
@@ -5,7 +5,7 @@
 //! Supports:
 //! - **Authcrypt** (ECDH-1PU+A256KW, A256CBC-HS512) — authenticated encryption
 //! - **Anoncrypt** (ECDH-ES+A256KW, A256CBC-HS512) — anonymous encryption
-//! - **Signed messages** (EdDSA / Ed25519)
+//! - **Signed messages** (EdDSA / Ed25519, and ES256 / P-256 verification)
 //! - **Plaintext messages**
 //! - **Forward/routing** (DIDComm Routing Protocol 2.0)
 //! - **Curves**: X25519, P-256, K-256 (secp256k1)

--- a/crates/messaging/affinidi-messaging-helpers/examples/protocol_comparison.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/protocol_comparison.rs
@@ -172,9 +172,8 @@ fn bench_tsp_payload(payload: &[u8], iterations: usize) -> (Duration, Duration, 
         .send_relationship_invite(alice_id, bob_id)
         .unwrap();
     bob_agent.receive(bob_id, &rfi.bytes).unwrap();
-    let digest = affinidi_tsp::message::direct::message_digest(&rfi).to_vec();
     let rfa = bob_agent
-        .send_relationship_accept(bob_id, alice_id, digest)
+        .send_relationship_accept(bob_id, alice_id)
         .unwrap();
     alice_agent.receive(alice_id, &rfa.bytes).unwrap();
 

--- a/crates/messaging/affinidi-messaging-helpers/examples/unified_messaging.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/unified_messaging.rs
@@ -121,9 +121,10 @@ fn setup_tsp() -> (TspAdapter, TspAdapter, String, String) {
         .send_relationship_invite(&alice_id, &bob_id)
         .unwrap();
     bob_agent.receive(&bob_id, &rfi.bytes).unwrap();
-    let digest = affinidi_tsp::message::direct::message_digest(&rfi).to_vec();
+    // The accept derives the invite's thread digest from the store (recorded by
+    // `receive` above), so it only needs the two VIDs.
     let rfa = bob_agent
-        .send_relationship_accept(&bob_id, &alice_id, digest)
+        .send_relationship_accept(&bob_id, &alice_id)
         .unwrap();
     alice_agent.receive(&alice_id, &rfa.bytes).unwrap();
 

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 30th June 2026
 
+### 0.16.37 — feat: ES256 (P-256) JWS verification; reject unknown JWS algs
+
+- `didcomm_compat` now verifies inner/top-level signed messages whose protected
+  header declares `alg: ES256` (ECDSA P-256) in addition to `EdDSA`, resolving
+  the signer's P-256 verification key from their DID document
+  (`publicKeyMultibase` p256-pub / `publicKeyJwk` EC P-256).
+- `verify_inner_jws` no longer falls back to EdDSA for an unrecognized (or
+  missing/undecodable) `alg` — it now returns an explicit error, removing the
+  implicit algorithm assumption.
+- `verify_inner_jws` also accepts the fully-specified `Ed25519` alg
+  (draft-ietf-jose-fully-specified-algorithms) as an alias for `EdDSA`, both
+  routed to Ed25519 verification.
+- Adds unit tests for the JWS/JWE header helpers (`extract_jws_signer_kid`,
+  `extract_jws_alg`, `inner_jwe_sender_did`, `did_part`).
+
 ### 0.16.36 — fix: accept sender-authenticated nested DIDComm envelopes again
 
 - The DIDComm unpack (`didcomm_compat`) only inspected the outermost layer, so it never

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -66,7 +66,7 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15.4", optional = true }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
 trust-tasks-rs = { version = "0.2", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.36"
+version = "0.16.37"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -66,7 +66,7 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
-affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
+affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15.4", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
 trust-tasks-rs = { version = "0.2", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -12,11 +12,14 @@
 //! - Sender public key resolution is done lazily during decryption, not eagerly.
 
 use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
-use affinidi_did_common::{document::DocumentExt, verification_method::VerificationRelationship};
+use affinidi_did_common::{
+    document::DocumentExt,
+    verification_method::{VerificationMethod, VerificationRelationship},
+};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_didcomm::{
     jwe::decrypt::decrypt,
-    jws::verify::verify_ed25519,
+    jws::verify::{VerifiedJws, verify_ed25519, verify_p256},
     message::{
         Message,
         pack::{pack_encrypted_anoncrypt, pack_encrypted_authcrypt},
@@ -322,19 +325,18 @@ async fn recurse_decrypted_plaintext(
 
     if value.get("payload").is_some() && value.get("signatures").is_some() {
         // Nested JWS: sign-then-encrypt. Verify the inner signature with the
-        // signer's resolved Ed25519 key and attribute non-repudiation. Never
-        // trust the kid without verifying — a bad signature must error.
+        // signer's resolved key (Ed25519/EdDSA or P-256/ES256) and attribute
+        // non-repudiation. Never trust the kid without verifying — a bad
+        // signature must error.
         let jws_str = std::str::from_utf8(plaintext)
             .map_err(|e| format!("Inner JWS is not valid UTF-8: {e}"))?;
+
         let signer_kid = extract_jws_signer_kid(&value)
             .ok_or("Inner JWS has no signer kid to resolve a verification key")?;
         let signer_did = did_part(&signer_kid);
-        let pubkey = resolve_did_ed25519_verification(&signer_did, Some(&signer_kid), did_resolver)
+        let alg = extract_jws_alg(&value).unwrap_or_default();
+        let verified = verify_inner_jws(jws_str, &alg, &signer_did, &signer_kid, did_resolver)
             .await
-            .ok_or_else(|| {
-                format!("Could not resolve Ed25519 verification key for signer {signer_kid}")
-            })?;
-        let verified = verify_ed25519(jws_str, &pubkey)
             .map_err(|e| format!("Inner JWS signature verification failed: {e}"))?;
         metadata.non_repudiation = true;
         metadata.sign_from = verified.signer_kid.or(Some(signer_kid));
@@ -406,6 +408,60 @@ fn extract_jws_signer_kid(jws: &serde_json::Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Extract the JWS signature algorithm (`alg`) from the first signature's
+/// integrity-protected header. Returns `None` if absent/undecodable.
+fn extract_jws_alg(jws: &serde_json::Value) -> Option<String> {
+    let sig = jws.get("signatures")?.as_array()?.first()?;
+    let protected_b64 = sig.get("protected").and_then(|p| p.as_str())?;
+    let bytes = BASE64_URL_SAFE_NO_PAD.decode(protected_b64).ok()?;
+    let header: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    header
+        .get("alg")
+        .and_then(|a| a.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Verify an inner/top-level JWS, dispatching on the JOSE `alg`:
+/// `EdDSA`/`Ed25519` (Ed25519) or `ES256` (P-256). Resolves the signer's
+/// verification key from their DID document and verifies the signature. Any
+/// other `alg` (including a missing/undecodable one) is rejected rather than
+/// assumed.
+async fn verify_inner_jws(
+    jws_str: &str,
+    alg: &str,
+    signer_did: &str,
+    signer_kid: &str,
+    did_resolver: &DIDCacheClient,
+) -> Result<VerifiedJws, String> {
+    match alg {
+        // `EdDSA` is the polymorphic JOSE alg (RFC 8037); `Ed25519` is its
+        // fully-specified equivalent (draft-ietf-jose-fully-specified-algorithms).
+        // Both denote Ed25519 signatures here.
+        "EdDSA" | "Ed25519" => {
+            let pubkey =
+                resolve_did_ed25519_verification(signer_did, Some(signer_kid), did_resolver)
+                    .await
+                    .ok_or_else(|| {
+                        format!(
+                            "Could not resolve Ed25519 verification key for signer {signer_kid}"
+                        )
+                    })?;
+            verify_ed25519(jws_str, &pubkey).map_err(|e| e.to_string())
+        }
+        "ES256" => {
+            let pubkey = resolve_did_p256_verification(signer_did, Some(signer_kid), did_resolver)
+                .await
+                .ok_or_else(|| {
+                    format!("Could not resolve P-256 verification key for signer {signer_kid}")
+                })?;
+            verify_p256(jws_str, &pubkey).map_err(|e| e.to_string())
+        }
+        other => Err(format!(
+            "Unsupported JWS signature algorithm {other:?} (expected EdDSA/Ed25519 or ES256)"
+        )),
+    }
+}
+
 /// Extract the inner JWE's sender DID from its protected header (`skid`, or
 /// `apu` fallback), mirroring the outer-layer logic in `MetaEnvelope::new`.
 fn inner_jwe_sender_did(jwe: &serde_json::Value) -> Option<String> {
@@ -459,13 +515,9 @@ async fn unpack_jws(
     let signer_kid =
         extract_jws_signer_kid(&value).ok_or("JWS has no signer kid to resolve a key")?;
     let signer_did = did_part(&signer_kid);
-    let pubkey = resolve_did_ed25519_verification(&signer_did, Some(&signer_kid), did_resolver)
+    let alg = extract_jws_alg(&value).unwrap_or_default();
+    let verified = verify_inner_jws(msg_string, &alg, &signer_did, &signer_kid, did_resolver)
         .await
-        .ok_or_else(|| {
-            format!("Could not resolve Ed25519 verification key for signer {signer_kid}")
-        })?;
-
-    let verified = verify_ed25519(msg_string, &pubkey)
         .map_err(|e| format!("JWS signature verification failed: {e}"))?;
 
     let msg = Message::from_json(&verified.payload)
@@ -481,10 +533,25 @@ async fn unpack_jws(
     Ok((msg, metadata))
 }
 
+/// Resolve the verification method a signer authenticates with: the exact
+/// `prefer_kid` when it appears in the DID's authentication relationship,
+/// otherwise the DID's first authentication key.
+async fn resolve_authentication_vm(
+    did: &str,
+    prefer_kid: Option<&str>,
+    did_resolver: &DIDCacheClient,
+) -> Option<VerificationMethod> {
+    let doc = did_resolver.resolve(did).await.ok()?;
+    let auth = doc.doc.find_authentication(None);
+    let kid = prefer_kid
+        .filter(|k| auth.iter().any(|a| a == k))
+        .map(|k| k.to_string())
+        .or_else(|| auth.first().map(|k| k.to_string()))?;
+    doc.doc.get_verification_method(&kid).cloned()
+}
+
 /// Resolve a DID's Ed25519 verification (signing) public key as raw 32 bytes.
 ///
-/// Picks the verification method named by `prefer_kid` when present in the
-/// authentication relationship, otherwise the DID's first authentication key.
 /// Supports `publicKeyMultibase` (multikey, `ed25519-pub` codec) and
 /// `publicKeyJwk` (`OKP`/`Ed25519`).
 async fn resolve_did_ed25519_verification(
@@ -492,22 +559,11 @@ async fn resolve_did_ed25519_verification(
     prefer_kid: Option<&str>,
     did_resolver: &DIDCacheClient,
 ) -> Option<[u8; 32]> {
-    let doc = did_resolver.resolve(did).await.ok()?;
-
-    // Prefer the exact authentication kid the signer claimed; fall back to the
-    // DID's first authentication key.
-    let auth = doc.doc.find_authentication(None);
-    let kid = prefer_kid
-        .filter(|k| auth.iter().any(|a| a == k))
-        .map(|k| k.to_string())
-        .or_else(|| auth.first().map(|k| k.to_string()))?;
-
-    let vm = doc.doc.get_verification_method(&kid)?;
+    let vm = resolve_authentication_vm(did, prefer_kid, did_resolver).await?;
 
     if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
         && let Some(multibase_str) = multibase_value.as_str()
-        && let Ok((codec, key_bytes)) =
-            affinidi_encoding::decode_multikey_with_codec(multibase_str)
+        && let Ok((codec, key_bytes)) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
         && codec == affinidi_encoding::ED25519_PUB
         && key_bytes.len() == 32
     {
@@ -522,6 +578,47 @@ async fn resolve_did_ed25519_verification(
         && x_bytes.len() == 32
     {
         return x_bytes.try_into().ok();
+    }
+
+    None
+}
+
+/// Resolve a DID's ECDSA P-256 verification (signing) public key as SEC1 bytes.
+///
+/// Supports `publicKeyMultibase` (multikey, `p256-pub` codec — compressed
+/// SEC1) and `publicKeyJwk` (`EC`/`P-256` — assembled into uncompressed SEC1).
+async fn resolve_did_p256_verification(
+    did: &str,
+    prefer_kid: Option<&str>,
+    did_resolver: &DIDCacheClient,
+) -> Option<Vec<u8>> {
+    let vm = resolve_authentication_vm(did, prefer_kid, did_resolver).await?;
+
+    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
+        && let Some(multibase_str) = multibase_value.as_str()
+        && let Ok((codec, key_bytes)) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
+        && codec == affinidi_encoding::P256_PUB
+    {
+        // Multikey for P-256 is the compressed SEC1 point (33 bytes).
+        return Some(key_bytes);
+    }
+
+    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk")
+        && jwk_value.get("kty").and_then(|v| v.as_str()) == Some("EC")
+        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some("P-256")
+        && let Some(x_b64) = jwk_value.get("x").and_then(|v| v.as_str())
+        && let Some(y_b64) = jwk_value.get("y").and_then(|v| v.as_str())
+        && let Ok(x_bytes) = BASE64_URL_SAFE_NO_PAD.decode(x_b64)
+        && let Ok(y_bytes) = BASE64_URL_SAFE_NO_PAD.decode(y_b64)
+        && x_bytes.len() == 32
+        && y_bytes.len() == 32
+    {
+        // Assemble the uncompressed SEC1 point: 0x04 || x || y.
+        let mut sec1 = Vec::with_capacity(65);
+        sec1.push(0x04);
+        sec1.extend_from_slice(&x_bytes);
+        sec1.extend_from_slice(&y_bytes);
+        return Some(sec1);
     }
 
     None
@@ -648,5 +745,102 @@ pub async fn pack_encrypted<S: SecretsResolver>(
         };
 
         Ok((packed, metadata))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// base64url-encode a JSON value as a JWS/JWE protected header.
+    fn protected_b64(v: &serde_json::Value) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(v).unwrap())
+    }
+
+    #[test]
+    fn did_part_strips_fragment() {
+        assert_eq!(did_part("did:example:alice#key-1"), "did:example:alice");
+        assert_eq!(did_part("did:example:alice"), "did:example:alice");
+    }
+
+    #[test]
+    fn jws_signer_kid_prefers_protected_header() {
+        let protected =
+            protected_b64(&json!({"alg": "ES256", "kid": "did:example:alice#protected"}));
+        let jws = json!({
+            "payload": "e30",
+            "signatures": [{
+                "protected": protected,
+                "header": {"kid": "did:example:mallory#unprotected"},
+                "signature": "AA"
+            }]
+        });
+        assert_eq!(
+            extract_jws_signer_kid(&jws).as_deref(),
+            Some("did:example:alice#protected"),
+            "integrity-protected kid must win over the unprotected one"
+        );
+    }
+
+    #[test]
+    fn jws_signer_kid_falls_back_to_unprotected() {
+        // Protected header carries only alg (no kid) — credo-ts / didcomm-python shape.
+        let protected = protected_b64(&json!({"alg": "EdDSA"}));
+        let jws = json!({
+            "payload": "e30",
+            "signatures": [{
+                "protected": protected,
+                "header": {"kid": "did:example:alice#unprotected"},
+                "signature": "AA"
+            }]
+        });
+        assert_eq!(
+            extract_jws_signer_kid(&jws).as_deref(),
+            Some("did:example:alice#unprotected")
+        );
+    }
+
+    #[test]
+    fn jws_alg_extracted_from_protected_header() {
+        let protected = protected_b64(&json!({"alg": "ES256", "kid": "did:example:alice#p256"}));
+        let jws =
+            json!({"payload": "e30", "signatures": [{"protected": protected, "signature": "AA"}]});
+        assert_eq!(extract_jws_alg(&jws).as_deref(), Some("ES256"));
+    }
+
+    #[test]
+    fn jws_alg_none_when_protected_undecodable() {
+        let jws = json!({"payload": "e30", "signatures": [{"protected": "!!not-base64!!", "signature": "AA"}]});
+        assert_eq!(extract_jws_alg(&jws), None);
+    }
+
+    #[test]
+    fn inner_jwe_sender_did_from_skid() {
+        let protected =
+            protected_b64(&json!({"alg": "ECDH-1PU+A256KW", "skid": "did:example:bob#key-x25519"}));
+        let jwe = json!({"protected": protected, "ciphertext": "x", "recipients": []});
+        assert_eq!(
+            inner_jwe_sender_did(&jwe).as_deref(),
+            Some("did:example:bob")
+        );
+    }
+
+    #[test]
+    fn inner_jwe_sender_did_from_apu_fallback() {
+        let apu = BASE64_URL_SAFE_NO_PAD.encode("did:example:carol#key-1");
+        let protected = protected_b64(&json!({"alg": "ECDH-1PU+A256KW", "apu": apu}));
+        let jwe = json!({"protected": protected});
+        assert_eq!(
+            inner_jwe_sender_did(&jwe).as_deref(),
+            Some("did:example:carol")
+        );
+    }
+
+    #[test]
+    fn inner_jwe_sender_did_none_for_anoncrypt() {
+        let protected = protected_b64(&json!({"alg": "ECDH-ES+A256KW"}));
+        let jwe = json!({"protected": protected});
+        assert_eq!(inner_jwe_sender_did(&jwe), None);
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tests/test_sender_authentication.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/test_sender_authentication.rs
@@ -413,7 +413,10 @@ async fn resolve_ka_public(did: &str, resolver: &DIDCacheClient) -> (String, Pub
         affinidi_encoding::P521_PUB => Curve::P521,
         other => panic!("unexpected KA codec {other:#x}"),
     };
-    (kid, PublicKeyAgreement::from_raw_bytes(curve, &bytes).unwrap())
+    (
+        kid,
+        PublicKeyAgreement::from_raw_bytes(curve, &bytes).unwrap(),
+    )
 }
 
 /// Decode the 32-byte `d` of an OKP/EC JWK (the JWKs here use url-safe base64).
@@ -456,7 +459,8 @@ async fn nested_wrappings_classified_correctly() {
         encrypt::anoncrypt(inner_jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
 
     // 3. anoncrypt(authcrypt(plaintext))
-    let anon_auth = encrypt::anoncrypt(authcrypt.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+    let anon_auth =
+        encrypt::anoncrypt(authcrypt.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
 
     // 4. anoncrypt(plaintext)
     let anon_plain = encrypt::anoncrypt(&plaintext, &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
@@ -493,13 +497,18 @@ async fn nested_wrappings_classified_correctly() {
     );
 
     // The exact inbound.rs anonymous-block decision.
-    let blocked =
-        |m: &affinidi_messaging_sdk::messages::compat::UnpackMetadata| {
-            !m.authenticated && m.sign_from.is_none()
-        };
+    let blocked = |m: &affinidi_messaging_sdk::messages::compat::UnpackMetadata| {
+        !m.authenticated && m.sign_from.is_none()
+    };
     assert!(!blocked(&m_authcrypt), "authcrypt must be accepted");
-    assert!(!blocked(&m_anon_signed), "anoncrypt(signed) must be accepted");
-    assert!(!blocked(&m_anon_auth), "anoncrypt(authcrypt) must be accepted");
+    assert!(
+        !blocked(&m_anon_signed),
+        "anoncrypt(signed) must be accepted"
+    );
+    assert!(
+        !blocked(&m_anon_auth),
+        "anoncrypt(authcrypt) must be accepted"
+    );
     assert!(blocked(&m_anon_plain), "pure anoncrypt must be blocked");
 }
 
@@ -525,5 +534,210 @@ async fn nested_signed_with_bad_signature_is_rejected() {
     assert!(
         result.is_err(),
         "a forged inner signature must be rejected, not pass as authenticated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ES256 (ECDSA P-256) signed messages.
+//
+// The EdDSA signed paths above use `sign_ed25519`. These exercise the ES256
+// dispatch arm end-to-end: `extract_jws_alg` → `verify_inner_jws` (`"ES256"`)
+// → `resolve_did_p256_verification` (P-256 did:key) → `verify_p256`. The
+// didcomm crate is verify-only for ES256, so the JWS is hand-built and signed
+// with `affinidi_crypto::p256`.
+// ---------------------------------------------------------------------------
+
+/// Hand-build an ES256 JWS (General JSON Serialization) over `payload`, signing
+/// the JWS signing input with the given P-256 private key.
+fn build_es256_jws(payload: &[u8], signer_kid: &str, p256_private: &[u8]) -> String {
+    let protected = json!({
+        "typ": "application/didcomm-signed+json",
+        "alg": "ES256",
+        "kid": signer_kid,
+    });
+    let protected_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&protected).unwrap());
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+    let signing_input = format!("{protected_b64}.{payload_b64}");
+    let sig = affinidi_crypto::p256::sign(p256_private, signing_input.as_bytes()).unwrap();
+    let jws = json!({
+        "payload": payload_b64,
+        "signatures": [{
+            "protected": protected_b64,
+            "signature": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&sig),
+        }],
+    });
+    serde_json::to_string(&jws).unwrap()
+}
+
+/// A P-256/ES256 signed message must verify, attribute the signer, and be
+/// accepted by the anonymous-block decision.
+#[tokio::test]
+async fn es256_signed_message_verifies_and_attributes_signer() {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    // A P-256 signer as a did:key (resolvable offline).
+    let (signer_did, key) =
+        affinidi_did_common::DID::generate_key(affinidi_crypto::KeyType::P256).unwrap();
+    let signer_did = signer_did.to_string();
+
+    let msg = build_test_message(&signer_did, BOB_DID, "https://example.com/es256");
+    let es256_jws = build_es256_jws(&msg.to_json().unwrap(), &key.id, key.private_bytes());
+
+    // Sign-then-encrypt: anoncrypt(signed(plaintext)) to Bob.
+    let anon_signed =
+        encrypt::anoncrypt(es256_jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let (unpacked, metadata) = didcomm_compat::unpack(&anon_signed, &resolver, &bob_secrets)
+        .await
+        .expect("ES256 signed message must unpack");
+
+    assert_eq!(unpacked.id, msg.id, "verified payload must survive");
+    assert!(
+        metadata.non_repudiation,
+        "ES256 signed message must set non_repudiation"
+    );
+    let blocked = !metadata.authenticated && metadata.sign_from.is_none();
+    assert!(!blocked, "ES256 signed message must be accepted");
+
+    let sign_from = metadata
+        .sign_from
+        .as_deref()
+        .expect("ES256 signed message must set sign_from");
+    let (did, _frag) = sign_from.split_once('#').expect("sign_from has fragment");
+    assert_eq!(did, signer_did, "sign_from DID must be the P-256 signer");
+}
+
+/// An ES256 JWS signed with the WRONG P-256 key but claiming the signer's kid
+/// must fail verification — the resolver fetches the real P-256 key.
+#[tokio::test]
+async fn es256_signed_with_wrong_key_is_rejected() {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    // The claimed signer (its real key lives in the resolved DID document)…
+    let (signer_did, _key) =
+        affinidi_did_common::DID::generate_key(affinidi_crypto::KeyType::P256).unwrap();
+    let signer_did = signer_did.to_string();
+    // …but we sign with a DIFFERENT P-256 key while claiming the signer's kid.
+    let wrong = affinidi_crypto::p256::generate_random();
+
+    let msg = build_test_message(&signer_did, BOB_DID, "https://example.com/es256");
+    let claimed_kid = format!("{signer_did}#forged");
+    let forged_jws = build_es256_jws(&msg.to_json().unwrap(), &claimed_kid, &wrong.private_bytes);
+    let anon_forged =
+        encrypt::anoncrypt(forged_jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let result = didcomm_compat::unpack(&anon_forged, &resolver, &bob_secrets).await;
+    assert!(
+        result.is_err(),
+        "an ES256 signature from the wrong key must be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fully-specified `Ed25519` alg (draft-ietf-jose-fully-specified-algorithms).
+//
+// `sign_ed25519` emits the polymorphic `EdDSA` alg. Verification must ALSO
+// accept the fully-specified `Ed25519` alg (both denote Ed25519 signatures),
+// and must still reject an unsupported alg rather than assuming a default.
+// ---------------------------------------------------------------------------
+
+/// Hand-build an Ed25519 JWS with an explicit `alg` value (so we can exercise
+/// both `EdDSA` and the fully-specified `Ed25519`).
+fn build_ed25519_jws(payload: &[u8], signer_kid: &str, ed_private: &[u8; 32], alg: &str) -> String {
+    let protected = json!({
+        "typ": "application/didcomm-signed+json",
+        "alg": alg,
+        "kid": signer_kid,
+    });
+    let protected_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&protected).unwrap());
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+    let signing_input = format!("{protected_b64}.{payload_b64}");
+    let sig = affinidi_crypto::jose::signing::sign(signing_input.as_bytes(), ed_private).unwrap();
+    let jws = json!({
+        "payload": payload_b64,
+        "signatures": [{
+            "protected": protected_b64,
+            "signature": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sig),
+        }],
+    });
+    serde_json::to_string(&jws).unwrap()
+}
+
+/// Shared body: a message signed with an Ed25519 key and declaring `alg` must
+/// verify and be attributed to the signer — whether the header uses the
+/// polymorphic `EdDSA` or the fully-specified `Ed25519`.
+async fn assert_ed25519_signed_message_accepted(alg: &str) {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    let (signer_did, key) =
+        affinidi_did_common::DID::generate_key(affinidi_crypto::KeyType::Ed25519).unwrap();
+    let signer_did = signer_did.to_string();
+    let ed_private: [u8; 32] = key
+        .private_bytes()
+        .try_into()
+        .expect("32-byte Ed25519 seed");
+
+    let msg = build_test_message(&signer_did, BOB_DID, "https://example.com/ed25519");
+    let jws = build_ed25519_jws(&msg.to_json().unwrap(), &key.id, &ed_private, alg);
+    let anon_signed = encrypt::anoncrypt(jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let (unpacked, metadata) = didcomm_compat::unpack(&anon_signed, &resolver, &bob_secrets)
+        .await
+        .unwrap_or_else(|e| panic!("{alg}-signed message must unpack: {e}"));
+
+    assert_eq!(unpacked.id, msg.id, "verified payload must survive ({alg})");
+    assert!(
+        metadata.non_repudiation,
+        "{alg}-signed message must set non_repudiation"
+    );
+    let sign_from = metadata
+        .sign_from
+        .as_deref()
+        .unwrap_or_else(|| panic!("{alg}-signed message must set sign_from"));
+    let (did, _frag) = sign_from.split_once('#').expect("sign_from has fragment");
+    assert_eq!(did, signer_did, "sign_from DID must be the signer ({alg})");
+}
+
+/// The polymorphic `EdDSA` alg (RFC 8037) must verify and attribute the signer.
+#[tokio::test]
+async fn eddsa_alg_signed_message_is_accepted() {
+    assert_ed25519_signed_message_accepted("EdDSA").await;
+}
+
+/// The fully-specified `Ed25519` alg must verify identically to `EdDSA`.
+#[tokio::test]
+async fn ed25519_alg_signed_message_is_accepted() {
+    assert_ed25519_signed_message_accepted("Ed25519").await;
+}
+
+/// A JWS declaring an unsupported alg (here `RS256`) must be rejected outright —
+/// the mediator never falls back to a default algorithm.
+#[tokio::test]
+async fn unsupported_alg_signed_message_is_rejected() {
+    let (resolver, _alice_secrets, bob_secrets) = setup().await;
+    let (bob_ka_kid, bob_ka_pub) = resolve_ka_public(BOB_DID, &resolver).await;
+
+    let (signer_did, key) =
+        affinidi_did_common::DID::generate_key(affinidi_crypto::KeyType::Ed25519).unwrap();
+    let signer_did = signer_did.to_string();
+    let ed_private: [u8; 32] = key
+        .private_bytes()
+        .try_into()
+        .expect("32-byte Ed25519 seed");
+
+    let msg = build_test_message(&signer_did, BOB_DID, "https://example.com/test");
+    // A validly-signed JWS, but the header declares an unsupported alg.
+    let jws = build_ed25519_jws(&msg.to_json().unwrap(), &key.id, &ed_private, "RS256");
+    let anon = encrypt::anoncrypt(jws.as_bytes(), &[(&bob_ka_kid, &bob_ka_pub)]).unwrap();
+
+    let result = didcomm_compat::unpack(&anon, &resolver, &bob_secrets).await;
+    assert!(
+        result.is_err(),
+        "a JWS with an unsupported alg (RS256) must be rejected, not assumed EdDSA"
     );
 }

--- a/crates/messaging/affinidi-tsp/README.md
+++ b/crates/messaging/affinidi-tsp/README.md
@@ -68,19 +68,13 @@ The lifecycle follows a state machine: **None** → **Pending**/**InviteReceived
 **Bidirectional**.
 
 ```rust
-use affinidi_tsp::message::direct::message_digest;
-
 // Alice sends a relationship invite to Bob
 let invite = agent.send_relationship_invite("did:example:alice", "did:example:bob")?;
-let digest = message_digest(&invite);
 
-// Bob receives and accepts the invite
+// Bob receives and accepts the invite. The accept derives the invite's thread
+// digest from the store (recorded by `receive`), so it only needs the two VIDs.
 let received = agent.receive("did:example:bob", &invite.bytes)?;
-let accept = agent.send_relationship_accept(
-    "did:example:bob",
-    "did:example:alice",
-    digest.to_vec(),
-)?;
+let accept = agent.send_relationship_accept("did:example:bob", "did:example:alice")?;
 
 // Alice processes the acceptance — relationship is now Bidirectional
 agent.receive("did:example:alice", &accept.bytes)?;


### PR DESCRIPTION
- Adds [ES256](https://identity.foundation/didcomm-messaging/spec/#algorithms) (p256) signature verification. This change is needed so DIDComm clients can use a single p256 key for both encryption and signing.
- Alg [EdDSA](https://datatracker.ietf.org/doc/rfc9864] name is deprecated in favor alg Ed25519. Adds ability to verify Ed25519 signatures with both Ed25519 and EdDSA as alg in headers.