### PR TITLE
feat: MessageTransport::outbox_message_ids — outbox-drain evidence hook (D1 Phase 2 §5a, core)

### DIFF
--- a/crates/messaging/affinidi-messaging-core/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 16th July 2026
 
+### 0.1.5 — `MessageTransport::outbox_message_ids` (outbox-drain evidence)
+
+Add `MessageTransport::outbox_message_ids()` — the hop-ids still held in the
+**sender's own outbox**, a transport's "not yet picked up" signal for the §5a
+outbox-drain confirmation. A hop-and-hold transport (DIDComm/TSP via a mediator)
+implements it; the default returns `None` (a stateless transport gives no such
+signal), so the addition is non-breaking.
+
+
 ### 0.1.4 — `MessageTransport` wire contract
 
 Add the `transport::MessageTransport` trait and its vocabulary

--- a/crates/messaging/affinidi-messaging-core/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-core"
 description = "Protocol-agnostic messaging traits for DIDComm and TSP"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-core/src/transport.rs
+++ b/crates/messaging/affinidi-messaging-core/src/transport.rs
@@ -144,6 +144,21 @@ pub trait MessageTransport: Send + Sync {
     /// makes at-least-once delivery safe: an un-acked message is redelivered
     /// rather than lost.
     async fn ack(&self, ack: InboundAck) -> Result<(), MessagingError>;
+
+    /// The hop-ids still held in the **sender's own outbox** — the transport's
+    /// "not yet picked up" signal (§5a outbox-drain evidence).
+    ///
+    /// A hop-and-hold transport (DIDComm/TSP via a mediator) keeps a sent
+    /// message in the sender's outbox until the recipient acks pickup, then
+    /// deletes it. So a [`SendReceipt::hop_id`] that has **drained** from this
+    /// set — after first appearing in it — is the transport-level evidence that
+    /// the recipient took delivery. The delivery layer polls this.
+    ///
+    /// The default returns `None`: a transport that gives no such signal (a
+    /// stateless REST POST) simply offers no outbox-drain evidence.
+    async fn outbox_message_ids(&self) -> Result<Option<Vec<String>>, MessagingError> {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The **upstream half** of the §5a *outbox-drain* delivery-evidence source: a
single additive hook on the transport contract.

`MessageTransport::outbox_message_ids()` — the hop-ids still held in the
**sender's own outbox**. A mediator holds a sent message in the sender's outbox
until the recipient acks pickup, then deletes it; a `Sent` outbox entry whose
hop-id has **drained** from that folder is transport-level evidence the
recipient took delivery.

- Default is `Ok(None)` — a stateless transport gives no such signal, so the
  addition breaks **no** existing implementor. Hop-and-hold transports
  (DIDComm/TSP via a mediator) override it.
- Definition only in this PR. Bump `affinidi-messaging-core` `0.1.4 → 0.1.5`.

## Why this is split from its consumers

The DIDComm adapter override (`sdk`) and the delivery-layer `poll_outbox_drain`
(`delivery`) that *consume* this method need core `0.1.5` resolved from
crates.io. Bundling upstream + consumers in one PR trips the documented
`check-publish-dry-run.sh` known-limitation (the downstream dry-run resolves the
older published core and fails to compile). So this upstream lands and publishes
first; the sdk + delivery consumers follow in a downstream PR — the same
core-`0.1.4`-contract-then-sdk-adapter ordering used across #604 → #607.

## Validated live (the invariant the consumers rely on)

Probed against a real `did:webvh` mediator: the DIDComm `hop_id = sha256(packed)`
**exactly** equals the mediator's Outbox `msg_id`, and that entry drains from the
outbox on pickup:

```
hop_id = sha256(packed) = 8c6987df…
Outbox msg_ids         = ["8c6987df…"]   ← exact match
hop_id == Outbox msg_id ✔  ·  hop_id DRAINED after pickup ✔
```

## Verification

`check` / `clippy` / `fmt` clean; `cargo publish -p affinidi-messaging-core
--dry-run` passes locally; version-bump guard green.