### PR TITLE
feat: bake TSPTransport service into generated did:peer and did:webvh DIDs

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 2nd July 2026
+
+### 0.1.18 — bake a `TSPTransport` service into generated `did:peer` / `did:webvh`
+
+- When the operator selects the `tsp` protocol, the generated mediator DID now
+  advertises a `TSPTransport` service so remote mediators can discover its TSP
+  endpoint for routed/nested forwarding. Previously the mediator only logged a
+  startup warning for `did:peer` / `did:webvh` (whose documents are bound to the
+  DID and cannot be mutated at runtime the way `did:web` is).
+  - `did:webvh`: the service is injected into the rendered document before the
+    SCID is computed, so it is covered by the log entry. Endpoint mirrors the
+    `DIDCommMessaging` HTTP endpoint (TSP and DIDComm share `/inbound`).
+  - `did:peer`: a `tsp` service segment (resolver-expanded to `TSPTransport`) is
+    added alongside the `dm` service.
+  - No-op when TSP is not enabled — the default document is byte-identical to
+    before. `did:key` cannot carry a service, so it is unaffected.
+- See `docs/tsp/enablement.md` for the operator walkthrough.
+
 ## 14th June 2026
 
 ### 0.1.13 — bump vta-sdk to 0.13

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.17"
+version = "0.1.18"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
@@ -9,9 +9,17 @@ use crate::cli::KeySuite;
 /// plus an optional DIDComm service endpoint. Any opt-in `key_suites` append
 /// extra key pairs after the mandatory Curve25519 pair — e.g. `p256` adds a
 /// P-256 verification key and a P-256 encryption key.
+///
+/// When `tsp_enabled` is set (the operator picked the `tsp` protocol) and a
+/// service endpoint is present, a `tsp` service is baked in alongside the
+/// DIDComm `dm` service — it resolves to `TSPTransport` and lets remote
+/// mediators discover this mediator's TSP endpoint for routed/nested
+/// forwarding. did:peer documents are bound to the DID string, so unlike
+/// did:web (mutated at runtime) the service *must* be set here, at generation.
 pub fn generate_did_peer(
     service_uri: Option<String>,
     key_suites: &[KeySuite],
+    tsp_enabled: bool,
 ) -> anyhow::Result<(String, Vec<Secret>)> {
     let mut keys = vec![
         (PeerKeyRole::Verification, KeyType::Ed25519),
@@ -22,7 +30,10 @@ pub fn generate_did_peer(
         keys.push((PeerKeyRole::Encryption, KeyType::P256));
     }
 
-    let services = service_uri.as_deref().map(mediator_services).transpose()?;
+    let services = service_uri
+        .as_deref()
+        .map(|uri| mediator_services(uri, tsp_enabled))
+        .transpose()?;
 
     let (did, secrets) = DID::generate_did_peer_with_services(keys, services)
         .map_err(|e| anyhow::anyhow!("Failed to generate did:peer: {e}"))?;
@@ -30,17 +41,17 @@ pub fn generate_did_peer(
     Ok((did, secrets))
 }
 
-fn mediator_services(service_uri: &str) -> anyhow::Result<Vec<PeerService>> {
+fn mediator_services(service_uri: &str, tsp_enabled: bool) -> anyhow::Result<Vec<PeerService>> {
     let service_uri = service_uri.trim_end_matches('/').to_string();
     let ws_uri = websocket_service_uri(&service_uri)?;
     let auth_uri = format!("{service_uri}/authenticate");
 
-    Ok(vec![
+    let mut services = vec![
         PeerService {
             type_: "dm".into(),
             endpoint: PeerServiceEndpoint::Long(OneOrMany::Many(vec![
                 PeerServiceEndpointLong {
-                    uri: service_uri,
+                    uri: service_uri.clone(),
                     accept: vec!["didcomm/v2".into()],
                     routing_keys: vec![],
                 },
@@ -57,7 +68,20 @@ fn mediator_services(service_uri: &str) -> anyhow::Result<Vec<PeerService>> {
             endpoint: PeerServiceEndpoint::Uri(auth_uri),
             id: Some("#auth".into()),
         },
-    ])
+    ];
+
+    // TSP shares the mediator's `/inbound` with DIDComm, so the endpoint
+    // mirrors the `dm` service's first (HTTP) URI. did:peer uses the `tsp`
+    // service abbreviation, which the resolver expands to `TSPTransport`.
+    if tsp_enabled {
+        services.push(PeerService {
+            type_: "tsp".into(),
+            endpoint: PeerServiceEndpoint::Uri(service_uri),
+            id: Some("#tsp".into()),
+        });
+    }
+
+    Ok(services)
 }
 
 fn websocket_service_uri(service_uri: &str) -> anyhow::Result<String> {
@@ -102,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_generate_did_peer() {
-        let (did, secrets) = generate_did_peer(None, &[]).unwrap();
+        let (did, secrets) = generate_did_peer(None, &[], false).unwrap();
         assert!(did.starts_with("did:peer:2.V"));
         assert_eq!(secrets.len(), 2);
         assert!(secrets[0].id.contains("#key-1"));
@@ -113,7 +137,7 @@ mod tests {
     fn test_generate_did_peer_with_p256_suite() {
         // P-256 appends a verification key (`#key-3`) and an encryption key
         // (`#key-4`) after the mandatory Ed25519 + X25519 pair.
-        let (did, secrets) = generate_did_peer(None, &[KeySuite::P256]).unwrap();
+        let (did, secrets) = generate_did_peer(None, &[KeySuite::P256], false).unwrap();
         // Two verification segments (Ed25519, P-256) and two encryption.
         assert_eq!(did.matches(".V").count(), 2);
         assert_eq!(did.matches(".E").count(), 2);
@@ -128,7 +152,8 @@ mod tests {
     #[test]
     fn test_generate_did_peer_with_service() {
         let (did, secrets) =
-            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[]).unwrap();
+            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[], false)
+                .unwrap();
         assert!(did.starts_with("did:peer:2.V"));
         assert_eq!(did.matches(".S").count(), 2);
         assert_eq!(secrets.len(), 2);
@@ -148,5 +173,34 @@ mod tests {
             services[1]["s"],
             "http://localhost:7037/mediator/v1/authenticate"
         );
+    }
+
+    #[test]
+    fn test_generate_did_peer_with_tsp_service() {
+        // With TSP enabled a third `tsp` service is baked in, sharing the
+        // mediator's HTTP `/inbound` base with DIDComm. The resolver expands
+        // the `tsp` abbreviation to `TSPTransport`.
+        let (did, _secrets) =
+            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[], true).unwrap();
+        assert_eq!(did.matches(".S").count(), 3);
+
+        let services = decode_service_segments(&did);
+        assert_eq!(services.len(), 3);
+
+        // dm + Authentication unchanged; the new tsp service points at the
+        // same HTTP base as the DIDComm `dm` first endpoint.
+        assert_eq!(services[0]["t"], "dm");
+        assert_eq!(services[1]["t"], "Authentication");
+        assert_eq!(services[2]["t"], "tsp");
+        assert!(services[2]["id"].as_str().unwrap().ends_with("#tsp"));
+        assert_eq!(services[2]["s"], "http://localhost:7037/mediator/v1");
+    }
+
+    #[test]
+    fn test_generate_did_peer_tsp_without_service_uri_adds_nothing() {
+        // No service URI means no services at all — TSP has nothing to
+        // advertise, so the flag is a no-op (no panic, no phantom segment).
+        let (did, _secrets) = generate_did_peer(None, &[], true).unwrap();
+        assert_eq!(did.matches(".S").count(), 0);
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -56,6 +56,7 @@ pub async fn generate_did_webvh(
     address: &str,
     service_url: &str,
     key_suites: &[KeySuite],
+    tsp_enabled: bool,
 ) -> anyhow::Result<DidWebvhResult> {
     let address = if address.starts_with("http://") || address.starts_with("https://") {
         address.to_string()
@@ -152,9 +153,21 @@ pub async fn generate_did_webvh(
     // doesn't flag it as unresolved; `didwebvh-rs` substitutes the actual
     // DID string after SCID computation.
     vars.insert_string("DID", "{DID}");
-    let did_document = template
+    let mut did_document = template
         .render(&vars)
         .map_err(|e| anyhow::anyhow!("Failed to render mediator template: {e}"))?;
+
+    // ── Opt-in TSP service ──────────────────────────────────────────
+    // did:webvh binds the document to the DID (SCID), so the mediator
+    // runtime cannot mutate it in place the way it does for did:web — the
+    // `TSPTransport` service must be baked in here, before `create_did`
+    // computes the SCID. The `{DID}#tsp` id keeps the same sentinel the
+    // template uses; `didwebvh-rs` resolves it across the whole document
+    // after SCID computation. No-op when the operator didn't enable TSP,
+    // so the default document is byte-identical to before.
+    if tsp_enabled {
+        augment_webvh_doc_with_tsp_service(&mut did_document)?;
+    }
 
     // ── Authorization + pre-rotation ───────────────────────────────
     let mut auth_key = Secret::generate_ed25519(None, None);
@@ -217,6 +230,71 @@ pub async fn generate_did_webvh(
     })
 }
 
+/// Inject a `TSPTransport` service into a rendered (pre-SCID) mediator DID
+/// document so did:webvh peers can discover the mediator's TSP endpoint.
+///
+/// TSP and DIDComm share the mediator's `/inbound`, so the TSP endpoint
+/// mirrors the first `DIDCommMessaging` service endpoint URI — matching the
+/// runtime's did:web behaviour (`augment_did_web_doc_with_tsp_service`). The
+/// service id keeps the `{DID}` sentinel (`{DID}#tsp`) so `create_did`
+/// resolves it alongside every other self-reference once the SCID is known.
+///
+/// Idempotent: if a `TSPTransport` service is already present the document is
+/// left unchanged. Errors only if the document has no `service` array or no
+/// DIDComm endpoint to mirror (a mediator template without one is a bug).
+fn augment_webvh_doc_with_tsp_service(did_document: &mut serde_json::Value) -> anyhow::Result<()> {
+    use serde_json::Value;
+
+    let service_type_is = |svc: &Value, want: &str| {
+        svc.get("type").is_some_and(|t| match t {
+            Value::String(s) => s == want,
+            Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(want)),
+            _ => false,
+        })
+    };
+
+    let services = did_document
+        .get_mut("service")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| anyhow::anyhow!("Rendered DID document has no `service` array"))?;
+
+    // Already advertised (e.g. a forked template) — leave it be.
+    if services
+        .iter()
+        .any(|svc| service_type_is(svc, "TSPTransport"))
+    {
+        return Ok(());
+    }
+
+    // Mirror the first DIDCommMessaging endpoint URI. The template renders
+    // `serviceEndpoint` as an array of `{uri, accept, routingKeys}` objects,
+    // but tolerate the object / bare-string shapes a forked template might use.
+    let uri = services
+        .iter()
+        .find(|svc| service_type_is(svc, "DIDCommMessaging"))
+        .and_then(|svc| svc.get("serviceEndpoint"))
+        .and_then(|ep| match ep {
+            Value::Array(arr) => arr.first().and_then(|e| e.get("uri")),
+            Value::Object(_) => ep.get("uri"),
+            _ => Some(ep),
+        })
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Rendered DID document has no DIDCommMessaging endpoint to mirror for TSP"
+            )
+        })?
+        .to_string();
+
+    services.push(serde_json::json!({
+        "id": "{DID}#tsp",
+        "type": ["TSPTransport"],
+        "serviceEndpoint": uri,
+    }));
+
+    Ok(())
+}
+
 /// Convert a did:webvh log entry into the equivalent did:web DID document.
 ///
 /// Re-exported from `affinidi-messaging-mediator-common` so the wizard's
@@ -241,6 +319,7 @@ mod tests {
             "https://mediator.example.com",
             "https://mediator.example.com/mediator/v1",
             &[],
+            false,
         )
         .await
         .unwrap();
@@ -312,6 +391,7 @@ mod tests {
             "https://mediator.example.com",
             "https://mediator.example.com/mediator/v1",
             &[KeySuite::P256],
+            false,
         )
         .await
         .unwrap();
@@ -367,10 +447,14 @@ mod tests {
 
     #[tokio::test]
     async fn webvh_key_ids_match_final_did() {
-        let result =
-            generate_did_webvh("mediator.example.com", "https://mediator.example.com", &[])
-                .await
-                .unwrap();
+        let result = generate_did_webvh(
+            "mediator.example.com",
+            "https://mediator.example.com",
+            &[],
+            false,
+        )
+        .await
+        .unwrap();
         for secret in &result.secrets {
             assert!(secret.id.starts_with(&result.did));
         }
@@ -384,6 +468,7 @@ mod tests {
             "https://mediator.example.com",
             "https://mediator.example.com/mediator/v1",
             &[],
+            false,
         )
         .await
         .unwrap();
@@ -415,5 +500,73 @@ mod tests {
         let err = webvh_log_to_did_web(r#"{"versionId":"1-abc"}"#, "did:webvh:QmScId:example.com")
             .unwrap_err();
         assert!(err.to_string().contains("state"));
+    }
+
+    #[tokio::test]
+    async fn webvh_tsp_enabled_bakes_in_tsptransport_service() {
+        let result = generate_did_webvh(
+            "https://mediator.example.com",
+            "https://mediator.example.com/mediator/v1",
+            &[],
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Keys are unchanged by the TSP service — it reuses the mediator's
+        // existing Ed25519 signing + X25519 key-agreement keys.
+        assert_eq!(result.secrets.len(), 2);
+
+        let entry: Value = serde_json::from_str(&result.did_doc).unwrap();
+        let doc = &entry["state"];
+        let services = doc["service"].as_array().unwrap();
+
+        let service_type_is =
+            |svc: &Value, want: &str| svc["type"] == json!([want]) || svc["type"] == json!(want);
+        let tsp = services
+            .iter()
+            .find(|svc| service_type_is(svc, "TSPTransport"))
+            .expect("TSPTransport service baked in");
+
+        // The `{DID}#tsp` sentinel was resolved to the final DID by create_did.
+        let tsp_id = tsp["id"].as_str().unwrap();
+        assert!(tsp_id.ends_with("#tsp"));
+        assert!(tsp_id.starts_with(&result.did));
+        assert!(!result.did_doc.contains("{DID}"));
+
+        // Endpoint mirrors the DIDComm HTTP endpoint (shared `/inbound`).
+        assert_eq!(
+            tsp["serviceEndpoint"].as_str().unwrap(),
+            "https://mediator.example.com/mediator/v1"
+        );
+
+        // DIDComm service is untouched.
+        assert!(
+            services
+                .iter()
+                .any(|svc| service_type_is(svc, "DIDCommMessaging"))
+        );
+    }
+
+    #[test]
+    fn augment_is_idempotent_when_tsp_already_present() {
+        // A document that already advertises TSP is left unchanged.
+        let mut doc: Value = serde_json::from_str(
+            r#"{"service":[{"id":"{DID}#tsp","type":["TSPTransport"],"serviceEndpoint":"https://x/"}]}"#,
+        )
+        .unwrap();
+        let before = doc.clone();
+        augment_webvh_doc_with_tsp_service(&mut doc).unwrap();
+        assert_eq!(doc, before);
+    }
+
+    #[test]
+    fn augment_errors_without_a_didcomm_endpoint_to_mirror() {
+        let mut doc: Value = serde_json::from_str(
+            r#"{"service":[{"id":"{DID}#auth","type":["Authentication"],"serviceEndpoint":"https://x/authenticate"}]}"#,
+        )
+        .unwrap();
+        let err = augment_webvh_doc_with_tsp_service(&mut doc).unwrap_err();
+        assert!(err.to_string().contains("DIDCommMessaging"));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -1232,8 +1232,11 @@ async fn mint_did_material(
     let (did, secrets, did_log, authorization_vc) = match config.did_method.as_str() {
         DID_PEER => {
             let service_uri = did_peer_service_url(&config.public_url, &config.api_prefix);
-            let (did, secrets) =
-                generators::did_peer::generate_did_peer(service_uri, &config.key_suite)?;
+            let (did, secrets) = generators::did_peer::generate_did_peer(
+                service_uri,
+                &config.key_suite,
+                config.tsp_enabled,
+            )?;
             (did, secrets, None, None)
         }
         DID_WEBVH => {
@@ -1254,6 +1257,7 @@ async fn mint_did_material(
                 &address,
                 &service_url,
                 &config.key_suite,
+                config.tsp_enabled,
             )
             .await?;
             (result.did, result.secrets, Some(result.did_doc), None)


### PR DESCRIPTION
## What

When the operator selects the `tsp` protocol, the setup wizard now advertises a `TSPTransport` service in the generated mediator DID document so remote mediators can discover its TSP endpoint for routed/nested forwarding.

Previously only **did:web** got this (the running mediator mutates its served document at startup). **did:peer** and **did:webvh** are bound to the DID and could not be mutated at runtime, so the mediator only logged a startup warning and operators had to hand-edit the DID.

## How

- **did:webvh** — inject the service into the rendered document **before** `create_did` computes the SCID, so it is covered by the log entry. Endpoint mirrors the `DIDCommMessaging` HTTP endpoint (TSP and DIDComm share `/inbound`); the `{DID}#tsp` sentinel is resolved by `didwebvh-rs` alongside every other self-reference.
- **did:peer** — add a `tsp` service segment (the resolver expands it to `TSPTransport`) alongside the `dm` service.
- **No-op when TSP is not enabled** — the default document is byte-identical to before. `did:key` cannot carry a service, so it is unaffected.

## Testing

- `cargo test -p affinidi-messaging-mediator-setup --bin mediator-setup` — 367 pass, incl. new tests: webvh `{DID}#tsp` SCID resolution, did:peer tsp segment, idempotency + missing-DIDComm-endpoint error paths.
- `cargo clippy --all-targets -- -D warnings` — clean.

Bumps `affinidi-messaging-mediator-setup` 0.1.14 → 0.1.15 (`publish = false`, no cascade).