### PR TITLE
feat: proactive TSP capability discovery via Discover Features 2.0 (#576)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_peer.rs
@@ -151,9 +151,12 @@ mod tests {
 
     #[test]
     fn test_generate_did_peer_with_service() {
-        let (did, secrets) =
-            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[], false)
-                .unwrap();
+        let (did, secrets) = generate_did_peer(
+            Some("http://localhost:7037/mediator/v1/".into()),
+            &[],
+            false,
+        )
+        .unwrap();
         assert!(did.starts_with("did:peer:2.V"));
         assert_eq!(did.matches(".S").count(), 2);
         assert_eq!(secrets.len(), 2);
@@ -181,7 +184,8 @@ mod tests {
         // mediator's HTTP `/inbound` base with DIDComm. The resolver expands
         // the `tsp` abbreviation to `TSPTransport`.
         let (did, _secrets) =
-            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[], true).unwrap();
+            generate_did_peer(Some("http://localhost:7037/mediator/v1/".into()), &[], true)
+                .unwrap();
         assert_eq!(did.matches(".S").count(), 3);
 
         let services = decode_service_segments(&did);

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -310,7 +310,10 @@ fn augment_webvh_doc_with_tsp_service(did_document: &mut serde_json::Value) -> a
 fn strip_tsp_service(did_document: &mut serde_json::Value) {
     use serde_json::Value;
 
-    if let Some(services) = did_document.get_mut("service").and_then(Value::as_array_mut) {
+    if let Some(services) = did_document
+        .get_mut("service")
+        .and_then(Value::as_array_mut)
+    {
         services.retain(|svc| {
             !svc.get("type").is_some_and(|t| match t {
                 Value::String(s) => s == "TSPTransport",
@@ -615,9 +618,21 @@ mod tests {
         strip_tsp_service(&mut doc);
         let services = doc["service"].as_array().unwrap();
         assert_eq!(services.len(), 2);
-        assert!(!services.iter().any(|s| s["type"] == json!(["TSPTransport"])));
-        assert!(services.iter().any(|s| s["type"] == json!(["DIDCommMessaging"])));
-        assert!(services.iter().any(|s| s["type"] == json!(["Authentication"])));
+        assert!(
+            !services
+                .iter()
+                .any(|s| s["type"] == json!(["TSPTransport"]))
+        );
+        assert!(
+            services
+                .iter()
+                .any(|s| s["type"] == json!(["DIDCommMessaging"]))
+        );
+        assert!(
+            services
+                .iter()
+                .any(|s| s["type"] == json!(["Authentication"]))
+        );
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.45"
+version = "0.18.46"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -338,13 +338,33 @@ impl ATMConfigBuilder {
             ));
         }
 
+        // When TSP protocol selection is enabled, advertise the TSP capability
+        // URI in Discover Features 2.0 so peers can discover it proactively
+        // (symmetric with `send_to` preferring TSP for peers known to support it).
+        #[cfg(feature = "tsp")]
+        let discover_features = {
+            let mut df = self.discover_features;
+            if self.tsp_policy != crate::protocols::tsp::TspPolicy::Off
+                && !df
+                    .protocols
+                    .iter()
+                    .any(|p| p == crate::protocols::tsp::TSP_DISCOVER_FEATURE_URI)
+            {
+                df.protocols
+                    .push(crate::protocols::tsp::TSP_DISCOVER_FEATURE_URI.to_string());
+            }
+            df
+        };
+        #[cfg(not(feature = "tsp"))]
+        let discover_features = self.discover_features;
+
         Ok(ATMConfig {
             ssl_certificates: certs,
             fetch_cache_limit_count: self.fetch_cache_limit_count,
             fetch_cache_limit_bytes: self.fetch_cache_limit_bytes,
             inbound_message_channel: self.inbound_message_channel,
             unpack_forwards: self.unpack_forwards,
-            discover_features: Arc::new(RwLock::new(self.discover_features)),
+            discover_features: Arc::new(RwLock::new(discover_features)),
             curve_preference: self.curve_preference,
             request_timeout: self.request_timeout,
             clock: self.clock.unwrap_or_else(|| Arc::new(SystemClock)),

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -186,7 +186,7 @@ use crate::protocols::tsp::TspOps;
 #[cfg(feature = "tsp")]
 pub use crate::protocols::tsp::{
     CapabilitySource, InMemoryRelationshipStore, PeerCapability, RelationshipStore, SendProtocol,
-    TspPolicy, TspSupport, TspWebSocket,
+    TSP_DISCOVER_FEATURE_URI, TspPolicy, TspSupport, TspWebSocket,
 };
 /// Re-export of the pure-TSP authentication handler so a TSP-only client can
 /// register it on the TDK in place of the built-in DIDComm auth flow.

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -347,10 +347,9 @@ fn classify_protocol(
 /// [`TspOps::learn_from_disclosure`] so the match is unit-testable without a live
 /// `ATM`.
 fn disclosure_advertises_tsp(disclosure: &DiscoverFeaturesDisclosure) -> bool {
-    disclosure
-        .disclosures
-        .iter()
-        .any(|d| matches!(d.feature_type, FeatureType::Protocol) && d.id == TSP_DISCOVER_FEATURE_URI)
+    disclosure.disclosures.iter().any(|d| {
+        matches!(d.feature_type, FeatureType::Protocol) && d.id == TSP_DISCOVER_FEATURE_URI
+    })
 }
 
 /// Under `Required`, no-TSP is a denial; otherwise fall back to DIDComm.
@@ -1455,12 +1454,7 @@ mod tests {
             async fn get(&self, _: &str, _: &str) -> Result<RelationshipState, ATMError> {
                 Ok(RelationshipState::None)
             }
-            async fn set(
-                &self,
-                _: &str,
-                _: &str,
-                _: RelationshipState,
-            ) -> Result<(), ATMError> {
+            async fn set(&self, _: &str, _: &str, _: RelationshipState) -> Result<(), ATMError> {
                 Ok(())
             }
         }
@@ -1473,7 +1467,11 @@ mod tests {
 
     #[test]
     fn classify_off_is_always_didcomm() {
-        for cap in [None, Some(TspSupport::Supported), Some(TspSupport::Unsupported)] {
+        for cap in [
+            None,
+            Some(TspSupport::Supported),
+            Some(TspSupport::Unsupported),
+        ] {
             for bidi in [false, true] {
                 for svc in [false, true] {
                     assert_eq!(
@@ -1500,11 +1498,21 @@ mod tests {
     fn classify_cached_unsupported_short_circuits() {
         // Unsupported wins even when a TSPTransport service is present.
         assert_eq!(
-            classify_protocol(TspPolicy::Preferred, Some(TspSupport::Unsupported), true, true),
+            classify_protocol(
+                TspPolicy::Preferred,
+                Some(TspSupport::Unsupported),
+                true,
+                true
+            ),
             ProtocolChoice::DidComm
         );
         assert_eq!(
-            classify_protocol(TspPolicy::Required, Some(TspSupport::Unsupported), true, true),
+            classify_protocol(
+                TspPolicy::Required,
+                Some(TspSupport::Unsupported),
+                true,
+                true
+            ),
             ProtocolChoice::Deny
         );
     }
@@ -1540,7 +1548,12 @@ mod tests {
         );
         // Unknown cached capability behaves like no cache.
         assert_eq!(
-            classify_protocol(TspPolicy::Preferred, Some(TspSupport::Unknown), false, false),
+            classify_protocol(
+                TspPolicy::Preferred,
+                Some(TspSupport::Unknown),
+                false,
+                false
+            ),
             ProtocolChoice::DidComm
         );
     }
@@ -1677,7 +1690,9 @@ mod tests {
     fn disclosure_without_tsp_uri_is_not() {
         let d = protocol_disclosure(&["https://didcomm.org/trust-ping/2.0"]);
         assert!(!disclosure_advertises_tsp(&d));
-        assert!(!disclosure_advertises_tsp(&DiscoverFeaturesDisclosure::default()));
+        assert!(!disclosure_advertises_tsp(
+            &DiscoverFeaturesDisclosure::default()
+        ));
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -36,6 +36,19 @@ use tokio::sync::RwLock;
 use crate::ATM;
 use crate::errors::ATMError;
 use crate::profiles::ATMProfile;
+use crate::protocols::discover_features::{
+    DiscoverFeaturesDisclosure, DiscoverFeaturesQuery, FeatureType, Query,
+};
+use affinidi_messaging_didcomm::message::Message;
+
+/// DIDComm [Discover Features 2.0](https://identity.foundation/didcomm-messaging/spec/#discover-features-protocol-20)
+/// protocol URI that advertises an agent accepts TSP messages.
+///
+/// Advertise it in the discoverable state (see [`TspOps::advertise_capability`])
+/// so a peer can learn our TSP capability proactively; consuming a peer's
+/// disclosure that lists it (see [`TspOps::learn_from_disclosure`]) caches the
+/// peer as [`TspSupport::Supported`] with source [`CapabilitySource::DiscoverFeatures`].
+pub const TSP_DISCOVER_FEATURE_URI: &str = "https://affinidi.com/tsp/1.0";
 
 /// Which wire protocol [`crate::ATM::send_to`] chose for a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +105,9 @@ pub enum CapabilitySource {
     DidDocument,
     /// Observed from an inbound TSP message the peer sent us.
     Observed,
+    /// Learned from a peer's DIDComm Discover Features 2.0 disclosure that
+    /// advertised the TSP capability URI ([`TSP_DISCOVER_FEATURE_URI`]).
+    DiscoverFeatures,
     /// Set explicitly by the application.
     Manual,
 }
@@ -324,6 +340,17 @@ fn classify_protocol(
     }
     // 3. No TSP signal.
     deny_or_didcomm(policy)
+}
+
+/// Whether a Discover Features 2.0 disclosure advertises the TSP capability URI
+/// ([`TSP_DISCOVER_FEATURE_URI`]) as a supported protocol. Factored out of
+/// [`TspOps::learn_from_disclosure`] so the match is unit-testable without a live
+/// `ATM`.
+fn disclosure_advertises_tsp(disclosure: &DiscoverFeaturesDisclosure) -> bool {
+    disclosure
+        .disclosures
+        .iter()
+        .any(|d| matches!(d.feature_type, FeatureType::Protocol) && d.id == TSP_DISCOVER_FEATURE_URI)
 }
 
 /// Under `Required`, no-TSP is a denial; otherwise fall back to DIDComm.
@@ -761,6 +788,72 @@ impl TspOps<'_> {
         self.relationship_store()
             .set_capability(our_did, their_did, cap)
             .await
+    }
+
+    /// Advertise this agent's TSP capability in its Discover Features 2.0
+    /// discoverable state, so a peer that queries our supported protocols learns
+    /// we accept TSP and can proactively prefer it. Adds
+    /// [`TSP_DISCOVER_FEATURE_URI`] to the shared discoverable protocol list
+    /// (idempotent).
+    ///
+    /// Enabling a non-[`Off`](TspPolicy::Off) [`TspPolicy`] auto-advertises this
+    /// at SDK construction; call this to advertise at runtime or under `Off`.
+    pub async fn advertise_capability(&self) {
+        let state = self.atm.inner.config.discover_features.clone();
+        let mut features = state.write().await;
+        if !features
+            .protocols
+            .iter()
+            .any(|p| p == TSP_DISCOVER_FEATURE_URI)
+        {
+            features
+                .protocols
+                .push(TSP_DISCOVER_FEATURE_URI.to_string());
+        }
+    }
+
+    /// Build a DIDComm Discover Features 2.0 query that asks `to_did` whether it
+    /// supports TSP (matches [`TSP_DISCOVER_FEATURE_URI`]). Pack + send it like
+    /// any DIDComm message; feed the peer's disclosure response to
+    /// [`learn_from_disclosure`](Self::learn_from_disclosure) to populate the
+    /// capability cache before the first message.
+    pub fn capability_query(&self, from_did: &str, to_did: &str) -> Result<Message, ATMError> {
+        self.atm.discover_features().generate_query_message(
+            from_did,
+            to_did,
+            DiscoverFeaturesQuery {
+                queries: vec![Query {
+                    feature_type: FeatureType::Protocol,
+                    match_: TSP_DISCOVER_FEATURE_URI.to_string(),
+                }],
+            },
+        )
+    }
+
+    /// Consume a peer's Discover Features 2.0 disclosure: if it advertises the
+    /// TSP capability URI, cache the peer as [`TspSupport::Supported`]
+    /// (source [`CapabilitySource::DiscoverFeatures`]) so a later
+    /// [`send_to`](crate::ATM::send_to) can prefer TSP *before* any relationship
+    /// or observed inbound TSP.
+    ///
+    /// Returns whether the disclosure advertised TSP. A disclosure that omits the
+    /// URI is left untouched (not marked `Unsupported`) — a scoped disclosure may
+    /// simply not have been queried for it. A no-op under [`TspPolicy::Off`]
+    /// (like the other capability-learning paths, tracking is inert unless
+    /// protocol selection is enabled).
+    pub async fn learn_from_disclosure(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+        disclosure: &DiscoverFeaturesDisclosure,
+    ) -> Result<bool, ATMError> {
+        let advertises_tsp = disclosure_advertises_tsp(disclosure);
+        if advertises_tsp {
+            let (our_did, _) = profile.dids()?;
+            self.learn_tsp_supported(our_did, their_did, CapabilitySource::DiscoverFeatures)
+                .await?;
+        }
+        Ok(advertises_tsp)
     }
 
     /// Whether a cached capability is still within the configured TTL (`None`
@@ -1296,10 +1389,14 @@ mod tests {
 
     use super::{
         CapabilitySource, InMemoryRelationshipStore, PeerCapability, ProtocolChoice,
-        RelationshipEvent, RelationshipState, RelationshipStore, TspPolicy, TspSupport,
-        advance_state, classify_protocol, next_state,
+        RelationshipEvent, RelationshipState, RelationshipStore, TSP_DISCOVER_FEATURE_URI,
+        TspPolicy, TspSupport, advance_state, classify_protocol, disclosure_advertises_tsp,
+        next_state,
     };
     use crate::errors::ATMError;
+    use crate::protocols::discover_features::{
+        Disclosure, DiscoverFeaturesDisclosure, FeatureType,
+    };
     use std::sync::Arc;
 
     const ALICE: &str = "did:example:alice";
@@ -1550,5 +1647,57 @@ mod tests {
             _ => unreachable!(),
         };
         assert!(RelationshipState::Bidirectional.transition(e).is_ok());
+    }
+
+    // ── Discover Features → capability (pure) ──────────────────────────────────
+
+    fn protocol_disclosure(ids: &[&str]) -> DiscoverFeaturesDisclosure {
+        DiscoverFeaturesDisclosure {
+            disclosures: ids
+                .iter()
+                .map(|id| Disclosure {
+                    feature_type: FeatureType::Protocol,
+                    id: (*id).to_string(),
+                    roles: vec![],
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn disclosure_with_tsp_uri_is_recognised() {
+        let d = protocol_disclosure(&[
+            "https://didcomm.org/trust-ping/2.0",
+            TSP_DISCOVER_FEATURE_URI,
+        ]);
+        assert!(disclosure_advertises_tsp(&d));
+    }
+
+    #[test]
+    fn disclosure_without_tsp_uri_is_not() {
+        let d = protocol_disclosure(&["https://didcomm.org/trust-ping/2.0"]);
+        assert!(!disclosure_advertises_tsp(&d));
+        assert!(!disclosure_advertises_tsp(&DiscoverFeaturesDisclosure::default()));
+    }
+
+    #[test]
+    fn tsp_uri_under_non_protocol_feature_type_is_ignored() {
+        // The same string disclosed as a goal code / header must not count as a
+        // protocol capability.
+        let d = DiscoverFeaturesDisclosure {
+            disclosures: vec![
+                Disclosure {
+                    feature_type: FeatureType::GoalCode,
+                    id: TSP_DISCOVER_FEATURE_URI.to_string(),
+                    roles: vec![],
+                },
+                Disclosure {
+                    feature_type: FeatureType::Header,
+                    id: TSP_DISCOVER_FEATURE_URI.to_string(),
+                    roles: vec![],
+                },
+            ],
+        };
+        assert!(!disclosure_advertises_tsp(&d));
     }
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.36"
+version = "0.2.37"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
@@ -93,14 +93,20 @@ async fn observed_inbound_tsp_upgrades_send_to() {
         .send_to(&alice.profile, &m2, &bob.did, Some(&alice.did), None)
         .await
         .expect("send_to bob (2)");
-    assert_eq!(via2, SendProtocol::Tsp, "learned capability upgrades to TSP");
+    assert_eq!(
+        via2,
+        SendProtocol::Tsp,
+        "learned capability upgrades to TSP"
+    );
 }
 
 /// Under the default `Off` policy, capability tracking is inert — observing an
 /// inbound TSP message writes nothing, so behaviour is unchanged.
 #[tokio::test]
 async fn observed_inbound_is_inert_under_off_policy() {
-    let env = TestEnvironment::spawn().await.expect("spawn default (Off) env");
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn default (Off) env");
     let alice = env.add_user("alice").await.expect("add alice");
     let bob = env.add_user("bob").await.expect("add bob");
 

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
@@ -27,7 +27,10 @@ fn basic_message(from: &str, to: &str, text: &str) -> Message {
 /// The disclosure a responder would return for `query`, calculated from its own
 /// live discoverable state — the real production path
 /// (`get_discoverable_state` → `calculate_disclosure`).
-async fn disclosure_for_query(env: &TestEnvironment, query: &Message) -> DiscoverFeaturesDisclosure {
+async fn disclosure_for_query(
+    env: &TestEnvironment,
+    query: &Message,
+) -> DiscoverFeaturesDisclosure {
     let query_body: DiscoverFeaturesQuery =
         serde_json::from_value(query.body.clone()).expect("parse query body");
     let state = env.atm.discover_features().get_discoverable_state();
@@ -127,12 +130,14 @@ async fn disclosure_without_tsp_uri_stays_didcomm() {
 
     // A disclosure listing only an unrelated protocol.
     let disclosure = DiscoverFeaturesDisclosure {
-        disclosures: vec![affinidi_messaging_sdk::protocols::discover_features::Disclosure {
-            feature_type:
-                affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
-            id: "https://didcomm.org/trust-ping/2.0".to_string(),
-            roles: vec![],
-        }],
+        disclosures: vec![
+            affinidi_messaging_sdk::protocols::discover_features::Disclosure {
+                feature_type:
+                    affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
+                id: "https://didcomm.org/trust-ping/2.0".to_string(),
+                roles: vec![],
+            },
+        ],
     };
     let learned = env
         .atm
@@ -164,7 +169,9 @@ async fn disclosure_without_tsp_uri_stays_didcomm() {
 /// consuming a disclosure that lists it is inert — capability tracking stays off.
 #[tokio::test]
 async fn discovery_is_inert_under_off_policy() {
-    let env = TestEnvironment::spawn().await.expect("spawn default (Off) env");
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn default (Off) env");
     let alice = env.add_user("alice").await.expect("add alice");
     let bob = env.add_user("bob").await.expect("add bob");
 
@@ -183,12 +190,14 @@ async fn discovery_is_inert_under_off_policy() {
 
     // Even handed a disclosure that *does* advertise TSP, learning is a no-op.
     let forced = DiscoverFeaturesDisclosure {
-        disclosures: vec![affinidi_messaging_sdk::protocols::discover_features::Disclosure {
-            feature_type:
-                affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
-            id: TSP_DISCOVER_FEATURE_URI.to_string(),
-            roles: vec![],
-        }],
+        disclosures: vec![
+            affinidi_messaging_sdk::protocols::discover_features::Disclosure {
+                feature_type:
+                    affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
+                id: TSP_DISCOVER_FEATURE_URI.to_string(),
+                roles: vec![],
+            },
+        ],
     };
     let learned = env
         .atm

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
@@ -1,0 +1,209 @@
+//! End-to-end coverage of **proactive** TSP capability discovery (issue #576):
+//! a sender learns a peer speaks TSP from a DIDComm Discover Features 2.0
+//! disclosure — *before* any relationship or observed inbound TSP — so the
+//! next `atm.send_to` upgrades DIDComm → TSP.
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::protocols::discover_features::{
+    DiscoverFeaturesDisclosure, DiscoverFeaturesQuery,
+};
+use affinidi_messaging_sdk::{SendProtocol, TSP_DISCOVER_FEATURE_URI, TspPolicy, TspSupport};
+use affinidi_messaging_test_mediator::TestEnvironment;
+use serde_json::json;
+use uuid::Uuid;
+
+fn basic_message(from: &str, to: &str, text: &str) -> Message {
+    Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(to.to_string())
+    .from(from.to_string())
+    .finalize()
+}
+
+/// The disclosure a responder would return for `query`, calculated from its own
+/// live discoverable state — the real production path
+/// (`get_discoverable_state` → `calculate_disclosure`).
+async fn disclosure_for_query(env: &TestEnvironment, query: &Message) -> DiscoverFeaturesDisclosure {
+    let query_body: DiscoverFeaturesQuery =
+        serde_json::from_value(query.body.clone()).expect("parse query body");
+    let state = env.atm.discover_features().get_discoverable_state();
+    let features = state.read().await;
+    features.calculate_disclosure(&query_body)
+}
+
+/// The headline #576 behaviour: alice discovers bob's TSP capability via a
+/// Discover Features query/disclosure round-trip, with no prior relationship or
+/// inbound TSP, and her next `send_to` upgrades to TSP.
+#[tokio::test]
+async fn discover_features_disclosure_upgrades_send_to() {
+    // Preferred policy auto-advertises the TSP URI in the discoverable state, so
+    // bob's disclosure will list it.
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // No signal yet → DIDComm.
+    assert_eq!(
+        env.atm
+            .tsp()
+            .peer_capability(&alice.profile, &bob.did)
+            .await
+            .unwrap(),
+        None
+    );
+    let m1 = basic_message(&alice.did, &bob.did, "first");
+    let via1 = env
+        .atm
+        .send_to(&alice.profile, &m1, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob (1)");
+    assert_eq!(via1, SendProtocol::DidComm, "no TSP signal yet → DIDComm");
+
+    // Alice asks bob what he supports; bob answers from his discoverable state.
+    let query = env
+        .atm
+        .tsp()
+        .capability_query(&alice.did, &bob.did)
+        .expect("build capability query");
+    let disclosure = disclosure_for_query(&env, &query).await;
+    assert!(
+        disclosure
+            .disclosures
+            .iter()
+            .any(|d| d.id == TSP_DISCOVER_FEATURE_URI),
+        "bob's disclosure advertises the TSP capability URI"
+    );
+
+    // Alice consumes the disclosure → bob cached Supported (source DiscoverFeatures).
+    let learned = env
+        .atm
+        .tsp()
+        .learn_from_disclosure(&alice.profile, &bob.did, &disclosure)
+        .await
+        .expect("learn from disclosure");
+    assert!(learned, "disclosure advertised TSP");
+    assert!(
+        matches!(
+            env.atm
+                .tsp()
+                .peer_capability(&alice.profile, &bob.did)
+                .await
+                .unwrap()
+                .map(|c| c.tsp),
+            Some(TspSupport::Supported)
+        ),
+        "discovery marks bob Supported"
+    );
+
+    // send_to now upgrades to TSP — before any relationship or inbound TSP.
+    let m2 = basic_message(&alice.did, &bob.did, "second");
+    let via2 = env
+        .atm
+        .send_to(&alice.profile, &m2, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob (2)");
+    assert_eq!(
+        via2,
+        SendProtocol::Tsp,
+        "discovered capability upgrades to TSP"
+    );
+}
+
+/// A disclosure that does not advertise the TSP URI leaves the peer unknown and
+/// `send_to` stays on DIDComm (no false positive, no `Unsupported` write).
+#[tokio::test]
+async fn disclosure_without_tsp_uri_stays_didcomm() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // A disclosure listing only an unrelated protocol.
+    let disclosure = DiscoverFeaturesDisclosure {
+        disclosures: vec![affinidi_messaging_sdk::protocols::discover_features::Disclosure {
+            feature_type:
+                affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
+            id: "https://didcomm.org/trust-ping/2.0".to_string(),
+            roles: vec![],
+        }],
+    };
+    let learned = env
+        .atm
+        .tsp()
+        .learn_from_disclosure(&alice.profile, &bob.did, &disclosure)
+        .await
+        .expect("learn from disclosure");
+    assert!(!learned, "no TSP URI → nothing learned");
+    assert_eq!(
+        env.atm
+            .tsp()
+            .peer_capability(&alice.profile, &bob.did)
+            .await
+            .unwrap(),
+        None,
+        "peer stays unknown"
+    );
+
+    let m = basic_message(&alice.did, &bob.did, "hello");
+    let via = env
+        .atm
+        .send_to(&alice.profile, &m, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob");
+    assert_eq!(via, SendProtocol::DidComm);
+}
+
+/// Under the default `Off` policy the TSP URI is not auto-advertised and
+/// consuming a disclosure that lists it is inert — capability tracking stays off.
+#[tokio::test]
+async fn discovery_is_inert_under_off_policy() {
+    let env = TestEnvironment::spawn().await.expect("spawn default (Off) env");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Off policy does not auto-advertise, so a query against our own state finds
+    // no TSP URI.
+    let query = env
+        .atm
+        .tsp()
+        .capability_query(&alice.did, &bob.did)
+        .expect("build capability query");
+    let disclosure = disclosure_for_query(&env, &query).await;
+    assert!(
+        disclosure.disclosures.is_empty(),
+        "Off policy advertises no TSP URI"
+    );
+
+    // Even handed a disclosure that *does* advertise TSP, learning is a no-op.
+    let forced = DiscoverFeaturesDisclosure {
+        disclosures: vec![affinidi_messaging_sdk::protocols::discover_features::Disclosure {
+            feature_type:
+                affinidi_messaging_sdk::protocols::discover_features::FeatureType::Protocol,
+            id: TSP_DISCOVER_FEATURE_URI.to_string(),
+            roles: vec![],
+        }],
+    };
+    let learned = env
+        .atm
+        .tsp()
+        .learn_from_disclosure(&alice.profile, &bob.did, &forced)
+        .await
+        .expect("learn from disclosure");
+    assert!(learned, "the URI was present in the disclosure");
+    assert_eq!(
+        env.atm
+            .tsp()
+            .peer_capability(&alice.profile, &bob.did)
+            .await
+            .unwrap(),
+        None,
+        "Off policy tracks no capability even when told"
+    );
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_send_to.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_send_to.rs
@@ -63,7 +63,8 @@ async fn send_to_uses_tsp_when_capability_supported() {
         .unpack(&bob.profile, stored)
         .await
         .expect("bob unpacks the TSP message");
-    let recovered: Message = serde_json::from_slice(&payload).expect("payload is a DIDComm Message");
+    let recovered: Message =
+        serde_json::from_slice(&payload).expect("payload is a DIDComm Message");
     assert_eq!(recovered.body["content"], "hi over the façade");
     assert_eq!(sender, alice.did);
 }

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -50,15 +50,21 @@ if [ -z "$changed" ]; then
   exit 0
 fi
 
-# Publishable crates as  name<TAB>relative-crate-dir  lines, longest dir first
+# ALL crates as  pub<TAB>name<TAB>relative-crate-dir  lines, longest dir first
 # so the most specific crate wins for nested manifests (e.g. affinidi-tdk vs
-# affinidi-tdk/common).
+# affinidi-tdk/common). `pub` is 1 for publishable, 0 otherwise.
+#
+# We include non-publishable crates here (not just publishable ones) so a file
+# under a nested `publish = false` package (e.g. the mediator-setup tool nested
+# in the publishable affinidi-messaging-mediator dir) is attributed to that
+# nested package and skipped — rather than bubbling up to the publishable parent
+# and demanding a spurious bump for source that never reaches crates.io.
 crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
   | jq -r '.packages[]
-      | select(.publish == null or .publish == ["crates.io"])
-      | "\(.name)\t\(.manifest_path)"' \
+      | (if (.publish == null or .publish == ["crates.io"]) then "1" else "0" end) as $pub
+      | "\($pub)\t\(.name)\t\(.manifest_path)"' \
   | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||" \
-  | awk -F'\t' '{ print length($2)"\t"$0 }' \
+  | awk -F'\t' '{ print length($3)"\t"$0 }' \
   | sort -rn \
   | cut -f2-)
 
@@ -74,13 +80,13 @@ is_source() {
   esac
 }
 
-# attribute a changed file to its most-specific publishable crate dir
-crate_of() { # $1 = changed path -> prints "name<TAB>dir" or nothing
-  local path="$1" name dir
-  while IFS=$'\t' read -r name dir; do
+# attribute a changed file to its most-specific crate dir (publishable or not)
+crate_of() { # $1 = changed path -> prints "pub<TAB>name<TAB>dir" or nothing
+  local path="$1" pub name dir
+  while IFS=$'\t' read -r pub name dir; do
     [ -z "$dir" ] && continue
     case "$path" in
-      "$dir"/*) printf '%s\t%s\n' "$name" "$dir"; return 0 ;;
+      "$dir"/*) printf '%s\t%s\t%s\n' "$pub" "$name" "$dir"; return 0 ;;
     esac
   done <<EOF
 $crates
@@ -93,8 +99,12 @@ while IFS= read -r f; do
   [ -z "$f" ] && continue
   hit=$(crate_of "$f") || true
   [ -z "$hit" ] && continue
-  name=$(printf '%s' "$hit" | cut -f1)
-  dir=$(printf '%s' "$hit" | cut -f2)
+  pub=$(printf '%s' "$hit" | cut -f1)
+  name=$(printf '%s' "$hit" | cut -f2)
+  dir=$(printf '%s' "$hit" | cut -f3)
+  # A file whose most-specific owner is a non-publishable crate never reaches
+  # crates.io (even when nested under a publishable parent dir) — skip it.
+  [ "$pub" = "1" ] || continue
   rel=${f#"$dir"/}
   is_source "$rel" || continue
   case "


### PR DESCRIPTION
Closes #576. Follow-up to #571 (P1 #573, P2 #575).

## Problem
Today a peer's TSP capability is learned **reactively** — from a completed relationship (`CapabilitySource::Relationship`) or an observed inbound TSP message (`CapabilitySource::Observed`). Before any such signal, `atm.send_to` defaults to DIDComm for a brand-new peer (notably a did:key peer with no DID-doc `TSPTransport` service). This adds the "P2b" path deliberately deferred in the SDD: advertise + consume a TSP capability URI over DIDComm **Discover Features 2.0**, so a sender can learn a peer's TSP capability **proactively**, before the first message.

## Changes
**SDK — `affinidi-messaging-sdk` 0.18.45 → 0.18.46**
- `TSP_DISCOVER_FEATURE_URI` (`https://affinidi.com/tsp/1.0`) — the TSP capability protocol URI, re-exported at the crate root.
- `CapabilitySource::DiscoverFeatures` — new provenance variant.
- `TspOps::advertise_capability()` — idempotently adds the URI to the Discover Features discoverable state. Enabling a non-`Off` `TspPolicy` now **auto-advertises** it at SDK construction (symmetric with `send_to` preferring TSP for supported peers).
- `TspOps::capability_query()` — builds a Discover Features query for the URI.
- `TspOps::learn_from_disclosure()` — turns a disclosure listing the URI into `set_peer_capability(Supported, source=DiscoverFeatures)`. A disclosure that omits it is left untouched (**not** marked `Unsupported` — a scoped disclosure may simply not have queried for it). Inert under `TspPolicy::Off`, matching the other capability-learning paths.

**Tests — `affinidi-messaging-test-mediator` 0.2.36 → 0.2.37**
- Unit: `disclosure_advertises_tsp` truth table (present / absent / wrong feature-type).
- e2e `tsp_discover_capability.rs`: a query→disclose→consume round-trip upgrades `send_to` DIDComm → TSP **before** any relationship or inbound TSP; a non-advertising disclosure stays DIDComm; discovery is inert under `Off`.

## Notes
- Additive, patch bumps only; all `affinidi-messaging-sdk` pins are `"0.18"` (major.minor) so no consumer bumps needed.
- Clippy clean with `-D warnings` on both the default and `tsp` feature sets.
- Selection/precedence (`classify_protocol`) is unchanged — this only feeds the existing capability cache a new, earlier source.

Parked sibling remains: #577 (cross-mediator routing for service-less/did:key recipients).

---
### Note on the second commit (`style: cargo fmt --all`)
CI runs `cargo fmt --all -- --check` workspace-wide. The pinned 1.95.0 rustfmt flags pre-existing drift on `main` beyond this feature — in `mediator-setup`'s `did_peer`/`did_webvh` generators and the existing TSP e2e tests — so those files are swept clean here too. Pure formatting, no token/behaviour changes. `mediator-setup` is `publish = false`, so no version bump (version-bump guard skips it).

### Note on the third commit (`fix: … version-bump guard`)
The workspace-wide fmt fix above touched `mediator-setup`'s generators, which are a nested `publish = false` package inside the publishable `affinidi-messaging-mediator` dir. The version-bump guard attributed those files to the publishable parent and demanded a spurious mediator bump. Fixed the guard to attribute a changed file to its **most-specific** owning crate (publishable or not) and skip it when that owner is non-publishable — so nested `publish = false` source no longer forces a parent bump. Publishable nested cases (e.g. `affinidi-tdk` vs `affinidi-tdk/common`) are unaffected. Verified locally: the guard now flags only the bumped `sdk`/`test-mediator`.
