### PR TITLE
feat: Vault Kubernetes/AppRole auth + Enterprise namespace

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.21"
+version = "0.15.22"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/vault.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/vault.rs
@@ -12,16 +12,25 @@
 //!   - `vault://vault.internal/secret/mediator` → mount `secret`,
 //!     namespace `mediator/`.
 //!
-//! Transport: always HTTPS against the configured endpoint. Local-
-//! dev operators running Vault without TLS should front it with a
-//! reverse proxy or use `vault server -dev-tls` — we don't offer an
-//! `insecure=1` knob because wizard-managed material always includes
-//! the mediator's admin credential and JWT key.
+//! Transport: HTTPS against the configured endpoint by default. The
+//! `?insecure=1` query parameter disables TLS verification for local
+//! dev / test only — never use it with production material, which
+//! includes the mediator's admin credential and JWT key.
 //!
-//! Auth: token auth only (Kubernetes, AppRole, JWT/OIDC and friends
-//! are documented follow-ups). `VAULT_TOKEN` env var is consulted at
-//! client construction; an empty value produces a clear error at
-//! probe time rather than a silent 403 on first write.
+//! Auth (selected by the `?auth=` query parameter, default `token`):
+//!   - `token` — `VAULT_TOKEN` env var (matches the `vault` CLI).
+//!   - `kubernetes` — the pod ServiceAccount JWT is exchanged for a
+//!     Vault token (`?role=`, optional `?k8s_mount=` / `?jwt_path=`).
+//!     The JWT is re-read on every login so kubelet rotation is
+//!     handled transparently.
+//!   - `approle` — `role_id`/`secret_id` from `VAULT_ROLE_ID` /
+//!     `VAULT_SECRET_ID` (optional `?approle_mount=`).
+//!
+//! Auth secrets never appear in the URL. For the renewable methods
+//! (Kubernetes / AppRole) a call that fails with 401/403 triggers a
+//! single re-authentication + retry, so an expired token or rotated
+//! JWT recovers without a restart. Vault Enterprise namespaces are
+//! supported via `?namespace=` (`X-Vault-Namespace`).
 //!
 //! Calls go through [`super::super::retry::with_retry`] with
 //! [`VaultRetryPolicy`]: 429, 5xx, RestClientError connect / IO
@@ -42,27 +51,51 @@ use base64::Engine;
 #[cfg(feature = "secrets-vault")]
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
 #[cfg(feature = "secrets-vault")]
+use crate::secrets::url::VaultAuth;
+#[cfg(feature = "secrets-vault")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "secrets-vault")]
-use tokio::sync::OnceCell;
+use std::future::Future;
+#[cfg(feature = "secrets-vault")]
+use std::pin::Pin;
+#[cfg(feature = "secrets-vault")]
+use tokio::sync::{OnceCell, RwLock};
+#[cfg(feature = "secrets-vault")]
+use tracing::warn;
 #[cfg(feature = "secrets-vault")]
 use vaultrs::{
-    client::{VaultClient, VaultClientSettingsBuilder},
+    auth::{approle, kubernetes},
+    client::{Client, VaultClient, VaultClientSettings, VaultClientSettingsBuilder},
     error::ClientError,
     kv2,
 };
 
 const BACKEND_LABEL: &str = "vault";
 
-/// Env var the Vault backend looks up at client construction. Matches
-/// the `VAULT_TOKEN` convention used by the `vault` CLI so operators
-/// don't learn a new variable.
+/// Env var supplying the token for `auth=token`. Matches the `vault` CLI.
 #[cfg(feature = "secrets-vault")]
 const VAULT_TOKEN_ENV: &str = "VAULT_TOKEN";
+/// Env vars supplying AppRole credentials for `auth=approle`.
+#[cfg(feature = "secrets-vault")]
+const VAULT_ROLE_ID_ENV: &str = "VAULT_ROLE_ID";
+#[cfg(feature = "secrets-vault")]
+const VAULT_SECRET_ID_ENV: &str = "VAULT_SECRET_ID";
+
+/// Boxed future returned by a KV operation closure; borrows the client.
+#[cfg(feature = "secrets-vault")]
+type VaultFut<'a, T> =
+    Pin<Box<dyn Future<Output = std::result::Result<T, ClientError>> + Send + 'a>>;
 
 #[cfg(feature = "secrets-vault")]
 pub(crate) fn open(url: BackendUrl) -> Result<DynSecretStore> {
-    let BackendUrl::Vault { endpoint, path } = url else {
+    let BackendUrl::Vault {
+        endpoint,
+        path,
+        auth,
+        enterprise_namespace,
+        insecure,
+    } = url
+    else {
         return Err(SecretStoreError::Other(
             "internal error: vault backend received non-vault URL".into(),
         ));
@@ -89,6 +122,9 @@ pub(crate) fn open(url: BackendUrl) -> Result<DynSecretStore> {
         address,
         mount,
         namespace,
+        enterprise_namespace,
+        auth,
+        verify_tls: !insecure,
         client: OnceCell::new(),
     }))
 }
@@ -111,10 +147,33 @@ pub struct VaultStore {
     mount: String,
     /// Per-key namespace path (always ends with `/` when non-empty).
     namespace: String,
-    /// Lazily-constructed client. Token discovery happens on first
-    /// use so a wizard run that never touches the backend doesn't
-    /// complain about a missing `VAULT_TOKEN`.
-    client: OnceCell<VaultClient>,
+    /// Vault Enterprise namespace (`X-Vault-Namespace`), if configured.
+    enterprise_namespace: Option<String>,
+    /// Selected auth method.
+    auth: VaultAuth,
+    /// Whether TLS certificates are verified (false only for `insecure=1`).
+    verify_tls: bool,
+    /// Lazily-authenticated client behind an `RwLock` so a renewable auth
+    /// method (Kubernetes / AppRole) can swap in a fresh token when the
+    /// current one expires. Authentication happens on first use so a
+    /// wizard run that never touches the backend doesn't require creds.
+    client: OnceCell<RwLock<VaultClient>>,
+}
+
+/// Read a required env var, erroring if it is unset or empty.
+#[cfg(feature = "secrets-vault")]
+fn require_env(var: &str) -> Result<String> {
+    let value = std::env::var(var).map_err(|_| SecretStoreError::Unreachable {
+        backend: BACKEND_LABEL,
+        reason: format!("{var} env var not set"),
+    })?;
+    if value.is_empty() {
+        return Err(SecretStoreError::Unreachable {
+            backend: BACKEND_LABEL,
+            reason: format!("{var} is set but empty"),
+        });
+    }
+    Ok(value)
 }
 
 #[cfg(feature = "secrets-vault")]
@@ -123,37 +182,128 @@ impl VaultStore {
         format!("{}{key}", self.namespace)
     }
 
-    async fn client(&self) -> Result<&VaultClient> {
-        self.client
-            .get_or_try_init(|| async {
-                let token =
-                    std::env::var(VAULT_TOKEN_ENV).map_err(|_| SecretStoreError::Unreachable {
+    /// Build client settings shared by every auth method — address, TLS
+    /// verification, and the optional Enterprise namespace — bearing the
+    /// supplied token (empty during the pre-login step of k8s/AppRole).
+    fn settings(&self, token: &str) -> Result<VaultClientSettings> {
+        let mut builder = VaultClientSettingsBuilder::default();
+        builder
+            .address(&self.address)
+            .token(token)
+            .verify(self.verify_tls);
+        if let Some(ns) = &self.enterprise_namespace {
+            builder.namespace(Some(ns.clone()));
+        }
+        builder.build().map_err(|e| SecretStoreError::Unreachable {
+            backend: BACKEND_LABEL,
+            reason: format!("could not build Vault client settings: {e}"),
+        })
+    }
+
+    fn build_client(&self, token: &str) -> Result<VaultClient> {
+        VaultClient::new(self.settings(token)?).map_err(|e| SecretStoreError::Unreachable {
+            backend: BACKEND_LABEL,
+            reason: format!("could not build Vault client: {e}"),
+        })
+    }
+
+    /// Authenticate using the configured method, returning a token-bearing
+    /// client. Kubernetes/AppRole perform a login round-trip; the
+    /// ServiceAccount JWT is re-read on every call so kubelet rotation is
+    /// handled transparently.
+    async fn authenticate(&self) -> Result<VaultClient> {
+        match &self.auth {
+            VaultAuth::Token => {
+                let token = require_env(VAULT_TOKEN_ENV)?;
+                self.build_client(&token)
+            }
+            VaultAuth::Kubernetes {
+                role,
+                mount,
+                jwt_path,
+            } => {
+                let jwt = std::fs::read_to_string(jwt_path).map_err(|e| {
+                    SecretStoreError::Unreachable {
                         backend: BACKEND_LABEL,
                         reason: format!(
-                            "VAULT_TOKEN env var not set — token auth is the only auth \
-                             method currently supported by the '{BACKEND_LABEL}' backend"
+                            "could not read Kubernetes ServiceAccount JWT at '{jwt_path}': {e}"
                         ),
-                    })?;
-                if token.is_empty() {
-                    return Err(SecretStoreError::Unreachable {
-                        backend: BACKEND_LABEL,
-                        reason: format!("{VAULT_TOKEN_ENV} is set but empty"),
-                    });
-                }
-                let settings = VaultClientSettingsBuilder::default()
-                    .address(&self.address)
-                    .token(token)
-                    .build()
+                    }
+                })?;
+                let mut client = self.build_client("")?;
+                let info = kubernetes::login(&client, mount, role, jwt.trim())
+                    .await
                     .map_err(|e| SecretStoreError::Unreachable {
                         backend: BACKEND_LABEL,
-                        reason: format!("could not build Vault client settings: {e}"),
+                        reason: format!(
+                            "Vault Kubernetes login (mount '{mount}', role '{role}') failed: {e}"
+                        ),
                     })?;
-                VaultClient::new(settings).map_err(|e| SecretStoreError::Unreachable {
-                    backend: BACKEND_LABEL,
-                    reason: format!("could not build Vault client: {e}"),
-                })
+                client.set_token(&info.client_token);
+                Ok(client)
+            }
+            VaultAuth::AppRole { mount } => {
+                let role_id = require_env(VAULT_ROLE_ID_ENV)?;
+                let secret_id = require_env(VAULT_SECRET_ID_ENV)?;
+                let mut client = self.build_client("")?;
+                let info = approle::login(&client, mount, &role_id, &secret_id)
+                    .await
+                    .map_err(|e| SecretStoreError::Unreachable {
+                        backend: BACKEND_LABEL,
+                        reason: format!("Vault AppRole login (mount '{mount}') failed: {e}"),
+                    })?;
+                client.set_token(&info.client_token);
+                Ok(client)
+            }
+        }
+    }
+
+    /// Lazily initialise the authenticated client cell.
+    async fn cell(&self) -> Result<&RwLock<VaultClient>> {
+        self.client
+            .get_or_try_init(|| async {
+                let client = self.authenticate().await?;
+                Ok(RwLock::new(client))
             })
             .await
+    }
+
+    /// Run a KV operation with transient-error retries, re-authenticating
+    /// once if it fails with 401/403 and the auth method can obtain a
+    /// fresh token. The outer `Result` carries setup/auth failures; the
+    /// inner one carries the (possibly-retried) API result so callers keep
+    /// their existing 404 handling.
+    async fn run<T, F>(&self, label: &str, op: F) -> Result<std::result::Result<T, ClientError>>
+    where
+        F: for<'a> Fn(&'a VaultClient) -> VaultFut<'a, T>,
+    {
+        let cell = self.cell().await?;
+        let first = {
+            let guard = cell.read().await;
+            with_retry(label, &VaultRetryPolicy, || op(&guard)).await
+        };
+        match first {
+            Err(err)
+                if self.auth.is_renewable() && matches!(api_status(&err), Some(401 | 403)) =>
+            {
+                match self.authenticate().await {
+                    Ok(fresh) => {
+                        *cell.write().await = fresh;
+                        let guard = cell.read().await;
+                        Ok(with_retry(label, &VaultRetryPolicy, || op(&guard)).await)
+                    }
+                    Err(reauth_err) => {
+                        warn!(
+                            backend = BACKEND_LABEL,
+                            error = %reauth_err,
+                            "vault re-authentication failed after an auth error"
+                        );
+                        Ok(Err(err))
+                    }
+                }
+            }
+            other => Ok(other),
+        }
     }
 }
 
@@ -214,13 +364,14 @@ impl SecretStore for VaultStore {
 
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let path = self.secret_path(key);
-        let client = self.client().await?;
         let label = format!("kv2::read({}/{path})", self.mount);
-        let result = with_retry(&label, &VaultRetryPolicy, || {
-            let path = path.clone();
-            async move { kv2::read::<VaultPayload>(client, &self.mount, &path).await }
-        })
-        .await;
+        let result = self
+            .run(&label, |client| {
+                let mount = self.mount.clone();
+                let path = path.clone();
+                Box::pin(async move { kv2::read::<VaultPayload>(client, &mount, &path).await })
+            })
+            .await?;
         let payload = match result {
             Ok(p) => p,
             Err(err) if matches!(api_status(&err), Some(404)) => return Ok(None),
@@ -242,17 +393,17 @@ impl SecretStore for VaultStore {
 
     async fn put(&self, key: &str, value: &[u8]) -> Result<()> {
         let path = self.secret_path(key);
-        let client = self.client().await?;
         let encoded = B64URL.encode(value);
         let label = format!("kv2::set({}/{path})", self.mount);
-        with_retry(&label, &VaultRetryPolicy, || {
+        self.run(&label, |client| {
+            let mount = self.mount.clone();
             let path = path.clone();
             let payload = VaultPayload {
                 value: encoded.clone(),
             };
-            async move { kv2::set(client, &self.mount, &path, &payload).await }
+            Box::pin(async move { kv2::set(client, &mount, &path, &payload).await })
         })
-        .await
+        .await?
         .map(|_| ())
         .map_err(|err| SecretStoreError::Unreachable {
             backend: BACKEND_LABEL,
@@ -262,13 +413,14 @@ impl SecretStore for VaultStore {
 
     async fn delete(&self, key: &str) -> Result<()> {
         let path = self.secret_path(key);
-        let client = self.client().await?;
         let label = format!("kv2::delete_latest({}/{path})", self.mount);
-        let result = with_retry(&label, &VaultRetryPolicy, || {
-            let path = path.clone();
-            async move { kv2::delete_latest(client, &self.mount, &path).await }
-        })
-        .await;
+        let result = self
+            .run(&label, |client| {
+                let mount = self.mount.clone();
+                let path = path.clone();
+                Box::pin(async move { kv2::delete_latest(client, &mount, &path).await })
+            })
+            .await?;
         match result {
             Ok(()) => Ok(()),
             Err(err) if matches!(api_status(&err), Some(404)) => Ok(()),
@@ -289,12 +441,13 @@ impl SecretStore for VaultStore {
     /// purged). We translate that to an empty list so the discovery
     /// hotkey shows "no entries" rather than an error banner.
     async fn list_namespace(&self) -> Result<Vec<String>> {
-        let client = self.client().await?;
         let label = format!("kv2::list({}/)", self.mount);
-        let result = with_retry(&label, &VaultRetryPolicy, || async move {
-            kv2::list(client, &self.mount, "").await
-        })
-        .await;
+        let result = self
+            .run(&label, |client| {
+                let mount = self.mount.clone();
+                Box::pin(async move { kv2::list(client, &mount, "").await })
+            })
+            .await?;
         match result {
             Ok(keys) => Ok(keys),
             Err(err) if matches!(api_status(&err), Some(404)) => Ok(Vec::new()),
@@ -320,6 +473,9 @@ mod tests {
                 .split_once('/')
                 .map(|(_, rest)| format!("{rest}/"))
                 .unwrap_or_default(),
+            enterprise_namespace: None,
+            auth: VaultAuth::Token,
+            verify_tls: true,
             client: OnceCell::new(),
         }
     }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/mod.rs
@@ -30,7 +30,7 @@ pub mod well_known;
 pub use envelope::{ENVELOPE_VERSION, Envelope};
 pub use error::{Result, SecretStoreError};
 pub use store::{DynSecretStore, SecretStore, open_store};
-pub use url::{BackendUrl, parse_url};
+pub use url::{BackendUrl, VaultAuth, parse_url};
 pub use well_known::{
     ADMIN_CREDENTIAL, AdminCredential, BOOTSTRAP_EPHEMERAL_SEED_PREFIX, BOOTSTRAP_SEED_INDEX,
     BootstrapSeedIndex, BootstrapSeedIndexEntry, JWT_SECRET, MediatorSecrets,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
@@ -9,7 +9,10 @@
 //! | `aws_secrets://` | `aws_secrets://<region>/<namespace>`        | `aws_secrets://us-east-1/prod/mediator/`   |
 //! | `gcp_secrets://` | `gcp_secrets://<project>/<namespace>`       | `gcp_secrets://my-proj/mediator-`          |
 //! | `azure_keyvault://` | `azure_keyvault://<vault-name-or-url>`   | `azure_keyvault://my-vault`                |
-//! | `vault://`       | `vault://<host[:port]>/<kv-path>`           | `vault://vault.internal/secret/mediator`   |
+//! | `vault://`       | `vault://<host[:port]>/<kv-path>[?auth=…]`  | `vault://vault.internal/secret/mediator`   |
+//!
+//! The `vault://` scheme accepts optional query parameters selecting a
+//! non-default auth method and transport options — see [`parse_vault`].
 //!
 //! `string://` is intentionally not supported — inline secrets in
 //! `mediator.toml` would defeat the whole point. CI scripts that used to
@@ -20,14 +23,61 @@ use url::Url;
 
 use crate::secrets::error::{Result, SecretStoreError};
 
+/// Default Vault Kubernetes auth mount (the `kubernetes` auth backend).
+pub const VAULT_DEFAULT_K8S_MOUNT: &str = "kubernetes";
+/// Default in-pod ServiceAccount JWT path used by Kubernetes auth.
+pub const VAULT_DEFAULT_JWT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+/// Default Vault AppRole auth mount.
+pub const VAULT_DEFAULT_APPROLE_MOUNT: &str = "approle";
+
+/// Vault authentication method, parsed from the `?auth=` query parameter
+/// of a `vault://` URL. Secret material (the token, or the AppRole
+/// `role_id`/`secret_id`) is never carried in the URL — it is read from
+/// the environment at login time so it never lands in `mediator.toml`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VaultAuth {
+    /// Token auth (default). Token read from `VAULT_TOKEN`.
+    Token,
+    /// Kubernetes auth: the pod's ServiceAccount JWT is exchanged for a
+    /// Vault token against `mount` using `role`.
+    Kubernetes {
+        role: String,
+        mount: String,
+        jwt_path: String,
+    },
+    /// AppRole auth. `role_id`/`secret_id` read from `VAULT_ROLE_ID` /
+    /// `VAULT_SECRET_ID` at login time.
+    AppRole { mount: String },
+}
+
+impl VaultAuth {
+    /// Whether this method can re-authenticate on its own (obtain a
+    /// fresh token) — true for Kubernetes/AppRole, false for a static
+    /// env-supplied token.
+    pub fn is_renewable(&self) -> bool {
+        !matches!(self, VaultAuth::Token)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BackendUrl {
     Keyring { service: String },
     File { path: String, encrypted: bool },
     Aws { region: String, namespace: String },
     Gcp { project: String, namespace: String },
     Azure { vault: String },
-    Vault { endpoint: String, path: String },
+    Vault {
+        endpoint: String,
+        path: String,
+        /// Selected auth method (defaults to [`VaultAuth::Token`]).
+        auth: VaultAuth,
+        /// Vault Enterprise namespace (`X-Vault-Namespace` header), from
+        /// `?namespace=`. Distinct from the per-key path namespace.
+        enterprise_namespace: Option<String>,
+        /// Skip TLS verification (`?insecure=1`) — dev/test only.
+        insecure: bool,
+    },
 }
 
 /// Parse a backend URL. Returns a structured [`BackendUrl`] or an
@@ -210,22 +260,110 @@ fn parse_azure(rest: &str, raw: &str) -> Result<BackendUrl> {
     Ok(BackendUrl::Azure { vault: resolved })
 }
 
+/// Parse a `vault://` URL.
+///
+/// Shape: `vault://<host[:port]>/<mount>[/<namespace>…][?<params>]`.
+///
+/// Query parameters (all optional):
+///   - `auth=token|kubernetes|approle` — auth method (default `token`).
+///   - `role=<name>` — Vault role (required for `kubernetes`).
+///   - `k8s_mount=<mount>` — Kubernetes auth mount (default `kubernetes`).
+///   - `jwt_path=<path>` — ServiceAccount JWT path
+///     (default `/var/run/secrets/kubernetes.io/serviceaccount/token`).
+///   - `approle_mount=<mount>` — AppRole auth mount (default `approle`).
+///   - `namespace=<ns>` — Vault Enterprise namespace header.
+///   - `insecure=1` — skip TLS verification (dev/test only).
+///
+/// No auth *secret* is accepted here: the token comes from `VAULT_TOKEN`
+/// and AppRole credentials from `VAULT_ROLE_ID` / `VAULT_SECRET_ID`.
 fn parse_vault(rest: &str, raw: &str) -> Result<BackendUrl> {
-    let (endpoint, path) = rest
-        .split_once('/')
-        .ok_or_else(|| SecretStoreError::InvalidUrl {
-            url: raw.to_string(),
-            reason: "vault:// requires '<host>[:<port>]/<kv-path>'".into(),
-        })?;
+    let (locator, query) = match rest.split_once('?') {
+        Some((l, q)) => (l, Some(q)),
+        None => (rest, None),
+    };
+    let (endpoint, path) =
+        locator
+            .split_once('/')
+            .ok_or_else(|| SecretStoreError::InvalidUrl {
+                url: raw.to_string(),
+                reason: "vault:// requires '<host>[:<port>]/<kv-path>'".into(),
+            })?;
     if endpoint.is_empty() {
         return Err(SecretStoreError::InvalidUrl {
             url: raw.to_string(),
             reason: "vault:// requires a non-empty endpoint".into(),
         });
     }
+
+    // Collect recognised query parameters. Values are taken verbatim
+    // (no percent-decoding) — the recognised params (roles, mounts, a
+    // JWT file path) don't need it, and avoiding it keeps `jwt_path`'s
+    // slashes intact.
+    let mut method: Option<&str> = None;
+    let mut role: Option<String> = None;
+    let mut k8s_mount = VAULT_DEFAULT_K8S_MOUNT.to_string();
+    let mut jwt_path = VAULT_DEFAULT_JWT_PATH.to_string();
+    let mut approle_mount = VAULT_DEFAULT_APPROLE_MOUNT.to_string();
+    let mut enterprise_namespace: Option<String> = None;
+    let mut insecure = false;
+
+    if let Some(query) = query {
+        for pair in query.split('&').filter(|p| !p.is_empty()) {
+            let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+            match k {
+                "auth" => method = Some(v),
+                "role" => role = Some(v.to_string()),
+                "k8s_mount" => k8s_mount = v.to_string(),
+                "jwt_path" => jwt_path = v.to_string(),
+                "approle_mount" => approle_mount = v.to_string(),
+                "namespace" => {
+                    enterprise_namespace = (!v.is_empty()).then(|| v.to_string());
+                }
+                "insecure" => insecure = matches!(v, "1" | "true" | "yes" | "on"),
+                other => {
+                    return Err(SecretStoreError::InvalidUrl {
+                        url: raw.to_string(),
+                        reason: format!("unknown query parameter '{other}' on vault:// URL"),
+                    });
+                }
+            }
+        }
+    }
+
+    let auth = match method.unwrap_or("token") {
+        "token" => VaultAuth::Token,
+        "kubernetes" | "k8s" => {
+            let role = role.filter(|r| !r.is_empty()).ok_or_else(|| {
+                SecretStoreError::InvalidUrl {
+                    url: raw.to_string(),
+                    reason: "vault:// auth=kubernetes requires a 'role' query parameter".into(),
+                }
+            })?;
+            VaultAuth::Kubernetes {
+                role,
+                mount: k8s_mount,
+                jwt_path,
+            }
+        }
+        "approle" => VaultAuth::AppRole {
+            mount: approle_mount,
+        },
+        other => {
+            return Err(SecretStoreError::InvalidUrl {
+                url: raw.to_string(),
+                reason: format!(
+                    "unknown vault auth method '{other}' — supported: token, kubernetes, approle"
+                ),
+            });
+        }
+    };
+
     Ok(BackendUrl::Vault {
         endpoint: endpoint.to_string(),
         path: path.to_string(),
+        auth,
+        enterprise_namespace,
+        insecure,
     })
 }
 
@@ -418,8 +556,107 @@ mod tests {
             BackendUrl::Vault {
                 endpoint: "vault.internal".into(),
                 path: "secret/mediator".into(),
+                auth: VaultAuth::Token,
+                enterprise_namespace: None,
+                insecure: false,
             }
         );
+    }
+
+    #[test]
+    fn vault_defaults_to_token_auth() {
+        let url = parse_url("vault://vault.internal/secret").unwrap();
+        match url {
+            BackendUrl::Vault { auth, .. } => assert_eq!(auth, VaultAuth::Token),
+            other => panic!("expected Vault, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vault_kubernetes_auth_with_defaults() {
+        let url = parse_url("vault://vault.internal/secret/mediator?auth=kubernetes&role=med").unwrap();
+        assert_eq!(
+            url,
+            BackendUrl::Vault {
+                endpoint: "vault.internal".into(),
+                path: "secret/mediator".into(),
+                auth: VaultAuth::Kubernetes {
+                    role: "med".into(),
+                    mount: VAULT_DEFAULT_K8S_MOUNT.into(),
+                    jwt_path: VAULT_DEFAULT_JWT_PATH.into(),
+                },
+                enterprise_namespace: None,
+                insecure: false,
+            }
+        );
+    }
+
+    #[test]
+    fn vault_kubernetes_auth_requires_role() {
+        assert!(parse_url("vault://vault.internal/secret?auth=kubernetes").is_err());
+    }
+
+    #[test]
+    fn vault_kubernetes_auth_custom_mount_and_jwt_path() {
+        let url = parse_url(
+            "vault://vault.internal/secret/mediator?auth=kubernetes&role=r&k8s_mount=k8s-prod&jwt_path=/var/run/token",
+        )
+        .unwrap();
+        match url {
+            BackendUrl::Vault { auth, .. } => assert_eq!(
+                auth,
+                VaultAuth::Kubernetes {
+                    role: "r".into(),
+                    mount: "k8s-prod".into(),
+                    jwt_path: "/var/run/token".into(),
+                }
+            ),
+            other => panic!("expected Vault, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vault_approle_auth() {
+        let url = parse_url("vault://vault.internal/secret?auth=approle&approle_mount=my-approle")
+            .unwrap();
+        match url {
+            BackendUrl::Vault { auth, .. } => assert_eq!(
+                auth,
+                VaultAuth::AppRole {
+                    mount: "my-approle".into()
+                }
+            ),
+            other => panic!("expected Vault, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vault_enterprise_namespace_and_insecure() {
+        let url =
+            parse_url("vault://vault.internal/secret/mediator?namespace=team-a&insecure=1").unwrap();
+        match url {
+            BackendUrl::Vault {
+                enterprise_namespace,
+                insecure,
+                auth,
+                ..
+            } => {
+                assert_eq!(enterprise_namespace, Some("team-a".into()));
+                assert!(insecure);
+                assert_eq!(auth, VaultAuth::Token);
+            }
+            other => panic!("expected Vault, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vault_unknown_query_param_errors() {
+        assert!(parse_url("vault://vault.internal/secret?bogus=1").is_err());
+    }
+
+    #[test]
+    fn vault_unknown_auth_method_errors() {
+        assert!(parse_url("vault://vault.internal/secret?auth=ldap").is_err());
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -874,10 +874,21 @@ fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result
             // URL is fine — it stays canonical when re-parsed.
             config.secret_azure_vault = vault;
         }
-        BackendUrl::Vault { endpoint, path } => {
+        BackendUrl::Vault { endpoint, path, .. } => {
+            // NOTE: the extended Vault auth parameters (auth method,
+            // enterprise namespace, insecure) are not yet round-tripped
+            // into wizard config fields — that wiring lands with the
+            // wizard support PR. Recipes still carry them in the raw URL.
             config.secret_storage = STORAGE_VAULT.into();
             config.secret_vault_endpoint = endpoint;
             config.secret_vault_mount = path;
+        }
+        // `BackendUrl` is `#[non_exhaustive]`; any scheme not yet wired
+        // into the wizard config falls through here.
+        _ => {
+            anyhow::bail!(
+                "Invalid secrets.storage '{raw}': backend not yet supported in recipe config"
+            );
         }
     }
     Ok(())


### PR DESCRIPTION
**Stacked PR series** bringing the mediator secret store + `mediator-setup` wizard to VTA parity for Kubernetes Secrets and HashiCorp Vault auth. Merge bottom-up:
1. feat/mediator-secrets-vault-auth
2. feat/mediator-secrets-k8s-backend
3. feat/mediator-setup-secrets-recipe
4. feat/mediator-setup-secrets-wizard
5. docs/mediator-secrets-k8s-vault

---
**PR 1 of 5.** Extend the `vault://` secrets backend to VTA's auth support.

- `?auth=token|kubernetes|approle` query param (default `token`, so existing `vault://host/mount` URLs are unchanged)
- Kubernetes auth: exchange the pod ServiceAccount JWT for a Vault token; JWT re-read on every login (kubelet rotation)
- AppRole auth: `role_id`/`secret_id` from `VAULT_ROLE_ID`/`VAULT_SECRET_ID`
- Vault Enterprise namespace via `?namespace=`; `?insecure=1` TLS-skip (dev only)
- renewable methods re-authenticate once on 401/403 and retry
- auth secrets never in the URL; `BackendUrl` sealed `#[non_exhaustive]`

`mediator-common` 0.15.21→0.15.22. Clippy clean with/without `secrets-vault`; 9 new parser tests.

⚠️ **Semver note:** this adds fields to the `Vault` enum variant (technically breaking for external `BackendUrl` matchers). Kept a patch bump per the W7 `#[non_exhaustive]` precedent to stay within "0.15" pins — say if you'd prefer minor (0.16.0) + cascade.