### PR TITLE
fix: surface a VTA 403 on refresh instead of masking it as unreachable

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Changelog history
 
+## 12th July 2026
+
+### 0.16.45 — surface a VTA 403 on refresh instead of masking it as "unreachable"
+
+- The hourly VTA secrets refresh re-authenticates from scratch every cycle, so a
+  recurring 403 is the VTA *rejecting* the mediator's freshly-authenticated
+  request (e.g. an expired ACL entry for its operating DID), not a stale client
+  token. Previously `integration::startup` collapsed a 403, a timeout, and a
+  network outage all into `SecretSource::Cache`, and the refresh task logged
+  every one at `DEBUG` as "VTA unreachable" — hiding a standing authorization
+  problem an operator never sees.
+- Uses the new `integration::startup_with_reason` (vta-sdk 0.18.21): on a cache
+  fallback, `FallbackReason::AuthDenied` now logs a `WARN` with actionable text
+  (check the ACL / access policy for the mediator's DID) plus a distinct
+  `vta_refresh_total{result="forbidden"}` metric. Unreachable/timeout keep the
+  `DEBUG` path — they self-heal on the next tick.
+- vta-sdk 0.18.21 also adds a REST reactive re-auth + retry-once on 401/403, so a
+  transiently-rejected token self-heals instead of falling back to cache.
+- Requires `vta-sdk >= 0.18.21`.
+
 ## 10th July 2026
 
 ### 0.16.44 — `?region=` on `aws_parameter_store://` targets

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.44"
+version = "0.16.45"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -97,7 +97,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.18", features = ["integration"] }
+vta-sdk = { version = "0.18.21", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
@@ -35,7 +35,7 @@ use std::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
-use vta_sdk::integration::{self, SecretSource, VtaServiceConfig};
+use vta_sdk::integration::{self, FallbackReason, SecretSource, VtaServiceConfig};
 
 /// Default refresh interval when `cache_ttl == 0` (no-expiry policy).
 /// Picks a sensible cadence so the cache still tracks the latest VTA
@@ -113,12 +113,12 @@ impl VtaRefresher {
             }
 
             let started = Instant::now();
-            let outcome = integration::startup(&self.service_config, &cache).await;
+            let outcome = integration::startup_with_reason(&self.service_config, &cache).await;
             metrics::histogram!(names::VTA_REFRESH_DURATION_SECONDS)
                 .record(started.elapsed().as_secs_f64());
 
             match outcome {
-                Ok(result) => match result.source {
+                Ok((result, fallback)) => match result.source {
                     SecretSource::Vta => {
                         metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "vta").increment(1);
                         if let Ok(since_epoch) = SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -136,16 +136,39 @@ impl VtaRefresher {
                         }
                     }
                     SecretSource::Cache => {
-                        metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "cache")
-                            .increment(1);
-                        // Refresh fell back to cache — VTA is unreachable
-                        // right now. The cache write didn't actually
-                        // re-fetch fresh material; the runtime secrets
-                        // are unchanged. Log at debug — operators only
-                        // care if this persists, in which case the
-                        // existing degraded-mode warning at boot
-                        // suffices.
-                        debug!("VTA refresh: VTA unreachable, runtime secrets unchanged");
+                        // Refresh fell back to cache. The cache write didn't
+                        // re-fetch fresh material; runtime secrets are
+                        // unchanged either way. But *why* it fell back
+                        // decides the severity: an authorization denial is
+                        // an operator problem that won't self-heal, whereas
+                        // transient unreachability clears on the next tick.
+                        match fallback {
+                            Some(FallbackReason::AuthDenied) => {
+                                metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "forbidden")
+                                    .increment(1);
+                                // Not "unreachable" — the VTA answered and
+                                // *rejected* us. A fresh re-auth happens every
+                                // cycle, so this is a standing authorization
+                                // problem (e.g. an expired ACL entry for the
+                                // mediator's operating DID), not a stale token.
+                                warn!(
+                                    context = %self.service_config.context.id,
+                                    "VTA refused the mediator's credential (401/403); \
+                                     running on cached secrets. Runtime keys are unchanged, \
+                                     but this will keep failing until the mediator's \
+                                     authorization is restored on the VTA (check the ACL / \
+                                     access policy for its operating DID)."
+                                );
+                            }
+                            _ => {
+                                metrics::counter!(names::VTA_REFRESH_TOTAL, "result" => "cache")
+                                    .increment(1);
+                                // Unreachable / timeout — log at debug; operators
+                                // only care if it persists, in which case the
+                                // boot-time degraded-mode warning suffices.
+                                debug!("VTA refresh: VTA unreachable, runtime secrets unchanged");
+                            }
+                        }
                     }
                 },
                 Err(err) => {


### PR DESCRIPTION
## Why

The mediator's hourly VTA secrets refresh (`tasks/vta_refresh.rs`) **re-authenticates from scratch every cycle** — on the DIDComm leg there is no bearer token at all. So a recurring **403** is the VTA *rejecting* the mediator's freshly-authenticated request (most consistent with an **expired ACL entry / access policy for the mediator's operating DID**), not a stale client-side token.

Previously the refresh task logged a 403, a timeout, and a network outage identically at **DEBUG** as *"VTA unreachable, runtime secrets unchanged"* — hiding a standing authorization problem an operator never sees.

## What

The refresh loop now calls `integration::startup_with_reason` (vta-sdk 0.18.21) and acts on the returned `FallbackReason`:

- **`AuthDenied`** → `warn!` with actionable text (check the ACL / access policy for the mediator's operating DID) + a distinct **`vta_refresh_total{result="forbidden"}`** metric.
- **Unreachable / timeout** keep the DEBUG path — they self-heal on the next tick.

Bumps `vta-sdk` to `0.18.21` and `affinidi-messaging-mediator` to `0.16.45`.

## Depends on

Requires **vta-sdk 0.18.21** (OpenVTC/verifiable-trust-infrastructure#634) published to crates.io first.

> Note: 0.18.20 mis-shipped a required `StartupResult` field as a patch, which broke this crate's own construction (`E0063`) in the wild. 0.18.21 makes it non-breaking by moving the reason into `startup_with_reason` instead. Once 0.18.21 publishes, a fresh resolve of this crate compiles again with no source change — this PR is the *feature* on top.

## Test

Verified locally against the vta-sdk 0.18.21 checkout (temporary `[patch.crates-io]`, not committed): `cargo build` + `clippy --features didcomm,tsp --all-targets` clean; `cargo fmt --check` clean; `release guards` green (version bumped).