### PR TITLE
feat: learn TSP capability from relationships and observed inbound TSP

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.45] - 2026-07-02
+
+- TSP capability learning (SDD phase 2): the per-peer TSP capability cache is now
+  populated automatically, so `atm.send_to` upgrades a peer from DIDComm to TSP once
+  we know their agent speaks it. A peer is marked `Supported` when a relationship
+  completes (`accept_relationship` / `record_incoming_control` reaching `Bidirectional`)
+  or when an authenticated inbound TSP message is observed (`unpack` / `unpack_bytes` /
+  `unpack_control`). Learning is a no-op under the default `TspPolicy::Off` (no extra
+  store writes) and skips redundant writes when a fresh `Supported` record already exists.
+
 ## [0.18.44] - 2026-07-02
 
 - Fix a poison-message loop: `MessagePickup::live_stream_next` / `live_stream_get` errored

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.44"
+version = "0.18.45"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -646,6 +646,11 @@ impl TspOps<'_> {
         )
         .await?;
         store.set(our_did, their_did, next).await?;
+        // A completed relationship confirms the peer's agent speaks TSP.
+        if next == RelationshipState::Bidirectional {
+            self.learn_tsp_supported(our_did, their_did, CapabilitySource::Relationship)
+                .await?;
+        }
         Ok(next)
     }
 
@@ -711,7 +716,14 @@ impl TspOps<'_> {
             ControlType::RelationshipFormingAccept => RelationshipEvent::ReceiveAccept,
             ControlType::RelationshipCancel => RelationshipEvent::ReceiveCancel,
         };
-        advance_state(self.relationship_store(), our_did, peer_did, event).await
+        let new_state = advance_state(self.relationship_store(), our_did, peer_did, event).await?;
+        // The initiator reaches Bidirectional here (on receiving the accept) —
+        // confirm the peer's TSP capability.
+        if new_state == RelationshipState::Bidirectional {
+            self.learn_tsp_supported(our_did, peer_did, CapabilitySource::Relationship)
+                .await?;
+        }
+        Ok(new_state)
     }
 
     // ── Protocol selection / capability ───────────────────────────────────────
@@ -761,6 +773,40 @@ impl TspOps<'_> {
                 now.saturating_sub(cap.learned_at_unix) <= ttl.as_secs()
             }
         }
+    }
+
+    /// Learn that `their_did` speaks TSP and cache it as [`TspSupport::Supported`]
+    /// with the given `source`. Called when a relationship completes
+    /// ([`CapabilitySource::Relationship`]) or an inbound TSP message is observed
+    /// ([`CapabilitySource::Observed`]).
+    ///
+    /// A no-op when the [`TspPolicy`] is [`Off`](TspPolicy::Off) — capability
+    /// tracking is inert unless protocol selection is enabled, so the default
+    /// build incurs no extra store writes. Skips the write when a fresh
+    /// `Supported` record already exists, so durable stores aren't rewritten on
+    /// every received message.
+    async fn learn_tsp_supported(
+        &self,
+        our_did: &str,
+        their_did: &str,
+        source: CapabilitySource,
+    ) -> Result<(), ATMError> {
+        if self.atm.inner.config.tsp_policy() == TspPolicy::Off {
+            return Ok(());
+        }
+        let store = self.relationship_store();
+        if let Some(cap) = store.get_capability(our_did, their_did).await?
+            && cap.tsp == TspSupport::Supported
+            && self.capability_is_fresh(&cap)
+        {
+            return Ok(());
+        }
+        let cap = PeerCapability {
+            tsp: TspSupport::Supported,
+            source,
+            learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+        };
+        store.set_capability(our_did, their_did, cap).await
     }
 
     /// Decide which wire protocol to use for a message to `their_did`, per the
@@ -911,6 +957,11 @@ impl TspOps<'_> {
         )
         .map_err(|e| ATMError::MsgReceiveError(format!("couldn't unpack TSP message: {e}")))?;
 
+        // Observing an authenticated inbound TSP message confirms the sender's
+        // agent speaks TSP (no-op unless a TSP policy is set).
+        self.learn_tsp_supported(profile_did, &unpacked.sender, CapabilitySource::Observed)
+            .await?;
+
         Ok((unpacked.payload, unpacked.sender))
     }
 
@@ -950,6 +1001,10 @@ impl TspOps<'_> {
         let control = unpacked.control.ok_or_else(|| {
             ATMError::MsgReceiveError("TSP message is not a control message".into())
         })?;
+        // An inbound control message is also authenticated inbound TSP — the
+        // sender's agent speaks TSP (no-op unless a TSP policy is set).
+        self.learn_tsp_supported(profile_did, &unpacked.sender, CapabilitySource::Observed)
+            .await?;
         Ok((control, unpacked.sender, unpacked.thread_digest))
     }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 2nd July 2026
 
+### 0.2.36 — TSP capability-learning e2e
+
+- New `tests/tsp_capability.rs` covers SDD phase 2: observing an inbound TSP message
+  upgrades a peer to `Supported` so `send_to` switches DIDComm → TSP; the same is inert
+  under the default `Off` policy; and a full relationship handshake (the repo's first
+  end-to-end TSP invite/accept) marks both peers `Supported`.
+
 ### 0.2.35 — TestEnvironment::spawn_with_tsp_policy + send_to e2e
 
 - New `TestEnvironment::spawn_with_tsp_policy(policy)` builds the SDK's `ATM` with a chosen

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.35"
+version = "0.2.36"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
@@ -1,0 +1,249 @@
+//! End-to-end coverage of TSP capability learning (SDD phase 2): a peer is
+//! marked `Supported` once we observe an inbound TSP message from them or
+//! complete a relationship, so `atm.send_to` auto-upgrades DIDComm → TSP.
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::messages::MessageProtocol;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_sdk::{SendProtocol, TspPolicy, TspSupport};
+use affinidi_messaging_test_mediator::TestEnvironment;
+use affinidi_tsp::relationship::RelationshipState;
+use serde_json::json;
+use uuid::Uuid;
+
+fn basic_message(from: &str, to: &str, text: &str) -> Message {
+    Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(to.to_string())
+    .from(from.to_string())
+    .finalize()
+}
+
+/// The headline phase-2 behaviour: alice sends DIDComm to a peer she knows
+/// nothing about; after the peer sends her a TSP message she unpacks, the peer
+/// is cached `Supported` and her next `send_to` upgrades to TSP.
+#[tokio::test]
+async fn observed_inbound_tsp_upgrades_send_to() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // No signal yet (bob's did:peer advertises no TSPTransport) → DIDComm.
+    assert_eq!(
+        env.atm
+            .tsp()
+            .peer_capability(&alice.profile, &bob.did)
+            .await
+            .unwrap(),
+        None
+    );
+    let m1 = basic_message(&alice.did, &bob.did, "first");
+    let via1 = env
+        .atm
+        .send_to(&alice.profile, &m1, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob (1)");
+    assert_eq!(via1, SendProtocol::DidComm, "no TSP signal yet → DIDComm");
+
+    // Bob sends Alice a TSP message; Alice fetches + unpacks it.
+    env.atm
+        .tsp()
+        .send(&bob.profile, &alice.did, b"hi from bob over tsp")
+        .await
+        .expect("bob sends TSP to alice");
+    let fetched = env
+        .atm
+        .fetch_messages(&alice.profile, &FetchOptions::default())
+        .await
+        .expect("alice fetches");
+    let stored = fetched
+        .success
+        .iter()
+        .find(|e| e.protocol == Some(MessageProtocol::Tsp))
+        .and_then(|e| e.msg.as_ref())
+        .expect("alice has a TSP message");
+    let (_payload, sender) = env
+        .atm
+        .tsp()
+        .unpack(&alice.profile, stored)
+        .await
+        .expect("alice unpacks bob's TSP message");
+    assert_eq!(sender, bob.did);
+
+    // Observing that inbound TSP cached bob as Supported → send_to upgrades.
+    let cap = env
+        .atm
+        .tsp()
+        .peer_capability(&alice.profile, &bob.did)
+        .await
+        .unwrap();
+    assert!(
+        matches!(cap.map(|c| c.tsp), Some(TspSupport::Supported)),
+        "observing inbound TSP marks the sender Supported"
+    );
+    let m2 = basic_message(&alice.did, &bob.did, "second");
+    let via2 = env
+        .atm
+        .send_to(&alice.profile, &m2, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob (2)");
+    assert_eq!(via2, SendProtocol::Tsp, "learned capability upgrades to TSP");
+}
+
+/// Under the default `Off` policy, capability tracking is inert — observing an
+/// inbound TSP message writes nothing, so behaviour is unchanged.
+#[tokio::test]
+async fn observed_inbound_is_inert_under_off_policy() {
+    let env = TestEnvironment::spawn().await.expect("spawn default (Off) env");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    env.atm
+        .tsp()
+        .send(&bob.profile, &alice.did, b"tsp under off")
+        .await
+        .expect("bob sends TSP to alice");
+    let fetched = env
+        .atm
+        .fetch_messages(&alice.profile, &FetchOptions::default())
+        .await
+        .expect("alice fetches");
+    let stored = fetched
+        .success
+        .first()
+        .and_then(|e| e.msg.as_ref())
+        .expect("alice has a message");
+    env.atm
+        .tsp()
+        .unpack(&alice.profile, stored)
+        .await
+        .expect("alice unpacks");
+
+    assert_eq!(
+        env.atm
+            .tsp()
+            .peer_capability(&alice.profile, &bob.did)
+            .await
+            .unwrap(),
+        None,
+        "Off policy tracks no capability"
+    );
+}
+
+/// Completing a relationship marks both peers `Supported`, so `send_to` uses
+/// TSP afterwards. Also the repo's first end-to-end TSP relationship handshake.
+#[tokio::test]
+async fn completed_relationship_marks_peers_tsp_supported() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Alice initiates: invite → Pending.
+    let alice_state = env
+        .atm
+        .tsp()
+        .form_relationship(&alice.profile, &bob.did)
+        .await
+        .expect("alice forms relationship");
+    assert_eq!(alice_state, RelationshipState::Pending);
+
+    // Bob receives the invite, records it, and accepts → Bidirectional.
+    let bob_inbox = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches invite");
+    let invite_stored = bob_inbox
+        .success
+        .first()
+        .and_then(|e| e.msg.as_ref())
+        .expect("bob has the invite");
+    let invite_qb2 = env.atm.tsp().decode(invite_stored).expect("decode invite");
+    let (invite, invite_sender, invite_digest) = env
+        .atm
+        .tsp()
+        .unpack_control(&bob.profile, &invite_qb2)
+        .await
+        .expect("bob unpacks the invite control");
+    assert_eq!(invite_sender, alice.did);
+    env.atm
+        .tsp()
+        .record_incoming_control(&bob.profile, &alice.did, &invite)
+        .await
+        .expect("bob records the invite");
+    let bob_state = env
+        .atm
+        .tsp()
+        .accept_relationship(&bob.profile, &alice.did, invite_digest)
+        .await
+        .expect("bob accepts");
+    assert_eq!(bob_state, RelationshipState::Bidirectional);
+    assert!(
+        matches!(
+            env.atm
+                .tsp()
+                .peer_capability(&bob.profile, &alice.did)
+                .await
+                .unwrap()
+                .map(|c| c.tsp),
+            Some(TspSupport::Supported)
+        ),
+        "bob learned alice speaks TSP"
+    );
+
+    // Alice receives the accept → Bidirectional, learns bob is Supported.
+    let alice_inbox = env
+        .atm
+        .fetch_messages(&alice.profile, &FetchOptions::default())
+        .await
+        .expect("alice fetches accept");
+    let accept_stored = alice_inbox
+        .success
+        .first()
+        .and_then(|e| e.msg.as_ref())
+        .expect("alice has the accept");
+    let accept_qb2 = env.atm.tsp().decode(accept_stored).expect("decode accept");
+    let (accept, accept_sender, _digest) = env
+        .atm
+        .tsp()
+        .unpack_control(&alice.profile, &accept_qb2)
+        .await
+        .expect("alice unpacks the accept control");
+    assert_eq!(accept_sender, bob.did);
+    let alice_final = env
+        .atm
+        .tsp()
+        .record_incoming_control(&alice.profile, &bob.did, &accept)
+        .await
+        .expect("alice records the accept");
+    assert_eq!(alice_final, RelationshipState::Bidirectional);
+    assert!(
+        matches!(
+            env.atm
+                .tsp()
+                .peer_capability(&alice.profile, &bob.did)
+                .await
+                .unwrap()
+                .map(|c| c.tsp),
+            Some(TspSupport::Supported)
+        ),
+        "alice learned bob speaks TSP"
+    );
+
+    // send_to now uses TSP.
+    let m = basic_message(&alice.did, &bob.did, "post-relationship");
+    let via = env
+        .atm
+        .send_to(&alice.profile, &m, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to after relationship");
+    assert_eq!(via, SendProtocol::Tsp);
+}


### PR DESCRIPTION
## What

Phase 2 of the TSP protocol-negotiation design (#571), building on #573. Auto-populates the per-peer TSP capability cache so `atm.send_to` upgrades a peer **DIDComm → TSP** once we know their agent speaks it — no per-message probing.

A peer is cached `Supported` when:
- a **relationship completes** — `accept_relationship`, or `record_incoming_control` reaching `Bidirectional`; or
- an **authenticated inbound TSP message is observed** — `unpack` / `unpack_bytes` / `unpack_control`.

## Properties

- **Inert under the default `TspPolicy::Off`** — no extra store writes, so the default build is unchanged.
- **Dedup** — skips the write when a fresh `Supported` record already exists, so durable `RelationshipStore` impls aren't rewritten on every received message.

For a **did:key** peer this delivers the headline behaviour from #571: DIDComm by default, auto-upgrading to TSP after the first inbound TSP message or a formed relationship (did:key can't advertise `TSPTransport`, so learned capability is the only signal).

## Testing

- New `tests/tsp_capability.rs`:
  - `observed_inbound_tsp_upgrades_send_to` — DIDComm first, then TSP after observing an inbound TSP message.
  - `observed_inbound_is_inert_under_off_policy` — the `Off` guarantee.
  - `completed_relationship_marks_peers_tsp_supported` — the repo's **first end-to-end TSP relationship handshake** (invite → record → accept → record), asserting both peers become `Supported` and `send_to` then uses TSP.
- 86 SDK lib tests pass; `cargo clippy -D warnings` clean on default **and** `tsp` (sdk + test-mediator).

Additive/patch: sdk 0.18.43 → 0.18.44, test-mediator 0.2.35 → 0.2.36.

## Status of #571

Phases 1 (#573) + 2 (this) complete the SDD. Parked (not scheduled): Discover-Features TSP URI advertisement, cross-mediator did:key routing.