### PR TITLE
feat: cross-mediator TSP routing for service-less (did:key) peers (#577 P1)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.47"
+version = "0.18.48"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -113,7 +113,7 @@ pub enum CapabilitySource {
 }
 
 /// A cached per-peer TSP capability record, stored by [`RelationshipStore`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PeerCapability {
     /// Whether the peer's agent accepts TSP.
     pub tsp: TspSupport,
@@ -122,6 +122,13 @@ pub struct PeerCapability {
     /// Unix seconds (against the SDK's configured clock) when learned — used
     /// for the capability TTL.
     pub learned_at_unix: u64,
+    /// The peer's mediator DID, when known — used by [`crate::ATM::send_to`] to
+    /// route a TSP message to a peer on a *different* mediator (a service-less
+    /// `did:key` peer can't advertise this in a DID document, so it is learned
+    /// from a routed relationship invite or set out-of-band). `None` means "assume
+    /// the peer shares the sender's mediator" (Direct delivery).
+    #[serde(default)]
+    pub mediator: Option<String>,
 }
 
 /// Pluggable backing store for TSP relationship state (and learned per-peer
@@ -222,7 +229,7 @@ impl RelationshipStore for InMemoryRelationshipStore {
         their_vid: &str,
     ) -> Result<Option<PeerCapability>, ATMError> {
         let key = (our_vid.to_string(), their_vid.to_string());
-        Ok(self.capabilities.read().await.get(&key).copied())
+        Ok(self.capabilities.read().await.get(&key).cloned())
     }
 
     async fn set_capability(
@@ -252,10 +259,13 @@ impl ATM {
     /// unchanged until an app opts in via
     /// [`with_tsp_policy`](crate::config::ATMConfigBuilder::with_tsp_policy).
     ///
-    /// v1 assumes the recipient shares (or its mediator federates with) the
-    /// sender's mediator; cross-mediator TSP routing to a service-less DID
-    /// (e.g. did:key) is out of scope here — use `atm.tsp().send_routed` for
-    /// explicit multi-hop.
+    /// TSP delivery is Direct (via the sender's mediator) when the recipient
+    /// shares that mediator. When the recipient's mediator is **known and
+    /// different** (learned from a routed relationship invite or set via
+    /// [`TspOps::set_peer_mediator`] — the service-less `did:key` case), the
+    /// message is instead routed cross-mediator with metadata privacy
+    /// ([`TspOps::send_nested_routed`]): the recipient stays hidden from the
+    /// sender's mediator.
     ///
     /// [`Message`]: affinidi_messaging_didcomm::message::Message
     pub async fn send_to(
@@ -272,7 +282,25 @@ impl ATM {
                 let payload = serde_json::to_vec(message).map_err(|e| {
                     ATMError::MsgSendError(format!("couldn't serialise message for TSP: {e}"))
                 })?;
-                self.tsp().send(profile, to, &payload).await?;
+                // Route cross-mediator (metadata-private) when the peer's mediator
+                // is known and differs from ours; otherwise Direct via our mediator.
+                let peer_mediator = self
+                    .tsp()
+                    .peer_capability(profile, to)
+                    .await?
+                    .and_then(|c| c.mediator);
+                let (_, own_mediator) = profile.dids()?;
+                match peer_mediator {
+                    Some(peer_mediator) if peer_mediator != own_mediator => {
+                        let route = [own_mediator.to_string(), peer_mediator];
+                        self.tsp()
+                            .send_nested_routed(profile, &route, to, &payload)
+                            .await?;
+                    }
+                    _ => {
+                        self.tsp().send(profile, to, &payload).await?;
+                    }
+                }
             }
             SendProtocol::DidComm => {
                 // Pack for the recipient, then wrap in a single `forward` to the
@@ -583,6 +611,65 @@ impl TspOps<'_> {
         self.send_raw(profile, &nested.bytes).await
     }
 
+    /// Send `payload` to `to_did` across mediators with **metadata privacy**:
+    /// the inner Direct message is sealed end-to-end to `to_did`, wrapped in a
+    /// **Nested** envelope sealed to the recipient's mediator (`route.last()`),
+    /// and **routed** through `route`.
+    ///
+    /// `route` is the hop list `[own_mediator, …, recipient_mediator]`. The sender
+    /// posts to its own mediator (`route[0]`), which forwards along the route to
+    /// the recipient's mediator; each intermediary sees only the *next hop*, never
+    /// `to_did` (it is sealed inside the Nested inner). The recipient's mediator
+    /// unwraps the Nested layer and delivers the Direct message to `to_did`
+    /// locally — so only the recipient's own mediator learns the recipient, which
+    /// is unavoidable for local delivery.
+    ///
+    /// This is the metadata-private counterpart to [`send_routed`](Self::send_routed),
+    /// which carries the recipient as a visible route hop.
+    pub async fn send_nested_routed(
+        &self,
+        profile: &Arc<ATMProfile>,
+        route: &[String],
+        to_did: &str,
+        payload: &[u8],
+    ) -> Result<(), ATMError> {
+        let intermediary = route
+            .last()
+            .ok_or_else(|| ATMError::MsgSendError("route must not be empty".into()))?;
+
+        let (from_did, _) = profile.dids()?;
+        let (signing_key, decryption_key) = self.profile_tsp_keys(from_did).await?;
+
+        // Inner Direct message sealed end-to-end to the final recipient.
+        let recipient = self.resolve_vid(to_did).await?;
+        let inner = direct::pack(
+            payload,
+            MessageType::Direct,
+            from_did,
+            to_did,
+            &signing_key,
+            &decryption_key,
+            &recipient.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack inner TSP message: {e}")))?;
+
+        // Wrap in a Nested envelope sealed to the recipient's mediator, so the
+        // recipient's identity is opaque to every earlier hop.
+        let intermediary_vid = self.resolve_vid(intermediary).await?;
+        let nested = affinidi_tsp::message::routed::pack_nested(
+            &inner,
+            from_did,
+            intermediary,
+            &signing_key,
+            &decryption_key,
+            &intermediary_vid.encryption_key,
+        )
+        .map_err(|e| ATMError::MsgSendError(format!("couldn't pack nested TSP message: {e}")))?;
+
+        // Route the Nested envelope through the hops to the recipient's mediator.
+        self.send_routed_opaque(profile, route, &nested.bytes).await
+    }
+
     /// Send a TSP **Control** message — a relationship-management message (invite /
     /// accept / cancel) to a peer.
     ///
@@ -639,6 +726,34 @@ impl TspOps<'_> {
         let next = next_state(store, our_did, their_did, RelationshipEvent::SendInvite).await?;
         self.send_control(profile, their_did, &ControlMessage::invite())
             .await?;
+        store.set(our_did, their_did, next).await?;
+        Ok(next)
+    }
+
+    /// Like [`form_relationship`](Self::form_relationship), but the invite
+    /// **advertises this agent's own mediator DID** in its route, so the peer can
+    /// learn where to route TSP messages back — needed to reach a cross-mediator
+    /// peer (e.g. a service-less `did:key` peer, whose DID document can't carry a
+    /// `TSPTransport` service). The peer records it via
+    /// [`record_incoming_control`](Self::record_incoming_control).
+    ///
+    /// Opt-in (SDD decision Q2): the plain
+    /// [`form_relationship`](Self::form_relationship) advertises nothing, so your
+    /// mediator is only disclosed when you deliberately use this routed form.
+    pub async fn form_relationship_routed(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+    ) -> Result<RelationshipState, ATMError> {
+        let (our_did, our_mediator) = profile.dids()?;
+        let store = self.relationship_store();
+        let next = next_state(store, our_did, their_did, RelationshipEvent::SendInvite).await?;
+        self.send_control(
+            profile,
+            their_did,
+            &ControlMessage::invite_routed(vec![our_mediator.to_string()]),
+        )
+        .await?;
         store.set(our_did, their_did, next).await?;
         Ok(next)
     }
@@ -743,6 +858,16 @@ impl TspOps<'_> {
             ControlType::RelationshipCancel => RelationshipEvent::ReceiveCancel,
         };
         let new_state = advance_state(self.relationship_store(), our_did, peer_did, event).await?;
+        // If the peer advertised its mediator in the control's route (a routed
+        // invite/accept), cache it so `send_to` can route to this peer on a
+        // different mediator. Learned once during the handshake; no-op under
+        // `TspPolicy::Off`, like the other capability-learning paths.
+        if self.atm.inner.config.tsp_policy() != TspPolicy::Off
+            && let Some(peer_mediator) = control.route.first()
+        {
+            self.set_peer_mediator(profile, peer_did, Some(peer_mediator.clone()))
+                .await?;
+        }
         // The initiator reaches Bidirectional here (on receiving the accept) —
         // confirm the peer's TSP capability.
         if new_state == RelationshipState::Bidirectional {
@@ -779,14 +904,48 @@ impl TspOps<'_> {
         support: TspSupport,
     ) -> Result<(), ATMError> {
         let (our_did, _) = profile.dids()?;
+        let store = self.relationship_store();
+        let existing = store.get_capability(our_did, their_did).await?;
         let cap = PeerCapability {
             tsp: support,
             source: CapabilitySource::Manual,
             learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+            // Preserve any learned mediator (this call sets support, not routing).
+            mediator: existing.and_then(|c| c.mediator),
         };
-        self.relationship_store()
-            .set_capability(our_did, their_did, cap)
-            .await
+        store.set_capability(our_did, their_did, cap).await
+    }
+
+    /// Record the `mediator` DID that a peer's TSP agent lives behind, so
+    /// [`crate::ATM::send_to`] can route a TSP message to a peer on a *different*
+    /// mediator (a service-less `did:key` peer can't advertise this in its DID
+    /// document). Learned automatically from a routed relationship invite
+    /// ([`form_relationship_routed`](Self::form_relationship_routed)); use this to
+    /// set it out-of-band. Pass `None` to clear it (assume the shared mediator).
+    ///
+    /// Preserves any known TSP support level for the peer.
+    pub async fn set_peer_mediator(
+        &self,
+        profile: &Arc<ATMProfile>,
+        their_did: &str,
+        mediator: Option<String>,
+    ) -> Result<(), ATMError> {
+        let (our_did, _) = profile.dids()?;
+        let store = self.relationship_store();
+        let existing = store.get_capability(our_did, their_did).await?;
+        let cap = PeerCapability {
+            tsp: existing
+                .as_ref()
+                .map(|c| c.tsp)
+                .unwrap_or(TspSupport::Unknown),
+            source: existing
+                .as_ref()
+                .map(|c| c.source)
+                .unwrap_or(CapabilitySource::Manual),
+            learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+            mediator,
+        };
+        store.set_capability(our_did, their_did, cap).await
     }
 
     /// Advertise this agent's TSP capability in its Discover Features 2.0
@@ -887,9 +1046,10 @@ impl TspOps<'_> {
             return Ok(());
         }
         let store = self.relationship_store();
-        if let Some(cap) = store.get_capability(our_did, their_did).await?
+        let existing = store.get_capability(our_did, their_did).await?;
+        if let Some(cap) = &existing
             && cap.tsp == TspSupport::Supported
-            && self.capability_is_fresh(&cap)
+            && self.capability_is_fresh(cap)
         {
             return Ok(());
         }
@@ -897,6 +1057,8 @@ impl TspOps<'_> {
             tsp: TspSupport::Supported,
             source,
             learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+            // Preserve any learned mediator (used for cross-mediator routing).
+            mediator: existing.and_then(|c| c.mediator),
         };
         store.set_capability(our_did, their_did, cap).await
     }
@@ -923,11 +1085,11 @@ impl TspOps<'_> {
         let (our_did, _) = profile.dids()?;
         let store = self.relationship_store();
 
-        let fresh_cap = store
+        let existing_cap = store
             .get_capability(our_did, their_did)
             .await?
-            .filter(|c| self.capability_is_fresh(c))
-            .map(|c| c.tsp);
+            .filter(|c| self.capability_is_fresh(c));
+        let fresh_cap = existing_cap.as_ref().map(|c| c.tsp);
         let bidirectional =
             store.get(our_did, their_did).await? == RelationshipState::Bidirectional;
 
@@ -953,6 +1115,7 @@ impl TspOps<'_> {
                         tsp: TspSupport::Supported,
                         source,
                         learned_at_unix: self.atm.inner.config.clock().unix_secs(),
+                        mediator: existing_cap.and_then(|c| c.mediator),
                     };
                     store.set_capability(our_did, their_did, cap).await?;
                 }
@@ -1436,9 +1599,13 @@ mod tests {
             tsp: TspSupport::Supported,
             source: CapabilitySource::Relationship,
             learned_at_unix: 42,
+            mediator: None,
         };
-        store.set_capability(ALICE, BOB, cap).await.unwrap();
-        assert_eq!(store.get_capability(ALICE, BOB).await.unwrap(), Some(cap));
+        store.set_capability(ALICE, BOB, cap.clone()).await.unwrap();
+        assert_eq!(
+            store.get_capability(ALICE, BOB).await.unwrap(),
+            Some(cap.clone())
+        );
 
         // Directional + independent of relationship state.
         assert_eq!(store.get_capability(BOB, ALICE).await.unwrap(), None);

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.37"
+version = "0.2.38"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -199,6 +199,24 @@ impl TestEnvironment {
         Self::new_with_config(mediator, tdk_config, atm_config).await
     }
 
+    /// Like [`new`](Self::new), but sets a
+    /// [`TspPolicy`](affinidi_messaging_sdk::TspPolicy) on the SDK so
+    /// `atm.send_to` protocol selection can be exercised — used by multi-mediator
+    /// topology tests that need TSP enabled on an existing mediator handle.
+    #[cfg(feature = "tsp")]
+    pub async fn new_with_tsp_policy(
+        mediator: TestMediatorHandle,
+        policy: affinidi_messaging_sdk::TspPolicy,
+    ) -> Result<Self, TestEnvironmentError> {
+        let tdk_config =
+            TDKConfig::headless().map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        let atm_config = ATMConfig::builder()
+            .with_tsp_policy(policy)
+            .build()
+            .map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
+        Self::new_with_config(mediator, tdk_config, atm_config).await
+    }
+
     /// Shared constructor: wire the SDK + TDK against `mediator` using
     /// the supplied `tdk_config`. The only difference between
     /// [`new`](Self::new) and [`spawn_with_tsp_auth`](Self::spawn_with_tsp_auth)

--- a/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
@@ -89,6 +89,8 @@ pub struct TestTopologyBuilder {
     mediators: usize,
     relay_mode: RelayMode,
     customize: Option<Box<dyn Fn(TestMediatorBuilder) -> TestMediatorBuilder + Send + Sync>>,
+    #[cfg(feature = "tsp")]
+    tsp_policy: Option<affinidi_messaging_sdk::TspPolicy>,
 }
 
 impl Default for TestTopologyBuilder {
@@ -97,6 +99,8 @@ impl Default for TestTopologyBuilder {
             mediators: 2,
             relay_mode: RelayMode::Blind,
             customize: None,
+            #[cfg(feature = "tsp")]
+            tsp_policy: None,
         }
     }
 }
@@ -111,6 +115,15 @@ impl TestTopologyBuilder {
     /// Relay posture for every mediator (default [`RelayMode::Blind`]).
     pub fn relay_mode(mut self, mode: RelayMode) -> Self {
         self.relay_mode = mode;
+        self
+    }
+
+    /// Set a [`TspPolicy`](affinidi_messaging_sdk::TspPolicy) on every node's SDK
+    /// so `atm.send_to` protocol selection (and cross-mediator TSP routing) can be
+    /// exercised. Defaults to unset (each node uses `TspPolicy::Off`).
+    #[cfg(feature = "tsp")]
+    pub fn tsp_policy(mut self, policy: affinidi_messaging_sdk::TspPolicy) -> Self {
+        self.tsp_policy = Some(policy);
         self
     }
 
@@ -162,7 +175,14 @@ impl TestTopologyBuilder {
                 .spawn()
                 .await
                 .map_err(|e| TestTopologyError::Mediator(e.to_string()))?;
-            nodes.push(TestEnvironment::new(handle).await?);
+            #[cfg(feature = "tsp")]
+            let node = match self.tsp_policy {
+                Some(policy) => TestEnvironment::new_with_tsp_policy(handle, policy).await?,
+                None => TestEnvironment::new(handle).await?,
+            };
+            #[cfg(not(feature = "tsp"))]
+            let node = TestEnvironment::new(handle).await?;
+            nodes.push(node);
         }
 
         Ok(TestTopology { nodes })

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_cross_mediator.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_cross_mediator.rs
@@ -1,0 +1,197 @@
+//! Cross-mediator TSP delivery for service-less (`did:key`-style) peers (#577 P1).
+//!
+//! - The metadata-private carriage primitive (`send_nested_routed`) delivers a
+//!   Nested-wrapped Direct message across two mediators, with the recipient
+//!   hidden from the sender's mediator (it is not a route hop).
+//! - `atm.send_to` routes cross-mediator automatically when the peer's mediator
+//!   is known and differs from the sender's.
+//! - The peer's mediator is learned from a routed relationship invite
+//!   (`form_relationship_routed` → `record_incoming_control`).
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_sdk::{SendProtocol, TspPolicy, TspSupport};
+use affinidi_messaging_test_mediator::{TestEnvironment, topology::TestTopology};
+use serde_json::json;
+use std::time::Duration;
+use uuid::Uuid;
+
+fn basic_message(from: &str, to: &str, text: &str) -> Message {
+    Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(to.to_string())
+    .from(from.to_string())
+    .finalize()
+}
+
+/// Poll a node's mailbox until a message lands (cross-mediator forwarding is
+/// asynchronous), returning the stored message.
+async fn poll_inbox(
+    env: &TestEnvironment,
+    profile: &std::sync::Arc<affinidi_messaging_sdk::profiles::ATMProfile>,
+) -> String {
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let fetched = env
+            .atm
+            .fetch_messages(profile, &FetchOptions::default())
+            .await
+            .expect("fetch messages");
+        if let Some(msg) = fetched.success.first().and_then(|e| e.msg.as_ref()) {
+            return msg.clone();
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    panic!("no message received within the deadline");
+}
+
+/// The carriage primitive: `send_nested_routed` delivers across two mediators
+/// while the recipient stays off the route (hidden from the sender's mediator).
+#[tokio::test]
+async fn send_nested_routed_delivers_cross_mediator() {
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .spawn()
+        .await
+        .expect("spawn two-mediator topology");
+    let mediator_a = topology.mediator_did(0).expect("mediator A").to_string();
+    let mediator_b = topology.mediator_did(1).expect("mediator B").to_string();
+    let alice = topology.add_user(0, "alice").await.expect("add alice on A");
+    let bob = topology.add_user(1, "bob").await.expect("add bob on B");
+
+    let payload = b"hello bob, nested over routed, recipient hidden from mediator A";
+    let route = vec![mediator_a, mediator_b];
+    topology
+        .node(0)
+        .unwrap()
+        .atm
+        .tsp()
+        .send_nested_routed(&alice.profile, &route, &bob.did, payload)
+        .await
+        .expect("alice sends nested+routed to bob on B");
+
+    let bob_env = topology.node(1).unwrap();
+    let stored = poll_inbox(bob_env, &bob.profile).await;
+    let (recovered, sender) = bob_env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, &stored)
+        .await
+        .expect("bob unpacks");
+    assert_eq!(recovered, payload);
+    assert_eq!(sender, alice.did);
+
+    topology.shutdown().await.expect("shutdown");
+}
+
+/// `send_to` routes cross-mediator automatically when the peer's mediator is
+/// known (here injected out-of-band) and differs from the sender's.
+#[tokio::test]
+async fn send_to_routes_cross_mediator_when_peer_mediator_known() {
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .tsp_policy(TspPolicy::Preferred)
+        .spawn()
+        .await
+        .expect("spawn two-mediator topology with Preferred policy");
+    let mediator_b = topology.mediator_did(1).expect("mediator B").to_string();
+    let alice = topology.add_user(0, "alice").await.expect("add alice on A");
+    let bob = topology.add_user(1, "bob").await.expect("add bob on B");
+    let a = topology.node(0).unwrap();
+
+    // Alice knows bob speaks TSP and lives on mediator B (learned out-of-band).
+    a.atm
+        .tsp()
+        .set_peer_capability(&alice.profile, &bob.did, TspSupport::Supported)
+        .await
+        .expect("set bob supported");
+    a.atm
+        .tsp()
+        .set_peer_mediator(&alice.profile, &bob.did, Some(mediator_b.clone()))
+        .await
+        .expect("set bob's mediator");
+
+    let msg = basic_message(&alice.did, &bob.did, "cross-mediator via send_to");
+    let via = a
+        .atm
+        .send_to(&alice.profile, &msg, &bob.did, Some(&alice.did), None)
+        .await
+        .expect("send_to bob");
+    assert_eq!(via, SendProtocol::Tsp, "known peer capability → TSP");
+
+    // Bob, on mediator B, receives and unpacks the routed message.
+    let bob_env = topology.node(1).unwrap();
+    let stored = poll_inbox(bob_env, &bob.profile).await;
+    let (payload, sender) = bob_env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, &stored)
+        .await
+        .expect("bob unpacks");
+    assert_eq!(sender, alice.did);
+    let recovered: Message = serde_json::from_slice(&payload).expect("payload is a Message");
+    assert_eq!(
+        recovered.body,
+        json!({ "content": "cross-mediator via send_to" })
+    );
+
+    topology.shutdown().await.expect("shutdown");
+}
+
+/// A **routed** invite advertises the inviter's mediator; the recipient learns
+/// and caches it via `record_incoming_control`, so a later `send_to` can route
+/// to that peer. (Single mediator — this exercises the learning wire path; the
+/// cross-mediator delivery is covered above.)
+#[tokio::test]
+async fn routed_invite_teaches_peer_mediator() {
+    let env = TestEnvironment::spawn_with_tsp_policy(TspPolicy::Preferred)
+        .await
+        .expect("spawn env with Preferred policy");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Alice's own mediator DID — what her routed invite advertises.
+    let (_, alice_mediator) = alice.profile.dids().expect("alice dids");
+    let alice_mediator = alice_mediator.to_string();
+
+    // Alice forms a relationship with a routed invite (advertises her mediator).
+    env.atm
+        .tsp()
+        .form_relationship_routed(&alice.profile, &bob.did)
+        .await
+        .expect("alice forms routed relationship");
+
+    // Bob fetches and records the invite.
+    let stored = poll_inbox(&env, &bob.profile).await;
+    let invite_qb2 = env.atm.tsp().decode(&stored).expect("decode invite");
+    let (invite, sender, _digest) = env
+        .atm
+        .tsp()
+        .unpack_control(&bob.profile, &invite_qb2)
+        .await
+        .expect("bob unpacks the invite control");
+    assert_eq!(sender, alice.did);
+    env.atm
+        .tsp()
+        .record_incoming_control(&bob.profile, &alice.did, &invite)
+        .await
+        .expect("bob records the invite");
+
+    // Bob now knows alice's mediator.
+    let cap = env
+        .atm
+        .tsp()
+        .peer_capability(&bob.profile, &alice.did)
+        .await
+        .unwrap()
+        .expect("bob has a capability record for alice");
+    assert_eq!(
+        cap.mediator,
+        Some(alice_mediator),
+        "bob learned alice's mediator from the routed invite"
+    );
+}


### PR DESCRIPTION
Implements #577 P1 (SDD `tasks/tsp-cross-mediator-routing-sdd.md`, decisions Q1–Q4). Built on a validated O1 spike (below).

## Problem
`atm.send_to` v1 assumed the recipient shared the sender's mediator. A `did:key` peer on a **different** mediator couldn't be reached — did:key carries no service/routingKeys, and nothing surfaced the peer's mediator to the sender.

## O1 spike (validated first)
The mediator routes on the cleartext `receiver`: `receiver != me` → opaque store-for-local-pickup (not a forward); only `receiver == me` triggers the relay/forward path. And routed mode exposes the *remaining route hops* to each intermediary but never the inner content. Consequences:
- Plain `send_routed([A,B,bob])` works cross-mediator but **reveals `bob`** to the sender's mediator A.
- Bare `send_nested(B, …)` can't cross mediators (A just stores it for local pickup).
- **Metadata-private cross-mediator carriage** = route `[A,B]` (bob absent) carrying a **Nested inner sealed to B**. A forwards seeing only `next=B`; B unwraps and delivers to bob locally. Proven end-to-end on the two-mediator harness.

## Changes (SDK — `affinidi-messaging-sdk` 0.18.47 → 0.18.48)
- `PeerCapability.mediator: Option<String>` — the peer's mediator DID (`None` = shares sender's mediator = today's Direct behaviour). All tsp-support writes preserve it; `#[serde(default)]` for store compatibility.
- `TspOps::send_nested_routed(profile, route, to_did, payload)` — the carriage primitive above.
- `TspOps::form_relationship_routed` — opt-in routed invite advertising the inviter's own mediator (Q2); `record_incoming_control` reads the control's route → caches the peer's mediator. `TspOps::set_peer_mediator` sets it out-of-band.
- `ATM::send_to` — routes via `send_nested_routed([own_med, peer_med])` when the peer's mediator is known and differs from ours; else Direct/DIDComm (unchanged).

## Test infra + e2e (`affinidi-messaging-test-mediator` 0.2.37 → 0.2.38)
- `TestTopology::tsp_policy` + `TestEnvironment::new_with_tsp_policy` — enable TSP selection on multi-mediator topologies.
- `tests/tsp_cross_mediator.rs`: (1) nested-routed cross-mediator delivery; (2) `send_to` auto-routes cross-mediator when the peer's mediator is known; (3) a routed invite teaches the peer's mediator.

## Notes
- Decisions locked (SDD): Q1 single mediator DID, Q2 opt-in advertise, Q3 Nested/metadata-private carriage, Q4 SDD-first.
- Additive; default and existing `tsp` behaviour unchanged when no mediator is learned (`send_to` stays Direct). Clippy clean (default + `tsp`), fmt clean, version-bump guard passes.
- Follow-ups (parked): #576 done; symmetric accept-side advertisement (SDD O3) and TTL-clear-on-routed-failure (O5) remain as enhancements.