### PR TITLE
fix: ack live inbound messages after handoff, not on receipt (D1-F5)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.3.19] - 2026-07-16
+
+- Ack (delete) live inbound messages only AFTER the handler has processed them,
+  not on receipt (D1-F5, R1.6/R1.7). `process_next_message` used
+  `live_stream_next(auto_delete = true)`, which deleted the mediator's copy the
+  instant the frame arrived — then dispatched the message to the handler in a
+  *spawned* task. A teardown (or crash) between the delete and the handler
+  running lost the message permanently, since the mediator had already dropped
+  it. The live path now pulls with `auto_delete = false` and acks via
+  `delete_message_background` inside `dispatch_message`, once the handler has had
+  the message; a teardown before that leaves the message queued for redelivery
+  on the next pickup instead. The operator's `auto_delete = false` opt-out is
+  honoured (no ack at all). Behaviour is otherwise unchanged: the offline-sync
+  drain already batch-acked after dispatch, and the TSP-multiplexed live path is
+  unchanged (its ack-after-handoff lands with TSP conformance). Failed acks are
+  non-fatal — the message is redelivered and de-duplicated by the receiver.
+
 ## [0.3.18] - 2026-07-16
 
 - Keep the caller-seeded DID resolver across listener restarts (D1-F4).

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.18"
+version = "0.3.19"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/listener.rs
@@ -269,24 +269,42 @@ impl Listener {
         }
 
         let wait_duration = Duration::from_secs(self.config.message_wait_duration_secs);
-        let auto_delete = self.config.auto_delete;
         let atm = self.atm()?;
         let profile = self.profile()?;
 
+        // R1.6/R1.7: pull the message WITHOUT acking it to the mediator
+        // (`auto_delete = false`). The mediator keeps its copy until we ack —
+        // and we ack only after the handler has processed the message, in
+        // `dispatch_message`. Acking on receipt (the old default) meant a
+        // teardown between receipt and the spawned handler task losing the
+        // message forever.
         let next = atm
             .message_pickup()
-            .live_stream_next(profile, Some(wait_duration), auto_delete)
+            .live_stream_next(profile, Some(wait_duration), false)
             .await
             .map_err(DIDCommServiceError::ATM)?;
 
         if let Some((message, meta)) = next {
+            // The mediator's queue-id (hash) for this frame, used to ack it
+            // after handoff. Honour the operator's `auto_delete = false` opt-out
+            // by acking only when auto-delete is enabled (the default).
+            let ack_id = self.config.auto_delete.then(|| meta.sha256_hash.clone());
             let meta = convert_meta(*meta);
             let listener_id = self.config.id.clone();
             let atm = atm.clone();
             let profile = profile.clone();
             let handler = self.handler.clone();
             tasks.spawn(async move {
-                Self::dispatch_message(&listener_id, &atm, &profile, &handler, message, meta).await;
+                Self::dispatch_message(
+                    &listener_id,
+                    &atm,
+                    &profile,
+                    &handler,
+                    message,
+                    meta,
+                    ack_id,
+                )
+                .await;
             });
         }
 
@@ -318,8 +336,19 @@ impl Listener {
                 let profile = profile.clone();
                 let handler = self.handler.clone();
                 tasks.spawn(async move {
-                    Self::dispatch_message(&listener_id, &atm, &profile, &handler, *message, meta)
-                        .await;
+                    // TSP-multiplexed path (phase 4): still acks on receipt via
+                    // `auto_delete` in `live_stream_next_frame`, so no
+                    // post-handoff ack here yet.
+                    Self::dispatch_message(
+                        &listener_id,
+                        &atm,
+                        &profile,
+                        &handler,
+                        *message,
+                        meta,
+                        None,
+                    )
+                    .await;
                 });
             }
             Some(InboundFrame::Tsp(packed)) => {
@@ -445,6 +474,10 @@ impl Listener {
         handler: &Arc<dyn DIDCommHandler>,
         message: affinidi_messaging_didcomm::Message,
         meta: affinidi_messaging_didcomm::UnpackMetadata,
+        // Mediator queue-id to ack (delete) AFTER handoff. `None` when the
+        // caller acks elsewhere (the TSP-multiplexed path) or `auto_delete` is
+        // off.
+        ack_id: Option<String>,
     ) {
         let sender_did = message.from.clone();
         let thread_id = get_thread_id(&message);
@@ -471,6 +504,17 @@ impl Listener {
             Err(e) => {
                 warn!(profile = %profile_alias, error = %e, "Unhandled handler error");
             }
+        }
+
+        // R1.6: ack (delete from the mediator) only NOW — after the handler has
+        // had the message. If the process is torn down before this line the
+        // message stays queued at the mediator and is redelivered on the next
+        // pickup, rather than being lost. A failed ack is non-fatal: the message
+        // is redelivered and de-duplicated by the receiver instead.
+        if let Some(sha256_hash) = ack_id
+            && let Err(e) = atm.delete_message_background(profile, &sha256_hash).await
+        {
+            warn!(profile = %profile_alias, error = %e, "Failed to ack (delete) message after handoff");
         }
     }
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -150,6 +150,8 @@ impl Listener {
                 match frame {
                     Some(InboundFrame::DidComm(message, meta)) => {
                         let meta = super::listener::convert_meta(*meta);
+                        // Offline drain acks the whole batch below via
+                        // `send_messages_received`, so no per-message ack here.
                         Listener::dispatch_message(
                             listener_id,
                             atm,
@@ -157,6 +159,7 @@ impl Listener {
                             handler,
                             *message,
                             meta,
+                            None,
                         )
                         .await;
                     }
@@ -208,7 +211,10 @@ impl Listener {
 
             for (message, meta) in offline_messages {
                 let meta = super::listener::convert_meta(meta);
-                Listener::dispatch_message(listener_id, atm, profile, handler, message, meta).await;
+                // Offline drain acks the whole batch below via
+                // `send_messages_received`, so no per-message ack here.
+                Listener::dispatch_message(listener_id, atm, profile, handler, message, meta, None)
+                    .await;
             }
 
             let delete_result = atm


### PR DESCRIPTION
## The bug (ack-before-handoff)

The live listener path `process_next_message` pulled the next message with
`live_stream_next(auto_delete = true)` — which **deletes the mediator's copy the
instant the frame arrives** — and *then* dispatched the message to the handler in
a **spawned** task:

```rust
let next = live_stream_next(profile, wait, /* auto_delete */ true).await?; // deletes NOW
if let Some((message, meta)) = next {
    tasks.spawn(async move { dispatch_message(...).await; });             // handler runs LATER
}
```

So the mediator dropped its copy before the handler ran. A teardown or crash
between the delete and the handler processing the message **lost it
permanently** — the mediator never redelivers an already-deleted message. This
is the R1.6 (persist-before-ack) / R1.7 (single dispatcher owns delete) class the
delivery-layer work targets.

## The fix (ack-after-handoff)

- `process_next_message` now pulls with `auto_delete = false` — the mediator
  keeps its copy.
- The ack (`delete_message_background`) moves **into `dispatch_message`, after
  `handler.handle` has processed the message**. A teardown before that leaves the
  message queued for redelivery on the next pickup instead of losing it.
- The operator's `auto_delete = false` opt-out is honoured (no ack at all) — the
  ack id is `None` in that case.
- A failed ack is non-fatal: the message is redelivered and de-duplicated by the
  receiver (at-least-once).

Mechanically, `dispatch_message` gains an `ack_id: Option<String>` (the mediator
queue-id / sha256, extracted before `convert_meta` drops it). It is `pub(crate)`
— **no public API change**.

## Deliberately unchanged

- **Offline-sync drain** (`mediator.rs`) — already batch-acks *after* dispatching
  the whole backlog via `send_messages_received`; both its call sites pass
  `ack_id = None`, so its behaviour is identical.
- **TSP-multiplexed live path** (`process_next_frame`, `#[cfg(feature = "tsp")]`)
  — keeps its current `auto_delete` behaviour (`ack_id = None`); its
  ack-after-handoff lands with TSP conformance (phase 4).

## Verification

- 77 lib tests pass in **both** default and `--features tsp`; `check` / `clippy`
  / `fmt` clean in both.
- The one failing integration test (`soft_restart_does_not_leak_a_dueling_websocket`)
  is **pre-existing and environmental** — it fails identically on clean `main`
  (`service 1 connects to mediator: Timeout`, an in-process `TestMediator`
  sandbox limitation) and touches none of this code. It runs in CI.
- Version-bump guard passes (`0.3.18 → 0.3.19`).

Fifth D1 increment (second breaking), after #602/#603/#604/#605. The DIDComm
`MessageTransport` adapter + conformance suite are the remaining Phase-1 work.