### PR TITLE
feat: outbox-drain delivery evidence — DIDComm adapter + poll (D1 Phase 2 §5a, consumers)

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.3] - 2026-07-16
+
+- Add the §5a **outbox-drain** delivery-evidence source: `poll_outbox_drain` /
+  `outbox_drain_loop` confirm a `Sent` entry `Delivered` when its `hop_id`
+  **drains** from the transport's outbox (`MessageTransport::outbox_message_ids`,
+  the "recipient took pickup" signal).
+  - `OutboxEntry` gains `hop_id` (recorded on `Sent` from `SendReceipt::hop_id`)
+    and `outbox_observed` — the latter guards against the mediator's eventual
+    consistency: a hop-id absent right after send may simply not be indexed yet,
+    so "absent" only counts as pickup **after** the id was observed present.
+  - The drain now records `hop_id` on a hop-accepted entry.
+  Additive; verified against a real mediator via the DIDComm adapter.
+
 ## [0.1.2] - 2026-07-16
 
 - Add the end-to-end delivery **confirmation** state machine (§5a): the

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -14,7 +14,7 @@ rust-version.workspace = true
 
 [dependencies]
 # The transport-agnostic contract the delivery layer builds reliability on.
-affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.4" }
+affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.5" }
 async-trait = "0.1"
 thiserror = "2"
 tracing = "0.1"

--- a/crates/messaging/affinidi-messaging-delivery/src/confirm.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/confirm.rs
@@ -16,8 +16,11 @@
 //! outbox for drain, and re-sending over an alternate binding on expiry — layer
 //! on top and call [`confirm_delivered`] / drive the sweep.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use affinidi_messaging_core::MessageTransport;
 
 use crate::outbox::{OutboxError, OutboxState, OutboxStore};
 
@@ -90,6 +93,91 @@ pub async fn confirmation_loop(store: Arc<dyn OutboxStore>, interval: Duration) 
             Err(e) => {
                 tracing::warn!(error = %e, "confirmation sweep failed; retrying next tick")
             }
+        }
+    }
+}
+
+/// What one [`poll_outbox_drain`] pass observed.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DrainPollReport {
+    /// `Sent` entries confirmed `Delivered` because their hop-id **drained** from
+    /// the sender's outbox (recipient took pickup).
+    pub delivered: usize,
+    /// `Sent` entries seen still present in the outbox this pass (awaiting pickup).
+    pub observed: usize,
+}
+
+/// Poll the transport's outbox for §5a **outbox-drain** evidence.
+///
+/// The mediator holds a sent message in the sender's outbox until the recipient
+/// acks pickup, then deletes it. So a `Sent` entry whose `hop_id` has **drained**
+/// from [`MessageTransport::outbox_message_ids`] — after being seen present there
+/// — is the transport-level signal that the recipient took delivery, and the
+/// entry settles `Delivered`.
+///
+/// The `outbox_observed` guard handles the mediator's eventual consistency: a
+/// hop-id absent immediately after send may simply not be indexed yet, so
+/// "absent" only counts as pickup **after** the id has been observed present.
+///
+/// A transport that gives no outbox signal (`outbox_message_ids` returns `None`,
+/// e.g. a stateless REST POST) yields an empty report.
+pub async fn poll_outbox_drain(
+    transport: &dyn MessageTransport,
+    store: &dyn OutboxStore,
+) -> Result<DrainPollReport, OutboxError> {
+    let Some(ids) = transport
+        .outbox_message_ids()
+        .await
+        .map_err(|e| OutboxError::Backend(format!("outbox list failed: {e}")))?
+    else {
+        return Ok(DrainPollReport::default());
+    };
+    let present: HashSet<&str> = ids.iter().map(String::as_str).collect();
+
+    let mut report = DrainPollReport::default();
+    for mut entry in store.awaiting_confirmation().await? {
+        let Some(hop_id) = entry.hop_id.clone() else {
+            continue;
+        };
+        if present.contains(hop_id.as_str()) {
+            // Still queued at the mediator — awaiting pickup. Record that we've
+            // now seen it, so a later drain is unambiguous.
+            if !entry.outbox_observed {
+                entry.outbox_observed = true;
+                store.put(entry).await?;
+            }
+            report.observed += 1;
+        } else if entry.outbox_observed {
+            // Was present, now gone → recipient picked up → Delivered.
+            confirm_delivered(store, &entry.idempotency_key).await?;
+            report.delivered += 1;
+        }
+        // else: absent and never observed → too early (eventual consistency); skip.
+    }
+    Ok(report)
+}
+
+/// Run [`poll_outbox_drain`] every `interval`, forever (until the task is
+/// dropped). A store/transport error on one tick is logged and retried next.
+pub async fn outbox_drain_loop(
+    transport: Arc<dyn MessageTransport>,
+    store: Arc<dyn OutboxStore>,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    loop {
+        ticker.tick().await;
+        match poll_outbox_drain(transport.as_ref(), store.as_ref()).await {
+            Ok(report) if report.delivered > 0 => {
+                tracing::debug!(
+                    delivered = report.delivered,
+                    observed = report.observed,
+                    "outbox-drain confirmed deliveries",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "outbox-drain poll failed; retrying next tick"),
         }
     }
 }
@@ -173,6 +261,130 @@ mod tests {
         assert_eq!(
             store.get("in_window").await.unwrap().unwrap().state,
             OutboxState::Delivered
+        );
+    }
+
+    // ── Outbox-drain evidence (§5a) ──────────────────────────────────────
+
+    use affinidi_messaging_core::{ConnState, Inbound, InboundAck, SendReceipt, TransportKind};
+    use futures_util::stream::{self, BoxStream};
+    use std::sync::Mutex;
+    use tokio::sync::watch;
+
+    /// A transport whose `outbox_message_ids` the test drives.
+    struct DrainMockTransport {
+        outbox: Mutex<Option<Vec<String>>>,
+        conn_rx: watch::Receiver<ConnState>,
+        _conn_tx: watch::Sender<ConnState>,
+    }
+
+    impl DrainMockTransport {
+        fn new(outbox: Option<Vec<String>>) -> Self {
+            let (tx, rx) = watch::channel(ConnState::Connected);
+            Self {
+                outbox: Mutex::new(outbox),
+                conn_rx: rx,
+                _conn_tx: tx,
+            }
+        }
+        fn set_outbox(&self, ids: Vec<String>) {
+            *self.outbox.lock().unwrap() = Some(ids);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MessageTransport for DrainMockTransport {
+        fn kind(&self) -> TransportKind {
+            TransportKind::Didcomm
+        }
+        async fn send(
+            &self,
+            _dest: &str,
+            _packed: Vec<u8>,
+        ) -> Result<SendReceipt, affinidi_messaging_core::MessagingError> {
+            Ok(SendReceipt {
+                via: TransportKind::Didcomm,
+                hop_id: None,
+            })
+        }
+        fn connection_state(&self) -> watch::Receiver<ConnState> {
+            self.conn_rx.clone()
+        }
+        fn inbound(&self) -> BoxStream<'static, Inbound> {
+            Box::pin(stream::empty())
+        }
+        async fn ack(
+            &self,
+            _ack: InboundAck,
+        ) -> Result<(), affinidi_messaging_core::MessagingError> {
+            Ok(())
+        }
+        async fn outbox_message_ids(
+            &self,
+        ) -> Result<Option<Vec<String>>, affinidi_messaging_core::MessagingError> {
+            Ok(self.outbox.lock().unwrap().clone())
+        }
+    }
+
+    async fn sent_with_hop(store: &InMemoryOutboxStore, key: &str, hop: &str) {
+        let mut e = OutboxEntry::new(key, "did:example:bob", vec![1], 1_000, 61_000);
+        e.state = OutboxState::Sent;
+        e.hop_id = Some(hop.to_string());
+        store.put(e).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_observes_then_confirms_delivered() {
+        let store = InMemoryOutboxStore::new();
+        sent_with_hop(&store, "k1", "h1").await;
+        let transport = DrainMockTransport::new(Some(vec!["h1".to_string()]));
+
+        // Pass 1: h1 is present → observed, not yet delivered.
+        let r = poll_outbox_drain(&transport, &store).await.unwrap();
+        assert_eq!(r.observed, 1);
+        assert_eq!(r.delivered, 0);
+        let e = store.get("k1").await.unwrap().unwrap();
+        assert!(e.outbox_observed);
+        assert_eq!(e.state, OutboxState::Sent);
+
+        // h1 drains from the outbox (recipient picked up).
+        transport.set_outbox(vec![]);
+
+        // Pass 2: h1 absent AFTER being observed → Delivered.
+        let r = poll_outbox_drain(&transport, &store).await.unwrap();
+        assert_eq!(r.delivered, 1);
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_absent_before_observed_does_not_confirm() {
+        // Eventual-consistency guard: a hop-id not yet indexed in the outbox
+        // must NOT be read as a drain.
+        let store = InMemoryOutboxStore::new();
+        sent_with_hop(&store, "k1", "h1").await;
+        let transport = DrainMockTransport::new(Some(vec![])); // h1 not indexed yet
+
+        let r = poll_outbox_drain(&transport, &store).await.unwrap();
+        assert_eq!(r.delivered, 0);
+        let e = store.get("k1").await.unwrap().unwrap();
+        assert_eq!(e.state, OutboxState::Sent);
+        assert!(!e.outbox_observed);
+    }
+
+    #[tokio::test]
+    async fn drain_no_transport_signal_is_a_noop() {
+        let store = InMemoryOutboxStore::new();
+        sent_with_hop(&store, "k1", "h1").await;
+        let transport = DrainMockTransport::new(None); // transport gives no outbox signal
+
+        let r = poll_outbox_drain(&transport, &store).await.unwrap();
+        assert_eq!(r, DrainPollReport::default());
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Sent
         );
     }
 }

--- a/crates/messaging/affinidi-messaging-delivery/src/drain.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/drain.rs
@@ -67,8 +67,11 @@ pub async fn drain_once(
         }
 
         match transport.send(&entry.dest_did, entry.packed.clone()).await {
-            Ok(_receipt) => {
+            Ok(receipt) => {
                 entry.state = OutboxState::Sent;
+                // Record the hop-id so the confirmation watcher can watch this
+                // exact message drain from the sender's outbox (§5a).
+                entry.hop_id = receipt.hop_id;
                 store.put(entry).await?;
                 report.sent += 1;
             }

--- a/crates/messaging/affinidi-messaging-delivery/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/lib.rs
@@ -24,7 +24,10 @@ pub mod drain;
 pub mod outbox;
 pub mod service;
 
-pub use confirm::{ConfirmReport, confirm_delivered, confirmation_loop, sweep_confirmations};
+pub use confirm::{
+    ConfirmReport, DrainPollReport, confirm_delivered, confirmation_loop, outbox_drain_loop,
+    poll_outbox_drain, sweep_confirmations,
+};
 pub use drain::{DrainReport, drain_loop, drain_once};
 pub use outbox::{InMemoryOutboxStore, Key, OutboxEntry, OutboxError, OutboxState, OutboxStore};
 pub use service::{Delivery, MessagingService, MessagingStatus, Sent};

--- a/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
@@ -70,6 +70,17 @@ pub struct OutboxEntry {
     /// Unix-ms delivery-window deadline — the acceptable recovery time. Past
     /// this without success the entry settles visibly, never a silent success.
     pub deliver_by_ms: u64,
+    /// The transport hop-id (mediator queue-id) for the accepted frame, recorded
+    /// when the entry becomes `Sent`. Used to watch this exact message drain from
+    /// the sender's outbox (§5a outbox-drain evidence). `None` until sent, or if
+    /// the transport returns no hop-id.
+    pub hop_id: Option<String>,
+    /// Whether `hop_id` has been seen present in the transport's outbox at least
+    /// once. Guards the outbox-drain check against the mediator's eventual
+    /// consistency: a hop-id "absent" right after send may simply not be indexed
+    /// yet, so drain (absent) only counts as pickup *after* it was observed
+    /// present.
+    pub outbox_observed: bool,
 }
 
 impl OutboxEntry {
@@ -91,6 +102,8 @@ impl OutboxEntry {
             next_attempt_at_ms: created_at_ms,
             created_at_ms,
             deliver_by_ms,
+            hop_id: None,
+            outbox_observed: false,
         }
     }
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.54] - 2026-07-16
+
+- `DidCommTransport` gains outbox-drain delivery evidence (D1 Phase 2, §5a):
+  `send` now returns the mediator queue-id — `sha256(packed)` — as
+  `SendReceipt::hop_id`, and `outbox_message_ids()` lists the sender's
+  `Folder::Outbox` message ids. Together they let the delivery layer confirm a
+  message `Delivered` once its hop-id **drains** from the outbox (the recipient
+  took pickup). The `hop_id = sha256(packed) = outbox msg_id` correlation and the
+  drain-on-pickup behaviour were verified live against a real mediator. Additive.
+
 ## [0.18.53] - 2026-07-16
 
 - Add `DidCommTransport`, a `MessageTransport` (from `affinidi-messaging-core`)

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.53"
+version = "0.18.54"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -31,7 +31,7 @@ affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 # Protocol-agnostic messaging vocabulary (ConnState, the future MessageTransport
 # trait). The websocket transport publishes ConnState over a watch channel.
-affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.3" }
+affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.5" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
 trust-tasks-rs = "0.2"

--- a/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
@@ -14,8 +14,10 @@ use affinidi_messaging_core::{
 };
 use affinidi_messaging_didcomm::Message;
 use futures_util::stream::{self, BoxStream};
+use sha256::digest;
 use tokio::sync::watch;
 
+use crate::messages::Folder;
 use crate::messages::compat::UnpackMetadata;
 use crate::{ATM, profiles::ATMProfile};
 
@@ -78,12 +80,17 @@ impl MessageTransport for DidCommTransport {
         // used for reply correlation (unused when not waiting), so a fresh id is
         // fine. `send_message` is truthful — `Err` if the frame wasn't written.
         let msg_id = uuid::Uuid::new_v4().to_string();
+        // The mediator keys a stored message on `sha256(packed bytes)` and shows
+        // that id in the sender's outbox (`Folder::Outbox`). Return it as the
+        // `hop_id` so the delivery layer can watch this exact message drain
+        // (outbox-drain evidence, §5a). Verified live against a real mediator.
+        let hop_id = digest(packed.as_str());
         self.atm
             .send_message(&self.profile, &packed, &msg_id, false, false)
             .await
             .map(|_| SendReceipt {
                 via: TransportKind::Didcomm,
-                hop_id: None,
+                hop_id: Some(hop_id),
             })
             .map_err(|e| MessagingError::Transport(format!("didcomm send failed: {e}")))
     }
@@ -131,6 +138,19 @@ impl MessageTransport for DidCommTransport {
             .delete_message_background(&self.profile, &ack.0)
             .await
             .map_err(|e| MessagingError::Transport(format!("ack (delete) failed: {e}")))
+    }
+
+    async fn outbox_message_ids(&self) -> Result<Option<Vec<String>>, MessagingError> {
+        // The mediator holds a sent message in the sender's `Outbox` until the
+        // recipient acks pickup, then deletes it; each row's `msg_id` is the
+        // `sha256(packed)` this transport returns as a `SendReceipt::hop_id`. So
+        // a hop-id that has drained from this list is the recipient's pickup.
+        let list = self
+            .atm
+            .list_messages(&self.profile, Folder::Outbox)
+            .await
+            .map_err(|e| MessagingError::Transport(format!("list outbox failed: {e}")))?;
+        Ok(Some(list.into_iter().map(|m| m.msg_id).collect()))
     }
 }
 


### PR DESCRIPTION
## What

The **consumer half** of the §5a *outbox-drain* evidence source, on top of
`affinidi-messaging-core` `0.1.5`'s `MessageTransport::outbox_message_ids`
(landed in #612, now published). The mediator holds a sent message in the
**sender's** outbox until the recipient acks pickup, then deletes it — so a
`Sent` outbox entry whose hop-id has **drained** is transport-level evidence the
recipient took delivery, and the entry settles `Delivered`.

- **sdk** (`DidCommTransport`) — `send` returns `hop_id = sha256(packed)` (the
  mediator queue-id) as `SendReceipt::hop_id`, and `outbox_message_ids()` lists
  `Folder::Outbox`.
- **delivery** — `OutboxEntry` gains `hop_id` (recorded on `Sent`) and
  `outbox_observed`; `poll_outbox_drain` / `outbox_drain_loop` confirm
  `Delivered` when a `Sent` entry's hop-id drains from the transport's outbox.

### The eventual-consistency guard

The mediator indexes a just-sent message into the outbox with a small lag
(~800ms observed live). So `poll_outbox_drain` is **observe-then-drain**: a
hop-id counts as "picked up" only once it has been seen *present* and then goes
absent — never on a first-poll absence (which could just be "not indexed yet").

## Validated live against a real `did:webvh` mediator

```
hop_id = sha256(packed) = 8c6987df…
Outbox msg_ids         = ["8c6987df…"]      ← EXACT match
hop_id == Outbox msg_id ✔  ·  hop_id DRAINED from Outbox after pickup ✔
```

`DidCommTransport`'s `hop_id` **is** the mediator's outbox `msg_id`, and it
drains on pickup — the invariant `poll_outbox_drain` relies on.

## Verification

- **3 new offline tests** (observe-then-drain → `Delivered`; the eventual-
  consistency guard; no-signal no-op) — 20 in the delivery crate.
- `clippy --all-targets` / `fmt` clean; version-bump guard green (sdk `0.18.54`,
  delivery `0.1.3`); `cargo publish --dry-run` passes for **both** crates
  against the published core `0.1.5`.

## Notes / follow-ups (from live probing)

- **`did:webvh` resolution needs the `did-webvh` feature** on
  `affinidi-did-resolver-cache-sdk` (off by default in the SDK/TDK chain) — a
  Phase-3 integration note for any VTI service reaching a `did:webvh` mediator.
- **`profile_enable_websocket` / `wait_for_websocket_ready`** appears to hang
  indefinitely when the websocket won't come up. Orthogonal to this PR (the
  outbox-drain path is REST), but worth a bounded timeout on that wait —
  flagging for a follow-up.

Downstream of #612 — the `Sent → Delivered` lifecycle now has its first
*transport-level* evidence source. Layer-receipt + protocol-reply evidence and
the Phase-3 VTI cut-over follow.

_Heads-up: the `soft_restart_does_not_leak_a_dueling_websocket` flake (#611)
may show Test Suite / Coverage red; it's environmental and unrelated to this
diff._