### PR TITLE
fix: warn when TSP connect_websocket opens a second socket on a live-streamed DID

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.18.50] - 2026-07-12
+
+- Footgun guard: `TspOps::connect_websocket` now warns when the profile already
+  has a live-stream pickup websocket. The mediator permits one websocket per DID,
+  so opening a second (raw-TSP) socket on the same DID makes it evict a duplicate
+  channel and the two flap. Combined DIDComm+TSP receivers should multiplex on the
+  single pickup socket via `MessagePickup::live_stream_next_frame` (or the
+  `affinidi-messaging-didcomm-service` crate) instead.
+
 ## [0.18.49] - 2026-07-04
 
 - Route the DIDComm pack and unpack paths through the shared

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.49"
+version = "0.18.50"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1301,6 +1301,24 @@ impl TspOps<'_> {
                 profile.inner.alias
             )));
         };
+
+        // Footgun guard: the mediator permits ONE websocket per DID. If this
+        // profile already has a live-stream pickup websocket, opening a second
+        // (raw-TSP) socket makes the mediator evict a duplicate channel, and the
+        // two sockets flap against each other. A node that needs both DIDComm and
+        // TSP should multiplex on the single pickup socket via
+        // `MessagePickup::live_stream_next_frame` (or the
+        // `affinidi-messaging-didcomm-service` crate), not open this second socket.
+        if mediator.ws_channel_tx.read().await.is_some() {
+            tracing::warn!(
+                "Profile ({}) already has a live-stream websocket; opening a raw-TSP \
+                 connect_websocket on the same DID will be evicted by the mediator \
+                 (one websocket per DID). For combined DIDComm+TSP receive, multiplex \
+                 via message_pickup().live_stream_next_frame instead.",
+                profile.inner.alias
+            );
+        }
+
         let Some(address) = &mediator.websocket_endpoint else {
             return Err(ATMError::ConfigError(format!(
                 "Profile ({}) is missing a valid websocket endpoint!",


### PR DESCRIPTION
## Summary

Eliminates the **two-socket footgun** at the SDK level. The mediator permits **one websocket per DID**. A node that wants both DIDComm and TSP but hand-rolls receive — a DIDComm pickup loop **plus** `atm.tsp().connect_websocket()` — opens a second socket on the same DID, the mediator evicts a duplicate channel, and the two flap against each other (~1s connect/close), breaking both.

`connect_websocket` now **warns** when the profile already has a live-stream pickup websocket, pointing at the correct combined-receive path: `MessagePickup::live_stream_next_frame` (or the `affinidi-messaging-didcomm-service` crate).

## Why a warn (not an error)

`connect_websocket` is a legitimate API for a **TSP-only** profile (no pickup socket) — that case is unaffected (no warn). The warn fires only in the footgun case (a pickup socket is already active), so it's non-breaking and purely advisory.

## Context

This is the ergonomic follow-up to the missing-coverage fix in #595. A downstream consumer (a Trust Registry) hit exactly this: it ran a DIDComm live-stream loop *and* a separate `connect_websocket` TSP loop, flapped, and neither transport stayed up. The fix there was to multiplex on the one socket; this guard steers the next consumer away from the same trap.

## Testing

Builds + clippy clean with `--features tsp`; fmt clean. Bumps `affinidi-messaging-sdk` `0.18.49 → 0.18.50` (version-bump guard) + CHANGELOG entry.
