### PR TITLE
test: cover multiplexed TSP receive over the shared live-stream socket

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -44,7 +44,7 @@ affinidi-did-common = "0.3"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
-affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator" }
+affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
 affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_live_stream.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_live_stream.rs
@@ -1,0 +1,126 @@
+//! Regression test for multiplexed TSP receive over the shared live-stream
+//! websocket.
+//!
+//! A `Protocols::BOTH` service opens ONE mediator websocket (the mediator allows
+//! one per DID) and pulls both DIDComm and TSP frames via
+//! `MessagePickup::live_stream_next_frame`. This test proves that a TSP message
+//! sent to the service is actually delivered to its `TspHandler` — i.e. that a
+//! TSP frame arriving on the live-stream is classified and surfaced as
+//! `InboundFrame::Tsp`, not silently dropped.
+//!
+//! Before the fix this hung: the frame reached the socket but was never routed
+//! to the `TspHandler`.
+
+#![cfg(feature = "tsp")]
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use affinidi_messaging_didcomm_service::{
+    DIDCommService, DIDCommServiceConfig, DIDCommServiceError, HandlerContext, ListenerConfig,
+    Protocols, Router, TspHandler, TspResponse, handler_fn, ignore_handler,
+};
+use affinidi_messaging_test_mediator::TestEnvironment;
+use affinidi_tdk_common::profiles::TDKProfile;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+const LISTENER_ID: &str = "svc";
+
+/// Records every TSP payload + sender the service receives.
+struct RecordingTspHandler {
+    received: Arc<Mutex<Vec<(Vec<u8>, String)>>>,
+}
+
+#[async_trait]
+impl TspHandler for RecordingTspHandler {
+    async fn handle(
+        &self,
+        _ctx: HandlerContext,
+        payload: Vec<u8>,
+        sender_vid: String,
+    ) -> Result<Option<TspResponse>, DIDCommServiceError> {
+        self.received.lock().unwrap().push((payload, sender_vid));
+        Ok(None)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tsp_frame_is_delivered_over_the_multiplexed_live_stream() {
+    let env = TestEnvironment::spawn().await.expect("spawn test mediator");
+
+    // Mint the service's identity on the mediator (registered LOCAL ALLOW_ALL).
+    let service = env
+        .mediator
+        .add_user("service")
+        .await
+        .expect("mint service identity");
+    let mediator_did = env.mediator.did().to_string();
+    let profile = TDKProfile::new(
+        "svc",
+        &service.did,
+        Some(mediator_did.as_str()),
+        service.secrets.clone(),
+    );
+
+    // Start a Protocols::BOTH service: one socket, DIDComm + TSP multiplexed.
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let config = DIDCommServiceConfig {
+        listeners: vec![ListenerConfig {
+            id: LISTENER_ID.into(),
+            profile,
+            protocols: Protocols::BOTH,
+            ..Default::default()
+        }],
+    };
+    let router = Router::new().fallback(handler_fn(ignore_handler));
+    let shutdown = CancellationToken::new();
+    let service_handle = DIDCommService::start_with_tsp(
+        config,
+        router,
+        RecordingTspHandler {
+            received: received.clone(),
+        },
+        shutdown.clone(),
+    )
+    .await
+    .expect("start service");
+    service_handle
+        .wait_connected(LISTENER_ID, Duration::from_secs(15))
+        .await
+        .expect("service connects to mediator");
+
+    // A client sends a TSP message to the service through the mediator.
+    let client = env.add_user("client").await.expect("add client");
+    let payload = b"hello over tsp".to_vec();
+    env.atm
+        .tsp()
+        .send(&client.profile, &service.did, &payload)
+        .await
+        .expect("client sends TSP to the service");
+
+    // The service must receive it on its single multiplexed live-stream socket.
+    for _ in 0..40 {
+        if !received.lock().unwrap().is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    let got = received.lock().unwrap().clone();
+    assert!(
+        !got.is_empty(),
+        "service never received the TSP frame over live_stream_next_frame — \
+         the multiplexed TSP frame was dropped"
+    );
+    assert_eq!(got[0].0, payload, "payload round-trips");
+    assert_eq!(
+        got[0].1, client.did,
+        "authenticated sender VID is the client"
+    );
+
+    shutdown.cancel();
+    service_handle.shutdown().await;
+    env.shutdown().await.ok();
+}


### PR DESCRIPTION
## Summary

The `didcomm-service` listener multiplexes DIDComm and TSP over a **single** mediator websocket (`Protocols::BOTH`) via `MessagePickup::live_stream_next_frame`, dispatching `InboundFrame::Tsp` to a `TspHandler`. This is the path the VTA uses in production — but it had **no test coverage**, despite a run of TSP live-stream drop/poison-loop fixes (#505, #574, #580).

This adds the missing regression test: a client sends a TSP message to a `Protocols::BOTH` service, and we assert it's classified as `InboundFrame::Tsp` and delivered to the `TspHandler` with the cryptographically-authenticated sender VID and intact payload.

## Why it matters

While porting this multiplex pattern into another consumer (a Trust Registry), the multiplexed TSP-receive path was the one piece with no reference test to check behaviour against. It works correctly on `main` — this locks that in so a future refactor of the websocket frame classification or `live_stream_next_frame` can't silently regress it (the exact class of bug #505/#574/#580 fixed).

## What's here

- `tests/tsp_live_stream.rs` — spawns the test mediator, starts a `Protocols::BOTH` service with a recording `TspHandler`, sends a client TSP message, and asserts delivery.
- Enables the `tsp` feature on the `affinidi-messaging-test-mediator` dev-dependency (needed for the client-side `atm.tsp().send`).

Passes on current `main`. Run with `cargo test -p affinidi-messaging-didcomm-service --features tsp --test tsp_live_stream`.

## Possible follow-up (not in this PR)

The **two-socket footgun** is the ergonomic gap: `atm.tsp().connect_websocket()` on a profile that already has a live-stream pickup socket makes the mediator evict a duplicate channel and flap. The blessed path is `live_stream_next_frame` (or this service crate). A guard/warn when a raw TSP socket is opened on a live-streamed profile would stop the next consumer hand-rolling it wrong.
