### PR TITLE
refactor: single source of truth for KeyType→key-agreement Curve mapping

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Affinidi Crypto Changelog
 
+## 4th July 2026 (0.2.4)
+
+Adds `KeyType::key_agreement_curve() -> Option<Curve>` (gated on the `jose`
+feature) — the single source of truth for the secrets-resolver `KeyType` →
+JOSE `Curve` mapping. Every DIDComm pack/unpack path in the workspace now
+routes its sender/recipient key-agreement curve selection through this one
+method instead of re-implementing the match, so the paths can never diverge.
+The mapping is exhaustive with no wildcard arm, so a future `KeyType` variant
+is a compile error until it is explicitly classified as key-agreement-capable
+or not. Additive (verify-only new method); patch bump keeps the
+`[patch.crates-io]` redirect valid — see
+[ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md).
+
 ## 30th June 2026 (0.2.3)
 
 Adds `jose::signing::verify_p256` — ECDSA P-256 signature verification over

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.3"
+version = "0.2.4"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/src/key_type.rs
+++ b/crates/core/affinidi-crypto/src/key_type.rs
@@ -94,3 +94,79 @@ impl fmt::Display for KeyType {
         }
     }
 }
+
+/// Key-agreement (ECDH) curve mapping.
+///
+/// Gated on the `jose` feature because [`Curve`](crate::jose::key_agreement::Curve)
+/// — the JOSE key-agreement curve set — only exists when the JOSE primitives
+/// are compiled in.
+#[cfg(feature = "jose")]
+impl KeyType {
+    /// The elliptic curve this key type uses for ECDH key agreement, or
+    /// `None` when the key type cannot perform key agreement.
+    ///
+    /// This is the **single source of truth** for the `KeyType` →
+    /// [`Curve`](crate::jose::key_agreement::Curve) mapping. Every DIDComm
+    /// pack/unpack path — authcrypt/anoncrypt sender-key selection and JWE
+    /// recipient decryption — routes through here instead of re-implementing
+    /// the match, so the paths can never disagree on which curve a key uses.
+    /// Signature-only or non-key-agreement suites (Ed25519, BLS12-381 G2,
+    /// ML-DSA, SLH-DSA) and [`KeyType::Unknown`] return `None`; callers
+    /// translate that into their own contextual error.
+    ///
+    /// The match is deliberately **exhaustive with no wildcard arm**: adding a
+    /// new [`KeyType`] variant is a compile error here until it is explicitly
+    /// classified, so a future key-agreement curve can never be silently
+    /// dropped from negotiation.
+    pub fn key_agreement_curve(&self) -> Option<crate::jose::key_agreement::Curve> {
+        use crate::jose::key_agreement::Curve;
+        match self {
+            KeyType::X25519 => Some(Curve::X25519),
+            KeyType::P256 => Some(Curve::P256),
+            KeyType::Secp256k1 => Some(Curve::K256),
+            KeyType::P384 => Some(Curve::P384),
+            KeyType::P521 => Some(Curve::P521),
+            KeyType::Ed25519 | KeyType::Bls12381G2 | KeyType::Unknown => None,
+            #[cfg(feature = "ml-dsa")]
+            KeyType::MlDsa44 | KeyType::MlDsa65 | KeyType::MlDsa87 => None,
+            #[cfg(feature = "slh-dsa")]
+            KeyType::SlhDsaSha2_128s => None,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "jose"))]
+mod key_agreement_curve_tests {
+    use super::KeyType;
+    use crate::jose::key_agreement::Curve;
+
+    #[test]
+    fn maps_every_key_agreement_curve() {
+        assert_eq!(KeyType::X25519.key_agreement_curve(), Some(Curve::X25519));
+        assert_eq!(KeyType::P256.key_agreement_curve(), Some(Curve::P256));
+        assert_eq!(KeyType::Secp256k1.key_agreement_curve(), Some(Curve::K256));
+        assert_eq!(KeyType::P384.key_agreement_curve(), Some(Curve::P384));
+        assert_eq!(KeyType::P521.key_agreement_curve(), Some(Curve::P521));
+    }
+
+    #[test]
+    fn signature_and_unknown_types_have_no_curve() {
+        assert_eq!(KeyType::Ed25519.key_agreement_curve(), None);
+        assert_eq!(KeyType::Bls12381G2.key_agreement_curve(), None);
+        assert_eq!(KeyType::Unknown.key_agreement_curve(), None);
+    }
+
+    #[cfg(feature = "ml-dsa")]
+    #[test]
+    fn ml_dsa_types_have_no_curve() {
+        assert_eq!(KeyType::MlDsa44.key_agreement_curve(), None);
+        assert_eq!(KeyType::MlDsa65.key_agreement_curve(), None);
+        assert_eq!(KeyType::MlDsa87.key_agreement_curve(), None);
+    }
+
+    #[cfg(feature = "slh-dsa")]
+    #[test]
+    fn slh_dsa_type_has_no_curve() {
+        assert_eq!(KeyType::SlhDsaSha2_128s.key_agreement_curve(), None);
+    }
+}

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Authentication
 
+## 4th July 2026 (0.3.9)
+
+Internal refactor: the local `_key_type_to_curve` helper is replaced by
+`affinidi_crypto::KeyType::key_agreement_curve()`, the shared single source of
+truth for the `KeyType` → key-agreement `Curve` mapping. No public API or
+behaviour change; patch bump — see ADR 0003.
+
 ## 13th June 2026 (0.3.8)
 
 Semver wave (W7 — release W11). `DIDAuthError` is now `#[non_exhaustive]` (match

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -728,7 +728,7 @@ where
         let Some(secret) = secrets_resolver.get_secret(kid).await else {
             continue;
         };
-        let Ok(curve) = _key_type_to_curve(secret.get_key_type()) else {
+        let Some(curve) = secret.get_key_type().key_agreement_curve() else {
             continue;
         };
         match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
@@ -778,20 +778,6 @@ where
         &[(pairing.recipient_kid, &pairing.recipient_pub)],
     )
     .map_err(|e| DIDAuthError::DIDComm(format!("pack failed: {e}")))
-}
-
-/// Map from secrets resolver KeyType to DIDComm Curve.
-fn _key_type_to_curve(key_type: affinidi_secrets_resolver::secrets::KeyType) -> Result<Curve> {
-    match key_type {
-        affinidi_secrets_resolver::secrets::KeyType::X25519 => Ok(Curve::X25519),
-        affinidi_secrets_resolver::secrets::KeyType::P256 => Ok(Curve::P256),
-        affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Ok(Curve::K256),
-        affinidi_secrets_resolver::secrets::KeyType::P384 => Ok(Curve::P384),
-        affinidi_secrets_resolver::secrets::KeyType::P521 => Ok(Curve::P521),
-        other => Err(DIDAuthError::DIDComm(format!(
-            "unsupported key type for key agreement: {other:?}"
-        ))),
-    }
 }
 
 /// Possible responses from checking authentication JWT tokens

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Changelog history
 
+## 4th July 2026
+
+### 0.16.41 — refactor: single source of truth for key-agreement curve mapping
+
+- The `pack_encrypted` and `unpack_jwe` paths now select their key-agreement
+  curve via the shared `affinidi_crypto::KeyType::key_agreement_curve()` helper
+  instead of two local copies of the `KeyType` → `Curve` match (one of them the
+  `key_type_to_curve` fn added in 0.16.40). No behaviour change — the mapping is
+  identical; this removes the duplication flagged in the 0.16.40 review.
+
 ## 3rd July 2026
 
 ### 0.16.40 — fix: negotiate shared key-agreement curve when packing encrypted replies

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.40"
+version = "0.16.41"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -220,13 +220,8 @@ impl MetaEnvelope {
             if let Some(kid) = recipient["header"]["kid"].as_str()
                 && let Some(secret) = secrets_resolver.get_secret(kid).await
             {
-                let curve = match secret.get_key_type() {
-                    affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
-                    affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
-                    affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
-                    affinidi_secrets_resolver::secrets::KeyType::P384 => Curve::P384,
-                    affinidi_secrets_resolver::secrets::KeyType::P521 => Curve::P521,
-                    _ => continue,
+                let Some(curve) = secret.get_key_type().key_agreement_curve() else {
+                    continue;
                 };
                 match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
                     Ok(pk) => {
@@ -723,9 +718,8 @@ pub async fn pack_encrypted<S: SecretsResolver>(
                 continue;
             };
             let key_type = secret.get_key_type();
-            let key_type_dbg = format!("{key_type:?}");
-            let Ok(curve) = key_type_to_curve(key_type) else {
-                skipped.push(format!("{kid} (unsupported key type: {key_type_dbg})"));
+            let Some(curve) = key_type.key_agreement_curve() else {
+                skipped.push(format!("{kid} (unsupported key type: {key_type:?})"));
                 continue;
             };
             match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
@@ -789,20 +783,6 @@ pub async fn pack_encrypted<S: SecretsResolver>(
         };
 
         Ok((packed, metadata))
-    }
-}
-
-/// Map a secrets-resolver `KeyType` to a DIDComm `Curve`.
-fn key_type_to_curve(
-    key_type: affinidi_secrets_resolver::secrets::KeyType,
-) -> Result<Curve, String> {
-    match key_type {
-        affinidi_secrets_resolver::secrets::KeyType::X25519 => Ok(Curve::X25519),
-        affinidi_secrets_resolver::secrets::KeyType::P256 => Ok(Curve::P256),
-        affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Ok(Curve::K256),
-        affinidi_secrets_resolver::secrets::KeyType::P384 => Ok(Curve::P384),
-        affinidi_secrets_resolver::secrets::KeyType::P521 => Ok(Curve::P521),
-        other => Err(format!("unsupported key type for key agreement: {other:?}")),
     }
 }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.18.49] - 2026-07-04
+
+- Route the DIDComm pack and unpack paths through the shared
+  `affinidi_crypto::KeyType::key_agreement_curve()` helper (single source of
+  truth for the `KeyType` → key-agreement `Curve` mapping) instead of two
+  local copies of the match.
+- Fix: the JWE unpack path previously handled only X25519/P-256/secp256k1
+  recipient keys and silently skipped P-384/P-521 (they fell through to
+  `_ => continue`), so a message encrypted to a local P-384/P-521 key failed
+  to decrypt with "no matching recipient". Consolidating onto the shared
+  helper restores P-384/P-521 recipient decryption, matching the pack path
+  and the mediator. Patch bump — see ADR 0003.
+
 ## [0.18.47] - 2026-07-03
 
 - Add `MessagePickup::send_delivery_request_frames` (+ `MessagePickupOps` delegate), the

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.48"
+version = "0.18.49"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/pack.rs
@@ -88,7 +88,7 @@ impl SharedState {
                     else {
                         continue;
                     };
-                    let Ok(curve) = key_type_to_curve(secret.get_key_type()) else {
+                    let Some(curve) = secret.get_key_type().key_agreement_curve() else {
                         continue;
                     };
                     match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
@@ -186,22 +186,5 @@ impl SharedState {
         }
         .instrument(_span)
         .await
-    }
-}
-
-/// Map from secrets resolver KeyType to DIDComm Curve.
-fn key_type_to_curve(
-    key_type: affinidi_secrets_resolver::secrets::KeyType,
-) -> Result<Curve, ATMError> {
-    match key_type {
-        affinidi_secrets_resolver::secrets::KeyType::X25519 => Ok(Curve::X25519),
-        affinidi_secrets_resolver::secrets::KeyType::P256 => Ok(Curve::P256),
-        affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Ok(Curve::K256),
-        affinidi_secrets_resolver::secrets::KeyType::P384 => Ok(Curve::P384),
-        affinidi_secrets_resolver::secrets::KeyType::P521 => Ok(Curve::P521),
-        other => Err(ATMError::DidcommError(
-            "key_type_to_curve".into(),
-            format!("unsupported key type for key agreement: {other:?}"),
-        )),
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/messages/unpack.rs
@@ -106,7 +106,7 @@ impl SharedState {
         value: &serde_json::Value,
         sha256_hash: &str,
     ) -> Result<(Message, UnpackMetadata), ATMError> {
-        use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement};
+        use affinidi_crypto::jose::key_agreement::PrivateKeyAgreement;
         use affinidi_messaging_didcomm::jwe::decrypt::decrypt;
 
         // Extract recipient KIDs from the JWE
@@ -122,11 +122,8 @@ impl SharedState {
             if let Some(kid) = recipient["header"]["kid"].as_str()
                 && let Some(secret) = self.tdk_common.secrets_resolver().get_secret(kid).await
             {
-                let curve = match secret.get_key_type() {
-                    affinidi_secrets_resolver::secrets::KeyType::X25519 => Curve::X25519,
-                    affinidi_secrets_resolver::secrets::KeyType::P256 => Curve::P256,
-                    affinidi_secrets_resolver::secrets::KeyType::Secp256k1 => Curve::K256,
-                    _ => continue,
+                let Some(curve) = secret.get_key_type().key_agreement_curve() else {
+                    continue;
                 };
                 match PrivateKeyAgreement::from_raw_bytes(curve, secret.get_private_bytes()) {
                     Ok(pk) => {


### PR DESCRIPTION
## What

The `KeyType` → key-agreement `Curve` match was copy-pasted across **five** call sites:

- `affinidi-did-authentication` (`_key_type_to_curve`)
- messaging SDK **pack** path (`key_type_to_curve`) and **unpack** path (inline)
- mediator **pack** path (`key_type_to_curve`, added in 0.16.40 / #586) and **unpack** path (inline)

This adds `affinidi_crypto::KeyType::key_agreement_curve() -> Option<Curve>` as the single source of truth and routes every site through it. Both types already live in `affinidi-crypto` (`KeyType` is re-exported by `affinidi-secrets-resolver`), so this introduces **no new dependency edges**. The method is gated on the `jose` feature, where `Curve` lives; all consumers already enable it.

This resolves the duplication finding raised in the #586 review.

## Bomb-proof & extensible

The mapping is **exhaustive with no wildcard arm** (mirroring the existing `Display`/`TryFrom` impls on `KeyType`). Adding a future `KeyType` variant is a **compile error** here until it is explicitly classified as key-agreement-capable or not — a new curve can never be silently dropped from negotiation. Signature-only / non-KA suites (Ed25519, BLS12-381 G2, ML-DSA, SLH-DSA) and `Unknown` return `None`; each caller maps `None` into its own contextual error. Unit tests cover every variant, including the `#[cfg]`-gated post-quantum arms.

## Latent bug fixed along the way

The SDK **JWE unpack** path only handled X25519 / P-256 / secp256k1 and silently skipped **P-384 / P-521** recipient keys (`_ => continue`), so a message encrypted to a local P-384/P-521 key failed to decrypt with "no matching recipient". The pack path and the mediator already handled all five. Consolidating onto the shared helper restores P-384/P-521 recipient decryption in the SDK unpack path — exactly the kind of divergence a single source of truth prevents.

## Versions (additive/internal, patch bumps per [ADR 0003](docs/adr/0003-public-api-semver-policy.md))

| crate | bump |
|---|---|
| `affinidi-crypto` | 0.2.3 → 0.2.4 (new method) |
| `affinidi-did-authentication` | 0.3.8 → 0.3.9 (internal) |
| `affinidi-messaging-sdk` | 0.18.48 → 0.18.49 (internal + P-384/P-521 unpack fix) |
| `affinidi-messaging-mediator` | 0.16.40 → 0.16.41 (internal) |

## Testing

- `cargo test -p affinidi-crypto --features "jose,post-quantum"` — new method tests (incl. cfg-gated PQ arms) pass
- `affinidi-did-authentication`, `affinidi-messaging-sdk` (65), `affinidi-messaging-mediator` `didcomm_compat` (13, incl. the #586 curve-negotiation regression suite now routed through the shared helper) all pass
- `cargo clippy … -D warnings` clean on default **and** `tsp` features
- `cargo fmt --all --check`, version-bump guard, toolchain-sync guard all green