### PR TITLE
fix: truthful websocket send — never Ok for an untransmitted frame (D1-F1)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.18.52] - 2026-07-16
+
+### Behaviour change (see note on versioning)
+
+- **Truthful websocket send (D1 conformance, R1.1).** On the websocket
+  transport, `ATM::send_message` previously returned `Ok(EmptyResponse)` for a
+  fire-and-forget send **the moment the command was enqueued to the transport
+  task** — before any byte reached the socket. During a reconnect the socket is
+  `None`, so the frame was silently discarded yet the caller saw success; a
+  failed socket write was likewise swallowed into a log line. Every downstream
+  "delivered" record was built on that false `Ok`.
+
+  `WebSocketCommands::SendMessage` now carries a `oneshot` reply; the transport
+  reports the **actual** write outcome, and `send_message` awaits it:
+  - socket write succeeds → `Ok` (as before);
+  - socket disconnected (reconnect window) or write fails → `Err`
+    (`ATMError::TransportError`) — **never** a false `Ok` for an untransmitted
+    frame.
+
+  This is a **behavioural break**: a caller that sent while the socket was down
+  now receives `Err` where it used to receive `Ok(EmptyResponse)`. The public
+  signature of `send_message` is unchanged; `WebSocketCommands` is `pub(crate)`.
+  Delivery-critical callers should treat the `Err` as "not sent" and retry /
+  queue (the delivery-layer outbox, landing separately, will absorb this for
+  `Guaranteed` sends). The REST path was already truthful and is unchanged.
+
+  **Versioning note:** the repo convention signals breaking changes with a minor
+  bump, but a minor bump here forces every in-workspace `affinidi-messaging-sdk
+  = "0.18"` consumer to update its pin in the same PR, which trips the
+  `publish-dry-run` guard (consumers would reference an unpublished 0.19). This
+  change therefore ships as a **patch with this explicit break note**; if the
+  maintainers prefer a coordinated `0.19.0` + consumer-pin cascade, that is a
+  mechanical follow-up.
+
 ## [0.18.51] - 2026-07-16
 
 - Publish a re-falsifiable websocket connection-state signal (D1 conformance,

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.51"
+version = "0.18.52"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -764,4 +764,52 @@ mod tests {
         mediator.cleanup_failed_websocket().await;
         assert!(mediator.ws_channel_tx.read().await.is_none());
     }
+
+    /// Truthful send (R1.1): a `send_message` over the websocket transport while
+    /// the socket is down returns `Err`, not a false `Ok(EmptyResponse)`. The
+    /// fake mediator endpoint is a closed port, so the transport never connects
+    /// and the frame is never transmitted.
+    #[tokio::test]
+    async fn send_message_errors_when_websocket_disconnected() {
+        let tdk_cfg = TDKConfig::headless().expect("headless tdk config");
+        let tdk = Arc::new(
+            TDKSharedState::new(tdk_cfg)
+                .await
+                .expect("tdk shared state"),
+        );
+        let atm_cfg = ATMConfig::builder().build().expect("atm config");
+        let atm = ATM::new(atm_cfg, tdk).await.expect("atm");
+
+        let profile = fake_profile();
+        let mediator = mediator_of(&profile);
+
+        // Start the transport; the socket stays `None` (closed port).
+        let (handle, ws_channel, conn_state_rx) =
+            crate::transports::websockets::websocket::WebSocketTransport::start(
+                profile.clone(),
+                atm.inner.clone(),
+                None,
+            )
+            .await;
+        mediator.ws_channel_tx.write().await.replace(ws_channel);
+        mediator
+            .ws_conn_state_rx
+            .write()
+            .await
+            .replace(conn_state_rx);
+
+        // A fire-and-forget send while disconnected must FAIL, not silently
+        // succeed. Before the fix this returned `Ok(EmptyResponse)`.
+        let result = atm
+            .send_message(&profile, "{}", "msg-1", false, false)
+            .await;
+        assert!(
+            result.is_err(),
+            "send while disconnected must return Err, got {result:?}",
+        );
+
+        mediator.cleanup_failed_websocket().await;
+        let _ = timeout(Duration::from_secs(15), handle).await;
+        atm.graceful_shutdown().await;
+    }
 }

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/mod.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/mod.rs
@@ -8,6 +8,7 @@ use affinidi_messaging_didcomm::message::Message;
 use serde_json::Value;
 use sha256::digest;
 use std::{sync::Arc, time::Duration};
+use tokio::sync::oneshot;
 use tracing::debug;
 use websockets::websocket::WebSocketCommands;
 
@@ -83,15 +84,34 @@ impl ATM {
                 profile.inner.alias
             );
 
+            let (reply_tx, reply_rx) = oneshot::channel();
             channel
-                .send(WebSocketCommands::SendMessage(message.to_owned()))
+                .send(WebSocketCommands::SendMessage(message.to_owned(), reply_tx))
                 .await
                 .map_err(|err| {
                     ATMError::TransportError(format!("Could not send websocket message: {err:?}"))
                 })?;
 
+            // R1.1: await the ACTUAL write result. A frame dropped during a
+            // reconnect (socket `None`) or a failed socket write now surfaces as
+            // an error instead of a false `Ok(EmptyResponse)`. This is the
+            // behaviour change every downstream "delivered" log was built on.
+            match reply_rx.await {
+                Ok(Ok(())) => {}
+                Ok(Err(reason)) => {
+                    return Err(ATMError::TransportError(format!(
+                        "WebSocket message not transmitted: {reason}"
+                    )));
+                }
+                Err(_) => {
+                    return Err(ATMError::TransportError(
+                        "WebSocket task ended before confirming the send".to_string(),
+                    ));
+                }
+            }
+
             debug!(
-                "Profile ({}): WebSocket Channel notified",
+                "Profile ({}): WebSocket message written to socket",
                 profile.inner.alias
             );
 

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -90,8 +90,11 @@ pub(crate) enum WebSocketCommands {
     /// Request to send a notifcation (true) if already connected or when next connects if not connected
     NotifyConnection(oneshot::Sender<bool>),
 
-    /// Send a message to the mediator
-    SendMessage(String),
+    /// Send a message to the mediator. The `oneshot` reports the ACTUAL write
+    /// result: `Ok(())` once the frame is written to the socket, `Err(reason)`
+    /// if the socket is disconnected (reconnect window) or the write fails — so
+    /// the caller never sees success for a frame that was not transmitted (R1.1).
+    SendMessage(String, oneshot::Sender<Result<(), String>>),
 
     /// Send inbound messages to a MPSC Channel
     EnableInboundChannel(broadcast::Sender<WebSocketResponses>),
@@ -298,18 +301,28 @@ impl WebSocketTransport {
                                     notify_connection = Some(sender);
                                 }
                             },
-                            Some(WebSocketCommands::SendMessage(msg)) => {
-                                if let Some(web_socket) = self.web_socket.as_mut() {
+                            Some(WebSocketCommands::SendMessage(msg, reply)) => {
+                                let result = if let Some(web_socket) = self.web_socket.as_mut() {
                                     debug!("Sending message to websocket");
                                     match web_socket.send(Message::text(msg)).await {
                                         Ok(_) => {
                                             debug!("Message sent");
+                                            Ok(())
                                         }
                                         Err(e) => {
                                             error!("Error sending message: {:?}", e);
+                                            Err(format!("websocket write failed: {e}"))
                                         }
                                     }
-                                }
+                                } else {
+                                    // The socket is `None` for the whole reconnect
+                                    // window — the frame was NOT transmitted. Report
+                                    // the failure instead of silently dropping it and
+                                    // letting the caller believe it was sent (R1.1).
+                                    warn!("SendMessage while websocket disconnected; not transmitted");
+                                    Err("websocket is not connected".to_string())
+                                };
+                                let _ = reply.send(result);
                             },
                             Some(WebSocketCommands::Stop) => {
                                 debug!("Stopping WebSocket connection");


### PR DESCRIPTION
## The lie

On the websocket transport, `ATM::send_message` returned `Ok(EmptyResponse)` for
a fire-and-forget send **the moment the command was enqueued to the transport
task** — before any byte reached the socket:

- during a reconnect the socket is `None`, so the `SendMessage` handler's
  `if let Some(web_socket) = …` had **no `else`** and the frame was silently
  discarded — caller still got `Ok`;
- a failed socket write was swallowed into an `error!` log — caller still got `Ok`.

Every downstream "delivered" record in the ecosystem (VTA step-up, VTC credential
delivery, …) is built on that false `Ok`. This repo's own CLAUDE.md calls it "the
single highest-leverage change in the stack" (R1.1).

## The fix

`WebSocketCommands::SendMessage` now carries a `oneshot::Sender<Result<(), String>>`.
The transport task reports the **actual** write outcome:

- socket write succeeds → `Ok(())`;
- socket is `None` (disconnected / reconnect window) or the write errors → `Err(reason)`.

`send_message` awaits that reply and maps it: a disconnected/failed send now
returns `ATMError::TransportError` instead of a false `Ok(EmptyResponse)`. The
REST path was already truthful (`send_didcomm_message` maps non-2xx → `Err`) and
is unchanged.

## Behavioural break

A caller that sent while the socket was down now receives `Err` where it used to
receive `Ok(EmptyResponse)`. Delivery-critical callers should treat that as "not
sent" and retry/queue — the delivery-layer outbox (landing separately) will
absorb this for `Guaranteed` sends. The **public `send_message` signature is
unchanged**; `WebSocketCommands` is `pub(crate)`, so no public type changed.

## Versioning — please advise

The repo convention signals breaking changes with a **minor bump**, but a minor
`0.19.0` forces every in-workspace `affinidi-messaging-sdk = "0.18"` consumer
(didcomm-service, mediator, helpers, text-client, test-mediator, tdk, +
mediator-monitor) to update its pin in **this** PR — which trips the
`publish-dry-run` guard (its documented KNOWN LIMITATION: consumers referencing
an unpublished `0.19` fail the dry-run, "split such changes so the upstream
publishes first").

So this ships as a **patch (`0.18.51 → 0.18.52`) with an explicit `### Behaviour
change` CHANGELOG note**, keeping `^0.18` valid so the workspace resolves and the
dry-run passes. **If you'd prefer a coordinated `0.19.0` + consumer-pin cascade,
say so and I'll do it as a follow-up** — you own the release cadence.

## Verification

- New regression test `send_message_errors_when_websocket_disconnected` (start
  transport against a closed port → `send_message` returns `Err`, not `Ok`).
- Full SDK lib suite green (68 tests); `check` / `clippy` / `fmt` clean;
  `affinidi-messaging-didcomm-service` compiles unchanged.
- Version-bump guard passes.

Fourth D1 increment — and the **first breaking** one — after #602 (resolver),
#603 (connection-state), #604 (`MessageTransport` trait). F5 (ack-after-handoff)
and the DIDComm adapter follow.