### PR TITLE
feat: layer-receipt delivery evidence (D1 Phase 2 §5a) — the strongest source

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.1.4] - 2026-07-16
+
+- Add the §5a **layer receipt** — the strongest delivery-confirmation evidence
+  (`receipt` module). When the *receiving* layer durably persists an inbound
+  message it emits a fire-and-forget receipt back to the sender; the *sending*
+  layer recognises it and settles the matching outbox entry `Sent → Delivered`.
+  Real end-to-end evidence for **every** `Guaranteed` message, one-way traffic
+  included, with no application-protocol reply — and the only evidence that
+  closes the mediator's power-loss window.
+  - `Receipt` (a typed JSON body marked by `RECEIPT_TYPE`) + `receipt_key` /
+    `receipt_of` recognisers; `ReceiptPacker` trait abstracts the crypto (like
+    `OutboxStore` abstracts storage — a service/SDK wires in a DID-encrypting
+    packer; the consume half needs none).
+  - `MessagingService`: the dispatcher **consumes** an inbound receipt
+    (`confirm_delivered`, never surfaced to the app; unknown key = no-op) —
+    always active. `MessagingService::with_receipts(.., packer)` additionally
+    **emits** a receipt for every unsolicited message it receives, echoing the
+    thread-id correlation. A request reply is *not* receipted (it is its own
+    protocol-reply evidence); a receipt is never receipted.
+  Additive (new module + constructor; `new` unchanged); pulls `serde`/`serde_json`.
+  8 new offline tests (28 total).
+
 ## [0.1.3] - 2026-07-16
 
 - Add the §5a **outbox-drain** delivery-evidence source: `poll_outbox_drain` /

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -19,6 +19,9 @@ async-trait = "0.1"
 thiserror = "2"
 tracing = "0.1"
 futures-util = "0.3"
+# The layer-receipt (§5a) wire body is a tiny typed JSON message.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 # `MessagingService` spawns the inbound dispatcher (`rt`) and uses
 # broadcast/oneshot/watch (`sync`); the drain uses `time`.
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }

--- a/crates/messaging/affinidi-messaging-delivery/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod confirm;
 pub mod drain;
 pub mod outbox;
+pub mod receipt;
 pub mod service;
 
 pub use confirm::{
@@ -30,4 +31,5 @@ pub use confirm::{
 };
 pub use drain::{DrainReport, drain_loop, drain_once};
 pub use outbox::{InMemoryOutboxStore, Key, OutboxEntry, OutboxError, OutboxState, OutboxStore};
+pub use receipt::{RECEIPT_TYPE, Receipt, ReceiptPacker, receipt_key, receipt_of};
 pub use service::{Delivery, MessagingService, MessagingStatus, Sent};

--- a/crates/messaging/affinidi-messaging-delivery/src/receipt.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/receipt.rs
@@ -1,0 +1,167 @@
+//! §5a **layer receipt** — the strongest delivery-confirmation evidence.
+//!
+//! Both peers run the delivery layer. When the *receiving* layer durably
+//! persists an inbound message, it emits a small fire-and-forget **receipt**
+//! back to the sender, echoing the layer correlation id (the message's thread
+//! id). The *sending* layer recognises that receipt and settles the matching
+//! outbox entry `Sent → Delivered` — real end-to-end evidence for **every**
+//! `Guaranteed` message, one-way traffic included, with no application-protocol
+//! reply. It is the only evidence that also closes the mediator's power-loss
+//! window (it is end-to-end, not mediator-trusting).
+//!
+//! **Fire-and-forget by design** (§5a "who acks the ack? nobody"): a lost
+//! receipt just means the sender's delivery window expires and it re-sends (same
+//! idempotency key); the receiver dedups the re-send and re-emits the receipt.
+//! Receipt loss is self-healing via the existing outbox-retry + receiver-dedup
+//! machinery — no recursion, no "guaranteed ack of a guaranteed ack". The only
+//! cost of a lost receipt is one extra round trip.
+//!
+//! ## Correlation
+//!
+//! A receipt confirms an outbox *idempotency key*. The receiving layer knows
+//! only what the wire surfaces, so it echoes the inbound message's **thread id**
+//! ([`Inbound::thread_id`]) — the layer's correlation anchor. For our own
+//! services (both run the layer) the sending layer stamps `thid == idempotency
+//! key` on a `Guaranteed` send, so the echo lines up; a spurious receipt for an
+//! unknown key is a harmless no-op ([`confirm_delivered`] returns `false`).
+//! Stamping the thread id automatically at pack time lands with the Phase-3
+//! packing integration; until then a caller that sets its own correlation id
+//! gets the same behaviour.
+//!
+//! ## Packing lives outside this crate
+//!
+//! Emitting a receipt requires DID-encrypting it to the recipient — a crypto
+//! concern this crate (which depends only on the transport contract) does not
+//! own, exactly as durable storage is abstracted behind [`OutboxStore`]. A
+//! service wires in a [`ReceiptPacker`] (the SDK packs via the mediator's
+//! `pack_encrypted`); the consume half needs no packer and is always active.
+//!
+//! [`Inbound::thread_id`]: affinidi_messaging_core::Inbound::thread_id
+//! [`confirm_delivered`]: crate::confirm::confirm_delivered
+//! [`OutboxStore`]: crate::outbox::OutboxStore
+
+use serde::{Deserialize, Serialize};
+
+use affinidi_messaging_core::{MessagingError, ReceivedMessage};
+
+use crate::outbox::Key;
+
+/// The delivery-layer receipt message type — the marker that distinguishes a
+/// layer receipt from application traffic on the wire. A specific URI so an
+/// application body cannot be mistaken for a receipt.
+pub const RECEIPT_TYPE: &str = "https://affinidi.com/delivery/1.0/receipt";
+
+/// A layer receipt: positive end-to-end evidence that the peer's delivery layer
+/// durably received the message whose idempotency key is [`Receipt::confirms`].
+///
+/// This is the message *body* the receiving layer sends back; the transport
+/// packs and moves it like any other message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Receipt {
+    /// Discriminates a receipt from any other message body; always
+    /// [`RECEIPT_TYPE`].
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The sender's outbox idempotency key this receipt confirms.
+    pub confirms: Key,
+}
+
+impl Receipt {
+    /// A receipt confirming `idempotency_key`.
+    pub fn new(idempotency_key: impl Into<Key>) -> Self {
+        Self {
+            kind: RECEIPT_TYPE.to_string(),
+            confirms: idempotency_key.into(),
+        }
+    }
+
+    /// Encode this receipt as packed-message *body* bytes.
+    pub fn encode(&self) -> Vec<u8> {
+        // A fixed two-field struct always serializes.
+        serde_json::to_vec(self).expect("receipt serializes")
+    }
+}
+
+/// Decode a message body as a layer receipt, returning the confirmed idempotency
+/// key. `None` for any body that is not a receipt (application traffic, or
+/// non-JSON), so a caller can cheaply tell layer traffic from application
+/// traffic without a separate type channel.
+pub fn receipt_key(payload: &[u8]) -> Option<Key> {
+    let receipt: Receipt = serde_json::from_slice(payload).ok()?;
+    (receipt.kind == RECEIPT_TYPE).then_some(receipt.confirms)
+}
+
+/// The idempotency key a received message is a receipt for, if it is one.
+pub fn receipt_of(message: &ReceivedMessage) -> Option<Key> {
+    receipt_key(&message.payload)
+}
+
+/// Packs a delivery-layer receipt into transport-ready bytes.
+///
+/// Packing is the crypto layer's concern and is deliberately **not** in this
+/// crate — exactly as durable storage is abstracted behind [`OutboxStore`]. A
+/// service wires in a packer that DID-encrypts the receipt body to the recipient
+/// (the SDK does this via the mediator's `pack_encrypted`); tests use a trivial
+/// one. Only the *emit* half needs a packer — the *consume* half (recognising an
+/// inbound receipt and confirming the outbox entry) is always active.
+///
+/// [`OutboxStore`]: crate::outbox::OutboxStore
+#[async_trait::async_trait]
+pub trait ReceiptPacker: Send + Sync {
+    /// Pack a receipt `body` addressed to `to` into bytes ready for
+    /// [`MessageTransport::send`]. Returns `Err` if the recipient can't be
+    /// resolved or the body can't be encrypted — the receipt is then dropped
+    /// (fire-and-forget; the sender's window recovers it).
+    ///
+    /// [`MessageTransport::send`]: affinidi_messaging_core::MessageTransport::send
+    async fn pack_receipt(&self, to: &str, body: Vec<u8>) -> Result<Vec<u8>, MessagingError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_messaging_core::Protocol;
+
+    fn message_with(payload: Vec<u8>) -> ReceivedMessage {
+        ReceivedMessage {
+            id: "m1".to_string(),
+            sender: Some("did:example:alice".to_string()),
+            recipient: "did:example:bob".to_string(),
+            payload,
+            protocol: Protocol::DIDComm,
+            verified: true,
+            encrypted: true,
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrips_the_confirmed_key() {
+        // A key with colons (DIDs, the default `to:now:seq` shape) must survive.
+        let key = "did:example:bob:1737000000000:7";
+        let bytes = Receipt::new(key).encode();
+        assert_eq!(receipt_key(&bytes).as_deref(), Some(key));
+        assert_eq!(receipt_of(&message_with(bytes)).as_deref(), Some(key));
+    }
+
+    #[test]
+    fn application_traffic_is_not_mistaken_for_a_receipt() {
+        // Non-JSON.
+        assert_eq!(receipt_key(b"not json at all"), None);
+        // JSON, but not a receipt.
+        assert_eq!(receipt_key(br#"{"hello":"world"}"#), None);
+        // JSON with a `confirms` but the wrong type marker.
+        assert_eq!(
+            receipt_key(br#"{"type":"https://example.com/other","confirms":"k"}"#),
+            None
+        );
+        // Empty body.
+        assert_eq!(receipt_key(b""), None);
+    }
+
+    #[test]
+    fn receipt_type_is_the_stable_marker() {
+        let bytes = Receipt::new("k").encode();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains(RECEIPT_TYPE));
+    }
+}

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -13,7 +13,9 @@ use futures_util::stream::{self, BoxStream, StreamExt};
 use tokio::sync::{broadcast, oneshot, watch};
 use tokio::task::JoinHandle;
 
+use crate::confirm::confirm_delivered;
 use crate::outbox::{Key, OutboxEntry, OutboxState, OutboxStore};
+use crate::receipt::{self, Receipt, ReceiptPacker};
 
 /// The delivery guarantee for a [`MessagingService::send`].
 #[derive(Debug, Clone)]
@@ -89,15 +91,43 @@ pub struct MessagingService {
 impl MessagingService {
     /// Build the service over `transport` + `outbox` and start the inbound
     /// dispatcher. Must be called inside a Tokio runtime.
+    ///
+    /// The layer-receipt **consume** half is always active — an inbound receipt
+    /// confirms its matching outbox entry `Sent → Delivered` (§5a). To also
+    /// **emit** receipts for messages this service receives, build with
+    /// [`with_receipts`](Self::with_receipts).
     pub fn new(transport: Arc<dyn MessageTransport>, outbox: Arc<dyn OutboxStore>) -> Self {
+        Self::build(transport, outbox, None)
+    }
+
+    /// Build the service and, additionally, **emit** a fire-and-forget layer
+    /// receipt (§5a) for every unsolicited message it durably receives, using
+    /// `receipt_packer` to encrypt the receipt to the sender. This is what lets
+    /// a peer's `Guaranteed` outbox entry settle `Delivered` with no
+    /// application-protocol reply.
+    pub fn with_receipts(
+        transport: Arc<dyn MessageTransport>,
+        outbox: Arc<dyn OutboxStore>,
+        receipt_packer: Arc<dyn ReceiptPacker>,
+    ) -> Self {
+        Self::build(transport, outbox, Some(receipt_packer))
+    }
+
+    fn build(
+        transport: Arc<dyn MessageTransport>,
+        outbox: Arc<dyn OutboxStore>,
+        receipt_packer: Option<Arc<dyn ReceiptPacker>>,
+    ) -> Self {
         let waiters: WaiterMap = Arc::new(Mutex::new(HashMap::new()));
         let (subscribers, _) = broadcast::channel(SUBSCRIBE_BUFFER);
         let conn_state = transport.connection_state();
 
         let dispatcher = tokio::spawn(run_dispatcher(
             transport.clone(),
+            outbox.clone(),
             waiters.clone(),
             subscribers.clone(),
+            receipt_packer,
         ));
 
         Self {
@@ -251,29 +281,66 @@ impl MessagingService {
     }
 }
 
-/// The single inbound dispatcher: read `inbound()` once, route each message to a
-/// matching `request` waiter (by thread id) or to `subscribe`, then ack it once
-/// after handoff.
+/// The single inbound dispatcher: read `inbound()` once, then for each message
+/// either
+/// 1. **consume** it as a layer receipt — confirm its outbox entry `Sent →
+///    Delivered` (§5a) and never surface it to the application; or
+/// 2. **route** it to a matching `request` waiter (by thread id) or to
+///    `subscribe`, emitting a fire-and-forget receipt for unsolicited traffic
+///    when a packer is configured;
+///
+/// then ack it once after handoff.
 async fn run_dispatcher(
     transport: Arc<dyn MessageTransport>,
+    outbox: Arc<dyn OutboxStore>,
     waiters: WaiterMap,
     subscribers: broadcast::Sender<Inbound>,
+    receipt_packer: Option<Arc<dyn ReceiptPacker>>,
 ) {
     let mut inbound = transport.inbound();
     while let Some(item) = inbound.next().await {
         let ack = item.ack.clone();
+
+        // 1. A layer receipt is consumed by the layer, not the application: it
+        //    confirms the matching outbox entry Sent → Delivered. A receipt for
+        //    an unknown/terminal key is a harmless no-op (spurious/duplicate).
+        if let Some(key) = receipt::receipt_of(&item.message) {
+            match confirm_delivered(outbox.as_ref(), &key).await {
+                Ok(true) => {
+                    tracing::debug!(idempotency_key = %key, "layer receipt confirmed delivery")
+                }
+                Ok(false) => {}
+                Err(e) => tracing::warn!(error = %e, "failed to apply layer receipt"),
+            }
+            if let Err(e) = transport.ack(ack).await {
+                tracing::warn!(error = %e, "failed to ack layer receipt");
+            }
+            continue;
+        }
+
+        // 2. Route application traffic.
         let waiter = item
             .thread_id
             .clone()
             .and_then(|thid| waiters.lock().expect("waiters mutex").remove(&thid));
 
         match waiter {
-            // A reply for an in-flight request → its waiter.
+            // A reply for an in-flight request → its waiter. A reply is its own
+            // evidence (the protocol-reply source); we do NOT also receipt it.
             Some(tx) => {
                 let _ = tx.send(item.message);
             }
-            // Unsolicited → subscribers (dropped if none are listening).
+            // Unsolicited → subscribers (dropped if none are listening). If we
+            // run the layer (a packer is configured), emit a fire-and-forget
+            // receipt echoing the correlation so the sender's Guaranteed outbox
+            // entry settles Delivered — end-to-end evidence, no app reply.
             None => {
+                if let Some(packer) = receipt_packer.as_ref()
+                    && let (Some(to), Some(confirms)) =
+                        (item.message.sender.clone(), item.thread_id.clone())
+                {
+                    spawn_receipt(transport.clone(), packer.clone(), to, confirms);
+                }
                 let _ = subscribers.send(item);
             }
         }
@@ -284,6 +351,29 @@ async fn run_dispatcher(
             tracing::warn!(error = %e, "failed to ack inbound message after handoff");
         }
     }
+}
+
+/// Pack and send a fire-and-forget layer receipt confirming `confirms` back to
+/// `to`, on a detached task so a slow pack/send never stalls the dispatcher. A
+/// pack or send failure is only logged: the receipt is self-healing (the
+/// sender's delivery window expires and it re-sends; the receiver re-emits).
+fn spawn_receipt(
+    transport: Arc<dyn MessageTransport>,
+    packer: Arc<dyn ReceiptPacker>,
+    to: String,
+    confirms: String,
+) {
+    tokio::spawn(async move {
+        let body = Receipt::new(confirms).encode();
+        match packer.pack_receipt(&to, body).await {
+            Ok(packed) => {
+                if let Err(e) = transport.send(&to, packed).await {
+                    tracing::debug!(error = %e, to = %to, "layer receipt send failed (self-healing on window expiry)");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, to = %to, "failed to pack layer receipt"),
+        }
+    });
 }
 
 /// A unique default idempotency key for a `Guaranteed` send with none supplied.
@@ -524,6 +614,171 @@ mod tests {
 
         h.conn_tx.send(ConnState::Connected).unwrap();
         assert_eq!(svc.status(), MessagingStatus::Connected);
+    }
+
+    // ── Layer-receipt evidence (§5a) ─────────────────────────────────────
+
+    /// A trivial packer: records who it packed for and wraps the body so the
+    /// test can prove the receipt reached the transport.
+    struct MockPacker {
+        packed_for: Mutex<Vec<String>>,
+    }
+    impl MockPacker {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                packed_for: Mutex::new(Vec::new()),
+            })
+        }
+    }
+    #[async_trait::async_trait]
+    impl ReceiptPacker for MockPacker {
+        async fn pack_receipt(&self, to: &str, body: Vec<u8>) -> Result<Vec<u8>, MessagingError> {
+            self.packed_for.lock().unwrap().push(to.to_string());
+            Ok(body) // "packed" == the raw receipt body, for assertion
+        }
+    }
+
+    /// An inbound whose payload IS a layer receipt confirming `confirms`.
+    fn inbound_receipt(confirms: &str, ack: &str) -> Inbound {
+        let mut item = inbound("receipt-msg", None, ack);
+        item.message.payload = Receipt::new(confirms).encode();
+        item
+    }
+
+    async fn sent_entry(outbox: &InMemoryOutboxStore, key: &str) {
+        let mut e = OutboxEntry::new(key, "did:example:bob", vec![1], 1_000, 61_000);
+        e.state = OutboxState::Sent;
+        outbox.put(e).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_layer_receipt_confirms_its_outbox_entry_and_is_not_routed() {
+        let h = mock();
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        sent_entry(&outbox, "k").await; // a Guaranteed send awaiting evidence
+        let svc = MessagingService::new(h.transport.clone(), outbox.clone());
+        let mut sub = svc.subscribe();
+
+        // A receipt for "k" arrives.
+        h.inbound_tx
+            .send(inbound_receipt("k", "q-receipt"))
+            .unwrap();
+
+        // The outbox entry settles Delivered (consumed by the layer)…
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            outbox.get("k").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+        // …the receipt is acked…
+        assert_eq!(h.transport.acked.lock().unwrap().as_slice(), &["q-receipt"]);
+        // …and never surfaced to the application.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), sub.next())
+                .await
+                .is_err(),
+            "a layer receipt must not reach subscribers"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_receipt_for_an_unknown_key_is_a_harmless_noop() {
+        let h = mock();
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let svc = MessagingService::new(h.transport.clone(), outbox.clone());
+        let _sub = svc.subscribe();
+
+        h.inbound_tx
+            .send(inbound_receipt("never-sent", "q"))
+            .unwrap();
+
+        // Nothing to confirm, but it's still consumed + acked, not an error.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(outbox.get("never-sent").await.unwrap().is_none());
+        assert_eq!(h.transport.acked.lock().unwrap().as_slice(), &["q"]);
+    }
+
+    #[tokio::test]
+    async fn an_unsolicited_message_emits_a_receipt_when_a_packer_is_configured() {
+        let h = mock();
+        let packer = MockPacker::new();
+        let svc = MessagingService::with_receipts(
+            h.transport.clone(),
+            Arc::new(InMemoryOutboxStore::new()),
+            packer.clone(),
+        );
+        let mut sub = svc.subscribe();
+
+        // Unsolicited (no matching waiter), with a sender + correlation thid.
+        h.inbound_tx
+            .send(inbound("push-1", Some("corr-key"), "q-push"))
+            .unwrap();
+
+        // Still delivered to the app…
+        let got = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .expect("subscribe yields the push")
+            .expect("stream item");
+        assert_eq!(got.message.id, "push-1");
+
+        // …and a receipt was packed for the sender and sent back to it,
+        // echoing the correlation as the confirmed key.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            packer.packed_for.lock().unwrap().as_slice(),
+            &["did:example:alice"]
+        );
+        let sent = h.transport.sent.lock().unwrap();
+        let (dest, body) = sent.last().expect("a receipt was sent");
+        assert_eq!(dest, "did:example:alice");
+        assert_eq!(receipt::receipt_key(body).as_deref(), Some("corr-key"));
+    }
+
+    #[tokio::test]
+    async fn a_reply_to_a_request_is_not_receipted() {
+        let h = mock();
+        let packer = MockPacker::new();
+        let svc = Arc::new(MessagingService::with_receipts(
+            h.transport.clone(),
+            Arc::new(InMemoryOutboxStore::new()),
+            packer.clone(),
+        ));
+
+        let svc2 = svc.clone();
+        let req = tokio::spawn(async move {
+            svc2.request("did:x", b"req".to_vec(), "thread-1", Duration::from_secs(5))
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The reply matches the in-flight request's waiter.
+        h.inbound_tx
+            .send(inbound("reply", Some("thread-1"), "q-reply"))
+            .unwrap();
+        assert_eq!(req.await.unwrap().unwrap().id, "reply");
+
+        // A reply is its own (protocol-reply) evidence — no layer receipt emitted.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            packer.packed_for.lock().unwrap().is_empty(),
+            "a request reply must not trigger a layer receipt"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_receipt_is_emitted_without_a_packer() {
+        let h = mock();
+        let svc = MessagingService::new(h.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let _sub = svc.subscribe();
+
+        h.inbound_tx
+            .send(inbound("push-1", Some("corr"), "q-push"))
+            .unwrap();
+
+        // Consume-only service: the push is delivered + acked, but nothing is
+        // sent back (no emit half).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(h.transport.sent.lock().unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

The **layer receipt** — the strongest §5a delivery-confirmation evidence, and
the natural pair to the outbox-drain source (#613). Both peers run the delivery
layer: when the *receiving* layer durably persists an inbound message it emits a
fire-and-forget **receipt** back to the sender; the *sending* layer recognises
it and settles the matching outbox entry `Sent → Delivered`.

Real end-to-end evidence for **every** `Guaranteed` message — one-way traffic
included, no application-protocol reply needed — and the only source that also
closes the mediator's power-loss durability window (it is end-to-end, not
mediator-trusting).

- **`receipt` module** — `Receipt` (a typed JSON body marked by `RECEIPT_TYPE`)
  + `receipt_key` / `receipt_of` recognisers. A **`ReceiptPacker`** trait
  abstracts the crypto exactly as `OutboxStore` abstracts storage: a service/SDK
  wires in a DID-encrypting packer; the consume half needs none.
- **`MessagingService` dispatcher — consume** (always active): an inbound
  receipt confirms its outbox entry (`confirm_delivered`) and is **never**
  surfaced to the application; a receipt for an unknown/terminal key is a
  harmless no-op.
- **`MessagingService::with_receipts(.., packer)` — emit**: additionally emits a
  fire-and-forget receipt for every **unsolicited** message received, echoing
  the thread-id correlation, on a detached task so a slow pack/send never stalls
  the dispatcher. A **request reply is not receipted** (it is its own
  *protocol-reply* evidence); a **receipt is never receipted** (no loops).

## Fire-and-forget by design

§5a "who acks the ack? nobody." A lost receipt just means the sender's delivery
window expires and it re-sends (same idempotency key); the receiver dedups the
re-send and re-emits. Self-healing via the existing outbox-retry + receiver-dedup
machinery — no "guaranteed ack of a guaranteed ack".

## Correlation & scope

A receipt confirms an outbox *idempotency key*; the receiving layer echoes the
inbound **thread id** (the layer's correlation anchor). For our own services the
sending layer stamps `thid == idempotency key` on a `Guaranteed` send, so the
echo lines up. Stamping that automatically **at pack time**, and the concrete
SDK/mediator `ReceiptPacker` impl (`pack_encrypted`), land with the **Phase-3
packing integration** — where the layer meets the crypto boundary. This PR ships
the transport-agnostic mechanism + both wiring halves, fully offline-tested,
mirroring how `OutboxStore` shipped as a trait + in-memory impl.

## Verification

- **8 new offline tests** (28 total): receipt codec roundtrip / app-traffic
  rejection; receipt confirms its entry & isn't routed; unknown-key no-op;
  unsolicited-message emits a receipt to the sender echoing the correlation;
  a request reply is not receipted; no emit without a packer.
- `clippy --all-targets` / `fmt` clean; `cargo publish -p
  affinidi-messaging-delivery --dry-run` passes against the published core
  `0.1.5`; version-bump guard green (delivery `0.1.4`). Single-crate, additive.

Downstream of #612/#613. §5a now has its two primary evidence sources —
layer-receipt (peers running the layer) and outbox-drain (standard-pickup third
parties). Remaining Phase 2: protocol-reply evidence + multi-transport status
aggregation; then the Phase-3 VTI cut-over.

_Heads-up: the `soft_restart_does_not_leak_a_dueling_websocket` flake (#611) may
show Test Suite / Coverage red; it's environmental and unrelated to this diff
(which touches only `affinidi-messaging-delivery`)._