### PR TITLE
feat: affinidi-messaging-delivery — durable outbox + drain (D1 Phase 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 
   # Messaging: core, DIDComm, TSP, SDK, mediator
   "crates/messaging/affinidi-messaging-core",
+  "crates/messaging/affinidi-messaging-delivery",
   "crates/messaging/affinidi-messaging-didcomm",
   "crates/messaging/affinidi-tsp",
   "crates/messaging/affinidi-messaging-sdk",

--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [0.1.0] - 2026-07-16
+
+Initial release — the durable outbox and its drain, the first increment of the
+reliable messaging delivery layer (D1 Phase 2) over the `MessageTransport`
+contract in `affinidi-messaging-core`.
+
+- `OutboxEntry` + `OutboxState` (`Queued → Sent → Delivered | Unconfirmed |
+  Failed`; `Sent` is hop-accept, **not** delivered).
+- `OutboxStore` trait + `InMemoryOutboxStore`, with per-`ordering_key` FIFO
+  gating in `due`.
+- `drain_once` / `drain_loop`: send due entries over a `MessageTransport`, mark
+  `Sent` on a truthful hop-accept (and stop re-sending — the mediator owns
+  redelivery), retry with exponential backoff on failure, and settle `Failed`
+  when the delivery window expires while still queued.
+
+End-to-end confirmation (`Sent → Delivered`) and the `MessagingService`
+front-end build on this in later increments.

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "affinidi-messaging-delivery"
+description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+readme = "README.md"
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+repository.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+# The transport-agnostic contract the delivery layer builds reliability on.
+affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.4" }
+async-trait = "0.1"
+thiserror = "2"
+tracing = "0.1"
+# `drain_loop` schedules the periodic drain; the core `drain_once` takes the
+# clock as a parameter and needs no runtime.
+tokio = { version = "1", default-features = false, features = ["time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "time", "sync"] }
+futures-util = "0.3"
+
+[lints]
+workspace = true

--- a/crates/messaging/affinidi-messaging-delivery/README.md
+++ b/crates/messaging/affinidi-messaging-delivery/README.md
@@ -1,0 +1,22 @@
+# affinidi-messaging-delivery
+
+The reliable **messaging delivery layer** for the Affinidi messaging stack. It
+sits just above the transports (`MessageTransport` in `affinidi-messaging-core`)
+and turns "truthful send" into effectively-once delivery for delivery-critical
+traffic, independent of the wire (DIDComm, TSP, REST).
+
+This first increment provides the **durable outbox** and its **drain loop**:
+
+- `OutboxEntry` — a transport-independent unit of delivery-critical work, keyed
+  by an idempotency key, with a lifecycle `Queued → Sent → Delivered |
+  Unconfirmed | Failed`.
+- `OutboxStore` — the storage abstraction (an in-memory store ships here;
+  services back it with a durable store, e.g. fjall).
+- `drain_once` / `drain_loop` — pick due entries, send them over a
+  `MessageTransport`, mark `Sent` on hop-acceptance (and **stop re-sending** —
+  the mediator owns redelivery), or retry with exponential backoff on failure.
+
+End-to-end delivery **confirmation** (`Sent → Delivered`, the §5a layer-receipt /
+protocol-reply / outbox-drain / escalate logic) and the `MessagingService`
+front-end (`send` / `request` / `subscribe` / `status`) build on this in
+subsequent increments.

--- a/crates/messaging/affinidi-messaging-delivery/src/drain.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/drain.rs
@@ -1,0 +1,254 @@
+//! The drain: send due outbox entries over a [`MessageTransport`], advancing
+//! their state on a truthful hop-accept (`Sent`) or rescheduling with backoff on
+//! failure.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use affinidi_messaging_core::MessageTransport;
+
+use crate::outbox::{OutboxError, OutboxState, OutboxStore};
+
+/// First-retry backoff.
+const BACKOFF_BASE_MS: u64 = 1_000;
+/// Backoff ceiling.
+const BACKOFF_CAP_MS: u64 = 60_000;
+
+/// Exponential backoff for the `attempts`-th failed send: 1s, 2s, 4s, … capped
+/// at 60s. `attempts == 0` is `0` (a fresh entry attempts immediately).
+///
+/// Jitter is deliberately omitted here so a drain is deterministic; a scheduler
+/// that needs anti-thundering-herd jitter can add it around this base.
+pub fn backoff_ms(attempts: u32) -> u64 {
+    if attempts == 0 {
+        return 0;
+    }
+    let shift = (attempts - 1).min(6); // 2^6 · base = 64s > cap
+    (BACKOFF_BASE_MS << shift).min(BACKOFF_CAP_MS)
+}
+
+/// What one [`drain_once`] pass did.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DrainReport {
+    /// Entries the transport hop-accepted this pass (→ `Sent`).
+    pub sent: usize,
+    /// Entries whose send failed and were rescheduled with backoff (stay
+    /// `Queued`).
+    pub retried: usize,
+    /// Entries whose delivery window expired while still queued (→ `Failed`).
+    pub failed: usize,
+}
+
+/// One drain pass at logical time `now_ms`: attempt every due entry once.
+///
+/// - **window expired** (`now_ms >= deliver_by_ms`) while still `Queued`: the
+///   entry never hop-accepted in time and delivery was expected → `Failed`
+///   (surfaced/escalated, never a silent success).
+/// - **`Ok(hop-accept)`** → `Sent`; the entry is **not** re-sent (the mediator
+///   owns redelivery — re-sending would double-send). End-to-end confirmation
+///   (`Sent → Delivered`) is a separate step.
+/// - **`Err`** (transport down / send failed): stay `Queued`, bump `attempts`,
+///   schedule `next_attempt_at_ms` with [`backoff_ms`].
+pub async fn drain_once(
+    store: &dyn OutboxStore,
+    transport: &dyn MessageTransport,
+    now_ms: u64,
+) -> Result<DrainReport, OutboxError> {
+    let due = store.due(now_ms).await?;
+    let mut report = DrainReport::default();
+
+    for mut entry in due {
+        if now_ms >= entry.deliver_by_ms {
+            entry.state = OutboxState::Failed;
+            store.put(entry).await?;
+            report.failed += 1;
+            continue;
+        }
+
+        match transport.send(&entry.dest_did, entry.packed.clone()).await {
+            Ok(_receipt) => {
+                entry.state = OutboxState::Sent;
+                store.put(entry).await?;
+                report.sent += 1;
+            }
+            Err(_e) => {
+                entry.attempts += 1;
+                entry.next_attempt_at_ms = now_ms.saturating_add(backoff_ms(entry.attempts));
+                store.put(entry).await?;
+                report.retried += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Run [`drain_once`] every `interval`, forever (until the task is dropped),
+/// using the wall clock. A store error on one tick is logged and retried on the
+/// next — the drain never aborts on a transient backend hiccup.
+pub async fn drain_loop(
+    store: Arc<dyn OutboxStore>,
+    transport: Arc<dyn MessageTransport>,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    loop {
+        ticker.tick().await;
+        match drain_once(store.as_ref(), transport.as_ref(), now_unix_ms()).await {
+            Ok(report) if report != DrainReport::default() => {
+                tracing::debug!(
+                    sent = report.sent,
+                    retried = report.retried,
+                    failed = report.failed,
+                    "outbox drain pass",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "outbox drain pass failed; retrying next tick"),
+        }
+    }
+}
+
+/// Current wall-clock time in Unix milliseconds (`0` before the epoch, which
+/// cannot happen in practice).
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outbox::{InMemoryOutboxStore, OutboxEntry};
+    use affinidi_messaging_core::{
+        ConnState, Inbound, InboundAck, MessageTransport, MessagingError, SendReceipt,
+        TransportKind,
+    };
+    use futures_util::stream::{self, BoxStream};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::watch;
+
+    /// A controllable transport: `send` succeeds and records the payload, or
+    /// fails when `fail` is set.
+    struct MockTransport {
+        fail: AtomicBool,
+        sent: Mutex<Vec<Vec<u8>>>,
+        _conn_tx: watch::Sender<ConnState>,
+        conn_rx: watch::Receiver<ConnState>,
+    }
+
+    impl MockTransport {
+        fn new(fail: bool) -> Self {
+            let (tx, rx) = watch::channel(ConnState::Connected);
+            Self {
+                fail: AtomicBool::new(fail),
+                sent: Mutex::new(Vec::new()),
+                _conn_tx: tx,
+                conn_rx: rx,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MessageTransport for MockTransport {
+        fn kind(&self) -> TransportKind {
+            TransportKind::Didcomm
+        }
+        async fn send(&self, _dest: &str, packed: Vec<u8>) -> Result<SendReceipt, MessagingError> {
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(MessagingError::Transport("mock send failed".into()));
+            }
+            self.sent.lock().unwrap().push(packed);
+            Ok(SendReceipt {
+                via: TransportKind::Didcomm,
+                hop_id: None,
+            })
+        }
+        fn connection_state(&self) -> watch::Receiver<ConnState> {
+            self.conn_rx.clone()
+        }
+        fn inbound(&self) -> BoxStream<'static, Inbound> {
+            Box::pin(stream::empty())
+        }
+        async fn ack(&self, _ack: InboundAck) -> Result<(), MessagingError> {
+            Ok(())
+        }
+    }
+
+    fn queued(key: &str, now: u64) -> OutboxEntry {
+        OutboxEntry::new(key, "did:example:bob", vec![9, 9], now, now + 60_000)
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        assert_eq!(backoff_ms(0), 0);
+        assert_eq!(backoff_ms(1), 1_000);
+        assert_eq!(backoff_ms(2), 2_000);
+        assert_eq!(backoff_ms(3), 4_000);
+        assert_eq!(backoff_ms(7), 60_000); // capped
+        assert_eq!(backoff_ms(100), 60_000);
+    }
+
+    #[tokio::test]
+    async fn hop_accept_marks_sent_and_transmits_once() {
+        let store = InMemoryOutboxStore::new();
+        store.put(queued("k1", 1_000)).await.unwrap();
+        let transport = MockTransport::new(false);
+
+        let report = drain_once(&store, &transport, 1_000).await.unwrap();
+        assert_eq!(report.sent, 1);
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Sent
+        );
+        assert_eq!(transport.sent.lock().unwrap().len(), 1);
+
+        // A second drain does NOT re-send a Sent entry.
+        let report = drain_once(&store, &transport, 2_000).await.unwrap();
+        assert_eq!(report, DrainReport::default());
+        assert_eq!(transport.sent.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_failure_reschedules_with_backoff() {
+        let store = InMemoryOutboxStore::new();
+        store.put(queued("k1", 1_000)).await.unwrap();
+        let transport = MockTransport::new(true);
+
+        let report = drain_once(&store, &transport, 1_000).await.unwrap();
+        assert_eq!(report.retried, 1);
+        let e = store.get("k1").await.unwrap().unwrap();
+        assert_eq!(e.state, OutboxState::Queued);
+        assert_eq!(e.attempts, 1);
+        assert_eq!(e.next_attempt_at_ms, 1_000 + backoff_ms(1));
+
+        // Not due again until the backoff elapses.
+        assert!(store.due(1_500).await.unwrap().is_empty());
+        assert_eq!(store.due(2_000).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn window_expiry_fails_without_sending() {
+        let store = InMemoryOutboxStore::new();
+        // deliver_by is now + 60_000; drain past it.
+        store.put(queued("k1", 1_000)).await.unwrap();
+        let transport = MockTransport::new(false);
+
+        let report = drain_once(&store, &transport, 1_000 + 60_000)
+            .await
+            .unwrap();
+        assert_eq!(report.failed, 1);
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Failed
+        );
+        assert!(
+            transport.sent.lock().unwrap().is_empty(),
+            "expired entry is not sent"
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-delivery/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/lib.rs
@@ -1,0 +1,26 @@
+//! Reliable messaging delivery layer over the [`MessageTransport`] contract.
+//!
+//! The layer turns a transport's *truthful send* into effectively-once delivery
+//! for delivery-critical (`Guaranteed`) traffic, independent of the wire. This
+//! crate's first increment is the **durable outbox** ([`outbox`]) and its
+//! **drain** ([`drain`]):
+//!
+//! - an [`OutboxEntry`] is a transport-independent unit of delivery-critical
+//!   work, keyed by an idempotency key, with a lifecycle
+//!   `Queued → Sent → Delivered | Unconfirmed | Failed`;
+//! - an [`OutboxStore`] persists entries (an in-memory store ships here;
+//!   services back it with a durable store);
+//! - [`drain_once`] / [`drain_loop`] pick due entries, send them over a
+//!   [`MessageTransport`], mark `Sent` on hop-acceptance (and stop re-sending —
+//!   the mediator owns redelivery), or retry with exponential backoff.
+//!
+//! End-to-end confirmation (`Sent → Delivered`) and the `MessagingService`
+//! front-end build on this in later increments.
+//!
+//! [`MessageTransport`]: affinidi_messaging_core::MessageTransport
+
+pub mod drain;
+pub mod outbox;
+
+pub use drain::{DrainReport, drain_loop, drain_once};
+pub use outbox::{InMemoryOutboxStore, Key, OutboxEntry, OutboxError, OutboxState, OutboxStore};

--- a/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
@@ -1,0 +1,287 @@
+//! The durable outbox: the model, the [`OutboxStore`] storage abstraction, and
+//! an in-memory implementation.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// An idempotency or ordering key. The idempotency key is the dedup anchor; the
+/// ordering key groups entries into a per-key FIFO.
+pub type Key = String;
+
+/// Lifecycle state of an outbox entry. Terminal states are `Delivered`,
+/// `Unconfirmed`, and `Failed`.
+///
+/// `Sent` is **not** terminal and **not** "delivered": it means the next hop
+/// accepted the bytes (durably queued at the mediator) and we are awaiting
+/// end-to-end evidence. Confirmation (`Sent → Delivered`) lands in a later
+/// increment; until then a `Sent` entry is simply not re-sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OutboxState {
+    /// Not yet handed off, or a failed attempt awaiting its next retry.
+    Queued,
+    /// Hop-accepted; awaiting end-to-end evidence. Not re-sent.
+    Sent,
+    /// Positive end-to-end evidence received.
+    Delivered,
+    /// The delivery window passed with no evidence possible — a truthful "we
+    /// can't know", never a false "delivered".
+    Unconfirmed,
+    /// The delivery window passed with delivery expected but unconfirmed —
+    /// escalated (surfaced), never silently dropped.
+    Failed,
+}
+
+impl OutboxState {
+    /// Whether no further work will change this entry.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            OutboxState::Delivered | OutboxState::Unconfirmed | OutboxState::Failed
+        )
+    }
+}
+
+/// A durable, transport-independent unit of delivery-critical work.
+///
+/// The entry records **who** the message is for (`dest_did`), not which wire —
+/// the transport is resolved at drain time. Timestamps are Unix milliseconds;
+/// the drain takes the clock as a parameter so it stays deterministic in tests.
+#[derive(Debug, Clone)]
+pub struct OutboxEntry {
+    /// Dedup anchor. The receiver drops a duplicate carrying the same key, which
+    /// is what makes at-least-once retry safe.
+    pub idempotency_key: Key,
+    /// The recipient DID (who), not the wire.
+    pub dest_did: String,
+    /// `None` = drain in parallel; `Some(k)` = per-`k` FIFO (an entry is due only
+    /// if no earlier-enqueued entry with the same key is still non-terminal).
+    pub ordering_key: Option<Key>,
+    /// The already-packed message to hand to `MessageTransport::send`.
+    pub packed: Vec<u8>,
+    /// Lifecycle state.
+    pub state: OutboxState,
+    /// Number of send attempts made so far.
+    pub attempts: u32,
+    /// Unix-ms time this entry is next eligible for a send attempt (backoff).
+    pub next_attempt_at_ms: u64,
+    /// Unix-ms time the entry was enqueued (FIFO ordering anchor).
+    pub created_at_ms: u64,
+    /// Unix-ms delivery-window deadline — the acceptable recovery time. Past
+    /// this without success the entry settles visibly, never a silent success.
+    pub deliver_by_ms: u64,
+}
+
+impl OutboxEntry {
+    /// A fresh `Queued` entry, eligible for an immediate first attempt.
+    pub fn new(
+        idempotency_key: impl Into<Key>,
+        dest_did: impl Into<String>,
+        packed: Vec<u8>,
+        created_at_ms: u64,
+        deliver_by_ms: u64,
+    ) -> Self {
+        Self {
+            idempotency_key: idempotency_key.into(),
+            dest_did: dest_did.into(),
+            ordering_key: None,
+            packed,
+            state: OutboxState::Queued,
+            attempts: 0,
+            next_attempt_at_ms: created_at_ms,
+            created_at_ms,
+            deliver_by_ms,
+        }
+    }
+
+    /// Builder-style: set the ordering key (per-key FIFO drain).
+    pub fn with_ordering_key(mut self, key: impl Into<Key>) -> Self {
+        self.ordering_key = Some(key.into());
+        self
+    }
+}
+
+/// Errors from an [`OutboxStore`] backend.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum OutboxError {
+    /// The backing store failed (I/O, serialization, lock poisoning, …).
+    #[error("outbox store backend error: {0}")]
+    Backend(String),
+}
+
+/// Durable storage for outbox entries. Services implement this over a durable
+/// store (e.g. fjall); [`InMemoryOutboxStore`] is provided for tests and
+/// ephemeral use.
+///
+/// `put` is an upsert keyed by `idempotency_key`, so re-persisting a mutated
+/// entry (new state / attempts / backoff) replaces it. `due` encodes the
+/// ordering-key FIFO gate so the drain doesn't have to.
+#[async_trait::async_trait]
+pub trait OutboxStore: Send + Sync {
+    /// Insert or replace an entry, keyed by its `idempotency_key`.
+    async fn put(&self, entry: OutboxEntry) -> Result<(), OutboxError>;
+
+    /// Look up an entry by idempotency key.
+    async fn get(&self, idempotency_key: &str) -> Result<Option<OutboxEntry>, OutboxError>;
+
+    /// Entries that are ready for a send attempt now: `Queued`, with
+    /// `next_attempt_at_ms <= now_ms`, and — for entries with an `ordering_key`
+    /// — only the earliest-enqueued non-terminal entry per key (so a per-key
+    /// FIFO is preserved). Returned oldest-first.
+    async fn due(&self, now_ms: u64) -> Result<Vec<OutboxEntry>, OutboxError>;
+}
+
+/// A non-durable [`OutboxStore`] backed by a `HashMap`. For tests and ephemeral
+/// use — a process restart loses queued work, so services back the outbox with
+/// a durable store in production.
+#[derive(Debug, Default)]
+pub struct InMemoryOutboxStore {
+    entries: Mutex<HashMap<Key, OutboxEntry>>,
+}
+
+impl InMemoryOutboxStore {
+    /// A new, empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<Key, OutboxEntry>>, OutboxError> {
+        self.entries
+            .lock()
+            .map_err(|_| OutboxError::Backend("outbox mutex poisoned".to_string()))
+    }
+}
+
+#[async_trait::async_trait]
+impl OutboxStore for InMemoryOutboxStore {
+    async fn put(&self, entry: OutboxEntry) -> Result<(), OutboxError> {
+        self.lock()?.insert(entry.idempotency_key.clone(), entry);
+        Ok(())
+    }
+
+    async fn get(&self, idempotency_key: &str) -> Result<Option<OutboxEntry>, OutboxError> {
+        Ok(self.lock()?.get(idempotency_key).cloned())
+    }
+
+    async fn due(&self, now_ms: u64) -> Result<Vec<OutboxEntry>, OutboxError> {
+        let entries = self.lock()?;
+
+        // Per ordering-key FIFO head: the earliest-enqueued NON-TERMINAL entry
+        // for each key gates the rest. Entries with no ordering key are
+        // independent.
+        let mut head_created_at: HashMap<&Key, u64> = HashMap::new();
+        for e in entries.values() {
+            if e.state.is_terminal() {
+                continue;
+            }
+            if let Some(key) = &e.ordering_key {
+                let head = head_created_at.entry(key).or_insert(e.created_at_ms);
+                if e.created_at_ms < *head {
+                    *head = e.created_at_ms;
+                }
+            }
+        }
+
+        let mut due: Vec<OutboxEntry> = entries
+            .values()
+            .filter(|e| e.state == OutboxState::Queued && e.next_attempt_at_ms <= now_ms)
+            .filter(|e| match &e.ordering_key {
+                // Only the FIFO head for this key is eligible.
+                Some(key) => head_created_at.get(key) == Some(&e.created_at_ms),
+                None => true,
+            })
+            .cloned()
+            .collect();
+
+        // Oldest-first, tie-broken by key for determinism.
+        due.sort_by(|a, b| {
+            a.created_at_ms
+                .cmp(&b.created_at_ms)
+                .then_with(|| a.idempotency_key.cmp(&b.idempotency_key))
+        });
+        Ok(due)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(key: &str, created: u64) -> OutboxEntry {
+        OutboxEntry::new(
+            key,
+            "did:example:bob",
+            vec![1, 2, 3],
+            created,
+            created + 60_000,
+        )
+    }
+
+    #[tokio::test]
+    async fn put_get_roundtrip_and_replace() {
+        let store = InMemoryOutboxStore::new();
+        store.put(entry("k1", 100)).await.unwrap();
+        assert_eq!(store.get("k1").await.unwrap().unwrap().attempts, 0);
+
+        // Upsert by idempotency key: a mutated copy replaces the original.
+        let mut e = store.get("k1").await.unwrap().unwrap();
+        e.attempts = 3;
+        e.state = OutboxState::Sent;
+        store.put(e).await.unwrap();
+        let got = store.get("k1").await.unwrap().unwrap();
+        assert_eq!(got.attempts, 3);
+        assert_eq!(got.state, OutboxState::Sent);
+    }
+
+    #[tokio::test]
+    async fn due_excludes_future_backoff_terminal_and_sent() {
+        let store = InMemoryOutboxStore::new();
+        store.put(entry("ready", 100)).await.unwrap();
+
+        let mut future = entry("future", 100);
+        future.next_attempt_at_ms = 10_000; // not yet due
+        store.put(future).await.unwrap();
+
+        let mut sent = entry("sent", 100);
+        sent.state = OutboxState::Sent; // awaiting confirmation, not re-sent
+        store.put(sent).await.unwrap();
+
+        let mut done = entry("done", 100);
+        done.state = OutboxState::Delivered; // terminal
+        store.put(done).await.unwrap();
+
+        let due = store.due(1_000).await.unwrap();
+        let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
+        assert_eq!(keys, vec!["ready"]);
+    }
+
+    #[tokio::test]
+    async fn ordering_key_gates_to_the_fifo_head() {
+        let store = InMemoryOutboxStore::new();
+        // Two entries share an ordering key; only the earliest-enqueued is due.
+        store
+            .put(entry("a", 100).with_ordering_key("did:webvh:x"))
+            .await
+            .unwrap();
+        store
+            .put(entry("b", 200).with_ordering_key("did:webvh:x"))
+            .await
+            .unwrap();
+        // An independent (no ordering key) entry is always due.
+        store.put(entry("c", 150)).await.unwrap();
+
+        let due = store.due(1_000).await.unwrap();
+        let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
+        // "a" (head of the ordered key) + "c" (independent); "b" waits behind "a".
+        assert_eq!(keys, vec!["a", "c"]);
+
+        // Once "a" reaches a terminal state, "b" becomes the head and is due.
+        let mut a = store.get("a").await.unwrap().unwrap();
+        a.state = OutboxState::Delivered;
+        store.put(a).await.unwrap();
+        let due = store.due(1_000).await.unwrap();
+        let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
+        assert_eq!(keys, vec!["c", "b"]);
+    }
+}


### PR DESCRIPTION
## What

A **new crate**, `affinidi-messaging-delivery` — the first increment of the
reliable messaging delivery layer (D1 Phase 2). It turns a transport's *truthful
send* (SDK ≥ 0.18.52) into effectively-once delivery for delivery-critical
traffic, over the `MessageTransport` contract in `affinidi-messaging-core`, and
is wire-agnostic (DIDComm now via `DidCommTransport` #607, TSP/REST later).

This PR is the **durable outbox and its drain**:

- **`OutboxEntry` + `OutboxState`** — `Queued → Sent → Delivered | Unconfirmed |
  Failed`. `Sent` is **hop-acceptance, not delivered**: the next hop accepted the
  bytes (durably queued at the mediator) and we await end-to-end evidence; a
  `Sent` entry is **not re-sent** (the mediator owns redelivery — re-sending
  double-sends).
- **`OutboxStore` trait + `InMemoryOutboxStore`** — storage abstraction (services
  back it with a durable store, e.g. fjall). `due()` encodes the per-`ordering_key`
  **FIFO gate** (only the earliest-enqueued non-terminal entry per key is
  eligible), so a keyed sequence (e.g. per-DID webvh publishes) drains in order.
- **`drain_once` / `drain_loop`** — `drain_once` takes the clock as a parameter
  (deterministic); `drain_loop` runs it on the wall clock. On a truthful
  `Ok(hop-accept)` → `Sent`; on `Err` → stay `Queued`, bump `attempts`, reschedule
  with exponential backoff (1s…60s); window expiry while queued → `Failed`
  (surfaced, never a silent success).

## Scope

- **New crate at `0.1.0`**, depends only on `affinidi-messaging-core` (the trait)
  + `async-trait`/`thiserror`/`tracing`/`tokio` (time). No SDK dependency yet — it
  works over `Arc<dyn MessageTransport>`, so the DIDComm adapter plugs in when the
  `MessagingService` front-end lands.
- **Deliberately not here** (next increments): end-to-end confirmation
  (`Sent → Delivered`: layer-receipt / protocol-reply / outbox-drain / escalate,
  §5a), the `MessagingService` API (`send`/`request`/`subscribe`/`status`), the
  inbound dispatcher, and status aggregation.

## Verification

- **7 unit tests, fully offline** (in-memory store + a mock `MessageTransport`, no
  mediator): put/get/replace; `due` gating (backoff / terminal / `Sent` excluded;
  ordering-key FIFO head); hop-accept → `Sent` + transmit-once (and no re-send of
  `Sent`); failure → backoff reschedule; window-expiry → `Failed` without sending.
- `check` / `clippy --all-targets` / `fmt` clean; workspace resolves with the new
  member; version-bump guard passes (new crate → 0.1.0).

Second Phase-2 increment, after #607 (the `DidCommTransport` adapter).