### PR TITLE
fix: migrate affinidi-trust-lists to quick-xml 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/crates/trust/affinidi-trust-lists/Cargo.toml
+++ b/crates/trust/affinidi-trust-lists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-trust-lists"
 description = "EU Trusted Lists (ETSI TS 119 612) for eIDAS 2.0 trust infrastructure."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -23,7 +23,7 @@ path = "examples/browse_trust_list.rs"
 [dependencies]
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/trust/affinidi-trust-lists/src/xml/mod.rs
+++ b/crates/trust/affinidi-trust-lists/src/xml/mod.rs
@@ -99,14 +99,29 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                 }
             }
             Ok(Event::Text(e)) => {
-                let text = e.unescape().unwrap_or_default().to_string();
+                // quick-xml 0.41 emits raw text between entity references; the
+                // references themselves arrive as separate `GeneralRef` events
+                // (see below), so accumulate rather than replace.
+                let text = e.decode().unwrap_or_default();
                 if in_x509_cert {
                     cert_base64.push_str(text.trim());
                 } else {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        text_buf = trimmed.to_string();
-                    }
+                    text_buf.push_str(&text);
+                }
+            }
+            Ok(Event::GeneralRef(e)) => {
+                // An entity reference inside element text (e.g. `&amp;` in an org
+                // name or URI). quick-xml 0.41 surfaces these as their own event;
+                // resolve predefined/numeric references and append so the value is
+                // reassembled exactly as 0.37's inline `unescape()` produced it.
+                let name = e.decode().unwrap_or_default();
+                let resolved = quick_xml::escape::unescape(&format!("&{name};"))
+                    .map(|c| c.into_owned())
+                    .unwrap_or_else(|_| name.into_owned());
+                if in_x509_cert {
+                    cert_base64.push_str(resolved.trim());
+                } else {
+                    text_buf.push_str(&resolved);
                 }
             }
             Ok(Event::End(e)) => {
@@ -116,25 +131,30 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                 // Build path string for context matching
                 let path_str = path.join("/");
 
+                // Trimmed snapshot of the element's accumulated text (Text +
+                // resolved GeneralRef events) for the handlers below; the raw
+                // accumulator is cleared at the end of this arm.
+                let text = text_buf.trim().to_string();
+
                 match local.as_str() {
                     "TSLVersionIdentifier" => {
-                        if let Ok(v) = text_buf.parse::<u32>() {
+                        if let Ok(v) = text.parse::<u32>() {
                             tsl_version = v;
                         }
                     }
                     "TSLSequenceNumber" => {
-                        if let Ok(v) = text_buf.parse::<u32>() {
+                        if let Ok(v) = text.parse::<u32>() {
                             tsl_sequence_number = v;
                         }
                     }
                     "TSLType" => {
-                        tsl_type_uri = text_buf.clone();
+                        tsl_type_uri = text.clone();
                     }
                     "SchemeTerritory" => {
                         if path_str.contains("OtherTSLPointer") {
-                            current_pointer_territory = text_buf.clone();
+                            current_pointer_territory = text.clone();
                         } else if scheme_territory.is_empty() {
-                            scheme_territory = text_buf.clone();
+                            scheme_territory = text.clone();
                         }
                     }
                     "Name" => {
@@ -143,38 +163,38 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                             && !path_str.contains("OtherTSLPointer")
                         {
                             if scheme_operator_name.is_empty() {
-                                scheme_operator_name = text_buf.clone();
+                                scheme_operator_name = text.clone();
                             }
                         } else if path_str.contains("OtherTSLPointer")
                             && path_str.contains("SchemeOperatorName")
                         {
-                            current_pointer_operator = Some(text_buf.clone());
+                            current_pointer_operator = Some(text.clone());
                         } else if path_str.contains("TSPName") {
                             if current_tsp_name.is_empty() {
-                                current_tsp_name = text_buf.clone();
+                                current_tsp_name = text.clone();
                             }
                         } else if path_str.contains("TSPTradeName") {
-                            current_tsp_trade_name = Some(text_buf.clone());
+                            current_tsp_trade_name = Some(text.clone());
                         } else if path_str.contains("ServiceName")
                             && current_service_name.is_empty()
                         {
-                            current_service_name = text_buf.clone();
+                            current_service_name = text.clone();
                         }
                     }
                     "ServiceTypeIdentifier" => {
-                        current_service_type = text_buf.clone();
+                        current_service_type = text.clone();
                     }
                     "ServiceStatus" => {
-                        current_service_status = text_buf.clone();
+                        current_service_status = text.clone();
                     }
                     "StatusStartingTime" => {
-                        current_status_time = text_buf.clone();
+                        current_status_time = text.clone();
                     }
                     "TSLLocation" => {
-                        current_pointer_location = text_buf.clone();
+                        current_pointer_location = text.clone();
                     }
                     "URI" if path_str.contains("TSPInformationURI") => {
-                        current_tsp_uris.push(text_buf.clone());
+                        current_tsp_uris.push(text.clone());
                     }
                     "X509Certificate" => {
                         in_x509_cert = false;
@@ -319,6 +339,31 @@ mod tests {
         assert_eq!(tl.scheme_information.scheme_territory, "DE");
         assert_eq!(tl.scheme_information.scheme_operator_name, "Test Authority");
         assert_eq!(tl.scheme_information.tsl_type, TslType::EuGeneric);
+    }
+
+    /// Element text containing XML entity references must be reassembled with the
+    /// entities resolved. Under quick-xml 0.41 the reader emits the surrounding
+    /// text and each `&…;` reference as separate events, so this exercises the
+    /// `Event::Text` + `Event::GeneralRef` accumulation path (predefined `&amp;`
+    /// and numeric `&#38;` both resolve to `&`).
+    #[test]
+    fn parse_resolves_entity_references_in_text() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<TrustServiceStatusList>
+  <SchemeInformation>
+    <SchemeOperatorName>
+      <Name>Foo &amp; Bar &#38; Baz &lt;Ltd&gt;</Name>
+    </SchemeOperatorName>
+    <SchemeTerritory>DE</SchemeTerritory>
+  </SchemeInformation>
+</TrustServiceStatusList>"#;
+
+        let tl = parse_trust_list_xml(xml).unwrap();
+        assert_eq!(
+            tl.scheme_information.scheme_operator_name, "Foo & Bar & Baz <Ltd>",
+            "predefined and numeric entity references are resolved and the text \
+             around them reassembled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Clears the two blocking RUSTSEC advisories that fail the `audit` CI job.

## Findings (from investigating the audit failure)
The `audit` job fails on **3 vulnerabilities** (the 7 unmaintained/unsound entries are warnings — `DENY_WARNINGS: false` — and don't fail it). None originate from recent feature work; all are 2026 advisory-DB drift.

Because **`Cargo.lock` is gitignored**, CI resolves dependencies fresh each run, which splits the fixes:

| Advisory | Crate | Pulled via | Fix | Action |
|---|---|---|---|---|
| RUSTSEC-2026-0185 | `quinn-proto 0.11.14` | `reqwest`'s **optional http3/QUIC** feature — not enabled, never compiled | ≥0.11.15 (published) | **None** — fresh resolve auto-picks 0.11.15; self-clears |
| RUSTSEC-2026-0194 / -0195 | `quick-xml 0.37.5` (quadratic-attr + unbounded-namespace DoS) | **direct** dep of `affinidi-trust-lists`, pinned `"0.37"` | ≥0.41.0 | **This PR** |

`affinidi-trust-lists` parses ETSI TS 119 612 XML fetched from trust authorities, so a compromised/MITM'd source could exercise these DoS paths.

## What this PR does
- Bumps `quick-xml` to `0.41` in `affinidi-trust-lists`.
- **Migrates the pull parser to the 0.41 model.** 0.41 emits entity references (`&amp;`, `&#38;`, …) as their own `Event::GeneralRef` instead of resolving them inline in `Event::Text`, and removed `BytesText::unescape()`. The parser now accumulates `Event::Text` (`decode()`) **plus** resolved `Event::GeneralRef` into the per-element buffer and trims at consumption — reproducing 0.37's inline-unescape result across entity-split text.
- Adds `parse_resolves_entity_references_in_text` covering predefined + numeric entity references.
- `affinidi-trust-lists` **0.1.2 → 0.1.3** (patch; public API unchanged, internal parser only).

## Verification
- `cargo audit` (with the repo's ignore list): **0 vulnerabilities** on a fresh resolve.
- `affinidi-trust-lists` tests: **36 passed** (incl. the new entity test).
- clippy `-D warnings` clean; `cargo fmt --check` clean; version-bump guard passes.
- Facade pins `affinidi-trust-lists = "0.1"` (major.minor) → 0.1.3 satisfies, no cascade.

RUSTSEC-2026-0185 (quinn-proto) is left to self-resolve via fresh lockfile resolution — no repo change is possible for it anyway since `Cargo.lock` isn't tracked.