### PR TITLE
feat: S3-backed did:webvh log + read-only setup probe for the mediator

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Changelog history
 
+## 14th July 2026
+
+### 0.17.1 — read the self-hosted `did.jsonl` log from `s3://`
+
+- The self-hosted `did:webvh` log (`did_web_self_hosted`) can now be sourced
+  from an `s3://` target in addition to `file://` and `aws_parameter_store://`.
+  On startup the runtime fetches the `did.jsonl` object and serves it at
+  `/.well-known/did.jsonl`, so the durable log lives in S3 rather than baked
+  into the container or a parameter.
+- `s3://` support requires the `aws` feature (pulled in by `secrets-aws`); the
+  scheme is parsed with the shared `s3_target` parser in mediator-common
+  (>= 0.15.30) so the runtime and the `mediator-setup` wizard cannot drift on
+  the target grammar. Without the `aws` feature, an `s3://` target fails fast
+  with an actionable rebuild message.
+
 ## 12th July 2026
 
 ### 0.16.45 — surface a VTA 403 on refresh instead of masking it as "unreachable"

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.0"
+version = "0.17.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -87,7 +87,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.29", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.30", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.2", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -66,9 +66,9 @@ secrets-vault = ["affinidi-messaging-mediator-common/secrets-vault"]
 secrets-k8s = ["affinidi-messaging-mediator-common/secrets-k8s"]
 
 ## AWS integration used by `did_web_self_hosted = "aws_parameter_store://..."`
-## (still loaded directly by the mediator, not via the secret store). Enabled
-## automatically by `secrets-aws`.
-aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
+## or `"s3://..."` (still loaded directly by the mediator, not via the secret
+## store). Enabled automatically by `secrets-aws`.
+aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
@@ -140,6 +140,7 @@ didwebvh-rs = "0.5.4"
 ## To build without: --no-default-features --features didcomm
 aws-config = { version = "1", optional = true }
 aws-sdk-ssm = { version = "1", optional = true }
+aws-sdk-s3 = { version = "1", optional = true }
 
 # ── Cryptography & Security ─────────────────────────────────────────────
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Changelog history
 
+## 14th July 2026
+
+### 0.15.30 — shared `s3://` target parser
+
+- New always-built `s3_target` module: `parse_s3_target`, `S3Target`,
+  `S3TargetError`, `is_s3_target` and `S3_SCHEME`. Pure (no AWS SDK), shared by
+  the mediator runtime (which reads its self-hosted `did.jsonl` log from an S3
+  object via `did_web_self_hosted`) and the `mediator-setup` wizard (which
+  publishes the minted log to one via `[output].did_log_target`), so the string
+  one writes is the string the other reads — the same drift-proofing pattern as
+  the existing `parameter_store` parser.
+- Grammar: `s3://<bucket>/<key>` with an optional `?region=<region>` query
+  parameter (absent means "use the ambient AWS chain"), mirroring the
+  `aws_parameter_store://` idiom.
+
 ## 10th July 2026
 
 ### 0.15.27 — shared `aws_parameter_store://` target parser

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.29"
+version = "0.15.30"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/lib.rs
@@ -33,6 +33,12 @@ pub mod did_web;
 /// to one), so the string one writes is the string the other reads.
 pub mod parameter_store;
 
+/// `s3://` target parsing. Pure (no AWS SDK), always built: shared by the
+/// mediator runtime (reading its self-hosted `did.jsonl` log from an S3
+/// object) and the `mediator-setup` wizard (publishing the minted log to
+/// one), so the string one writes is the string the other reads.
+pub mod s3_target;
+
 #[cfg(feature = "server")]
 pub mod circuit_breaker;
 /// Database wiring: the lean `DatabaseConfig` serde struct is always

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/s3_target.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/s3_target.rs
@@ -1,0 +1,257 @@
+//! `s3://` target parsing.
+//!
+//! One grammar, one parser, shared by the two sides that must agree on it:
+//! the mediator runtime reads its self-hosted `did.jsonl` log from an S3
+//! object (`did_web_self_hosted`), and the `mediator-setup` wizard publishes
+//! the minted log to one (`[output].did_log_target`). The string the wizard
+//! writes is the string the operator pastes into `mediator.toml`, so the two
+//! cannot be allowed to drift.
+//!
+//! ```text
+//! s3://my-bucket/mediator/did.jsonl?region=eu-west-1   explicit region
+//! s3://my-bucket/mediator/did.jsonl                    ambient region chain
+//! s3://my-bucket/did.jsonl                             key at bucket root
+//! ```
+//!
+//! The bucket is everything between `://` and the first `/`; the key is
+//! everything after that first `/` up to the query string. Both must be
+//! non-empty — S3 has no "bucket-only" object. Region is a query parameter
+//! (not a path segment) so it can never be confused with a key that itself
+//! contains slashes.
+//!
+//! Region is optional. When absent the caller falls back to the ambient AWS
+//! chain (`AWS_REGION`, then the profile, then IMDS), which is what the
+//! runtime already resolves for its shared `SdkConfig`.
+//!
+//! `url::Url::parse` is deliberately not used here for symmetry with the
+//! `aws_parameter_store` / `aws_secrets` schemes, which cannot use it
+//! (underscores are illegal in a URI scheme). Keeping one hand-split parser
+//! style across every target scheme avoids surprising divergence.
+
+use thiserror::Error;
+
+/// URI scheme for an Amazon S3 object target.
+pub const S3_SCHEME: &str = "s3";
+
+/// Why an `s3://` target could not be parsed.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum S3TargetError {
+    /// No `://` separator, or a scheme other than `s3`.
+    #[error("invalid target '{target}': expected '{S3_SCHEME}://<bucket>/<key>'")]
+    NotS3 {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// The bucket name was empty (`s3:///key`).
+    #[error("invalid target '{target}': bucket name is empty")]
+    EmptyBucket {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// No key was supplied (`s3://bucket` or `s3://bucket/`). S3 has no
+    /// bucket-only object, so an empty key is always an error.
+    #[error(
+        "invalid target '{target}': object key is empty \
+         (write '{S3_SCHEME}://<bucket>/<key>')"
+    )]
+    EmptyKey {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// `?region=` was present but empty.
+    #[error("invalid target '{target}': 'region' query parameter is empty")]
+    EmptyRegion {
+        /// The offending target, verbatim.
+        target: String,
+    },
+    /// A query parameter other than `region` was supplied.
+    #[error(
+        "invalid target '{target}': unknown query parameter '{key}' (only 'region' is supported)"
+    )]
+    UnknownQueryParameter {
+        /// The offending target, verbatim.
+        target: String,
+        /// The unrecognised key.
+        key: String,
+    },
+}
+
+/// A parsed `s3://` target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3Target {
+    /// S3 bucket name.
+    pub bucket: String,
+    /// S3 object key (no leading slash — everything after `bucket/`).
+    pub key: String,
+    /// Region from `?region=`. `None` means "use the ambient AWS chain".
+    pub region: Option<String>,
+}
+
+/// True when `target` uses the `s3://` scheme. Cheap prefix test for callers
+/// deciding whether they need an AWS client at all.
+pub fn is_s3_target(target: &str) -> bool {
+    target.starts_with(S3_SCHEME) && target[S3_SCHEME.len()..].starts_with("://")
+}
+
+/// Parse a full `s3://…` target.
+///
+/// Validates the scheme, a non-empty bucket and key, and that the only query
+/// parameter is `region`. Does no I/O, so callers can validate a target up
+/// front — before minting, provisioning, or writing anything.
+pub fn parse_s3_target(target: &str) -> Result<S3Target, S3TargetError> {
+    let err_target = || target.to_string();
+
+    let rest = target
+        .strip_prefix(S3_SCHEME)
+        .and_then(|r| r.strip_prefix("://"))
+        .ok_or_else(|| S3TargetError::NotS3 {
+            target: err_target(),
+        })?;
+
+    // Path is everything before the query string; region lives in the query
+    // so a key with internal slashes survives untouched.
+    let (path, query) = match rest.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (rest, None),
+    };
+
+    // Bucket is up to the first '/', key is the remainder.
+    let (bucket, key) = match path.split_once('/') {
+        Some((bucket, key)) => (bucket, key),
+        None => (path, ""),
+    };
+
+    if bucket.is_empty() {
+        return Err(S3TargetError::EmptyBucket {
+            target: err_target(),
+        });
+    }
+    if key.is_empty() {
+        return Err(S3TargetError::EmptyKey {
+            target: err_target(),
+        });
+    }
+
+    let mut region = None;
+    if let Some(query) = query {
+        for pair in query.split('&').filter(|p| !p.is_empty()) {
+            let (k, value) = pair.split_once('=').unwrap_or((pair, ""));
+            match k {
+                "region" => {
+                    if value.is_empty() {
+                        return Err(S3TargetError::EmptyRegion {
+                            target: err_target(),
+                        });
+                    }
+                    region = Some(value.to_string());
+                }
+                other => {
+                    return Err(S3TargetError::UnknownQueryParameter {
+                        target: err_target(),
+                        key: other.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(S3Target {
+        bucket: bucket.to_string(),
+        key: key.to_string(),
+        region,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(t: &str) -> S3Target {
+        parse_s3_target(t).expect("target should parse")
+    }
+
+    #[test]
+    fn bucket_and_key_split_on_first_slash() {
+        let t = parse("s3://my-bucket/mediator/did.jsonl");
+        assert_eq!(t.bucket, "my-bucket");
+        assert_eq!(t.key, "mediator/did.jsonl");
+        assert_eq!(t.region, None);
+    }
+
+    #[test]
+    fn key_at_bucket_root() {
+        let t = parse("s3://my-bucket/did.jsonl");
+        assert_eq!(t.bucket, "my-bucket");
+        assert_eq!(t.key, "did.jsonl");
+    }
+
+    #[test]
+    fn region_query_parameter_is_extracted() {
+        let t = parse("s3://my-bucket/mediator/did.jsonl?region=eu-west-1");
+        assert_eq!(t.bucket, "my-bucket");
+        assert_eq!(t.key, "mediator/did.jsonl");
+        assert_eq!(t.region.as_deref(), Some("eu-west-1"));
+    }
+
+    #[test]
+    fn region_does_not_eat_the_key() {
+        // The key keeps every slash; region is only ever the query value.
+        let t = parse("s3://b/a/b/c/did.jsonl?region=us-east-1");
+        assert_eq!(t.key, "a/b/c/did.jsonl");
+        assert_eq!(t.region.as_deref(), Some("us-east-1"));
+    }
+
+    #[test]
+    fn wrong_scheme_is_rejected() {
+        assert_eq!(
+            parse_s3_target("file:///tmp/did.jsonl"),
+            Err(S3TargetError::NotS3 {
+                target: "file:///tmp/did.jsonl".into()
+            })
+        );
+        assert!(!is_s3_target("file:///tmp/did.jsonl"));
+        assert!(is_s3_target("s3://b/k"));
+    }
+
+    #[test]
+    fn empty_bucket_is_rejected() {
+        assert_eq!(
+            parse_s3_target("s3:///did.jsonl"),
+            Err(S3TargetError::EmptyBucket {
+                target: "s3:///did.jsonl".into()
+            })
+        );
+    }
+
+    #[test]
+    fn empty_key_is_rejected() {
+        for t in ["s3://my-bucket", "s3://my-bucket/"] {
+            assert_eq!(
+                parse_s3_target(t),
+                Err(S3TargetError::EmptyKey { target: t.into() })
+            );
+        }
+    }
+
+    #[test]
+    fn empty_region_is_rejected() {
+        assert_eq!(
+            parse_s3_target("s3://b/k?region="),
+            Err(S3TargetError::EmptyRegion {
+                target: "s3://b/k?region=".into()
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_query_parameter_is_rejected() {
+        assert_eq!(
+            parse_s3_target("s3://b/k?acl=public"),
+            Err(S3TargetError::UnknownQueryParameter {
+                target: "s3://b/k?acl=public".into(),
+                key: "acl".into()
+            })
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -7,8 +7,8 @@
 //! - Reading the TOML file + applying env overrides.
 //! - Resolving `mediator_did` / `admin_did` from either a literal DID or
 //!   `aws_parameter_store://<name>[?region=<region>]`.
-//! - Reading the self-hosted DID document from `file://` or
-//!   `aws_parameter_store://`.
+//! - Reading the self-hosted DID document from `file://`,
+//!   `aws_parameter_store://`, or `s3://`.
 //! - Hostname resolution and forwarding-loop protection.
 //!
 //! The `aws_parameter_store://` grammar lives in `mediator-common`'s
@@ -23,6 +23,9 @@ use affinidi_messaging_mediator_common::parameter_store::parse_parameter_store_t
 use affinidi_messaging_mediator_common::parameter_store::{
     PARAMETER_STORE_SCHEME, is_parameter_store_target,
 };
+#[cfg(feature = "aws")]
+use affinidi_messaging_mediator_common::s3_target::parse_s3_target;
+use affinidi_messaging_mediator_common::s3_target::{S3_SCHEME, is_s3_target};
 use affinidi_secrets_resolver::SecretsResolver;
 #[cfg(feature = "aws")]
 use aws_config::{Region, SdkConfig};
@@ -38,9 +41,9 @@ use tracing::{error, info, warn};
 use super::AwsConfig;
 use super::processors::ForwardingConfig;
 
-/// Check if any DID-resolution field uses `aws_parameter_store://`,
-/// requiring the AWS SDK to be initialised. Secret-store backends are
-/// excluded — those are handled via `MediatorSecrets`, which owns its own
+/// Check if any DID-resolution field uses `aws_parameter_store://` or
+/// `s3://`, requiring the AWS SDK to be initialised. Secret-store backends
+/// are excluded — those are handled via `MediatorSecrets`, which owns its own
 /// AWS SDK client when the `secrets-aws` feature is enabled.
 pub(crate) fn config_needs_aws(raw: &super::ConfigRaw) -> bool {
     is_parameter_store_target(&raw.mediator_did)
@@ -49,7 +52,7 @@ pub(crate) fn config_needs_aws(raw: &super::ConfigRaw) -> bool {
             .server
             .did_web_self_hosted
             .as_deref()
-            .is_some_and(is_parameter_store_target)
+            .is_some_and(|t| is_parameter_store_target(t) || is_s3_target(t))
 }
 
 /// Extract the AWS `SdkConfig` from an `Option<AwsConfig>`, returning a clear
@@ -243,6 +246,71 @@ pub(crate) async fn aws_parameter_store(
     })
 }
 
+/// Fetch an object body named by a full `s3://…` target, decoded as UTF-8.
+///
+/// `target` is parsed by the shared grammar. An optional `?region=` overrides
+/// the ambient region for this call only — the rest of the process keeps
+/// using the shared `SdkConfig`.
+#[cfg(feature = "aws")]
+pub(crate) async fn aws_s3(
+    target: &str,
+    aws_config: &SdkConfig,
+) -> Result<String, MediatorError> {
+    let parsed = parse_s3_target(target)
+        .map_err(|e| MediatorError::ConfigError(12, "NA".into(), e.to_string()))?;
+
+    // Region in the target wins, so the object can live somewhere other than
+    // the region the rest of the SDK defaulted to.
+    let regional_config;
+    let aws_config = match parsed.region {
+        Some(region) => {
+            regional_config = aws_config.to_builder().region(Region::new(region)).build();
+            &regional_config
+        }
+        None => aws_config,
+    };
+    let s3 = aws_sdk_s3::Client::new(aws_config);
+
+    let response = s3
+        .get_object()
+        .bucket(&parsed.bucket)
+        .key(&parsed.key)
+        .send()
+        .await
+        .map_err(|e| {
+            error!(
+                "Could not get s3 object (bucket={:?} key={:?}). {e:?}",
+                parsed.bucket, parsed.key
+            );
+            MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                format!(
+                    "Could not get s3 object (bucket={:?} key={:?}). {e:?}",
+                    parsed.bucket, parsed.key
+                ),
+            )
+        })?;
+
+    let bytes = response.body.collect().await.map_err(|e| {
+        error!("Could not read s3 object body. {e:?}");
+        MediatorError::ConfigError(
+            12,
+            "NA".into(),
+            format!("Could not read s3 object body. {e:?}"),
+        )
+    })?;
+
+    String::from_utf8(bytes.to_vec()).map_err(|e| {
+        error!("s3 object is not valid UTF-8. {e}");
+        MediatorError::ConfigError(
+            12,
+            "NA".into(),
+            format!("s3 object is not valid UTF-8. {e}"),
+        )
+    })
+}
+
 /// Reads a file and returns a vector of strings, one for each line in the file.
 /// Strips lines starting with `#` (comments). Used by the runtime document /
 /// DID-resolution helpers below; the config-loading copy lives in the
@@ -278,7 +346,7 @@ where
     Ok(lines)
 }
 
-/// Reads document from file or aws_parameter_store
+/// Reads document from `file://`, `aws_parameter_store://`, or `s3://`.
 pub(crate) async fn read_document(
     document_path: &str,
     #[cfg_attr(not(feature = "aws"), allow(unused_variables))] aws_config: &Option<AwsConfig>,
@@ -302,11 +370,27 @@ pub(crate) async fn read_document(
                 ));
             }
         }
+        S3_SCHEME => {
+            #[cfg(feature = "aws")]
+            {
+                let cfg = require_aws_config(aws_config, "document_path (s3://)")?;
+                aws_s3(document_path, cfg).await?
+            }
+            #[cfg(not(feature = "aws"))]
+            {
+                let _ = path;
+                return Err(MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    "s3:// requires the 'aws' feature. Rebuild with: cargo build --features aws".into(),
+                ));
+            }
+        }
         _ => {
             return Err(MediatorError::ConfigError(
                 12,
                 "NA".into(),
-                "Invalid document_path format! Expecting file:// or aws_parameter_store:// ..."
+                "Invalid document_path format! Expecting file://, aws_parameter_store://, or s3:// ..."
                     .into(),
             ));
         }
@@ -512,7 +596,24 @@ pub(crate) async fn load_forwarding_protection_blocks(
 
 #[cfg(test)]
 mod tests {
-    use super::{join_api_path, normalize_api_prefix, read_did_config};
+    use super::{join_api_path, normalize_api_prefix, read_did_config, read_document};
+
+    /// The runtime document reader accepts `file://`, `aws_parameter_store://`,
+    /// and `s3://`. An unknown scheme must fail with a message that names all
+    /// three, so an operator's typo is self-diagnosing.
+    #[tokio::test]
+    async fn read_document_rejects_unknown_scheme() {
+        let err = read_document("gs://bucket/obj", &None)
+            .await
+            .expect_err("unknown scheme is not a document source");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("file://")
+                && msg.contains("aws_parameter_store://")
+                && msg.contains("s3://"),
+            "error should name the accepted schemes, got: {msg}"
+        );
+    }
 
     /// `mediator-setup` documents that a `file://` DID target does not
     /// round-trip into `mediator_did`. Pin the runtime half of that claim so

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/helpers.rs
@@ -252,10 +252,7 @@ pub(crate) async fn aws_parameter_store(
 /// the ambient region for this call only — the rest of the process keeps
 /// using the shared `SdkConfig`.
 #[cfg(feature = "aws")]
-pub(crate) async fn aws_s3(
-    target: &str,
-    aws_config: &SdkConfig,
-) -> Result<String, MediatorError> {
+pub(crate) async fn aws_s3(target: &str, aws_config: &SdkConfig) -> Result<String, MediatorError> {
     let parsed = parse_s3_target(target)
         .map_err(|e| MediatorError::ConfigError(12, "NA".into(), e.to_string()))?;
 
@@ -382,7 +379,8 @@ pub(crate) async fn read_document(
                 return Err(MediatorError::ConfigError(
                     12,
                     "NA".into(),
-                    "s3:// requires the 'aws' feature. Rebuild with: cargo build --features aws".into(),
+                    "s3:// requires the 'aws' feature. Rebuild with: cargo build --features aws"
+                        .into(),
                 ));
             }
         }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -432,8 +432,8 @@ impl TryFrom<ConfigRaw> for Config {
                 return Err(MediatorError::ConfigError(
                     12,
                     "NA".into(),
-                    "Configuration uses aws_secrets:// or aws_parameter_store:// but the 'aws' \
-                     feature is not enabled. Rebuild with: cargo build --features aws"
+                    "Configuration uses aws_secrets://, aws_parameter_store://, or s3:// but the \
+                     'aws' feature is not enabled. Rebuild with: cargo build --features aws"
                         .into(),
                 ));
             }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Changelog history
 
+## 16th July 2026
+
+### 0.1.22 — publish the did:webvh log, and a read-only probe for AWS-managed backends
+
+- New recipe key `[output].did_log_target` publishes the minted did:webvh log
+  (`did.jsonl` content) after provisioning, to `s3://<bucket>/<key>[?region=]`
+  (gated by `publish-aws`), `aws_parameter_store://`, or `file://`. Defaults to
+  `None`; validated at recipe load like `did_target`. Prefer `s3://`: the
+  did:webvh v1.0 log embeds the full DID document per entry, so it grows with
+  key rotation and can outgrow Parameter Store's value-size limit.
+- When a `did_log_target` is set and the deployment self-hosts its log, the
+  generated `mediator.toml` points `did_web_self_hosted` at that same target
+  (instead of `file://./conf/did.jsonl`), so a mediator on ephemeral compute
+  reads the published copy that survives the one-shot setup task — no
+  hand-editing. The `s3://` grammar is `mediator-common`'s shared `s3_target`
+  parser, the same one the runtime (>= 0.17.1) resolves, so the two sides
+  cannot drift.
+- Headless / non-interactive / recipe flows now request a **read-only** secret
+  backend probe, honoured **only for `aws_secrets://`** — where entries are
+  pre-created out-of-band (e.g. by CDK) under the IaC-owns-lifecycle contract,
+  so setup needs no create/delete rights (matching the runtime's boot probe).
+  Every other backend is narrowed back to the write round-trip at a single
+  choke point, so setup still fails fast on missing write permissions. The
+  interactive wizard keeps the write probe throughout.
+
 ## 10th July 2026
 
 ### 0.1.21 — publish the minted public DID to an optional target

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.21"
+version = "0.1.22"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -36,7 +36,7 @@ secrets-k8s = ["affinidi-messaging-mediator-common/secrets-k8s"]
 # "aws_parameter_store://<region>/<name>"` can publish the minted DID. Kept
 # separate from `secrets-aws` (AWS secret *storage*) so a build that only
 # stores secrets in AWS doesn't have to pull the SSM client, and vice versa.
-publish-aws = ["dep:aws-config", "dep:aws-sdk-ssm"]
+publish-aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 
 [dependencies]
 # ── TUI Framework ────────────────────────────────────────────────────────
@@ -154,6 +154,7 @@ tracing = "0.1"
 ## existing `aws-sdk-ssm` dependency.
 aws-config = { version = "1", optional = true }
 aws-sdk-ssm = { version = "1", optional = true }
+aws-sdk-s3 = { version = "1", optional = true }
 
 [dev-dependencies]
 ## Test fixtures from `provision_client::test_helpers` (e.g.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
@@ -167,8 +167,9 @@ listen_address = "0.0.0.0:7037"
 
 # Optional: publish the minted did:webvh log document (did.jsonl content)
 # after provisioning, so a self-hosted mediator on ephemeral compute can
-# serve /.well-known/did.jsonl after the one-shot setup task exits. Point
-# `did_web_self_hosted` in mediator.toml at the SAME target.
+# serve /.well-known/did.jsonl after the one-shot setup task exits. The
+# generated mediator.toml points `did_web_self_hosted` at this SAME target
+# automatically, so the runtime reads the published copy — no hand-editing.
 #
 #   did_log_target = "s3://my-bucket/mediator/did.jsonl?region=eu-west-1"
 #   did_log_target = "aws_parameter_store:///mediator/did-log?region=eu-west-1"

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/examples/mediator-build.toml
@@ -165,6 +165,21 @@ listen_address = "0.0.0.0:7037"
 # else (a relying party, a CI step, an operator); to put it in
 # mediator.toml, paste the file's contents as `mediator_did = "did://..."`.
 
+# Optional: publish the minted did:webvh log document (did.jsonl content)
+# after provisioning, so a self-hosted mediator on ephemeral compute can
+# serve /.well-known/did.jsonl after the one-shot setup task exits. Point
+# `did_web_self_hosted` in mediator.toml at the SAME target.
+#
+#   did_log_target = "s3://my-bucket/mediator/did.jsonl?region=eu-west-1"
+#   did_log_target = "aws_parameter_store:///mediator/did-log?region=eu-west-1"
+#   did_log_target = "file:///run/mediator/did.jsonl"
+#
+# All three forms round-trip into `did_web_self_hosted` (which reads a DID
+# *document*, not a DID string). Prefer s3:// for a rotating deployment: the
+# did:webvh v1.0 log embeds the full DID document in every entry (no JSON
+# Patch), so it grows with each key rotation and can outgrow Parameter
+# Store's value-size limit -- S3 has no such ceiling.
+
 
 # ── Install ─────────────────────────────────────────────────────────────────
 [install]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -491,6 +491,12 @@ pub struct WizardConfig {
     /// Publish target for the minted DID string (recipe `[output].did_target`;
     /// never prompted). `None` = don't publish.
     pub did_target: Option<String>,
+    /// Publish target for the minted did:webvh log document (recipe
+    /// `[output].did_log_target`; never prompted). `None` = don't publish.
+    /// A self-hosted mediator on ephemeral compute points its
+    /// `did_web_self_hosted` at the same target so the runtime can serve
+    /// `/.well-known/did.jsonl` after the one-shot setup task exits.
+    pub did_log_target: Option<String>,
 }
 
 impl WizardConfig {
@@ -613,6 +619,7 @@ impl Default for WizardConfig {
             listen_address: DEFAULT_LISTEN_ADDR.into(),
             api_prefix: DEFAULT_API_PREFIX.into(),
             did_target: None,
+            did_log_target: None,
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -493,9 +493,10 @@ pub struct WizardConfig {
     pub did_target: Option<String>,
     /// Publish target for the minted did:webvh log document (recipe
     /// `[output].did_log_target`; never prompted). `None` = don't publish.
-    /// A self-hosted mediator on ephemeral compute points its
-    /// `did_web_self_hosted` at the same target so the runtime can serve
-    /// `/.well-known/did.jsonl` after the one-shot setup task exits.
+    /// When set (and the deployment self-hosts its log), the generated
+    /// mediator.toml points `did_web_self_hosted` at this same target, so a
+    /// mediator on ephemeral compute can serve `/.well-known/did.jsonl`
+    /// after the one-shot setup task exits.
     pub did_log_target: Option<String>,
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
@@ -193,7 +193,14 @@ async fn phase1_emit_request(config: &crate::app::WizardConfig) -> anyhow::Resul
     // secret store — no point minting a request, writing it to disk,
     // and then discovering `aws_secrets://...` can't talk to AWS.
     let backend_url = crate::config_writer::build_backend_url(config);
-    let store = crate::secret_backend::open_and_probe_secret_backend(&backend_url).await?;
+    // Headless flow: read-only probe. The well-known secrets are pre-created
+    // out-of-band (e.g. by CDK), so setup only overwrites them and never needs
+    // create/delete rights — matching the runtime's read-only boot probe.
+    let store = crate::secret_backend::open_and_probe_secret_backend(
+        &backend_url,
+        crate::secret_backend::ProvisionProbe::ReadOnly,
+    )
+    .await?;
 
     // Refuse to clobber an in-flight bootstrap. The backend index is
     // our cross-invocation state now; any entry means "a request is

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/bootstrap_headless.rs
@@ -193,9 +193,11 @@ async fn phase1_emit_request(config: &crate::app::WizardConfig) -> anyhow::Resul
     // secret store — no point minting a request, writing it to disk,
     // and then discovering `aws_secrets://...` can't talk to AWS.
     let backend_url = crate::config_writer::build_backend_url(config);
-    // Headless flow: read-only probe. The well-known secrets are pre-created
-    // out-of-band (e.g. by CDK), so setup only overwrites them and never needs
-    // create/delete rights — matching the runtime's read-only boot probe.
+    // Headless flow: *request* a read-only probe. It takes effect only for
+    // `aws_secrets://` (entries pre-created out-of-band, e.g. by CDK, so setup
+    // only overwrites them — matching the runtime's read-only boot probe). For
+    // any other backend `open_and_probe_secret_backend` narrows it back to a
+    // write round-trip, which fails fast on missing create/write rights.
     let store = crate::secret_backend::open_and_probe_secret_backend(
         &backend_url,
         crate::secret_backend::ProvisionProbe::ReadOnly,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -134,7 +134,18 @@ fn generate_toml(config: &WizardConfig, generated: &GeneratedValues) -> anyhow::
         let should_self_host = generated.did_log_jsonl_written
             && self_host_domain_match(&generated.mediator_did, &config.public_url);
         if should_self_host {
-            server["did_web_self_hosted"] = toml_edit::value("file://./conf/did.jsonl");
+            // Point the runtime at the published log target when the recipe
+            // set one: every supported `did_log_target` scheme (`s3://`,
+            // `aws_parameter_store://`, `file://`) is readable by the
+            // runtime's `read_document`, and on ephemeral compute the local
+            // `./conf/did.jsonl` dies with the one-shot setup task while the
+            // published object survives. Without a target, the local copy is
+            // the only source there is.
+            let self_hosted = config
+                .did_log_target
+                .as_deref()
+                .unwrap_or("file://./conf/did.jsonl");
+            server["did_web_self_hosted"] = toml_edit::value(self_hosted);
         } else {
             server
                 .as_table_like_mut()
@@ -1150,6 +1161,60 @@ storage = "keyring://affinidi-mediator"
         let toml = generate_toml(&config, &generated).unwrap();
         assert!(has_active_did_web_self_hosted(&toml));
         assert!(toml.contains("did_web_self_hosted = \"file://./conf/did.jsonl\""));
+    }
+
+    #[test]
+    fn test_did_log_target_becomes_did_web_self_hosted() {
+        // When the recipe publishes the log (`[output].did_log_target`),
+        // the generated mediator.toml must point `did_web_self_hosted` at
+        // that same target — not at the local `./conf/did.jsonl`, which on
+        // ephemeral compute dies with the one-shot setup task. This is the
+        // whole point of the shared target grammar: the string the wizard
+        // writes is the string the runtime reads, with no hand-editing.
+        let config = WizardConfig {
+            did_method: DID_WEBVH.into(),
+            secret_storage: STORAGE_STRING.into(),
+            public_url: "https://mediator.example.com".into(),
+            did_log_target: Some("s3://my-bucket/mediator/did.jsonl?region=eu-west-1".into()),
+            ..WizardConfig::default()
+        };
+        let generated = GeneratedValues {
+            mediator_did: "did:webvh:QmScid:mediator.example.com".into(),
+            did_log_jsonl_written: true,
+            ..test_generated()
+        };
+        let toml = generate_toml(&config, &generated).unwrap();
+        assert!(has_active_did_web_self_hosted(&toml));
+        assert!(toml.contains(
+            "did_web_self_hosted = \"s3://my-bucket/mediator/did.jsonl?region=eu-west-1\""
+        ));
+        // Only the template's commented fallback may still mention the local
+        // file — no *active* line may point at it.
+        assert!(!toml.lines().any(|line| {
+            line.trim_start()
+                .starts_with("did_web_self_hosted = \"file://")
+        }));
+    }
+
+    #[test]
+    fn test_did_log_target_without_self_host_stays_commented() {
+        // A publish target alone must not activate the line: if the DID's
+        // host doesn't match the public URL, this mediator is not the
+        // authority for the log no matter where it was published.
+        let config = WizardConfig {
+            did_method: DID_VTA.into(),
+            secret_storage: STORAGE_STRING.into(),
+            public_url: "https://mediator.example.com".into(),
+            did_log_target: Some("s3://my-bucket/mediator/did.jsonl".into()),
+            ..WizardConfig::default()
+        };
+        let generated = GeneratedValues {
+            mediator_did: "did:webvh:QmScid:webvh.vta-host.com".into(),
+            did_log_jsonl_written: true,
+            ..test_generated()
+        };
+        let toml = generate_toml(&config, &generated).unwrap();
+        assert!(!has_active_did_web_self_hosted(&toml));
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -350,10 +350,12 @@ async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
 
     // Non-interactive / recipe paths don't run the online-VTA sub-flow, so
     // there's no captured session — VTA-managed DID creation isn't
-    // supported from `--from` / `--non-interactive` yet. Headless flows use a
-    // read-only backend probe: the well-known secrets are pre-created
-    // out-of-band (e.g. by CDK), so setup only overwrites them and never needs
-    // create/delete rights — matching the runtime, which also probes read-only.
+    // supported from `--from` / `--non-interactive` yet. Headless flows
+    // *request* a read-only backend probe; it takes effect only for
+    // `aws_secrets://`, where the entries are pre-created out-of-band (e.g. by
+    // CDK) so setup only overwrites them — matching the runtime, which also
+    // probes read-only. Every other backend is narrowed back to a write
+    // round-trip in `open_and_probe_secret_backend`.
     generate_and_write(
         &config,
         None,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -173,7 +173,14 @@ async fn main() -> anyhow::Result<()> {
                 // (WizardStep::Output) — no stdin prompt here.
 
                 println!("  Generating cryptographic material...\n");
-                match generate_and_write(&app.config, app.vta_session.as_ref(), true).await {
+                match generate_and_write(
+                    &app.config,
+                    app.vta_session.as_ref(),
+                    true,
+                    secret_backend::ProvisionProbe::ReadWrite,
+                )
+                .await
+                {
                     Ok(()) => {
                         // Clean up the sealed-handoff request / seed
                         // files if the setup went through that flow.
@@ -343,8 +350,11 @@ async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
 
     // Non-interactive / recipe paths don't run the online-VTA sub-flow, so
     // there's no captured session — VTA-managed DID creation isn't
-    // supported from `--from` / `--non-interactive` yet.
-    generate_and_write(&config, None, true).await?;
+    // supported from `--from` / `--non-interactive` yet. Headless flows use a
+    // read-only backend probe: the well-known secrets are pre-created
+    // out-of-band (e.g. by CDK), so setup only overwrites them and never needs
+    // create/delete rights — matching the runtime, which also probes read-only.
+    generate_and_write(&config, None, true, secret_backend::ProvisionProbe::ReadOnly).await?;
     offer_build_and_guidance(&config);
 
     Ok(())
@@ -410,7 +420,13 @@ async fn run_from_recipe(
             }
             HeadlessOutcome::Applied { session, artifacts } => {
                 println!("  Generating cryptographic material...\n");
-                generate_and_write(&config, Some(&session), false).await?;
+                generate_and_write(
+                    &config,
+                    Some(&session),
+                    false,
+                    secret_backend::ProvisionProbe::ReadOnly,
+                )
+                .await?;
                 bootstrap_headless::cleanup_artifacts(&artifacts);
                 println!(
                     "  \x1b[32m\u{2714}\x1b[0m Setup artefacts removed — \
@@ -422,7 +438,7 @@ async fn run_from_recipe(
         }
     } else {
         println!("  Generating cryptographic material...\n");
-        generate_and_write(&config, None, false).await?;
+        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadOnly).await?;
         None
     };
 
@@ -1142,13 +1158,17 @@ async fn generate_and_write(
     config: &app::WizardConfig,
     vta_session: Option<&vta::VtaSession>,
     save_recipe: bool,
+    probe: secret_backend::ProvisionProbe,
 ) -> anyhow::Result<()> {
     let artefacts = mint_artefacts(config, vta_session).await?;
-    provision_secret_backend(config, &artefacts, vta_session).await?;
+    provision_secret_backend(config, &artefacts, vta_session, probe).await?;
     write_config_artefacts(config, &artefacts, save_recipe)?;
-    // Optional: publish the minted DID to the recipe's `[output].did_target`.
-    // No-op unless a target is configured.
+    // Optional: publish the minted DID + its did:webvh log to the recipe's
+    // `[output].did_target` / `[output].did_log_target`. No-op unless a target
+    // is configured.
     publish::publish_did_artefacts(&artefacts.mediator_did, config.did_target.as_deref()).await?;
+    publish::publish_did_log_artefacts(artefacts.did_doc.as_deref(), config.did_log_target.as_deref())
+        .await?;
     print_completion_summary(config, &artefacts, vta_session);
     Ok(())
 }
@@ -1411,6 +1431,7 @@ async fn provision_secret_backend(
     config: &app::WizardConfig,
     artefacts: &MintedArtefacts,
     vta_session: Option<&vta::VtaSession>,
+    probe: secret_backend::ProvisionProbe,
 ) -> anyhow::Result<()> {
     let backend_url = config_writer::build_backend_url(config);
     println!("  Provisioning unified secret backend: {backend_url}");
@@ -1429,7 +1450,7 @@ async fn provision_secret_backend(
         );
     }
     let mediator_secrets_store =
-        secret_backend::open_and_probe_secret_backend(&backend_url).await?;
+        secret_backend::open_and_probe_secret_backend(&backend_url, probe).await?;
 
     // JWT signing key — only when generated. Provide-mode skips this
     // and relies on the boot-time env-var/flag path.
@@ -2545,9 +2566,14 @@ mod generate_and_write_tests {
         let dir = cwd.dir().to_path_buf();
         let config = did_peer_config(&dir);
 
-        generate_and_write(&config, None, /*save_recipe=*/ true)
-            .await
-            .expect("generate_and_write must succeed for did:peer");
+        generate_and_write(
+            &config,
+            None,
+            /*save_recipe=*/ true,
+            secret_backend::ProvisionProbe::ReadWrite,
+        )
+        .await
+        .expect("generate_and_write must succeed for did:peer");
 
         // Phase: write_config — mediator.toml + atm-functions.lua.
         let toml_path = dir.join("conf").join("mediator.toml");
@@ -2725,9 +2751,14 @@ mod generate_and_write_tests {
         let dir = cwd.dir().to_path_buf();
         let config = did_peer_config(&dir);
 
-        generate_and_write(&config, None, /*save_recipe=*/ false)
-            .await
-            .expect("generate_and_write must succeed");
+        generate_and_write(
+            &config,
+            None,
+            /*save_recipe=*/ false,
+            secret_backend::ProvisionProbe::ReadWrite,
+        )
+        .await
+        .expect("generate_and_write must succeed");
 
         let recipe_path = dir.join("conf").join("mediator-build.toml");
         assert!(
@@ -2769,9 +2800,14 @@ mod generate_and_write_tests {
             ..app::WizardConfig::default()
         };
 
-        generate_and_write(&config, None, /*save_recipe=*/ false)
-            .await
-            .expect("generate_and_write must succeed for did:peer file:// backend");
+        generate_and_write(
+            &config,
+            None,
+            /*save_recipe=*/ false,
+            secret_backend::ProvisionProbe::ReadWrite,
+        )
+        .await
+        .expect("generate_and_write must succeed for did:peer file:// backend");
 
         assert!(
             secrets_path.exists(),
@@ -2812,7 +2848,7 @@ mod generate_and_write_tests {
         let mut config = did_peer_config(&dir);
         config.admin_did_mode = ADMIN_SKIP.into();
 
-        generate_and_write(&config, None, false)
+        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadWrite)
             .await
             .expect("generate_and_write with ADMIN_SKIP");
 
@@ -2932,7 +2968,9 @@ mod generate_and_write_tests {
         let mut config = did_peer_config(&dir);
         config.jwt_mode = JWT_MODE_PROVIDE.into();
 
-        generate_and_write(&config, None, false).await.unwrap();
+        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadWrite)
+            .await
+            .unwrap();
 
         let unified_text = std::fs::read_to_string(dir.join("unified-secrets.json")).unwrap();
         assert!(

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -354,7 +354,13 @@ async fn run_non_interactive(args: Args) -> anyhow::Result<()> {
     // read-only backend probe: the well-known secrets are pre-created
     // out-of-band (e.g. by CDK), so setup only overwrites them and never needs
     // create/delete rights — matching the runtime, which also probes read-only.
-    generate_and_write(&config, None, true, secret_backend::ProvisionProbe::ReadOnly).await?;
+    generate_and_write(
+        &config,
+        None,
+        true,
+        secret_backend::ProvisionProbe::ReadOnly,
+    )
+    .await?;
     offer_build_and_guidance(&config);
 
     Ok(())
@@ -438,7 +444,13 @@ async fn run_from_recipe(
         }
     } else {
         println!("  Generating cryptographic material...\n");
-        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadOnly).await?;
+        generate_and_write(
+            &config,
+            None,
+            false,
+            secret_backend::ProvisionProbe::ReadOnly,
+        )
+        .await?;
         None
     };
 
@@ -1167,8 +1179,11 @@ async fn generate_and_write(
     // `[output].did_target` / `[output].did_log_target`. No-op unless a target
     // is configured.
     publish::publish_did_artefacts(&artefacts.mediator_did, config.did_target.as_deref()).await?;
-    publish::publish_did_log_artefacts(artefacts.did_doc.as_deref(), config.did_log_target.as_deref())
-        .await?;
+    publish::publish_did_log_artefacts(
+        artefacts.did_doc.as_deref(),
+        config.did_log_target.as_deref(),
+    )
+    .await?;
     print_completion_summary(config, &artefacts, vta_session);
     Ok(())
 }
@@ -2848,9 +2863,14 @@ mod generate_and_write_tests {
         let mut config = did_peer_config(&dir);
         config.admin_did_mode = ADMIN_SKIP.into();
 
-        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadWrite)
-            .await
-            .expect("generate_and_write with ADMIN_SKIP");
+        generate_and_write(
+            &config,
+            None,
+            false,
+            secret_backend::ProvisionProbe::ReadWrite,
+        )
+        .await
+        .expect("generate_and_write with ADMIN_SKIP");
 
         let toml_text = std::fs::read_to_string(dir.join("conf").join("mediator.toml")).unwrap();
         let parsed: toml::Value = toml::from_str(&toml_text).unwrap();
@@ -2968,9 +2988,14 @@ mod generate_and_write_tests {
         let mut config = did_peer_config(&dir);
         config.jwt_mode = JWT_MODE_PROVIDE.into();
 
-        generate_and_write(&config, None, false, secret_backend::ProvisionProbe::ReadWrite)
-            .await
-            .unwrap();
+        generate_and_write(
+            &config,
+            None,
+            false,
+            secret_backend::ProvisionProbe::ReadWrite,
+        )
+        .await
+        .unwrap();
 
         let unified_text = std::fs::read_to_string(dir.join("unified-secrets.json")).unwrap();
         assert!(

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -308,7 +308,10 @@ async fn put_s3_object(target: &S3Target, value: &str, label: &str) -> anyhow::R
 #[cfg(feature = "publish-aws")]
 fn render_s3_target(target: &S3Target) -> String {
     match &target.region {
-        Some(region) => format!("{S3_SCHEME}://{}/{}?region={region}", target.bucket, target.key),
+        Some(region) => format!(
+            "{S3_SCHEME}://{}/{}?region={region}",
+            target.bucket, target.key
+        ),
         None => format!("{S3_SCHEME}://{}/{}", target.bucket, target.key),
     }
 }
@@ -443,7 +446,11 @@ mod tests {
         ] {
             validate_target(target).unwrap_or_else(|e| panic!("{target} should validate: {e}"));
             let parsed = parse_s3(target).expect("shared parser accepts it");
-            assert_eq!(render_s3_target(&parsed), target, "round-trip must be exact");
+            assert_eq!(
+                render_s3_target(&parsed),
+                target,
+                "round-trip must be exact"
+            );
         }
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -84,7 +84,7 @@ pub async fn publish_did_log_artefacts(
     // Strict JSON-Lines requires each record to end with `\n`; normalise to
     // exactly one so the served `/.well-known/did.jsonl` is well-formed and
     // future log entries append cleanly.
-    let normalised = format!("{}\n", log.trim_end_matches('\n'));
+    let normalised = format!("{}\n", log.trim_end());
     publish_value(target, &normalised, "DID log")
         .await
         .with_context(|| format!("publishing DID log to '{target}'"))

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/publish.rs
@@ -1,15 +1,20 @@
-//! Optional publishing of the minted public DID.
+//! Optional publishing of the minted public DID and its did:webvh log.
 //!
-//! Publishes the mediator's public DID string to a store the runtime (or a
-//! relying party) reads, so a one-shot `mediator-setup` task can hand off the
-//! identity directly.
+//! Publishes the mediator's public DID string (`[output].did_target`) and/or
+//! its did:webvh log document (`[output].did_log_target`) to a store the
+//! runtime (or a relying party) reads, so a one-shot `mediator-setup` task can
+//! hand off the identity directly.
 //!
-//! Opt-in: the recipe's `[output].did_target` defaults to `None`, so
-//! interactive/local setups are unaffected. Supported targets:
+//! Opt-in: both targets default to `None`, so interactive/local setups are
+//! unaffected. Supported targets:
 //!
 //! - `aws_parameter_store://<name>[?region=<region>]` — write it to an SSM
 //!   parameter (gated by the `publish-aws` build feature).
-//! - `file://<path>` — write the DID string to a local file.
+//! - `s3://<bucket>/<key>[?region=<region>]` — write it to an S3 object
+//!   (gated by the `publish-aws` build feature). Preferred for the DID *log*,
+//!   which grows with key rotation and can outgrow Parameter Store's value
+//!   limit.
+//! - `file://<path>` — write the value to a local file.
 //!
 //! # Only the parameter-store target round-trips
 //!
@@ -39,6 +44,7 @@
 use affinidi_messaging_mediator_common::parameter_store::{
     PARAMETER_STORE_SCHEME, ParameterStoreTarget, parse_parameter_store_target,
 };
+use affinidi_messaging_mediator_common::s3_target::{S3_SCHEME, S3Target, parse_s3_target};
 use anyhow::{Context, anyhow, bail};
 
 /// Publish the minted public DID string to the optional `[output].did_target`.
@@ -52,6 +58,36 @@ pub async fn publish_did_artefacts(did: &str, did_target: Option<&str>) -> anyho
     publish_value(target, did, "DID")
         .await
         .with_context(|| format!("publishing DID to '{target}'"))
+}
+
+/// Publish the minted did:webvh log (`did.jsonl` content) to the optional
+/// `[output].did_log_target`. A no-op when the target is `None` or there is no
+/// log to publish (non-webvh deployments).
+///
+/// Unlike [`publish_did_artefacts`] (the DID *string*), every supported log
+/// target round-trips into the runtime's `did_web_self_hosted`, which reads a
+/// DID *document* via `read_document` — `file://`, `aws_parameter_store://`,
+/// and `s3://` are all accepted there. `s3://` is the intended target for a
+/// self-hosted mediator on ephemeral compute: the log grows with each key
+/// rotation (did:webvh v1.0 embeds the full document per entry, no JSON
+/// Patch), so it can outgrow Parameter Store's value-size limit — S3 has no
+/// such ceiling.
+pub async fn publish_did_log_artefacts(
+    log_content: Option<&str>,
+    did_log_target: Option<&str>,
+) -> anyhow::Result<()> {
+    let (Some(target), Some(log)) = (did_log_target, log_content) else {
+        return Ok(());
+    };
+
+    println!("\n\x1b[1mPublishing DID log\x1b[0m");
+    // Strict JSON-Lines requires each record to end with `\n`; normalise to
+    // exactly one so the served `/.well-known/did.jsonl` is well-formed and
+    // future log entries append cleanly.
+    let normalised = format!("{}\n", log.trim_end_matches('\n'));
+    publish_value(target, &normalised, "DID log")
+        .await
+        .with_context(|| format!("publishing DID log to '{target}'"))
 }
 
 /// Validate a publish target without performing any I/O. Called at recipe-load
@@ -84,9 +120,24 @@ pub fn validate_target(target: &str) -> anyhow::Result<()> {
                 parse_target(target).map(|_| ())
             }
         }
+        S3_SCHEME => {
+            #[cfg(not(feature = "publish-aws"))]
+            {
+                bail!(
+                    "invalid target '{target}': publishing to {S3_SCHEME}:// \
+                     requires the 'publish-aws' build feature; rebuild with \
+                     `--features publish-aws`, or use a file:// target"
+                );
+            }
+            #[cfg(feature = "publish-aws")]
+            {
+                parse_s3(target).map(|_| ())
+            }
+        }
         other => bail!(
-            "unsupported target scheme '{other}://' for DID publishing (expected \
-             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]' or 'file://<path>')"
+            "unsupported target scheme '{other}://' for publishing (expected \
+             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]', \
+             '{S3_SCHEME}://<bucket>/<key>[?region=<region>]', or 'file://<path>')"
         ),
     }
 }
@@ -101,6 +152,12 @@ fn split_target(target: &str) -> anyhow::Result<(&str, &str)> {
 /// surfacing its error verbatim — it already names the correct form.
 fn parse_target(target: &str) -> anyhow::Result<ParameterStoreTarget> {
     parse_parameter_store_target(target).map_err(|e| anyhow!("{e}"))
+}
+
+/// Parse an `s3://` target through the shared grammar, surfacing its error
+/// verbatim — it already names the correct form.
+fn parse_s3(target: &str) -> anyhow::Result<S3Target> {
+    parse_s3_target(target).map_err(|e| anyhow!("{e}"))
 }
 
 /// Route a single value to its target based on the URI scheme.
@@ -126,9 +183,11 @@ async fn publish_value(target: &str, value: &str, label: &str) -> anyhow::Result
         (PARAMETER_STORE_SCHEME, _) => {
             put_ssm_parameter(&parse_target(target)?, value, label).await
         }
+        (S3_SCHEME, _) => put_s3_object(&parse_s3(target)?, value, label).await,
         (other, _) => bail!(
             "unsupported target scheme '{other}://' for {label} (expected \
-             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]' or 'file://<path>')"
+             '{PARAMETER_STORE_SCHEME}://<name>[?region=<region>]', \
+             '{S3_SCHEME}://<bucket>/<key>[?region=<region>]', or 'file://<path>')"
         ),
     }
 }
@@ -202,6 +261,68 @@ async fn put_ssm_parameter(
     )
 }
 
+/// Write `value` to the S3 object named by `target`, overwriting any existing
+/// object. Unlike Parameter Store there is no value-size ceiling, so this is
+/// the target of choice for a did:webvh log that grows with key rotation.
+#[cfg(feature = "publish-aws")]
+async fn put_s3_object(target: &S3Target, value: &str, label: &str) -> anyhow::Result<()> {
+    use aws_sdk_s3::error::DisplayErrorContext;
+    use aws_sdk_s3::primitives::ByteStream;
+
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    // No `?region=` means the ambient chain (AWS_REGION, profile, IMDS) —
+    // the same resolution the mediator runtime performs when it reads back.
+    if let Some(region) = &target.region {
+        loader = loader.region(aws_sdk_s3::config::Region::new(region.clone()));
+    }
+    let config = loader.load().await;
+    let s3 = aws_sdk_s3::Client::new(&config);
+
+    s3.put_object()
+        .bucket(&target.bucket)
+        .key(&target.key)
+        .body(ByteStream::from(value.as_bytes().to_vec()))
+        .content_type("application/jsonl")
+        .send()
+        .await
+        // DisplayErrorContext walks the SDK error's source chain so the service
+        // message (e.g. AccessDenied, NoSuchBucket) is surfaced, not just Debug.
+        .map_err(|e| {
+            anyhow!(
+                "S3 PutObject(s3://{}/{}) failed: {}",
+                target.bucket,
+                target.key,
+                DisplayErrorContext(&e)
+            )
+        })?;
+
+    println!(
+        "  \x1b[32m\u{2714}\x1b[0m Published {label} \u{2192} \x1b[36m{}\x1b[0m",
+        render_s3_target(target)
+    );
+    Ok(())
+}
+
+/// Render a parsed S3 target back to the string an operator pastes into
+/// `mediator.toml` as `did_web_self_hosted`.
+#[cfg(feature = "publish-aws")]
+fn render_s3_target(target: &S3Target) -> String {
+    match &target.region {
+        Some(region) => format!("{S3_SCHEME}://{}/{}?region={region}", target.bucket, target.key),
+        None => format!("{S3_SCHEME}://{}/{}", target.bucket, target.key),
+    }
+}
+
+#[cfg(not(feature = "publish-aws"))]
+async fn put_s3_object(_target: &S3Target, _value: &str, label: &str) -> anyhow::Result<()> {
+    // Unreachable in practice — `validate_target` rejects the scheme at recipe
+    // load in this build — but kept so the call site type-checks either way.
+    bail!(
+        "publishing {label} to {S3_SCHEME}:// requires the 'publish-aws' \
+         build feature; rebuild with `--features publish-aws`"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,10 +356,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_unsupported_scheme() {
-        let err = validate_target("s3://bucket/key").expect_err("unknown scheme must fail");
+        let err = validate_target("gs://bucket/key").expect_err("unknown scheme must fail");
         assert!(
             err.to_string()
-                .contains("unsupported target scheme 's3://'"),
+                .contains("unsupported target scheme 'gs://'"),
             "{err}"
         );
     }
@@ -260,14 +381,70 @@ mod tests {
 
     #[tokio::test]
     async fn unsupported_scheme_errors_at_publish_time() {
-        let err = publish_value("s3://bucket/key", "did:webvh:abc", "DID")
+        let err = publish_value("gs://bucket/key", "did:webvh:abc", "DID")
             .await
             .expect_err("unknown scheme must error");
         assert!(
             err.to_string()
-                .contains("unsupported target scheme 's3://'"),
+                .contains("unsupported target scheme 'gs://'"),
             "{err}"
         );
+    }
+
+    #[tokio::test]
+    async fn publish_did_log_no_target_or_no_log_is_a_noop() {
+        // Both must be present to publish anything.
+        publish_did_log_artefacts(Some("{\"log\":1}"), None)
+            .await
+            .expect("no target = no-op");
+        publish_did_log_artefacts(None, Some("file:///tmp/should-not-write"))
+            .await
+            .expect("no log = no-op");
+    }
+
+    #[tokio::test]
+    async fn publish_did_log_file_target_normalises_trailing_newline() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let log_path = dir.path().join("nested/did.jsonl");
+        let target = format!("file://{}", log_path.display());
+
+        // Input has no trailing newline; strict JSON-Lines needs exactly one.
+        publish_did_log_artefacts(Some("{\"versionId\":\"1-abc\"}"), Some(&target))
+            .await
+            .expect("file log publish should succeed");
+
+        assert_eq!(
+            std::fs::read_to_string(&log_path).unwrap(),
+            "{\"versionId\":\"1-abc\"}\n"
+        );
+    }
+
+    #[cfg(feature = "publish-aws")]
+    #[test]
+    fn validate_accepts_an_s3_target() {
+        for target in [
+            "s3://my-bucket/did.jsonl",
+            "s3://my-bucket/mediator/did.jsonl",
+            "s3://my-bucket/mediator/did.jsonl?region=eu-west-1",
+        ] {
+            validate_target(target).unwrap_or_else(|e| panic!("{target} should validate: {e}"));
+        }
+    }
+
+    /// The published S3 target must be pasteable into `mediator.toml` as
+    /// `did_web_self_hosted`, so the wizard and the runtime have to agree on
+    /// the grammar. Assert against the shared parser rather than a local copy.
+    #[cfg(feature = "publish-aws")]
+    #[test]
+    fn published_s3_target_round_trips_through_the_shared_grammar() {
+        for target in [
+            "s3://my-bucket/mediator/did.jsonl?region=eu-west-1",
+            "s3://my-bucket/did.jsonl",
+        ] {
+            validate_target(target).unwrap_or_else(|e| panic!("{target} should validate: {e}"));
+            let parsed = parse_s3(target).expect("shared parser accepts it");
+            assert_eq!(render_s3_target(&parsed), target, "round-trip must be exact");
+        }
     }
 
     /// The published target must be pasteable into `mediator.toml` as

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -352,11 +352,15 @@ pub struct OutputSection {
     /// `None` (default) = don't publish.
     ///
     /// All three forms round-trip into the runtime's `did_web_self_hosted`,
-    /// which reads a DID *document* (`read_document`). `s3://` is the intended
-    /// target for a self-hosted mediator on ephemeral compute: the log grows
-    /// with each key rotation (did:webvh v1.0 embeds the full document per
-    /// entry — no JSON Patch), so it can outgrow Parameter Store's value-size
-    /// limit; S3 has no such ceiling.
+    /// which reads a DID *document* (`read_document`) — and when the
+    /// deployment self-hosts its log, the generated mediator.toml points
+    /// `did_web_self_hosted` at this same target automatically, so the
+    /// runtime reads the published copy rather than the local
+    /// `./conf/did.jsonl` that dies with a one-shot setup task. `s3://` is
+    /// the intended target for a self-hosted mediator on ephemeral compute:
+    /// the log grows with each key rotation (did:webvh v1.0 embeds the full
+    /// document per entry — no JSON Patch), so it can outgrow Parameter
+    /// Store's value-size limit; S3 has no such ceiling.
     #[serde(default)]
     pub did_log_target: Option<String>,
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -345,6 +345,20 @@ pub struct OutputSection {
     /// paste the DID itself as `did://<did>`.
     #[serde(default)]
     pub did_target: Option<String>,
+    /// Optional target to publish the minted did:webvh log document
+    /// (`did.jsonl` content) to after provisioning
+    /// (`s3://<bucket>/<key>[?region=<region>]`,
+    /// `aws_parameter_store://<name>[?region=<region>]`, or `file://<path>`).
+    /// `None` (default) = don't publish.
+    ///
+    /// All three forms round-trip into the runtime's `did_web_self_hosted`,
+    /// which reads a DID *document* (`read_document`). `s3://` is the intended
+    /// target for a self-hosted mediator on ephemeral compute: the log grows
+    /// with each key rotation (did:webvh v1.0 embeds the full document per
+    /// entry — no JSON Patch), so it can outgrow Parameter Store's value-size
+    /// limit; S3 has no such ceiling.
+    #[serde(default)]
+    pub did_log_target: Option<String>,
 }
 
 fn default_config_path() -> String {
@@ -366,6 +380,7 @@ impl Default for OutputSection {
             listen_address: default_listen_address(),
             api_prefix: default_api_prefix(),
             did_target: None,
+            did_log_target: None,
         }
     }
 }
@@ -623,12 +638,17 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
     config.listen_address = recipe.output.listen_address.clone();
     config.api_prefix = recipe.output.api_prefix.clone();
     config.did_target = recipe.output.did_target.clone();
+    config.did_log_target = recipe.output.did_log_target.clone();
 
-    // Validate the publish target's scheme now, at recipe load, so a bad
+    // Validate the publish targets' schemes now, at recipe load, so a bad
     // target fails before anything is minted, provisioned, or written.
     if let Some(target) = &config.did_target {
         crate::publish::validate_target(target)
             .map_err(|e| anyhow::anyhow!("invalid [output].did_target: {e}"))?;
+    }
+    if let Some(target) = &config.did_log_target {
+        crate::publish::validate_target(target)
+            .map_err(|e| anyhow::anyhow!("invalid [output].did_log_target: {e}"))?;
     }
 
     Ok(config)
@@ -809,6 +829,9 @@ pub fn from_wizard_config(config: &WizardConfig) -> String {
     out.push_str(&format!("api_prefix = \"{}\"\n", config.api_prefix));
     if let Some(target) = &config.did_target {
         out.push_str(&format!("did_target = \"{target}\"\n"));
+    }
+    if let Some(target) = &config.did_log_target {
+        out.push_str(&format!("did_log_target = \"{target}\"\n"));
     }
     out.push('\n');
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
@@ -22,15 +22,37 @@ pub fn open_secret_backend(backend_url: &str) -> anyhow::Result<MediatorSecrets>
         .map_err(|e| anyhow::anyhow!("open secret backend '{backend_url}': {e}"))
 }
 
+/// Which liveness probe to run when opening the backend for provisioning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisionProbe {
+    /// Write → read → delete a random `mediator_probe_<uuid>` sentinel. Fails
+    /// fast on missing **write** permissions before any crypto material is
+    /// minted. Used by the interactive wizard, which may be pointed at a fresh
+    /// backend the operator must be able to create secrets in.
+    ReadWrite,
+    /// Read-only reachability check (fixed `mediator_probe_readonly` sentinel,
+    /// never written — `Ok` even when absent). Used by the **headless / recipe**
+    /// flow, where the backend's well-known keys are provisioned out-of-band
+    /// (e.g. CDK pre-creates the Secrets Manager entries) so setup only
+    /// overwrites them and never needs create/delete rights — matching the
+    /// mediator runtime, which also probes read-only at boot and on `/readyz`.
+    ReadOnly,
+}
+
 /// Open the unified secret backend and probe it, so a misconfigured or
 /// unreachable store (e.g. `aws_secrets://` with no credentials) fails fast with
-/// an actionable error instead of part-way through provisioning.
-pub async fn open_and_probe_secret_backend(backend_url: &str) -> anyhow::Result<MediatorSecrets> {
+/// an actionable error instead of part-way through provisioning. The `probe`
+/// mode selects a write round-trip (interactive) or a read-only check (headless).
+pub async fn open_and_probe_secret_backend(
+    backend_url: &str,
+    probe: ProvisionProbe,
+) -> anyhow::Result<MediatorSecrets> {
     let store = open_secret_backend(backend_url)?;
-    store
-        .probe()
-        .await
-        .map_err(|e| anyhow::anyhow!("secret backend '{backend_url}' failed probe: {e}"))?;
+    let result = match probe {
+        ProvisionProbe::ReadWrite => store.probe().await,
+        ProvisionProbe::ReadOnly => store.probe_readonly().await,
+    };
+    result.map_err(|e| anyhow::anyhow!("secret backend '{backend_url}' failed probe: {e}"))?;
     Ok(store)
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/secret_backend.rs
@@ -31,23 +31,57 @@ pub enum ProvisionProbe {
     /// backend the operator must be able to create secrets in.
     ReadWrite,
     /// Read-only reachability check (fixed `mediator_probe_readonly` sentinel,
-    /// never written — `Ok` even when absent). Used by the **headless / recipe**
-    /// flow, where the backend's well-known keys are provisioned out-of-band
-    /// (e.g. CDK pre-creates the Secrets Manager entries) so setup only
-    /// overwrites them and never needs create/delete rights — matching the
+    /// never written — `Ok` even when absent). Requested by the **headless /
+    /// recipe** flow, but honoured **only for `aws_secrets://`** backends,
+    /// where the Secrets Manager entries are provisioned out-of-band (e.g. CDK
+    /// pre-creates them) so setup only overwrites them and never needs
+    /// create/delete rights — the IaC-owns-lifecycle contract, matching the
     /// mediator runtime, which also probes read-only at boot and on `/readyz`.
+    ///
+    /// For every other backend (`file://`, `keyring://`, `vault://`, …) the
+    /// setup tool itself creates the secrets, so a requested `ReadOnly` is
+    /// narrowed back to [`ReadWrite`](Self::ReadWrite) by
+    /// [`open_and_probe_secret_backend`] — the write round-trip still fails
+    /// fast on missing permissions, even headless.
     ReadOnly,
+}
+
+/// Whether `backend_url` names an AWS-managed secret store (`aws_secrets://`).
+/// Only these follow the IaC-owns-lifecycle principle and are eligible for the
+/// read-only provisioning probe; see [`ProvisionProbe::ReadOnly`].
+fn is_aws_secrets_backend(backend_url: &str) -> bool {
+    backend_url.starts_with("aws_secrets://")
+}
+
+/// Resolve the probe actually run for `backend_url` from the one `requested`.
+/// A `ReadOnly` request is honoured only for AWS-managed backends; for anything
+/// else it falls back to `ReadWrite`. `ReadWrite` requests pass through
+/// unchanged. Pure so the narrowing rule can be unit-tested directly.
+fn effective_probe(backend_url: &str, requested: ProvisionProbe) -> ProvisionProbe {
+    match requested {
+        ProvisionProbe::ReadOnly if !is_aws_secrets_backend(backend_url) => {
+            ProvisionProbe::ReadWrite
+        }
+        other => other,
+    }
 }
 
 /// Open the unified secret backend and probe it, so a misconfigured or
 /// unreachable store (e.g. `aws_secrets://` with no credentials) fails fast with
-/// an actionable error instead of part-way through provisioning. The `probe`
-/// mode selects a write round-trip (interactive) or a read-only check (headless).
+/// an actionable error instead of part-way through provisioning.
+///
+/// A requested [`ProvisionProbe::ReadOnly`] is honoured **only for
+/// `aws_secrets://`** backends (the IaC-owns-lifecycle contract); for every
+/// other backend it is narrowed back to [`ProvisionProbe::ReadWrite`], so the
+/// setup tool — which creates those secrets itself — keeps the write round-trip
+/// that fails fast on missing permissions, even in headless flows. Interactive
+/// callers always pass `ReadWrite` and are unaffected.
 pub async fn open_and_probe_secret_backend(
     backend_url: &str,
     probe: ProvisionProbe,
 ) -> anyhow::Result<MediatorSecrets> {
     let store = open_secret_backend(backend_url)?;
+    let probe = effective_probe(backend_url, probe);
     let result = match probe {
         ProvisionProbe::ReadWrite => store.probe().await,
         ProvisionProbe::ReadOnly => store.probe_readonly().await,
@@ -68,5 +102,45 @@ mod tests {
             open_secret_backend(&url).is_ok(),
             "a file:// backend URL should open"
         );
+    }
+
+    #[test]
+    fn readonly_probe_is_honoured_only_for_aws_secrets() {
+        // AWS-managed store: IaC owns the lifecycle, so ReadOnly stands.
+        assert_eq!(
+            effective_probe(
+                "aws_secrets://us-east-1/mediator/",
+                ProvisionProbe::ReadOnly
+            ),
+            ProvisionProbe::ReadOnly,
+        );
+        // Every other backend creates its own secrets → narrow to ReadWrite.
+        for url in [
+            "file:///tmp/secrets.json",
+            "keyring://affinidi-mediator",
+            "vault://vault.example.com/secret",
+            "gcp_secrets://proj/mediator/",
+        ] {
+            assert_eq!(
+                effective_probe(url, ProvisionProbe::ReadOnly),
+                ProvisionProbe::ReadWrite,
+                "{url} should fall back to a write round-trip",
+            );
+        }
+    }
+
+    #[test]
+    fn readwrite_probe_passes_through_for_every_backend() {
+        for url in [
+            "aws_secrets://us-east-1/mediator/",
+            "file:///tmp/secrets.json",
+            "keyring://affinidi-mediator",
+        ] {
+            assert_eq!(
+                effective_probe(url, ProvisionProbe::ReadWrite),
+                ProvisionProbe::ReadWrite,
+                "{url} must keep an explicit ReadWrite request",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds durable **S3 storage** for the self-hosted `did:webvh` `did.jsonl` log, and gives the **headless `mediator-setup`** flow a **read-only** secret-backend probe **for AWS Secrets Manager only**.

### S3 did.jsonl log
- New `s3_target` module in `mediator-common`: pure `s3://` URL parsing (no AWS SDK), always built, so the string `mediator-setup` writes is exactly the one the runtime reads.
- Runtime resolves `did_web_self_hosted = "s3://<bucket>/<key>?region=..."` and reads the log object at boot (behind the `aws` feature, now also pulling `aws-sdk-s3`).
- `mediator-setup publish` can publish the minted DID's `did.jsonl` to an `s3://` target (behind `publish-aws`, alongside the existing SSM target).

### Read-only setup probe (AWS-only)
- `secret_backend`: add `ProvisionProbe { ReadWrite, ReadOnly }`; `open_and_probe_secret_backend` dispatches to `.probe()` vs `.probe_readonly()`.
- Headless / non-interactive / recipe flows (incl. VTA `phase1_emit_request`) **request** a read-only probe, but it is honoured **only for `aws_secrets://`** backends — where the entries are pre-created out-of-band (e.g. by CDK) under the IaC-owns-lifecycle contract, so setup only overwrites them and needs **no create/delete** rights.
- Every other backend (`file://`, `keyring://`, `vault://`, `gcp_secrets://`, `azure_keyvault://`) is narrowed back to the **write round-trip** at the single choke point (`effective_probe` in `open_and_probe_secret_backend`), so setup still fails fast on missing write/create permissions — even headless. The interactive wizard keeps the write-probe throughout.
- Builds on the runtime-only read-only probe work (#589 / #591), scoping the setup-tool half to the backend class the contract actually applies to.

## Testing
- `cargo fmt --check`, `clippy -D warnings` clean on mediator-setup.
- Feature matrix: `cargo check --no-default-features --features secrets-{keyring,aws,gcp,azure,vault}` all compile.
- `cargo test -p affinidi-messaging-mediator-setup` → **398 passed**.
