### PR TITLE
fix: match TSP DID advertisement to the built feature set

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 2nd July 2026
+
+### 0.16.39 — warn when TSP is advertised on a build without the `tsp` feature
+
+- Added a startup consistency check for DIDComm-only builds: if the mediator's
+  DID document advertises a `TSPTransport` service but the binary was built
+  without the `tsp` feature, the mediator now warns. Some DID templates (VTA /
+  self-hosted webvh `didcomm-mediator`) carry a `#tsp` service unconditionally;
+  without the `tsp` feature the mediator can't sniff or handle TSP at ingress,
+  so remote peers routing TSP here would have their messages misclassified as
+  DIDComm and rejected. This is the inverse of the existing "TSP enabled but no
+  service advertised" warning. No behaviour change to TSP-enabled builds.
+
 ## 30th June 2026
 
 ### 0.16.37 — feat: ES256 (P-256) JWS verification; reject unknown JWS algs

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.38"
+version = "0.16.39"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -1030,6 +1030,54 @@ fn augment_did_web_doc_with_tsp_service(doc: &mut Document, did: &str) -> Option
     serde_json::to_string(doc).ok()
 }
 
+/// Warn when the mediator's DID document advertises a `TSPTransport` service but
+/// the binary was built **without** the `tsp` feature. Some DID templates (e.g.
+/// the VTA / self-hosted webvh `didcomm-mediator` template) may carry a `#tsp`
+/// service unconditionally; if TSP was not compiled in, the mediator cannot
+/// actually sniff or handle TSP at ingress, so remote peers that resolve the
+/// service and route TSP here will have their messages misclassified as DIDComm
+/// and rejected. This is the inverse of [`apply_tsp_did_advertisement`]'s
+/// "TSP on but nothing advertised" warning; it runs only on non-TSP builds.
+///
+/// The `TSPTransport` type is spelled out here rather than referenced via
+/// `affinidi_tsp::TSP_SERVICE_TYPE` because that crate is not a dependency when
+/// the `tsp` feature is off; the two must stay in sync (both are `"TSPTransport"`).
+#[cfg(not(feature = "tsp"))]
+pub(crate) fn warn_if_tsp_advertised_without_feature(config: &Config) {
+    const TSP_SERVICE_TYPE: &str = "TSPTransport";
+
+    let advertises_tsp = config
+        .mediator_did_document
+        .as_ref()
+        .map(|doc| {
+            doc.service
+                .iter()
+                .any(|s| s.type_.iter().any(|t| t == TSP_SERVICE_TYPE))
+        })
+        .or_else(|| {
+            config
+                .mediator_did_doc
+                .as_ref()
+                .and_then(|json| serde_json::from_str::<Document>(json).ok())
+                .map(|doc| {
+                    doc.service
+                        .iter()
+                        .any(|s| s.type_.iter().any(|t| t == TSP_SERVICE_TYPE))
+                })
+        })
+        .unwrap_or(false);
+
+    if advertises_tsp {
+        warn!(
+            "The mediator DID document advertises a '{TSP_SERVICE_TYPE}' service, but this \
+             binary was built without the `tsp` feature. Remote mediators will attempt to \
+             route TSP here and their messages will be rejected. Either rebuild with \
+             `--features didcomm,tsp` or remove the '{TSP_SERVICE_TYPE}' service from the \
+             DID document (for VTA-managed DIDs, disable TSP in the DID template)."
+        );
+    }
+}
+
 pub async fn init(config_file: &str, with_ansi: bool) -> Result<Config, MediatorError> {
     // Read configuration file parameters. `read_config_file` lives in the config
     // crate now (returns its lean `ConfigError`); map it back to MediatorError.

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -502,6 +502,12 @@ pub async fn serve_internal(
     #[cfg(feature = "tsp")]
     crate::common::config::apply_tsp_did_advertisement(&mut config);
 
+    // Inverse guard for TSP-less builds: some DID templates advertise a
+    // `TSPTransport` service unconditionally, which would mislead peers into
+    // routing TSP to a mediator that can't handle it. Warn if so.
+    #[cfg(not(feature = "tsp"))]
+    crate::common::config::warn_if_tsp_advertised_without_feature(&config);
+
     // Preload the mediator's own DID document so it can pack/unpack DIDComm
     // messages without hitting the network (did:web/did:webvh self-resolution
     // needs HTTPS, which may be unreachable from the mediator's own network).

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## 2nd July 2026
 
+### 0.1.19 — strip `TSPTransport` from generated `did:webvh` when TSP is disabled
+
+- The shipped `didcomm-mediator` template (vta-sdk) advertises a `#tsp`
+  `TSPTransport` service **unconditionally**. On the self-hosted `did:webvh`
+  path the wizard now strips that service when the operator did **not** enable
+  the `tsp` protocol, so a DIDComm-only mediator no longer advertises a
+  transport it cannot serve (which would make remote peers route TSP that the
+  mediator then rejects). When TSP *is* enabled the service is kept/ensured as
+  before. `did:peer` already only added the service when TSP was enabled.
+- Note: VTA-managed DIDs are rendered server-side and still carry the template's
+  unconditional `#tsp`; the mediator now warns about that mismatch at startup
+  (see the `affinidi-messaging-mediator` changelog). Gating it at the source
+  needs a vta-sdk template change (tracked separately).
+
 ### 0.1.18 — bake a `TSPTransport` service into generated `did:peer` / `did:webvh`
 
 - When the operator selects the `tsp` protocol, the generated mediator DID now

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.18"
+version = "0.1.19"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -157,16 +157,22 @@ pub async fn generate_did_webvh(
         .render(&vars)
         .map_err(|e| anyhow::anyhow!("Failed to render mediator template: {e}"))?;
 
-    // ── Opt-in TSP service ──────────────────────────────────────────
-    // did:webvh binds the document to the DID (SCID), so the mediator
-    // runtime cannot mutate it in place the way it does for did:web — the
-    // `TSPTransport` service must be baked in here, before `create_did`
-    // computes the SCID. The `{DID}#tsp` id keeps the same sentinel the
-    // template uses; `didwebvh-rs` resolves it across the whole document
-    // after SCID computation. No-op when the operator didn't enable TSP,
-    // so the default document is byte-identical to before.
+    // ── TSP service, matched to the operator's choice ───────────────
+    // did:webvh binds the document to the DID (SCID), so the mediator runtime
+    // cannot mutate it the way it does for did:web — the `TSPTransport` service
+    // must be settled here, before `create_did` computes the SCID.
+    //
+    // The shipped `didcomm-mediator` template advertises a `#tsp` service
+    // *unconditionally*, so we normalise both ways: ensure it's present when
+    // TSP is enabled (a no-op with the current template; a safety net for a
+    // forked template that lacks it), and strip it when TSP is off so a
+    // DIDComm-only mediator doesn't mislead peers into routing TSP it can't
+    // handle. The `{DID}#tsp` id keeps the template's sentinel; `didwebvh-rs`
+    // resolves it across the whole document after SCID computation.
     if tsp_enabled {
         augment_webvh_doc_with_tsp_service(&mut did_document)?;
+    } else {
+        strip_tsp_service(&mut did_document);
     }
 
     // ── Authorization + pre-rotation ───────────────────────────────
@@ -295,6 +301,26 @@ fn augment_webvh_doc_with_tsp_service(did_document: &mut serde_json::Value) -> a
     Ok(())
 }
 
+/// Remove any `TSPTransport` service from a rendered (pre-SCID) DID document.
+///
+/// The shipped `didcomm-mediator` template advertises a `#tsp` service
+/// unconditionally; when the operator did **not** enable TSP we drop it so a
+/// DIDComm-only mediator doesn't advertise a transport it can't serve. A no-op
+/// when no such service is present (e.g. a forked template without one).
+fn strip_tsp_service(did_document: &mut serde_json::Value) {
+    use serde_json::Value;
+
+    if let Some(services) = did_document.get_mut("service").and_then(Value::as_array_mut) {
+        services.retain(|svc| {
+            !svc.get("type").is_some_and(|t| match t {
+                Value::String(s) => s == "TSPTransport",
+                Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some("TSPTransport")),
+                _ => false,
+            })
+        });
+    }
+}
+
 /// Convert a did:webvh log entry into the equivalent did:web DID document.
 ///
 /// Re-exported from `affinidi-messaging-mediator-common` so the wizard's
@@ -346,13 +372,19 @@ mod tests {
         assert_eq!(doc["authentication"].as_array().unwrap().len(), 1);
         assert_eq!(doc["keyAgreement"].as_array().unwrap().len(), 1);
 
-        // Locate services by `type` rather than position — the template may
-        // advertise additional transports (e.g. a `#tsp` TSPTransport entry)
-        // ahead of the DIDComm one, and the canonical preference order is not
-        // this test's concern.
+        // Locate services by `type` rather than position — the canonical
+        // preference order is not this test's concern.
         let services = doc["service"].as_array().unwrap();
         let service_type_is =
             |svc: &Value, want: &str| svc["type"] == json!([want]) || svc["type"] == json!(want);
+        // TSP was NOT enabled, so the template's unconditional `#tsp` service
+        // must be stripped — a DIDComm-only mediator must not advertise TSP.
+        assert!(
+            !services
+                .iter()
+                .any(|svc| service_type_is(svc, "TSPTransport")),
+            "TSPTransport must be stripped when TSP is disabled"
+        );
         let didcomm = services
             .iter()
             .find(|svc| service_type_is(svc, "DIDCommMessaging"))
@@ -568,5 +600,32 @@ mod tests {
         .unwrap();
         let err = augment_webvh_doc_with_tsp_service(&mut doc).unwrap_err();
         assert!(err.to_string().contains("DIDCommMessaging"));
+    }
+
+    #[test]
+    fn strip_removes_tsp_but_keeps_other_services() {
+        let mut doc: Value = serde_json::from_str(
+            r#"{"service":[
+                {"id":"{DID}#service","type":["DIDCommMessaging"],"serviceEndpoint":[{"uri":"https://x/"}]},
+                {"id":"{DID}#tsp","type":["TSPTransport"],"serviceEndpoint":"https://x/"},
+                {"id":"{DID}#auth","type":["Authentication"],"serviceEndpoint":"https://x/authenticate"}
+            ]}"#,
+        )
+        .unwrap();
+        strip_tsp_service(&mut doc);
+        let services = doc["service"].as_array().unwrap();
+        assert_eq!(services.len(), 2);
+        assert!(!services.iter().any(|s| s["type"] == json!(["TSPTransport"])));
+        assert!(services.iter().any(|s| s["type"] == json!(["DIDCommMessaging"])));
+        assert!(services.iter().any(|s| s["type"] == json!(["Authentication"])));
+    }
+
+    #[test]
+    fn strip_is_a_noop_without_a_tsp_service() {
+        let src = r#"{"service":[{"id":"{DID}#service","type":["DIDCommMessaging"],"serviceEndpoint":[{"uri":"https://x/"}]}]}"#;
+        let mut doc: Value = serde_json::from_str(src).unwrap();
+        let before = doc.clone();
+        strip_tsp_service(&mut doc);
+        assert_eq!(doc, before);
     }
 }


### PR DESCRIPTION
## Problem

The shipped `didcomm-mediator` template (vta-sdk 0.18.14) advertises a `#tsp` `TSPTransport` service **unconditionally**. So a mediator built **without** the `tsp` feature can still publish a TSP endpoint it cannot serve: a remote peer resolves the service and routes TSP, but the DIDComm-only ingress has no `#[cfg(tsp)]` sniff, so the bytes are misclassified as DIDComm and rejected.

This surfaced while closing out the TSP-enablement work (#565/#567): only `did:peer` respected `tsp_enabled`; `did:webvh` and VTA-managed DIDs advertised TSP regardless.

## Fix

- **Self-hosted `did:webvh` (setup wizard):** strip the template's unconditional `#tsp` service when the operator did **not** enable the `tsp` protocol; still ensure it when they did. (`did:peer` already only added it when enabled.)
- **Mediator runtime:** add a startup consistency check on DIDComm-only builds — warn when the DID document advertises `TSPTransport` but the binary lacks the `tsp` feature (the inverse of the existing "TSP enabled but nothing advertised" warning). This is the only in-repo lever for the **VTA-managed** case, whose DID is rendered server-side; gating it at the source needs a vta-sdk template change (tracked in a follow-up issue).

No behaviour change to TSP-enabled builds.

## Testing

- `cargo test -p affinidi-messaging-mediator-setup --bin mediator-setup` — 380 pass (incl. strengthened webvh test now asserting TSP is stripped when disabled, + strip unit tests).
- `cargo test -p affinidi-messaging-mediator --lib` — 147 pass.
- `cargo clippy -D warnings` clean on mediator default (didcomm) **and** dual (didcomm,tsp) builds, and setup `--all-targets`.

Bumps `affinidi-messaging-mediator` 0.16.38 → 0.16.39 and `affinidi-messaging-mediator-setup` 0.1.18 → 0.1.19 (setup `publish = false`).