### PR TITLE
fix: log rapid duplicate-WebSocket churn at debug, not warn

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.41"
+version = "0.16.42"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -369,14 +369,35 @@ impl StreamingTask {
         let replacing = if let Some(old) = clients.get(&value.did_hash) {
             let since_last = old.registered_at.elapsed();
             let churn = since_last < CHURN_WINDOW;
-            warn!(
-                did = did,
-                old_session = old.session_id,
-                new_session = new_session_id,
-                since_last_ms = since_last.as_millis() as u64,
-                churn,
-                "Duplicate WebSocket connection: closing old session in favour of new one",
-            );
+            let since_last_ms = since_last.as_millis() as u64;
+            let msg = "Duplicate WebSocket connection: closing old session in favour of new one";
+            // A churning DID replaces its own socket every few seconds
+            // (e.g. two client sessions for the same DID dueling over the
+            // one-socket-per-DID slot). Logging every flip at WARN buries
+            // the log — a two-hour duel emits thousands of identical lines.
+            // Emit churn at DEBUG and let the dedicated
+            // `WEBSOCKET_DUPLICATE_CHURN_TOTAL` counter be the operator
+            // signal (rate-alert on it). A genuine, spaced-out duplicate
+            // (non-churn) is still noteworthy, so keep it at WARN.
+            if churn {
+                debug!(
+                    did = did,
+                    old_session = old.session_id,
+                    new_session = new_session_id,
+                    since_last_ms,
+                    churn,
+                    "{msg}",
+                );
+            } else {
+                warn!(
+                    did = did,
+                    old_session = old.session_id,
+                    new_session = new_session_id,
+                    since_last_ms,
+                    churn,
+                    "{msg}",
+                );
+            }
             metrics::counter!(WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL).increment(1);
             if churn {
                 // Rapid replacement for the same DID — surface the flip-flop


### PR DESCRIPTION
## Problem

When two client sessions for the same DID duel over the mediator's one-socket-per-DID slot, the mediator replaces the socket every few seconds and logged **every flip at WARN**. A two-hour duel buried the log under thousands of identical lines (observed: **3,164 in ~2h**, 93% `churn=true`).

## Fix

Emit churn (a replacement within `CHURN_WINDOW`, 5s) at **DEBUG**, and let the dedicated `WEBSOCKET_DUPLICATE_CHURN_TOTAL` counter be the operator alerting signal (rate-alert on it). A genuine, spaced-out duplicate (non-churn) is still noteworthy, so it stays at **WARN**.

The one-socket invariant and the churn redelivery damping are unchanged — this only changes the log level of the per-flip line.

- `affinidi-messaging-mediator` 0.16.41 → 0.16.42

## Testing

- `cargo check -p affinidi-messaging-mediator` ✅
- `cargo fmt` ✅

## Context

The churn itself was a client-side session leak, fixed at the source in OpenVTC/verifiable-trust-infrastructure#632 (`vta_sdk::integration::startup` now shuts its transient DIDComm session down). This PR reduces the mediator's log noise while any such duel is in progress.