### PR TITLE
ci: cache mediator-image Rust deps with cargo-chef and normalise version tag

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Image version tag to publish (e.g. v0.16.36). Defaults to the crate version on the checked-out ref."
+        description: "Version to publish: accepts a full tag (affinidi-messaging-mediator-vX.Y.Z), vX.Y.Z, or X.Y.Z. Defaults to the crate version (or the tag, when dispatched on one)."
         required: false
         type: string
 
@@ -59,7 +59,6 @@ jobs:
       - id: v
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ inputs.version }}
           CRATE_MANIFEST: crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -77,7 +76,29 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Buildx
+        id: buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Cache Rust build mounts (amd64)
+        id: cargo-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: cache-mount
+          key: cargo-mnt-amd64-${{ hashFiles('Cargo.lock', 'docker/mediator.Dockerfile') }}
+          restore-keys: |
+            cargo-mnt-amd64-
+
+      - name: Inject Rust build mounts (amd64)
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "cache-mount/registry": { "target": "/usr/local/cargo/registry", "id": "cargo-registry" },
+              "cache-mount/git": { "target": "/usr/local/cargo/git", "id": "cargo-git" },
+              "cache-mount/target": { "target": "/app/target", "id": "cargo-target-amd64" }
+            }
+          skip-extraction: ${{ steps.cargo-cache.outputs.cache-hit }}
 
       - name: Build image (amd64, load locally)
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
@@ -117,7 +138,29 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Buildx
+        id: buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Cache Rust build mounts (${{ matrix.arch }})
+        id: cargo-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: cache-mount
+          key: cargo-mnt-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'docker/mediator.Dockerfile') }}
+          restore-keys: |
+            cargo-mnt-${{ matrix.arch }}-
+
+      - name: Inject Rust build mounts (${{ matrix.arch }})
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "cache-mount/registry": { "target": "/usr/local/cargo/registry", "id": "cargo-registry" },
+              "cache-mount/git": { "target": "/usr/local/cargo/git", "id": "cargo-git" },
+              "cache-mount/target": { "target": "/app/target", "id": "cargo-target-${{ matrix.arch }}" }
+            }
+          skip-extraction: ${{ steps.cargo-cache.outputs.cache-hit }}
 
       - name: Log in to GHCR
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/docker/ci/resolve-version.sh
+++ b/docker/ci/resolve-version.sh
@@ -2,35 +2,45 @@
 # Resolve the mediator image version tag for the publish workflow.
 #
 # Inputs (environment):
-#   EVENT_NAME     - github.event_name (push | workflow_dispatch | pull_request)
-#   REF_NAME       - github.ref_name (the tag name on a push)
-#   INPUT_VERSION  - workflow_dispatch 'version' input (optional)
+#   REF_NAME       - github.ref_name (branch or tag the workflow runs on)
+#   INPUT_VERSION  - workflow_dispatch 'version' input (optional). Accepts a
+#                    full release tag (affinidi-messaging-mediator-vX.Y.Z), a
+#                    bare vX.Y.Z, or X.Y.Z.
 #   CRATE_MANIFEST - mediator Cargo.toml for the crate-version fallback
 #                    (default: crates/messaging/affinidi-messaging-mediator/Cargo.toml)
 #
 # Output: appends `version=` and `is_latest=` to $GITHUB_OUTPUT (or stdout when
 # unset, so the script is runnable locally). Diagnostics go to stderr.
+#
+# Whatever the source, the result is normalised to a single `vX.Y.Z`: the
+# `affinidi-messaging-mediator-` tag prefix is stripped and a lone `v` ensured.
 set -euo pipefail
 
-: "${EVENT_NAME:=}"
 : "${REF_NAME:=}"
 : "${INPUT_VERSION:=}"
 : "${CRATE_MANIFEST:=crates/messaging/affinidi-messaging-mediator/Cargo.toml}"
 
-if [ "$EVENT_NAME" = "push" ]; then
-  version="${REF_NAME#affinidi-messaging-mediator-}"
-elif [ -n "$INPUT_VERSION" ]; then
+if [ -n "$INPUT_VERSION" ]; then
+  # Explicit dispatch input wins.
   version="$INPUT_VERSION"
 else
-  # Default to the crate version on the checked-out ref. awk (not GNU-only
-  # `sed '0,/re/'`) grabs the first `version = "..."`, i.e. the [package] one.
-  version="$(awk -F'"' '/^version[[:space:]]*=[[:space:]]*"/{print $2; exit}' "$CRATE_MANIFEST")"
-  if [ -z "$version" ]; then
-    echo "::error::could not read crate version from $CRATE_MANIFEST" >&2
-    exit 1
-  fi
+  case "$REF_NAME" in
+    affinidi-messaging-mediator-v* | v[0-9]*)
+      # Running on a release tag (push or dispatch-on-tag).
+      version="$REF_NAME" ;;
+    *)
+      # Default to the crate version on the checked-out ref. awk (not GNU-only
+      # `sed '0,/re/'`) grabs the first `version = "..."`, i.e. the [package] one.
+      version="$(awk -F'"' '/^version[[:space:]]*=[[:space:]]*"/{print $2; exit}' "$CRATE_MANIFEST")"
+      if [ -z "$version" ]; then
+        echo "::error::could not read crate version from $CRATE_MANIFEST" >&2
+        exit 1
+      fi ;;
+  esac
 fi
 
+# Normalise: accept a full release tag, a bare vX.Y.Z, or X.Y.Z from any source.
+version="${version#affinidi-messaging-mediator-}"
 case "$version" in
   v*) ;;
   *) version="v${version}" ;;

--- a/docker/mediator.Dockerfile
+++ b/docker/mediator.Dockerfile
@@ -13,12 +13,19 @@
 # here and has no OS secret service in a container, and it carries a sample DID
 # that must never be baked into a published image. See that file's header for
 # the run-time contract; docker/ci/boot-probe.sh asserts both boot paths.
+#
+# Build caching: cargo-chef caches the dependency graph as a layer keyed on the
+# manifests/lockfile, and BuildKit cache mounts keep the cargo registry + target
+# dir warm across builds. A source-only change then recompiles just the
+# workspace crates instead of the whole graph. Binaries are copied out of the
+# (unmounted) target cache inside the build step so they survive into runtime.
 
 ARG RUST_VERSION=1.95.0
 ARG PORT=7037
+ARG CARGO_CHEF_VERSION=0.1.77
 
-FROM rust:${RUST_VERSION}-slim-bookworm AS rust
-
+FROM rust:${RUST_VERSION}-slim-bookworm AS chef
+WORKDIR /app
 # build-essential: cc, needed by jemalloc (a default feature) and openssl-sys.
 # pkg-config + libdbus: the cross-platform keyring secret store (pulled by the
 # TDK layer) links dbus on Linux. libssl: openssl-sys in the dependency graph.
@@ -26,17 +33,34 @@ RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         build-essential pkg-config libdbus-1-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
+ARG CARGO_CHEF_VERSION
+RUN cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION}
 
-FROM rust AS builder
-WORKDIR /app
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+ARG TARGETARCH
+COPY --from=planner /app/recipe.json recipe.json
+# Cook dependencies for the exact feature sets used below. The registry/git
+# caches are arch-independent; the target cache is scoped per arch.
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=cargo-target-${TARGETARCH},target=/app/target,sharing=locked \
+    cargo chef cook --release --recipe-path recipe.json -p affinidi-messaging-mediator --features tsp,secrets-aws \
+    && cargo chef cook --release --recipe-path recipe.json -p affinidi-messaging-mediator-setup --no-default-features --features secrets-aws,publish-aws
 COPY . .
 # didcomm + redis-backend + jemalloc come from defaults; add tsp + secrets-aws
 # (secrets-aws pulls in the `aws` feature required by aws_secrets:// /
-# aws_parameter_store://).
-RUN cargo build --release -p affinidi-messaging-mediator --features tsp,secrets-aws
-# mediator-setup: only the AWS backends the cloud deployment uses.
-RUN cargo build --release -p affinidi-messaging-mediator-setup \
-    --no-default-features --features secrets-aws,publish-aws
+# aws_parameter_store://). mediator-setup carries only the AWS backends used.
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=cargo-target-${TARGETARCH},target=/app/target,sharing=locked \
+    cargo build --release -p affinidi-messaging-mediator --features tsp,secrets-aws \
+    && cargo build --release -p affinidi-messaging-mediator-setup --no-default-features --features secrets-aws,publish-aws \
+    && mkdir -p /out \
+    && cp target/release/mediator target/release/mediator-setup /out/
 
 # Runtime base pinned by digest: nothing here is rebuilt from source, so the
 # digest is the only thing fixing what ships. Bump it to pick up CVE fixes.
@@ -53,8 +77,8 @@ WORKDIR /app
 # `-c conf/mediator.toml` relative to WORKDIR, so this is the file it reads.
 COPY crates/messaging/affinidi-messaging-mediator/conf conf
 COPY docker/conf/mediator.toml conf/mediator.toml
-COPY --from=builder /app/target/release/mediator /usr/local/bin
-COPY --from=builder /app/target/release/mediator-setup /usr/local/bin
+COPY --from=builder /out/mediator /usr/local/bin
+COPY --from=builder /out/mediator-setup /usr/local/bin
 RUN groupadd -r lowPrivGroup && useradd -r -g lowPrivGroup lowPrivUser
 USER lowPrivUser
 EXPOSE $PORT


### PR DESCRIPTION
## What

Two related changes to the mediator container-image publish pipeline.

### Build caching (the main win)
The image build previously recompiled the entire dependency graph plus all workspace crates on every run, because a single `COPY . . && cargo build` layer busts on any in-context file change (~15 min).

- Rewrites `docker/mediator.Dockerfile` around **cargo-chef**: the dependency graph is cooked into a layer keyed on the manifests/lockfile, and **BuildKit cache mounts** keep the cargo registry, git, and target dirs warm.
- A source-only change now recompiles just the workspace crates instead of the whole graph.
- Because cache mounts are not part of image layers, the built binaries are copied out to a normal path inside the build step so they survive into the runtime image.
- Persists the cache mounts across CI runs with `actions/cache` + `buildkit-cache-dance` in the `verify-image` and `build` jobs, keyed per architecture.

Measured locally: a source-only rebuild dropped from ~15 min to **~3m45s** (dependency graph served from cache).

### Version-tag normalisation
`resolve-version.sh` now normalises **any** source — dispatch input, push/tag ref, or crate fallback — to a single `vX.Y.Z`, stripping the `affinidi-messaging-mediator-` prefix.

Previously a `workflow_dispatch` input carrying the full release tag produced a mis-normalised `vaffinidi-messaging-mediator-vX.Y.Z` image tag.

## Compatibility

The runtime artifact is unchanged in shape: same feature set (`tsp,secrets-aws`), same entrypoint, same baked config, same listen port. Verified the freshly-built image boots green on both the default-config and AWS-config probe paths, and that all environment variables the deployment injects are honoured by the binary.

## Validation
- `actionlint`, `yamllint`, `shellcheck` clean
- Cold build + boot-probe pass locally (native arm64)
- Incremental rebuild confirms the cache-mount speedup
- All version-resolution paths produce `vX.Y.Z`