### PR TITLE
feat: recipe + config round-trip for k8s and Vault auth

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.23"
+version = "0.15.24"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/mod.rs
@@ -30,7 +30,10 @@ pub mod well_known;
 pub use envelope::{ENVELOPE_VERSION, Envelope};
 pub use error::{Result, SecretStoreError};
 pub use store::{DynSecretStore, SecretStore, open_store};
-pub use url::{BackendUrl, VaultAuth, parse_url};
+pub use url::{
+    BackendUrl, VAULT_DEFAULT_APPROLE_MOUNT, VAULT_DEFAULT_JWT_PATH, VAULT_DEFAULT_K8S_MOUNT,
+    VaultAuth, parse_url,
+};
 pub use well_known::{
     ADMIN_CREDENTIAL, AdminCredential, BOOTSTRAP_EPHEMERAL_SEED_PREFIX, BOOTSTRAP_SEED_INDEX,
     BootstrapSeedIndex, BootstrapSeedIndexEntry, JWT_SECRET, MediatorSecrets,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.14"
+version = "0.1.15"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -23,12 +23,14 @@ default = [
   "secrets-gcp",
   "secrets-azure",
   "secrets-vault",
+  "secrets-k8s",
 ]
 secrets-keyring = ["affinidi-messaging-mediator-common/secrets-keyring"]
 secrets-aws = ["affinidi-messaging-mediator-common/secrets-aws"]
 secrets-gcp = ["affinidi-messaging-mediator-common/secrets-gcp"]
 secrets-azure = ["affinidi-messaging-mediator-common/secrets-azure"]
 secrets-vault = ["affinidi-messaging-mediator-common/secrets-vault"]
+secrets-k8s = ["affinidi-messaging-mediator-common/secrets-k8s"]
 
 [dependencies]
 # ── TUI Framework ────────────────────────────────────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -392,6 +392,27 @@ pub struct WizardConfig {
     /// (`secret/mediator`). The backend splits the first segment off
     /// as the mount and uses the rest as the namespace.
     pub secret_vault_mount: String,
+    /// Vault auth method: `token` (default), `kubernetes`, or `approle`.
+    /// Empty is treated as `token`.
+    pub secret_vault_auth: String,
+    /// Vault role for `kubernetes` auth (required for that method).
+    pub secret_vault_role: String,
+    /// Vault Kubernetes auth mount. Empty → backend default (`kubernetes`).
+    pub secret_vault_k8s_mount: String,
+    /// ServiceAccount JWT path for `kubernetes` auth. Empty → backend
+    /// default (`/var/run/secrets/kubernetes.io/serviceaccount/token`).
+    pub secret_vault_jwt_path: String,
+    /// Vault AppRole auth mount. Empty → backend default (`approle`).
+    pub secret_vault_approle_mount: String,
+    /// Vault Enterprise namespace (`X-Vault-Namespace`). Empty → none.
+    pub secret_vault_namespace: String,
+    /// Skip TLS verification for `vault://` (dev/test only).
+    pub secret_vault_insecure: bool,
+    /// Kubernetes namespace for the `k8s://` backend. Empty → resolved
+    /// from the in-pod ServiceAccount / kubeconfig at connect time.
+    pub secret_k8s_namespace: String,
+    /// Name of the `Secret` object for the `k8s://` backend.
+    pub secret_k8s_secret_name: String,
     /// `true` when the operator chose `file://?encrypt=1`. Influences
     /// the backend URL written to `mediator.toml` and whether the
     /// wizard prompts for a passphrase.
@@ -544,6 +565,15 @@ impl Default for WizardConfig {
             secret_azure_vault: DEFAULT_AZURE_VAULT.into(),
             secret_vault_endpoint: DEFAULT_VAULT_ENDPOINT.into(),
             secret_vault_mount: DEFAULT_VAULT_MOUNT.into(),
+            secret_vault_auth: String::new(),
+            secret_vault_role: String::new(),
+            secret_vault_k8s_mount: String::new(),
+            secret_vault_jwt_path: String::new(),
+            secret_vault_approle_mount: String::new(),
+            secret_vault_namespace: String::new(),
+            secret_vault_insecure: false,
+            secret_k8s_namespace: String::new(),
+            secret_k8s_secret_name: DEFAULT_K8S_SECRET_NAME.into(),
             secret_file_encrypted: false,
             ssl_mode: String::new(),
             ssl_cert_path: String::new(),

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -381,10 +381,17 @@ pub fn build_backend_url(config: &WizardConfig) -> String {
             config.secret_gcp_project, config.secret_gcp_namespace
         ),
         STORAGE_AZURE => format!("azure_keyvault://{}", config.secret_azure_vault),
-        STORAGE_VAULT => format!(
-            "vault://{}/{}",
-            config.secret_vault_endpoint, config.secret_vault_mount
-        ),
+        STORAGE_VAULT => vault_backend_url(config),
+        STORAGE_K8S => {
+            if config.secret_k8s_namespace.is_empty() {
+                format!("k8s://{}", config.secret_k8s_secret_name)
+            } else {
+                format!(
+                    "k8s://{}/{}",
+                    config.secret_k8s_namespace, config.secret_k8s_secret_name
+                )
+            }
+        }
         // string:// is no longer supported by the mediator's SecretStore
         // URL parser; fall back to a keyring default and warn in stdout
         // during `generate_and_write`. The wildcard catches any future
@@ -393,6 +400,60 @@ pub fn build_backend_url(config: &WizardConfig) -> String {
         // they have callers today.
         _ => "keyring://affinidi-mediator".to_string(),
     }
+}
+
+/// Assemble a `vault://` URL including any non-default auth-method and
+/// transport query parameters. Defaults are omitted, so a plain
+/// token-auth setup renders the same compact URL as before and a recipe
+/// round-trip (parse → fields → build) stays stable.
+fn vault_backend_url(config: &WizardConfig) -> String {
+    use affinidi_messaging_mediator_common::secrets::{
+        VAULT_DEFAULT_APPROLE_MOUNT, VAULT_DEFAULT_JWT_PATH, VAULT_DEFAULT_K8S_MOUNT,
+    };
+    let mut url = format!(
+        "vault://{}/{}",
+        config.secret_vault_endpoint, config.secret_vault_mount
+    );
+    let mut params: Vec<String> = Vec::new();
+    match config.secret_vault_auth.as_str() {
+        "kubernetes" => {
+            params.push("auth=kubernetes".to_string());
+            if !config.secret_vault_role.is_empty() {
+                params.push(format!("role={}", config.secret_vault_role));
+            }
+            if !config.secret_vault_k8s_mount.is_empty()
+                && config.secret_vault_k8s_mount != VAULT_DEFAULT_K8S_MOUNT
+            {
+                params.push(format!("k8s_mount={}", config.secret_vault_k8s_mount));
+            }
+            if !config.secret_vault_jwt_path.is_empty()
+                && config.secret_vault_jwt_path != VAULT_DEFAULT_JWT_PATH
+            {
+                params.push(format!("jwt_path={}", config.secret_vault_jwt_path));
+            }
+        }
+        "approle" => {
+            params.push("auth=approle".to_string());
+            if !config.secret_vault_approle_mount.is_empty()
+                && config.secret_vault_approle_mount != VAULT_DEFAULT_APPROLE_MOUNT
+            {
+                params.push(format!("approle_mount={}", config.secret_vault_approle_mount));
+            }
+        }
+        // "token" or empty → default auth, no `auth=` query parameter.
+        _ => {}
+    }
+    if !config.secret_vault_namespace.is_empty() {
+        params.push(format!("namespace={}", config.secret_vault_namespace));
+    }
+    if config.secret_vault_insecure {
+        params.push("insecure=1".to_string());
+    }
+    if !params.is_empty() {
+        url.push('?');
+        url.push_str(&params.join("&"));
+    }
+    url
 }
 
 #[cfg(test)]
@@ -537,6 +598,132 @@ mod tests {
             build_backend_url(&cfg),
             "vault://vault.example.com:8200/secret/mediator"
         );
+    }
+
+    #[test]
+    fn build_backend_url_vault_token_auth_omits_query() {
+        // Explicit token auth (or empty) renders the same compact URL as
+        // before — no `?auth=token`.
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_VAULT.into(),
+            secret_vault_endpoint: "vault.internal".into(),
+            secret_vault_mount: "secret/mediator".into(),
+            secret_vault_auth: "token".into(),
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "vault://vault.internal/secret/mediator"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_vault_kubernetes_auth() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_VAULT.into(),
+            secret_vault_endpoint: "vault.internal".into(),
+            secret_vault_mount: "secret/mediator".into(),
+            secret_vault_auth: "kubernetes".into(),
+            secret_vault_role: "mediator".into(),
+            // Backend-default mount/jwt_path are omitted from the URL.
+            secret_vault_k8s_mount: "kubernetes".into(),
+            secret_vault_namespace: "team-a".into(),
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "vault://vault.internal/secret/mediator?auth=kubernetes&role=mediator&namespace=team-a"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_vault_kubernetes_custom_mount_and_insecure() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_VAULT.into(),
+            secret_vault_endpoint: "vault.internal".into(),
+            secret_vault_mount: "secret/mediator".into(),
+            secret_vault_auth: "kubernetes".into(),
+            secret_vault_role: "med".into(),
+            secret_vault_k8s_mount: "k8s-prod".into(),
+            secret_vault_insecure: true,
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "vault://vault.internal/secret/mediator?auth=kubernetes&role=med&k8s_mount=k8s-prod&insecure=1"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_vault_approle_auth() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_VAULT.into(),
+            secret_vault_endpoint: "vault.internal".into(),
+            secret_vault_mount: "secret/mediator".into(),
+            secret_vault_auth: "approle".into(),
+            secret_vault_approle_mount: "my-approle".into(),
+            ..WizardConfig::default()
+        };
+        assert_eq!(
+            build_backend_url(&cfg),
+            "vault://vault.internal/secret/mediator?auth=approle&approle_mount=my-approle"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_k8s_with_namespace() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_K8S.into(),
+            secret_k8s_namespace: "affinidi".into(),
+            secret_k8s_secret_name: "mediator-secrets".into(),
+            ..WizardConfig::default()
+        };
+        assert_eq!(build_backend_url(&cfg), "k8s://affinidi/mediator-secrets");
+    }
+
+    #[test]
+    fn build_backend_url_k8s_without_namespace() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_K8S.into(),
+            secret_k8s_namespace: String::new(),
+            secret_k8s_secret_name: "mediator-secrets".into(),
+            ..WizardConfig::default()
+        };
+        assert_eq!(build_backend_url(&cfg), "k8s://mediator-secrets");
+    }
+
+    /// A `vault://…?auth=kubernetes` URL survives the recipe round-trip
+    /// (build → parse-back → build) unchanged.
+    #[test]
+    fn vault_kubernetes_url_round_trips_through_recipe() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_VAULT.into(),
+            secret_vault_endpoint: "vault.internal".into(),
+            secret_vault_mount: "secret/mediator".into(),
+            secret_vault_auth: "kubernetes".into(),
+            secret_vault_role: "mediator".into(),
+            secret_vault_namespace: "team-a".into(),
+            ..WizardConfig::default()
+        };
+        let url = build_backend_url(&cfg);
+        let mut round = WizardConfig::default();
+        crate::recipe::apply_secrets_storage(&url, &mut round).unwrap();
+        assert_eq!(build_backend_url(&round), url);
+    }
+
+    /// A `k8s://` URL survives the recipe round-trip unchanged.
+    #[test]
+    fn k8s_url_round_trips_through_recipe() {
+        let cfg = WizardConfig {
+            secret_storage: STORAGE_K8S.into(),
+            secret_k8s_namespace: "affinidi".into(),
+            secret_k8s_secret_name: "mediator-secrets".into(),
+            ..WizardConfig::default()
+        };
+        let url = build_backend_url(&cfg);
+        let mut round = WizardConfig::default();
+        crate::recipe::apply_secrets_storage(&url, &mut round).unwrap();
+        assert_eq!(build_backend_url(&round), url);
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/consts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/consts.rs
@@ -17,6 +17,7 @@ pub const STORAGE_AWS: &str = "aws_secrets://";
 pub const STORAGE_GCP: &str = "gcp_secrets://";
 pub const STORAGE_AZURE: &str = "azure_keyvault://";
 pub const STORAGE_VAULT: &str = "vault://";
+pub const STORAGE_K8S: &str = "k8s://";
 pub const STORAGE_VTA: &str = "vta://";
 
 /// Mediator persistence backend selectors written to `[storage].backend`
@@ -186,3 +187,5 @@ pub const DEFAULT_AZURE_VAULT: &str = "";
 /// Vault ships with `vault server -dev`.
 pub const DEFAULT_VAULT_ENDPOINT: &str = "";
 pub const DEFAULT_VAULT_MOUNT: &str = "secret/mediator";
+/// Default name of the `Secret` object for the `k8s://` backend.
+pub const DEFAULT_K8S_SECRET_NAME: &str = "mediator-secrets";

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -806,7 +806,7 @@ pub fn from_wizard_config(config: &WizardConfig) -> String {
 ///
 /// Deprecated schemes (`string://`, `vta://`) error with a pointer to
 /// the supported alternative.
-fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result<()> {
+pub(crate) fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result<()> {
     // Bare scheme (no body) — preserve the pre-cloud-config behaviour:
     // set `secret_storage` to the scheme, leave per-backend fields at
     // their wizard defaults. Operators upgrading from older recipes
@@ -818,6 +818,7 @@ fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result
         STORAGE_GCP,
         STORAGE_AZURE,
         STORAGE_VAULT,
+        STORAGE_K8S,
     ];
     if let Some(&scheme) = bare_schemes.iter().find(|&&s| raw == s) {
         config.secret_storage = scheme.into();
@@ -841,10 +842,10 @@ fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result
     // Full URL — let the shared parser handle each scheme's body and
     // surface its diagnostics verbatim. Splitting per-backend fields
     // here mirrors the wizard's own `enter_key_storage_phase` chain.
-    use affinidi_messaging_mediator_common::secrets::{BackendUrl, parse_url};
+    use affinidi_messaging_mediator_common::secrets::{BackendUrl, VaultAuth, parse_url};
     let parsed = parse_url(raw).map_err(|e| {
         anyhow::anyhow!(
-            "Invalid secrets.storage '{raw}': {e} (expected one of {STORAGE_FILE}, {STORAGE_KEYRING}, {STORAGE_AWS}, {STORAGE_GCP}, {STORAGE_AZURE}, {STORAGE_VAULT})",
+            "Invalid secrets.storage '{raw}': {e} (expected one of {STORAGE_FILE}, {STORAGE_KEYRING}, {STORAGE_AWS}, {STORAGE_GCP}, {STORAGE_AZURE}, {STORAGE_VAULT}, {STORAGE_K8S})",
         )
     })?;
     match parsed {
@@ -874,17 +875,46 @@ fn apply_secrets_storage(raw: &str, config: &mut WizardConfig) -> anyhow::Result
             // URL is fine — it stays canonical when re-parsed.
             config.secret_azure_vault = vault;
         }
-        BackendUrl::Vault { endpoint, path, .. } => {
-            // NOTE: the extended Vault auth parameters (auth method,
-            // enterprise namespace, insecure) are not yet round-tripped
-            // into wizard config fields — that wiring lands with the
-            // wizard support PR. Recipes still carry them in the raw URL.
+        BackendUrl::Vault {
+            endpoint,
+            path,
+            auth,
+            enterprise_namespace,
+            insecure,
+        } => {
             config.secret_storage = STORAGE_VAULT.into();
             config.secret_vault_endpoint = endpoint;
             config.secret_vault_mount = path;
+            match auth {
+                VaultAuth::Token => config.secret_vault_auth = "token".into(),
+                VaultAuth::Kubernetes {
+                    role,
+                    mount,
+                    jwt_path,
+                } => {
+                    config.secret_vault_auth = "kubernetes".into();
+                    config.secret_vault_role = role;
+                    config.secret_vault_k8s_mount = mount;
+                    config.secret_vault_jwt_path = jwt_path;
+                }
+                VaultAuth::AppRole { mount } => {
+                    config.secret_vault_auth = "approle".into();
+                    config.secret_vault_approle_mount = mount;
+                }
+            }
+            config.secret_vault_namespace = enterprise_namespace.unwrap_or_default();
+            config.secret_vault_insecure = insecure;
         }
-        // `BackendUrl` is `#[non_exhaustive]`; any scheme not yet wired
-        // into the wizard config falls through here.
+        BackendUrl::Kubernetes {
+            namespace,
+            secret_name,
+        } => {
+            config.secret_storage = STORAGE_K8S.into();
+            config.secret_k8s_namespace = namespace.unwrap_or_default();
+            config.secret_k8s_secret_name = secret_name;
+        }
+        // `BackendUrl` is `#[non_exhaustive]`; a variant with no wizard
+        // mapping yet falls through here.
         _ => {
             anyhow::bail!(
                 "Invalid secrets.storage '{raw}': backend not yet supported in recipe config"


### PR DESCRIPTION
**Stacked PR series** bringing the mediator secret store + `mediator-setup` wizard to VTA parity for Kubernetes Secrets and HashiCorp Vault auth. Merge bottom-up:
1. feat/mediator-secrets-vault-auth
2. feat/mediator-secrets-k8s-backend
3. feat/mediator-setup-secrets-recipe
4. feat/mediator-setup-secrets-wizard
5. docs/mediator-secrets-k8s-vault

---
**PR 3 of 5.** (Base: PR 2.) Wire the new backends into the headless setup paths so both work via `--from <recipe>` / `--non-interactive` without the TUI.

- `WizardConfig` gains k8s + Vault-auth fields
- `build_backend_url` assembles `vault://…?auth=…` (defaults omitted → stable round-trips) and `k8s://<ns>/<name>`
- `recipe::apply_secrets_storage` accepts the `k8s://` bare scheme and splits parsed Vault-auth + k8s URLs back into config
- `secrets-k8s` forwarded from mediator-setup; mediator-common re-exports the Vault default-mount consts
- new build/round-trip tests; the CLI-vs-recipe byte-identical guard still passes (370 tests)

`mediator-common` 0.15.23→0.15.24; `mediator-setup` 0.1.14→0.1.15.