### PR TITLE
docs: custom-resolver example + README section (resolver extensibility, #583)

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -99,6 +99,62 @@ let resolver = DIDCacheClient::new(config).await?;
 
 Network mode still caches locally to reduce remote calls.
 
+### Custom Resolvers
+
+Each DID method is resolved through a chain of pluggable resolvers. You can
+replace, extend, or add priority/fallback layers for a method by implementing a
+resolver trait and registering it on the client.
+
+Implement the **sync** [`Resolver`] trait when resolution is pure computation
+(the SDK's blanket impl makes it an `AsyncResolver` automatically), or implement
+[`AsyncResolver`] directly when it needs network/database IO. A resolver returns
+`None` for DIDs it doesn't handle, so the next resolver in the chain gets a turn.
+
+```rust
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, MethodName, Resolution, Resolver};
+use affinidi_did_common::{DID, Document};
+
+struct StubKeyResolver;
+impl Resolver for StubKeyResolver {
+    fn name(&self) -> &str { "StubKeyResolver" }
+    fn resolve(&self, did: &DID) -> Resolution {
+        if did.method().name() != "key" { return None; }
+        // ... build and return Some(Ok(document)) ...
+    }
+}
+
+let mut client = DIDCacheClient::new(config).await?;
+client.set_resolver(MethodName::Key, Box::new(StubKeyResolver)); // replaces the built-in
+```
+
+Registration API:
+
+- `set_resolver(method, r)` — replace all resolvers for a method with `r`.
+- `prepend_resolver(method, r)` — try `r` first, then fall through to existing (e.g. override-with-fallback).
+- `append_resolver(method, r)` — try `r` last (fallback).
+- `clear_resolvers` / `remove_resolver` / `find_resolver` — manage the chain.
+
+**Register during setup, before the client is cloned/shared** — registration
+takes `&mut self` and panics if the client has already been cloned.
+
+**Caching interaction:** `resolve()` checks the cache first, so re-registering a
+resolver does not affect DIDs already cached (immutable methods like `did:key`
+are cached until capacity-evicted). Register resolvers before resolving, or use a
+fresh client.
+
+**Scope (current):** registering a resolver for a method that is **already
+built in** (`did:key`, `did:web`, `did:ethr`, …) takes effect through the public
+`resolve()` API. A resolver for a **brand-new** method (e.g. `did:example`) is
+not yet reachable via `resolve()`, which validates the method against the
+built-in `DIDMethod` set before dispatch. See
+[issue #583](https://github.com/affinidi/affinidi-tdk-rs/issues/583).
+
+Runnable example: [`examples/custom_resolver.rs`](examples/custom_resolver.rs) —
+`cargo run --example custom_resolver`.
+
+[`Resolver`]: https://docs.rs/affinidi-did-resolver-traits
+[`AsyncResolver`]: https://docs.rs/affinidi-did-resolver-traits
+
 ## Caching Strategy
 
 The cache uses **per-method TTL** to avoid unnecessary re-resolution:

--- a/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
@@ -1,0 +1,105 @@
+//! Register a **custom DID resolver** with the cache client.
+//!
+//! `DIDCacheClient` resolves each DID method through a chain of pluggable
+//! resolvers. This example swaps in a custom resolver for a built-in method
+//! (`did:key`) by implementing the sync [`Resolver`] trait — resolution here is
+//! pure computation, so the blanket impl turns it into an
+//! [`AsyncResolver`](affinidi_did_resolver_cache_sdk::AsyncResolver)
+//! automatically. (For a method that needs network or database IO, implement
+//! `AsyncResolver` directly instead.)
+//!
+//! This pattern is useful for tests (a deterministic mock resolver), for
+//! swapping in an alternate/self-hosted resolution backend, or for adding a
+//! caching/transform layer in front of a method.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example custom_resolver
+//! ```
+//!
+//! ## Note on brand-new methods
+//!
+//! Registering a resolver for a method that is **already built in** (`did:key`,
+//! `did:web`, `did:ethr`, …) works through the public [`DIDCacheClient::resolve`]
+//! API, as shown here. A resolver for a *genuinely new* method (e.g.
+//! `did:example`) is not yet reachable via `resolve()` — the public entry point
+//! validates the method against the built-in `DIDMethod` set first. See the
+//! crate README ("Custom resolvers") for details.
+
+use affinidi_did_common::{DID, Document};
+use affinidi_did_resolver_cache_sdk::{
+    DIDCacheClient, MethodName, Resolution, Resolver, ResolverError, config::DIDCacheConfigBuilder,
+    errors::DIDCacheError,
+};
+
+// Two distinct Ed25519 did:key values. The cache is keyed per-DID, and did:key
+// is immutable (cached forever once resolved), so we resolve one with the
+// built-in and a *different*, not-yet-cached one with the custom resolver — a
+// re-resolve of the same DID would return the cached result and never reach the
+// newly-registered resolver.
+const DID_KEY_BUILTIN: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+const DID_KEY_CUSTOM: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+/// A custom `did:key` resolver that returns a minimal, deterministic Document
+/// instead of deriving one from the key material — the kind of stub a test
+/// suite might register to avoid real key expansion.
+///
+/// Implementing the **sync** [`Resolver`] trait is the simplest path for a
+/// resolver whose work is pure computation; the SDK's blanket impl makes it
+/// usable anywhere a `Box<dyn AsyncResolver>` is expected.
+struct StubKeyResolver;
+
+impl Resolver for StubKeyResolver {
+    fn name(&self) -> &str {
+        "StubKeyResolver"
+    }
+
+    fn resolve(&self, did: &DID) -> Resolution {
+        // Return `None` for anything that isn't ours so the next resolver in the
+        // chain gets a turn — this is how composition works.
+        if did.method().name() != "key" {
+            return None;
+        }
+        let did_str = did.to_string();
+        let doc_json = format!(
+            r#"{{"id":"{did_str}","verificationMethod":[],"authentication":[],"assertionMethod":[],"keyAgreement":[],"capabilityInvocation":[],"capabilityDelegation":[],"service":[]}}"#
+        );
+        Some(
+            serde_json::from_str::<Document>(&doc_json)
+                .map_err(|e| ResolverError::InvalidDocument(e.to_string())),
+        )
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), DIDCacheError> {
+    // Local mode — no network calls, resolution runs entirely in-process.
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await?;
+
+    // Baseline: the built-in did:key resolver derives verification methods from
+    // the key material (Ed25519 yields 2).
+    let before = client.resolve(DID_KEY_BUILTIN).await?;
+    println!(
+        "built-in did:key resolver -> {} verification method(s)",
+        before.doc.verification_method.len()
+    );
+
+    // Register the custom resolver for the `key` method. `set_resolver` REPLACES
+    // the built-in for that method; use `prepend_resolver`/`append_resolver` to
+    // add priority/fallback layers instead. Do this during setup, *before* the
+    // client is cloned or shared — registration borrows the client mutably and
+    // panics if it has already been cloned.
+    client.set_resolver(MethodName::Key, Box::new(StubKeyResolver));
+
+    // Resolve a *different* did:key (not yet cached) — the public resolve() call
+    // now dispatches to our stub, which returns 0 verification methods.
+    let after = client.resolve(DID_KEY_CUSTOM).await?;
+    println!(
+        "custom  did:key resolver -> {} verification method(s) (document id: {})",
+        after.doc.verification_method.len(),
+        after.doc.id
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Part 1 of #583 — the docs/example half. The pluggable-resolver API (from the now-closed #216–#218 epic) works but was undocumented; this makes it discoverable.

## Changes
- **`examples/custom_resolver.rs`** — registers a custom `did:key` resolver via the sync `Resolver` trait (blanket-impl'd to `AsyncResolver`) and shows it taking effect through the public `resolve()` API. Also demonstrates the caching-interaction gotcha (immutable methods are cached, so register before resolving / use a fresh DID). Verified: `cargo run --example custom_resolver` prints built-in did:key → 2 verification methods, custom stub → 0.
- **README "Custom resolvers" section** — trait choice (sync `Resolver` vs async `AsyncResolver`), the `set_/prepend_/append_resolver` priority model, the register-before-clone rule, the cache interaction, and the current scope limit.

## Notes
- Docs/example only — no crate source change, so **no version bump** (README `*.md` and `examples/` are excluded from the version-bump guard).
- **Finding surfaced during this work** (added to #583): the public `resolve()` validates the method against the closed `DIDMethod` enum before dispatch, so a resolver for a *brand-new* method (e.g. `did:example`) is registered but never reached via `resolve()` — only overriding built-in methods works end-to-end. The README and example are honest about this. The fix is the more substantial half of #583.