### PR TITLE
feat: bound mediator memory, fix two state leaks, drop O(n) audit-log inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,50 @@ Per-crate version history is summarised here; for the full code history see
   in-memory single-use TTL helper, and documents that **replay prevention is a
   MUST** (matching a nonce value is not sufficient).
 
+### Fixed
+
+- **Two unbounded-growth paths in the mediator's in-memory state.**
+  **`affinidi-messaging-mediator` 0.16.46**, **`affinidi-messaging-mediator-common`
+  0.15.28**.
+  - *Per-IP and per-DID rate limiters never reclaimed keys.* `governor` only
+    frees entries via `retain_recent()`, which was never called, so every source
+    IP the mediator had ever seen kept a `DashMap` entry for the process
+    lifetime. The per-IP limiter is **on by default** (`rate_limit_per_ip = 100`)
+    and keyed on unauthenticated, client-chosen input — a client rotating
+    through an IPv6 /64 inserted an entry per request. Both limiters now run a
+    60s background sweep. `retain_recent()` only drops fully-replenished
+    buckets, which are indistinguishable from never-seen keys, so the sweep
+    cannot let a client exceed its quota.
+  - *The forwarding processor's per-endpoint state map never reclaimed
+    entries.* `endpoints` is keyed by the service-endpoint URL from a peer's DID
+    Doc — remote-controlled — and tracked `last_activity` but never reaped on
+    it. Entries idle for more than 5 minutes are now dropped by the existing
+    idle-connection reaper.
+
+- **Audit-log and forward-queue inserts were O(n) in the Fjall backend.**
+  **`affinidi-messaging-mediator` 0.16.46**. `audit_log_record` and
+  `forward_queue_enqueue` need the keyspace length to enforce their bound, and
+  Fjall has no O(1) exact length, so each insert scanned and JSON-decoded the
+  entire keyspace — up to 10,000 decodes per audit record, making a full ring
+  quadratic. Both lengths are now kept in memory (seeded by one key-only scan at
+  open, maintained under the write lock). `audit_log_list` also paginates by
+  reverse iteration instead of scanning the whole ring. Filling the 10,000-entry
+  audit ring drops from ~35s to ~3s, and the trim/pagination semantics are
+  unchanged (the same conformance suite and a new ring-cap regression test pass
+  against both the old and new code).
+
 ### Changed
+
+- **Fjall backend no longer opens the `message_meta` and `acls` keyspaces.**
+  **`affinidi-messaging-mediator` 0.16.46**. Both were opened at startup but
+  never read or written — per-message metadata lives inline in `messages`, and
+  the ACL bitmask lives inline in the `accounts` record. Each open keyspace
+  carries its own memtable (64 MiB flush threshold), so dropping them removes
+  two memtables' worth of headroom from the process. No data migration is
+  needed: nothing was ever stored in them.
+
+- **`vta-sdk` updated to 0.19.0** (from 0.18.21) in
+  **`affinidi-messaging-mediator` 0.16.46**. No source changes were required.
 
 - **`affinidi-sd-jwt-vc` merged into `affinidi-vc` (W18b).** SD-JWT VC is a
   credential format, so it now lives at `affinidi_vc::sd_jwt_vc` (in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,53 @@ Per-crate version history is summarised here; for the full code history see
   in-memory single-use TTL helper, and documents that **replay prevention is a
   MUST** (matching a nonce value is not sufficient).
 
+### Changed
+
+- **Mediator memory: byte budgets, storage tuning, and jemalloc — defaults now
+  hold a node under ~256 MB RSS.** **`affinidi-messaging-mediator` 0.17.0**,
+  **`affinidi-messaging-mediator-config` 0.2.0**,
+  **`affinidi-messaging-mediator-common` 0.15.29**,
+  **`affinidi-messaging-test-mediator` 0.2.39**. New operator reference:
+  [docs/memory-tuning.md](crates/messaging/affinidi-messaging-mediator/docs/memory-tuning.md).
+
+  Measured on the Fjall backend: **~23 MB idle**, and **~44 MB after writing
+  500 MB of message bodies** (previously ~546 MB for the same load — resident
+  memory tracked the data volume rather than any budget).
+
+  - *Buffers are bounded by bytes, not message counts.* The WebSocket send queues
+    were `5 slots x 10 MiB x 10 000 connections`, and the live-delivery pub/sub
+    ring was 1024 slots of up to 10 MiB — neither number meant anything in bytes.
+    They are now sized by `limits.ws_send_buffer` (32 MiB, a single pool shared by
+    *all* connections) and `limits.pubsub_buffer` (16 MiB, divided by
+    `message_size` to get the ring's slot count).
+  - *A slow WebSocket client no longer stalls live delivery for everyone.*
+    Dispatch awaited each client's queue from the single loop that serves every
+    DID, so one stalled socket head-of-line blocked the rest. Sends are now
+    non-blocking; a client that cannot keep up has its *push* dropped, never the
+    message — the message is already durable in its inbox and arrives on the next
+    poll or on reconnect. New metric `ws_live_delivery_dropped_total`.
+  - *Fjall is tuned via `[storage.fjall]`* — `block_cache` (16 MiB),
+    `write_buffer` (32 MiB across all keyspaces) and `max_journal` (128 MiB).
+    Fjall's stock defaults allow 64 MiB of memtable *per keyspace*, and the
+    mediator opens 14. Note `max_journal` is the load-bearing bound: Fjall's own
+    global write-buffer cap is a dead field in 3.1.x, and `write_buffer` only
+    applies when a data directory is first created. **Redis is unaffected** — its
+    memory lives in the Redis server and is governed by `maxmemory` in
+    `redis.conf`; the guide covers both.
+  - *The binary uses jemalloc* (`jemalloc` feature, on by default). With the
+    system allocator the storage backend's write-buffer churn is never returned to
+    the OS, so RSS ratchets to its high-water mark and reads like a leak.
+
+- **BREAKING: `limits.message_size` is now enforced at ingress.**
+  **`affinidi-messaging-mediator` 0.17.0**. It was documented, parsed and
+  env-overridable, but never read at runtime — the real ceiling was
+  `http_size`/`ws_size` (10 MiB), not the advertised 1 MiB. Messages over
+  `message_size` are now rejected with `message.size.exceeded`
+  (413 Payload Too Large). **Upgrade note:** if your clients send messages larger
+  than 1 MiB they will start failing; raise `limits.message_size` to restore the
+  previous behaviour. Enforcing it is what gives every in-memory budget above a
+  real per-item ceiling.
+
 ### Fixed
 
 - **Two unbounded-growth paths in the mediator's in-memory state.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.45"
+version = "0.16.46"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -80,7 +80,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.27", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.28", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.1", path = "affinidi-messaging-mediator-config" }
@@ -97,7 +97,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.18.21", features = ["integration"] }
+vta-sdk = { version = "0.19.0", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.16.46"
+version = "0.17.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -17,9 +17,16 @@ name = "mediator"
 path = "src/main.rs"
 
 [features]
-## Default: DIDComm v2 protocol support + Redis storage backend.
+## Default: DIDComm v2 protocol support + Redis storage backend + jemalloc.
 ## AWS integration is opt-in: use --features aws when deploying to AWS.
-default = ["didcomm", "redis-backend"]
+default = ["didcomm", "redis-backend", "jemalloc"]
+
+## Use jemalloc as the binary's global allocator (see the dependency comment).
+## On by default: with the system allocator the process holds its RSS high-water
+## mark for its lifetime. Disable (`--no-default-features`) if you need to
+## profile against the system allocator or are building for a target jemalloc
+## doesn't support.
+jemalloc = ["dep:tikv-jemallocator"]
 
 ## Storage backends for the `MediatorStore` trait. At least one must be
 ## enabled for the binary to function. Multiple may be enabled, but the
@@ -80,10 +87,10 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.28", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.29", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
-affinidi-messaging-mediator-config = { version = "0.1", path = "affinidi-messaging-mediator-config" }
+affinidi-messaging-mediator-config = { version = "0.2", path = "affinidi-messaging-mediator-config" }
 ## Humantime for the VTA cache TTL (`[secrets].cache_ttl = "30d"`).
 humantime = "2"
 ## CLI parsing for the mediator binary's subcommands (`mediator`,
@@ -186,6 +193,22 @@ rand = "0.10"
 regex = "1"
 semver = "1"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
+
+# ── Allocator ────────────────────────────────────────────────────────────
+## jemalloc, used by the `mediator` binary only (set as the global allocator
+## in main.rs — a library must never impose an allocator on its consumers).
+##
+## The default system allocator (glibc malloc on Linux) does not return the
+## mediator's freed pages to the OS: the storage backend's write-buffer churn
+## is a sawtooth of large short-lived allocations, and glibc retains those
+## arenas, so RSS ratchets up to its high-water mark and stays there. That
+## reads as a leak in monitoring even though the live heap is flat. jemalloc's
+## decay-based purging returns the pages, so RSS tracks live memory.
+##
+## Not available on MSVC; the cfg gate below falls back to the system
+## allocator there.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -308,6 +308,9 @@ See:
   for the three setup modes (Online / Sealed-mint / Sealed-export).
 - [docs/secrets-backend.md](docs/secrets-backend.md) — well-known key
   schemas, HA topology, and the migration path from the legacy schema.
+- [docs/memory-tuning.md](docs/memory-tuning.md) — what the mediator holds
+  in memory, which knob to raise for throughput, and how the Fjall and Redis
+  backends differ (they put their memory in different places).
 
 ### Re-running the wizard / tearing down
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.27"
+version = "0.15.28"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.28"
+version = "0.15.29"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -48,7 +48,9 @@ use tokio::sync::{Mutex, broadcast};
 use tokio_stream::StreamExt;
 use tracing::{debug, warn};
 
-const PUBSUB_BROADCAST_CAPACITY: usize = 1024;
+/// Fallback ring size when no tuning is supplied. Production derives this from
+/// `limits.pubsub_buffer / limits.message_size` via `with_pubsub_capacity`.
+const PUBSUB_BROADCAST_CAPACITY: usize = 32;
 const STATIC_TIMESLOT_BATCH: u32 = 100;
 
 /// Redis-backed [`MediatorStore`].
@@ -64,6 +66,9 @@ pub struct RedisStore {
     circuit_breaker: Arc<CircuitBreaker>,
     lua_scripts_path: Option<String>,
     broadcast_channels: Arc<Mutex<HashMap<String, broadcast::Sender<PubSubRecord>>>>,
+    /// Slots in the local broadcast ring that bridges Redis pub/sub to the
+    /// streaming task. See `with_pubsub_capacity`.
+    pubsub_capacity: usize,
 }
 
 impl RedisStore {
@@ -87,7 +92,22 @@ impl RedisStore {
             )),
             lua_scripts_path,
             broadcast_channels: Arc::new(Mutex::new(HashMap::new())),
+            pubsub_capacity: PUBSUB_BROADCAST_CAPACITY,
         }
+    }
+
+    /// Size the local broadcast ring that bridges Redis pub/sub to the streaming
+    /// task.
+    ///
+    /// `tokio::sync::broadcast` retains all `capacity` slots for the life of the
+    /// channel — a slot is freed only when overwritten `capacity` sends later,
+    /// not when a subscriber reads it. The ring is therefore a standing
+    /// reservation of `capacity x message_size` bytes, so its capacity has to be
+    /// derived from a byte budget. Note this bounds the *mediator's* memory; the
+    /// Redis server's own memory is governed by `maxmemory` in `redis.conf`.
+    pub fn with_pubsub_capacity(mut self, capacity: usize) -> Self {
+        self.pubsub_capacity = capacity.max(1);
+        self
     }
 
     /// Get a clone of the auto-reconnecting multiplexed Redis connection.
@@ -1003,7 +1023,7 @@ impl MediatorStore for RedisStore {
         // connection and bridge incoming messages into a broadcast
         // channel. The bridge task lives until the underlying pubsub
         // connection drops or the broadcast Sender is removed.
-        let (sender, receiver) = broadcast::channel(PUBSUB_BROADCAST_CAPACITY);
+        let (sender, receiver) = broadcast::channel(self.pubsub_capacity);
         let mut pubsub = self.handler.get_pubsub_connection().await?;
         let channel_name = format!("CHANNEL:{mediator_uuid}");
         pubsub.subscribe(&channel_name).await.map_err(|err| {

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
@@ -128,6 +128,13 @@ fn decode_tsp_forward(message: &str) -> Option<Vec<u8>> {
         .filter(|bytes| bytes.first() == Some(&0xF8))
 }
 
+/// How long an endpoint may sit idle before its cached state is reaped.
+///
+/// Must stay comfortably above both the rate tracker's window (10s) and the
+/// retry backoff ceiling (`max_backoff_ms`, 60s by default), so that state
+/// still in active use is never dropped out from under a retry.
+const ENDPOINT_IDLE_TTL: Duration = Duration::from_secs(300);
+
 /// State for a connection to a remote mediator endpoint
 struct EndpointState {
     rate_tracker: EndpointRateTracker,
@@ -248,8 +255,10 @@ impl ForwardingProcessor {
             }
         });
 
-        // Spawn a background task to clean up idle WebSocket connections
+        // Spawn a background task to clean up idle WebSocket connections and
+        // idle per-endpoint state.
         let ws_pool = self.ws_pool.clone();
+        let endpoints = self.endpoints.clone();
         let idle_timeout = Duration::from_secs(self.config.ws_idle_timeout_seconds);
         tokio::spawn(async move {
             loop {
@@ -276,6 +285,27 @@ impl ForwardingProcessor {
                         "Closed {} idle WebSocket connections ({} remaining)",
                         closed,
                         pool.len()
+                    );
+                }
+                drop(pool);
+
+                // `endpoints` is keyed by the service endpoint URL out of a
+                // peer's DID Doc, so its key space is remote-controlled and it
+                // would otherwise grow for the process lifetime. Entries only
+                // cache a rate window and a failure count, both of which are
+                // meaningless once an endpoint has been silent this long, so
+                // dropping them just means the next forward starts fresh.
+                let mut endpoints = endpoints.write().await;
+                let before = endpoints.len();
+                endpoints.retain(|_, state| {
+                    now.duration_since(state.last_activity) <= ENDPOINT_IDLE_TTL
+                });
+                let reaped = before - endpoints.len();
+                if reaped > 0 {
+                    debug!(
+                        "Reaped {} idle forwarding endpoint(s) ({} remaining)",
+                        reaped,
+                        endpoints.len()
                     );
                 }
             }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-config"
-version = "0.1.2"
+version = "0.2.0"
 description = "Raw TOML configuration schema for the Affinidi Messaging Mediator (shared by the mediator and its setup tool)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/env.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/env.rs
@@ -163,6 +163,31 @@ pub fn apply_env_overrides(config: &mut ConfigRaw) {
         config.limits.did_rate_limit_burst,
         "LIMIT_DID_RATE_LIMIT_BURST"
     );
+    env_override!(config.limits.ws_send_buffer, "LIMIT_WS_SEND_BUFFER");
+    env_override!(config.limits.pubsub_buffer, "LIMIT_PUBSUB_BUFFER");
+
+    // `[storage]` is optional, and `[storage.fjall]` is optional within it, so
+    // these only override a section that already exists. An env var alone does
+    // not conjure a storage backend into being — selecting the backend is a
+    // deliberate choice that belongs in the file.
+    if let Some(storage) = config.storage.as_mut() {
+        env_override!(storage.backend, "STORAGE_BACKEND");
+        env_override_opt!(storage.data_dir, "STORAGE_DATA_DIR");
+        if storage.fjall.is_none()
+            && (std::env::var("STORAGE_FJALL_BLOCK_CACHE").is_ok()
+                || std::env::var("STORAGE_FJALL_WRITE_BUFFER").is_ok()
+                || std::env::var("STORAGE_FJALL_MAX_JOURNAL").is_ok())
+        {
+            // Any one of the knobs being set means the operator wants to tune;
+            // materialise the section at its defaults so the override lands.
+            storage.fjall = Some(crate::FjallConfig::default());
+        }
+        if let Some(fjall) = storage.fjall.as_mut() {
+            env_override!(fjall.block_cache, "STORAGE_FJALL_BLOCK_CACHE");
+            env_override!(fjall.write_buffer, "STORAGE_FJALL_WRITE_BUFFER");
+            env_override!(fjall.max_journal, "STORAGE_FJALL_MAX_JOURNAL");
+        }
+    }
 
     env_override!(
         config.processors.forwarding.enabled,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/limits.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/limits.rs
@@ -37,10 +37,25 @@ pub struct LimitsConfigRaw {
     pub did_rate_limit_per_second: String,
     #[serde(default = "default_did_rate_limit_burst")]
     pub did_rate_limit_burst: String,
+    #[serde(default = "default_ws_send_buffer")]
+    pub ws_send_buffer: String,
+    #[serde(default = "default_pubsub_buffer")]
+    pub pubsub_buffer: String,
 }
 
 fn default_rate_limit_per_ip() -> String {
     "100".to_string()
+}
+
+/// 32 MiB — aggregate ceiling across every live WebSocket send queue.
+fn default_ws_send_buffer() -> String {
+    "33554432".to_string()
+}
+
+/// 16 MiB — the live-delivery pub/sub ring. Divided by `message_size` to get
+/// the ring's slot count, so this is a true byte ceiling.
+fn default_pubsub_buffer() -> String {
+    "16777216".to_string()
 }
 fn default_rate_limit_burst() -> String {
     "50".to_string()

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
@@ -113,4 +113,75 @@ pub struct StorageConfig {
     /// it doesn't exist.
     #[serde(default)]
     pub data_dir: Option<String>,
+    /// `[storage.fjall]` — memory tuning for the embedded Fjall backend.
+    /// Ignored when `backend = "redis"`: Redis holds its data in the Redis
+    /// *server*, so its memory is governed by `maxmemory` in `redis.conf`,
+    /// not by anything the mediator can set. See the memory-tuning guide.
+    #[serde(default)]
+    pub fjall: Option<FjallConfig>,
+}
+
+/// `[storage.fjall]` — memory knobs for the embedded Fjall backend.
+///
+/// Fjall ships with defaults sized for a general-purpose embedded database
+/// (32 MiB block cache, 64 MiB of memtable *per keyspace*, 512 MiB of journal).
+/// The mediator opens 14 keyspaces, so the stock per-keyspace memtable default
+/// alone allows ~896 MiB of write buffer. These knobs bring that down to a
+/// budget the operator chooses.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FjallConfig {
+    /// Block cache, in bytes. Caches decompressed data blocks read from disk;
+    /// this is the read-side memory and the first thing to raise for read
+    /// throughput. Default 16 MiB (Fjall's own default is 32 MiB).
+    #[serde(default = "default_fjall_block_cache")]
+    pub block_cache: String,
+    /// Total write-buffer (memtable) budget in bytes, divided across the
+    /// mediator's keyspaces by write weight. Default 32 MiB.
+    ///
+    /// **Applies at data-directory creation only.** Fjall persists each
+    /// keyspace's memtable size when the keyspace is first created and has no
+    /// runtime setter, so changing this against an existing `data_dir` has no
+    /// effect on already-created keyspaces. `max_journal` (below) bounds
+    /// unflushed memory on existing directories.
+    #[serde(default = "default_fjall_write_buffer")]
+    pub write_buffer: String,
+    /// Journal size ceiling in bytes. Default 128 MiB (Fjall's default is
+    /// 512 MiB).
+    ///
+    /// This is the load-bearing global bound. Fjall's own global write-buffer
+    /// cap (`max_write_buffer_size`) is a dead field in 3.1.x — declared, with a
+    /// setter, but never read — so there is *no* global memtable ceiling. What
+    /// does exist: when the journal exceeds this size, Fjall force-rotates the
+    /// keyspaces pinning the oldest journal, which flushes their memtables. So
+    /// this indirectly caps total unflushed memory, and unlike `write_buffer` it
+    /// takes effect on every open, including existing data directories.
+    ///
+    /// Lower = tighter memory, more frequent flushes (more write amplification).
+    #[serde(default = "default_fjall_max_journal")]
+    pub max_journal: String,
+}
+
+/// 16 MiB.
+fn default_fjall_block_cache() -> String {
+    "16777216".to_string()
+}
+
+/// 32 MiB, split across keyspaces by write weight.
+fn default_fjall_write_buffer() -> String {
+    "33554432".to_string()
+}
+
+/// 128 MiB.
+fn default_fjall_max_journal() -> String {
+    "134217728".to_string()
+}
+
+impl Default for FjallConfig {
+    fn default() -> Self {
+        Self {
+            block_cache: default_fjall_block_cache(),
+            write_buffer: default_fjall_write_buffer(),
+            max_journal: default_fjall_max_journal(),
+        }
+    }
 }

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -443,6 +443,28 @@ oob_invite_ttl = "86400"
 ### bursty authenticated clients once did_rate_limit_per_second is enabled.
 # did_rate_limit_burst = "10"
 
+### Env: LIMIT_WS_SEND_BUFFER
+### Total bytes of queued live-delivery messages across ALL WebSocket
+### connections (32 MiB). This is one shared pool, not a per-connection budget:
+### the aggregate is capped here no matter how many clients are connected.
+### When it is exhausted, live pushes are DROPPED rather than queued — not
+### message loss, since the message is already durable in the recipient's inbox
+### and arrives on its next poll or on reconnect. Watch
+### `ws_live_delivery_dropped_total` to see if this is happening.
+### Scale: raise for many concurrent live-streaming clients or large messages
+### (a client's queue also caps at 8 messages); costs up to this much RSS.
+# ws_send_buffer = "33554432"
+
+### Env: LIMIT_PUBSUB_BUFFER
+### Bytes reserved for the live-delivery pub/sub ring (16 MiB). The ring's slot
+### count is derived as pubsub_buffer / message_size, so at the defaults it holds
+### 16 messages. A ring slot stays occupied until it is overwritten, so this is a
+### standing ceiling, not a transient queue.
+### Scale: raise if you see "Streaming subscriber lagged" warnings under bursts —
+### lagging costs a live push (the message still lands in the inbox), it does not
+### lose messages. Costs up to this much RSS.
+# pubsub_buffer = "16777216"
+
 ### ****************************************************************************************************************************
 ### Forwarding processor configuration
 ###
@@ -536,3 +558,59 @@ enabled = "true"
 ### Reclaim expired session records on backends without native TTL
 ### (Fjall, in-memory). No-op on Redis, which expires sessions itself.
 enabled = "true"
+### ****************************************************************************************************************************
+### Storage backend
+### ****************************************************************************************************************************
+### Absent = Redis (the historical default), configured via [database] above.
+### Uncomment to run the embedded Fjall backend instead — a single-process,
+### on-disk LSM store for self-hosted deployments that don't want to operate a
+### separate Redis. Fjall does NOT support cross-process pub/sub, so it cannot
+### run multiple mediator instances against one data directory.
+###
+### See docs/memory-tuning.md for the full memory model and how these interact.
+# [storage]
+### Env: STORAGE_BACKEND — "redis" (default) or "fjall"
+# backend = "fjall"
+### Env: STORAGE_DATA_DIR — required when backend = "fjall"
+# data_dir = "/var/lib/mediator/data"
+
+### ─── Fjall memory tuning ────────────────────────────────────────────────────
+### Ignored unless backend = "fjall". These have no Redis equivalent: with the
+### Redis backend the data lives in the Redis *server*, so its memory is governed
+### by `maxmemory` / `maxmemory-policy` in redis.conf, not by the mediator.
+###
+### The shipped defaults hold a mediator under ~256 MB RSS. Raise them for
+### throughput — all three trade memory for speed.
+# [storage.fjall]
+
+### Env: STORAGE_FJALL_BLOCK_CACHE
+### Read cache for decompressed data blocks, in bytes. Default 16 MiB.
+### Scale: the first knob to raise for READ throughput (message pickup, ACL
+### lookups). A larger cache means fewer disk reads. Costs exactly this many
+### bytes of RSS once warm.
+# block_cache = "16777216"
+
+### Env: STORAGE_FJALL_WRITE_BUFFER
+### Total in-memory write buffer (memtables) across all keyspaces, in bytes.
+### Default 32 MiB, divided between keyspaces by how much each one writes.
+### Scale: raise for WRITE throughput — a bigger buffer means fewer, larger
+### flushes to disk and less write amplification. Costs up to this many bytes of
+### RSS under sustained writes.
+###
+### NOTE: this applies when the data directory is FIRST CREATED. Fjall persists
+### each keyspace's memtable size at creation and offers no way to change it
+### later, so editing this against an existing `data_dir` will not resize
+### keyspaces that already exist. `max_journal` below still bounds them.
+# write_buffer = "33554432"
+
+### Env: STORAGE_FJALL_MAX_JOURNAL
+### Journal size ceiling in bytes. Default 128 MiB.
+### This is the real global memory bound. Fjall has NO global write-buffer cap
+### (its `max_write_buffer_size` setting is a no-op in 3.1.x), and each keyspace
+### only flushes when its own memtable fills. What does bound things: once the
+### journal grows past this, Fjall force-flushes the keyspaces holding it open.
+### Unlike write_buffer, this takes effect on every start, including on an
+### existing data_dir.
+### Scale: raise to reduce flush frequency (better write throughput, more RSS);
+### lower to clamp memory harder at the cost of more disk I/O.
+# max_journal = "134217728"

--- a/crates/messaging/affinidi-messaging-mediator/docs/memory-tuning.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/memory-tuning.md
@@ -1,0 +1,171 @@
+# Mediator Memory Tuning
+
+The mediator ships with defaults chosen to hold a single node **under ~256 MB
+RSS** while idle-to-moderately loaded. Every structure that grows with load is
+bounded by a **byte budget** you can raise, not by a message count you have to
+reason about:
+
+```toml
+[limits]
+ws_send_buffer = "33554432"   # 32 MiB — all WebSocket send queues, combined
+pubsub_buffer  = "16777216"   # 16 MiB — the live-delivery pub/sub ring
+
+[storage.fjall]               # embedded backend only; ignored for Redis
+block_cache  = "16777216"     # 16 MiB — read cache
+write_buffer = "33554432"     # 32 MiB — memtables, all keyspaces combined
+max_journal  = "134217728"    # 128 MiB — the real global memory bound
+```
+
+This document is the operator reference for what the mediator holds in memory,
+which knob to turn for more performance, and what it costs you.
+
+---
+
+## Where the memory goes
+
+| Component | Default | Grows with | Knob |
+|---|---|---|---|
+| Base process (tokio, axum, TLS) | ~25 MB | nothing | — |
+| Storage write buffer (Fjall) | up to 32 MiB | sustained writes | `storage.fjall.write_buffer` |
+| Storage read cache (Fjall) | up to 16 MiB | reads (warms once) | `storage.fjall.block_cache` |
+| WebSocket send queues | up to 32 MiB | slow live-delivery clients | `limits.ws_send_buffer` |
+| Live-delivery pub/sub ring | up to 16 MiB | message throughput | `limits.pubsub_buffer` |
+| DID document cache | ~2–8 MB | distinct DIDs seen | `did_resolver.cache_capacity` |
+
+Measured on the shipped defaults with the Fjall backend: **~23 MB idle**, and
+**~44 MB after writing 500 MB of message bodies** — resident memory tracks the
+budget, not the data volume.
+
+## Storage: the backends differ completely
+
+**This is the most important thing to understand before tuning.** The two
+backends put their memory in different *places*, so they need different knobs.
+
+### Fjall (embedded)
+
+Fjall runs **inside the mediator process**, so its caches are the mediator's RSS.
+Everything under `[storage.fjall]` applies, and the mediator is the only thing
+you need to size.
+
+Fjall's own defaults are sized for a general-purpose embedded database, and are a
+poor fit here: it allows **64 MiB of write buffer per keyspace**, and the
+mediator opens 14 keyspaces. Left alone, that permits roughly **900 MiB** of
+memtable. The shipped `[storage.fjall]` defaults exist to bring that down.
+
+Two Fjall behaviours are worth knowing, because they are not obvious:
+
+1. **There is no global write-buffer cap.** Fjall exposes a
+   `max_write_buffer_size` setting, but in 3.1.x it is a dead field — declared,
+   with a setter, never read. Each keyspace flushes only when *its own* memtable
+   fills. So `write_buffer` is divided up front across keyspaces (weighted by how
+   much each one writes), and `max_journal` acts as the real ceiling: once the
+   journal outgrows it, Fjall force-flushes the keyspaces holding it open.
+   **`max_journal` is the knob that actually bounds memory.**
+
+2. **`write_buffer` only applies to a new data directory.** Fjall persists each
+   keyspace's memtable size when the keyspace is first created, and offers no way
+   to change it afterwards. Editing `write_buffer` against an existing `data_dir`
+   will not resize keyspaces that already exist — you would need a fresh data
+   directory. `block_cache` and `max_journal` **do** apply on every start,
+   including to existing directories, so `max_journal` remains your lever there.
+
+### Redis
+
+Redis holds its data in the **Redis server**, a separate process. The mediator
+keeps only a connection and a small local ring, so **`[storage.fjall]` is ignored
+and there is nothing equivalent to tune on the mediator side.** Size Redis in
+`redis.conf`:
+
+```conf
+maxmemory 512mb
+maxmemory-policy noeviction   # do NOT evict: the mediator's queues are durable state
+```
+
+Use `noeviction`. An LRU policy would let Redis silently discard queued messages
+and session state under pressure. You want writes to fail loudly instead.
+
+`limits.ws_send_buffer` and `limits.pubsub_buffer` are mediator-side and apply to
+**both** backends.
+
+## Tuning for throughput
+
+All four knobs trade memory for speed. Raise the one that matches your
+bottleneck.
+
+**Write-heavy** (high message ingest) — raise `storage.fjall.write_buffer` and
+`max_journal` together. A bigger write buffer means fewer, larger flushes and
+less write amplification. Remember `write_buffer` needs a fresh `data_dir` to
+take effect; `max_journal` does not.
+
+**Read-heavy** (frequent message pickup, large ACLs) — raise
+`storage.fjall.block_cache`. This is a straight cache-hit-rate trade: more memory,
+fewer disk reads. Costs exactly what you give it, once warm.
+
+**Many live-streaming clients** — raise `limits.ws_send_buffer`. Watch
+`ws_live_delivery_dropped_total` (below) to decide.
+
+**Bursty throughput with lag warnings** — raise `limits.pubsub_buffer`.
+
+**Many distinct DIDs** — raise `did_resolver.cache_capacity` (a count, not bytes;
+each cached DID document is roughly 1–10 KB).
+
+## What happens when a budget is exhausted
+
+**No messages are lost.** Every message is durably stored in the recipient's
+inbox *before* it is ever pushed live. Live delivery is an optimisation on top of
+that, so when a buffer fills the mediator drops the *push*, not the message — the
+client receives it on its next poll or when it reconnects.
+
+Two signals tell you a budget is too small:
+
+| Signal | Means | Fix |
+|---|---|---|
+| `ws_live_delivery_dropped_total` rising | A client's send queue or the global byte pool filled | Raise `limits.ws_send_buffer`, or find the slow client |
+| `Streaming subscriber lagged` in logs | The pub/sub ring was overwritten before it could be read | Raise `limits.pubsub_buffer` |
+
+Both are latency symptoms, not correctness ones. A steadily rising drop count
+usually means one slow WebSocket consumer, not an undersized buffer — check
+before you raise the budget.
+
+## Message size
+
+```toml
+[limits]
+message_size = "1048576"    # 1 MiB — enforced at ingress
+http_size    = "10485760"   # 10 MiB — transport cap
+ws_size      = "10485760"   # 10 MiB — transport cap
+```
+
+`message_size` is the ceiling on a single message the mediator will accept, copy,
+queue, and fan out. **Every in-memory budget above is sized against it**, so it is
+the multiplier on all of them: doubling `message_size` halves how many messages
+fit in the same `pubsub_buffer`.
+
+`http_size` and `ws_size` are *transport* caps — they bound one request or one
+frame. Keep them at or above `message_size`.
+
+> **Upgrade note.** `message_size` was documented but never enforced before
+> mediator 0.16.46; the effective ceiling was `http_size`/`ws_size` (10 MiB).
+> If your clients send messages larger than 1 MiB, they will now be rejected with
+> `message.size.exceeded`. Raise `message_size` to restore the old behaviour.
+
+## The allocator
+
+The mediator binary uses **jemalloc** (the `jemalloc` feature, on by default).
+
+This is not a micro-optimisation. With the system allocator (glibc malloc), the
+storage backend's write-buffer churn — large, short-lived allocations — is not
+returned to the OS. RSS ratchets up to its high-water mark and stays there, which
+looks exactly like a leak on a memory graph even though the live heap is flat.
+jemalloc's decay-based purging returns those pages, so **RSS tracks live memory**
+and the numbers in this document are meaningful.
+
+Build with `--no-default-features` to fall back to the system allocator (for
+profiling, or on a target jemalloc does not support) — and expect resident memory
+to read high and flat if you do.
+
+## Cross-references
+
+- [`conf/mediator.toml`](../conf/mediator.toml) — every knob, with `Env:` names
+- [setup-guide.md](setup-guide.md) — operator walkthrough
+- [secrets-backend.md](secrets-backend.md) — secret storage reference

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/limits.rs
@@ -39,6 +39,12 @@ pub struct LimitsConfig {
     pub did_rate_limit_per_second: u32,
     /// Burst size for per-DID rate limiting (additional requests allowed in a burst).
     pub did_rate_limit_burst: u32,
+    /// Aggregate byte ceiling across every live WebSocket send queue.
+    /// Collapses `slots x message_size x connections` into one real number.
+    pub ws_send_buffer: usize,
+    /// Byte ceiling for the live-delivery pub/sub ring. The ring's slot count is
+    /// derived from this — see [`LimitsConfig::pubsub_capacity`].
+    pub pubsub_buffer: usize,
 }
 
 impl Default for LimitsConfig {
@@ -68,7 +74,30 @@ impl Default for LimitsConfig {
             max_websocket_connections_per_did: 100,
             did_rate_limit_per_second: 0,
             did_rate_limit_burst: 10,
+            ws_send_buffer: 33_554_432,
+            pubsub_buffer: 16_777_216,
         }
+    }
+}
+
+impl LimitsConfig {
+    /// Slot count for the live-delivery pub/sub ring, derived from the byte
+    /// budget: `pubsub_buffer / message_size`.
+    ///
+    /// A `tokio::sync::broadcast` ring holds all of its `capacity` slots for the
+    /// life of the channel — a slot is freed only when it is overwritten
+    /// `capacity` sends later, not when a subscriber reads it. So the ring costs
+    /// `capacity x message_size` bytes as a *standing reservation*, and picking a
+    /// capacity by feel (it was 1024) silently reserves that much memory. Deriving
+    /// it from a byte budget makes the ceiling explicit and honest.
+    ///
+    /// Floored at 8 so a small `pubsub_buffer` cannot collapse the ring to a
+    /// single slot, which would make even a momentary hiccup lag the subscriber.
+    /// Lag is not message loss (the message is durable in the recipient's inbox
+    /// and arrives on the next poll), but it does cost a live push.
+    pub fn pubsub_capacity(&self) -> usize {
+        let per_slot = self.message_size.max(1);
+        (self.pubsub_buffer / per_slot).max(8)
     }
 }
 
@@ -189,6 +218,14 @@ impl std::convert::TryFrom<LimitsConfigRaw> for LimitsConfig {
                 warn_default("did_rate_limit_burst", "10");
                 10
             }),
+            ws_send_buffer: raw.ws_send_buffer.parse().unwrap_or_else(|_| {
+                warn_default("ws_send_buffer", "33554432");
+                33_554_432
+            }),
+            pubsub_buffer: raw.pubsub_buffer.parse().unwrap_or_else(|_| {
+                warn_default("pubsub_buffer", "16777216");
+                16_777_216
+            }),
         })
     }
 }
@@ -252,8 +289,12 @@ mod tests {
             max_websocket_connections_per_did: "250".to_string(),
             did_rate_limit_per_second: "50".to_string(),
             did_rate_limit_burst: "20".to_string(),
+            ws_send_buffer: "8388608".to_string(),
+            pubsub_buffer: "4194304".to_string(),
         };
         let limits = LimitsConfig::try_from(raw).unwrap();
+        assert_eq!(limits.ws_send_buffer, 8_388_608);
+        assert_eq!(limits.pubsub_buffer, 4_194_304);
         assert_eq!(limits.attachments_max_count, 5);
         assert_eq!(limits.crypto_operations_per_message, 500);
         assert_eq!(limits.deleted_messages, 75);
@@ -307,6 +348,8 @@ mod tests {
             max_websocket_connections_per_did: "100".to_string(),
             did_rate_limit_per_second: "0".to_string(),
             did_rate_limit_burst: "10".to_string(),
+            ws_send_buffer: "67108864".to_string(),
+            pubsub_buffer: "33554432".to_string(),
         };
         let limits = LimitsConfig::try_from(raw).unwrap();
         // Invalid values should fall back to unwrap_or defaults

--- a/crates/messaging/affinidi-messaging-mediator/src/common/did_rate_limiter.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/did_rate_limiter.rs
@@ -6,9 +6,14 @@
 //! determine whether the request should proceed.
 
 use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DashMapStateStore};
-use std::{num::NonZeroU32, sync::Arc};
+use std::{num::NonZeroU32, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
 type KeyedLimiter = RateLimiter<String, DashMapStateStore<String>, DefaultClock>;
+
+/// How often to sweep fully-replenished buckets out of the keyed state store.
+const GC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Application-level rate limiter keyed by DID hash.
 #[derive(Clone)]
@@ -40,6 +45,43 @@ impl DidRateLimiter {
             None => true,
             Some(limiter) => limiter.check_key(&did_hash.to_owned()).is_ok(),
         }
+    }
+
+    /// Spawn the background sweep that reclaims idle buckets.
+    ///
+    /// Same reclamation gap as the per-IP limiter: `governor` never drops keys
+    /// on its own, so every DID that has ever authenticated would keep a
+    /// `DashMap` entry for the process lifetime. `retain_recent` only drops
+    /// buckets that have fully replenished, so it cannot let a DID exceed its
+    /// quota.
+    ///
+    /// No-op when rate limiting is disabled (the default: `per_second == 0`).
+    pub fn spawn_gc(&self, shutdown: CancellationToken) {
+        let Some(limiter) = self.limiter.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(GC_INTERVAL);
+            ticker.tick().await; // the first tick fires immediately
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => break,
+                    _ = ticker.tick() => {
+                        let before = limiter.len();
+                        limiter.retain_recent();
+                        limiter.shrink_to_fit();
+                        let after = limiter.len();
+                        if before != after {
+                            debug!(
+                                "Per-DID rate limiter GC: reclaimed {} idle bucket(s), {} live",
+                                before - after,
+                                after
+                            );
+                        }
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
@@ -87,6 +87,14 @@ pub mod names {
     pub const ACTIVE_WEBSOCKET_CONNECTIONS: &str = "active_websocket_connections";
     /// counter: Messages delivered via WebSocket live streaming
     pub const WEBSOCKET_MESSAGES_TOTAL: &str = "websocket_messages_total";
+    /// counter: Live-delivery pushes dropped because the send-buffer byte budget
+    /// (`limits.ws_send_buffer`) or a connection's queue was full. Not message
+    /// loss — the message is durable in the recipient's inbox and arrives on the
+    /// next poll or on reconnect. A rising rate means slow WebSocket consumers,
+    /// or a `ws_send_buffer` sized too small for the live-delivery fan-out.
+    pub const WS_LIVE_DELIVERY_DROPPED: &str = "ws_live_delivery_dropped_total";
+    /// gauge: Bytes currently free in the global WebSocket send-buffer pool.
+    pub const WS_SEND_BUFFER_AVAILABLE_BYTES: &str = "ws_send_buffer_available_bytes";
     /// counter: Old WebSocket sessions displaced by a newer duplicate for the same DID
     pub const WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL: &str =
         "websocket_duplicate_replacements_total";

--- a/crates/messaging/affinidi-messaging-mediator/src/common/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/mod.rs
@@ -11,3 +11,4 @@ pub mod request_metrics;
 pub mod session;
 pub mod storage_timeout;
 pub mod time;
+pub mod ws_budget;

--- a/crates/messaging/affinidi-messaging-mediator/src/common/rate_limiter.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/rate_limiter.rs
@@ -14,12 +14,16 @@ use governor::{
     state::keyed::DashMapStateStore,
 };
 use http::{HeaderValue, Request, StatusCode, header};
-use std::{net::SocketAddr, num::NonZeroU32, sync::Arc};
+use std::{net::SocketAddr, num::NonZeroU32, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service};
-use tracing::warn;
+use tracing::{debug, warn};
 
 type KeyedLimiter =
     RateLimiter<std::net::IpAddr, DashMapStateStore<std::net::IpAddr>, DefaultClock>;
+
+/// How often to sweep fully-replenished buckets out of the keyed state store.
+const GC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Shared rate limiter state
 #[derive(Clone)]
@@ -38,6 +42,47 @@ impl RateLimiterState {
         Self {
             limiter: Some(Arc::new(RateLimiter::keyed(quota))),
         }
+    }
+
+    /// Spawn the background sweep that reclaims idle buckets.
+    ///
+    /// `governor` never reclaims keys on its own, so without this every source
+    /// IP the mediator has ever seen keeps a `DashMap` entry for the process
+    /// lifetime. The store is keyed on unauthenticated, client-chosen input —
+    /// a client rotating through an IPv6 /64 inserts an entry per request — so
+    /// it is an unbounded growth path reachable pre-auth.
+    ///
+    /// `retain_recent` only drops keys whose bucket has fully replenished. Such
+    /// a key is by definition indistinguishable from one that was never
+    /// present, so sweeping cannot let a client exceed its quota.
+    ///
+    /// No-op when rate limiting is disabled (there is no map to sweep).
+    pub fn spawn_gc(&self, shutdown: CancellationToken) {
+        let Some(limiter) = self.limiter.clone() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(GC_INTERVAL);
+            ticker.tick().await; // the first tick fires immediately
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => break,
+                    _ = ticker.tick() => {
+                        let before = limiter.len();
+                        limiter.retain_recent();
+                        limiter.shrink_to_fit();
+                        let after = limiter.len();
+                        if before != after {
+                            debug!(
+                                "Per-IP rate limiter GC: reclaimed {} idle bucket(s), {} live",
+                                before - after,
+                                after
+                            );
+                        }
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/common/ws_budget.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/ws_budget.rs
@@ -1,0 +1,136 @@
+//! Global byte budget for WebSocket live-delivery send queues.
+//!
+//! # Why a byte budget rather than a slot count
+//!
+//! Each live WebSocket connection has an mpsc queue of messages waiting to be
+//! written to the socket. Bounding that queue by *slots* bounds nothing useful:
+//! a slot holds a whole packed message, so the real cost is
+//! `slots × message_size × connections`. At the shipped defaults that is
+//! `5 × 10 MiB × 10 000` — half a terabyte of headroom for a buffer nobody
+//! intends to be large. The slot count says nothing about bytes, which is the
+//! resource that actually runs out.
+//!
+//! So the queues share one pool of *bytes*. A message reserves its own length
+//! from the pool before it is queued and releases it once the connection's
+//! writer has taken it off the queue. The aggregate across every connection is
+//! therefore capped at `total_bytes`, no matter how many connections exist or
+//! how big their messages are. Per-connection depth is still capped by the mpsc
+//! slot count, so one client cannot drain the whole pool by itself.
+//!
+//! # Why reservation failure drops the notification
+//!
+//! Reserving is non-blocking and gives up immediately when the pool is
+//! exhausted. It must be: the streaming task dispatches to every DID from a
+//! single loop, so *awaiting* a slow client's queue there would head-of-line
+//! block live delivery for every other DID on the mediator.
+//!
+//! Dropping is safe because live delivery is an optimisation, not the delivery
+//! guarantee. The message is already durably in the recipient's inbox before it
+//! is ever published here — a dropped push just means the client picks it up on
+//! its next poll or on inbox redelivery when it reconnects. This is the same
+//! contract the pub/sub layer already relies on when a subscriber lags.
+
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// A byte reservation held for as long as a message sits in a connection's send
+/// queue. Dropping it returns the bytes to the pool, so the queue item must own
+/// it — see [`crate::tasks::websocket_streaming::QueuedCommand`].
+pub type SendPermit = OwnedSemaphorePermit;
+
+/// Shared, cloneable handle to the global WebSocket send-buffer pool.
+#[derive(Clone)]
+pub struct WsSendBudget {
+    pool: Arc<Semaphore>,
+    total_bytes: usize,
+}
+
+impl WsSendBudget {
+    /// `total_bytes` is the aggregate ceiling across *all* live connections.
+    ///
+    /// Clamped to `Semaphore::MAX_PERMITS`, which is far above any sane budget;
+    /// the clamp exists so a misconfigured value degrades to "very large" rather
+    /// than panicking inside tokio.
+    pub fn new(total_bytes: usize) -> Self {
+        let total_bytes = total_bytes.min(Semaphore::MAX_PERMITS);
+        Self {
+            pool: Arc::new(Semaphore::new(total_bytes)),
+            total_bytes,
+        }
+    }
+
+    /// Reserve `bytes` from the pool, or return `None` if it cannot be covered
+    /// right now. Never blocks.
+    ///
+    /// A message larger than the entire pool would otherwise be unsendable
+    /// forever, so it is clamped to the full budget: it can still go out, but
+    /// only when the pool is completely free. That keeps an oversized message
+    /// stalled rather than permanently undeliverable, and `message_size` is
+    /// enforced at ingress anyway, so it should not arise unless the budget is
+    /// configured below `message_size`.
+    pub fn try_reserve(&self, bytes: usize) -> Option<SendPermit> {
+        let want = bytes.clamp(1, self.total_bytes);
+        // `try_acquire_many_owned` takes a u32; the clamp above already bounds
+        // `want` by the pool size, which is itself a u32-safe permit count.
+        let want = u32::try_from(want).unwrap_or(u32::MAX);
+        self.pool.clone().try_acquire_many_owned(want).ok()
+    }
+
+    /// Bytes currently available. Diagnostics and metrics only.
+    pub fn available_bytes(&self) -> usize {
+        self.pool.available_permits()
+    }
+
+    /// The configured ceiling.
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reservations_are_capped_by_the_pool() {
+        let budget = WsSendBudget::new(1000);
+
+        let a = budget.try_reserve(600).expect("first fits");
+        assert_eq!(budget.available_bytes(), 400);
+
+        // 600 + 600 > 1000, so the second must be refused rather than queued.
+        assert!(
+            budget.try_reserve(600).is_none(),
+            "pool must refuse a reservation it cannot cover"
+        );
+
+        // Releasing the first makes room again.
+        drop(a);
+        assert_eq!(budget.available_bytes(), 1000);
+        assert!(budget.try_reserve(600).is_some());
+    }
+
+    #[test]
+    fn oversized_message_clamps_to_the_whole_pool() {
+        let budget = WsSendBudget::new(100);
+
+        // Larger than the entire pool: allowed, but only by taking all of it.
+        let p = budget.try_reserve(10_000).expect("clamps to the full pool");
+        assert_eq!(budget.available_bytes(), 0);
+        assert!(budget.try_reserve(1).is_none());
+
+        drop(p);
+        assert_eq!(budget.available_bytes(), 100);
+    }
+
+    #[test]
+    fn permits_release_when_the_queue_item_drops() {
+        let budget = WsSendBudget::new(500);
+        {
+            let _held = budget.try_reserve(500).expect("fits");
+            assert_eq!(budget.available_bytes(), 0);
+        }
+        // Scope exit == the websocket writer consumed the item.
+        assert_eq!(budget.available_bytes(), 500);
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -9,7 +9,9 @@ use crate::{
     common::jwt_auth::{AuthError, authenticate_token},
     common::session::Session,
     messages::inbound::handle_inbound,
-    tasks::websocket_streaming::{StreamingUpdate, StreamingUpdateState, WebSocketCommands},
+    tasks::websocket_streaming::{
+        QueuedCommand, StreamingUpdate, StreamingUpdateState, WS_CHANNEL_SLOTS, WebSocketCommands,
+    },
 };
 #[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::message::Message as DidcommMessage;
@@ -372,7 +374,8 @@ async fn handle_socket(
         metrics::gauge!(ACTIVE_WEBSOCKET_CONNECTIONS).increment(1.0);
 
         // Register the transmission channel between websocket_streaming task and this websocket.
-        let (tx, mut rx): (Sender<WebSocketCommands>, Receiver<WebSocketCommands>) = mpsc::channel(5);
+        let (tx, mut rx): (Sender<QueuedCommand>, Receiver<QueuedCommand>) =
+            mpsc::channel(WS_CHANNEL_SLOTS);
         if let Some(streaming) = &state.streaming_task {
 
             let start = StreamingUpdate {
@@ -559,8 +562,11 @@ async fn handle_socket(
                     }
                 }
                 value = rx.recv() => {
-                    if let Some(msg) = value {
-                        match msg {
+                    if let Some(queued) = value {
+                        // Destructuring drops `_permit` at the end of this arm,
+                        // returning the message's bytes to the global send pool
+                        // once it has been written to the socket.
+                        match queued.cmd {
                             WebSocketCommands::Message(msg) => {
                                 debug!("ws: Received message from streaming task");
                                 // In raw-TSP mode the notification body carries no id we can

--- a/crates/messaging/affinidi-messaging-mediator/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/main.rs
@@ -1,6 +1,34 @@
 use affinidi_messaging_mediator::{commands, server::start};
 use clap::{Parser, Subcommand};
 
+// ─── Allocator ──────────────────────────────────────────────────────────────
+//
+// Set on the binary only. A library that installs a #[global_allocator] forces
+// it on every consumer, so this deliberately does not live in lib.rs.
+//
+// Why not the system allocator: the storage backend churns large, short-lived
+// buffers (write buffers, packed message bodies). glibc malloc keeps those
+// arenas rather than returning them, so RSS ratchets to the high-water mark and
+// never falls back — indistinguishable from a leak on a memory graph.
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+/// jemalloc tuning, read by jemalloc itself at startup via this well-known symbol.
+///
+/// `background_thread:true` runs the purger off the request path.
+/// `dirty_decay_ms` / `muzzy_decay_ms` are how long freed pages linger before
+/// being returned to the OS; jemalloc's defaults (10s / 10s) are tuned for
+/// throughput on allocation-heavy workloads, and hold RSS well above the live
+/// heap. 5s keeps the memory graph honest at a negligible cost here, because
+/// the mediator's hot path is I/O-bound, not allocation-bound.
+///
+/// Raise these (or drop the `jemalloc` feature) if you are optimising for
+/// allocation throughput over resident footprint.
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[unsafe(export_name = "malloc_conf")]
+pub static MALLOC_CONF: &[u8] = b"background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
+
 /// Affinidi Messaging Mediator.
 ///
 /// Without a subcommand, runs the mediator HTTP server (the historical

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -32,11 +32,46 @@ use tracing::{Instrument, debug, span};
 #[cfg(any(feature = "didcomm", feature = "tsp"))]
 use super::{ProcessMessageResponse, WrapperType};
 
+/// Reject a message larger than `limits.message_size`.
+///
+/// Every ingress path (HTTP `POST /inbound`, WebSocket text, WebSocket binary /
+/// TSP) funnels through `handle_inbound` or `handle_inbound_tsp`, so this is the
+/// one place the ceiling has to hold.
+///
+/// The transport caps (`http_size`, `ws_size`) are deliberately *larger* than
+/// this — they bound a single request or frame, whereas this bounds the message
+/// the mediator will copy, queue, store, and fan out. Every in-memory buffer is
+/// sized against this value, so it has to be enforced for those bounds to mean
+/// anything.
+fn check_message_size(
+    state: &SharedData,
+    session: &Session,
+    len: usize,
+) -> Result<(), MediatorError> {
+    let limit = state.config.limits.message_size;
+    if len > limit {
+        return Err(MediatorError::problem(
+            37,
+            &session.session_id,
+            None,
+            ProblemReportSorter::Error,
+            ProblemReportScope::Message,
+            "message.size.exceeded",
+            "Message size {1} exceeds the mediator limit of {2} bytes",
+            vec![len.to_string(), limit.to_string()],
+            StatusCode::PAYLOAD_TOO_LARGE,
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) async fn handle_inbound(
     #[cfg_attr(not(feature = "didcomm"), allow(unused_variables))] state: &SharedData,
     session: &Session,
     #[cfg_attr(not(feature = "didcomm"), allow(unused_variables))] message: &str,
 ) -> Result<InboundMessageResponse, MediatorError> {
+    check_message_size(state, session, message.len())?;
+
     // Try DIDComm first if enabled
     #[cfg(feature = "didcomm")]
     {
@@ -80,6 +115,8 @@ pub(crate) async fn handle_inbound_tsp(
     raw: &[u8],
 ) -> Result<InboundMessageResponse, MediatorError> {
     use affinidi_tsp::MessageType as TspMessageType;
+
+    check_message_size(state, session, raw.len())?;
 
     let meta = TspMetaEnvelope::parse(raw).map_err(|e| {
         MediatorError::problem(

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -547,6 +547,7 @@ pub async fn serve_internal(
         config.limits.did_rate_limit_per_second,
         config.limits.did_rate_limit_burst,
     );
+    did_rate_limiter.spawn_gc(shutdown_token.clone());
     if config.limits.did_rate_limit_per_second > 0 {
         info!(
             "Per-DID rate limiting enabled: {} req/s per DID, burst: {}",
@@ -611,6 +612,7 @@ pub async fn serve_internal(
         config.limits.rate_limit_per_ip,
         config.limits.rate_limit_burst,
     );
+    rate_limiter.spawn_gc(shutdown_token.clone());
     if config.limits.rate_limit_per_ip > 0 {
         info!(
             "Rate limiting enabled: {} req/s per IP, burst: {}",

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -9,9 +9,10 @@ use crate::{
         },
         did_rate_limiter::DidRateLimiter,
         error_codes,
-        metrics::{self, metrics_handler},
+        metrics::{self, metrics_handler, names::WS_SEND_BUFFER_AVAILABLE_BYTES},
         rate_limiter::{RateLimitLayer, RateLimiterState},
         request_id::RequestIdLayer,
+        ws_budget::WsSendBudget,
     },
     handlers::{
         admin_status, application_routes, health_checker_handler, liveness_handler,
@@ -40,6 +41,38 @@ use tower_http::trace::{self, TraceLayer};
 use tracing::{Level, error, info, warn};
 use tracing_subscriber::EnvFilter;
 use url::Url;
+
+/// Resolve `[storage.fjall]` into the store's typed tuning.
+///
+/// A free function rather than a `TryFrom` impl because the raw type lives in
+/// the config crate and the target type in the store — the same orphan-rule
+/// dance as `database_config_from_raw`.
+///
+/// Absent section => [`FjallTuning::default`], which is the point: an operator
+/// who never writes `[storage.fjall]` still gets the tuned defaults, not Fjall's
+/// stock ones (64 MiB of memtable per keyspace x 14 keyspaces).
+#[cfg(feature = "fjall-backend")]
+fn fjall_tuning_from_raw(
+    raw: Option<&affinidi_messaging_mediator_config::FjallConfig>,
+) -> crate::store::FjallTuning {
+    use crate::store::FjallTuning;
+
+    let defaults = FjallTuning::default();
+    let Some(raw) = raw else { return defaults };
+
+    let parse = |field: &str, value: &str, fallback: u64| -> u64 {
+        value.parse().unwrap_or_else(|_| {
+            warn!("Could not parse storage.fjall.{field} ('{value}'), using default: {fallback}");
+            fallback
+        })
+    };
+
+    FjallTuning {
+        block_cache: parse("block_cache", &raw.block_cache, defaults.block_cache),
+        write_buffer: parse("write_buffer", &raw.write_buffer, defaults.write_buffer),
+        max_journal: parse("max_journal", &raw.max_journal, defaults.max_journal),
+    }
+}
 
 /// Run the mediator HTTP server from a TOML config path.
 ///
@@ -140,16 +173,27 @@ pub async fn start(config_path: &str) -> Result<(), MediatorError> {
                                 "[storage] backend = \"fjall\" requires `data_dir`".into(),
                             )
                         })?;
-                    info!("Opening Fjall data directory at {data_dir}");
-                    let store = crate::store::FjallStore::open_with_circuit_breaker(
+                    let tuning = fjall_tuning_from_raw(
+                        config.storage.as_ref().and_then(|s| s.fjall.as_ref()),
+                    );
+                    info!(
+                        "Opening Fjall data directory at {data_dir} \
+                         (block_cache={} MiB, write_buffer={} MiB, max_journal={} MiB)",
+                        tuning.block_cache / (1024 * 1024),
+                        tuning.write_buffer / (1024 * 1024),
+                        tuning.max_journal / (1024 * 1024),
+                    );
+                    let store = crate::store::FjallStore::open_with_tuning(
                         &data_dir,
                         config.database.circuit_breaker_threshold,
                         config.database.circuit_breaker_recovery_secs,
+                        tuning,
                     )
                     .map_err(|e| {
                         error!("Failed to open Fjall data directory: {e}");
                         e
-                    })?;
+                    })?
+                    .with_pubsub_capacity(config.limits.pubsub_capacity());
                     Some(Arc::new(store) as Arc<_>)
                 }
                 #[cfg(not(feature = "fjall-backend"))]
@@ -273,7 +317,8 @@ pub async fn serve_internal(
                 config.database.circuit_breaker_threshold,
                 config.database.circuit_breaker_recovery_secs,
                 config.database.functions_file.clone(),
-            );
+            )
+            .with_pubsub_capacity(config.limits.pubsub_capacity());
             let init_cfg = affinidi_messaging_mediator_common::store::redis::RedisInitConfig {
                 mediator_did_hash: config.mediator_did_hash.clone(),
                 admin_did: config.admin_did.clone(),
@@ -474,11 +519,19 @@ pub async fn serve_internal(
     // (restart-and-degrade) rather than spawned detached, so a panic or a
     // transient startup error restarts it instead of silently killing live
     // delivery. Not load-bearing — clients fall back to message-pickup polling.
+    // Global byte pool shared by every WebSocket send queue. Bounds the
+    // aggregate at `limits.ws_send_buffer` regardless of connection count.
+    let ws_send_budget = WsSendBudget::new(config.limits.ws_send_buffer);
+    // `metrics` is shadowed here by `crate::common::metrics`, so reach for the
+    // crate explicitly.
+    ::metrics::gauge!(WS_SEND_BUFFER_AVAILABLE_BYTES).set(ws_send_budget.total_bytes() as f64);
+
     let streaming_task = if config.streaming_enabled {
         Some(StreamingTask::spawn_supervised(
             &supervisor,
             store.clone(),
             &config.streaming_uuid,
+            ws_send_budget.clone(),
         ))
     } else {
         None

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -79,7 +79,7 @@ use affinidi_messaging_sdk::{
     },
 };
 use async_trait::async_trait;
-use fjall::{Config as FjallConfig, Database, Keyspace, KeyspaceCreateOptions};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions};
 use serde::{Deserialize, Serialize};
 use sha256::digest;
 use std::{
@@ -93,7 +93,84 @@ use std::{
 };
 use tokio::sync::{Mutex, Notify, broadcast};
 
-const PUBSUB_BROADCAST_CAPACITY: usize = 1024;
+/// Fallback ring size when no tuning is supplied (tests, the embedded builder).
+/// Production derives this from `limits.pubsub_buffer / limits.message_size`.
+const PUBSUB_BROADCAST_CAPACITY: usize = 32;
+
+/// Memory tuning for the embedded Fjall database.
+///
+/// Fjall's stock defaults are sized for a general-purpose embedded store, not
+/// for a service that opens 14 keyspaces: 64 MiB of memtable *per keyspace*
+/// would permit ~896 MiB of write buffer on its own. These values come from
+/// `[storage.fjall]`.
+#[derive(Clone, Copy, Debug)]
+pub struct FjallTuning {
+    /// Block cache (read-side), in bytes.
+    pub block_cache: u64,
+    /// Total memtable budget across all keyspaces, in bytes. Split by
+    /// [`KEYSPACE_WRITE_WEIGHTS`].
+    pub write_buffer: u64,
+    /// Journal ceiling, in bytes. The only *effective* global bound on unflushed
+    /// memory — see the field docs on the config type.
+    pub max_journal: u64,
+}
+
+impl Default for FjallTuning {
+    fn default() -> Self {
+        Self {
+            block_cache: 16 * 1024 * 1024,
+            write_buffer: 32 * 1024 * 1024,
+            max_journal: 128 * 1024 * 1024,
+        }
+    }
+}
+
+/// Relative share of the write-buffer budget each keyspace gets.
+///
+/// Every open keyspace carries its own memtable, and Fjall flushes a keyspace
+/// when *its* memtable crosses *its* threshold — there is no global trigger. So
+/// the budget has to be divided up front, and dividing it evenly would be wrong:
+/// `messages` stores whole message bodies inline while `admins` stores a byte
+/// per row. Weighting by how much each keyspace actually writes keeps the hot
+/// ones from flushing constantly while the cold ones sit on memory they will
+/// never use.
+const KEYSPACE_WRITE_WEIGHTS: &[(&str, u32)] = &[
+    // Whole message bodies, inline. By far the heaviest writer.
+    (PARTITION_MESSAGES, 40),
+    // One small row per message, but written on every message.
+    (PARTITION_INBOX, 10),
+    (PARTITION_OUTBOX, 10),
+    (PARTITION_EXPIRY, 5),
+    // Whole message bodies again, but only for messages being forwarded.
+    (PARTITION_FORWARD_QUEUE, 20),
+    (PARTITION_FORWARD_PENDING, 3),
+    // Per-session and per-account rows: steady but small.
+    (PARTITION_SESSIONS, 4),
+    (PARTITION_ACCOUNTS, 2),
+    (PARTITION_STREAMING_CLIENTS, 2),
+    (PARTITION_AUDIT_LOG, 2),
+    // Cold: written on admin action only.
+    (PARTITION_ACCESS_LISTS, 1),
+    (PARTITION_ADMINS, 1),
+    (PARTITION_OOB_INVITES, 1),
+    (PARTITION_GLOBALS, 1),
+];
+
+/// Never size a memtable below this. A memtable smaller than a few pages would
+/// flush on almost every write, turning a cold keyspace into an IO hotspot.
+const MIN_MEMTABLE_BYTES: u64 = 1024 * 1024;
+
+/// This keyspace's slice of the write-buffer budget.
+fn memtable_size_for(keyspace: &str, write_buffer: u64) -> u64 {
+    let total: u32 = KEYSPACE_WRITE_WEIGHTS.iter().map(|(_, w)| w).sum();
+    let weight = KEYSPACE_WRITE_WEIGHTS
+        .iter()
+        .find(|(name, _)| *name == keyspace)
+        .map(|(_, w)| *w)
+        .unwrap_or(1);
+    let share = write_buffer.saturating_mul(u64::from(weight)) / u64::from(total);
+    share.max(MIN_MEMTABLE_BYTES)
+}
 
 const PARTITION_MESSAGES: &str = "messages";
 const PARTITION_INBOX: &str = "inbox";
@@ -155,6 +232,8 @@ pub struct FjallStore {
     /// Fires on every `forward_queue_enqueue` so blocking
     /// `forward_queue_read` callers wake up immediately.
     forward_notify: Arc<Notify>,
+    /// Slots in the live-delivery broadcast ring. See `with_pubsub_capacity`.
+    pubsub_capacity: usize,
     /// Live entry count of the `audit_log` keyspace. Seeded at open,
     /// maintained under `write_lock`. See the module-level note.
     audit_log_len: AtomicUsize,
@@ -385,6 +464,14 @@ impl FjallStore {
         Self::open_with_circuit_breaker(path, DEFAULT_CB_THRESHOLD, DEFAULT_CB_RECOVERY_SECS)
     }
 
+    /// Size the live-delivery broadcast ring. See
+    /// [`MemoryStore::with_pubsub_capacity`](crate::store::MemoryStore::with_pubsub_capacity)
+    /// for why this must come from a byte budget.
+    pub fn with_pubsub_capacity(mut self, capacity: usize) -> Self {
+        self.pubsub_capacity = capacity.max(1);
+        self
+    }
+
     /// Like [`open`](Self::open) but with explicit circuit-breaker tuning.
     /// The mediator threads `[database] circuit_breaker_threshold` /
     /// `circuit_breaker_recovery_secs` here so the Fjall backend degrades
@@ -394,25 +481,55 @@ impl FjallStore {
         circuit_breaker_threshold: u32,
         circuit_breaker_recovery_secs: u64,
     ) -> Result<Self, MediatorError> {
+        Self::open_with_tuning(
+            path,
+            circuit_breaker_threshold,
+            circuit_breaker_recovery_secs,
+            FjallTuning::default(),
+        )
+    }
+
+    /// Open with explicit memory tuning from `[storage.fjall]`.
+    ///
+    /// `block_cache` and `max_journal` are database-level and are applied on
+    /// every open, including existing data directories. The per-keyspace
+    /// memtable sizes derived from `write_buffer` are **only honoured when a
+    /// keyspace is first created**: Fjall persists a keyspace's memtable size at
+    /// creation and exposes no setter, so against an existing `data_dir` the
+    /// closure below is never called for keyspaces that already exist. That is
+    /// why `max_journal` — which forces rotation once the journal grows past it,
+    /// and therefore caps unflushed memtable memory — is the load-bearing bound.
+    pub fn open_with_tuning<P: AsRef<Path>>(
+        path: P,
+        circuit_breaker_threshold: u32,
+        circuit_breaker_recovery_secs: u64,
+        tuning: FjallTuning,
+    ) -> Result<Self, MediatorError> {
         let path = path.as_ref().to_path_buf();
-        let cfg = FjallConfig::new(&path);
-        let db = Database::create_or_recover(cfg).map_err(|e| {
-            MediatorError::InternalError(
-                500,
-                "fjall".into(),
-                format!("FjallStore::open: failed to open database at {path:?}: {e}"),
-            )
-        })?;
+        let db = Database::builder(&path)
+            .cache_size(tuning.block_cache)
+            .max_journaling_size(tuning.max_journal)
+            .open()
+            .map_err(|e| {
+                MediatorError::InternalError(
+                    500,
+                    "fjall".into(),
+                    format!("FjallStore::open: failed to open database at {path:?}: {e}"),
+                )
+            })?;
 
         let open_partition = |name: &str| -> Result<Keyspace, MediatorError> {
-            db.keyspace(name, KeyspaceCreateOptions::default)
-                .map_err(|e| {
-                    MediatorError::InternalError(
-                        500,
-                        "fjall".into(),
-                        format!("FjallStore::open: failed to open partition '{name}': {e}"),
-                    )
-                })
+            let memtable = memtable_size_for(name, tuning.write_buffer);
+            db.keyspace(name, move || {
+                KeyspaceCreateOptions::default().max_memtable_size(memtable)
+            })
+            .map_err(|e| {
+                MediatorError::InternalError(
+                    500,
+                    "fjall".into(),
+                    format!("FjallStore::open: failed to open partition '{name}': {e}"),
+                )
+            })
         };
 
         let forward_queue = open_partition(PARTITION_FORWARD_QUEUE)?;
@@ -452,6 +569,7 @@ impl FjallStore {
             next_stream_seq: AtomicU64::new(0),
             broadcast_channels: Arc::new(Mutex::new(HashMap::new())),
             forward_notify: Arc::new(Notify::new()),
+            pubsub_capacity: PUBSUB_BROADCAST_CAPACITY,
             audit_log_len: AtomicUsize::new(audit_log_len),
             forward_queue_len: AtomicUsize::new(forward_queue_len),
             circuit_breaker: CircuitBreaker::new(
@@ -2540,7 +2658,7 @@ impl MediatorStore for FjallStore {
         if let Some(sender) = channels.get(mediator_uuid) {
             return Ok(sender.subscribe());
         }
-        let (sender, receiver) = broadcast::channel(PUBSUB_BROADCAST_CAPACITY);
+        let (sender, receiver) = broadcast::channel(self.pubsub_capacity);
         channels.insert(mediator_uuid.to_string(), sender);
         Ok(receiver)
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -7,24 +7,23 @@
 //! configurations that require multiple mediator instances sharing
 //! storage.
 //!
-//! # Status: skeleton
+//! # Keyspace layout
 //!
-//! This file is the structural foundation. All [`MediatorStore`] trait
-//! methods are present so the type satisfies the trait, but most
-//! return `MediatorError::InternalError(..., "FjallStore::method not
-//! yet implemented")`. Subsequent commits land actual implementations.
+//! Fjall 3.x renamed "partition" to "keyspace"; the `PARTITION_*`
+//! constants below keep the older name for continuity with the on-disk
+//! layout, which is unchanged. Each keyspace carries its own memtable,
+//! so the count here is also the process's memtable count.
 //!
-//! # Partition layout (planned)
-//!
-//! - `messages`           — `msg_id` → message body (UTF-8)
-//! - `message_meta`       — `msg_id` → JSON-serialised
-//!   [`MessageMetaData`]
+//! - `messages`           — `msg_id` → message body (UTF-8). Also carries
+//!   the per-message metadata (`bytes`, peer DID hashes, timestamp), so
+//!   `get_message_metadata` reads it directly; there is no separate
+//!   metadata keyspace.
 //! - `inbox`              — `{did_hash}:{stream_id}` → inbox entry
 //! - `outbox`             — `{did_hash}:{stream_id}` → outbox entry
 //! - `expiry`             — `{expires_at_secs}:{msg_id}` → empty
 //! - `sessions`           — `session_id` → JSON-serialised [`Session`]
-//! - `accounts`           — `did_hash` → JSON-serialised account record
-//! - `acls`               — `did_hash` → ACL bitmask hex
+//! - `accounts`           — `did_hash` → JSON-serialised account record.
+//!   Carries the ACL bitmask inline, so there is no separate ACL keyspace.
 //! - `access_lists`       — `{did_hash}:{member_did_hash}` → empty
 //! - `admins`             — `did_hash` → role flag (1=Admin,
 //!   2=RootAdmin, 3=Mediator)
@@ -45,6 +44,14 @@
 //! [`broadcast::channel`] with no Fjall-side persistence — subscribers
 //! disconnect on mediator restart. Forward-queue blocking reads use a
 //! [`Notify`] that fires on each `forward_queue_enqueue`.
+//!
+//! The `audit_log` and `forward_queue` keyspaces keep a live entry count
+//! in an [`AtomicUsize`]. Fjall has no O(1) exact length — both
+//! `Keyspace::len` and `approximate_len` are unusable here (the former
+//! scans, the latter counts tombstones) — and both keyspaces need their
+//! length on every insert to enforce a bound. The counters are seeded by
+//! one key-only scan at open and maintained under `write_lock`
+//! thereafter, which is sound because this backend is single-process.
 
 use affinidi_messaging_mediator_common::{
     circuit_breaker::CircuitBreaker,
@@ -80,7 +87,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         Arc,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -89,13 +96,11 @@ use tokio::sync::{Mutex, Notify, broadcast};
 const PUBSUB_BROADCAST_CAPACITY: usize = 1024;
 
 const PARTITION_MESSAGES: &str = "messages";
-const PARTITION_MESSAGE_META: &str = "message_meta";
 const PARTITION_INBOX: &str = "inbox";
 const PARTITION_OUTBOX: &str = "outbox";
 const PARTITION_EXPIRY: &str = "expiry";
 const PARTITION_SESSIONS: &str = "sessions";
 const PARTITION_ACCOUNTS: &str = "accounts";
-const PARTITION_ACLS: &str = "acls";
 const PARTITION_ACCESS_LISTS: &str = "access_lists";
 const PARTITION_ADMINS: &str = "admins";
 const PARTITION_OOB_INVITES: &str = "oob_invites";
@@ -110,12 +115,6 @@ const PARTITION_AUDIT_LOG: &str = "audit_log";
 /// Construct with [`FjallStore::open`] and a path to a directory the
 /// mediator may write to. Drops the underlying [`Database`] on shutdown
 /// — outstanding readers must be released first.
-//
-// Many fields are unused at the moment because the trait methods are
-// stubbed; subsequent commits land per-method implementations that
-// read/write each partition. The `dead_code` allowance is removed
-// once enough methods land.
-#[allow(dead_code)]
 pub struct FjallStore {
     /// Top-level Fjall database. Cloned cheaply (internal `Arc`).
     db: Database,
@@ -125,13 +124,11 @@ pub struct FjallStore {
 
     // ─── Partitions ─────────────────────────────────────────────────
     messages: Keyspace,
-    message_meta: Keyspace,
     inbox: Keyspace,
     outbox: Keyspace,
     expiry: Keyspace,
     sessions: Keyspace,
     accounts: Keyspace,
-    acls: Keyspace,
     access_lists: Keyspace,
     admins: Keyspace,
     oob_invites: Keyspace,
@@ -158,6 +155,12 @@ pub struct FjallStore {
     /// Fires on every `forward_queue_enqueue` so blocking
     /// `forward_queue_read` callers wake up immediately.
     forward_notify: Arc<Notify>,
+    /// Live entry count of the `audit_log` keyspace. Seeded at open,
+    /// maintained under `write_lock`. See the module-level note.
+    audit_log_len: AtomicUsize,
+    /// Live entry count of the `forward_queue` keyspace. Seeded at open,
+    /// maintained under `write_lock`. See the module-level note.
+    forward_queue_len: AtomicUsize,
     /// Probe-driven circuit breaker. The embedded store has no
     /// per-request connection chokepoint like the Redis backend, so the
     /// breaker is driven by a cheap point read in
@@ -412,23 +415,36 @@ impl FjallStore {
                 })
         };
 
+        let forward_queue = open_partition(PARTITION_FORWARD_QUEUE)?;
+        let audit_log = open_partition(PARTITION_AUDIT_LOG)?;
+
+        // Seed the bounded-keyspace counters. `Keyspace::len` is a
+        // key-only scan (it never materialises values), and it runs once
+        // per process against keyspaces that are small by construction:
+        // `audit_log` is a ring capped at AUDIT_LOG_MAX_ENTRIES, and
+        // `forward_queue` is drained by the forwarding processor.
+        let audit_log_len = audit_log
+            .len()
+            .map_err(|e| Self::db_err("open:audit_log_len", e))?;
+        let forward_queue_len = forward_queue
+            .len()
+            .map_err(|e| Self::db_err("open:forward_queue_len", e))?;
+
         Ok(Self {
             messages: open_partition(PARTITION_MESSAGES)?,
-            message_meta: open_partition(PARTITION_MESSAGE_META)?,
             inbox: open_partition(PARTITION_INBOX)?,
             outbox: open_partition(PARTITION_OUTBOX)?,
             expiry: open_partition(PARTITION_EXPIRY)?,
             sessions: open_partition(PARTITION_SESSIONS)?,
             accounts: open_partition(PARTITION_ACCOUNTS)?,
-            acls: open_partition(PARTITION_ACLS)?,
             access_lists: open_partition(PARTITION_ACCESS_LISTS)?,
             admins: open_partition(PARTITION_ADMINS)?,
             oob_invites: open_partition(PARTITION_OOB_INVITES)?,
-            forward_queue: open_partition(PARTITION_FORWARD_QUEUE)?,
+            forward_queue,
             forward_pending: open_partition(PARTITION_FORWARD_PENDING)?,
             globals: open_partition(PARTITION_GLOBALS)?,
             streaming_clients: open_partition(PARTITION_STREAMING_CLIENTS)?,
-            audit_log: open_partition(PARTITION_AUDIT_LOG)?,
+            audit_log,
             db,
             path,
             write_lock: Arc::new(Mutex::new(())),
@@ -436,6 +452,8 @@ impl FjallStore {
             next_stream_seq: AtomicU64::new(0),
             broadcast_channels: Arc::new(Mutex::new(HashMap::new())),
             forward_notify: Arc::new(Notify::new()),
+            audit_log_len: AtomicUsize::new(audit_log_len),
+            forward_queue_len: AtomicUsize::new(forward_queue_len),
             circuit_breaker: CircuitBreaker::new(
                 circuit_breaker_threshold,
                 circuit_breaker_recovery_secs,
@@ -524,32 +542,17 @@ impl FjallStore {
             .map_err(|e| Self::db_err("access_list_contains", e))
     }
 
-    /// O(n) count of entries currently in the forward queue. Used by
+    /// O(1) count of entries currently in the forward queue. Used by
     /// `forward_queue_len` and the `max_len` trim in
     /// `forward_queue_enqueue`.
-    fn forward_queue_count_inner(&self) -> Result<usize, MediatorError> {
-        let mut count = 0usize;
-        for guard in self.forward_queue.iter() {
-            let _ = guard
-                .into_inner()
-                .map_err(|e| Self::db_err("forward_queue_count:iter", e))?;
-            count += 1;
-        }
-        Ok(count)
+    fn forward_queue_count_inner(&self) -> usize {
+        self.forward_queue_len.load(Ordering::Acquire)
     }
 
-    /// O(n) count of audit-log entries. Used by `audit_log_record` for the
-    /// ring trim and by `audit_log_list` for cursor maths. Bounded by
-    /// `AUDIT_LOG_MAX_ENTRIES`.
-    fn audit_log_count_inner(&self) -> Result<usize, MediatorError> {
-        let mut count = 0usize;
-        for guard in self.audit_log.iter() {
-            let _ = guard
-                .into_inner()
-                .map_err(|e| Self::db_err("audit_log_count:iter", e))?;
-            count += 1;
-        }
-        Ok(count)
+    /// O(1) count of audit-log entries. Used by `audit_log_record` for the
+    /// ring trim and by `audit_log_list` for cursor maths.
+    fn audit_log_count_inner(&self) -> usize {
+        self.audit_log_len.load(Ordering::Acquire)
     }
 
     /// Read a consumer group's `last_delivered` stream ID from the
@@ -2019,16 +2022,21 @@ impl MediatorStore for FjallStore {
         // Bounded ring: drop the oldest entries (lowest keys, first in ascending
         // order) once we'd exceed the cap. `+1` accounts for the entry we're
         // adding in this same batch.
-        let current = self.audit_log_count_inner()?;
+        let current = self.audit_log_count_inner();
+        let mut removed = 0usize;
         if current >= AUDIT_LOG_MAX_ENTRIES {
             let over = current - AUDIT_LOG_MAX_ENTRIES + 1;
             let mut to_remove = Vec::with_capacity(over);
+            // Steady state `over` is 1, so this walks one key, not the ring.
+            // `key()` skips materialising the value, unlike `into_inner()`.
             for guard in self.audit_log.iter().take(over) {
-                let (key, _) = guard
-                    .into_inner()
-                    .map_err(|e| Self::db_err("audit_log_record:trim", e))?;
-                to_remove.push(key);
+                to_remove.push(
+                    guard
+                        .key()
+                        .map_err(|e| Self::db_err("audit_log_record:trim", e))?,
+                );
             }
+            removed = to_remove.len();
             for k in to_remove {
                 batch.remove(&self.audit_log, k.as_ref());
             }
@@ -2037,6 +2045,11 @@ impl MediatorStore for FjallStore {
         batch
             .commit()
             .map_err(|e| Self::db_err("audit_log_record:commit", e))?;
+
+        // Only after the batch is durable, so a failed commit can't drift the
+        // counter. Both ops are under `write_lock`, so this is not racy.
+        self.audit_log_len
+            .store(current + 1 - removed, Ordering::Release);
         Ok(())
     }
 
@@ -2046,28 +2059,25 @@ impl MediatorStore for FjallStore {
         limit: u32,
     ) -> Result<MediatorAuditLogList, MediatorError> {
         let limit = limit.min(100) as usize;
-        let total = self.audit_log_count_inner()?;
+        let total = self.audit_log_count_inner();
 
-        // Entries are stored oldest-first (ascending key). The newest-first page
-        // [cursor, cursor+limit) maps onto the oldest-first index window
-        // [start, end); we decode only that window, then reverse it.
-        let end = total.saturating_sub(cursor as usize);
-        let start = end.saturating_sub(limit);
-
-        let mut entries: Vec<AuditLogEntry> = Vec::with_capacity(end - start);
-        for (i, guard) in self.audit_log.iter().enumerate() {
-            if i < start {
-                continue;
-            }
-            if i >= end {
-                break;
-            }
-            let (_, value) = guard
-                .into_inner()
+        // Entries are stored oldest-first (ascending key), and the caller wants
+        // them newest-first, so walk the keyspace in reverse: skip `cursor`,
+        // decode `limit`. That touches `cursor + limit` entries rather than
+        // scanning and decoding the whole ring.
+        let mut entries: Vec<AuditLogEntry> = Vec::with_capacity(limit);
+        for guard in self
+            .audit_log
+            .iter()
+            .rev()
+            .skip(cursor as usize)
+            .take(limit)
+        {
+            let value = guard
+                .value()
                 .map_err(|e| Self::db_err("audit_log_list:iter", e))?;
             entries.push(Self::decode(&value)?);
         }
-        entries.reverse(); // oldest-first window → newest-first page
 
         let next_cursor = if cursor as usize + entries.len() >= total {
             0
@@ -2198,18 +2208,22 @@ impl MediatorStore for FjallStore {
         );
 
         // Approximate `max_len` trim: drop oldest entries when over.
+        let current = self.forward_queue_count_inner();
+        let mut removed = 0usize;
         if max_len > 0 {
             let mut to_remove = Vec::new();
-            let current = self.forward_queue_count_inner()?;
             if current >= max_len {
                 let over = current - max_len + 1; // +1 because we're adding one
+                // `key()` skips materialising the value, unlike `into_inner()`.
                 for guard in self.forward_queue.iter().take(over) {
-                    let (key, _) = guard
-                        .into_inner()
-                        .map_err(|e| Self::db_err("forward_queue_enqueue:trim", e))?;
-                    to_remove.push(key);
+                    to_remove.push(
+                        guard
+                            .key()
+                            .map_err(|e| Self::db_err("forward_queue_enqueue:trim", e))?,
+                    );
                 }
             }
+            removed = to_remove.len();
             for k in to_remove {
                 batch.remove(&self.forward_queue, k.as_ref());
             }
@@ -2217,13 +2231,18 @@ impl MediatorStore for FjallStore {
         batch
             .commit()
             .map_err(|e| Self::db_err("forward_queue_enqueue:commit", e))?;
+
+        // Only after the batch is durable, so a failed commit can't drift the
+        // counter. Still under `write_lock`, so this is not racy.
+        self.forward_queue_len
+            .store(current + 1 - removed, Ordering::Release);
         drop(_guard);
         self.forward_notify.notify_waiters();
         Ok(stream_id)
     }
 
     async fn forward_queue_len(&self) -> Result<usize, MediatorError> {
-        self.forward_queue_count_inner()
+        Ok(self.forward_queue_count_inner())
     }
 
     async fn forward_queue_read(
@@ -2325,14 +2344,29 @@ impl MediatorStore for FjallStore {
     async fn forward_queue_delete(&self, stream_ids: &[&str]) -> Result<(), MediatorError> {
         let _guard = self.write_lock.lock().await;
         let mut batch = self.db.batch();
+        // Removing an absent key is a no-op in Fjall but would still decrement
+        // the counter, so only count the ones that are actually there. Callers
+        // legitimately re-delete (duplicate acks, autoclaim races).
+        let mut removed = 0usize;
         for id in stream_ids {
             if let Some(sid) = parse_stream_id_string(id) {
-                batch.remove(&self.forward_queue, encode_stream_id(sid.0, sid.1).to_vec());
+                let key = encode_stream_id(sid.0, sid.1).to_vec();
+                if self
+                    .forward_queue
+                    .contains_key(&key)
+                    .map_err(|e| Self::db_err("forward_queue_delete:contains", e))?
+                {
+                    removed += 1;
+                    batch.remove(&self.forward_queue, key);
+                }
             }
         }
         batch
             .commit()
             .map_err(|e| Self::db_err("forward_queue_delete:commit", e))?;
+
+        // Only after the batch is durable. Still under `write_lock`.
+        self.forward_queue_len.fetch_sub(removed, Ordering::AcqRel);
         Ok(())
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -57,7 +57,9 @@ use std::{
 };
 use tokio::sync::{Mutex, Notify, broadcast};
 
-const PUBSUB_BROADCAST_CAPACITY: usize = 1024;
+/// Fallback ring size when no tuning is supplied (tests, the embedded builder).
+/// Production derives this from `limits.pubsub_buffer / limits.message_size`.
+const PUBSUB_BROADCAST_CAPACITY: usize = 32;
 
 // ─── Internal types ─────────────────────────────────────────────────────────
 
@@ -297,12 +299,27 @@ pub struct MemoryStore {
     state: Arc<Mutex<MemoryState>>,
     broadcast_channels: Arc<Mutex<HashMap<String, broadcast::Sender<PubSubRecord>>>>,
     forward_notify: Arc<Notify>,
+    /// Slots in the live-delivery broadcast ring. See `with_pubsub_capacity`.
+    pubsub_capacity: usize,
 }
 
 impl MemoryStore {
     /// Construct an empty in-memory store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Size the live-delivery broadcast ring.
+    ///
+    /// `tokio::sync::broadcast` holds every one of its `capacity` slots for the
+    /// life of the channel — a slot is not freed when a subscriber reads it, only
+    /// when it is overwritten `capacity` sends later. So the ring is a *standing*
+    /// reservation of `capacity x message_size` bytes, not a transient queue, and
+    /// the capacity must be derived from a byte budget rather than picked by feel.
+    /// See [`pubsub_capacity_for`].
+    pub fn with_pubsub_capacity(mut self, capacity: usize) -> Self {
+        self.pubsub_capacity = capacity.max(1);
+        self
     }
 }
 
@@ -312,6 +329,7 @@ impl Default for MemoryStore {
             state: Arc::new(Mutex::new(MemoryState::default())),
             broadcast_channels: Arc::new(Mutex::new(HashMap::new())),
             forward_notify: Arc::new(Notify::new()),
+            pubsub_capacity: PUBSUB_BROADCAST_CAPACITY,
         }
     }
 }
@@ -322,6 +340,7 @@ impl Clone for MemoryStore {
             state: Arc::clone(&self.state),
             broadcast_channels: Arc::clone(&self.broadcast_channels),
             forward_notify: Arc::clone(&self.forward_notify),
+            pubsub_capacity: self.pubsub_capacity,
         }
     }
 }
@@ -1561,7 +1580,7 @@ impl MediatorStore for MemoryStore {
         if let Some(sender) = channels.get(mediator_uuid) {
             return Ok(sender.subscribe());
         }
-        let (sender, receiver) = broadcast::channel(PUBSUB_BROADCAST_CAPACITY);
+        let (sender, receiver) = broadcast::channel(self.pubsub_capacity);
         channels.insert(mediator_uuid.to_string(), sender);
         Ok(receiver)
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/mod.rs
@@ -21,7 +21,7 @@ pub mod fjall_store;
 mod fjall_migrations;
 
 #[cfg(feature = "fjall-backend")]
-pub use fjall_store::FjallStore;
+pub use fjall_store::{FjallStore, FjallTuning};
 
 #[cfg(feature = "memory-backend")]
 pub mod memory_store;

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -22,8 +22,9 @@
 */
 use crate::common::metrics::names::{
     WEBSOCKET_DUPLICATE_CHURN_TOTAL, WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL,
-    WEBSOCKET_REDELIVERED_MESSAGES_TOTAL,
+    WEBSOCKET_REDELIVERED_MESSAGES_TOTAL, WS_LIVE_DELIVERY_DROPPED,
 };
+use crate::common::ws_budget::{SendPermit, WsSendBudget};
 use crate::tasks::supervisor::TaskSupervisor;
 use affinidi_messaging_mediator_common::{
     errors::MediatorError,
@@ -56,10 +57,18 @@ const REDELIVERY_PAGE: usize = 50;
 /// remainder is left for the client to pick up via normal message-pickup.
 const REDELIVERY_MAX: usize = 1000;
 
+/// Slots in a single connection's send queue.
+///
+/// This is the per-connection *depth* cap; the aggregate *byte* cap is the
+/// shared [`WsSendBudget`]. Depth still matters: without it one client could
+/// reserve the entire global pool for itself. Together they bound a connection
+/// at `WS_CHANNEL_SLOTS × message_size` and all connections at the pool size.
+pub const WS_CHANNEL_SLOTS: usize = 8;
+
 /// One registered streaming client for a DID.
 struct ClientEntry {
     /// Channel to the per-connection websocket handler.
-    tx: mpsc::Sender<WebSocketCommands>,
+    tx: mpsc::Sender<QueuedCommand>,
     /// Session id of the owning websocket (used for churn/diagnostic logs).
     session_id: String,
     /// Whether live delivery is currently active for this client.
@@ -75,7 +84,7 @@ struct ClientEntry {
 /// Deregister: Remove the hash map entry for the DID hash.
 pub enum StreamingUpdateState {
     Register {
-        channel: mpsc::Sender<WebSocketCommands>,
+        channel: mpsc::Sender<QueuedCommand>,
         session_id: String,
         did: String,
     },
@@ -90,6 +99,68 @@ pub enum WebSocketCommands {
     Close,           // Close the websocket connection
 }
 
+/// A command sitting in a connection's send queue, together with the byte
+/// reservation it holds against the global [`WsSendBudget`].
+///
+/// The permit is owned by the queue item on purpose: it is released exactly when
+/// the item is dropped, which is when the connection's writer has taken it off
+/// the queue. There is no separate "release" call to forget.
+pub struct QueuedCommand {
+    pub cmd: WebSocketCommands,
+    /// `None` for control commands (`Close`), which carry no payload and must
+    /// never be refused for want of buffer bytes.
+    _permit: Option<SendPermit>,
+}
+
+impl QueuedCommand {
+    /// A control command. Always admissible — it holds no bytes.
+    fn control(cmd: WebSocketCommands) -> Self {
+        Self { cmd, _permit: None }
+    }
+}
+
+/// Queue a payload to one client without blocking.
+///
+/// Returns `false` if the message was dropped — either the global byte pool is
+/// exhausted or this connection's queue is full. Both mean the client is not
+/// keeping up; the message is already durable in its inbox, so it will arrive on
+/// the next poll or on reconnect redelivery.
+///
+/// Non-blocking is the whole point: this is called from the single streaming
+/// loop that serves every DID, so awaiting one slow client here would stall live
+/// delivery for all of them.
+fn try_queue_message(
+    tx: &mpsc::Sender<QueuedCommand>,
+    budget: &WsSendBudget,
+    did_hash: &str,
+    message: String,
+) -> bool {
+    let Some(permit) = budget.try_reserve(message.len()) else {
+        warn!(
+            "WebSocket send buffer exhausted ({} bytes total); dropping live notification for {}. \
+             Client will pick the message up from its inbox.",
+            budget.total_bytes(),
+            did_hash
+        );
+        metrics::counter!(WS_LIVE_DELIVERY_DROPPED).increment(1);
+        return false;
+    };
+
+    let queued = QueuedCommand {
+        cmd: WebSocketCommands::Message(message),
+        _permit: Some(permit),
+    };
+
+    if tx.try_send(queued).is_err() {
+        // Channel full (slow consumer) or closed (socket gone). Either way the
+        // push is dropped; a closed channel is reaped by the caller.
+        debug!("Send queue unavailable for {did_hash}; dropping live notification");
+        metrics::counter!(WS_LIVE_DELIVERY_DROPPED).increment(1);
+        return false;
+    }
+    true
+}
+
 /// Used to update the streaming state.
 /// did_hash: The DID hash to update the state for.
 /// state: The state to update to.
@@ -102,6 +173,8 @@ pub struct StreamingUpdate {
 pub struct StreamingTask {
     pub uuid: String,
     pub channel: mpsc::Sender<StreamingUpdate>,
+    /// Global byte pool shared by every connection's send queue.
+    pub send_budget: WsSendBudget,
 }
 
 impl StreamingTask {
@@ -124,12 +197,16 @@ impl StreamingTask {
         supervisor: &TaskSupervisor,
         database: Arc<dyn MediatorStore>,
         mediator_uuid: &str,
+        send_budget: WsSendBudget,
     ) -> Self {
-        // Create the inter-task channel - allows up to 10 queued messages
+        // Control-plane channel (register/start/stop/deregister). Carries no
+        // message bodies — a handful of small structs — so a slot count is the
+        // right bound here and 10 is plenty.
         let (tx, rx) = mpsc::channel(10);
         let task = StreamingTask {
             channel: tx,
             uuid: mediator_uuid.to_string(),
+            send_budget,
         };
         let rx = Arc::new(Mutex::new(rx));
 
@@ -262,65 +339,69 @@ impl StreamingTask {
 
     /// Forward one streaming notification to the WebSocket sender for
     /// its target DID, dropping clients whose channels have closed.
+    ///
+    /// Never awaits a client's send queue: this runs in the single loop that
+    /// serves every DID, so blocking on one slow socket would stall live
+    /// delivery for all of them. A client that cannot keep up has its push
+    /// dropped (see [`try_queue_message`]).
     async fn dispatch_payload(
         &self,
         database: &dyn MediatorStore,
         clients: &mut HashMap<String, ClientEntry>,
         payload: PubSubRecord,
     ) {
-        match clients.get(&payload.did_hash) {
+        let PubSubRecord {
+            did_hash,
+            message,
+            force_delivery,
+        } = payload;
+        match clients.get(&did_hash) {
             Some(entry) => {
-                if payload.force_delivery || entry.active {
-                    if let Err(err) = entry
-                        .tx
-                        .send(WebSocketCommands::Message(payload.message.clone()))
-                        .await
-                    {
-                        warn!(
-                            "Dead WebSocket channel for ({}), cleaning up: {}",
-                            payload.did_hash, err
-                        );
-                        clients.remove(&payload.did_hash);
+                if force_delivery || entry.active {
+                    // A closed channel means the socket is gone and the entry is
+                    // stale; a *full* one means a slow client, which is not a
+                    // reason to tear the connection down. Distinguish them, or a
+                    // brief burst would evict a perfectly healthy client.
+                    if entry.tx.is_closed() {
+                        warn!("Dead WebSocket channel for ({did_hash}), cleaning up");
+                        clients.remove(&did_hash);
                         if let Err(e) = database
                             .streaming_set_state(
-                                &payload.did_hash,
+                                &did_hash,
                                 &self.uuid,
                                 StreamingClientState::Deregistered,
                             )
                             .await
                         {
-                            error!(
-                                "Error deregistering dead client ({}): {}",
-                                payload.did_hash, e
-                            );
+                            error!("Error deregistering dead client ({did_hash}): {e}");
                         }
-                    } else {
-                        debug!("Sent message to client ({})", payload.did_hash);
+                    } else if try_queue_message(
+                        &entry.tx,
+                        &self.send_budget,
+                        &did_hash,
+                        // Moved, not cloned: the body already exists in the
+                        // broadcast ring slot, and `payload` is owned here.
+                        message,
+                    ) {
+                        debug!("Sent message to client ({did_hash})");
                     }
                 } else {
-                    debug!(
-                        "pub/sub msg received for did_hash({}) but it is not active",
-                        payload.did_hash
-                    );
+                    debug!("pub/sub msg received for did_hash({did_hash}) but it is not active");
                     if let Err(err) = database
                         .streaming_set_state(
-                            &payload.did_hash,
+                            &did_hash,
                             &self.uuid,
                             StreamingClientState::Registered,
                         )
                         .await
                     {
-                        error!(
-                            "Error stopping streaming for client ({}): {}",
-                            payload.did_hash, err
-                        );
+                        error!("Error stopping streaming for client ({did_hash}): {err}");
                     }
                 }
             }
             None => {
                 warn!(
-                    "pub/sub msg received for did_hash({}) but it doesn't exist in clients HashMap",
-                    payload.did_hash
+                    "pub/sub msg received for did_hash({did_hash}) but it doesn't exist in clients HashMap"
                 );
             }
         }
@@ -361,7 +442,9 @@ impl StreamingTask {
                  the upstream session is missing its authenticated DID. \
                  Closing the channel."
             );
-            let _ = client_tx.send(WebSocketCommands::Close).await;
+            let _ = client_tx
+                .send(QueuedCommand::control(WebSocketCommands::Close))
+                .await;
             return;
         }
 
@@ -406,7 +489,10 @@ impl StreamingTask {
                 metrics::counter!(WEBSOCKET_DUPLICATE_CHURN_TOTAL).increment(1);
             }
             // Channel already exists, close the old one.
-            let _ = old.tx.send(WebSocketCommands::Close).await;
+            let _ = old
+                .tx
+                .send(QueuedCommand::control(WebSocketCommands::Close))
+                .await;
             true
         } else {
             false
@@ -458,6 +544,7 @@ impl StreamingTask {
                 spawn_inbox_redelivery(
                     Arc::clone(database),
                     client_tx.clone(),
+                    self.send_budget.clone(),
                     value.did_hash.clone(),
                     new_session_id.to_string(),
                     Arc::clone(replay_in_progress),
@@ -484,7 +571,8 @@ impl StreamingTask {
 /// message id.
 fn spawn_inbox_redelivery(
     database: Arc<dyn MediatorStore>,
-    client_tx: mpsc::Sender<WebSocketCommands>,
+    client_tx: mpsc::Sender<QueuedCommand>,
+    budget: WsSendBudget,
     did_hash: String,
     session_id: String,
     replay_in_progress: Arc<DashSet<String>>,
@@ -525,16 +613,15 @@ fn spawn_inbox_redelivery(
                 }
                 let Some(msg) = element.msg else { continue };
 
-                if client_tx
-                    .send(WebSocketCommands::Message(msg))
-                    .await
-                    .is_err()
-                {
-                    // The surviving socket is already gone; nothing to do — the
-                    // messages remain in the inbox for the next connection.
+                // Fetched with `DoNotDelete`, so anything not queued here stays
+                // in the inbox. Stopping the drain early is therefore lossless —
+                // the client picks the remainder up via normal message-pickup,
+                // exactly as it does when REDELIVERY_MAX is hit.
+                if !try_queue_message(&client_tx, &budget, &did_hash, msg) {
                     debug!(
                         did_hash = %did_hash,
-                        "Surviving socket closed mid-redelivery; stopping drain"
+                        "Send queue or byte budget unavailable mid-redelivery; \
+                         stopping drain, remainder left for message-pickup"
                     );
                     break 'drain;
                 }
@@ -582,6 +669,9 @@ mod tests {
         StreamingTask {
             uuid: "test-mediator".to_string(),
             channel: tx,
+            // Generous budget: these tests exercise registration/redelivery, not
+            // buffer exhaustion (which `ws_budget` covers directly).
+            send_budget: WsSendBudget::new(16 * 1024 * 1024),
         }
     }
 
@@ -637,7 +727,10 @@ mod tests {
             .await
             .expect("A receives a command")
         {
-            Some(WebSocketCommands::Close) => {}
+            Some(QueuedCommand {
+                cmd: WebSocketCommands::Close,
+                ..
+            }) => {}
             other => panic!("expected Close on old socket, got {:?}", other.is_some()),
         }
 
@@ -646,7 +739,10 @@ mod tests {
             .await
             .expect("B receives the redelivered message")
         {
-            Some(WebSocketCommands::Message(msg)) => assert_eq!(msg, stored),
+            Some(QueuedCommand {
+                cmd: WebSocketCommands::Message(msg),
+                ..
+            }) => assert_eq!(msg, stored),
             _ => panic!("expected redelivered Message on the surviving socket"),
         }
 

--- a/crates/messaging/affinidi-messaging-mediator/tests/fjall_counters.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/fjall_counters.rs
@@ -1,0 +1,200 @@
+//! Regression tests for the Fjall backend's in-memory entry counters.
+//!
+//! `audit_log` and `forward_queue` are both bounded keyspaces, so both need
+//! their length on every insert to enforce the bound. Fjall has no O(1) exact
+//! length, so [`FjallStore`] maintains the counts in memory: seeded by one scan
+//! at open, then adjusted under `write_lock`.
+//!
+//! That trades an O(n) scan per insert for a value that can *drift* — a count
+//! that disagrees with the keyspace silently corrupts the bound (a ring that
+//! trims too eagerly, or never trims at all). These tests pin the three ways it
+//! could drift: the trim path, a reopen, and a delete of a key that isn't there.
+
+#![cfg(all(feature = "fjall-backend", feature = "didcomm"))]
+
+use affinidi_messaging_mediator::store::FjallStore;
+use affinidi_messaging_mediator_common::{
+    store::{MediatorStore, types::ForwardQueueEntry},
+    types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditAction, AuditLogEntry},
+};
+use std::sync::Arc;
+
+fn audit_entry(i: usize) -> AuditLogEntry {
+    AuditLogEntry {
+        timestamp: 1000 + i as u64,
+        actor_did_hash: format!("actor{i}"),
+        target_did_hash: format!("target{i}"),
+        action: AuditAction::SetAcl,
+        detail: format!("entry {i}"),
+    }
+}
+
+fn forward_entry(i: usize) -> ForwardQueueEntry {
+    ForwardQueueEntry {
+        stream_id: String::new(),
+        message: format!("message {i}"),
+        to_did_hash: "to_hash".into(),
+        from_did_hash: "from_hash".into(),
+        from_did: "did:example:from".into(),
+        to_did: "did:example:to".into(),
+        endpoint_url: "https://example.com/".into(),
+        received_at_ms: 0,
+        delay_milli: 0,
+        expires_at: 0,
+        retry_count: 0,
+        hop_count: 0,
+    }
+}
+
+/// The ring must cap at `AUDIT_LOG_MAX_ENTRIES` and keep the *newest* entries.
+///
+/// This is the path where a drifting counter does real damage: the trim
+/// computes `over` from the count, so an over-count trims live entries and an
+/// under-count lets the ring grow past its bound.
+///
+/// Doubles as a guard on the fix that motivated the counter — the old code ran
+/// a full O(n) scan per insert, so this test was quadratic (~10^8 decodes).
+#[tokio::test]
+async fn audit_log_ring_caps_and_keeps_newest() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let store = Arc::new(FjallStore::open(dir.path()).expect("open"));
+    store.initialize().await.expect("initialize");
+
+    let overshoot = 25usize;
+    for i in 0..AUDIT_LOG_MAX_ENTRIES + overshoot {
+        store
+            .audit_log_record(&audit_entry(i))
+            .await
+            .expect("record");
+    }
+
+    // Newest-first. The first page must start at the very last entry written,
+    // proving the trim dropped from the old end, not the new one.
+    let page = store.audit_log_list(0, 100).await.expect("list");
+    let newest = AUDIT_LOG_MAX_ENTRIES + overshoot - 1;
+    assert_eq!(page.entries[0].detail, format!("entry {newest}"));
+
+    // Walk the whole ring and count it. This is the assertion that actually
+    // catches drift: it counts what's *in the keyspace*, not what the counter
+    // claims. They must agree, and both must equal the cap.
+    let mut total = 0usize;
+    let mut cursor = 0u32;
+    let mut oldest_seen = String::new();
+    loop {
+        let page = store.audit_log_list(cursor, 100).await.expect("page");
+        if page.entries.is_empty() {
+            break;
+        }
+        total += page.entries.len();
+        if let Some(last) = page.entries.last() {
+            oldest_seen = last.detail.clone();
+        }
+        if page.cursor == 0 {
+            break;
+        }
+        cursor = page.cursor;
+    }
+    assert_eq!(
+        total, AUDIT_LOG_MAX_ENTRIES,
+        "ring must hold exactly the cap, not {total}"
+    );
+
+    // The `overshoot` oldest entries are the ones that should have been dropped.
+    assert_eq!(oldest_seen, format!("entry {overshoot}"));
+}
+
+/// A counter seeded at open must match what's on disk, or every later insert
+/// inherits the error. Covers the `Keyspace::len` seeding scan.
+#[tokio::test]
+async fn counters_survive_reopen() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    {
+        let store = Arc::new(FjallStore::open(dir.path()).expect("open"));
+        store.initialize().await.expect("initialize");
+        for i in 0..7 {
+            store
+                .audit_log_record(&audit_entry(i))
+                .await
+                .expect("record");
+        }
+        for i in 0..4 {
+            store
+                .forward_queue_enqueue(&forward_entry(i), 0)
+                .await
+                .expect("enqueue");
+        }
+        assert_eq!(store.forward_queue_len().await.expect("len"), 4);
+    }
+
+    // Reopen against the same directory: the counters are rebuilt by scanning.
+    let store = Arc::new(FjallStore::open(dir.path()).expect("reopen"));
+    store.initialize().await.expect("initialize");
+
+    assert_eq!(
+        store.forward_queue_len().await.expect("len"),
+        4,
+        "forward_queue counter must be reseeded from disk on reopen"
+    );
+
+    // The audit counter has no direct getter; `audit_log_list` derives its
+    // terminal cursor from it, so a wrong count shows up as a wrong page.
+    let page = store.audit_log_list(0, 100).await.expect("list");
+    assert_eq!(page.entries.len(), 7);
+    assert_eq!(
+        page.cursor, 0,
+        "7 entries in a 100-entry page exhausts the log"
+    );
+}
+
+/// Deleting a stream ID that isn't in the queue must not move the counter.
+///
+/// Fjall treats removing an absent key as a no-op, so a naive `-= ids.len()`
+/// would under-count. Callers really do re-delete: duplicate acks and autoclaim
+/// races both replay stream IDs.
+#[tokio::test]
+async fn forward_queue_delete_is_idempotent() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let store = Arc::new(FjallStore::open(dir.path()).expect("open"));
+    store.initialize().await.expect("initialize");
+
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        ids.push(
+            store
+                .forward_queue_enqueue(&forward_entry(i), 0)
+                .await
+                .expect("enqueue"),
+        );
+    }
+    assert_eq!(store.forward_queue_len().await.expect("len"), 3);
+
+    store
+        .forward_queue_delete(&[ids[0].as_str()])
+        .await
+        .expect("delete");
+    assert_eq!(store.forward_queue_len().await.expect("len"), 2);
+
+    // Re-delete the same id, plus one that never existed.
+    store
+        .forward_queue_delete(&[ids[0].as_str(), "999999999999-0"])
+        .await
+        .expect("redelete");
+    assert_eq!(
+        store.forward_queue_len().await.expect("len"),
+        2,
+        "re-deleting an absent id must not decrement the counter"
+    );
+
+    // The counter still governs the `max_len` trim, so prove it's not just the
+    // getter that's right: enqueue under a cap of 2 and expect a trim of one.
+    store
+        .forward_queue_enqueue(&forward_entry(99), 2)
+        .await
+        .expect("enqueue with cap");
+    assert_eq!(
+        store.forward_queue_len().await.expect("len"),
+        2,
+        "enqueue at max_len=2 must trim the oldest, holding the queue at 2"
+    );
+}

--- a/crates/messaging/affinidi-messaging-mediator/tests/fjall_memory_budget.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/fjall_memory_budget.rs
@@ -1,0 +1,99 @@
+//! Memory-budget check for the Fjall backend under sustained write load.
+//!
+//! `#[ignore]`d: this measures resident set size, which is meaningless in a
+//! debug build (and noisy under a parallel test runner). Run it deliberately:
+//!
+//! ```sh
+//! cargo test --release --no-default-features --features didcomm,fjall-backend \
+//!     --test fjall_memory_budget -- --ignored --nocapture
+//! ```
+//!
+//! What it pins: Fjall has **no global memtable cap**. `max_write_buffer_size`
+//! exists in the API but is a dead field in 3.1.x (declared, has a setter, never
+//! read), and each keyspace flushes only when *its own* memtable crosses *its
+//! own* threshold. With Fjall's stock 64 MiB-per-keyspace default across the
+//! mediator's 14 keyspaces, sustained writes can hold ~900 MiB of write buffer.
+//!
+//! So the ceiling has to come from `[storage.fjall]`: a `write_buffer` budget
+//! split across keyspaces by weight, plus `max_journal`, which force-rotates the
+//! keyspaces pinning the oldest journal and is therefore the only bound that
+//! also applies to an already-created data directory.
+//!
+//! This writes far more data than the budget and asserts the process does not
+//! grow to match it.
+
+#![cfg(all(feature = "fjall-backend", feature = "didcomm"))]
+
+use affinidi_messaging_mediator::store::FjallStore;
+use affinidi_messaging_mediator_common::store::MediatorStore;
+use std::sync::Arc;
+
+/// Resident set size of this process, in bytes.
+fn rss_bytes() -> u64 {
+    let pid = std::process::id();
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .expect("ps");
+    let kb: u64 = String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .expect("rss kb");
+    kb * 1024
+}
+
+const MIB: u64 = 1024 * 1024;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measures RSS; only meaningful in --release"]
+async fn write_load_stays_within_the_configured_budget() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    // `open` uses FjallTuning::default() — the same tuning the mediator applies
+    // when `[storage.fjall]` is absent, which is the case this must hold for.
+    let store = Arc::new(FjallStore::open(dir.path()).expect("open"));
+    store.initialize().await.expect("initialize");
+
+    let baseline = rss_bytes();
+    println!("baseline RSS: {:.1} MiB", baseline as f64 / MIB as f64);
+
+    // 2 000 messages x 256 KiB = 500 MiB of message bodies pushed through the
+    // store: well past the 32 MiB write-buffer budget and the 128 MiB journal
+    // cap, so an unbounded write buffer would show up plainly.
+    let body = "x".repeat(256 * 1024);
+    let total_written = 2_000u64 * body.len() as u64;
+
+    for i in 0..2_000u32 {
+        store
+            .store_message(
+                &format!("msg{i}"),
+                &body,
+                &format!("recipient{}", i % 50),
+                Some("sender"),
+                0,
+                0, // queue_maxlen: 0 = unbounded, so nothing trims the load away
+            )
+            .await
+            .expect("store_message");
+    }
+
+    let peak = rss_bytes();
+    let growth = peak.saturating_sub(baseline);
+
+    println!(
+        "wrote {:.0} MiB of bodies; RSS {:.1} -> {:.1} MiB (growth {:.1} MiB)",
+        total_written as f64 / MIB as f64,
+        baseline as f64 / MIB as f64,
+        peak as f64 / MIB as f64,
+        growth as f64 / MIB as f64,
+    );
+
+    // The whole point: RSS must track the *budget*, not the data volume. A
+    // generous ceiling — this asserts "bounded", not a precise figure, so it
+    // won't flake on allocator or page-cache noise.
+    assert!(
+        peak < 256 * MIB,
+        "RSS {:.1} MiB exceeded the 256 MiB budget after writing {:.0} MiB",
+        peak as f64 / MIB as f64,
+        total_written as f64 / MIB as f64,
+    );
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.38"
+version = "0.2.39"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -30,7 +30,7 @@ tsp = ["affinidi-messaging-mediator/tsp", "affinidi-messaging-sdk/tsp"]
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.16", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.17", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [


### PR DESCRIPTION
Started as a memory-usage analysis of the mediator, which turned up two leaks, a quadratic write path, and a set of buffers that were bounded by message count rather than bytes. Fixes all of it, adds operator-facing tuning, and pins the result with a measurement.

## Results (real `mediator` binary, Fjall backend, release)

| | RSS |
|---|---|
| Idle | **22.9 MB** |
| After writing 500 MB of message bodies | **44.3 MB** |
| *Same load, before this PR* | ***545.9 MB*** |

That last row is an A/B against the previous configuration, run to confirm the storage tuning is load-bearing rather than cosmetic: with Fjall's stock defaults essentially all 500 MB written stayed resident. Resident memory tracked the *data volume* because there was no budget. It now tracks the budget.

Reproduce: `tests/fjall_memory_budget.rs` (`#[ignore]`d — RSS is only meaningful in `--release`).

## Commit 1 — leaks + the O(n) audit log

**Two unbounded-growth paths.** Both were state that tracked its own idle time with nothing reaping on it.

- **Rate limiters.** `governor` only frees keys via `retain_recent()`, which was never called anywhere in the repo. The per-IP limiter is **on by default** and keyed on unauthenticated, client-chosen input, so a client rotating through an IPv6 /64 inserted one entry per request, retained for the process lifetime. Both limiters now run a 60s sweep. This is safe by construction: `retain_recent()` only drops buckets that have *fully replenished*, and such a bucket is indistinguishable from a key that was never there — so GC cannot let anyone escape their quota.
- **Forwarding `endpoints`.** Keyed by the endpoint URL from a peer's DID Doc (remote-controlled). It already tracked `last_activity`; nothing read it. The existing idle-WebSocket reaper now also drops endpoints idle beyond 5 minutes.

**Audit-log inserts were O(n).** `audit_log_record` and `forward_queue_enqueue` need the keyspace length to enforce their bound, and Fjall has **no O(1) exact length** (`Keyspace::len()` is itself a scan; `approximate_len()` counts tombstones). So each insert scanned and JSON-decoded the entire keyspace — up to 10,000 decodes per audit record, making a full ring quadratic. Both lengths are now maintained in memory, seeded by one key-only scan at open and adjusted under the existing write lock (sound because the Fjall backend is single-process by design).

**Filling the 10,000-entry ring: 35.0s → ~3s.** The new ring-cap test passes against **both the old and new code**, so it is a genuine regression guard rather than a test written to match the implementation.

Also removed the `message_meta` and `acls` keyspaces — both were opened at startup but never read *or* written (per-message metadata lives inline in `messages`, the ACL bitmask inline in `accounts`), while each carried its own memtable. Deleting a stale `#[allow(dead_code)]` is what surfaced them. No migration needed; nothing was ever stored there.

## Commit 2 — byte budgets, storage tuning, jemalloc

**Buffers bounded by bytes, not counts.** The WebSocket send queues were `5 slots × 10 MiB × 10,000 connections`; the pub/sub ring was 1024 slots of up to 10 MiB. Neither figure meant anything in bytes, which is the resource that actually runs out. Now sized by `limits.ws_send_buffer` (32 MiB — **one pool shared by every connection**, so the aggregate is capped regardless of connection count) and `limits.pubsub_buffer` (16 MiB, divided by `message_size` for the ring's slot count). Worth knowing: a `tokio::sync::broadcast` ring holds *all* its capacity slots for the life of the channel — a slot frees only when overwritten, not when read — so capacity is a standing reservation and has to come from a byte budget.

**A slow WebSocket client no longer stalls live delivery for every other DID.** `dispatch_payload` awaited each client's queue from the single loop that serves all DIDs, so one stalled socket head-of-line blocked the rest. Shrinking the buffers would only have made this bite sooner. Sends are now non-blocking; a client that cannot keep up loses its *push*, never the message — it is already durable in the recipient's inbox and arrives on the next poll or on reconnect, which is the contract the pub/sub layer already relied on when a subscriber lagged. New metric `ws_live_delivery_dropped_total`.

**`[storage.fjall]` tuning** — `block_cache` (16 MiB), `write_buffer` (32 MiB across all keyspaces, split by write weight), `max_journal` (128 MiB). Two Fjall behaviours shaped this, both verified against the 3.1.5 source:

- **There is no global memtable cap.** `max_write_buffer_size` is a dead field — declared, has a setter, never read. Each keyspace flushes only when its *own* memtable fills, and stock Fjall allows 64 MiB per keyspace × 14 keyspaces ≈ 900 MiB. `max_journal` is therefore the load-bearing bound: it force-rotates the keyspaces pinning the oldest journal.
- **`write_buffer` only applies to a fresh `data_dir`.** Fjall persists each keyspace's memtable size at creation and exposes no setter. `block_cache` and `max_journal` do apply on every open, including existing directories.

**Redis is deliberately untouched.** Its data lives in the Redis *server*, so its memory is governed by `maxmemory` in `redis.conf` — nothing the mediator can set. The guide covers both backends (and recommends `noeviction`, since an LRU policy would silently discard durable queue and session state).

**jemalloc** (`jemalloc` feature, default on), on the **binary only** — a library that installs a `#[global_allocator]` forces it on every consumer. `malloc_conf` tunes decay so freed pages actually return to the OS; with the system allocator the storage backend's write-buffer churn is never released and RSS ratchets to its high-water mark, reading like a leak even when the live heap is flat.

**New operator guide:** `docs/memory-tuning.md` — where memory goes, which knob to raise for read vs write throughput, what it costs, and what the drop/lag signals mean.

## ⚠️ Breaking: `limits.message_size` is now enforced

It was documented, parsed and env-overridable — and **never read at runtime**. The effective ceiling was `http_size`/`ws_size` (10 MiB), not the advertised 1 MiB. Messages over `message_size` are now rejected with `message.size.exceeded` (413).

**Upgrade note:** clients sending messages larger than 1 MiB will start failing. Raise `limits.message_size` to restore the previous behaviour.

This is deliberate, not incidental: without a real per-item ceiling, none of the byte budgets above are true bounds — "a 16 MiB ring" means nothing if an item can be 10 MiB.

## Versions

`affinidi-messaging-mediator` **0.17.0** (minor, not patch — `StreamingUpdateState`, `StreamingTask::spawn_supervised` and `LimitsConfig` all changed shape, plus the `message_size` behaviour change), `-config` 0.2.0, `-common` 0.15.29, `test-mediator` 0.2.39.

## Verification

- `clippy --all-targets -D warnings` on three feature sets: default (redis), `didcomm,fjall-backend,memory-backend`, `didcomm,tsp,fjall-backend`
- `cargo fmt --check` clean
- **269 mediator + 37 test-mediator tests pass**
- `cargo deny`: licenses + bans clean (jemalloc included). Advisories show 6 failures — **pre-existing on `main`**, in the `rustls 0.24` → `aws-sdk` chain; re-confirmed identical before and after this branch.
- RSS measured on the real binary booted against a Fjall config, not estimated.
