### PR TITLE
feat: derive Serialize/Deserialize on OutboxEntry + OutboxState (durable OutboxStore)

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.7] - 2026-07-17
+
+- Derive `Serialize`/`Deserialize` on `OutboxEntry` and `OutboxState` so a
+  **durable** `OutboxStore` can persist entries (a service backing the outbox
+  with an on-disk keyspace — the production path; the in-memory store is
+  dev-only). Format-agnostic: JSON encodes `packed` as a byte array, CBOR/bincode
+  compactly. Additive; no field or API change. 1 new roundtrip test.
+
 ## [0.1.6] - 2026-07-16
 
 - Add **escalate-on-expiry** (§5a): when a `Sent` entry's delivery window passes

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use serde::{Deserialize, Serialize};
+
 /// An idempotency or ordering key. The idempotency key is the dedup anchor; the
 /// ordering key groups entries into a per-key FIFO.
 pub type Key = String;
@@ -15,7 +17,7 @@ pub type Key = String;
 /// accepted the bytes (durably queued at the mediator) and we are awaiting
 /// end-to-end evidence. Confirmation (`Sent → Delivered`) lands in a later
 /// increment; until then a `Sent` entry is simply not re-sent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum OutboxState {
     /// Not yet handed off, or a failed attempt awaiting its next retry.
@@ -47,7 +49,12 @@ impl OutboxState {
 /// The entry records **who** the message is for (`dest_did`), not which wire —
 /// the transport is resolved at drain time. Timestamps are Unix milliseconds;
 /// the drain takes the clock as a parameter so it stays deterministic in tests.
-#[derive(Debug, Clone)]
+///
+/// `Serialize`/`Deserialize` so a durable [`OutboxStore`] can persist entries
+/// (e.g. a service backing the outbox with an on-disk keyspace). The derive is
+/// format-agnostic — a JSON store encodes `packed` as a byte array, a CBOR/
+/// bincode store compactly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutboxEntry {
     /// Dedup anchor. The receiver drops a duplicate carrying the same key, which
     /// is what makes at-least-once retry safe.
@@ -249,6 +256,34 @@ mod tests {
             created,
             created + 60_000,
         )
+    }
+
+    #[test]
+    fn entry_survives_a_serde_roundtrip() {
+        // A durable OutboxStore persists entries via serde; every field must
+        // survive the round trip (incl. the §5a hop_id / outbox_observed and a
+        // non-Queued state).
+        let mut e = entry("k1", 1_000).with_ordering_key("ord");
+        e.state = OutboxState::Sent;
+        e.attempts = 3;
+        e.next_attempt_at_ms = 1_500;
+        e.hop_id = Some("hop-abc".to_string());
+        e.outbox_observed = true;
+
+        let json = serde_json::to_vec(&e).unwrap();
+        let back: OutboxEntry = serde_json::from_slice(&json).unwrap();
+
+        assert_eq!(back.idempotency_key, "k1");
+        assert_eq!(back.dest_did, "did:example:bob");
+        assert_eq!(back.ordering_key.as_deref(), Some("ord"));
+        assert_eq!(back.packed, vec![1, 2, 3]);
+        assert_eq!(back.state, OutboxState::Sent);
+        assert_eq!(back.attempts, 3);
+        assert_eq!(back.next_attempt_at_ms, 1_500);
+        assert_eq!(back.created_at_ms, 1_000);
+        assert_eq!(back.deliver_by_ms, 61_000);
+        assert_eq!(back.hop_id.as_deref(), Some("hop-abc"));
+        assert!(back.outbox_observed);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Derive `Serialize`/`Deserialize` on `OutboxEntry` and `OutboxState`.

A **durable** `OutboxStore` — a service backing the delivery outbox with an
on-disk keyspace, which is the production path (the shipped `InMemoryOutboxStore`
is dev-only, loses queued work on restart) — must persist entries via serde. The
types were `Debug`/`Clone` only, so they couldn't be serialized. This is the one
gap that surfaced wiring the layer into a real durable backend (VTI's fjall-backed
store): every `pub` field `OutboxStore::due`'s per-`ordering_key` FIFO gating
reads is already public; only the derives were missing.

Format-agnostic: a JSON store encodes `packed` as a byte array, a CBOR/bincode
store compactly — the derive imposes no format.

## Verification

Additive — no field, variant, or API change (`OutboxState` stays
`#[non_exhaustive]`). 1 new roundtrip test asserting every field (incl. the §5a
`hop_id`/`outbox_observed` and a non-`Queued` state) survives serde — 35 tests
total. `clippy`/`fmt` clean; `cargo publish --dry-run` green against the published
core `0.1.5`; version-bump guard green (delivery `0.1.7`). Single-crate.

Unblocks the Phase-3 VTI cut-over's durable `OutboxStore` (over `vti_common::Store`).

_Heads-up: the `soft_restart_does_not_leak_a_dueling_websocket` flake (#611) may
show Test Suite / Coverage red; environmental, unrelated to this diff._