### PR TITLE
style: cargo fmt secrets backends and setup wizard

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.24"
+version = "0.15.25"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/k8s.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/k8s.rs
@@ -114,9 +114,13 @@ impl K8sStore {
     /// Build a namespaced `Secret` API handle, resolving the namespace and
     /// loading credentials from the in-cluster SA or local kubeconfig.
     async fn api(&self) -> Result<Api<Secret>> {
-        let client = Client::try_default()
-            .await
-            .map_err(|e| kube_error(&self.secret_name, "failed to initialise Kubernetes client", e))?;
+        let client = Client::try_default().await.map_err(|e| {
+            kube_error(
+                &self.secret_name,
+                "failed to initialise Kubernetes client",
+                e,
+            )
+        })?;
         let namespace = self
             .namespace
             .clone()
@@ -222,10 +226,9 @@ impl SecretStore for K8sStore {
     async fn delete(&self, key: &str) -> Result<()> {
         let api = self.api().await?;
         for attempt in 0..MAX_CONFLICT_RETRIES {
-            let Some(mut existing) = api
-                .get_opt(&self.secret_name)
-                .await
-                .map_err(|e| kube_error(&self.secret_name, "failed to read Kubernetes Secret", e))?
+            let Some(mut existing) = api.get_opt(&self.secret_name).await.map_err(|e| {
+                kube_error(&self.secret_name, "failed to read Kubernetes Secret", e)
+            })?
             else {
                 return Ok(()); // Secret absent → nothing to delete.
             };

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/vault.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/vault.rs
@@ -45,13 +45,13 @@ use crate::secrets::retry::{RetryPolicy, Retryable, with_retry};
 #[cfg(feature = "secrets-vault")]
 use crate::secrets::store::SecretStore;
 #[cfg(feature = "secrets-vault")]
+use crate::secrets::url::VaultAuth;
+#[cfg(feature = "secrets-vault")]
 use async_trait::async_trait;
 #[cfg(feature = "secrets-vault")]
 use base64::Engine;
 #[cfg(feature = "secrets-vault")]
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
-#[cfg(feature = "secrets-vault")]
-use crate::secrets::url::VaultAuth;
 #[cfg(feature = "secrets-vault")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "secrets-vault")]
@@ -283,9 +283,7 @@ impl VaultStore {
             with_retry(label, &VaultRetryPolicy, || op(&guard)).await
         };
         match first {
-            Err(err)
-                if self.auth.is_renewable() && matches!(api_status(&err), Some(401 | 403)) =>
-            {
+            Err(err) if self.auth.is_renewable() && matches!(api_status(&err), Some(401 | 403)) => {
                 match self.authenticate().await {
                     Ok(fresh) => {
                         *cell.write().await = fresh;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/url.rs
@@ -65,11 +65,24 @@ impl VaultAuth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BackendUrl {
-    Keyring { service: String },
-    File { path: String, encrypted: bool },
-    Aws { region: String, namespace: String },
-    Gcp { project: String, namespace: String },
-    Azure { vault: String },
+    Keyring {
+        service: String,
+    },
+    File {
+        path: String,
+        encrypted: bool,
+    },
+    Aws {
+        region: String,
+        namespace: String,
+    },
+    Gcp {
+        project: String,
+        namespace: String,
+    },
+    Azure {
+        vault: String,
+    },
     Vault {
         endpoint: String,
         path: String,
@@ -292,13 +305,12 @@ fn parse_vault(rest: &str, raw: &str) -> Result<BackendUrl> {
         Some((l, q)) => (l, Some(q)),
         None => (rest, None),
     };
-    let (endpoint, path) =
-        locator
-            .split_once('/')
-            .ok_or_else(|| SecretStoreError::InvalidUrl {
-                url: raw.to_string(),
-                reason: "vault:// requires '<host>[:<port>]/<kv-path>'".into(),
-            })?;
+    let (endpoint, path) = locator
+        .split_once('/')
+        .ok_or_else(|| SecretStoreError::InvalidUrl {
+            url: raw.to_string(),
+            reason: "vault:// requires '<host>[:<port>]/<kv-path>'".into(),
+        })?;
     if endpoint.is_empty() {
         return Err(SecretStoreError::InvalidUrl {
             url: raw.to_string(),
@@ -344,12 +356,12 @@ fn parse_vault(rest: &str, raw: &str) -> Result<BackendUrl> {
     let auth = match method.unwrap_or("token") {
         "token" => VaultAuth::Token,
         "kubernetes" | "k8s" => {
-            let role = role.filter(|r| !r.is_empty()).ok_or_else(|| {
-                SecretStoreError::InvalidUrl {
-                    url: raw.to_string(),
-                    reason: "vault:// auth=kubernetes requires a 'role' query parameter".into(),
-                }
-            })?;
+            let role =
+                role.filter(|r| !r.is_empty())
+                    .ok_or_else(|| SecretStoreError::InvalidUrl {
+                        url: raw.to_string(),
+                        reason: "vault:// auth=kubernetes requires a 'role' query parameter".into(),
+                    })?;
             VaultAuth::Kubernetes {
                 role,
                 mount: k8s_mount,
@@ -631,7 +643,8 @@ mod tests {
 
     #[test]
     fn vault_kubernetes_auth_with_defaults() {
-        let url = parse_url("vault://vault.internal/secret/mediator?auth=kubernetes&role=med").unwrap();
+        let url =
+            parse_url("vault://vault.internal/secret/mediator?auth=kubernetes&role=med").unwrap();
         assert_eq!(
             url,
             BackendUrl::Vault {
@@ -689,8 +702,8 @@ mod tests {
 
     #[test]
     fn vault_enterprise_namespace_and_insecure() {
-        let url =
-            parse_url("vault://vault.internal/secret/mediator?namespace=team-a&insecure=1").unwrap();
+        let url = parse_url("vault://vault.internal/secret/mediator?namespace=team-a&insecure=1")
+            .unwrap();
         match url {
             BackendUrl::Vault {
                 enterprise_namespace,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.16"
+version = "0.1.17"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -5632,7 +5632,10 @@ mod tests {
         app.text_input = Input::new("secret/mediator".into());
         app.confirm_text_input();
         // Mount confirmed → the auth-method picker (selection mode).
-        assert_eq!(app.key_storage_phase, Some(KeyStoragePhase::VaultAuthMethod));
+        assert_eq!(
+            app.key_storage_phase,
+            Some(KeyStoragePhase::VaultAuthMethod)
+        );
         assert_eq!(app.mode, InputMode::Selecting);
 
         app.selection_index = 0; // Token
@@ -5656,7 +5659,10 @@ mod tests {
         app.confirm_text_input(); // endpoint → mount
         app.text_input = Input::new("secret/mediator".into());
         app.confirm_text_input(); // mount → auth method
-        assert_eq!(app.key_storage_phase, Some(KeyStoragePhase::VaultAuthMethod));
+        assert_eq!(
+            app.key_storage_phase,
+            Some(KeyStoragePhase::VaultAuthMethod)
+        );
 
         app.selection_index = 1; // Kubernetes
         app.select_current();
@@ -5770,7 +5776,10 @@ mod tests {
         assert_eq!(app.config.secret_vault_mount, "kv/prod-mediator");
         // Mount now leads into the auth-method picker rather than
         // finishing the step directly.
-        assert_eq!(app.key_storage_phase, Some(KeyStoragePhase::VaultAuthMethod));
+        assert_eq!(
+            app.key_storage_phase,
+            Some(KeyStoragePhase::VaultAuthMethod)
+        );
 
         // Pick Token (the default) to complete the sub-flow.
         app.selection_index = 0;

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -437,7 +437,10 @@ fn vault_backend_url(config: &WizardConfig) -> String {
             if !config.secret_vault_approle_mount.is_empty()
                 && config.secret_vault_approle_mount != VAULT_DEFAULT_APPROLE_MOUNT
             {
-                params.push(format!("approle_mount={}", config.secret_vault_approle_mount));
+                params.push(format!(
+                    "approle_mount={}",
+                    config.secret_vault_approle_mount
+                ));
             }
         }
         // "token" or empty → default auth, no `auth=` query parameter.


### PR DESCRIPTION
Formatting-only cleanup after the k8s/Vault secrets series (#557–#564). The functional code was committed after `cargo clippy` but before a `cargo fmt` pass, so `main` carried rustfmt diffs in the secrets backends + wizard. This applies rustfmt to those 5 files — no behavior change.

Patch-bumps the two touched publishable crates to satisfy the release guard: mediator-common 0.15.24→0.15.25, mediator-setup 0.1.16→0.1.17.