### PR TITLE
fix: reach custom-method resolvers through the public resolve() API (#583)

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.11"
+version = "0.8.12"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -142,12 +142,12 @@ resolver does not affect DIDs already cached (immutable methods like `did:key`
 are cached until capacity-evicted). Register resolvers before resolving, or use a
 fresh client.
 
-**Scope (current):** registering a resolver for a method that is **already
-built in** (`did:key`, `did:web`, `did:ethr`, …) takes effect through the public
-`resolve()` API. A resolver for a **brand-new** method (e.g. `did:example`) is
-not yet reachable via `resolve()`, which validates the method against the
-built-in `DIDMethod` set before dispatch. See
-[issue #583](https://github.com/affinidi/affinidi-tdk-rs/issues/583).
+**Brand-new methods:** registering a resolver for a method with no built-in
+support (e.g. `did:example`) works through the public `resolve()` API — an
+unrecognised method is tagged `DIDMethod::OTHER` and dispatched to the
+registered resolver (the concrete name is preserved in `ResolveResponse::did`).
+If no resolver is registered for the method, `resolve()` returns
+`UnsupportedMethod`.
 
 Runnable example: [`examples/custom_resolver.rs`](examples/custom_resolver.rs) —
 `cargo run --example custom_resolver`.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
@@ -1,30 +1,20 @@
 //! Register a **custom DID resolver** with the cache client.
 //!
 //! `DIDCacheClient` resolves each DID method through a chain of pluggable
-//! resolvers. This example swaps in a custom resolver for a built-in method
-//! (`did:key`) by implementing the sync [`Resolver`] trait — resolution here is
-//! pure computation, so the blanket impl turns it into an
+//! resolvers. This example plugs in a brand-new method, `did:example`, by
+//! implementing the sync [`Resolver`] trait — resolution here is pure
+//! computation, so the blanket impl turns it into an
 //! [`AsyncResolver`](affinidi_did_resolver_cache_sdk::AsyncResolver)
 //! automatically. (For a method that needs network or database IO, implement
 //! `AsyncResolver` directly instead.)
 //!
-//! This pattern is useful for tests (a deterministic mock resolver), for
-//! swapping in an alternate/self-hosted resolution backend, or for adding a
-//! caching/transform layer in front of a method.
+//! The same pattern also *overrides* a built-in method — register a resolver for
+//! `MethodName::Key` and it replaces the built-in `did:key` resolver.
 //!
 //! Run with:
 //! ```sh
 //! cargo run --example custom_resolver
 //! ```
-//!
-//! ## Note on brand-new methods
-//!
-//! Registering a resolver for a method that is **already built in** (`did:key`,
-//! `did:web`, `did:ethr`, …) works through the public [`DIDCacheClient::resolve`]
-//! API, as shown here. A resolver for a *genuinely new* method (e.g.
-//! `did:example`) is not yet reachable via `resolve()` — the public entry point
-//! validates the method against the built-in `DIDMethod` set first. See the
-//! crate README ("Custom resolvers") for details.
 
 use affinidi_did_common::{DID, Document};
 use affinidi_did_resolver_cache_sdk::{
@@ -32,32 +22,22 @@ use affinidi_did_resolver_cache_sdk::{
     errors::DIDCacheError,
 };
 
-// Two distinct Ed25519 did:key values. The cache is keyed per-DID, and did:key
-// is immutable (cached forever once resolved), so we resolve one with the
-// built-in and a *different*, not-yet-cached one with the custom resolver — a
-// re-resolve of the same DID would return the cached result and never reach the
-// newly-registered resolver.
-const DID_KEY_BUILTIN: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
-const DID_KEY_CUSTOM: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-
-/// A custom `did:key` resolver that returns a minimal, deterministic Document
-/// instead of deriving one from the key material — the kind of stub a test
-/// suite might register to avoid real key expansion.
+/// A toy resolver for `did:example:*` that synthesises a minimal DID Document.
 ///
 /// Implementing the **sync** [`Resolver`] trait is the simplest path for a
-/// resolver whose work is pure computation; the SDK's blanket impl makes it
+/// method whose resolution is pure computation; the SDK's blanket impl makes it
 /// usable anywhere a `Box<dyn AsyncResolver>` is expected.
-struct StubKeyResolver;
+struct ExampleResolver;
 
-impl Resolver for StubKeyResolver {
+impl Resolver for ExampleResolver {
     fn name(&self) -> &str {
-        "StubKeyResolver"
+        "ExampleResolver"
     }
 
     fn resolve(&self, did: &DID) -> Resolution {
         // Return `None` for anything that isn't ours so the next resolver in the
         // chain gets a turn — this is how composition works.
-        if did.method().name() != "key" {
+        if did.method().name() != "example" {
             return None;
         }
         let did_str = did.to_string();
@@ -77,29 +57,29 @@ async fn main() -> Result<(), DIDCacheError> {
     let config = DIDCacheConfigBuilder::default().build();
     let mut client = DIDCacheClient::new(config).await?;
 
-    // Baseline: the built-in did:key resolver derives verification methods from
-    // the key material (Ed25519 yields 2).
-    let before = client.resolve(DID_KEY_BUILTIN).await?;
-    println!(
-        "built-in did:key resolver -> {} verification method(s)",
-        before.doc.verification_method.len()
+    // Register the custom resolver for the `example` method. Do this during
+    // setup, *before* the client is cloned or shared — registration borrows the
+    // client mutably and panics if it has already been cloned.
+    client.set_resolver(
+        MethodName::Other("example".to_string()),
+        Box::new(ExampleResolver),
     );
 
-    // Register the custom resolver for the `key` method. `set_resolver` REPLACES
-    // the built-in for that method; use `prepend_resolver`/`append_resolver` to
-    // add priority/fallback layers instead. Do this during setup, *before* the
-    // client is cloned or shared — registration borrows the client mutably and
-    // panics if it has already been cloned.
-    client.set_resolver(MethodName::Key, Box::new(StubKeyResolver));
-
-    // Resolve a *different* did:key (not yet cached) — the public resolve() call
-    // now dispatches to our stub, which returns 0 verification methods.
-    let after = client.resolve(DID_KEY_CUSTOM).await?;
+    // Resolve a DID of the brand-new method through the public `resolve()` API —
+    // the cache client dispatches to our resolver.
+    let response = client.resolve("did:example:alice").await?;
     println!(
-        "custom  did:key resolver -> {} verification method(s) (document id: {})",
-        after.doc.verification_method.len(),
-        after.doc.id
+        "resolved {} via a custom resolver -> document id {}",
+        "did:example:alice", response.doc.id
     );
+
+    // Custom resolvers can also override a built-in method: registering for
+    // `MethodName::Key` replaces the built-in `did:key` resolver. Use
+    // `prepend_resolver`/`append_resolver` to add priority/fallback layers
+    // instead of replacing. (Note: `resolve()` caches per-DID, and immutable
+    // methods like `did:key` are cached until eviction — register resolvers
+    // before resolving, or the cached document is returned.)
+    println!("tip: set_resolver(MethodName::Key, ...) overrides the built-in did:key resolver.");
 
     Ok(())
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -69,6 +69,10 @@ pub enum DIDMethod {
     SCID,
     EBSI,
     EXAMPLE,
+    /// A DID method with no built-in support — resolved only if a custom
+    /// resolver has been registered for it (see [`DIDCacheClient::set_resolver`]).
+    /// The concrete method name is preserved in [`ResolveResponse::did`].
+    OTHER,
 }
 
 /// Helper function to convert a DIDMethod to a string
@@ -86,6 +90,7 @@ impl fmt::Display for DIDMethod {
             DIDMethod::SCID => write!(f, "scid"),
             DIDMethod::EBSI => write!(f, "ebsi"),
             DIDMethod::EXAMPLE => write!(f, "example"),
+            DIDMethod::OTHER => write!(f, "other"),
         }
     }
 }
@@ -127,6 +132,10 @@ impl DIDMethod {
     ///
     /// Returns `false` for deterministic methods where the document is derived
     /// entirely from the DID string itself (key, peer, jwk, ethr, pkh, example).
+    ///
+    /// A custom (`OTHER`) method is treated as **mutable** — its resolver may
+    /// fetch from external infrastructure, so the cached document is given the
+    /// mutable TTL rather than being kept forever.
     pub fn is_mutable(&self) -> bool {
         matches!(
             self,
@@ -135,6 +144,7 @@ impl DIDMethod {
                 | DIDMethod::CHEQD
                 | DIDMethod::SCID
                 | DIDMethod::EBSI
+                | DIDMethod::OTHER
         )
     }
 }
@@ -368,7 +378,16 @@ impl DIDCacheClient {
             )));
         }
 
-        let method: DIDMethod = parsed_did.method().to_string().as_str().try_into()?;
+        // Map the parsed method onto the cache's method tag. An unknown method is
+        // tagged `OTHER` (rather than rejected) so a registered custom resolver
+        // can still handle it; if none is registered, `local_resolve` reports it
+        // as unsupported.
+        let method: DIDMethod = parsed_did
+            .method()
+            .to_string()
+            .as_str()
+            .try_into()
+            .unwrap_or(DIDMethod::OTHER);
 
         let hash = DIDCacheClient::hash_did(did);
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
@@ -39,9 +39,8 @@ impl DIDCacheClient {
             DIDMethod::Scid { .. } => Err(DIDCacheError::UnsupportedMethod(
                 "did:scid is not enabled".to_string(),
             )),
-            _ => Err(DIDCacheError::DIDError(format!(
-                "No resolver registered for DID method '{}'",
-                did.method()
+            _ => Err(DIDCacheError::UnsupportedMethod(format!(
+                "no resolver registered for DID method '{method_name}'"
             ))),
         }
     }
@@ -49,7 +48,7 @@ impl DIDCacheClient {
 
 #[cfg(test)]
 mod tests {
-    use crate::{DIDCacheClient, MethodName, config};
+    use crate::{DIDCacheClient, DIDMethod, MethodName, config, errors::DIDCacheError};
     use affinidi_did_common::DID;
     use affinidi_did_common::Document;
     use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
@@ -362,6 +361,39 @@ mod tests {
         let did: DID = "did:test:alice".parse().unwrap();
         let result = client.local_resolve(&did).await;
         assert!(result.is_err());
+    }
+
+    /// Regression for #583: a registered custom resolver is reachable through the
+    /// public `resolve()` API — previously `resolve()` rejected unknown methods
+    /// (with `UnsupportedMethod`) before consulting the resolver chain, so only
+    /// `local_resolve` could reach a custom-method resolver.
+    #[tokio::test]
+    async fn custom_resolver_reachable_via_public_resolve() {
+        let config = config::DIDCacheConfigBuilder::default().build();
+        let mut client = DIDCacheClient::new(config).await.unwrap();
+        client.set_resolver(
+            MethodName::Other("test".to_string()),
+            Box::new(TestResolver),
+        );
+
+        let response = client.resolve("did:test:alice").await.unwrap();
+        assert_eq!(response.doc.id.as_str(), "did:test:alice");
+        // The cache tags an unknown method as `OTHER`; the concrete name is in `did`.
+        assert_eq!(response.method, DIDMethod::OTHER);
+        assert_eq!(response.did, "did:test:alice");
+    }
+
+    /// An unknown method with no registered resolver surfaces as `UnsupportedMethod`
+    /// through the public `resolve()` API.
+    #[tokio::test]
+    async fn unregistered_method_via_public_resolve_is_unsupported() {
+        let config = config::DIDCacheConfigBuilder::default().build();
+        let client = DIDCacheClient::new(config).await.unwrap();
+        let err = client.resolve("did:nope:whatever").await.unwrap_err();
+        assert!(
+            matches!(err, DIDCacheError::UnsupportedMethod(_)),
+            "expected UnsupportedMethod, got: {err:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes the robustness half of #583. (Docs/example half was #584.)

## Problem
The pluggable-resolver architecture lets you register a resolver for any method, but `DIDCacheClient::resolve()` validated the method against the closed, built-in set **before** consulting the resolver chain:

```rust
let method: DIDMethod = parsed_did.method().to_string().as_str().try_into()?;  // Err(UnsupportedMethod) for unknown
```

So a resolver for a brand-new method (e.g. `did:example`) was only reachable via the internal `local_resolve` — the public API rejected it. (Overriding built-in methods already worked.)

## Fix
- **`DIDMethod::OTHER` tag.** The cache-sdk's `DIDMethod` is `#[wasm_bindgen]`, so it must stay a C-style enum — `OTHER` is a unit variant; the concrete method name is preserved in `ResolveResponse::did`. `resolve()` now maps an unrecognised method to `OTHER` (`try_into().unwrap_or(OTHER)`) instead of erroring, so a registered custom resolver handles it. `OTHER` is treated as **mutable** for cache TTL (a custom resolver may fetch remotely, so don't cache it forever).
- **`local_resolve`** returns `UnsupportedMethod` (not a generic error) when no resolver is registered — consistent with the feature-disabled branches.
- **Example + README** updated: `examples/custom_resolver.rs` now demonstrates a genuinely new `did:example` method through the public `resolve()` (supersedes the "not reachable yet" caveat added in #584).
- **Tests:** custom resolver reachable via public `resolve()`; unregistered method → `UnsupportedMethod`. `TryFrom<&str>` is unchanged (still errors on unknown — that unit test still passes).

## Versioning / blast radius
- `affinidi-did-resolver-cache-sdk` **0.8.11 → 0.8.12** (patch). Adding `OTHER` is **additive in practice**: no code anywhere in the workspace exhaustively matches this enum (the cache-server uses `== DIDMethod::WEBVH` equality, not a `match`), so `OTHER` breaks no build and dependents' `"0.8"` pins are unaffected — no cascade.

## Verification
- `cargo run --example custom_resolver` → `resolved did:example:alice via a custom resolver`.
- Targeted tests pass (custom-resolver ×3, unregistered ×2, did_method ×4, is_mutable ×3); clippy `-D warnings` clean; fmt clean; version-bump guard passes.