### PR TITLE
feat: protocol-reply delivery evidence (D1 Phase 2 §5a) — completes the evidence trio

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.5] - 2026-07-16
+
+- Add the §5a **protocol-reply** evidence source (the third §5a source, after
+  layer-receipt and outbox-drain). An inbound message arriving *in the thread of*
+  a `Sent` outbox entry — thread id matches its idempotency key — is proof the
+  peer received the original `Guaranteed` send (you cannot reply in-thread to a
+  message you never got), so the dispatcher settles that entry `Delivered` with
+  no application ack of our own. Where the peer already replies (registry
+  response, RPC, approver approve/deny), that reply *is* the receipt.
+  - Consume-only, event-driven in the inbound dispatcher; needs no packer.
+    Idempotent — a no-op when no `Sent` entry matches, and harmless when a layer
+    receipt already confirmed the same entry. The reply is still delivered to the
+    application as ordinary traffic.
+  - A reply that confirms one of our own sends is **not** itself receipted (it is
+    a reply, not a fresh `Guaranteed` push; its thread id is the original thread,
+    not the reply's own key).
+  Additive (dispatcher behaviour; no API change). 2 new offline tests (30 total).
+
 ## [0.1.4] - 2026-07-16
 
 - Add the §5a **layer receipt** — the strongest delivery-confirmation evidence

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -318,7 +318,31 @@ async fn run_dispatcher(
             continue;
         }
 
-        // 2. Route application traffic.
+        // 2. Protocol-reply evidence (§5a): a peer replying *in the thread* of one
+        //    of our Guaranteed sends proves it received the original — you cannot
+        //    reply in-thread to a message you never got. So an inbound whose
+        //    thread id matches a `Sent` outbox entry confirms it `Delivered`,
+        //    with no application ack of our own. Idempotent: a no-op when no
+        //    `Sent` entry matches, and harmless if a layer receipt already
+        //    confirmed the same entry. The reply is still ordinary application
+        //    traffic — it is also routed below.
+        let confirmed_our_send = match item.thread_id.as_deref() {
+            Some(thid) => match confirm_delivered(outbox.as_ref(), thid).await {
+                Ok(confirmed) => {
+                    if confirmed {
+                        tracing::debug!(idempotency_key = %thid, "protocol reply confirmed delivery");
+                    }
+                    confirmed
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to apply protocol-reply evidence");
+                    false
+                }
+            },
+            None => false,
+        };
+
+        // 3. Route application traffic.
         let waiter = item
             .thread_id
             .clone()
@@ -331,11 +355,16 @@ async fn run_dispatcher(
                 let _ = tx.send(item.message);
             }
             // Unsolicited → subscribers (dropped if none are listening). If we
-            // run the layer (a packer is configured), emit a fire-and-forget
-            // receipt echoing the correlation so the sender's Guaranteed outbox
-            // entry settles Delivered — end-to-end evidence, no app reply.
+            // run the layer (a packer is configured) AND this is a fresh inbound
+            // rather than a reply to our own Guaranteed send, emit a fire-and-
+            // forget receipt echoing the correlation so *that* sender's outbox
+            // entry settles Delivered. A message that just confirmed one of our
+            // sends is a reply, not a fresh Guaranteed push, so it needs no
+            // receipt from us (its thread id is the original thread, not the
+            // reply's own key — a receipt would be a no-op on the peer anyway).
             None => {
-                if let Some(packer) = receipt_packer.as_ref()
+                if !confirmed_our_send
+                    && let Some(packer) = receipt_packer.as_ref()
                     && let (Some(to), Some(confirms)) =
                         (item.message.sender.clone(), item.thread_id.clone())
                 {
@@ -779,6 +808,61 @@ mod tests {
         // sent back (no emit half).
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(h.transport.sent.lock().unwrap().is_empty());
+    }
+
+    // ── Protocol-reply evidence (§5a) ────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_reply_in_thread_confirms_a_guaranteed_send_and_still_delivers() {
+        let h = mock();
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        sent_entry(&outbox, "thid-x").await; // a Guaranteed send awaiting evidence
+        let svc = MessagingService::new(h.transport.clone(), outbox.clone());
+        let mut sub = svc.subscribe();
+
+        // A peer replies in the thread of our send (thid == the idempotency key).
+        h.inbound_tx
+            .send(inbound("the-reply", Some("thid-x"), "q-reply"))
+            .unwrap();
+
+        // The reply is evidence → the outbox entry settles Delivered…
+        let got = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .expect("subscribe yields the reply")
+            .expect("stream item");
+        // …and is STILL delivered to the application (it is a real message).
+        assert_eq!(got.message.id, "the-reply");
+        assert_eq!(
+            outbox.get("thid-x").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reply_confirming_our_send_is_not_receipted() {
+        let h = mock();
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        sent_entry(&outbox, "thid-x").await;
+        let packer = MockPacker::new();
+        let svc =
+            MessagingService::with_receipts(h.transport.clone(), outbox.clone(), packer.clone());
+        let _sub = svc.subscribe();
+
+        h.inbound_tx
+            .send(inbound("the-reply", Some("thid-x"), "q-reply"))
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Confirmed our send (protocol reply)…
+        assert_eq!(
+            outbox.get("thid-x").await.unwrap().unwrap().state,
+            OutboxState::Delivered
+        );
+        // …and, being a reply to our own send, is NOT itself receipted.
+        assert!(
+            packer.packed_for.lock().unwrap().is_empty(),
+            "a reply confirming our send must not trigger a receipt"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

The **protocol-reply** evidence source — the third and final §5a source, after
layer-receipt (#614) and outbox-drain (#613). Where the peer already replies
(registry response, RPC, an approver's approve/deny), **that reply *is* the
receipt**.

An inbound message arriving **in the thread of** a `Sent` outbox entry — its
thread id matches the entry's idempotency key — is proof the peer received the
original `Guaranteed` send (you cannot reply in-thread to a message you never
got). So the inbound dispatcher settles that entry `Delivered`, with no
application ack of our own.

- **Consume-only**, event-driven in the dispatcher; needs no packer. **Idempotent**
  — a no-op when no `Sent` entry matches, and harmless when a layer receipt
  already confirmed the same entry (`confirm_delivered` is idempotent, so the two
  sources compose). The reply is **still delivered to the application** as
  ordinary traffic.
- A reply that confirms one of our own sends is **not** itself receipted: it is a
  reply, not a fresh `Guaranteed` push, and its thread id is the *original*
  thread rather than the reply's own key — a receipt echoing it would be a no-op
  on the peer anyway. This cleanly separates the two directions of evidence (the
  layer-receipt wiring already skipped request-waiter replies for exactly this
  reason; now the async-reply case is handled too).

## Verification

- **2 new offline tests** (30 total): a reply in-thread confirms the send *and*
  is still delivered to the app; a reply confirming our own send is not receipted.
  All prior layer-receipt/outbox-drain tests unchanged and green.
- `clippy --all-targets` / `fmt` clean; `cargo publish -p
  affinidi-messaging-delivery --dry-run` passes against the published core
  `0.1.5`; version-bump guard green (delivery `0.1.5`). Single-crate, additive
  (dispatcher behaviour; no API change).

Downstream of #612/#613/#614. **§5a now has all three evidence sources** —
layer-receipt (peers running the layer), outbox-drain (standard-pickup third
parties), and protocol-reply (peers that already answer). That functionally
completes the Phase-2 confirmation story; the Phase-3 VTI cut-over is next.

_Heads-up: the `soft_restart_does_not_leak_a_dueling_websocket` flake (#611) may
show Test Suite / Coverage red; it's environmental and unrelated to this diff
(which touches only `affinidi-messaging-delivery`)._