### PR TITLE
feat: publish a re-falsifiable websocket connection-state signal

### DIFF
--- a/crates/messaging/affinidi-messaging-core/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi Messaging Core Changelog
 
+## 16th July 2026
+
+### 0.1.3 — `ConnState` transport connection vocabulary
+
+Add `transport::ConnState` (`Connecting` / `Connected` / `Disconnected`), a
+`#[non_exhaustive]` enum for the re-falsifiable connection state a messaging
+transport publishes over a `watch` channel. It is the shared vocabulary the
+DIDComm websocket transport now emits and the forthcoming `MessageTransport`
+trait / delivery layer observe, so connectivity is a live signal rather than a
+boot-time latch (R6.2). Additive; no existing API changed.
+
 ## 14th June 2026
 
 ### 0.1.2 — non_exhaustive MessagingError (W7 sweep)

--- a/crates/messaging/affinidi-messaging-core/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-core"
 description = "Protocol-agnostic messaging traits for DIDComm and TSP"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-core/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-core/src/lib.rs
@@ -23,8 +23,10 @@
 
 pub mod error;
 pub mod traits;
+pub mod transport;
 pub mod types;
 
 pub use error::MessagingError;
 pub use traits::{IdentityResolver, MessagingProtocol, RelationshipManager};
+pub use transport::ConnState;
 pub use types::{Protocol, ReceivedMessage, RelationshipState, ResolvedIdentity};

--- a/crates/messaging/affinidi-messaging-core/src/transport.rs
+++ b/crates/messaging/affinidi-messaging-core/src/transport.rs
@@ -1,0 +1,28 @@
+//! Transport-agnostic connection vocabulary shared by messaging transports
+//! (DIDComm today, TSP later). Kept here in `affinidi-messaging-core` — the
+//! protocol-agnostic base of the messaging stack — so every transport and the
+//! delivery layer above them speak the same words.
+
+use serde::{Deserialize, Serialize};
+
+/// Re-falsifiable connection / reachability state of a messaging transport.
+///
+/// A conforming transport MUST publish a transition on **every** drop and
+/// **every** (re)connect for the life of the process — this is not a boot-time
+/// latch (rule R6.2). Transports carry it over a [`tokio::sync::watch`] channel
+/// they own, so the delivery layer, health endpoints, and retry loops all
+/// observe the *same* latest value rather than each inferring connectivity.
+///
+/// [`tokio::sync::watch`]: https://docs.rs/tokio/latest/tokio/sync/watch/index.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ConnState {
+    /// Establishing the first connection; no successful connect yet.
+    Connecting,
+    /// Connected to the next hop (mediator / relay) — sends can be attempted.
+    Connected,
+    /// The connection has dropped; the transport is retrying or idle. A send
+    /// attempted now is not on the wire.
+    Disconnected,
+}

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## [0.18.50] - 2026-07-12
+## [0.18.51] - 2026-07-16
+
+- Publish a re-falsifiable websocket connection-state signal (D1 conformance,
+  R6.2). The reconnect loop lives entirely inside the SDK's `WebSocketTransport`
+  task and previously emitted nothing on drop/reconnect, so every consumer's
+  connectivity view (`ListenerEvent`, health flags) was a boot-time latch. The
+  transport now owns a `tokio::sync::watch::<ConnState>` (from the new
+  `affinidi-messaging-core::ConnState`): it publishes `Connected` at the single
+  reconnect-success site and `Disconnected` from `fail_pending_requests` (the
+  one choke point every drop funnels through). Exposed additively via
+  `ATMProfile::connection_state() -> Option<watch::Receiver<ConnState>>`
+  (`None` for a REST-only profile). No existing API changed; the internal
+  `WebSocketTransport::start`/`start_with_options` now also return the receiver.
 
 - Footgun guard: `TspOps::connect_websocket` now warns when the profile already
   has a live-stream pickup websocket. The mediator permits one websocket per DID,

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.50"
+version = "0.18.51"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -30,6 +30,9 @@ tsp = [
 affinidi-tdk-common = "0.6"
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
+# Protocol-agnostic messaging vocabulary (ConnState, the future MessageTransport
+# trait). The websocket transport publishes ConnState over a watch channel.
+affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.3" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
 trust-tasks-rs = "0.2"

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -18,6 +18,7 @@ use affinidi_did_common::{
     Document,
     service::{Endpoint, Service},
 };
+use affinidi_messaging_core::ConnState;
 use affinidi_tdk_common::profiles::TDKProfile;
 use ahash::AHashMap as HashMap;
 use serde_json::Value;
@@ -30,7 +31,7 @@ use std::{
 };
 use tokio::{
     select,
-    sync::{RwLock, broadcast, mpsc, oneshot},
+    sync::{RwLock, broadcast, mpsc, oneshot, watch},
 };
 use tracing::debug;
 
@@ -194,6 +195,21 @@ impl ATMProfile {
 
         Ok(())
     }
+
+    /// A re-falsifiable view of this profile's DIDComm websocket connection
+    /// state.
+    ///
+    /// Returns a [`watch::Receiver<ConnState>`] that transitions to
+    /// [`ConnState::Connected`] on every successful (re)connect and
+    /// [`ConnState::Disconnected`] on every drop, for the life of the
+    /// transport task — it is a live signal, not a boot-time latch. Returns
+    /// `None` if no websocket transport is running for this profile (REST-only,
+    /// or before `profile_enable_websocket`). Callers observe drops/reconnects
+    /// with [`watch::Receiver::changed`].
+    pub async fn connection_state(&self) -> Option<watch::Receiver<ConnState>> {
+        let mediator = self.inner.mediator.as_ref().as_ref()?;
+        mediator.ws_conn_state_rx.read().await.clone()
+    }
 }
 
 #[derive(Debug)]
@@ -204,6 +220,12 @@ pub struct Mediator {
 
     /// MPSC Channel to send commands to the WebSocket connection
     pub(crate) ws_channel_tx: RwLock<Option<mpsc::Sender<WebSocketCommands>>>,
+
+    /// Re-falsifiable connection-state signal for the WebSocket transport,
+    /// published by the transport task on every drop/reconnect. `None` when no
+    /// websocket transport is running for this mediator. Cloned out by
+    /// [`ATMProfile::connection_state`].
+    pub(crate) ws_conn_state_rx: RwLock<Option<watch::Receiver<ConnState>>>,
 
     /// Unique ID that is used for anything requiring a unique transaction identifier
     pub(crate) tx_uuid: AtomicU32,
@@ -225,6 +247,7 @@ impl Mediator {
             rest_endpoint: Mediator::find_rest_endpoint(&mediator_doc),
             websocket_endpoint: Mediator::find_ws_endpoint(&mediator_doc),
             ws_channel_tx: RwLock::new(None),
+            ws_conn_state_rx: RwLock::new(None),
             tx_uuid: AtomicU32::new(0),
         };
 
@@ -320,6 +343,9 @@ impl Mediator {
     /// `Stop` so the task exits cleanly and drops its arcs on the way out.
     pub(crate) async fn cleanup_failed_websocket(&self) {
         let sender = self.ws_channel_tx.write().await.take();
+        // Drop the stale connection-state receiver alongside the command sender;
+        // a fresh one is installed on the next `WebSocketTransport::start`.
+        let _ = self.ws_conn_state_rx.write().await.take();
         if let Some(sender) = sender {
             let _ = sender.send(WebSocketCommands::Stop).await;
         }
@@ -436,13 +462,18 @@ impl ATM {
 
         debug!("Profile({}): enabling...", profile.inner.alias);
 
-        let (_, ws_channel) = WebSocketTransport::start(
+        let (_, ws_channel, conn_state_rx) = WebSocketTransport::start(
             profile.clone(),
             self.inner.clone(),
             self.inner.config.inbound_message_channel.clone(),
         )
         .await;
         mediator.ws_channel_tx.write().await.replace(ws_channel);
+        mediator
+            .ws_conn_state_rx
+            .write()
+            .await
+            .replace(conn_state_rx);
 
         // Every error path past WebSocketTransport::start MUST clear the
         // sender slot and tell the spawned task to stop. Otherwise the task
@@ -484,7 +515,7 @@ impl ATM {
 
         debug!("Profile({}): enabling...", profile.inner.alias);
 
-        let (_, ws_channel) = WebSocketTransport::start_with_options(
+        let (_, ws_channel, conn_state_rx) = WebSocketTransport::start_with_options(
             profile.clone(),
             self.inner.clone(),
             self.inner.config.inbound_message_channel.clone(),
@@ -493,6 +524,11 @@ impl ATM {
         )
         .await;
         mediator.ws_channel_tx.write().await.replace(ws_channel);
+        mediator
+            .ws_conn_state_rx
+            .write()
+            .await
+            .replace(conn_state_rx);
 
         // Every error path past WebSocketTransport::start_with_options MUST
         // clear the sender slot and tell the spawned task to stop. Otherwise
@@ -585,6 +621,7 @@ mod tests {
             rest_endpoint: Some("http://127.0.0.1:1/".to_string()),
             websocket_endpoint: Some("ws://127.0.0.1:1/".to_string()),
             ws_channel_tx: RwLock::new(None),
+            ws_conn_state_rx: RwLock::new(None),
             tx_uuid: AtomicU32::new(0),
         };
         Arc::new(ATMProfile {
@@ -631,7 +668,7 @@ mod tests {
 
         // Start the transport directly — same call sequence
         // `profile_enable_websocket` performs internally.
-        let (handle, ws_channel) =
+        let (handle, ws_channel, _conn_state_rx) =
             crate::transports::websockets::websocket::WebSocketTransport::start(
                 profile.clone(),
                 atm.inner.clone(),
@@ -662,6 +699,57 @@ mod tests {
             .expect("websocket task did not terminate within 15s")
             .expect("websocket task panicked");
 
+        atm.graceful_shutdown().await;
+    }
+
+    /// The connection-state signal is `None` until a transport runs, then is
+    /// exposed via `ATMProfile::connection_state()` starting at `Connecting`.
+    #[tokio::test]
+    async fn connection_state_is_exposed_and_starts_connecting() {
+        let tdk_cfg = TDKConfig::headless().expect("headless tdk config");
+        let tdk = Arc::new(
+            TDKSharedState::new(tdk_cfg)
+                .await
+                .expect("tdk shared state"),
+        );
+        let atm_cfg = ATMConfig::builder().build().expect("atm config");
+        let atm = ATM::new(atm_cfg, tdk).await.expect("atm");
+
+        let profile = fake_profile();
+
+        // No websocket transport yet → no signal.
+        assert!(
+            profile.connection_state().await.is_none(),
+            "no signal before a transport is started",
+        );
+
+        let mediator = mediator_of(&profile);
+        let (handle, ws_channel, conn_state_rx) =
+            crate::transports::websockets::websocket::WebSocketTransport::start(
+                profile.clone(),
+                atm.inner.clone(),
+                None,
+            )
+            .await;
+        mediator.ws_channel_tx.write().await.replace(ws_channel);
+        mediator
+            .ws_conn_state_rx
+            .write()
+            .await
+            .replace(conn_state_rx);
+
+        // Exposed once running, and initial state is `Connecting`. The fake
+        // mediator endpoint is a closed port, so it never reaches `Connected`
+        // and the initial state is stable for the assertion.
+        let rx = profile
+            .connection_state()
+            .await
+            .expect("connection_state present once the transport is running");
+        assert_eq!(*rx.borrow(), ConnState::Connecting);
+
+        // Tear down the spawned task.
+        mediator.cleanup_failed_websocket().await;
+        let _ = timeout(Duration::from_secs(15), handle).await;
         atm.graceful_shutdown().await;
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -4,6 +4,7 @@
 
 use super::{WebSocketResponses, ws_cache::MessageCache};
 use crate::{ATM, SharedState, errors::ATMError, profiles::ATMProfile};
+use affinidi_messaging_core::ConnState;
 use ahash::{HashMap, HashMapExt};
 use futures_util::{SinkExt, StreamExt};
 use rand::RngExt;
@@ -14,7 +15,7 @@ use tokio::{
     sync::{
         broadcast,
         mpsc::{self, Receiver, Sender},
-        oneshot,
+        oneshot, watch,
     },
     task::JoinHandle,
     time::{Interval, interval_at},
@@ -72,6 +73,13 @@ pub(crate) struct WebSocketTransport {
 
     /// Skip unpacking messages - return them as packed strings instead
     skip_unpack_messages: bool,
+
+    /// Re-falsifiable connection-state signal. A transition is published on
+    /// every successful (re)connect (`Connected`) and every drop
+    /// (`Disconnected`), so observers see live connectivity rather than a
+    /// boot-time latch. The matching `Receiver` is handed to the caller by
+    /// `start`/`start_with_options` and stored on the `Mediator`.
+    conn_state_tx: watch::Sender<ConnState>,
 }
 
 /// WebSocket Commands
@@ -112,8 +120,13 @@ impl WebSocketTransport {
         profile: Arc<ATMProfile>,
         shared: Arc<SharedState>,
         direct_channel: Option<broadcast::Sender<WebSocketResponses>>,
-    ) -> (JoinHandle<()>, Sender<WebSocketCommands>) {
+    ) -> (
+        JoinHandle<()>,
+        Sender<WebSocketCommands>,
+        watch::Receiver<ConnState>,
+    ) {
         let (task_tx, mut task_rx) = mpsc::channel::<WebSocketCommands>(32);
+        let (conn_state_tx, conn_state_rx) = watch::channel(ConnState::Connecting);
         let handle = tokio::spawn(async move {
             let mut websocket = WebSocketTransport {
                 profile: profile.clone(),
@@ -133,10 +146,11 @@ impl WebSocketTransport {
                 next_requests_list: VecDeque::new(),
                 skip_toggle_live_delivery: false,
                 skip_unpack_messages: false,
+                conn_state_tx,
             };
             websocket.run(&mut task_rx).await;
         });
-        (handle, task_tx)
+        (handle, task_tx, conn_state_rx)
     }
 
     pub(crate) async fn start_with_options(
@@ -145,8 +159,13 @@ impl WebSocketTransport {
         direct_channel: Option<broadcast::Sender<WebSocketResponses>>,
         skip_toggle_live_delivery: bool,
         skip_unpack_messages: bool,
-    ) -> (JoinHandle<()>, Sender<WebSocketCommands>) {
+    ) -> (
+        JoinHandle<()>,
+        Sender<WebSocketCommands>,
+        watch::Receiver<ConnState>,
+    ) {
         let (task_tx, mut task_rx) = mpsc::channel::<WebSocketCommands>(32);
+        let (conn_state_tx, conn_state_rx) = watch::channel(ConnState::Connecting);
         let handle = tokio::spawn(async move {
             let mut websocket = WebSocketTransport {
                 profile: profile.clone(),
@@ -166,10 +185,11 @@ impl WebSocketTransport {
                 next_requests_list: VecDeque::new(),
                 skip_toggle_live_delivery,
                 skip_unpack_messages,
+                conn_state_tx,
             };
             websocket.run(&mut task_rx).await;
         });
-        (handle, task_tx)
+        (handle, task_tx, conn_state_rx)
     }
 
     /// Starts the WebSocket Connection and management to the mediator
@@ -217,6 +237,9 @@ impl WebSocketTransport {
                         debug!("Attempt to reconnect");
                         self.web_socket = self._handle_connection(&atm).await;
                         if self.web_socket.is_some() {
+                            // Single success site for the first connect AND every
+                            // reconnect — publish the live connection signal here.
+                            let _ = self.conn_state_tx.send(ConnState::Connected);
                             // Arm the proactive-refresh timer for this socket.
                             refresh_deadline = self.refresh_deadline();
                             if notify_connection.is_some() {
@@ -540,6 +563,12 @@ impl WebSocketTransport {
     /// them, or their response was lost with the socket — so they will not be
     /// answered on the reconnected socket.
     fn fail_pending_requests(&mut self) {
+        // Every websocket drop funnels through here (missed pong, server close,
+        // reset, socket error, forced token-refresh reconnect), so this is the
+        // single place that publishes the `Disconnected` transition. The
+        // reconnect loop republishes `Connected` on the next successful connect.
+        let _ = self.conn_state_tx.send(ConnState::Disconnected);
+
         let mut notified = 0usize;
 
         // Pending `Next` waiters


### PR DESCRIPTION
## Problem

The websocket reconnect loop lives entirely inside the SDK's
`WebSocketTransport` task, and it emitted **nothing** on drop or reconnect. So
every consumer's view of connectivity — `ListenerEvent`, `ConnectionHandle`,
health flags — is a **boot-time latch**: it reflects the listener task's
lifecycle, never the SDK's own private socket reconnects. A socket that drops and
comes back (missed pong, mediator restart, token-refresh reconnect) is invisible
to callers, who keep believing they're "connected." That is the R6.2 defect and
the root of the F2/F3/F6 dead-retry / stale-status findings downstream.

## Change

Add a transport-agnostic `ConnState` (`Connecting` / `Connected` / `Disconnected`)
to `affinidi-messaging-core` — the protocol-agnostic base both DIDComm and TSP
build on — and have the DIDComm websocket transport own a
`tokio::sync::watch::<ConnState>` it publishes on:

- **`Connected`** at the single reconnect-success site (`websocket.rs`), which
  covers the first connect *and* every reconnect.
- **`Disconnected`** from `fail_pending_requests()` — the one choke point that
  all five drop paths (missed pong, server `Close`, reset, socket error, forced
  token-refresh reconnect) already funnel through, so one emit covers every drop.

Exposed additively:

```rust
impl ATMProfile {
    pub async fn connection_state(&self) -> Option<watch::Receiver<ConnState>>;
}
```

`None` for a REST-only profile. `watch` gives the re-falsifiable semantics the
delivery layer needs: observers always read the latest value, redundant identical
states collapse, and every drop/reconnect is a transition — never a latch.

## Scope / risk

- **Additive.** No existing public API changed. The internal (`pub(crate)`)
  `WebSocketTransport::start` / `start_with_options` now also return the receiver;
  all call sites updated.
- New dependency edge `affinidi-messaging-sdk → affinidi-messaging-core` (the
  natural layering direction; no new external crates — `ConnState` uses `serde`,
  already a core dep).
- `check` / `clippy` / `fmt` clean; new unit test
  (`connection_state_is_exposed_and_starts_connecting`) + existing profile tests
  green; `affinidi-messaging-didcomm-service` compiles unchanged against the SDK.
- Versions: `affinidi-messaging-core 0.1.2 → 0.1.3`,
  `affinidi-messaging-sdk 0.18.50 → 0.18.51` (both additive), CHANGELOGs updated.

Second, non-breaking increment of the messaging delivery-layer conformance work
(D1). Follows #602 (resolver survives restarts). `ConnState` is the vocabulary the
forthcoming `MessageTransport` trait's `connection_state()` will reuse.