### PR TITLE
feat: native Kubernetes Secrets backend

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -56,6 +56,7 @@ secrets-aws = ["affinidi-messaging-mediator-common/secrets-aws", "aws"]
 secrets-gcp = ["affinidi-messaging-mediator-common/secrets-gcp"]
 secrets-azure = ["affinidi-messaging-mediator-common/secrets-azure"]
 secrets-vault = ["affinidi-messaging-mediator-common/secrets-vault"]
+secrets-k8s = ["affinidi-messaging-mediator-common/secrets-k8s"]
 
 ## AWS integration used by `did_web_self_hosted = "aws_parameter_store://..."`
 ## (still loaded directly by the mediator, not via the secret store). Enabled

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.22"
+version = "0.15.23"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -85,6 +85,7 @@ secrets-azure = [
   "dep:azure_core",
 ]
 secrets-vault = ["server", "dep:vaultrs"]
+secrets-k8s = ["server", "dep:kube", "dep:k8s-openapi"]
 
 # ── Test-only injectable clock ──────────────────────────────────────
 ## Compiles `types::clock::TestClock`, a manually-advanced clock for fast
@@ -147,6 +148,15 @@ azure_core = { version = "0.35", optional = true }
 vaultrs = { version = "0.8", default-features = false, features = [
   "rustls",
 ], optional = true }
+## Native Kubernetes Secrets backend. `kube` talks to the API server
+## (in-cluster ServiceAccount or local kubeconfig); rustls-tls keeps it
+## on the workspace TLS story. `k8s-openapi` "latest" pins the generated
+## API types to the newest supported Kubernetes version.
+kube = { version = "3.1", default-features = false, features = [
+  "client",
+  "rustls-tls",
+], optional = true }
+k8s-openapi = { version = "0.27", features = ["latest"], optional = true }
 
 # ── Async stream helpers (used by the redis-store pubsub bridge) ─────────
 tokio-stream = { version = "0.1", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/k8s.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/k8s.rs
@@ -1,0 +1,322 @@
+//! Native Kubernetes Secrets backend (feature `secrets-k8s`).
+//!
+//! URL shape: `k8s://<namespace>/<secret-name>` or `k8s://<secret-name>`
+//! (namespace omitted → resolved from the ServiceAccount / kubeconfig).
+//!
+//! Layout: every mediator well-known key becomes one entry in the `data`
+//! map of a *single* `Secret` object. This is the RBAC-minimal mapping —
+//! the pod ServiceAccount only needs `get`/`create`/`update` on one named
+//! Secret — and it keeps the whole secret bundle atomic. Values are the
+//! raw envelope bytes stored as a `ByteString`; Kubernetes base64-encodes
+//! them on the wire, so no extra encoding happens at this layer.
+//!
+//! Auth is resolved by [`Client::try_default`]: the in-cluster
+//! ServiceAccount when running inside a pod, or the local kubeconfig
+//! (`~/.kube/config` / `$KUBECONFIG`) otherwise. Writes read-modify-write
+//! the Secret and use `replace` with the fetched `resourceVersion` for
+//! optimistic concurrency, retrying a bounded number of times on a 409
+//! conflict so concurrent writers don't clobber one another.
+
+use crate::secrets::error::{Result, SecretStoreError};
+use crate::secrets::store::DynSecretStore;
+use crate::secrets::url::BackendUrl;
+
+#[cfg(feature = "secrets-k8s")]
+use async_trait::async_trait;
+#[cfg(feature = "secrets-k8s")]
+use k8s_openapi::ByteString;
+#[cfg(feature = "secrets-k8s")]
+use k8s_openapi::api::core::v1::Secret;
+#[cfg(feature = "secrets-k8s")]
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+#[cfg(feature = "secrets-k8s")]
+use kube::api::{Api, PostParams};
+#[cfg(feature = "secrets-k8s")]
+use kube::{Client, Error as KubeError};
+#[cfg(feature = "secrets-k8s")]
+use std::collections::BTreeMap;
+
+#[cfg(feature = "secrets-k8s")]
+use crate::secrets::store::SecretStore;
+
+const BACKEND_LABEL: &str = "k8s";
+
+/// Bounded retries on a 409 conflict during read-modify-write.
+#[cfg(feature = "secrets-k8s")]
+const MAX_CONFLICT_RETRIES: usize = 5;
+
+#[cfg(feature = "secrets-k8s")]
+pub(crate) fn open(url: BackendUrl) -> Result<DynSecretStore> {
+    let BackendUrl::Kubernetes {
+        namespace,
+        secret_name,
+    } = url
+    else {
+        return Err(SecretStoreError::Other(
+            "internal error: k8s backend received non-k8s URL".into(),
+        ));
+    };
+    Ok(std::sync::Arc::new(K8sStore {
+        namespace,
+        secret_name,
+    }))
+}
+
+#[cfg(not(feature = "secrets-k8s"))]
+pub(crate) fn open(_url: BackendUrl) -> Result<DynSecretStore> {
+    Err(SecretStoreError::BackendUnavailable {
+        backend: BACKEND_LABEL,
+        reason: "compiled without the 'secrets-k8s' feature; rebuild with \
+                 `cargo build --features secrets-k8s` to enable"
+            .into(),
+    })
+}
+
+#[cfg(feature = "secrets-k8s")]
+pub struct K8sStore {
+    /// Explicit namespace, or `None` to resolve from the SA / kubeconfig.
+    namespace: Option<String>,
+    /// Name of the `Secret` object holding every mediator key.
+    secret_name: String,
+}
+
+/// Whether a `kube` error is a 409 Conflict (optimistic-concurrency clash).
+#[cfg(feature = "secrets-k8s")]
+fn is_conflict(err: &KubeError) -> bool {
+    matches!(err, KubeError::Api(resp) if resp.code == 409)
+}
+
+/// Map a `kube` error to a `SecretStoreError`, unrolling its source chain
+/// (the top-level `Display` is usually a terse "ApiError" that hides the
+/// real cause — RBAC denial, DNS, TLS…). A 403 becomes `PermissionDenied`.
+#[cfg(feature = "secrets-k8s")]
+fn kube_error(secret_name: &str, context: &str, err: KubeError) -> SecretStoreError {
+    let mut msg = format!("{context}: {err}");
+    let mut source = std::error::Error::source(&err);
+    while let Some(cause) = source {
+        msg.push_str(&format!("\n  caused by: {cause}"));
+        source = cause.source();
+    }
+    if matches!(&err, KubeError::Api(resp) if resp.code == 403) {
+        return SecretStoreError::PermissionDenied {
+            key: secret_name.to_string(),
+            reason: msg,
+        };
+    }
+    SecretStoreError::Unreachable {
+        backend: BACKEND_LABEL,
+        reason: msg,
+    }
+}
+
+#[cfg(feature = "secrets-k8s")]
+impl K8sStore {
+    /// Build a namespaced `Secret` API handle, resolving the namespace and
+    /// loading credentials from the in-cluster SA or local kubeconfig.
+    async fn api(&self) -> Result<Api<Secret>> {
+        let client = Client::try_default()
+            .await
+            .map_err(|e| kube_error(&self.secret_name, "failed to initialise Kubernetes client", e))?;
+        let namespace = self
+            .namespace
+            .clone()
+            .unwrap_or_else(|| client.default_namespace().to_string());
+        Ok(Api::namespaced(client, &namespace))
+    }
+}
+
+#[cfg(feature = "secrets-k8s")]
+#[async_trait]
+impl SecretStore for K8sStore {
+    fn backend(&self) -> &'static str {
+        BACKEND_LABEL
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let api = self.api().await?;
+        // `get_opt` maps a 404 (missing Secret) to `Ok(None)` — the
+        // legitimate first-boot case.
+        let Some(secret) = api
+            .get_opt(&self.secret_name)
+            .await
+            .map_err(|e| kube_error(&self.secret_name, "failed to read Kubernetes Secret", e))?
+        else {
+            return Ok(None);
+        };
+        // A present Secret that simply lacks this key means the individual
+        // secret isn't stored yet → absent, not an error.
+        match secret.data.unwrap_or_default().get(key) {
+            Some(ByteString(bytes)) => Ok(Some(bytes.clone())),
+            None => Ok(None),
+        }
+    }
+
+    async fn put(&self, key: &str, value: &[u8]) -> Result<()> {
+        let api = self.api().await?;
+        for attempt in 0..MAX_CONFLICT_RETRIES {
+            match api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| kube_error(&self.secret_name, "failed to read Kubernetes Secret", e))?
+            {
+                Some(mut existing) => {
+                    // Preserve every other key (and the resourceVersion, for
+                    // optimistic concurrency); touch only ours. `string_data`
+                    // is write-only and never round-trips on GET — clear it.
+                    let mut data = existing.data.take().unwrap_or_default();
+                    data.insert(key.to_string(), ByteString(value.to_vec()));
+                    existing.data = Some(data);
+                    existing.string_data = None;
+                    match api
+                        .replace(&self.secret_name, &PostParams::default(), &existing)
+                        .await
+                    {
+                        Ok(_) => return Ok(()),
+                        Err(e) if is_conflict(&e) && attempt + 1 < MAX_CONFLICT_RETRIES => continue,
+                        Err(e) => {
+                            return Err(kube_error(
+                                &self.secret_name,
+                                "failed to update Kubernetes Secret",
+                                e,
+                            ));
+                        }
+                    }
+                }
+                None => {
+                    let mut data = BTreeMap::new();
+                    data.insert(key.to_string(), ByteString(value.to_vec()));
+                    let secret = Secret {
+                        metadata: ObjectMeta {
+                            name: Some(self.secret_name.clone()),
+                            ..Default::default()
+                        },
+                        data: Some(data),
+                        type_: Some("Opaque".to_string()),
+                        ..Default::default()
+                    };
+                    match api.create(&PostParams::default(), &secret).await {
+                        Ok(_) => return Ok(()),
+                        // Another writer created it first — loop back and
+                        // apply as an update.
+                        Err(e) if is_conflict(&e) && attempt + 1 < MAX_CONFLICT_RETRIES => continue,
+                        Err(e) => {
+                            return Err(kube_error(
+                                &self.secret_name,
+                                "failed to create Kubernetes Secret",
+                                e,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Err(SecretStoreError::Unreachable {
+            backend: BACKEND_LABEL,
+            reason: format!(
+                "exhausted {MAX_CONFLICT_RETRIES} conflict retries writing key '{key}' to Secret '{}'",
+                self.secret_name
+            ),
+        })
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let api = self.api().await?;
+        for attempt in 0..MAX_CONFLICT_RETRIES {
+            let Some(mut existing) = api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| kube_error(&self.secret_name, "failed to read Kubernetes Secret", e))?
+            else {
+                return Ok(()); // Secret absent → nothing to delete.
+            };
+            let mut data = existing.data.take().unwrap_or_default();
+            if data.remove(key).is_none() {
+                return Ok(()); // Key already absent → no-op.
+            }
+            existing.data = Some(data);
+            existing.string_data = None;
+            match api
+                .replace(&self.secret_name, &PostParams::default(), &existing)
+                .await
+            {
+                Ok(_) => return Ok(()),
+                Err(e) if is_conflict(&e) && attempt + 1 < MAX_CONFLICT_RETRIES => continue,
+                Err(e) => {
+                    return Err(kube_error(
+                        &self.secret_name,
+                        "failed to update Kubernetes Secret",
+                        e,
+                    ));
+                }
+            }
+        }
+        Err(SecretStoreError::Unreachable {
+            backend: BACKEND_LABEL,
+            reason: format!(
+                "exhausted {MAX_CONFLICT_RETRIES} conflict retries deleting key '{key}' from Secret '{}'",
+                self.secret_name
+            ),
+        })
+    }
+
+    /// List the keys held inside the backing Secret (one per stored
+    /// mediator secret). A missing Secret yields an empty list so wizard
+    /// discovery shows "no entries" rather than an error.
+    async fn list_namespace(&self) -> Result<Vec<String>> {
+        let api = self.api().await?;
+        let Some(secret) = api
+            .get_opt(&self.secret_name)
+            .await
+            .map_err(|e| kube_error(&self.secret_name, "failed to read Kubernetes Secret", e))?
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(secret.data.unwrap_or_default().into_keys().collect())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "secrets-k8s")]
+mod tests {
+    use super::*;
+    use crate::secrets::url::parse_url;
+
+    #[test]
+    fn open_with_explicit_namespace() {
+        let url = parse_url("k8s://affinidi/mediator-secrets").unwrap();
+        let store = open(url).expect("open k8s backend");
+        assert_eq!(store.backend(), BACKEND_LABEL);
+    }
+
+    #[test]
+    fn open_without_namespace() {
+        let url = parse_url("k8s://mediator-secrets").unwrap();
+        let store = open(url).expect("open k8s backend");
+        assert_eq!(store.backend(), BACKEND_LABEL);
+    }
+
+    /// Opt-in live-cluster test. Requires a reachable cluster (in-pod SA or
+    /// a kubeconfig context) with RBAC allowing get/create/update on the
+    /// target Secret.
+    ///
+    /// Run with:
+    ///   MEDIATOR_TEST_K8S_URL=k8s://default/ci-mediator-secrets \
+    ///   cargo test -p affinidi-messaging-mediator-common \
+    ///     --features secrets-k8s k8s_live_roundtrip -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn k8s_live_roundtrip() {
+        use crate::secrets::store::open_store;
+        let url = std::env::var("MEDIATOR_TEST_K8S_URL")
+            .expect("set MEDIATOR_TEST_K8S_URL to run the live Kubernetes test");
+        let store = open_store(&url).unwrap();
+        store.probe().await.expect("probe");
+        let key = format!("mediator_probe_{}", uuid::Uuid::new_v4().simple());
+        let payload = b"payload-bytes".to_vec();
+        store.put(&key, &payload).await.unwrap();
+        let got = store.get(&key).await.unwrap().unwrap();
+        assert_eq!(got, payload);
+        store.delete(&key).await.unwrap();
+        assert!(store.get(&key).await.unwrap().is_none());
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod azure;
 pub(crate) mod file;
 pub(crate) mod file_encrypted;
 pub(crate) mod gcp;
+pub(crate) mod k8s;
 pub(crate) mod keyring;
 pub(crate) mod memory;
 pub(crate) mod vault;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/store.rs
@@ -118,6 +118,7 @@ pub fn open_store(url: &str) -> Result<DynSecretStore> {
         BackendUrl::Gcp { .. } => backends::gcp::open(parsed),
         BackendUrl::Azure { .. } => backends::azure::open(parsed),
         BackendUrl::Vault { .. } => backends::vault::open(parsed),
+        BackendUrl::Kubernetes { .. } => backends::k8s::open(parsed),
     }
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
@@ -10,9 +10,12 @@
 //! | `gcp_secrets://` | `gcp_secrets://<project>/<namespace>`       | `gcp_secrets://my-proj/mediator-`          |
 //! | `azure_keyvault://` | `azure_keyvault://<vault-name-or-url>`   | `azure_keyvault://my-vault`                |
 //! | `vault://`       | `vault://<host[:port]>/<kv-path>[?auth=…]`  | `vault://vault.internal/secret/mediator`   |
+//! | `k8s://`         | `k8s://<namespace>/<secret-name>`           | `k8s://affinidi/mediator-secrets`          |
 //!
 //! The `vault://` scheme accepts optional query parameters selecting a
 //! non-default auth method and transport options — see [`parse_vault`].
+//! The `k8s://` scheme stores every mediator key inside one namespaced
+//! `Secret` object — see [`parse_k8s`].
 //!
 //! `string://` is intentionally not supported — inline secrets in
 //! `mediator.toml` would defeat the whole point. CI scripts that used to
@@ -78,6 +81,13 @@ pub enum BackendUrl {
         /// Skip TLS verification (`?insecure=1`) — dev/test only.
         insecure: bool,
     },
+    Kubernetes {
+        /// Explicit namespace, or `None` to resolve from the in-pod
+        /// ServiceAccount / kubeconfig context at connect time.
+        namespace: Option<String>,
+        /// Name of the `Secret` object holding every mediator key.
+        secret_name: String,
+    },
 }
 
 /// Parse a backend URL. Returns a structured [`BackendUrl`] or an
@@ -106,11 +116,12 @@ pub fn parse_url(raw: &str) -> Result<BackendUrl> {
         "gcp_secrets" => parse_gcp(rest, raw),
         "azure_keyvault" => parse_azure(rest, raw),
         "vault" => parse_vault(rest, raw),
+        "k8s" => parse_k8s(rest, raw),
         other => Err(SecretStoreError::InvalidUrl {
             url: raw.to_string(),
             reason: format!(
                 "unknown scheme '{other}://' — supported schemes: keyring, file, aws_secrets, \
-                 gcp_secrets, azure_keyvault, vault"
+                 gcp_secrets, azure_keyvault, vault, k8s"
             ),
         }),
     }
@@ -364,6 +375,52 @@ fn parse_vault(rest: &str, raw: &str) -> Result<BackendUrl> {
         auth,
         enterprise_namespace,
         insecure,
+    })
+}
+
+/// Parse a `k8s://` URL.
+///
+/// Shape: `k8s://<namespace>/<secret-name>` or `k8s://<secret-name>`.
+/// When the namespace segment is omitted (or empty), the backend resolves
+/// it from the in-pod ServiceAccount / kubeconfig context at connect time.
+fn parse_k8s(rest: &str, raw: &str) -> Result<BackendUrl> {
+    if rest.contains('?') {
+        return Err(SecretStoreError::InvalidUrl {
+            url: raw.to_string(),
+            reason: "k8s:// takes no query parameters".into(),
+        });
+    }
+    if rest.is_empty() {
+        return Err(SecretStoreError::InvalidUrl {
+            url: raw.to_string(),
+            reason: "k8s:// requires a Secret name, e.g. k8s://<namespace>/<secret-name>".into(),
+        });
+    }
+    // Split on the first '/': `<namespace>/<secret-name>`. An empty
+    // namespace segment (`k8s:///name`) means "resolve at connect time".
+    // A trailing slash (`k8s://ns/`) leaves an empty secret name, which is
+    // rejected below rather than silently treated as the name.
+    let (namespace, secret_name) = match rest.split_once('/') {
+        Some((ns, name)) => ((!ns.is_empty()).then(|| ns.to_string()), name),
+        None => (None, rest),
+    };
+    if secret_name.is_empty() {
+        return Err(SecretStoreError::InvalidUrl {
+            url: raw.to_string(),
+            reason: "k8s:// requires a non-empty Secret name".into(),
+        });
+    }
+    if secret_name.contains('/') {
+        return Err(SecretStoreError::InvalidUrl {
+            url: raw.to_string(),
+            reason: "k8s:// Secret name must not contain '/' — expected \
+                     k8s://<namespace>/<secret-name>"
+                .into(),
+        });
+    }
+    Ok(BackendUrl::Kubernetes {
+        namespace,
+        secret_name: secret_name.to_string(),
     })
 }
 
@@ -657,6 +714,55 @@ mod tests {
     #[test]
     fn vault_unknown_auth_method_errors() {
         assert!(parse_url("vault://vault.internal/secret?auth=ldap").is_err());
+    }
+
+    #[test]
+    fn k8s_with_namespace() {
+        assert_eq!(
+            parse_url("k8s://affinidi/mediator-secrets").unwrap(),
+            BackendUrl::Kubernetes {
+                namespace: Some("affinidi".into()),
+                secret_name: "mediator-secrets".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn k8s_without_namespace() {
+        assert_eq!(
+            parse_url("k8s://mediator-secrets").unwrap(),
+            BackendUrl::Kubernetes {
+                namespace: None,
+                secret_name: "mediator-secrets".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn k8s_empty_namespace_segment_is_none() {
+        assert_eq!(
+            parse_url("k8s:///mediator-secrets").unwrap(),
+            BackendUrl::Kubernetes {
+                namespace: None,
+                secret_name: "mediator-secrets".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn k8s_missing_secret_name_errors() {
+        assert!(parse_url("k8s://").is_err());
+        assert!(parse_url("k8s://affinidi/").is_err());
+    }
+
+    #[test]
+    fn k8s_extra_path_segment_errors() {
+        assert!(parse_url("k8s://ns/a/b").is_err());
+    }
+
+    #[test]
+    fn k8s_query_param_errors() {
+        assert!(parse_url("k8s://ns/secret?key=seed").is_err());
     }
 
     #[test]


### PR DESCRIPTION
**Stacked PR series** bringing the mediator secret store + `mediator-setup` wizard to VTA parity for Kubernetes Secrets and HashiCorp Vault auth. Merge bottom-up:
1. feat/mediator-secrets-vault-auth
2. feat/mediator-secrets-k8s-backend
3. feat/mediator-setup-secrets-recipe
4. feat/mediator-setup-secrets-wizard
5. docs/mediator-secrets-k8s-vault

---
**PR 2 of 5.** (Base: PR 1.) Native `k8s://` secrets backend reading/writing a namespaced Kubernetes `Secret` via the API server.

- URL `k8s://<namespace>/<secret-name>` or `k8s://<secret-name>` (namespace resolved from the pod SA / kubeconfig)
- one Secret holds every mediator key as a `data` entry (raw envelope bytes; K8s base64-encodes on the wire) — RBAC-minimal, atomic
- auth via `Client::try_default()`; read-modify-write with `replace` + resourceVersion (optimistic concurrency, bounded 409-retry); `get` maps missing Secret/key → `None`; `list_namespace` returns the Secret's keys
- new `secrets-k8s` feature (`kube` 3.1 + `k8s-openapi` 0.27, matching VTA), forwarded from the mediator binary; `cargo deny` licenses+bans pass

`mediator-common` 0.15.22→0.15.23. 6 new URL tests + ignored live-cluster test.