### PR TITLE
feat: symmetric TSP replies — TspHandler returns Option<TspResponse> (ADR 0005 stage 6)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.14] - 2026-07-02
+
+Symmetric TSP replies (ADR 0005 stage 6). `TspHandler::handle` now returns
+`Result<Option<TspResponse>, DIDCommServiceError>` instead of `Result<(), _>`, mirroring
+`DIDCommHandler`: return `Ok(Some(TspResponse::new(bytes)))` and the service seals the reply
+to the authenticated `sender_vid` and routes it back over the *same* shared mediator socket
+(no second connection, no consumer-side outbound plumbing). Routing rule: `send_routed(
+[profile_mediator_did, sender_vid])` when the listener profile has a mediator, else a TSP
+Direct `send` fallback. `Ok(None)` keeps the previous one-way (fire-and-forget) behaviour;
+cross-mediator replies remain a consumer concern via `AffinidiMessageService::send_tsp_routed`.
+
+**Breaking**: existing `TspHandler` implementors must change their return type (`Ok(())`
+→ `Ok(None)`, or return `Ok(Some(..))` to reply). `IgnoreTspHandler` now returns `Ok(None)`.
+`tsp`-feature only; default builds are source-compatible. New `TspResponse` type re-exported
+from the crate root.
+
 ## [0.3.12] - 2026-06-30
 
 Fixes the publish-verify failure that has blocked the release pipeline since the listener

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.13"
+version = "0.3.14"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/handler/mod.rs
@@ -35,16 +35,45 @@ pub trait DIDCommHandler: Send + Sync + 'static {
     ) -> Result<Option<DIDCommResponse>, DIDCommServiceError>;
 }
 
+/// A reply a [`TspHandler`] asks the service to send back to the sender.
+///
+/// The service seals `payload` to the message's authenticated `sender_vid` and
+/// routes it back over the same shared mediator websocket (see
+/// [`AffinidiMessageService::dispatch_tsp`](crate::AffinidiMessageService) for
+/// the routing rule). This is the TSP analogue of [`DIDCommResponse`]: the
+/// handler decides *what* to say, the service handles *how* it gets there.
+///
+/// Correlation (matching a reply to its request) is the application's concern —
+/// a TSP frame carries no thread id, so embed any request/response id in
+/// `payload` (e.g. a Trust Task `#response` document's `threadId`).
+#[derive(Debug, Clone)]
+pub struct TspResponse {
+    /// Cleartext reply bytes. Sealed + routed to the sender by the service.
+    pub payload: Vec<u8>,
+}
+
+impl TspResponse {
+    /// Construct a reply from raw cleartext bytes.
+    #[must_use]
+    pub fn new(payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            payload: payload.into(),
+        }
+    }
+}
+
 /// Top-level handler for incoming **TSP** messages.
 ///
 /// The message service unpacks the TSP frame off the shared websocket and
 /// invokes this with the cleartext `payload` and the cryptographically
-/// authenticated `sender_vid` (a DID). TSP inbound is one-way at this layer (no
-/// reply is packed here, mirroring how a TSP frame carries a Trust Task into the
-/// application spine), so the handler returns `Ok(())` on success.
+/// authenticated `sender_vid` (a DID).
 ///
 /// Symmetric with [`DIDCommHandler`]: a multiplexing service routes DIDComm
-/// frames to the `DIDCommHandler` and TSP frames to the `TspHandler`.
+/// frames to the `DIDCommHandler` and TSP frames to the `TspHandler`. Return
+/// `Ok(Some(response))` to send a reply back to the sender — the service seals
+/// and routes it over the same shared socket, so consumers never touch the
+/// outbound TSP plumbing — `Ok(None)` for one-way (fire-and-forget) receipt, or
+/// `Err(_)` to signal a processing failure (logged, no reply sent).
 #[async_trait]
 pub trait TspHandler: Send + Sync + 'static {
     async fn handle(
@@ -52,7 +81,7 @@ pub trait TspHandler: Send + Sync + 'static {
         ctx: HandlerContext,
         payload: Vec<u8>,
         sender_vid: String,
-    ) -> Result<(), DIDCommServiceError>;
+    ) -> Result<Option<TspResponse>, DIDCommServiceError>;
 }
 
 /// No-op [`TspHandler`] that silently drops TSP messages — the TSP analogue of
@@ -66,8 +95,8 @@ impl TspHandler for IgnoreTspHandler {
         _ctx: HandlerContext,
         _payload: Vec<u8>,
         _sender_vid: String,
-    ) -> Result<(), DIDCommServiceError> {
-        Ok(())
+    ) -> Result<Option<TspResponse>, DIDCommServiceError> {
+        Ok(None)
     }
 }
 
@@ -117,4 +146,16 @@ pub async fn ignore_handler(
     _message: Message,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tsp_response_new_accepts_bytes_and_vec() {
+        assert_eq!(TspResponse::new(b"pong".to_vec()).payload, b"pong");
+        assert_eq!(TspResponse::new(&b"pong"[..]).payload, b"pong");
+        assert_eq!(TspResponse::new(vec![1u8, 2, 3]).payload, vec![1, 2, 3]);
+    }
 }

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::{ConfigError, DIDCommServiceError, PolicyViolation, StartupError,
 pub use handler::{
     DIDCommHandler, DefaultErrorHandler, ErrorHandler, Extension, Extensions, FromMessageParts,
     HandlerContext, IgnoreTspHandler, MESSAGE_PICKUP_STATUS_TYPE, TRUST_PING_TYPE, TRUST_PONG_TYPE,
-    TspHandler, ignore_handler, trust_ping_handler,
+    TspHandler, TspResponse, ignore_handler, trust_ping_handler,
 };
 pub use middleware::{
     MessagePolicy, MiddlewareHandler, MiddlewareResult, Next, RequestLogging, middleware_fn,

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -376,9 +376,52 @@ impl Listener {
         };
 
         let profile_alias = profile.inner.alias.clone();
-        if let Err(e) = handler.handle(ctx, payload, sender_vid).await {
-            warn!(profile = %profile_alias, error = %e, "Unhandled TSP handler error");
+        match handler.handle(ctx, payload, sender_vid.clone()).await {
+            Ok(Some(response)) => {
+                if let Err(e) = Self::send_tsp_reply(atm, profile, &sender_vid, &response).await {
+                    warn!(profile = %profile_alias, error = %e, "Failed to send TSP reply");
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(profile = %profile_alias, error = %e, "Unhandled TSP handler error");
+            }
         }
+    }
+
+    /// Seal a [`TspHandler`] reply to the authenticated sender and route it back
+    /// over the same shared mediator websocket — the TSP analogue of
+    /// [`send_response`](Self::send_response).
+    ///
+    /// Routing rule: when the listener's profile has a mediator (the common
+    /// case — the sender is reachable through the same mediator we're connected
+    /// to), route metadata-privately as `[mediator_did, sender_vid]` via
+    /// `send_routed`. If the profile has no mediator configured, fall back to a
+    /// TSP Direct `send`. Cross-mediator senders (a sender reachable only via a
+    /// *different* mediator) are not resolved here — a handler that needs that
+    /// can return `Ok(None)` and drive [`AffinidiMessageService::send_tsp_routed`]
+    /// itself with an explicit route.
+    #[cfg(feature = "tsp")]
+    async fn send_tsp_reply(
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        sender_vid: &str,
+        response: &crate::handler::TspResponse,
+    ) -> Result<(), DIDCommServiceError> {
+        match profile.dids() {
+            Ok((_, mediator_did)) => {
+                let route = [mediator_did.to_string(), sender_vid.to_string()];
+                atm.tsp()
+                    .send_routed(profile, &route, &response.payload)
+                    .await?;
+            }
+            Err(_) => {
+                atm.tsp()
+                    .send(profile, sender_vid, &response.payload)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 
     pub(crate) async fn dispatch_message(

--- a/docs/adr/0005-affinidi-message-service.md
+++ b/docs/adr/0005-affinidi-message-service.md
@@ -139,3 +139,56 @@ compatibility shim over it (DIDComm-only configuration).
 
 Each stage is a separate PR; stage 5 lands in the VTI repo against the published
 result of 1–4.
+
+## Amendment (2026-07-02) — stage 6: symmetric TSP replies
+
+Stages 1–5 make a node *receive* TSP and *initiate* a TSP send, but the two
+handler surfaces were left asymmetric:
+
+- **DIDComm**: `DIDCommHandler::handle -> Result<Option<DIDCommResponse>, _>`;
+  the listener's `dispatch_message` auto-sends the returned response. A built-in
+  `trust_ping_handler` round-trips for free.
+- **TSP**: `TspHandler::handle -> Result<(), _>`; `dispatch_tsp` discarded any
+  result. A consumer wanting a request/response round-trip (e.g. a VTA health
+  probe, or any Trust Task that returns a document) had to reach into
+  `ctx.atm.tsp()` and re-derive the route back to the sender by hand — the exact
+  outbound plumbing this ADR set out to centralise.
+
+**Decision.** Make `TspHandler` symmetric with `DIDCommHandler`:
+
+```rust
+pub struct TspResponse { pub payload: Vec<u8> }   // sealed + routed to sender_vid
+
+pub trait TspHandler {
+    async fn handle(&self, ctx, payload, sender_vid)
+        -> Result<Option<TspResponse>, DIDCommServiceError>;   // was Result<(), _>
+}
+```
+
+`dispatch_tsp` now mirrors `dispatch_message`: on `Ok(Some(resp))` it seals
+`resp.payload` to the authenticated `sender_vid` and routes it back over the
+**same** shared mediator socket — consumers never touch outbound TSP.
+
+**Reply-routing rule.** A TSP unpack yields only the sender's VID (a bare DID),
+not its mediator, so — unlike DIDComm, where mediator routing falls out of the
+recipient's DID doc — the service must choose a route. It uses the listener
+profile's own mediator: `send_routed([profile_mediator_did, sender_vid])`
+(`ATMProfile::dids()` gives both). This is correct for the common case where
+both parties share one mediator (the case the health probe and most intra-fleet
+traffic hit). If the profile has no mediator, it falls back to a TSP Direct
+`send`. Cross-mediator replies (sender reachable only via a *different* mediator)
+are out of scope for the auto-reply — a handler that needs that returns
+`Ok(None)` and drives `AffinidiMessageService::send_tsp_routed` with an explicit
+route.
+
+**Correlation** stays at the application layer: a TSP frame carries no thread id,
+so a request/response id must live in the payload (e.g. a Trust Task `#response`
+document's `threadId`). The transport ferries bytes; it does not correlate.
+
+**Breaking**: `Result<(), _>` → `Result<Option<TspResponse>, _>`. Existing
+implementors migrate `Ok(())` → `Ok(None)`; `IgnoreTspHandler` returns `Ok(None)`.
+`tsp`-feature-only surface; default builds are source-compatible. Consequently
+the VTI stage-5 `VtaTspHandler` (which today drops the Trust Task response) can
+return it as `Ok(Some(..))` and the round-trip completes — enabling the `pnm
+health` TSP probe end-to-end. Shipped in `affinidi-messaging-didcomm-service`
+0.3.14.


### PR DESCRIPTION
## Summary

Closes the reply/round-trip gap left by ADR 0005 stages 1–5, which multiplex inbound and unify outbound *send* but leave `TspHandler` one-way. Makes `TspHandler` symmetric with `DIDCommHandler` so the service handles TSP round-trips the same way it already handles DIDComm trust-pings.

## What changed

- **`TspHandler::handle`** now returns `Result<Option<TspResponse>, DIDCommServiceError>` (was `Result<(), _>`). New `TspResponse { payload }` type, re-exported from the crate root.
- **`dispatch_tsp`** mirrors `dispatch_message`: on `Ok(Some(resp))` it seals `resp.payload` to the authenticated `sender_vid` and routes it back over the **same** shared mediator socket — `send_routed([profile_mediator_did, sender_vid])`, with a TSP Direct `send` fallback when the profile has no mediator. Consumers never touch outbound TSP plumbing.
- **`IgnoreTspHandler`** → `Ok(None)`.
- ADR 0005 amended with **stage 6**; `CHANGELOG` updated; crate bumped **0.3.13 → 0.3.14**.

## Routing rule

A TSP unpack yields only the sender's VID (a bare DID), not its mediator — unlike DIDComm where mediator routing falls out of the recipient's DID doc. So the auto-reply routes via the listener profile's own mediator (`ATMProfile::dids()`), correct for the common same-mediator case (health probes, intra-fleet traffic). Cross-mediator replies stay a consumer concern via `AffinidiMessageService::send_tsp_routed`. Correlation stays at the application layer (a TSP frame carries no thread id).

## Breaking

`tsp`-feature only. Existing `TspHandler` implementors migrate `Ok(())` → `Ok(None)`, or return `Ok(Some(..))` to reply. Default builds are source-compatible.

## Downstream

Enables the VTI stage-5 `VtaTspHandler` to return its Trust Task response as `Ok(Some(..))`, completing the round-trip that the `pnm health` TSP probe needs end-to-end.

## Testing

77 lib tests pass; `clippy -D warnings` clean in **both** default and `tsp` configs.