### PR TITLE
fix: make the offline-sync poller TSP-aware to stop a poison loop

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.16] - 2026-07-03
+
+- Fix a TSP poison-loop in the offline-sync poller. `AffinidiMessageService` runs a periodic
+  offline/backlog drain (`run_periodic_offline_sync`, every 30s) alongside the TSP-aware live
+  loop, but that drain was DIDComm-only: it blindly `atm.unpack()`d every queued message, so
+  a queued **TSP** frame failed to unpack ("Cannot parse message as JSON") and — never being
+  acked/deleted — was redelivered every 30s forever. The drain is now TSP-aware: it fetches
+  the backlog via the new `send_delivery_request_frames`, routes TSP frames to the same
+  `TspHandler` the live loop uses, dispatches DIDComm frames as before, and acks **all**
+  fetched frames (including undeliverable ones) so nothing loops. `tsp`-feature only; the
+  DIDComm-only path is unchanged.
+
 ## [0.3.15] - 2026-07-02
 
 - Fix inbound TSP: `dispatch_tsp` handed the **qb64** pickup string (`base64url(qb2)`, `-E…`

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.15"
+version = "0.3.16"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -199,12 +199,14 @@ impl Listener {
         let atm_clone = atm.clone();
         let profile_clone = profile.clone();
         let handler_clone = self.handler.clone();
+        let tsp_handler_clone = self.tsp_handler.clone();
         tasks.spawn(async move {
             Listener::run_periodic_offline_sync(
                 &listener_id,
                 &atm_clone,
                 &profile_clone,
                 &handler_clone,
+                tsp_handler_clone.as_ref(),
                 &shutdown_clone,
             )
             .await;

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -11,7 +11,7 @@ use trust_tasks_rs::specs::messaging::acl;
 
 use super::listener::Listener;
 use crate::error::{DIDCommServiceError, StartupError};
-use crate::handler::DIDCommHandler;
+use crate::handler::{DIDCommHandler, TspHandler};
 
 const OFFLINE_SYNC_INTERVAL_SECS: u64 = 30;
 /// Short retry used only when the very first drains can't run yet because the
@@ -56,6 +56,7 @@ impl Listener {
         atm: &ATM,
         profile: &Arc<ATMProfile>,
         handler: &Arc<dyn DIDCommHandler>,
+        tsp_handler: Option<&Arc<dyn TspHandler>>,
         shutdown: &CancellationToken,
     ) {
         let profile_alias = profile.inner.alias.clone();
@@ -71,6 +72,7 @@ impl Listener {
                 atm,
                 profile,
                 handler,
+                tsp_handler,
             )
             .await
             {
@@ -111,6 +113,7 @@ impl Listener {
         atm: &ATM,
         profile: &Arc<ATMProfile>,
         handler: &Arc<dyn DIDCommHandler>,
+        tsp_handler: Option<&Arc<dyn TspHandler>>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let wait_for_response = true;
         let messages_limit = 100;
@@ -127,31 +130,92 @@ impl Listener {
             return Ok(());
         }
 
-        let offline_messages = atm
-            .message_pickup()
-            .send_delivery_request(profile, Some(messages_limit), wait_for_response)
-            .await?;
+        // TSP-aware drain: fetch the backlog as classified frames so a TSP
+        // frame goes to the TSP handler (like the live loop) instead of being
+        // DIDComm-unpacked and left to poison-loop. Undeliverable frames are
+        // acked too so the mediator stops redelivering them.
+        #[cfg(feature = "tsp")]
+        {
+            use affinidi_messaging_sdk::protocols::message_pickup::InboundFrame;
 
-        let message_ids: Vec<_> = offline_messages.iter().map(|(m, _)| m.id.clone()).collect();
+            let frames = atm
+                .message_pickup()
+                .send_delivery_request_frames(profile, Some(messages_limit), wait_for_response)
+                .await?;
 
-        debug!(profile = %profile.inner.alias, count = offline_messages.len(), "Retrieved offline messages");
+            let ack_ids: Vec<String> = frames.iter().map(|(_, id)| id.clone()).collect();
+            debug!(profile = %profile.inner.alias, count = frames.len(), "Retrieved offline frames");
 
-        for (message, meta) in offline_messages {
-            let meta = super::listener::convert_meta(meta);
-            Listener::dispatch_message(listener_id, atm, profile, handler, message, meta).await;
+            for (frame, _id) in frames {
+                match frame {
+                    Some(InboundFrame::DidComm(message, meta)) => {
+                        let meta = super::listener::convert_meta(*meta);
+                        Listener::dispatch_message(listener_id, atm, profile, handler, *message, meta)
+                            .await;
+                    }
+                    Some(InboundFrame::Tsp(packed)) => match tsp_handler {
+                        Some(h) => {
+                            Listener::dispatch_tsp(listener_id, atm, profile, h, *packed).await;
+                        }
+                        None => warn!(
+                            profile = %profile.inner.alias,
+                            "Offline TSP frame but no TSP handler configured — dropping (acked)"
+                        ),
+                    },
+                    // `InboundFrame` is `#[non_exhaustive]`.
+                    Some(_) => warn!(
+                        profile = %profile.inner.alias,
+                        "Unrecognised offline frame kind — dropping (acked)"
+                    ),
+                    // Undeliverable (bad encoding / DIDComm unpack failure): drop
+                    // it; it's in `ack_ids` so the mediator stops redelivering.
+                    None => {}
+                }
+            }
+
+            if !ack_ids.is_empty() {
+                let delete_result = atm
+                    .message_pickup()
+                    .send_messages_received(profile, &ack_ids, wait_for_response)
+                    .await?;
+                if delete_result.is_none() {
+                    warn!(profile = %profile.inner.alias, "No status reply for offline messages ack");
+                }
+            }
+
+            Ok(())
         }
 
-        let delete_result = atm
-            .message_pickup()
-            .send_messages_received(profile, &message_ids, wait_for_response)
-            .await?;
+        #[cfg(not(feature = "tsp"))]
+        {
+            let _ = tsp_handler;
 
-        if delete_result.is_some() {
-            debug!(profile = %profile.inner.alias, "Offline messages acknowledged and deleted");
-        } else {
-            warn!(profile = %profile.inner.alias, "No status reply for offline messages ack");
+            let offline_messages = atm
+                .message_pickup()
+                .send_delivery_request(profile, Some(messages_limit), wait_for_response)
+                .await?;
+
+            let message_ids: Vec<_> = offline_messages.iter().map(|(m, _)| m.id.clone()).collect();
+
+            debug!(profile = %profile.inner.alias, count = offline_messages.len(), "Retrieved offline messages");
+
+            for (message, meta) in offline_messages {
+                let meta = super::listener::convert_meta(meta);
+                Listener::dispatch_message(listener_id, atm, profile, handler, message, meta).await;
+            }
+
+            let delete_result = atm
+                .message_pickup()
+                .send_messages_received(profile, &message_ids, wait_for_response)
+                .await?;
+
+            if delete_result.is_some() {
+                debug!(profile = %profile.inner.alias, "Offline messages acknowledged and deleted");
+            } else {
+                warn!(profile = %profile.inner.alias, "No status reply for offline messages ack");
+            }
+
+            Ok(())
         }
-
-        Ok(())
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.18.47] - 2026-07-03
+
+- Add `MessagePickup::send_delivery_request_frames` (+ `MessagePickupOps` delegate), the
+  offline/backlog counterpart of `live_stream_next_frame`: it returns each queued message as
+  an `InboundFrame` (DIDComm or TSP) paired with its ack id, so an offline-sync consumer can
+  route TSP frames to a TSP handler instead of DIDComm-unpacking (and poison-looping on)
+  them. Undeliverable attachments (bad encoding, or a non-TSP frame that fails DIDComm
+  unpack) yield `(None, id)` so the caller still acks them. `tsp`-feature only; additive.
+
 ## [0.18.45] - 2026-07-02
 
 - TSP capability learning (SDD phase 2): the per-peer TSP capability cache is now

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.46"
+version = "0.18.47"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -546,6 +546,42 @@ impl MessagePickup {
         limit: Option<usize>,
         wait_for_response: bool,
     ) -> Result<Vec<(Message, UnpackMetadata)>, ATMError> {
+        let message = self
+            ._request_delivery(atm, profile, limit, wait_for_response)
+            .await?;
+        self._handle_delivery(atm, &message).await
+    }
+
+    /// TSP-aware sibling of [`send_delivery_request`]: returns each queued
+    /// message as an [`InboundFrame`] (DIDComm or TSP) paired with the
+    /// attachment id needed to acknowledge/delete it — so an offline-sync
+    /// consumer can route TSP frames to a TSP handler instead of DIDComm-
+    /// unpacking (and poison-looping on) them. Undeliverable attachments yield
+    /// `(None, id)` so the caller still acks them. Requires the `tsp` feature.
+    #[cfg(feature = "tsp")]
+    pub async fn send_delivery_request_frames(
+        &self,
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        limit: Option<usize>,
+        wait_for_response: bool,
+    ) -> Result<Vec<(Option<InboundFrame>, String)>, ATMError> {
+        let message = self
+            ._request_delivery(atm, profile, limit, wait_for_response)
+            .await?;
+        self._handle_delivery_frames(atm, &message).await
+    }
+
+    /// Send a Message-Pickup 3.0 delivery-request and return the mediator's
+    /// `delivery` message (whose attachments are the queued messages). Shared by
+    /// [`send_delivery_request`] and [`send_delivery_request_frames`].
+    async fn _request_delivery(
+        &self,
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        limit: Option<usize>,
+        wait_for_response: bool,
+    ) -> Result<Message, ATMError> {
         let _span = span!(Level::DEBUG, "send_delivery_request",);
 
         async move {
@@ -597,12 +633,79 @@ impl MessagePickup {
                 .send_message(profile, &msg, &msg_id, wait_for_response, false)
                 .await?
             {
-                SendMessageResponse::Message(message) => self._handle_delivery(atm, &message).await,
+                SendMessageResponse::Message(message) => Ok(*message),
                 _ => Err(ATMError::MsgReceiveError("No Messages from API".into())),
             }
         }
         .instrument(_span)
         .await
+    }
+
+    /// TSP-aware sibling of [`_handle_delivery`]: classify each delivered
+    /// attachment (DIDComm vs TSP) and return it as an [`InboundFrame`] paired
+    /// with the attachment id needed to ack/delete it. Undeliverable
+    /// attachments — bad base64/utf8, or a non-TSP frame that fails DIDComm
+    /// unpack — yield `(None, id)` so the caller still acks them and the
+    /// mediator stops redelivering (no poison loop). Unlike [`_handle_delivery`],
+    /// a TSP frame is surfaced (`InboundFrame::Tsp`) rather than DIDComm-unpacked
+    /// and dropped.
+    #[cfg(feature = "tsp")]
+    pub(crate) async fn _handle_delivery_frames(
+        &self,
+        atm: &ATM,
+        message: &Message,
+    ) -> Result<Vec<(Option<InboundFrame>, String)>, ATMError> {
+        let mut out: Vec<(Option<InboundFrame>, String)> = Vec::new();
+
+        let Some(attachments) = &message.attachments else {
+            return Ok(out);
+        };
+
+        for attachment in attachments {
+            // No id => we can't ack/delete it individually; skip (leaving it
+            // queued is preferable to acking the wrong message).
+            let Some(id) = attachment.id.clone() else {
+                warn!("Delivery attachment has no id; cannot ack — skipping");
+                continue;
+            };
+            let Some(b64) = &attachment.data.base64 else {
+                warn!("Attachment type not supported: {:?}", attachment.data);
+                out.push((None, id));
+                continue;
+            };
+            let decoded = match BASE64_URL_SAFE_NO_PAD.decode(b64.clone()) {
+                Ok(bytes) => match String::from_utf8(bytes) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!("Error decoding attachment to utf8: ({e:?}). id({id})");
+                        out.push((None, id));
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    warn!("Error decoding base64: ({e:?}). id({id})");
+                    out.push((None, id));
+                    continue;
+                }
+            };
+
+            if atm.tsp().is_tsp(&decoded) {
+                out.push((Some(InboundFrame::Tsp(Box::new(decoded))), id));
+            } else {
+                match atm.unpack(&decoded).await {
+                    Ok((mut m, u)) => {
+                        m.id = id.clone();
+                        out.push((Some(InboundFrame::DidComm(Box::new(m), Box::new(u))), id));
+                    }
+                    Err(e) => {
+                        warn!("Error unpacking message: ({e:?}); dropping. id({id})");
+                        out.push((None, id));
+                    }
+                }
+            }
+        }
+
+        Ok(out)
     }
 
     /// Iterates through each attachment and unpacks each message into an array to return
@@ -969,6 +1072,22 @@ impl<'a> MessagePickupOps<'a> {
     ) -> Result<Option<InboundFrame>, ATMError> {
         MessagePickup::default()
             .live_stream_next_frame(self.atm, profile, wait, auto_delete)
+            .await
+    }
+
+    /// Sends a Message Pickup 3.0 `Delivery Request` and returns each queued
+    /// message as an [`InboundFrame`] (DIDComm or TSP) paired with its ack id —
+    /// the offline/backlog counterpart of [`live_stream_next_frame`].
+    /// See [`MessagePickup::send_delivery_request_frames`] for full documentation.
+    #[cfg(feature = "tsp")]
+    pub async fn send_delivery_request_frames(
+        &self,
+        profile: &Arc<ATMProfile>,
+        limit: Option<usize>,
+        wait_for_response: bool,
+    ) -> Result<Vec<(Option<InboundFrame>, String)>, ATMError> {
+        MessagePickup::default()
+            .send_delivery_request_frames(self.atm, profile, limit, wait_for_response)
             .await
     }
 }


### PR DESCRIPTION
## The bug

`AffinidiMessageService::listen()` spawns **two** consumers on the one mediator connection: the TSP-aware live loop (`live_stream_next_frame`) and a periodic **offline/backlog drain** (`run_periodic_offline_sync`, every 30s). The drain was **DIDComm-only** — `MessagePickup::_handle_delivery` blindly `atm.unpack()`d every queued attachment. A queued **TSP** frame therefore failed to unpack:

```
WARN affinidi_messaging_sdk::protocols::message_pickup: Error unpacking message: DidcommError("Cannot parse message as JSON", "invalid number at line 1 column 2")
```

…and because the drain only acks the messages it *successfully* unpacked, the TSP frame was **never acked/deleted** → `message_count` stayed > 0 → the mediator redelivered it **every 30s forever**. (Observed on a live VTA: the ping dispatched via the live loop, but a queued TSP frame poison-looped in the drain.)

## Fix

**SDK** — add `MessagePickup::send_delivery_request_frames` (+ `MessagePickupOps` delegate), the offline/backlog counterpart of `live_stream_next_frame`. It returns each queued message as an `InboundFrame` (DIDComm or TSP) paired with its **ack id**; undeliverable attachments (bad encoding / non-TSP frame that fails DIDComm unpack) yield `(None, id)` so the caller can still ack them. (`send_delivery_request` is refactored to share a `_request_delivery` helper — no behaviour change.)

**didcomm-service** — the offline-sync drain (`sync_offline_messages`) now uses it: routes TSP frames to the same `TspHandler` the live loop uses, dispatches DIDComm frames as before, and acks **all** fetched frames (including undeliverable ones) so nothing loops. `tsp`-feature only; the DIDComm-only build path is unchanged.

## Testing

clippy `-D warnings` clean in **default and tsp** for both crates; 89 (sdk) + 77 (service) lib tests pass. `affinidi-messaging-sdk` 0.18.46 → **0.18.47**; `affinidi-messaging-didcomm-service` 0.3.15 → **0.3.16**.

## Context

Third and final path in the TSP-inbound saga: #574 fixed `live_stream_next`/`live_stream_get`, #578 fixed the live-loop decode, and this fixes the offline-sync drain — the one still poison-looping every 30s on a live VTA after #578.