### PR TITLE
fix: delete + skip unexpected packed frames in message pickup (poison-loop)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.18.44] - 2026-07-02
+
+- Fix a poison-message loop: `MessagePickup::live_stream_next` / `live_stream_get` errored
+  (without deleting) when a **packed** frame (e.g. a TSP/CESR message) arrived on a
+  DIDComm-only stream, so the mediator redelivered it every pickup cycle forever. They now
+  delete the undeliverable packed frame (when `auto_delete`) and skip it (`Ok(None)`) with a
+  warning, keeping the stream live. A consumer that wants packed frames should use
+  `live_stream_next_frame` (multiplexed) or `live_stream_next_packed`. Behaviour change:
+  these paths return `Ok(None)` instead of `Err(MsgReceiveError)` on an unexpected packed
+  frame.
+
 ## [0.18.43] - 2026-07-02
 
 - TSP-preferred protocol selection (SDD phase 1). New `ATM::send_to(profile, message, to,

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.43"
+version = "0.18.44"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -299,10 +299,23 @@ impl MessagePickup {
                             debug!("WebSocket disconnected while awaiting next message");
                             Ok(None)
                         }
-                        Ok(WebSocketResponses::PackedMessageReceived(_)) => {
-                            Err(ATMError::MsgReceiveError(
-                                "Received packed message when expecting unpacked message. Use live_stream_next_packed() for packed messages.".into()
-                            ))
+                        Ok(WebSocketResponses::PackedMessageReceived(packed_msg)) => {
+                            // A DIDComm-only stream can't handle a packed (e.g.
+                            // TSP/CESR) frame. Erroring here without removing it
+                            // left the message in the mediator queue, so the
+                            // pickup redelivered it every cycle — a poison loop.
+                            // Delete it (when auto_delete) and skip; a consumer
+                            // that wants packed frames uses `live_stream_next_frame`
+                            // / `live_stream_next_packed`.
+                            warn!(
+                                "Dropping unexpected packed message on a DIDComm-only stream \
+                                 (use live_stream_next_frame for multiplexed TSP + DIDComm)"
+                            );
+                            if auto_delete {
+                                let sha256_hash = sha256::digest(packed_msg.as_str());
+                                atm.delete_message_background(profile, &sha256_hash).await?;
+                            }
+                            Ok(None)
                         }
                         Err(e) => {
                             warn!("Error receiving message: {:?}", e);
@@ -491,10 +504,23 @@ impl MessagePickup {
                                 "Connection reset while awaiting response for {msg_id}"
                             )))
                         }
-                        Ok(WebSocketResponses::PackedMessageReceived(_)) => {
-                            Err(ATMError::MsgReceiveError(
-                                "Received packed message when expecting unpacked message. Use live_stream_next_packed() for packed messages.".into()
-                            ))
+                        Ok(WebSocketResponses::PackedMessageReceived(packed_msg)) => {
+                            // A DIDComm-only stream can't handle a packed (e.g.
+                            // TSP/CESR) frame. Erroring here without removing it
+                            // left the message in the mediator queue, so the
+                            // pickup redelivered it every cycle — a poison loop.
+                            // Delete it (when auto_delete) and skip; a consumer
+                            // that wants packed frames uses `live_stream_next_frame`
+                            // / `live_stream_next_packed`.
+                            warn!(
+                                "Dropping unexpected packed message on a DIDComm-only stream \
+                                 (use live_stream_next_frame for multiplexed TSP + DIDComm)"
+                            );
+                            if auto_delete {
+                                let sha256_hash = sha256::digest(packed_msg.as_str());
+                                atm.delete_message_background(profile, &sha256_hash).await?;
+                            }
+                            Ok(None)
                         }
                         Err(e) => {
                             warn!("Error receiving message: {:?}", e);


### PR DESCRIPTION
## The bug

`MessagePickup::live_stream_next` and `live_stream_get` returned `Err(MsgReceiveError("Received packed message when expecting unpacked message ..."))` when a **packed** frame (e.g. a TSP/CESR message) arrived on a DIDComm-only stream — but **never deleted it**. The mediator kept redelivering the same frame every pickup cycle, forever.

Observed downstream (verifiable-trust-infrastructure): a VTA that advertised TSP but ran a DIDComm-only listener logged this every ~30s:
```
Received packed message when expecting unpacked message. Use live_stream_next_packed()
Error unpacking message: DidcommError("Cannot parse message as JSON", "invalid number at line 1 column 2")   ← forever
```

## Fix

A DIDComm-only stream can never process a packed frame, so drop it instead of poison-looping: delete the message (when `auto_delete`) and return `Ok(None)` to skip, with a warning pointing consumers at `live_stream_next_frame` (multiplexed TSP + DIDComm) or `live_stream_next_packed`. The multiplexing `live_stream_next_frame` already classifies + auto-deletes correctly (`PackedMessageReceived → InboundFrame::Tsp`); this brings the two DIDComm-only paths in line.

## Behaviour change

`live_stream_next` / `live_stream_get` now return `Ok(None)` instead of `Err(MsgReceiveError)` on an unexpected packed frame — strictly more useful (the `Err` was unactionable; the caller could only loop). `affinidi-messaging-sdk` 0.18.42 → **0.18.43**.

## Relationship to the downstream fix

The VTA side is already fixed independently (OpenVTC/verifiable-trust-infrastructure#613 — a `tsp`-compiled VTA now always uses the multiplexing listener, so it never hits the DIDComm-only path). This PR is **defense-in-depth** for any other DIDComm-only consumer that receives an unexpected packed frame.