### PR TITLE
feat: TSP-preferred protocol selection with DIDComm fallback (send_to)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.18.43] - 2026-07-02
+
+- TSP-preferred protocol selection (SDD phase 1). New `ATM::send_to(profile, message, to,
+  from, sign_by)` façade automatically picks TSP or DIDComm and returns the `SendProtocol`
+  used. Selection is governed by a new `TspPolicy` (`Off` default / `Preferred` / `Required`)
+  set via `ATMConfigBuilder::with_tsp_policy`; with the default `Off` nothing changes.
+- Per-peer TSP capability cache folded into `RelationshipStore` (new `get_capability` /
+  `set_capability` trait methods with default no-op impls, so existing stores keep
+  compiling; `InMemoryRelationshipStore` persists it). New `TspOps::select_protocol`,
+  `peer_capability`, `set_peer_capability`; `PeerCapability` / `TspSupport` /
+  `CapabilitySource` types; a configurable capability TTL via
+  `ATMConfigBuilder::with_tsp_capability_ttl` measured against the injected clock.
+- Selection precedence: a fresh cached capability, else a `Bidirectional` relationship
+  (→ TSP, cached), else a DID-doc `TSPTransport` service (→ TSP, tentative), else DIDComm
+  (or an error under `Required`). Additive/patch — no breaking changes.
+
 ## [0.18.41] - 2026-06-29
 
 - TSP relationship methods follow affinidi-tsp 0.1.10's spec-compliant Control encoding:

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.42"
+version = "0.18.43"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -57,6 +57,20 @@ pub struct ATMConfig {
     /// [`ATMConfigBuilder::with_relationship_store`].
     #[cfg(feature = "tsp")]
     pub(crate) relationship_store: Arc<dyn crate::protocols::tsp::RelationshipStore>,
+
+    /// Protocol-selection policy for [`crate::ATM::send_to`]. Defaults to
+    /// [`TspPolicy::Off`] — send_to sends DIDComm and never picks TSP — so
+    /// enabling the `tsp` feature alone changes no behaviour. Set
+    /// [`TspPolicy::Preferred`] / [`TspPolicy::Required`] via
+    /// [`ATMConfigBuilder::with_tsp_policy`] to opt in.
+    #[cfg(feature = "tsp")]
+    pub(crate) tsp_policy: crate::protocols::tsp::TspPolicy,
+
+    /// How long a learned per-peer TSP capability stays fresh before it is
+    /// re-derived. `None` (default) = never expires. Measured against the
+    /// injected [`clock`](Self::clock).
+    #[cfg(feature = "tsp")]
+    pub(crate) tsp_capability_ttl: Option<Duration>,
 }
 
 impl ATMConfig {
@@ -80,6 +94,19 @@ impl ATMConfig {
     #[cfg(feature = "tsp")]
     pub(crate) fn relationship_store(&self) -> &Arc<dyn crate::protocols::tsp::RelationshipStore> {
         &self.relationship_store
+    }
+
+    /// The protocol-selection policy for [`crate::ATM::send_to`].
+    #[cfg(feature = "tsp")]
+    pub(crate) fn tsp_policy(&self) -> crate::protocols::tsp::TspPolicy {
+        self.tsp_policy
+    }
+
+    /// The freshness window for a learned per-peer TSP capability (`None` =
+    /// never expires).
+    #[cfg(feature = "tsp")]
+    pub(crate) fn tsp_capability_ttl(&self) -> Option<Duration> {
+        self.tsp_capability_ttl
     }
 
     /// Returns a builder for `ATMConfig`
@@ -118,6 +145,10 @@ pub struct ATMConfigBuilder {
     clock: Option<Arc<dyn Clock>>,
     #[cfg(feature = "tsp")]
     relationship_store: Option<Arc<dyn crate::protocols::tsp::RelationshipStore>>,
+    #[cfg(feature = "tsp")]
+    tsp_policy: crate::protocols::tsp::TspPolicy,
+    #[cfg(feature = "tsp")]
+    tsp_capability_ttl: Option<Duration>,
 }
 
 impl Default for ATMConfigBuilder {
@@ -134,6 +165,10 @@ impl Default for ATMConfigBuilder {
             clock: None,
             #[cfg(feature = "tsp")]
             relationship_store: None,
+            #[cfg(feature = "tsp")]
+            tsp_policy: crate::protocols::tsp::TspPolicy::Off,
+            #[cfg(feature = "tsp")]
+            tsp_capability_ttl: None,
         }
     }
 }
@@ -253,6 +288,28 @@ impl ATMConfigBuilder {
         self
     }
 
+    /// Set the protocol-selection policy for [`crate::ATM::send_to`].
+    ///
+    /// Defaults to [`crate::protocols::tsp::TspPolicy::Off`] (send_to always
+    /// sends DIDComm). [`Preferred`](crate::protocols::tsp::TspPolicy::Preferred)
+    /// picks TSP when the peer is known/derivable to speak it and falls back to
+    /// DIDComm otherwise; [`Required`](crate::protocols::tsp::TspPolicy::Required)
+    /// errors instead of falling back.
+    #[cfg(feature = "tsp")]
+    pub fn with_tsp_policy(mut self, policy: crate::protocols::tsp::TspPolicy) -> Self {
+        self.tsp_policy = policy;
+        self
+    }
+
+    /// Set how long a learned per-peer TSP capability stays fresh before it is
+    /// re-derived. Defaults to `None` (never expires). Measured against the
+    /// injected [`clock`](ATMConfigBuilder::with_clock).
+    #[cfg(feature = "tsp")]
+    pub fn with_tsp_capability_ttl(mut self, ttl: Duration) -> Self {
+        self.tsp_capability_ttl = Some(ttl);
+        self
+    }
+
     pub fn build(self) -> Result<ATMConfig, ATMError> {
         // Process any custom SSL certificates
         let mut certs = vec![];
@@ -295,6 +352,10 @@ impl ATMConfigBuilder {
             relationship_store: self.relationship_store.unwrap_or_else(|| {
                 Arc::new(crate::protocols::tsp::InMemoryRelationshipStore::default())
             }),
+            #[cfg(feature = "tsp")]
+            tsp_policy: self.tsp_policy,
+            #[cfg(feature = "tsp")]
+            tsp_capability_ttl: self.tsp_capability_ttl,
         })
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -184,7 +184,10 @@ use crate::protocols::tsp::TspOps;
 /// Re-exports of the TSP relationship-store API so consumers can implement a
 /// durable store or select one via the config builder.
 #[cfg(feature = "tsp")]
-pub use crate::protocols::tsp::{InMemoryRelationshipStore, RelationshipStore, TspWebSocket};
+pub use crate::protocols::tsp::{
+    CapabilitySource, InMemoryRelationshipStore, PeerCapability, RelationshipStore, SendProtocol,
+    TspPolicy, TspSupport, TspWebSocket,
+};
 /// Re-export of the pure-TSP authentication handler so a TSP-only client can
 /// register it on the TDK in place of the built-in DIDComm auth flow.
 #[cfg(feature = "tsp")]

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -37,13 +37,90 @@ use crate::ATM;
 use crate::errors::ATMError;
 use crate::profiles::ATMProfile;
 
-/// Pluggable backing store for TSP relationship state.
+/// Which wire protocol [`crate::ATM::send_to`] chose for a message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SendProtocol {
+    /// Sent as a TSP Direct message (`atm.tsp().send`).
+    Tsp,
+    /// Sent as a DIDComm message (`pack_encrypted` + `send_message`).
+    DidComm,
+}
+
+/// Policy governing whether [`crate::ATM::send_to`] may pick TSP over DIDComm.
+///
+/// Set via [`crate::config::ATMConfigBuilder::with_tsp_policy`]. Defaults to
+/// [`Off`](TspPolicy::Off), so enabling the `tsp` feature alone changes no
+/// send behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum TspPolicy {
+    /// Never pick TSP — [`send_to`](crate::ATM::send_to) always sends DIDComm.
+    #[default]
+    Off,
+    /// Pick TSP when the peer is known/derivable to speak it; otherwise fall
+    /// back to DIDComm.
+    Preferred,
+    /// Pick TSP when the peer is known/derivable to speak it; otherwise return
+    /// an error instead of falling back to DIDComm.
+    Required,
+}
+
+/// A peer's known TSP capability — whether its **agent** accepts TSP messages.
+///
+/// Distinct from a DID-document `TSPTransport` advertisement, which only says
+/// the peer's **mediator** speaks TSP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum TspSupport {
+    /// Not yet known — derive from live signals / negotiate.
+    Unknown,
+    /// The peer's agent is known to accept TSP.
+    Supported,
+    /// The peer's agent is known not to accept TSP.
+    Unsupported,
+}
+
+/// How a [`PeerCapability`] was learned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum CapabilitySource {
+    /// Derived from a completed TSP relationship (`Bidirectional`).
+    Relationship,
+    /// Derived from a `TSPTransport` service on the peer's DID document
+    /// (a mediator-level, tentative signal).
+    DidDocument,
+    /// Observed from an inbound TSP message the peer sent us.
+    Observed,
+    /// Set explicitly by the application.
+    Manual,
+}
+
+/// A cached per-peer TSP capability record, stored by [`RelationshipStore`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PeerCapability {
+    /// Whether the peer's agent accepts TSP.
+    pub tsp: TspSupport,
+    /// How this record was learned.
+    pub source: CapabilitySource,
+    /// Unix seconds (against the SDK's configured clock) when learned — used
+    /// for the capability TTL.
+    pub learned_at_unix: u64,
+}
+
+/// Pluggable backing store for TSP relationship state (and learned per-peer
+/// capability).
 ///
 /// The relationship state machine (invite → accept → bidirectional, plus
 /// cancel) is keyed on the `(our_vid, their_vid)` DID pair. The SDK drives the
 /// pure FSM in [`affinidi_tsp::relationship::RelationshipState`] and persists
 /// each new state through this trait, so where the state lives (memory, a
 /// database, …) is up to the consumer.
+///
+/// The same store also caches each peer's learned TSP [`capability`](PeerCapability)
+/// (used by [`crate::ATM::send_to`]); the capability methods have default no-op
+/// implementations so existing stores keep compiling, and durable stores can
+/// override them to persist capability alongside relationship state.
 ///
 /// The default implementation is [`InMemoryRelationshipStore`]; supply a
 /// durable one via
@@ -61,6 +138,28 @@ pub trait RelationshipStore: Send + Sync {
         their_vid: &str,
         state: RelationshipState,
     ) -> Result<(), ATMError>;
+
+    /// Cached TSP capability for the `(our_vid, their_vid)` pair, or `None` if
+    /// unknown. Default impl returns `None` (no capability cache);
+    /// [`InMemoryRelationshipStore`] and durable stores override it.
+    async fn get_capability(
+        &self,
+        _our_vid: &str,
+        _their_vid: &str,
+    ) -> Result<Option<PeerCapability>, ATMError> {
+        Ok(None)
+    }
+
+    /// Persist a learned TSP capability for the `(our_vid, their_vid)` pair.
+    /// Default impl is a no-op.
+    async fn set_capability(
+        &self,
+        _our_vid: &str,
+        _their_vid: &str,
+        _capability: PeerCapability,
+    ) -> Result<(), ATMError> {
+        Ok(())
+    }
 }
 
 /// Default, ephemeral [`RelationshipStore`] backed by an in-memory map.
@@ -74,6 +173,7 @@ pub trait RelationshipStore: Send + Sync {
 #[derive(Default)]
 pub struct InMemoryRelationshipStore {
     inner: RwLock<HashMap<(String, String), RelationshipState>>,
+    capabilities: RwLock<HashMap<(String, String), PeerCapability>>,
 }
 
 #[async_trait::async_trait]
@@ -98,6 +198,139 @@ impl RelationshipStore for InMemoryRelationshipStore {
         let key = (our_vid.to_string(), their_vid.to_string());
         self.inner.write().await.insert(key, state);
         Ok(())
+    }
+
+    async fn get_capability(
+        &self,
+        our_vid: &str,
+        their_vid: &str,
+    ) -> Result<Option<PeerCapability>, ATMError> {
+        let key = (our_vid.to_string(), their_vid.to_string());
+        Ok(self.capabilities.read().await.get(&key).copied())
+    }
+
+    async fn set_capability(
+        &self,
+        our_vid: &str,
+        their_vid: &str,
+        capability: PeerCapability,
+    ) -> Result<(), ATMError> {
+        let key = (our_vid.to_string(), their_vid.to_string());
+        self.capabilities.write().await.insert(key, capability);
+        Ok(())
+    }
+}
+
+impl ATM {
+    /// Send `message` to `to`, automatically choosing TSP or DIDComm per the
+    /// configured [`TspPolicy`] (see [`TspOps::select_protocol`]).
+    ///
+    /// - **DIDComm**: the message is packed (`pack_encrypted`) and sent to the
+    ///   profile's mediator.
+    /// - **TSP**: the message is serialised to JSON and sent as a TSP Direct
+    ///   message (`atm.tsp().send`), which seals it end-to-end; the recipient
+    ///   unpacks the TSP envelope to recover the same JSON [`Message`].
+    ///
+    /// Returns which [`SendProtocol`] was used. With the default
+    /// [`TspPolicy::Off`] this always sends DIDComm, so existing behaviour is
+    /// unchanged until an app opts in via
+    /// [`with_tsp_policy`](crate::config::ATMConfigBuilder::with_tsp_policy).
+    ///
+    /// v1 assumes the recipient shares (or its mediator federates with) the
+    /// sender's mediator; cross-mediator TSP routing to a service-less DID
+    /// (e.g. did:key) is out of scope here — use `atm.tsp().send_routed` for
+    /// explicit multi-hop.
+    ///
+    /// [`Message`]: affinidi_messaging_didcomm::message::Message
+    pub async fn send_to(
+        &self,
+        profile: &Arc<ATMProfile>,
+        message: &affinidi_messaging_didcomm::message::Message,
+        to: &str,
+        from: Option<&str>,
+        sign_by: Option<&str>,
+    ) -> Result<SendProtocol, ATMError> {
+        let protocol = self.tsp().select_protocol(profile, to).await?;
+        match protocol {
+            SendProtocol::Tsp => {
+                let payload = serde_json::to_vec(message).map_err(|e| {
+                    ATMError::MsgSendError(format!("couldn't serialise message for TSP: {e}"))
+                })?;
+                self.tsp().send(profile, to, &payload).await?;
+            }
+            SendProtocol::DidComm => {
+                // Pack for the recipient, then wrap in a single `forward` to the
+                // profile's mediator (`next` = recipient) so it lands in the
+                // recipient's mailbox — the standard DIDComm delivery path,
+                // mirroring TSP's mediator-relative delivery. v1's single-mediator
+                // scope means the recipient shares this mediator.
+                let (packed, _meta) = self.pack_encrypted(message, to, from, sign_by).await?;
+                let (_, mediator_did) = profile.dids()?;
+                let (fwd_id, fwd) = self
+                    .routing()
+                    .forward_message(profile, false, &packed, mediator_did, to, None, None)
+                    .await?;
+                self.send_message(profile, &fwd, &fwd_id, false, false)
+                    .await?;
+            }
+        }
+        Ok(protocol)
+    }
+}
+
+/// The outcome of the pure [`classify_protocol`] precedence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProtocolChoice {
+    /// Use TSP. `cache` names the source to persist as `Supported`, or `None`
+    /// to leave the cache untouched (a tentative signal).
+    Tsp { cache: Option<CapabilitySource> },
+    /// Use DIDComm.
+    DidComm,
+    /// No TSP capability under `Required` policy — the caller turns this into an
+    /// error.
+    Deny,
+}
+
+/// Pure protocol-selection precedence, factored out of
+/// [`TspOps::select_protocol`] so the full truth table is unit-testable without
+/// a live `ATM`. `fresh_cap` is the cached capability (if any, already
+/// TTL-filtered); `has_tsp_service` is whether the peer's DID document
+/// advertises a `TSPTransport` service.
+fn classify_protocol(
+    policy: TspPolicy,
+    fresh_cap: Option<TspSupport>,
+    bidirectional: bool,
+    has_tsp_service: bool,
+) -> ProtocolChoice {
+    if policy == TspPolicy::Off {
+        return ProtocolChoice::DidComm;
+    }
+    // 1. A fresh cached agent-level capability wins.
+    match fresh_cap {
+        Some(TspSupport::Supported) => return ProtocolChoice::Tsp { cache: None },
+        Some(TspSupport::Unsupported) => return deny_or_didcomm(policy),
+        _ => {}
+    }
+    // 2a. A completed relationship is a strong agent-level signal — cache it.
+    if bidirectional {
+        return ProtocolChoice::Tsp {
+            cache: Some(CapabilitySource::Relationship),
+        };
+    }
+    // 2b. A DID-doc `TSPTransport` service is a mediator-level (tentative)
+    // signal — attempt TSP but don't cache it as an agent-level capability.
+    if has_tsp_service {
+        return ProtocolChoice::Tsp { cache: None };
+    }
+    // 3. No TSP signal.
+    deny_or_didcomm(policy)
+}
+
+/// Under `Required`, no-TSP is a denial; otherwise fall back to DIDComm.
+fn deny_or_didcomm(policy: TspPolicy) -> ProtocolChoice {
+    match policy {
+        TspPolicy::Required => ProtocolChoice::Deny,
+        _ => ProtocolChoice::DidComm,
     }
 }
 
@@ -479,6 +712,119 @@ impl TspOps<'_> {
             ControlType::RelationshipCancel => RelationshipEvent::ReceiveCancel,
         };
         advance_state(self.relationship_store(), our_did, peer_did, event).await
+    }
+
+    // ── Protocol selection / capability ───────────────────────────────────────
+
+    /// The cached TSP [`capability`](PeerCapability) for the `(profile, their_did)`
+    /// pair, or `None` if unknown or expired (per the configured TTL / clock).
+    pub async fn peer_capability(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+    ) -> Result<Option<PeerCapability>, ATMError> {
+        let (our_did, _) = profile.dids()?;
+        let cap = self
+            .relationship_store()
+            .get_capability(our_did, their_did)
+            .await?;
+        Ok(cap.filter(|c| self.capability_is_fresh(c)))
+    }
+
+    /// Explicitly record a peer's TSP [`capability`](PeerCapability) — e.g. the
+    /// app learned it out of band. Stamped with the current clock time and
+    /// [`CapabilitySource::Manual`].
+    pub async fn set_peer_capability(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+        support: TspSupport,
+    ) -> Result<(), ATMError> {
+        let (our_did, _) = profile.dids()?;
+        let cap = PeerCapability {
+            tsp: support,
+            source: CapabilitySource::Manual,
+            learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+        };
+        self.relationship_store()
+            .set_capability(our_did, their_did, cap)
+            .await
+    }
+
+    /// Whether a cached capability is still within the configured TTL (`None`
+    /// TTL = always fresh).
+    fn capability_is_fresh(&self, cap: &PeerCapability) -> bool {
+        match self.atm.inner.config.tsp_capability_ttl() {
+            None => true,
+            Some(ttl) => {
+                let now = self.atm.inner.config.clock().unix_secs();
+                now.saturating_sub(cap.learned_at_unix) <= ttl.as_secs()
+            }
+        }
+    }
+
+    /// Decide which wire protocol to use for a message to `their_did`, per the
+    /// configured [`TspPolicy`].
+    ///
+    /// Gathers the signals ([`peer_capability`](Self::peer_capability), the
+    /// relationship state, and — only if those are inconclusive — a DID-doc
+    /// `TSPTransport` lookup) and applies the precedence in [`classify_protocol`].
+    /// When a `Bidirectional` relationship is the deciding signal, the peer is
+    /// cached as [`TspSupport::Supported`]. Under [`TspPolicy::Required`] a
+    /// no-TSP outcome is an error rather than a DIDComm fallback.
+    pub async fn select_protocol(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+    ) -> Result<SendProtocol, ATMError> {
+        let policy = self.atm.inner.config.tsp_policy();
+        if policy == TspPolicy::Off {
+            return Ok(SendProtocol::DidComm);
+        }
+
+        let (our_did, _) = profile.dids()?;
+        let store = self.relationship_store();
+
+        let fresh_cap = store
+            .get_capability(our_did, their_did)
+            .await?
+            .filter(|c| self.capability_is_fresh(c))
+            .map(|c| c.tsp);
+        let bidirectional =
+            store.get(our_did, their_did).await? == RelationshipState::Bidirectional;
+
+        // Only resolve the peer's DID document (a network/cache lookup) when the
+        // cheap store signals don't already settle it.
+        let needs_resolve = !matches!(
+            fresh_cap,
+            Some(TspSupport::Supported | TspSupport::Unsupported)
+        ) && !bidirectional;
+        let has_tsp_service = if needs_resolve {
+            self.resolve_vid(their_did)
+                .await
+                .map(|vid| !vid.endpoints.is_empty())
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        match classify_protocol(policy, fresh_cap, bidirectional, has_tsp_service) {
+            ProtocolChoice::Tsp { cache } => {
+                if let Some(source) = cache {
+                    let cap = PeerCapability {
+                        tsp: TspSupport::Supported,
+                        source,
+                        learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+                    };
+                    store.set_capability(our_did, their_did, cap).await?;
+                }
+                Ok(SendProtocol::Tsp)
+            }
+            ProtocolChoice::DidComm => Ok(SendProtocol::DidComm),
+            ProtocolChoice::Deny => Err(ATMError::MsgSendError(format!(
+                "TspPolicy::Required but no TSP capability is known for {their_did}"
+            ))),
+        }
     }
 
     /// POST an already-packed TSP message (raw qb2 bytes) to the mediator
@@ -894,9 +1240,11 @@ mod tests {
     // `affinidi-messaging-test-mediator`.
 
     use super::{
-        InMemoryRelationshipStore, RelationshipEvent, RelationshipState, RelationshipStore,
-        advance_state, next_state,
+        CapabilitySource, InMemoryRelationshipStore, PeerCapability, ProtocolChoice,
+        RelationshipEvent, RelationshipState, RelationshipStore, TspPolicy, TspSupport,
+        advance_state, classify_protocol, next_state,
     };
+    use crate::errors::ATMError;
     use std::sync::Arc;
 
     const ALICE: &str = "did:example:alice";
@@ -924,6 +1272,124 @@ mod tests {
         assert_eq!(
             store.get(BOB, ALICE).await.unwrap(),
             RelationshipState::None
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_capability_roundtrip() {
+        let store = InMemoryRelationshipStore::default();
+        // Unknown pair → None.
+        assert_eq!(store.get_capability(ALICE, BOB).await.unwrap(), None);
+
+        let cap = PeerCapability {
+            tsp: TspSupport::Supported,
+            source: CapabilitySource::Relationship,
+            learned_at_unix: 42,
+        };
+        store.set_capability(ALICE, BOB, cap).await.unwrap();
+        assert_eq!(store.get_capability(ALICE, BOB).await.unwrap(), Some(cap));
+
+        // Directional + independent of relationship state.
+        assert_eq!(store.get_capability(BOB, ALICE).await.unwrap(), None);
+        assert_eq!(
+            store.get(ALICE, BOB).await.unwrap(),
+            RelationshipState::None
+        );
+
+        // Default trait impl (no override) is a no-op that reports Unknown.
+        struct NoCap;
+        #[async_trait::async_trait]
+        impl RelationshipStore for NoCap {
+            async fn get(&self, _: &str, _: &str) -> Result<RelationshipState, ATMError> {
+                Ok(RelationshipState::None)
+            }
+            async fn set(
+                &self,
+                _: &str,
+                _: &str,
+                _: RelationshipState,
+            ) -> Result<(), ATMError> {
+                Ok(())
+            }
+        }
+        let nocap = NoCap;
+        nocap.set_capability(ALICE, BOB, cap).await.unwrap(); // no-op, no error
+        assert_eq!(nocap.get_capability(ALICE, BOB).await.unwrap(), None);
+    }
+
+    // ── classify_protocol truth table (pure) ──────────────────────────────────
+
+    #[test]
+    fn classify_off_is_always_didcomm() {
+        for cap in [None, Some(TspSupport::Supported), Some(TspSupport::Unsupported)] {
+            for bidi in [false, true] {
+                for svc in [false, true] {
+                    assert_eq!(
+                        classify_protocol(TspPolicy::Off, cap, bidi, svc),
+                        ProtocolChoice::DidComm
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn classify_cached_supported_wins() {
+        // A Supported cache short-circuits before relationship / service checks.
+        for policy in [TspPolicy::Preferred, TspPolicy::Required] {
+            assert_eq!(
+                classify_protocol(policy, Some(TspSupport::Supported), false, false),
+                ProtocolChoice::Tsp { cache: None }
+            );
+        }
+    }
+
+    #[test]
+    fn classify_cached_unsupported_short_circuits() {
+        // Unsupported wins even when a TSPTransport service is present.
+        assert_eq!(
+            classify_protocol(TspPolicy::Preferred, Some(TspSupport::Unsupported), true, true),
+            ProtocolChoice::DidComm
+        );
+        assert_eq!(
+            classify_protocol(TspPolicy::Required, Some(TspSupport::Unsupported), true, true),
+            ProtocolChoice::Deny
+        );
+    }
+
+    #[test]
+    fn classify_relationship_selects_tsp_and_caches() {
+        assert_eq!(
+            classify_protocol(TspPolicy::Preferred, None, true, false),
+            ProtocolChoice::Tsp {
+                cache: Some(CapabilitySource::Relationship)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_did_doc_service_is_tentative_tsp_no_cache() {
+        assert_eq!(
+            classify_protocol(TspPolicy::Preferred, None, false, true),
+            ProtocolChoice::Tsp { cache: None }
+        );
+    }
+
+    #[test]
+    fn classify_no_signal_falls_back_or_denies() {
+        // No signal (e.g. a did:key peer we've never talked to).
+        assert_eq!(
+            classify_protocol(TspPolicy::Preferred, None, false, false),
+            ProtocolChoice::DidComm
+        );
+        assert_eq!(
+            classify_protocol(TspPolicy::Required, None, false, false),
+            ProtocolChoice::Deny
+        );
+        // Unknown cached capability behaves like no cache.
+        assert_eq!(
+            classify_protocol(TspPolicy::Preferred, Some(TspSupport::Unknown), false, false),
+            ProtocolChoice::DidComm
         );
     }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog history
 
+## 2nd July 2026
+
+### 0.2.35 — TestEnvironment::spawn_with_tsp_policy + send_to e2e
+
+- New `TestEnvironment::spawn_with_tsp_policy(policy)` builds the SDK's `ATM` with a chosen
+  `TspPolicy`, so `atm.send_to` protocol selection can be driven end-to-end. New
+  `tests/tsp_send_to.rs` exercises the TSP branch (capability `Supported` → TSP, DIDComm
+  `Message` recovered from the TSP payload), the DIDComm fallback (`Unsupported` → forward
+  delivery), and the `Required`-policy error. Internal `new_with_config` now takes the
+  `ATMConfig` explicitly; no behaviour change to existing spawns.
+
 ## 29th June 2026
 
 ### 0.2.34 — TSP federation: advertise TSPTransport in the mediator's did:peer

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.34"
+version = "0.2.35"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -164,7 +164,10 @@ impl TestEnvironment {
             .build()
             .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
 
-        Self::new_with_config(mediator, tdk_config).await
+        let atm_config = ATMConfig::builder()
+            .build()
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        Self::new_with_config(mediator, tdk_config, atm_config).await
     }
 
     /// Use an existing [`TestMediatorHandle`] — for tests that want
@@ -173,7 +176,27 @@ impl TestEnvironment {
     pub async fn new(mediator: TestMediatorHandle) -> Result<Self, TestEnvironmentError> {
         let tdk_config =
             TDKConfig::headless().map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
-        Self::new_with_config(mediator, tdk_config).await
+        let atm_config = ATMConfig::builder()
+            .build()
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        Self::new_with_config(mediator, tdk_config, atm_config).await
+    }
+
+    /// Spawn the default mediator (with the `tsp` feature) and wire up the SDK
+    /// with a chosen [`TspPolicy`](affinidi_messaging_sdk::TspPolicy) so
+    /// `atm.send_to` protocol selection can be exercised end-to-end.
+    #[cfg(feature = "tsp")]
+    pub async fn spawn_with_tsp_policy(
+        policy: affinidi_messaging_sdk::TspPolicy,
+    ) -> Result<Self, TestEnvironmentError> {
+        let mediator = TestMediator::spawn().await?;
+        let tdk_config =
+            TDKConfig::headless().map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        let atm_config = ATMConfig::builder()
+            .with_tsp_policy(policy)
+            .build()
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        Self::new_with_config(mediator, tdk_config, atm_config).await
     }
 
     /// Shared constructor: wire the SDK + TDK against `mediator` using
@@ -183,6 +206,7 @@ impl TestEnvironment {
     async fn new_with_config(
         mediator: TestMediatorHandle,
         tdk_config: TDKConfig,
+        atm_config: ATMConfig,
     ) -> Result<Self, TestEnvironmentError> {
         let tdk = Arc::new(
             TDKSharedState::new(tdk_config)
@@ -199,9 +223,6 @@ impl TestEnvironment {
         let mediator_secrets = mediator.mediator_secrets().to_vec();
         tdk.secrets_resolver().insert_vec(&mediator_secrets).await;
 
-        let atm_config = ATMConfig::builder()
-            .build()
-            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
         let atm = ATM::new(atm_config, tdk.clone())
             .await
             .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_send_to.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_send_to.rs
@@ -1,0 +1,144 @@
+//! End-to-end coverage of the `atm.send_to` protocol-selection façade: with a
+//! non-`Off` [`TspPolicy`], send_to picks TSP or DIDComm per the peer's known
+//! capability and delivers over the chosen wire, and the recipient recovers the
+//! same DIDComm [`Message`] either way.
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::messages::MessageProtocol;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_sdk::{SendProtocol, TspPolicy, TspSupport};
+use affinidi_messaging_test_mediator::TestEnvironment;
+use serde_json::json;
+use uuid::Uuid;
+
+fn basic_message(from: &str, to: &str, text: &str) -> Message {
+    Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(to.to_string())
+    .from(from.to_string())
+    .finalize()
+}
+
+/// `Preferred` policy + a `Supported` capability → send_to uses TSP, and the
+/// recipient recovers the DIDComm `Message` from the TSP payload.
+#[tokio::test]
+async fn send_to_uses_tsp_when_capability_supported() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Record that bob's agent speaks TSP.
+    env.atm
+        .tsp()
+        .set_peer_capability(&alice.profile, &bob.did, TspSupport::Supported)
+        .await
+        .expect("record bob's TSP capability");
+
+    let msg = basic_message(&alice.did, &bob.did, "hi over the façade");
+    let via = env
+        .atm
+        .send_to(&alice.profile, &msg, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob");
+    assert_eq!(via, SendProtocol::Tsp, "capability Supported selects TSP");
+
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches");
+    let element = fetched.success.first().expect("bob has a message");
+    assert_eq!(element.protocol, Some(MessageProtocol::Tsp));
+    let stored = element.msg.as_ref().expect("body");
+
+    let (payload, sender) = env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, stored)
+        .await
+        .expect("bob unpacks the TSP message");
+    let recovered: Message = serde_json::from_slice(&payload).expect("payload is a DIDComm Message");
+    assert_eq!(recovered.body["content"], "hi over the façade");
+    assert_eq!(sender, alice.did);
+}
+
+/// `Preferred` policy + an `Unsupported` capability → send_to falls back to
+/// DIDComm, delivered via a forward the recipient unpacks natively.
+#[tokio::test]
+async fn send_to_falls_back_to_didcomm_when_unsupported() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    env.atm
+        .tsp()
+        .set_peer_capability(&alice.profile, &bob.did, TspSupport::Unsupported)
+        .await
+        .expect("record bob as not TSP-capable");
+
+    let msg = basic_message(&alice.did, &bob.did, "hi over didcomm");
+    let via = env
+        .atm
+        .send_to(&alice.profile, &msg, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob");
+    assert_eq!(
+        via,
+        SendProtocol::DidComm,
+        "capability Unsupported falls back to DIDComm"
+    );
+
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches");
+    let element = fetched.success.first().expect("bob has a message");
+    assert_eq!(element.protocol, Some(MessageProtocol::DidComm));
+    let stored = element.msg.as_ref().expect("body");
+
+    let (recovered, _meta) = env
+        .atm
+        .unpack(stored)
+        .await
+        .expect("bob unpacks the DIDComm message");
+    assert_eq!(recovered.body["content"], "hi over didcomm");
+}
+
+/// `Required` policy + no TSP capability → send_to errors instead of silently
+/// falling back to DIDComm.
+#[tokio::test]
+async fn send_to_required_errors_without_capability() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Required)
+        .await
+        .expect("spawn env with Required policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Explicitly Unsupported so the outcome is deterministic regardless of what
+    // bob's DID document advertises.
+    env.atm
+        .tsp()
+        .set_peer_capability(&alice.profile, &bob.did, TspSupport::Unsupported)
+        .await
+        .expect("record bob as not TSP-capable");
+
+    let msg = basic_message(&alice.did, &bob.did, "nope");
+    let err = env
+        .atm
+        .send_to(&alice.profile, &msg, &bob.did, Some(&alice.did), None)
+        .await
+        .expect_err("Required + no TSP capability must error");
+    assert!(
+        format!("{err}").contains("Required"),
+        "error should explain the Required-policy denial, got: {err}"
+    );
+}


### PR DESCRIPTION
## What

Phase 1 of the TSP protocol-negotiation design (#571). Adds an `ATM::send_to` façade that automatically picks TSP or DIDComm per a configurable policy, so callers no longer hard-code the wire protocol. Motivated by did:key recipients, whose DID documents can't advertise a `TSPTransport` service.

Reframe from the architecture review: TSP already *reaches* did:key peers (the send path relays via the sender's mediator, keyed on `sha256(vid)`; `DidVidResolver` resolves did:key to keys fine). The real gap is **capability signaling** — knowing the peer's *agent* speaks TSP — which this PR addresses with a learned, cached capability.

## Design (decisions locked with @stormer78)

- **Policy** — `ATMConfigBuilder::with_tsp_policy(TspPolicy { Off | Preferred | Required })`, default **Off** (zero behaviour change until opted in). `Required` errors instead of falling back.
- **Capability cache** — folded into the existing pluggable `RelationshipStore` (new `get_capability` / `set_capability` with **default no-op impls**, so existing stores keep compiling; `InMemoryRelationshipStore` persists them). Configurable TTL via `with_tsp_capability_ttl` against the injected clock.
- **Selection precedence** (`TspOps::select_protocol`): fresh cached capability → `Bidirectional` relationship (→ TSP, cached `Supported`) → DID-doc `TSPTransport` (→ TSP, tentative) → DIDComm (or error under `Required`).
- **send_to wire branches** — TSP serialises the DIDComm `Message` and seals it end-to-end (recipient recovers the same `Message`); DIDComm forwards it to the recipient's mailbox.

For a did:key peer: DIDComm by default, auto-upgrading to TSP once a relationship is formed (that wiring is Phase 2). Single-mediator scope for v1.

## Testing

- SDK unit tests: full `classify_protocol` truth table (policy × cache × relationship × service) + capability-store round-trip + default-impl no-op. 86 lib tests pass.
- e2e (`tests/tsp_send_to.rs`, new `TestEnvironment::spawn_with_tsp_policy`): TSP branch (capability `Supported` → TSP, DIDComm `Message` recovered from the TSP payload), DIDComm fallback (`Unsupported` → forward delivery), `Required` error. All pass; existing tsp e2e unaffected.
- `cargo clippy -D warnings` clean on default **and** `tsp` (all-targets), both sdk and test-mediator.

Additive/patch: sdk 0.18.42 → 0.18.43, test-mediator 0.2.34 → 0.2.35.

## Follow-ups (tracked)

Phase 2 (handshake-only negotiation): relationship-completion → `Supported`, observed inbound TSP → `Supported`. Parked: Discover-Features TSP URI, cross-mediator did:key routing.