### PR TITLE
feat: end-to-end delivery confirmation state machine (D1 Phase 2 §5a)

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.1.2] - 2026-07-16
+
+- Add the end-to-end delivery **confirmation** state machine (§5a): the
+  `Sent → Delivered | Unconfirmed` transitions a hop-accepted entry awaits.
+  - `confirm_delivered(store, key)` — record evidence: `Sent → Delivered`
+    (idempotent; a re-delivered receipt for an already-`Delivered` entry is a
+    no-op).
+  - `sweep_confirmations(store, now)` / `confirmation_loop` — settle any `Sent`
+    entry whose delivery window expired without evidence to `Unconfirmed` (a
+    truthful "we can't know", distinct from the drain's `Failed` for a `Queued`
+    entry that never even hop-accepted).
+  - `OutboxStore::awaiting_confirmation()` — the `Sent` entries the sweep checks
+    (default returns none; `InMemoryOutboxStore` overrides it).
+  - `MessagingService::confirm(key)` — the evidence entry point (called by a
+    layer-receipt recognizer or a protocol-reply handler) — and
+    `delivery_state(key)` to poll the outcome after a `Guaranteed` `send`.
+  The *evidence sources* — the receiver auto-emitting a layer receipt, polling
+  the mediator's own outbox for drain, and re-sending over an alternate binding
+  on expiry — layer on top of this state machine (they need live-mediator
+  interaction). Additive; fully offline-tested.
+
 ## [0.1.1] - 2026-07-16
 
 - Add the `MessagingService` front-end and its single inbound dispatcher — the

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/confirm.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/confirm.rs
@@ -1,0 +1,178 @@
+//! End-to-end delivery confirmation (§5a): the `Sent → Delivered | Unconfirmed`
+//! transitions.
+//!
+//! A `Sent` entry is hop-accepted (durably queued at the mediator), **not**
+//! delivered. It is watched until either:
+//!
+//! - **evidence arrives** → [`confirm_delivered`] transitions it `Delivered`
+//!   (the strongest evidence — a layer receipt — proves the recipient has and
+//!   will process the message; a correlated protocol reply is equivalent); or
+//! - **the delivery window passes with no evidence** → the sweep
+//!   ([`sweep_confirmations`]) settles it `Unconfirmed`, a truthful "we can't
+//!   know", never a false "delivered".
+//!
+//! This module owns the state machine. The *evidence sources* — the receiver
+//! auto-emitting a layer receipt on durable persist, polling the mediator's own
+//! outbox for drain, and re-sending over an alternate binding on expiry — layer
+//! on top and call [`confirm_delivered`] / drive the sweep.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::outbox::{OutboxError, OutboxState, OutboxStore};
+
+/// What one [`sweep_confirmations`] pass settled.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConfirmReport {
+    /// `Sent` entries whose window expired with no evidence (→ `Unconfirmed`).
+    pub unconfirmed: usize,
+}
+
+/// Record end-to-end delivery evidence for `idempotency_key`: transition its
+/// outbox entry `Sent → Delivered`.
+///
+/// Returns `Ok(true)` if an entry was transitioned, `Ok(false)` if there was no
+/// matching `Sent` entry (absent, or already terminal — evidence is
+/// **idempotent**, so a re-delivered receipt for an already-`Delivered` entry is
+/// a harmless no-op).
+pub async fn confirm_delivered(
+    store: &dyn OutboxStore,
+    idempotency_key: &str,
+) -> Result<bool, OutboxError> {
+    if let Some(mut entry) = store.get(idempotency_key).await?
+        && entry.state == OutboxState::Sent
+    {
+        entry.state = OutboxState::Delivered;
+        store.put(entry).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// One confirmation sweep at logical time `now_ms`: any `Sent` entry whose
+/// delivery window has passed without evidence settles `Unconfirmed`.
+///
+/// `Unconfirmed` is deliberately distinct from `Failed`: the message *was*
+/// hop-accepted (the mediator took it), we just never got end-to-end evidence —
+/// a truthful "we can't know", not "delivery failed". (A `Queued` entry that
+/// expires before it can even hop-accept is the drain's `Failed` case.)
+pub async fn sweep_confirmations(
+    store: &dyn OutboxStore,
+    now_ms: u64,
+) -> Result<ConfirmReport, OutboxError> {
+    let mut report = ConfirmReport::default();
+    for mut entry in store.awaiting_confirmation().await? {
+        if now_ms >= entry.deliver_by_ms {
+            entry.state = OutboxState::Unconfirmed;
+            store.put(entry).await?;
+            report.unconfirmed += 1;
+        }
+    }
+    Ok(report)
+}
+
+/// Run [`sweep_confirmations`] every `interval`, forever (until the task is
+/// dropped), using the wall clock. A store error on one tick is logged and
+/// retried on the next.
+pub async fn confirmation_loop(store: Arc<dyn OutboxStore>, interval: Duration) {
+    let mut ticker = tokio::time::interval(interval);
+    loop {
+        ticker.tick().await;
+        match sweep_confirmations(store.as_ref(), now_unix_ms()).await {
+            Ok(report) if report != ConfirmReport::default() => {
+                tracing::debug!(
+                    unconfirmed = report.unconfirmed,
+                    "confirmation sweep settled entries as Unconfirmed",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "confirmation sweep failed; retrying next tick")
+            }
+        }
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outbox::{InMemoryOutboxStore, OutboxEntry};
+
+    /// A `Sent` entry with `deliver_by = created + 60s`.
+    async fn sent_entry(store: &InMemoryOutboxStore, key: &str, created: u64) {
+        let mut e = OutboxEntry::new(key, "did:example:bob", vec![1], created, created + 60_000);
+        e.state = OutboxState::Sent;
+        store.put(e).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn evidence_confirms_a_sent_entry_and_is_idempotent() {
+        let store = InMemoryOutboxStore::new();
+        sent_entry(&store, "k1", 1_000).await;
+
+        assert!(confirm_delivered(&store, "k1").await.unwrap());
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+
+        // Evidence is idempotent: a second (re-delivered) receipt is a no-op.
+        assert!(!confirm_delivered(&store, "k1").await.unwrap());
+        // Unknown key → no-op, not an error.
+        assert!(!confirm_delivered(&store, "nope").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn confirm_does_not_touch_a_queued_entry() {
+        let store = InMemoryOutboxStore::new();
+        // Queued (not yet hop-accepted) — evidence for it shouldn't apply.
+        store
+            .put(OutboxEntry::new("k1", "did:x", vec![1], 1_000, 61_000))
+            .await
+            .unwrap();
+        assert!(!confirm_delivered(&store, "k1").await.unwrap());
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Queued
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_settles_expired_sent_entries_unconfirmed() {
+        let store = InMemoryOutboxStore::new();
+        sent_entry(&store, "expired", 1_000).await; // deliver_by = 61_000
+        sent_entry(&store, "in_window", 1_000).await;
+        // Confirm one so it's terminal (Delivered) — the sweep ignores it.
+        confirm_delivered(&store, "in_window").await.unwrap();
+
+        // Before expiry: nothing settled.
+        assert_eq!(
+            sweep_confirmations(&store, 30_000)
+                .await
+                .unwrap()
+                .unconfirmed,
+            0
+        );
+
+        // Past the window: the still-Sent entry settles Unconfirmed.
+        let report = sweep_confirmations(&store, 61_000).await.unwrap();
+        assert_eq!(report.unconfirmed, 1);
+        assert_eq!(
+            store.get("expired").await.unwrap().unwrap().state,
+            OutboxState::Unconfirmed
+        );
+        // The Delivered entry is untouched.
+        assert_eq!(
+            store.get("in_window").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-delivery/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/lib.rs
@@ -19,10 +19,12 @@
 //!
 //! [`MessageTransport`]: affinidi_messaging_core::MessageTransport
 
+pub mod confirm;
 pub mod drain;
 pub mod outbox;
 pub mod service;
 
+pub use confirm::{ConfirmReport, confirm_delivered, confirmation_loop, sweep_confirmations};
 pub use drain::{DrainReport, drain_loop, drain_once};
 pub use outbox::{InMemoryOutboxStore, Key, OutboxEntry, OutboxError, OutboxState, OutboxStore};
 pub use service::{Delivery, MessagingService, MessagingStatus, Sent};

--- a/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
@@ -130,6 +130,17 @@ pub trait OutboxStore: Send + Sync {
     /// — only the earliest-enqueued non-terminal entry per key (so a per-key
     /// FIFO is preserved). Returned oldest-first.
     async fn due(&self, now_ms: u64) -> Result<Vec<OutboxEntry>, OutboxError>;
+
+    /// All `Sent` entries — hop-accepted and awaiting end-to-end evidence (§5a).
+    /// The confirmation sweep ([`crate::confirm::sweep_confirmations`]) checks
+    /// these against `deliver_by_ms`.
+    ///
+    /// The default returns none, so a store that doesn't override it simply
+    /// never sweeps confirmations (safe, but a `Sent` entry never settles
+    /// `Unconfirmed`). A durable store SHOULD override this.
+    async fn awaiting_confirmation(&self) -> Result<Vec<OutboxEntry>, OutboxError> {
+        Ok(Vec::new())
+    }
 }
 
 /// A non-durable [`OutboxStore`] backed by a `HashMap`. For tests and ephemeral
@@ -201,6 +212,15 @@ impl OutboxStore for InMemoryOutboxStore {
                 .then_with(|| a.idempotency_key.cmp(&b.idempotency_key))
         });
         Ok(due)
+    }
+
+    async fn awaiting_confirmation(&self) -> Result<Vec<OutboxEntry>, OutboxError> {
+        Ok(self
+            .lock()?
+            .values()
+            .filter(|e| e.state == OutboxState::Sent)
+            .cloned()
+            .collect())
     }
 }
 

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -13,7 +13,7 @@ use futures_util::stream::{self, BoxStream, StreamExt};
 use tokio::sync::{broadcast, oneshot, watch};
 use tokio::task::JoinHandle;
 
-use crate::outbox::{Key, OutboxEntry, OutboxStore};
+use crate::outbox::{Key, OutboxEntry, OutboxState, OutboxStore};
 
 /// The delivery guarantee for a [`MessagingService::send`].
 #[derive(Debug, Clone)]
@@ -215,6 +215,35 @@ impl MessagingService {
             ConnState::Connected => MessagingStatus::Connected,
             _ => MessagingStatus::Disconnected,
         }
+    }
+
+    /// Record end-to-end delivery evidence for a `Guaranteed` send:
+    /// its outbox entry transitions `Sent → Delivered` (§5a).
+    ///
+    /// Call this from an evidence source — a layer-receipt recognizer, or a
+    /// protocol-reply handler that knows the reply confirms `idempotency_key`.
+    /// Idempotent: `Ok(true)` if it transitioned an entry, `Ok(false)` if there
+    /// was no matching `Sent` entry (unknown or already terminal).
+    pub async fn confirm(&self, idempotency_key: &str) -> Result<bool, MessagingError> {
+        crate::confirm::confirm_delivered(self.outbox.as_ref(), idempotency_key)
+            .await
+            .map_err(|e| MessagingError::Transport(format!("confirm failed: {e}")))
+    }
+
+    /// The current outbox state of a `Guaranteed` send (`Queued` / `Sent` /
+    /// `Delivered` / `Unconfirmed` / `Failed`), or `None` if the key was never
+    /// enqueued. Callers poll this to learn a delivery outcome after `send`
+    /// returned `Accepted`. (A `BestEffort` send has no outbox entry.)
+    pub async fn delivery_state(
+        &self,
+        idempotency_key: &str,
+    ) -> Result<Option<OutboxState>, MessagingError> {
+        Ok(self
+            .outbox
+            .get(idempotency_key)
+            .await
+            .map_err(|e| MessagingError::Transport(format!("outbox read failed: {e}")))?
+            .map(|entry| entry.state))
     }
 
     fn remove_waiter(&self, thid: &str) {
@@ -495,5 +524,49 @@ mod tests {
 
         h.conn_tx.send(ConnState::Connected).unwrap();
         assert_eq!(svc.status(), MessagingStatus::Connected);
+    }
+
+    #[tokio::test]
+    async fn confirm_upgrades_a_sent_guaranteed_send_to_delivered() {
+        let h = mock();
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let svc = MessagingService::new(h.transport.clone(), outbox.clone());
+
+        // Guaranteed send → Queued.
+        svc.send(
+            "did:x",
+            b"m".to_vec(),
+            Delivery::Guaranteed {
+                idempotency_key: Some("k".to_string()),
+                ordering_key: None,
+                deliver_by: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            svc.delivery_state("k").await.unwrap(),
+            Some(OutboxState::Queued)
+        );
+
+        // Simulate the drain hop-accepting it (Queued → Sent).
+        let mut e = outbox.get("k").await.unwrap().unwrap();
+        e.state = OutboxState::Sent;
+        outbox.put(e).await.unwrap();
+        assert_eq!(
+            svc.delivery_state("k").await.unwrap(),
+            Some(OutboxState::Sent)
+        );
+
+        // Evidence arrives → Delivered (idempotent).
+        assert!(svc.confirm("k").await.unwrap());
+        assert!(!svc.confirm("k").await.unwrap());
+        assert_eq!(
+            svc.delivery_state("k").await.unwrap(),
+            Some(OutboxState::Delivered)
+        );
+
+        // An unknown key has no delivery state.
+        assert_eq!(svc.delivery_state("unknown").await.unwrap(), None);
     }
 }


### PR DESCRIPTION
## What

The §5a **confirmation** state machine — the last substantive piece of the
delivery layer. A `Sent` outbox entry is *hop-accepted* (durably queued at the
mediator), **not delivered**; this watches it to a truthful terminal state:

- **`confirm_delivered(store, key)`** — evidence arrived → `Sent → Delivered`.
  **Idempotent** (a re-delivered receipt for an already-`Delivered` entry is a
  no-op — receipt loss is self-healing via the outbox retry + this dedup), and it
  only touches `Sent` entries (never a `Queued` one).
- **`sweep_confirmations(store, now)` / `confirmation_loop`** — any `Sent` entry
  whose delivery window expired **without evidence** settles `Unconfirmed`: a
  truthful "we can't know". This is deliberately **distinct from `Failed`** (the
  drain's state for a `Queued` entry that expired before it could even
  hop-accept) — hop-accepted-but-unconfirmed ≠ never-sent.
- **`OutboxStore::awaiting_confirmation()`** — the `Sent` entries the sweep
  checks. Has a **default returning none** (so the trait change is additive — a
  store that doesn't override it simply never sweeps); `InMemoryOutboxStore`
  overrides it.
- **`MessagingService::confirm(key)`** — the evidence entry point a layer-receipt
  recognizer or protocol-reply handler calls; **`delivery_state(key)`** to poll
  the outcome after a `Guaranteed` `send` returned `Accepted`.

## The confirmation hierarchy, and what's deferred

The design's §5a evidence, strongest first: **layer receipt** → **protocol reply**
→ **outbox-drain poll** → **escalate on window expiry**. This PR is the **state
machine** those all drive. The **evidence *sources*** are deliberately deferred
because they need **live-mediator interaction**:

- the *receiver* auto-emitting a layer receipt on durable persist (a two-sided
  protocol);
- polling the mediator's *own outbox* (`message-list`, `Folder::Outbox`) to see a
  message drain (the SDK message-list API + a live mediator);
- re-sending over an alternate binding on expiry (DID-doc resolution).

Each of those calls `confirm_delivered` / drives the sweep — so they compose onto
this without reshaping it. Splitting here keeps the offline-verifiable core clean
and leaves the mediator-dependent parts for a focused, live-validated follow-up.

## Verification

- **4 new offline tests** (17 total in the crate): evidence → `Delivered` +
  idempotent + unknown-key no-op; evidence doesn't touch a `Queued` entry; sweep
  settles expired `Sent` → `Unconfirmed` while leaving `Delivered` untouched;
  and through `MessagingService`: `Queued → Sent → confirm → Delivered` + poll.
- `check` / `clippy --all-targets` / `fmt` clean; version-bump guard passes
  (`0.1.1 → 0.1.2`).

Fourth Phase-2 increment, after #607/#608/#609. With this, the delivery layer's
core state machine is complete: truthful send, at-least-once outbox with backoff,
thread-id demux + ack-after-handoff, and the full `Queued → Sent → Delivered |
Unconfirmed | Failed` lifecycle. The remaining work is the mediator-dependent
evidence sources and the VTI cut-over (Phase 3).