### PR TITLE
fix: tolerate partial redis_version from ElastiCache Serverless

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Changelog history
 
+## 15th July 2026
+
+### 0.15.30 — tolerate partial `redis_version` from ElastiCache Serverless
+
+- `check_server_version` no longer requires a full `MAJOR.MINOR.PATCH` from
+  `INFO server`. OSS Valkey/Redis report a complete version (e.g. `7.2.4`), but
+  ElastiCache Serverless reports a truncated `redis_version` carrying only the
+  major (e.g. `8`), which made the strict `semver` parse fail ("unexpected end of
+  input while parsing minor version number") and the mediator `exit(1)` on
+  startup even though the engine (AWS-reported Valkey 8.1) is compatible.
+- The reported value is now normalized: take the leading numeric dotted core,
+  zero-fill any missing minor/patch, and record how many components were present.
+  Compatibility is decided by precision — `>=2` components are range-checked
+  precisely against `REDIS_VERSION_REQ` (unchanged behaviour), while a bare major
+  is accepted iff it is a supported line (`SUPPORTED_MAJOR_VERSIONS = [7, 8]`),
+  since a `>=7.1` range check is ambiguous for a bare major.
+- Adds pure, unit-tested helpers `normalize_redis_version` and
+  `assess_redis_version`.
+
 ## 10th July 2026
 
 ### 0.15.27 — shared `aws_parameter_store://` target parser

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.29"
+version = "0.15.30"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/database/mod.rs
@@ -46,6 +46,77 @@ pub struct DatabaseHandler {
 #[cfg(feature = "redis-backend")]
 const REDIS_VERSION_REQ: &str = ">=7.1, <9.0";
 
+/// Major engine lines that [`REDIS_VERSION_REQ`] is known to cover.
+///
+/// Managed engines — notably **ElastiCache Serverless for Valkey / Redis OSS** —
+/// answer `INFO server` with a `redis_version` that carries only the *major*
+/// component (e.g. `8`), unlike OSS Valkey/Redis which report a full
+/// `MAJOR.MINOR.PATCH` (e.g. `7.2.4`). A bare major cannot be meaningfully
+/// range-checked against `>=7.1` (is it `7.0` or `7.9`?), so when only a major is
+/// reported we accept it iff it is one of these supported lines. Keep this in sync
+/// with `REDIS_VERSION_REQ`.
+#[cfg(feature = "redis-backend")]
+const SUPPORTED_MAJOR_VERSIONS: &[u64] = &[7, 8];
+
+/// Outcome of checking a reported `redis_version` against [`REDIS_VERSION_REQ`].
+#[cfg(feature = "redis-backend")]
+#[derive(Debug, PartialEq, Eq)]
+enum VersionVerdict {
+    Compatible,
+    Incompatible,
+}
+
+/// Coerce a `redis_version` value from `INFO server` into a full [`Version`],
+/// returning the parsed version plus the number of numeric components that were
+/// actually present (1, 2 or 3).
+///
+/// OSS Valkey/Redis report a complete `MAJOR.MINOR.PATCH` (e.g. `7.2.4`). Managed
+/// engines can report fewer components — ElastiCache Serverless reports only the
+/// major (e.g. `8`). We take the leading numeric dotted core (ignoring an optional
+/// `v` prefix and any non-numeric suffix) and zero-fill the missing minor/patch so
+/// the value always parses; the returned precision lets the caller decide how
+/// strictly it can range-check.
+#[cfg(feature = "redis-backend")]
+fn normalize_redis_version(raw: &str) -> Result<(Version, usize), semver::Error> {
+    let core = raw.trim();
+    let core = core.strip_prefix('v').unwrap_or(core);
+    let numeric: Vec<&str> = core
+        .split('.')
+        .take_while(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+        .collect();
+    if numeric.is_empty() {
+        // Nothing numeric to work with — surface a parse error for the raw value.
+        return Version::parse(core).map(|version| (version, 3));
+    }
+    let present = numeric.len().min(3);
+    let major = numeric[0];
+    let minor = numeric.get(1).copied().unwrap_or("0");
+    let patch = numeric.get(2).copied().unwrap_or("0");
+    Version::parse(&format!("{major}.{minor}.{patch}")).map(|version| (version, present))
+}
+
+/// Decide whether a reported `redis_version` is compatible with `req`.
+///
+/// - When the minor is known (≥ 2 components), range-check precisely — this is the
+///   original strict behaviour for OSS Valkey/Redis.
+/// - When only the major is known (ElastiCache Serverless reports e.g. `8`), a
+///   `>=7.1` range check would be ambiguous, so accept iff the major is a supported
+///   line ([`SUPPORTED_MAJOR_VERSIONS`]).
+#[cfg(feature = "redis-backend")]
+fn assess_redis_version(raw: &str, req: &VersionReq) -> Result<VersionVerdict, semver::Error> {
+    let (version, present) = normalize_redis_version(raw)?;
+    let compatible = if present >= 2 {
+        req.matches(&version)
+    } else {
+        SUPPORTED_MAJOR_VERSIONS.contains(&version.major)
+    };
+    Ok(if compatible {
+        VersionVerdict::Compatible
+    } else {
+        VersionVerdict::Incompatible
+    })
+}
+
 #[cfg(feature = "redis-backend")]
 impl DatabaseHandler {
     /// Creates a new `DatabaseHandler`, establishing a multiplexed connection and verifying
@@ -256,28 +327,12 @@ impl DatabaseHandler {
             .next();
 
         if let Some(version) = server_version {
-            let semver_version: Version = match Version::parse(&version) {
-                Ok(result) => result,
-                Err(err) => {
-                    return Err(MediatorError::problem_with_log(
-                        7,
-                        "NA",
-                        None,
-                        ProblemReportSorter::Error,
-                        ProblemReportScope::Protocol,
-                        "me.res.storage.version",
-                        "Cannot parse database version ({1}). Reason: {2}",
-                        vec![version.clone(), err.to_string()],
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Cannot parse database version ({version}). Reason: {err}"),
-                    ));
+            match assess_redis_version(&version, &redis_version_req) {
+                Ok(VersionVerdict::Compatible) => {
+                    info!("Redis version is compatible: {}", version);
+                    Ok(version.to_owned())
                 }
-            };
-            if redis_version_req.matches(&semver_version) {
-                info!("Redis version is compatible: {}", version);
-                Ok(version.to_owned())
-            } else {
-                Err(MediatorError::problem_with_log(
+                Ok(VersionVerdict::Incompatible) => Err(MediatorError::problem_with_log(
                     8,
                     "NA",
                     None,
@@ -290,7 +345,19 @@ impl DatabaseHandler {
                     format!(
                         "Database version {version} does not match expected {redis_version_req}"
                     ),
-                ))
+                )),
+                Err(err) => Err(MediatorError::problem_with_log(
+                    7,
+                    "NA",
+                    None,
+                    ProblemReportSorter::Error,
+                    ProblemReportScope::Protocol,
+                    "me.res.storage.version",
+                    "Cannot parse database version ({1}). Reason: {2}",
+                    vec![version.clone(), err.to_string()],
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Cannot parse database version ({version}). Reason: {err}"),
+                )),
             }
         } else {
             Err(MediatorError::problem(
@@ -344,6 +411,115 @@ impl DatabaseHandler {
 
         if is_tls {
             info!("Redis TLS connection detected (rediss://)");
+        }
+    }
+}
+
+#[cfg(all(test, feature = "redis-backend"))]
+mod version_checks {
+    use super::{
+        REDIS_VERSION_REQ, SUPPORTED_MAJOR_VERSIONS, VersionVerdict, assess_redis_version,
+        normalize_redis_version,
+    };
+    use semver::{Version, VersionReq};
+
+    fn req() -> VersionReq {
+        VersionReq::parse(REDIS_VERSION_REQ).unwrap()
+    }
+
+    #[test]
+    fn normalizes_full_partial_and_prefixed_versions() {
+        // OSS Valkey/Redis: full MAJOR.MINOR.PATCH.
+        assert_eq!(
+            normalize_redis_version("7.2.4").unwrap(),
+            (Version::new(7, 2, 4), 3)
+        );
+        // Managed proxy reporting MAJOR.MINOR.
+        assert_eq!(
+            normalize_redis_version("8.1").unwrap(),
+            (Version::new(8, 1, 0), 2)
+        );
+        // ElastiCache Serverless: bare major only.
+        assert_eq!(
+            normalize_redis_version("8").unwrap(),
+            (Version::new(8, 0, 0), 1)
+        );
+        // Optional `v` prefix and surrounding whitespace are tolerated.
+        assert_eq!(
+            normalize_redis_version(" v7.4.0 ").unwrap(),
+            (Version::new(7, 4, 0), 3)
+        );
+        // Non-numeric suffix is dropped; only the numeric core is kept.
+        assert_eq!(
+            normalize_redis_version("7.4.0-serverless").unwrap(),
+            (Version::new(7, 4, 0), 2)
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_versions() {
+        assert!(normalize_redis_version("").is_err());
+        assert!(normalize_redis_version("unknown").is_err());
+    }
+
+    #[test]
+    fn full_and_minor_versions_are_range_checked() {
+        assert_eq!(
+            assess_redis_version("7.2.4", &req()).unwrap(),
+            VersionVerdict::Compatible
+        );
+        assert_eq!(
+            assess_redis_version("8.1", &req()).unwrap(),
+            VersionVerdict::Compatible
+        );
+        // Genuinely below the >=7.1 floor.
+        assert_eq!(
+            assess_redis_version("7.0", &req()).unwrap(),
+            VersionVerdict::Incompatible
+        );
+        // At/above the <9.0 ceiling.
+        assert_eq!(
+            assess_redis_version("9.0.0", &req()).unwrap(),
+            VersionVerdict::Incompatible
+        );
+        assert_eq!(
+            assess_redis_version("6.2.0", &req()).unwrap(),
+            VersionVerdict::Incompatible
+        );
+    }
+
+    #[test]
+    fn bare_major_uses_supported_lines() {
+        // ElastiCache Serverless reports only the major (e.g. Valkey 8 -> "8").
+        assert_eq!(
+            assess_redis_version("8", &req()).unwrap(),
+            VersionVerdict::Compatible
+        );
+        assert_eq!(
+            assess_redis_version("7", &req()).unwrap(),
+            VersionVerdict::Compatible
+        );
+        assert_eq!(
+            assess_redis_version("6", &req()).unwrap(),
+            VersionVerdict::Incompatible
+        );
+        assert_eq!(
+            assess_redis_version("9", &req()).unwrap(),
+            VersionVerdict::Incompatible
+        );
+    }
+
+    #[test]
+    fn supported_majors_stay_within_requirement() {
+        // Guard against SUPPORTED_MAJOR_VERSIONS drifting out of REDIS_VERSION_REQ:
+        // every supported major must satisfy the requirement at some minor.
+        let req = req();
+        for &major in SUPPORTED_MAJOR_VERSIONS {
+            let ok = (0..10).any(|minor| req.matches(&Version::new(major, minor, 0)));
+            assert!(
+                ok,
+                "supported major {major} has no minor within {REDIS_VERSION_REQ}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Problem

The mediator refuses to start against **ElastiCache Serverless for Valkey**. During database init it runs `INFO server`, extracts the `redis_version` field, and parses it as a strict `semver::Version` (which mandates a full `MAJOR.MINOR.PATCH`), then range-checks against `REDIS_VERSION_REQ = ">=7.1, <9.0"`.

Observed on a Valkey **8.1** serverless cache:

```
Database ping ok! Expected (PONG) received (PONG)          <- connection is fine
ERROR Error opening database: ... code: e.p.me.res.storage.version,
  comment: Cannot parse database version (...).
  Reason: unexpected end of input while parsing minor version number
Mediator failed: Database Error ... 500                     <- exit(1) -> crash loop
```

The TLS connection succeeds; the mediator dies purely on the **version parse**, so the task crash-loops and never stabilises.

## What engines report for `redis_version`

- **OSS Valkey / Redis** report a **full** `MAJOR.MINOR.PATCH` in `INFO server` (e.g. `redis_version:7.2.4`), and Valkey additionally exposes `valkey_version`.
- **ElastiCache Serverless** front-ends the engine with a managed proxy and reports a **truncated** `redis_version` carrying only the **major** component (e.g. `8`). The semver error is specifically *"unexpected end of input while parsing minor version number"* (parser consumed a major, then hit end-of-input), and the AWS control plane describes the same cache as `Engine=valkey, MajorEngineVersion=8, FullEngineVersion=8.1`.

A strict 3-component semver parse therefore cannot accept what ElastiCache Serverless returns, even though the engine (Valkey 8.1) is well within the supported range.

## Fix

Parse the **leading numeric dotted core** (`MAJOR[.MINOR[.PATCH]]`, ignoring an optional `v` prefix and any non-numeric suffix), **zero-fill** missing minor/patch so it always yields a valid `semver::Version`, and track how many components were actually present. Decide compatibility by precision:

- **≥ 2 components** present (`MAJOR.MINOR[.PATCH]`, e.g. OSS `7.2.4` or a proxy reporting `8.1`): range-check precisely against `>=7.1, <9.0` — **unchanged behaviour**.
- **Only MAJOR** present (managed/serverless, e.g. `8`): the exact minor is unknown, so a `>=7.1` range check is ambiguous. Accept iff the major is one of the supported major lines `SUPPORTED_MAJOR_VERSIONS = {7, 8}` — admitting ElastiCache Serverless Valkey 7.x/8.x regardless of whether the proxy reports the major as `7` (Redis-compat) or `8` (Valkey), while still rejecting out-of-support majors like `6` or `9`.

`SUPPORTED_MAJOR_VERSIONS` lives next to `REDIS_VERSION_REQ` so the two stay in sync (a unit test guards that every supported major has a minor satisfying the requirement).

The decision is extracted into pure helpers (`normalize_redis_version`, `assess_redis_version`) so it is fully unit-tested without a live database.

## Test matrix (`req = ">=7.1, <9.0"`)

| Reported `redis_version` | Precision | Verdict       | Why                                  |
|--------------------------|-----------|---------------|--------------------------------------|
| `7.2.4`                  | 3         | Compatible    | in range                             |
| `8.1`                    | 2         | Compatible    | 8.1.0 in range                       |
| `7.4.0-serverless`       | 2         | Compatible    | numeric core `7.4` → 7.4.0 in range  |
| `8` (ElastiCache SL)     | 1         | Compatible    | major ∈ {7, 8}                       |
| `7`                      | 1         | Compatible    | major ∈ {7, 8}                       |
| `7.0`                    | 2         | Incompatible  | 7.0.0 < 7.1                          |
| `6`                      | 1         | Incompatible  | major ∉ {7, 8}                       |
| `9`                      | 1         | Incompatible  | major ∉ {7, 8}                       |
| `` / `unknown`           | –         | Parse error   | unchanged error path                 |

All 5 new unit tests pass (`cargo test -p affinidi-messaging-mediator-common --features redis-backend version_checks`).

> Draft: opened for review of the parsing approach before finalising.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>