### PR TITLE
feat: use the read-only secret probe at boot and on /readyz

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog history
 
+## 9th July 2026
+
+### 0.16.43 — use the read-only secret-backend probe at boot and on /readyz
+
+- The startup secret-backend reachability check and the `/readyz` liveness probe
+  now call `SecretStore::probe_readonly()` instead of the write-based probe, so
+  the running service no longer needs write access to its secret backend just to
+  confirm the backend is reachable.
+
 ## 4th July 2026
 
 ### 0.16.41 — refactor: single source of truth for key-agreement curve mapping

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.42"
+version = "0.16.43"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -466,7 +466,8 @@ impl TryFrom<ConfigRaw> for Config {
             )
         })?;
         let mediator_secrets = MediatorSecrets::new(store);
-        mediator_secrets.probe().await.map_err(|e| {
+        // Read-only probe: verify reachability without needing write perms.
+        mediator_secrets.probe_readonly().await.map_err(|e| {
             MediatorError::ConfigError(
                 12,
                 "NA".into(),

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -259,7 +259,8 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
     // (Phase E), so a backend that was reachable at boot is highly
     // likely still reachable here. Re-probing on every /readyz catches
     // mid-flight credential expiries / network blips that the boot-
-    // time probe couldn't.
+    // time probe couldn't. Uses the read-only probe, so repeated /readyz
+    // polling never writes/deletes a sentinel (no write perms on the role).
     //
     // /readyz is unauthenticated, so the response must not echo the
     // backend URL or the underlying probe error: those can leak
@@ -267,7 +268,7 @@ pub async fn readiness_handler(State(state): State<SharedData>) -> impl IntoResp
     // strings to anyone who can reach the load-balancer probe path.
     // Keep a boolean `secrets_backend_reachable` for monitoring; log
     // the detailed error at warn level for operators.
-    let backend_reachable = match state.config.secrets_backend.probe().await {
+    let backend_reachable = match state.config.secrets_backend.probe_readonly().await {
         Ok(()) => {
             checks.push(serde_json::json!({
                 "name": "secrets_backend",


### PR DESCRIPTION
## Summary

Downstream follow-up to #589. Repoints the runtime's two secret-backend reachability checks — startup (`Config::TryFrom`) and the `/readyz` liveness handler — to `probe_readonly()` instead of the write-based probe. The running service no longer needs write access to its secret backend just to confirm reachability, and repeated `/readyz` polling no longer writes/deletes a sentinel. Bumps `affinidi-messaging-mediator` to 0.16.43.

> **Stacked on #589** (base branch `feat/mediator-readonly-secret-probe`). Depends on `affinidi-messaging-mediator-common` 0.15.26, which adds `probe_readonly()`. The `publish dry-run` / `verify-publish` checks will fail until 0.15.26 is published — merge and publish #589 first, then rebase this onto `main`.

> **Scope note:** this narrows the *probe's* requirement, not the runtime's overall one. In VTA mode the runtime still write-caches the fetched bundle (best-effort, non-fatal), and `rotate-admin` writes deliberately. A fully read-only role fits self-hosted mode, or VTA mode when the write-through cache can be sacrificed.

## Testing
- `cargo clippy --all-targets` clean with `-D warnings --cfg tracing_unstable`.
- `cargo fmt --check` clean.
- Version-bump guard passes for both changed publishable crates.
