### PR TITLE
feat: advertise TSPTransport on VTA-minted mediators only when TSP enabled

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 2nd July 2026
 
+### 0.1.20 — advertise `TSPTransport` on VTA-minted mediators only when TSP is enabled
+
+- Completes the TSP-advertisement consistency work for the VTA-managed DID
+  path. When the operator enables the `tsp` protocol, the wizard now injects a
+  `SERVICE_TSP` service object into the VTA provisioning request's
+  `integration_template_vars`, so the VTA renders a `#tsp` `TSPTransport`
+  service on the minted mediator DID (endpoint mirrors the DIDComm `URL`). When
+  TSP is off, nothing is injected and the mediator advertises no TSP transport.
+- Requires vta-sdk >= 0.18.15, whose `didcomm-mediator` template renders `#tsp`
+  only when `SERVICE_TSP` is supplied (previously it was unconditional). The
+  self-hosted `did:webvh` / `did:peer` paths were already handled in 0.1.18 /
+  0.1.19; this closes the last (VTA) gap.
+
 ### 0.1.19 — strip `TSPTransport` from generated `did:webvh` when TSP is disabled
 
 - The shipped `didcomm-mediator` template (vta-sdk) advertises a `#tsp`

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.19"
+version = "0.1.20"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -1556,6 +1556,7 @@ impl WizardApp {
     /// become inputs so we don't re-resolve; the webvh server pick
     /// and path are read from state.
     fn start_vta_provision(&mut self, rest_url: Option<String>, mediator_did: String) {
+        let tsp_enabled = self.config.tsp_enabled;
         let Some(st) = self.vta_connect.as_mut() else {
             return;
         };
@@ -1595,6 +1596,7 @@ impl WizardApp {
                 context,
                 mediator_url,
                 label,
+                tsp_enabled,
                 webvh_server_id,
                 webvh_path,
                 tx,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/runner.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/runner.rs
@@ -70,14 +70,12 @@ pub async fn run_provision_flight(
     context: String,
     mediator_url: String,
     label: Option<String>,
+    tsp_enabled: bool,
     webvh_server_id: Option<String>,
     webvh_path: Option<String>,
     tx: UnboundedSender<VtaEvent>,
 ) {
-    let mut ask = ProvisionAsk::didcomm_mediator(context, mediator_url);
-    if let Some(label) = label {
-        ask = ask.with_label(label);
-    }
+    let ask = build_mediator_ask(context, mediator_url, label, tsp_enabled);
     let messages: Arc<dyn OperatorMessages> = Arc::new(MediatorMessages);
     provision_client::run_provision_flight(
         vta_did,
@@ -92,4 +90,81 @@ pub async fn run_provision_flight(
         tx,
     )
     .await;
+}
+
+/// Build the `didcomm-mediator` provisioning ask, optionally advertising a
+/// `TSPTransport` service on the minted mediator DID.
+///
+/// The `didcomm-mediator` template (vta-sdk >= 0.18.15) renders `#tsp` only
+/// when `SERVICE_TSP` is supplied. The template renderer does not recurse into
+/// injected values, so we pass the fully-resolved service object: the endpoint
+/// mirrors the DIDComm `{URL}` (TSP and DIDComm share `/inbound`) and `{DID}`
+/// stays a sentinel the VTA's webvh layer resolves after SCID computation
+/// (identical to the P-256 verification-method slots). Omitted when TSP is off,
+/// so a DIDComm-only mediator advertises no TSP transport.
+fn build_mediator_ask(
+    context: String,
+    mediator_url: String,
+    label: Option<String>,
+    tsp_enabled: bool,
+) -> ProvisionAsk {
+    let mut ask = ProvisionAsk::didcomm_mediator(context, mediator_url.clone());
+    if let Some(label) = label {
+        ask = ask.with_label(label);
+    }
+    if tsp_enabled {
+        ask.integration_template_vars.insert(
+            "SERVICE_TSP".to_string(),
+            serde_json::json!({
+                "id": "{DID}#tsp",
+                "type": "TSPTransport",
+                "serviceEndpoint": mediator_url,
+            }),
+        );
+    }
+    ask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mediator_ask_advertises_tsp_when_enabled() {
+        let ask = build_mediator_ask(
+            "ctx".into(),
+            "https://mediator.example.com/mediator/v1".into(),
+            None,
+            true,
+        );
+        let tsp = ask
+            .integration_template_vars
+            .get("SERVICE_TSP")
+            .expect("SERVICE_TSP present when TSP enabled");
+        assert_eq!(tsp["id"], "{DID}#tsp");
+        assert_eq!(tsp["type"], "TSPTransport");
+        // Endpoint mirrors the DIDComm URL var (shared `/inbound`).
+        assert_eq!(
+            tsp["serviceEndpoint"],
+            "https://mediator.example.com/mediator/v1"
+        );
+        assert_eq!(
+            ask.integration_template_vars.get("URL").unwrap(),
+            "https://mediator.example.com/mediator/v1"
+        );
+    }
+
+    #[test]
+    fn mediator_ask_omits_tsp_when_disabled() {
+        let ask = build_mediator_ask(
+            "ctx".into(),
+            "https://mediator.example.com/mediator/v1".into(),
+            None,
+            false,
+        );
+        assert!(
+            !ask.integration_template_vars.contains_key("SERVICE_TSP"),
+            "SERVICE_TSP must be absent when TSP is disabled"
+        );
+    }
 }


### PR DESCRIPTION
## What

Closes the last gap in the TSP-advertisement consistency work (#565, #569): the **VTA-managed** DID path.

When the operator enables the `tsp` protocol, the wizard now injects a `SERVICE_TSP` service object into the VTA provisioning request's `integration_template_vars`. The VTA then renders a `#tsp` `TSPTransport` service on the minted mediator DID (endpoint mirrors the DIDComm `URL` — TSP and DIDComm share `/inbound`). When TSP is off, nothing is injected and the minted mediator advertises no TSP transport.

## Depends on

vta-sdk **0.18.15** (OpenVTC/verifiable-trust-infrastructure#608, merged + published), whose `didcomm-mediator` template renders `#tsp` only when `SERVICE_TSP` is supplied (previously unconditional). This PR's fresh resolve picks up 0.18.15.

## How

- `vta/runner.rs`: extracted `build_mediator_ask(context, url, label, tsp_enabled)`; inserts `SERVICE_TSP` when enabled. The template renderer does not recurse into injected values, so the object is fully resolved — endpoint = mediator URL, `{DID}` stays a sentinel the VTA's webvh layer resolves after SCID (identical to the P-256 VM slots).
- `app.rs`: `start_vta_provision` passes `self.config.tsp_enabled` through.

The self-hosted `did:webvh` / `did:peer` paths were already handled in 0.1.18 / 0.1.19; their generator tests still pass against vta-sdk 0.18.15 (the template no longer emits `#tsp` unconditionally, and the #569 augment/strip still lands the right result).

## Testing

- `cargo test -p affinidi-messaging-mediator-setup --bin mediator-setup` — 382 pass, incl. new `build_mediator_ask` unit tests (SERVICE_TSP present when enabled with the right shape/endpoint; absent when disabled).
- `cargo clippy --all-targets -D warnings` — clean.

Bumps `affinidi-messaging-mediator-setup` 0.1.19 → 0.1.20 (`publish = false`).