### PR TITLE
feat: publish the minted public DID to an optional target

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 10th July 2026
+
+### 0.16.44 — `?region=` on `aws_parameter_store://` targets
+
+- `mediator_did`, `admin_did` and `did_web_self_hosted` now accept an optional
+  `?region=<region>` on an `aws_parameter_store://` value, so a parameter can
+  live in a region other than the one the process resolved by default. Absent,
+  the ambient AWS chain is used exactly as before — existing configs are
+  unaffected.
+- The scheme is now parsed by `mediator-common`'s shared `parameter_store`
+  module, the same one the `mediator-setup` wizard uses to publish, so a
+  published target can be pasted into `mediator.toml` verbatim. The parameter
+  name is everything between `://` and `?` and keeps its leading slash, which
+  AWS requires for a hierarchy (`aws_parameter_store:///mediator/did`).
+- `read_did_config` now trims the fetched value. A parameter set by hand via
+  the console or CLI often carries a trailing newline, which previously reached
+  the DID resolver and failed far from its cause.
+
 ## 9th July 2026
 
 ### 0.16.43 — use the read-only secret-backend probe at boot and on /readyz

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.43"
+version = "0.16.44"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -80,7 +80,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.27", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.1", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 10th July 2026
+
+### 0.15.27 — shared `aws_parameter_store://` target parser
+
+- New always-built `parameter_store` module: `parse_parameter_store_target`,
+  `ParameterStoreTarget`, `ParameterStoreTargetError`, `is_parameter_store_target`
+  and `PARAMETER_STORE_SCHEME`. Pure (no AWS SDK), shared by the mediator runtime
+  (which reads `mediator_did` / `admin_did` / `did_web_self_hosted` from a
+  parameter) and the `mediator-setup` wizard (which publishes the minted DID to
+  one), so the string one writes is the string the other reads.
+- The parameter name is everything between `://` and `?`, passed to AWS verbatim.
+  AWS requires a hierarchical name to carry a leading `/` (`/mediator/did`, not
+  `mediator/did`), so the name is never split on `/`, and an unqualified
+  hierarchy is rejected up front with a message naming the correct form.
+- Region is an optional `?region=` query parameter — the idiom `vault://` already
+  uses for its options. Absent means "use the ambient AWS chain". Encoding it as
+  a leading path segment would be ambiguous against the name's own leading slash.
+
 ## 9th July 2026
 
 ### 0.15.26 — add read-only secret-backend probe

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.26"
+version = "0.15.27"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -27,6 +27,12 @@ pub mod types;
 /// the `mediator-setup` wizard (writing the `did-web.json` artefact).
 pub mod did_web;
 
+/// `aws_parameter_store://` target parsing. Pure (no AWS SDK), always
+/// built: shared by the mediator runtime (reading `mediator_did` from a
+/// parameter) and the `mediator-setup` wizard (publishing the minted DID
+/// to one), so the string one writes is the string the other reads.
+pub mod parameter_store;
+
 #[cfg(feature = "server")]
 pub mod circuit_breaker;
 /// Database wiring: the lean `DatabaseConfig` serde struct is always

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/parameter_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/parameter_store.rs
@@ -1,0 +1,280 @@
+//! `aws_parameter_store://` target parsing.
+//!
+//! One grammar, one parser, shared by the two sides that must agree on it:
+//! the mediator runtime reads `mediator_did` / `admin_did` /
+//! `did_web_self_hosted` from a parameter, and the `mediator-setup` wizard
+//! publishes the minted DID to one. The string the wizard writes is the
+//! string the operator pastes into `mediator.toml`, so the two cannot be
+//! allowed to drift.
+//!
+//! ```text
+//! aws_parameter_store:///mediator/did?region=eu-west-1   explicit region
+//! aws_parameter_store:///mediator/did                    ambient region chain
+//! aws_parameter_store://mediator-did                     flat name
+//! ```
+//!
+//! The parameter name is everything between `://` and `?`. AWS requires a
+//! hierarchical name to carry a leading `/` — `/Dev/DBServer/MySQL/db-string13`
+//! is valid, `Dev/DBServer` is not — so the name is passed through verbatim
+//! rather than being split on `/`. That is why the region is a query
+//! parameter and not a leading path segment: a path segment would be
+//! ambiguous against the name's own leading slash.
+//!
+//! Region is optional. When absent the caller falls back to the ambient AWS
+//! chain (`AWS_REGION`, then the profile, then IMDS), which is what the
+//! runtime already resolves for its shared `SdkConfig`.
+//!
+//! `url::Url::parse` is deliberately not used: underscores are illegal in a
+//! URI scheme, so it rejects `aws_parameter_store://` outright. The same
+//! hand-split applies to the `aws_secrets` / `gcp_secrets` / `azure_keyvault`
+//! schemes in `secrets::url`.
+
+use thiserror::Error;
+
+/// URI scheme for a Systems Manager Parameter Store target.
+pub const PARAMETER_STORE_SCHEME: &str = "aws_parameter_store";
+
+/// Why an `aws_parameter_store://` target could not be parsed.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParameterStoreTargetError {
+    /// No `://` separator, or a scheme other than `aws_parameter_store`.
+    #[error("invalid target '{target}': expected '{PARAMETER_STORE_SCHEME}://<name>'")]
+    NotParameterStore {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// The parameter name was empty.
+    #[error("invalid target '{target}': parameter name is empty")]
+    EmptyName {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// The name contains a `/` but does not begin with one. AWS rejects
+    /// these, so catch it before the API call rather than after.
+    #[error(
+        "invalid target '{target}': a hierarchical parameter name must begin with '/' \
+         (AWS rejects '{name}'; write '{PARAMETER_STORE_SCHEME}:///{name}')"
+    )]
+    UnqualifiedHierarchy {
+        /// The offending target, verbatim.
+        target: String,
+        /// The name as written, without its required leading slash.
+        name: String,
+    },
+    /// `?region=` was present but empty.
+    #[error("invalid target '{target}': 'region' query parameter is empty")]
+    EmptyRegion {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// A query parameter other than `region` was supplied.
+    #[error(
+        "invalid target '{target}': unknown query parameter '{key}' (only 'region' is supported)"
+    )]
+    UnknownQueryParameter {
+        /// The offending target, verbatim.
+        target: String,
+        /// The unrecognised key.
+        key: String,
+    },
+}
+
+/// A parsed `aws_parameter_store://` target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParameterStoreTarget {
+    /// Fully qualified SSM parameter name, passed to the API verbatim.
+    pub name: String,
+    /// Region from `?region=`. `None` means "use the ambient AWS chain".
+    pub region: Option<String>,
+}
+
+/// True when `target` uses the `aws_parameter_store://` scheme. Cheap
+/// prefix test for callers deciding whether they need an AWS client at all.
+pub fn is_parameter_store_target(target: &str) -> bool {
+    target.starts_with(PARAMETER_STORE_SCHEME)
+        && target[PARAMETER_STORE_SCHEME.len()..].starts_with("://")
+}
+
+/// Parse a full `aws_parameter_store://…` target.
+///
+/// Validates the scheme, a non-empty name, AWS's leading-slash rule for
+/// hierarchical names, and that the only query parameter is `region`. Does
+/// no I/O, so callers can validate a target up front — before minting,
+/// provisioning, or writing anything.
+pub fn parse_parameter_store_target(
+    target: &str,
+) -> Result<ParameterStoreTarget, ParameterStoreTargetError> {
+    let err_target = || target.to_string();
+
+    let rest = target
+        .strip_prefix(PARAMETER_STORE_SCHEME)
+        .and_then(|r| r.strip_prefix("://"))
+        .ok_or_else(|| ParameterStoreTargetError::NotParameterStore {
+            target: err_target(),
+        })?;
+
+    // Name is everything before the query string, so a leading '/' and any
+    // internal hierarchy separators survive untouched.
+    let (name, query) = match rest.split_once('?') {
+        Some((name, query)) => (name, Some(query)),
+        None => (rest, None),
+    };
+
+    if name.is_empty() {
+        return Err(ParameterStoreTargetError::EmptyName {
+            target: err_target(),
+        });
+    }
+    if name.contains('/') && !name.starts_with('/') {
+        return Err(ParameterStoreTargetError::UnqualifiedHierarchy {
+            target: err_target(),
+            name: name.to_string(),
+        });
+    }
+
+    let mut region = None;
+    if let Some(query) = query {
+        for pair in query.split('&').filter(|p| !p.is_empty()) {
+            let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            match key {
+                "region" => {
+                    if value.is_empty() {
+                        return Err(ParameterStoreTargetError::EmptyRegion {
+                            target: err_target(),
+                        });
+                    }
+                    region = Some(value.to_string());
+                }
+                other => {
+                    return Err(ParameterStoreTargetError::UnknownQueryParameter {
+                        target: err_target(),
+                        key: other.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(ParameterStoreTarget {
+        name: name.to_string(),
+        region,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(t: &str) -> ParameterStoreTarget {
+        parse_parameter_store_target(t).expect("target should parse")
+    }
+
+    #[test]
+    fn hierarchical_name_keeps_its_leading_slash() {
+        // The whole reason region is a query param: the name's own leading
+        // slash must survive, and AWS requires it for a hierarchy.
+        let t = parse("aws_parameter_store:///mediator/did");
+        assert_eq!(t.name, "/mediator/did");
+        assert_eq!(t.region, None);
+    }
+
+    #[test]
+    fn flat_name_needs_no_leading_slash() {
+        let t = parse("aws_parameter_store://mediator-did");
+        assert_eq!(t.name, "mediator-did");
+        assert_eq!(t.region, None);
+    }
+
+    #[test]
+    fn region_query_parameter_is_extracted() {
+        let t = parse("aws_parameter_store:///mediator/did?region=eu-west-1");
+        assert_eq!(t.name, "/mediator/did");
+        assert_eq!(t.region.as_deref(), Some("eu-west-1"));
+    }
+
+    #[test]
+    fn region_does_not_eat_the_name() {
+        // Regression guard for the `<region>/<name>` grammar this replaced,
+        // which would have parsed the region out of the path and left the
+        // name as `mediator/did` — a name AWS rejects.
+        let t = parse("aws_parameter_store:///mediator/did?region=us-east-1");
+        assert_eq!(t.name, "/mediator/did");
+        assert!(!t.name.starts_with("us-east-1"));
+    }
+
+    #[test]
+    fn hierarchical_name_without_leading_slash_is_rejected() {
+        // AWS: "For parameters in a hierarchy, you must include a leading
+        // forward slash character (/)". Catch it before the API call.
+        let err = parse_parameter_store_target("aws_parameter_store://mediator/did").unwrap_err();
+        assert_eq!(
+            err,
+            ParameterStoreTargetError::UnqualifiedHierarchy {
+                target: "aws_parameter_store://mediator/did".into(),
+                name: "mediator/did".into(),
+            }
+        );
+        // The message tells the operator exactly what to write instead.
+        assert!(
+            err.to_string()
+                .contains("aws_parameter_store:///mediator/did")
+        );
+    }
+
+    #[test]
+    fn old_region_in_path_grammar_is_now_a_clear_error() {
+        // `aws_parameter_store://eu-west-1/mediator/did` used to mean
+        // region=eu-west-1, name=mediator/did. It now fails loudly rather
+        // than silently writing to an AWS-invalid name.
+        let err = parse_parameter_store_target("aws_parameter_store://eu-west-1/mediator/did")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ParameterStoreTargetError::UnqualifiedHierarchy { .. }
+        ));
+    }
+
+    #[test]
+    fn wrong_scheme_is_rejected() {
+        for target in ["s3://bucket/key", "not-a-uri", "aws_parameter_store:/x"] {
+            assert!(matches!(
+                parse_parameter_store_target(target).unwrap_err(),
+                ParameterStoreTargetError::NotParameterStore { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        assert!(matches!(
+            parse_parameter_store_target("aws_parameter_store://").unwrap_err(),
+            ParameterStoreTargetError::EmptyName { .. }
+        ));
+        assert!(matches!(
+            parse_parameter_store_target("aws_parameter_store://?region=eu-west-1").unwrap_err(),
+            ParameterStoreTargetError::EmptyName { .. }
+        ));
+    }
+
+    #[test]
+    fn empty_and_unknown_query_parameters_are_rejected() {
+        assert!(matches!(
+            parse_parameter_store_target("aws_parameter_store:///a?region=").unwrap_err(),
+            ParameterStoreTargetError::EmptyRegion { .. }
+        ));
+        assert!(matches!(
+            parse_parameter_store_target("aws_parameter_store:///a?profile=prod").unwrap_err(),
+            ParameterStoreTargetError::UnknownQueryParameter { .. }
+        ));
+    }
+
+    #[test]
+    fn scheme_predicate_matches_the_parser() {
+        assert!(is_parameter_store_target("aws_parameter_store:///a"));
+        assert!(is_parameter_store_target("aws_parameter_store://a"));
+        assert!(!is_parameter_store_target("aws_parameter_store:/a"));
+        assert!(!is_parameter_store_target("aws_parameter_storex://a"));
+        assert!(!is_parameter_store_target("file:///a"));
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -19,7 +19,11 @@ log_json = "false"
 ### this field is ignored.
 ### Supported formats:
 ###   did://<did_string>
-###   aws_parameter_store://<parameter_name>
+###   aws_parameter_store://<parameter_name>[?region=<region>]
+### A hierarchical parameter name keeps its leading slash, so it reads as
+### three slashes: aws_parameter_store:///mediator/did?region=eu-west-1
+### Without ?region= the ambient AWS region is used (AWS_REGION, profile,
+### then IMDS). The mediator-setup wizard publishes to this exact format.
 mediator_did = "did://did:peer:2.Vz6MkksX9huJxJwvLtj9vc3gXbT2m1WVy4Uoi3ssEiSSH2ZYJ.EzQ3shVZJV9gKezYsvy5tC1LCwjjWSms2zCfZhvnRK48BNoHH3"
 
 ### ****************************************************************************************************************************
@@ -76,7 +80,7 @@ admin_did = "did://did:peer:2.Vz6MkksX9huJxJwvLtj9vc3gXbT2m1WVy4Uoi3ssEiSSH2ZYJ.
 ### Path to the self-hosted DID Document
 ### Supported formats:
 ###   file://<path>
-###   aws_parameter_store://<parameter_name>
+###   aws_parameter_store://<parameter_name>[?region=<region>]
 ### When enabled, adds a did:web route at /.well-known/did.json.
 ### Inactive by default — uncomment only when this mediator should
 ### serve its own DID document/log (e.g. did:webvh self-hosted at

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -512,7 +512,33 @@ pub(crate) async fn load_forwarding_protection_blocks(
 
 #[cfg(test)]
 mod tests {
-    use super::{join_api_path, normalize_api_prefix};
+    use super::{join_api_path, normalize_api_prefix, read_did_config};
+
+    /// `mediator-setup` documents that a `file://` DID target does not
+    /// round-trip into `mediator_did`. Pin the runtime half of that claim so
+    /// the docs and the code cannot drift apart.
+    #[tokio::test]
+    async fn read_did_config_rejects_a_file_target() {
+        let err = read_did_config("file:///run/mediator/did.txt", &None, "mediator_did")
+            .await
+            .expect_err("file:// is not a DID source");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did://") && msg.contains("aws_parameter_store://"),
+            "error should name the two accepted schemes, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_did_config_trims_surrounding_whitespace() {
+        // A DID is a single token. The trim exists for parameter-store values
+        // set by hand (a trailing newline is easy to leave behind); assert it
+        // through the one scheme reachable without an AWS client.
+        let did = read_did_config("did://  did:peer:2.Vz6Mk\n", &None, "mediator_did")
+            .await
+            .expect("literal DID resolves");
+        assert_eq!(did, "did:peer:2.Vz6Mk");
+    }
 
     #[test]
     fn normalize_empty_forms_collapse_to_root() {

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -6,17 +6,26 @@
 //!
 //! - Reading the TOML file + applying env overrides.
 //! - Resolving `mediator_did` / `admin_did` from either a literal DID or
-//!   `aws_parameter_store://<name>`.
+//!   `aws_parameter_store://<name>[?region=<region>]`.
 //! - Reading the self-hosted DID document from `file://` or
 //!   `aws_parameter_store://`.
 //! - Hostname resolution and forwarding-loop protection.
+//!
+//! The `aws_parameter_store://` grammar lives in `mediator-common`'s
+//! `parameter_store` module, shared with the `mediator-setup` wizard that
+//! publishes to it, so the string the wizard writes is the string read here.
 
 use affinidi_did_common::{Document, DocumentExt, service::Endpoint};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_mediator_common::errors::MediatorError;
+#[cfg(feature = "aws")]
+use affinidi_messaging_mediator_common::parameter_store::parse_parameter_store_target;
+use affinidi_messaging_mediator_common::parameter_store::{
+    PARAMETER_STORE_SCHEME, is_parameter_store_target,
+};
 use affinidi_secrets_resolver::SecretsResolver;
 #[cfg(feature = "aws")]
-use aws_config::SdkConfig;
+use aws_config::{Region, SdkConfig};
 #[cfg(feature = "aws")]
 use aws_sdk_ssm::types::ParameterType;
 use std::{
@@ -34,14 +43,13 @@ use super::processors::ForwardingConfig;
 /// excluded — those are handled via `MediatorSecrets`, which owns its own
 /// AWS SDK client when the `secrets-aws` feature is enabled.
 pub(crate) fn config_needs_aws(raw: &super::ConfigRaw) -> bool {
-    let aws_param = |s: &str| s.starts_with("aws_parameter_store://");
-    aws_param(&raw.mediator_did)
-        || aws_param(&raw.server.admin_did)
+    is_parameter_store_target(&raw.mediator_did)
+        || is_parameter_store_target(&raw.server.admin_did)
         || raw
             .server
             .did_web_self_hosted
-            .as_ref()
-            .is_some_and(|s| aws_param(s))
+            .as_deref()
+            .is_some_and(is_parameter_store_target)
 }
 
 /// Extract the AWS `SdkConfig` from an `Option<AwsConfig>`, returning a clear
@@ -74,7 +82,9 @@ fn parse_scheme<'a>(input: &'a str, field_name: &str) -> Result<(&'a str, &'a st
 ///
 /// Supported schemes:
 /// - `did://<did-string>` — literal DID.
-/// - `aws_parameter_store://<parameter-name>` — fetched at startup.
+/// - `aws_parameter_store://<parameter-name>[?region=<region>]` — fetched at
+///   startup. See [`affinidi_messaging_mediator_common::parameter_store`] for
+///   the grammar; `mediator-setup` publishes to the same one.
 ///
 /// `vta://` is no longer supported here; when VTA integration is enabled
 /// the mediator DID is discovered from the admin credential at startup.
@@ -86,14 +96,14 @@ pub(crate) async fn read_did_config(
     let (scheme, path) = parse_scheme(did_config, field_name)?;
     let content: String = match scheme {
         "did" => path.to_string(),
-        "aws_parameter_store" => {
+        PARAMETER_STORE_SCHEME => {
             #[cfg(feature = "aws")]
             {
                 let cfg = require_aws_config(
                     aws_config,
-                    &format!("{field_name} (aws_parameter_store://)"),
+                    &format!("{field_name} ({PARAMETER_STORE_SCHEME}://)"),
                 )?;
-                aws_parameter_store(path, cfg).await?
+                aws_parameter_store(did_config, cfg).await?
             }
             #[cfg(not(feature = "aws"))]
             {
@@ -118,7 +128,10 @@ pub(crate) async fn read_did_config(
         }
     };
 
-    Ok(content)
+    // A DID is a single token, and a parameter set by hand via the console or
+    // CLI often carries a trailing newline. Trim rather than hand a stray
+    // "\n" to the DID resolver, which fails far from the cause.
+    Ok(content.trim().to_string())
 }
 
 pub(crate) fn get_hostname(host_name: &str) -> Result<String, MediatorError> {
@@ -150,16 +163,35 @@ pub(crate) fn get_hostname(host_name: &str) -> Result<String, MediatorError> {
     }
 }
 
+/// Fetch a parameter named by a full `aws_parameter_store://…` target.
+///
+/// `target` is parsed by the shared grammar, so the name keeps its leading
+/// slash and an optional `?region=` overrides the ambient region for this
+/// call only — the rest of the process keeps using the shared `SdkConfig`.
 #[cfg(feature = "aws")]
 pub(crate) async fn aws_parameter_store(
-    parameter_name: &str,
+    target: &str,
     aws_config: &SdkConfig,
 ) -> Result<String, MediatorError> {
+    let parsed = parse_parameter_store_target(target)
+        .map_err(|e| MediatorError::ConfigError(12, "NA".into(), e.to_string()))?;
+    let parameter_name = parsed.name;
+
+    // Region in the target wins, so a parameter can live somewhere other
+    // than the region the rest of the SDK defaulted to.
+    let regional_config;
+    let aws_config = match parsed.region {
+        Some(region) => {
+            regional_config = aws_config.to_builder().region(Region::new(region)).build();
+            &regional_config
+        }
+        None => aws_config,
+    };
     let ssm = aws_sdk_ssm::Client::new(aws_config);
 
     let response = ssm
         .get_parameter()
-        .set_name(Some(parameter_name.to_string()))
+        .set_name(Some(parameter_name.clone()))
         .send()
         .await
         .map_err(|e| {
@@ -254,11 +286,11 @@ pub(crate) async fn read_document(
     let (scheme, path) = parse_scheme(document_path, "document_path")?;
     let content: String = match scheme {
         "file" => read_file_lines(path)?.concat(),
-        "aws_parameter_store" => {
+        PARAMETER_STORE_SCHEME => {
             #[cfg(feature = "aws")]
             {
                 let cfg = require_aws_config(aws_config, "document_path (aws_parameter_store://)")?;
-                aws_parameter_store(path, cfg).await?
+                aws_parameter_store(document_path, cfg).await?
             }
             #[cfg(not(feature = "aws"))]
             {

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Changelog history
 
+## 9th July 2026
+
+### 0.1.21 — publish the minted public DID to an optional target
+
+- After provisioning, the wizard can publish the mediator's public DID string
+  to a target from the recipe's `[output].did_target` — either `file://<path>`
+  or `aws_parameter_store://<region>/<name>` (SSM, gated by the new
+  `publish-aws` build feature). Defaults to `None`, so interactive and local
+  setups are unaffected.
+- The SSM region is part of the target (`<region>/<name>`) so the publish
+  destination is self-describing and never silently inherits the secret-storage
+  backend's region.
+- The target scheme is validated at recipe load — before anything is minted,
+  provisioned, or written — so a malformed target fails fast.
+
 ## 2nd July 2026
 
 ### 0.1.20 — advertise `TSPTransport` on VTA-minted mediators only when TSP is enabled

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,20 +2,28 @@
 
 ## Changelog history
 
-## 9th July 2026
+## 10th July 2026
 
 ### 0.1.21 — publish the minted public DID to an optional target
 
 - After provisioning, the wizard can publish the mediator's public DID string
   to a target from the recipe's `[output].did_target` — either `file://<path>`
-  or `aws_parameter_store://<region>/<name>` (SSM, gated by the new
+  or `aws_parameter_store://<name>[?region=<region>]` (SSM, gated by the new
   `publish-aws` build feature). Defaults to `None`, so interactive and local
   setups are unaffected.
-- The SSM region is part of the target (`<region>/<name>`) so the publish
-  destination is self-describing and never silently inherits the secret-storage
-  backend's region.
-- The target scheme is validated at recipe load — before anything is minted,
-  provisioned, or written — so a malformed target fails fast.
+- The parameter-store target uses `mediator-common`'s shared `parameter_store`
+  grammar — the same one the mediator runtime parses when it reads `mediator_did`
+  — so the published target can be pasted into `mediator.toml` verbatim. A
+  hierarchical name keeps its leading slash (`aws_parameter_store:///mediator/did`),
+  which AWS requires; the region is an optional `?region=` query parameter rather
+  than a leading path segment, which would be ambiguous against that slash.
+- Without `?region=` the ambient AWS chain is used (`AWS_REGION`, profile, IMDS),
+  so the publish destination never silently inherits the secret-storage backend's
+  region.
+- The target is validated at recipe load — before anything is minted, provisioned,
+  or written — including rejecting an `aws_parameter_store://` target in a build
+  without the `publish-aws` feature, which previously failed only after
+  provisioning had already run.
 
 ## 2nd July 2026
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -24,6 +24,12 @@
   or written — including rejecting an `aws_parameter_store://` target in a build
   without the `publish-aws` feature, which previously failed only after
   provisioning had already run.
+- Documented that **only the `aws_parameter_store://` target round-trips**. The
+  mediator resolves `mediator_did` / `admin_did` from `did://<did>` or
+  `aws_parameter_store://` only, so a `file://` target hands the DID to an
+  out-of-band consumer (a relying party, a CI step, an operator) rather than to
+  `mediator.toml`, where the DID itself is pasted as `did://<did>`. Unchanged
+  behaviour — previously unstated.
 
 ## 2nd July 2026
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.20"
+version = "0.1.21"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -24,6 +24,7 @@ default = [
   "secrets-azure",
   "secrets-vault",
   "secrets-k8s",
+  "publish-aws",
 ]
 secrets-keyring = ["affinidi-messaging-mediator-common/secrets-keyring"]
 secrets-aws = ["affinidi-messaging-mediator-common/secrets-aws"]
@@ -31,6 +32,11 @@ secrets-gcp = ["affinidi-messaging-mediator-common/secrets-gcp"]
 secrets-azure = ["affinidi-messaging-mediator-common/secrets-azure"]
 secrets-vault = ["affinidi-messaging-mediator-common/secrets-vault"]
 secrets-k8s = ["affinidi-messaging-mediator-common/secrets-k8s"]
+# AWS SSM client + config, so an `[output].did_target =
+# "aws_parameter_store://<region>/<name>"` can publish the minted DID. Kept
+# separate from `secrets-aws` (AWS secret *storage*) so a build that only
+# stores secrets in AWS doesn't have to pull the SSM client, and vice versa.
+publish-aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
 
 [dependencies]
 # ── TUI Framework ────────────────────────────────────────────────────────
@@ -141,6 +147,13 @@ humantime = "2"
 
 # ── Logging ──────────────────────────────────────────────────────────────
 tracing = "0.1"
+
+# ── AWS SSM (optional — gated by the `publish-aws` feature) ──────────────
+## Publishes the minted DID to SSM Parameter Store when `[output].did_target`
+## uses `aws_parameter_store://`. Pinned to `1` to match the runtime crate's
+## existing `aws-sdk-ssm` dependency.
+aws-config = { version = "1", optional = true }
+aws-sdk-ssm = { version = "1", optional = true }
 
 [dev-dependencies]
 ## Test fixtures from `provision_client::test_helpers` (e.g.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
@@ -146,15 +146,24 @@ listen_address = "0.0.0.0:7037"
 
 # Optional: publish the minted public DID string after provisioning.
 # Omit (the default) to publish nowhere -- interactive/local setups.
-# Either a local file, or an SSM parameter:
+# Either an SSM parameter, or a local file:
 #
-#   did_target = "file:///run/mediator/did.txt"
 #   did_target = "aws_parameter_store:///mediator/did?region=eu-west-1"
+#   did_target = "file:///run/mediator/did.txt"
 #
 # A hierarchical SSM name keeps its leading slash (hence three slashes);
 # AWS rejects a hierarchy without one. Without ?region= the ambient AWS
-# region is used. The aws_parameter_store:// value written here is the
-# same string mediator.toml accepts for `mediator_did`.
+# region is used (AWS_REGION, profile, then IMDS).
+#
+# Only the aws_parameter_store:// form round-trips: it is exactly the
+# string mediator.toml accepts for `mediator_did`, so it can be pasted
+# across verbatim.
+#
+# A file:// target does NOT round-trip. The mediator cannot read
+# `mediator_did` from a file -- it accepts only did://<did> and
+# aws_parameter_store://. Use a file target to hand the DID to something
+# else (a relying party, a CI step, an operator); to put it in
+# mediator.toml, paste the file's contents as `mediator_did = "did://..."`.
 
 
 # ── Install ─────────────────────────────────────────────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
@@ -144,6 +144,18 @@ config_path = "conf/mediator.toml"
 # Listen address for the mediator (ip:port).
 listen_address = "0.0.0.0:7037"
 
+# Optional: publish the minted public DID string after provisioning.
+# Omit (the default) to publish nowhere -- interactive/local setups.
+# Either a local file, or an SSM parameter:
+#
+#   did_target = "file:///run/mediator/did.txt"
+#   did_target = "aws_parameter_store:///mediator/did?region=eu-west-1"
+#
+# A hierarchical SSM name keeps its leading slash (hence three slashes);
+# AWS rejects a hierarchy without one. Without ?region= the ambient AWS
+# region is used. The aws_parameter_store:// value written here is the
+# same string mediator.toml accepts for `mediator_did`.
+
 
 # ── Install ─────────────────────────────────────────────────────────────────
 [install]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -488,6 +488,9 @@ pub struct WizardConfig {
     /// the DID document points at the same URLs the mediator actually
     /// serves. Empty / `/` means "serve at host root".
     pub api_prefix: String,
+    /// Publish target for the minted DID string (recipe `[output].did_target`;
+    /// never prompted). `None` = don't publish.
+    pub did_target: Option<String>,
 }
 
 impl WizardConfig {
@@ -609,6 +612,7 @@ impl Default for WizardConfig {
             admin_did_mode: String::new(),
             listen_address: DEFAULT_LISTEN_ADDR.into(),
             api_prefix: DEFAULT_API_PREFIX.into(),
+            did_target: None,
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -9,6 +9,7 @@ mod discovery;
 mod docker;
 mod exit_recap;
 mod generators;
+mod publish;
 mod recipe;
 mod reprovision;
 mod sealed_handoff;
@@ -1145,6 +1146,9 @@ async fn generate_and_write(
     let artefacts = mint_artefacts(config, vta_session).await?;
     provision_secret_backend(config, &artefacts, vta_session).await?;
     write_config_artefacts(config, &artefacts, save_recipe)?;
+    // Optional: publish the minted DID to the recipe's `[output].did_target`.
+    // No-op unless a target is configured.
+    publish::publish_did_artefacts(&artefacts.mediator_did, config.did_target.as_deref()).await?;
     print_completion_summary(config, &artefacts, vta_session);
     Ok(())
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -1,0 +1,228 @@
+//! Optional publishing of the minted public DID.
+//!
+//! Publishes the mediator's public DID string to a store the runtime (or a
+//! relying party) reads, so a one-shot `mediator-setup` task can hand off the
+//! identity directly.
+//!
+//! Opt-in: the recipe's `[output].did_target` defaults to `None`, so
+//! interactive/local setups are unaffected. Supported targets:
+//!
+//! - `file://<path>` — write the DID string to a local file.
+//! - `aws_parameter_store://<region>/<name>` — write it to an SSM parameter in
+//!   the given region (gated by the `publish-aws` build feature). The region is
+//!   part of the target so the publish destination is self-describing and never
+//!   silently inherits the secret-storage backend's region.
+
+use anyhow::{Context, anyhow, bail};
+
+/// Publish the minted public DID string to the optional `[output].did_target`.
+/// A no-op when the target is `None`.
+pub async fn publish_did_artefacts(did: &str, did_target: Option<&str>) -> anyhow::Result<()> {
+    let Some(target) = did_target else {
+        return Ok(());
+    };
+
+    println!("\n\x1b[1mPublishing public identity\x1b[0m");
+    publish_value(target, did, "DID")
+        .await
+        .with_context(|| format!("publishing DID to '{target}'"))
+}
+
+/// Validate a publish target's scheme (and, for SSM, that a region and name are
+/// present) without performing any I/O. Called at recipe-load time so a bad
+/// target fails before anything is minted, provisioned, or written.
+pub fn validate_target(target: &str) -> anyhow::Result<()> {
+    let (scheme, rest) = split_target(target)?;
+    match scheme {
+        "file" => {
+            if rest.is_empty() {
+                bail!("invalid target '{target}': file:// needs a path");
+            }
+            Ok(())
+        }
+        "aws_parameter_store" => parse_ssm_target(rest, target).map(|_| ()),
+        other => bail!(
+            "unsupported target scheme '{other}://' for DID publishing \
+             (expected 'aws_parameter_store://<region>/<name>' or 'file://<path>')"
+        ),
+    }
+}
+
+fn split_target(target: &str) -> anyhow::Result<(&str, &str)> {
+    target
+        .split_once("://")
+        .ok_or_else(|| anyhow!("invalid target '{target}': expected '<scheme>://<location>'"))
+}
+
+/// Split an `aws_parameter_store://` body `<region>/<name>` into its parts.
+fn parse_ssm_target<'a>(rest: &'a str, target: &str) -> anyhow::Result<(&'a str, &'a str)> {
+    let (region, name) = rest.split_once('/').ok_or_else(|| {
+        anyhow!(
+            "invalid target '{target}': aws_parameter_store:// needs \
+             '<region>/<name>' (e.g. aws_parameter_store://eu-west-1/mediator/did)"
+        )
+    })?;
+    if region.is_empty() || name.is_empty() {
+        bail!(
+            "invalid target '{target}': aws_parameter_store:// needs a non-empty \
+             region and name as '<region>/<name>'"
+        );
+    }
+    Ok((region, name))
+}
+
+/// Route a single value to its target based on the URI scheme.
+async fn publish_value(target: &str, value: &str, label: &str) -> anyhow::Result<()> {
+    let (scheme, rest) = split_target(target)?;
+
+    match scheme {
+        "file" => {
+            let path = std::path::Path::new(rest);
+            if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating parent directory for '{rest}'"))?;
+            }
+            std::fs::write(path, value)
+                .with_context(|| format!("writing {label} to file '{rest}'"))?;
+            println!(
+                "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \x1b[36m{target}\x1b[0m"
+            );
+            Ok(())
+        }
+        "aws_parameter_store" => {
+            let (region, name) = parse_ssm_target(rest, target)?;
+            put_ssm_parameter(name, value, label, region).await
+        }
+        other => bail!(
+            "unsupported target scheme '{other}://' for {label} \
+             (expected 'aws_parameter_store://<region>/<name>' or 'file://<path>')"
+        ),
+    }
+}
+
+/// Write `value` to SSM Parameter Store parameter `name`, overwriting any
+/// existing value. The DID string is small, so the default Standard tier
+/// (4 KB) is always sufficient.
+#[cfg(feature = "publish-aws")]
+async fn put_ssm_parameter(
+    name: &str,
+    value: &str,
+    label: &str,
+    region: &str,
+) -> anyhow::Result<()> {
+    use aws_sdk_ssm::error::DisplayErrorContext;
+    use aws_sdk_ssm::types::ParameterType;
+
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_sdk_ssm::config::Region::new(region.to_string()))
+        .load()
+        .await;
+    let ssm = aws_sdk_ssm::Client::new(&config);
+
+    ssm.put_parameter()
+        .name(name)
+        .value(value)
+        .r#type(ParameterType::String)
+        .overwrite(true)
+        .send()
+        .await
+        // DisplayErrorContext walks the SDK error's source chain so the service
+        // message (e.g. AccessDenied, throttling) is surfaced, not just Debug.
+        .map_err(|e| {
+            anyhow!(
+                "SSM PutParameter({name}) failed: {}",
+                DisplayErrorContext(&e)
+            )
+        })?;
+
+    println!(
+        "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \
+         \x1b[36maws_parameter_store://{region}/{name}\x1b[0m"
+    );
+    Ok(())
+}
+
+#[cfg(not(feature = "publish-aws"))]
+async fn put_ssm_parameter(
+    _name: &str,
+    _value: &str,
+    label: &str,
+    _region: &str,
+) -> anyhow::Result<()> {
+    bail!(
+        "publishing {label} to aws_parameter_store:// requires the 'publish-aws' build feature; \
+         rebuild with `--features publish-aws`"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_target_is_a_noop() {
+        // No target set: publishing must succeed without touching anything —
+        // this is the interactive/local default.
+        publish_did_artefacts("did:webvh:abc", None)
+            .await
+            .expect("no-op publish should succeed");
+    }
+
+    #[tokio::test]
+    async fn file_target_writes_bare_value() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let did_path = dir.path().join("nested/did.txt");
+        let did_target = format!("file://{}", did_path.display());
+
+        publish_did_artefacts("did:webvh:abc", Some(&did_target))
+            .await
+            .expect("file publish should succeed");
+
+        assert_eq!(std::fs::read_to_string(&did_path).unwrap(), "did:webvh:abc");
+    }
+
+    #[test]
+    fn validate_accepts_file_and_ssm_targets() {
+        validate_target("file:///tmp/mediator-did.txt").expect("file target is valid");
+        validate_target("aws_parameter_store://eu-west-1/mediator/did")
+            .expect("ssm target with region is valid");
+    }
+
+    #[test]
+    fn validate_rejects_ssm_target_without_region() {
+        let err = validate_target("aws_parameter_store://mediator-did")
+            .expect_err("ssm target without '<region>/<name>' must fail");
+        assert!(err.to_string().contains("<region>/<name>"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_scheme() {
+        let err = validate_target("s3://bucket/key").expect_err("unknown scheme must fail");
+        assert!(
+            err.to_string()
+                .contains("unsupported target scheme 's3://'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_missing_scheme_separator() {
+        let err = validate_target("not-a-uri").expect_err("missing '://' must fail");
+        assert!(
+            err.to_string().contains("expected '<scheme>://<location>'"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_scheme_errors_at_publish_time() {
+        let err = publish_value("s3://bucket/key", "did:webvh:abc", "DID")
+            .await
+            .expect_err("unknown scheme must error");
+        assert!(
+            err.to_string()
+                .contains("unsupported target scheme 's3://'"),
+            "{err}"
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -8,11 +8,23 @@
 //! interactive/local setups are unaffected. Supported targets:
 //!
 //! - `file://<path>` — write the DID string to a local file.
-//! - `aws_parameter_store://<region>/<name>` — write it to an SSM parameter in
-//!   the given region (gated by the `publish-aws` build feature). The region is
-//!   part of the target so the publish destination is self-describing and never
-//!   silently inherits the secret-storage backend's region.
+//! - `aws_parameter_store://<name>[?region=<region>]` — write it to an SSM
+//!   parameter (gated by the `publish-aws` build feature).
+//!
+//! The parameter-store grammar is `mediator-common`'s
+//! [`affinidi_messaging_mediator_common::parameter_store`], the same one the
+//! runtime uses to *read* `mediator_did`. That is deliberate: the target
+//! published here is the string an operator pastes into `mediator.toml`, so
+//! producer and consumer must not drift. A hierarchical parameter name keeps
+//! its leading slash (`aws_parameter_store:///mediator/did`) because AWS
+//! rejects a hierarchy without one, and the region is a `?region=` query
+//! parameter rather than a leading path segment, which would be ambiguous
+//! against that slash. Without `?region=`, the ambient AWS chain is used —
+//! never the secret-storage backend's region.
 
+use affinidi_messaging_mediator_common::parameter_store::{
+    PARAMETER_STORE_SCHEME, ParameterStoreTarget, parse_parameter_store_target,
+};
 use anyhow::{Context, anyhow, bail};
 
 /// Publish the minted public DID string to the optional `[output].did_target`.
@@ -28,9 +40,13 @@ pub async fn publish_did_artefacts(did: &str, did_target: Option<&str>) -> anyho
         .with_context(|| format!("publishing DID to '{target}'"))
 }
 
-/// Validate a publish target's scheme (and, for SSM, that a region and name are
-/// present) without performing any I/O. Called at recipe-load time so a bad
-/// target fails before anything is minted, provisioned, or written.
+/// Validate a publish target without performing any I/O. Called at recipe-load
+/// time so a bad target fails before anything is minted, provisioned, or
+/// written.
+///
+/// Rejects an `aws_parameter_store://` target in a build without the
+/// `publish-aws` feature: that is knowable here, and failing at publish time
+/// would leave a provisioned-but-unreported setup.
 pub fn validate_target(target: &str) -> anyhow::Result<()> {
     let (scheme, rest) = split_target(target)?;
     match scheme {
@@ -40,10 +56,23 @@ pub fn validate_target(target: &str) -> anyhow::Result<()> {
             }
             Ok(())
         }
-        "aws_parameter_store" => parse_ssm_target(rest, target).map(|_| ()),
+        PARAMETER_STORE_SCHEME => {
+            #[cfg(not(feature = "publish-aws"))]
+            {
+                bail!(
+                    "invalid target '{target}': publishing to {PARAMETER_STORE_SCHEME}:// \
+                     requires the 'publish-aws' build feature; rebuild with \
+                     `--features publish-aws`, or use a file:// target"
+                );
+            }
+            #[cfg(feature = "publish-aws")]
+            {
+                parse_target(target).map(|_| ())
+            }
+        }
         other => bail!(
-            "unsupported target scheme '{other}://' for DID publishing \
-             (expected 'aws_parameter_store://<region>/<name>' or 'file://<path>')"
+            "unsupported target scheme '{other}://' for DID publishing (expected \
+             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]' or 'file://<path>')"
         ),
     }
 }
@@ -54,71 +83,64 @@ fn split_target(target: &str) -> anyhow::Result<(&str, &str)> {
         .ok_or_else(|| anyhow!("invalid target '{target}': expected '<scheme>://<location>'"))
 }
 
-/// Split an `aws_parameter_store://` body `<region>/<name>` into its parts.
-fn parse_ssm_target<'a>(rest: &'a str, target: &str) -> anyhow::Result<(&'a str, &'a str)> {
-    let (region, name) = rest.split_once('/').ok_or_else(|| {
-        anyhow!(
-            "invalid target '{target}': aws_parameter_store:// needs \
-             '<region>/<name>' (e.g. aws_parameter_store://eu-west-1/mediator/did)"
-        )
-    })?;
-    if region.is_empty() || name.is_empty() {
-        bail!(
-            "invalid target '{target}': aws_parameter_store:// needs a non-empty \
-             region and name as '<region>/<name>'"
-        );
-    }
-    Ok((region, name))
+/// Parse an `aws_parameter_store://` target through the shared grammar,
+/// surfacing its error verbatim — it already names the correct form.
+fn parse_target(target: &str) -> anyhow::Result<ParameterStoreTarget> {
+    parse_parameter_store_target(target).map_err(|e| anyhow!("{e}"))
 }
 
 /// Route a single value to its target based on the URI scheme.
 async fn publish_value(target: &str, value: &str, label: &str) -> anyhow::Result<()> {
-    let (scheme, rest) = split_target(target)?;
+    // Re-validate rather than assume the caller did: `publish_value` is the
+    // last gate before an external write.
+    validate_target(target)?;
 
-    match scheme {
-        "file" => {
-            let path = std::path::Path::new(rest);
+    match split_target(target)? {
+        ("file", path) => {
+            let path = std::path::Path::new(path);
             if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
                 std::fs::create_dir_all(parent)
-                    .with_context(|| format!("creating parent directory for '{rest}'"))?;
+                    .with_context(|| format!("creating parent directory for '{target}'"))?;
             }
             std::fs::write(path, value)
-                .with_context(|| format!("writing {label} to file '{rest}'"))?;
+                .with_context(|| format!("writing {label} to file '{target}'"))?;
             println!(
                 "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \x1b[36m{target}\x1b[0m"
             );
             Ok(())
         }
-        "aws_parameter_store" => {
-            let (region, name) = parse_ssm_target(rest, target)?;
-            put_ssm_parameter(name, value, label, region).await
+        (PARAMETER_STORE_SCHEME, _) => {
+            put_ssm_parameter(&parse_target(target)?, value, label).await
         }
-        other => bail!(
-            "unsupported target scheme '{other}://' for {label} \
-             (expected 'aws_parameter_store://<region>/<name>' or 'file://<path>')"
+        (other, _) => bail!(
+            "unsupported target scheme '{other}://' for {label} (expected \
+             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]' or 'file://<path>')"
         ),
     }
 }
 
-/// Write `value` to SSM Parameter Store parameter `name`, overwriting any
+/// Write `value` to the SSM parameter named by `target`, overwriting any
 /// existing value. The DID string is small, so the default Standard tier
-/// (4 KB) is always sufficient.
+/// (4 KB) is always sufficient — no tier handling needed.
 #[cfg(feature = "publish-aws")]
 async fn put_ssm_parameter(
-    name: &str,
+    target: &ParameterStoreTarget,
     value: &str,
     label: &str,
-    region: &str,
 ) -> anyhow::Result<()> {
     use aws_sdk_ssm::error::DisplayErrorContext;
     use aws_sdk_ssm::types::ParameterType;
 
-    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-        .region(aws_sdk_ssm::config::Region::new(region.to_string()))
-        .load()
-        .await;
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    // No `?region=` means the ambient chain (AWS_REGION, profile, IMDS) —
+    // the same resolution the mediator runtime performs when it reads back.
+    if let Some(region) = &target.region {
+        loader = loader.region(aws_sdk_ssm::config::Region::new(region.clone()));
+    }
+    let config = loader.load().await;
     let ssm = aws_sdk_ssm::Client::new(&config);
 
+    let name = &target.name;
     ssm.put_parameter()
         .name(name)
         .value(value)
@@ -136,22 +158,33 @@ async fn put_ssm_parameter(
         })?;
 
     println!(
-        "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \
-         \x1b[36maws_parameter_store://{region}/{name}\x1b[0m"
+        "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \x1b[36m{}\x1b[0m",
+        render_target(target)
     );
     Ok(())
 }
 
+/// Render a parsed target back to the string an operator can paste into
+/// `mediator.toml` as `mediator_did`.
+#[cfg(feature = "publish-aws")]
+fn render_target(target: &ParameterStoreTarget) -> String {
+    match &target.region {
+        Some(region) => format!("{PARAMETER_STORE_SCHEME}://{}?region={region}", target.name),
+        None => format!("{PARAMETER_STORE_SCHEME}://{}", target.name),
+    }
+}
+
 #[cfg(not(feature = "publish-aws"))]
 async fn put_ssm_parameter(
-    _name: &str,
+    _target: &ParameterStoreTarget,
     _value: &str,
     label: &str,
-    _region: &str,
 ) -> anyhow::Result<()> {
+    // Unreachable in practice — `validate_target` rejects the scheme at recipe
+    // load in this build — but kept so the call site type-checks either way.
     bail!(
-        "publishing {label} to aws_parameter_store:// requires the 'publish-aws' build feature; \
-         rebuild with `--features publish-aws`"
+        "publishing {label} to {PARAMETER_STORE_SCHEME}:// requires the 'publish-aws' \
+         build feature; rebuild with `--features publish-aws`"
     )
 }
 
@@ -182,17 +215,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_file_and_ssm_targets() {
+    fn validate_accepts_a_file_target() {
         validate_target("file:///tmp/mediator-did.txt").expect("file target is valid");
-        validate_target("aws_parameter_store://eu-west-1/mediator/did")
-            .expect("ssm target with region is valid");
-    }
-
-    #[test]
-    fn validate_rejects_ssm_target_without_region() {
-        let err = validate_target("aws_parameter_store://mediator-did")
-            .expect_err("ssm target without '<region>/<name>' must fail");
-        assert!(err.to_string().contains("<region>/<name>"), "{err}");
     }
 
     #[test]
@@ -214,6 +238,12 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_rejects_empty_file_path() {
+        let err = validate_target("file://").expect_err("empty path must fail");
+        assert!(err.to_string().contains("needs a path"), "{err}");
+    }
+
     #[tokio::test]
     async fn unsupported_scheme_errors_at_publish_time() {
         let err = publish_value("s3://bucket/key", "did:webvh:abc", "DID")
@@ -224,5 +254,54 @@ mod tests {
                 .contains("unsupported target scheme 's3://'"),
             "{err}"
         );
+    }
+
+    /// The published target must be pasteable into `mediator.toml` as
+    /// `mediator_did`, so the wizard and the runtime have to agree on the
+    /// grammar. Assert against the shared parser rather than a local copy.
+    #[cfg(feature = "publish-aws")]
+    #[test]
+    fn published_target_round_trips_through_the_shared_grammar() {
+        for target in [
+            "aws_parameter_store:///mediator/did?region=eu-west-1",
+            "aws_parameter_store:///mediator/did",
+            "aws_parameter_store://mediator-did",
+        ] {
+            validate_target(target).unwrap_or_else(|e| panic!("{target} should validate: {e}"));
+            let parsed = parse_target(target).expect("shared parser accepts it");
+            assert_eq!(render_target(&parsed), target, "round-trip must be exact");
+        }
+    }
+
+    #[cfg(feature = "publish-aws")]
+    #[test]
+    fn validate_rejects_a_hierarchy_without_its_leading_slash() {
+        // AWS rejects the name `mediator/did`; catch it at recipe load, not
+        // after provisioning. This is also the shape the old
+        // `<region>/<name>` grammar produced.
+        let err = validate_target("aws_parameter_store://eu-west-1/mediator/did")
+            .expect_err("unqualified hierarchy must fail");
+        assert!(err.to_string().contains("must begin with '/'"), "{err}");
+    }
+
+    #[cfg(feature = "publish-aws")]
+    #[test]
+    fn validate_rejects_an_unknown_query_parameter() {
+        let err = validate_target("aws_parameter_store:///mediator/did?profile=prod")
+            .expect_err("unknown query parameter must fail");
+        assert!(
+            err.to_string().contains("only 'region' is supported"),
+            "{err}"
+        );
+    }
+
+    /// Without the feature, an SSM target must fail at *recipe load* rather
+    /// than after `mint_artefacts` / `provision_secret_backend` have run.
+    #[cfg(not(feature = "publish-aws"))]
+    #[test]
+    fn validate_rejects_ssm_target_when_publish_aws_is_off() {
+        let err = validate_target("aws_parameter_store:///mediator/did")
+            .expect_err("ssm target must fail without the publish-aws feature");
+        assert!(err.to_string().contains("publish-aws"), "{err}");
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -7,9 +7,11 @@
 //! Opt-in: the recipe's `[output].did_target` defaults to `None`, so
 //! interactive/local setups are unaffected. Supported targets:
 //!
-//! - `file://<path>` — write the DID string to a local file.
 //! - `aws_parameter_store://<name>[?region=<region>]` — write it to an SSM
 //!   parameter (gated by the `publish-aws` build feature).
+//! - `file://<path>` — write the DID string to a local file.
+//!
+//! # Only the parameter-store target round-trips
 //!
 //! The parameter-store grammar is `mediator-common`'s
 //! [`affinidi_messaging_mediator_common::parameter_store`], the same one the
@@ -21,6 +23,18 @@
 //! parameter rather than a leading path segment, which would be ambiguous
 //! against that slash. Without `?region=`, the ambient AWS chain is used —
 //! never the secret-storage backend's region.
+//!
+//! **A `file://` target does not round-trip.** The runtime resolves
+//! `mediator_did` / `admin_did` from `did://<did>` or `aws_parameter_store://`
+//! only — `read_did_config` rejects `file://`, because a config field pointing
+//! at a file the mediator must read at boot is a deployment coupling the
+//! unified-secrets migration deliberately removed. So a file target is for
+//! out-of-band consumers: a relying party, a CI step, an operator reading the
+//! value. To use it in `mediator.toml`, paste the file's contents in as
+//! `mediator_did = "did://<did>"`, not the `file://` URL.
+//!
+//! (`did_web_self_hosted` is unrelated and *does* accept `file://` — it names
+//! a DID *document*, not a DID string, and is read by `read_document`.)
 
 use affinidi_messaging_mediator_common::parameter_store::{
     PARAMETER_STORE_SCHEME, ParameterStoreTarget, parse_parameter_store_target,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -334,8 +334,10 @@ pub struct OutputSection {
     #[serde(default = "default_api_prefix")]
     pub api_prefix: String,
     /// Optional target to publish the minted public DID string to after
-    /// provisioning (`aws_parameter_store://<region>/<name>` or
-    /// `file://<path>`). `None` (default) = don't publish.
+    /// provisioning (`aws_parameter_store://<name>[?region=<region>]` or
+    /// `file://<path>`). `None` (default) = don't publish. The
+    /// `aws_parameter_store://` form is exactly what `mediator.toml`'s
+    /// `mediator_did` accepts, so the published target can be pasted across.
     #[serde(default)]
     pub did_target: Option<String>,
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -333,6 +333,11 @@ pub struct OutputSection {
     /// reverse proxy.
     #[serde(default = "default_api_prefix")]
     pub api_prefix: String,
+    /// Optional target to publish the minted public DID string to after
+    /// provisioning (`aws_parameter_store://<region>/<name>` or
+    /// `file://<path>`). `None` (default) = don't publish.
+    #[serde(default)]
+    pub did_target: Option<String>,
 }
 
 fn default_config_path() -> String {
@@ -353,6 +358,7 @@ impl Default for OutputSection {
             config_path: default_config_path(),
             listen_address: default_listen_address(),
             api_prefix: default_api_prefix(),
+            did_target: None,
         }
     }
 }
@@ -609,6 +615,14 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
     config.config_path = recipe.output.config_path.clone();
     config.listen_address = recipe.output.listen_address.clone();
     config.api_prefix = recipe.output.api_prefix.clone();
+    config.did_target = recipe.output.did_target.clone();
+
+    // Validate the publish target's scheme now, at recipe load, so a bad
+    // target fails before anything is minted, provisioned, or written.
+    if let Some(target) = &config.did_target {
+        crate::publish::validate_target(target)
+            .map_err(|e| anyhow::anyhow!("invalid [output].did_target: {e}"))?;
+    }
 
     Ok(config)
 }
@@ -785,7 +799,11 @@ pub fn from_wizard_config(config: &WizardConfig) -> String {
     out.push_str("[output]\n");
     out.push_str(&format!("config_path = \"{}\"\n", config.config_path));
     out.push_str(&format!("listen_address = \"{}\"\n", config.listen_address));
-    out.push_str(&format!("api_prefix = \"{}\"\n\n", config.api_prefix));
+    out.push_str(&format!("api_prefix = \"{}\"\n", config.api_prefix));
+    if let Some(target) = &config.did_target {
+        out.push_str(&format!("did_target = \"{target}\"\n"));
+    }
+    out.push('\n');
 
     // Install (default: not enabled in recipe — user can enable manually)
     out.push_str("[install]\n");

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -335,9 +335,14 @@ pub struct OutputSection {
     pub api_prefix: String,
     /// Optional target to publish the minted public DID string to after
     /// provisioning (`aws_parameter_store://<name>[?region=<region>]` or
-    /// `file://<path>`). `None` (default) = don't publish. The
-    /// `aws_parameter_store://` form is exactly what `mediator.toml`'s
-    /// `mediator_did` accepts, so the published target can be pasted across.
+    /// `file://<path>`). `None` (default) = don't publish.
+    ///
+    /// Only the `aws_parameter_store://` form round-trips: it is exactly what
+    /// `mediator.toml`'s `mediator_did` accepts, so the published target can be
+    /// pasted across verbatim. The runtime cannot read `mediator_did` from a
+    /// file, so a `file://` target serves out-of-band consumers (a relying
+    /// party, a CI step, an operator) — to use its contents in `mediator.toml`,
+    /// paste the DID itself as `did://<did>`.
     #[serde(default)]
     pub did_target: Option<String>,
 }


### PR DESCRIPTION
## Summary

Adds an opt-in post-provisioning step to the setup wizard that publishes the mediator's minted **public DID string** to a target configured in the recipe's `[output].did_target`. A no-op unless a target is set, so interactive and local setups are unaffected.

Supported targets:
- `file://<path>` — write the DID string to a local file.
- `aws_parameter_store://<region>/<name>` — write it to an SSM parameter (gated by the `publish-aws` build feature).

### Design notes
- **Region is part of the target** (`<region>/<name>`) rather than inherited from the secret-storage backend, so the publish destination is self-describing and can't silently default to the wrong region when secrets live in a non-AWS backend.
- **Dedicated `publish-aws` feature** pulls the AWS SSM client, kept separate from `secrets-aws` (AWS secret *storage*) so neither concern drags in the other's dependencies.
- **Upfront validation**: the target scheme is validated at recipe load, before anything is minted, provisioned, or written, so a malformed target fails fast.
- SSM errors are rendered via `DisplayErrorContext` so the underlying service message is surfaced instead of an opaque debug string.

Bumps `affinidi-messaging-mediator-setup` to 0.1.21 (`publish = false`).

## Testing
- `cargo clippy --all-targets` clean with `-D warnings --cfg tracing_unstable`, both with default features and with `--no-default-features --features secrets-keyring` (exercises the feature-off path).
- `cargo fmt --check` clean.
- Unit tests: target validation (file, SSM with/without region, unsupported scheme, missing separator), no-op default, and file publish.
