### PR TITLE
fix: decode qb64 TSP pickup frame before unpack in dispatch_tsp

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.15] - 2026-07-02
+
+- Fix inbound TSP: `dispatch_tsp` handed the **qb64** pickup string (`base64url(qb2)`, `-E…`
+  text) straight to `atm.tsp().unpack_bytes`, which expects **decoded qb2** — so every
+  multiplexed inbound TSP frame failed with `couldn't parse TSP envelope: missing -E
+  envelope wrapper` and was dropped. Use `atm.tsp().unpack` (decodes base64url first),
+  matching the mediator round-trip tests. The raw-TSP `connect_websocket` path already
+  yields decoded qb2 and is unaffected. This is what made a TSP Trust-Ping to a VTA fail
+  end-to-end even with the listener correctly in `Protocols::BOTH`.
+
 ## [0.3.14] - 2026-07-02
 
 Symmetric TSP replies (ADR 0005 stage 6). `TspHandler::handle` now returns

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.14"
+version = "0.3.15"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -352,10 +352,14 @@ impl Listener {
         handler: &Arc<dyn TspHandler>,
         packed: String,
     ) {
-        // NOTE: the packed frame surfaces as a String off the pickup socket; the
-        // exact qb2/qb64 encoding handed to `unpack_bytes` is confirmed by the
-        // live VTA↔mediator run.
-        let (payload, sender_vid) = match atm.tsp().unpack_bytes(profile, packed.as_bytes()).await {
+        // The pickup socket surfaces the frame as the **qb64** stored string
+        // (`base64url(qb2)`, i.e. `-E…` text) — NOT raw qb2. Use `unpack`, which
+        // decodes the base64url first; `unpack_bytes(packed.as_bytes())` would
+        // feed the ASCII `'-','E',…` bytes straight into the CESR parser and
+        // fail with "missing -E envelope wrapper". (The raw-TSP `connect_websocket`
+        // path yields already-decoded qb2 and correctly uses `unpack_bytes`; this
+        // DIDComm-multiplexed path does not.)
+        let (payload, sender_vid) = match atm.tsp().unpack(profile, &packed).await {
             Ok(v) => v,
             Err(e) => {
                 warn!(profile = %profile.inner.alias, error = %e, "Failed to unpack TSP frame");


### PR DESCRIPTION
## The bug

Inbound TSP was broken end-to-end. `AffinidiMessageService`'s `dispatch_tsp` (`listener.rs:358`) handed the **qb64** pickup string — `base64url(qb2)`, i.e. `-E…` ASCII text — straight to `atm.tsp().unpack_bytes`, which expects **decoded qb2** bytes (leading CESR count code `0xF8`). The parser saw `'-' (0x2D) 'E' (0x45) …` and failed:

```
Failed to unpack TSP frame ... couldn't parse TSP envelope: missing -E envelope wrapper
```

Every multiplexed inbound TSP frame was dropped, so a TSP Trust-Ping to a VTA never got a reply — **even with the listener correctly in `Protocols::BOTH`**. (Downstream this also fed a ~30s redelivery loop, since the undecoded frame kept being re-pickup'd.)

## Fix

```rust
- atm.tsp().unpack_bytes(profile, packed.as_bytes())
+ atm.tsp().unpack(profile, &packed)   // decodes base64url, then unpack_bytes
```

`unpack` is `decode(stored)` → `unpack_bytes(qb2)`. This matches the passing mediator round-trip tests (`affinidi-messaging-test-mediator/tests/tsp_delivery.rs`, which receive with `.unpack(&profile, stored)`). The raw-TSP `connect_websocket` / `TspWebSocket::recv` path yields **already-decoded qb2** `Binary` frames and correctly keeps `unpack_bytes` — only the DIDComm-multiplexed pickup path (qb64 String) was wrong.

## Testing

77 lib tests pass; clippy `-D warnings` clean in default and `tsp`. `affinidi-messaging-didcomm-service` 0.3.14 → **0.3.15**.

## Context

This is the receive-side counterpart to the downstream VTA fix (OpenVTC/verifiable-trust-infrastructure#613, always-listen-BOTH) — the listener was finally reaching this code, which then couldn't decode the frame. Found via a live VTA↔mediator TSP Trust-Ping.