### PR TITLE
style: cargo fmt affinidi-messaging-didcomm-service (rustfmt drift from #580)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.16"
+version = "0.3.17"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -150,8 +150,15 @@ impl Listener {
                 match frame {
                     Some(InboundFrame::DidComm(message, meta)) => {
                         let meta = super::listener::convert_meta(*meta);
-                        Listener::dispatch_message(listener_id, atm, profile, handler, *message, meta)
-                            .await;
+                        Listener::dispatch_message(
+                            listener_id,
+                            atm,
+                            profile,
+                            handler,
+                            *message,
+                            meta,
+                        )
+                        .await;
                     }
                     Some(InboundFrame::Tsp(packed)) => match tsp_handler {
                         Some(h) => {


### PR DESCRIPTION
Unblocks the workspace-wide Rustfmt CI gate, which has been failing on `main` since #580.

## Problem
CI runs `cargo fmt --all -- --check` across the whole workspace. #580 (`0d66d88`) left a `Listener::dispatch_message(...)` call in `affinidi-messaging-didcomm-service/src/service/mediator.rs` that rustfmt 1.95 wants wrapped, so the **Rustfmt** check now fails on *every* PR (it's why #581's fresh run showed fmt red, though #581 itself was clean).

## Fix
- `cargo fmt` on `affinidi-messaging-didcomm-service` — wraps the one over-long call. Pure formatting, no behaviour change.
- Bump `affinidi-messaging-didcomm-service` **0.3.16 → 0.3.17** (patch) to satisfy the version-bump guard, since the fix touches crate source.

## Verification
- `cargo fmt --all -- --check` clean workspace-wide.
- Version-bump guard passes.

Note: this is the third time post-merge rustfmt drift has failed the workspace-wide gate on an unrelated PR — worth a `cargo fmt --all --check` pre-commit hook or tightening the pre-merge gate so it's caught before landing.