### PR TITLE
fix: keep the seeded DID resolver across listener restarts

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.18] - 2026-07-16
+
+- Keep the caller-seeded DID resolver across listener restarts (D1-F4).
+  `Listener::connect()` runs on every iteration of the restart loop
+  (`restart::run_with_restart`), but it consumed the pre-seeded `TDKConfig`
+  with `Option::take()` — leaving the field `None`, so every retry after the
+  first fell back to a cold `TDKConfig::headless()` and lost the caller's
+  DID resolver and its warm cache. It now `clone()`s the config instead; both
+  `TDKConfig` and its `DIDCacheClient` are `Arc`-cheap clones that share the
+  same underlying resolver state, so every reconnect keeps the warm resolver.
+  Behaviour-preserving for the first connect; fixes the degraded-resolution +
+  extra cold-resolver cost on every subsequent reconnect.
+
 ## [0.3.16] - 2026-07-03
 
 - Fix a TSP poison-loop in the offline-sync poller. `AffinidiMessageService` runs a periodic

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.17"
+version = "0.3.18"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -121,7 +121,15 @@ impl Listener {
         // Clear the connection handle so outbound callers get NotConnected
         let _ = self.connection_tx.send(None);
 
-        let tdk_config = match self.config.tdk_config.take() {
+        // Clone rather than `take()` the caller-seeded config: `connect()` runs
+        // on every restart-loop iteration (see `restart::run_with_restart`), and
+        // `Option::take` left the field `None` after the first attempt, so every
+        // subsequent retry fell back to a cold `TDKConfig::headless()` — losing
+        // the caller's pre-seeded DID resolver and its warm cache (F4). Both
+        // `TDKConfig` and its `DIDCacheClient` are Arc-cheap clones that share the
+        // same underlying resolver state, so cloning keeps the warm resolver
+        // across every reconnect.
+        let tdk_config = match self.config.tdk_config.clone() {
             Some(cfg) => cfg,
             None => affinidi_tdk_common::config::TDKConfig::headless()?,
         };


### PR DESCRIPTION
## Problem

`Listener::connect()` (`affinidi-messaging-didcomm-service`) is called on **every**
iteration of the restart loop (`restart::run_with_restart` → `connect()` per attempt),
but it pulled the caller-pre-seeded `TDKConfig` out with `Option::take()`:

```rust
let tdk_config = match self.config.tdk_config.take() {
    Some(cfg) => cfg,
    None => TDKConfig::headless()?,
};
```

`take()` leaves the field `None`, so only the **first** connect uses the seeded config
(with its pre-built, cache-warm `DIDCacheClient`). Every subsequent restart-loop retry
finds `None` and falls back to a cold `TDKConfig::headless()` — no DID resolver, no
warm cache. The result is degraded DID resolution and a fresh cold-resolver build on
every reconnect, exactly when the process is already under stress (a flapping mediator).

## Fix

Clone the config instead of taking it. Both `TDKConfig` (`#[derive(Clone)]`) and its
`did_resolver: Option<DIDCacheClient>` are `Arc`-cheap clones that share the same
underlying resolver state (Moka cache + resolver map are `Arc`-backed), so cloning keeps
the caller's warm resolver across every reconnect. The field stays populated for the next
retry.

Behaviour-preserving on the first connect; the no-seed case still falls back to
`headless()` exactly as before.

## Scope / risk

- One crate (`affinidi-messaging-didcomm-service`), one call site. No signature or public
  API change.
- `cargo check` / `clippy` clean; `cargo fmt` applied.
- Version bump `0.3.17 → 0.3.18` + CHANGELOG entry.

This is the first, non-breaking increment of the messaging delivery-layer conformance
work (the transport/config layer must survive restarts) tracked in the VTI networking
remediation — see `../design-docs` in the ecosystem workspace.