### PR TITLE
fix: websocket connect deadlock from truthful-send (#611 root cause) + de-flake the gate test

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/tests/soft_restart_websocket.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/tests/soft_restart_websocket.rs
@@ -25,16 +25,57 @@ use std::time::Duration;
 use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_didcomm_service::{
     DIDCommResponse, DIDCommService, DIDCommServiceConfig, DIDCommServiceError, Extension,
-    HandlerContext, ListenerConfig, MESSAGE_PICKUP_STATUS_TYPE, RestartPolicy, RetryConfig, Router,
-    TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
+    HandlerContext, ListenerConfig, ListenerEvent, MESSAGE_PICKUP_STATUS_TYPE, RestartPolicy,
+    RetryConfig, Router, TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
 };
 use affinidi_messaging_test_mediator::TestMediator;
 use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
 use affinidi_tdk_common::profiles::TDKProfile;
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 const REPORT_PROBLEM_TYPE: &str = "https://didcomm.org/report-problem/2.0/problem-report";
 const LISTENER_ID: &str = "vta-main";
+
+/// Connect gate for loaded CI runners (#611). A single `connect()` attempt
+/// may legitimately spend up to 10s inside the service's `profile_add`
+/// timeout, and the test's restart policy backs off 1–2s between attempts —
+/// so the old flat 15s budget fit barely one and a half attempts, and one
+/// slow attempt on a saturated runner failed the whole test. 60s fits about
+/// five full attempts; when healthy the wait returns in well under a second,
+/// so the larger budget costs nothing.
+const CONNECT_BUDGET: Duration = Duration::from_secs(60);
+
+/// Wait for the listener to connect, panicking with every lifecycle event
+/// seen so far when the budget expires — so a CI failure names the actual
+/// connect error(s) instead of an opaque `Timeout(Elapsed(()))`.
+async fn wait_connected_or_dump_events(
+    service: &DIDCommService,
+    events: &mut broadcast::Receiver<ListenerEvent>,
+    generation: &str,
+) {
+    if service
+        .wait_connected(LISTENER_ID, CONNECT_BUDGET)
+        .await
+        .is_ok()
+    {
+        return;
+    }
+    let mut seen = Vec::new();
+    loop {
+        match events.try_recv() {
+            Ok(event) => seen.push(format!("{event:?}")),
+            Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                seen.push(format!("({n} earlier event(s) dropped)"));
+            }
+            Err(_) => break,
+        }
+    }
+    panic!(
+        "service {generation} failed to connect to the mediator within \
+         {CONNECT_BUDGET:?}; lifecycle events observed: {seen:#?}"
+    );
+}
 
 /// Counts `w.websocket.duplicate-channel` problem reports delivered to the
 /// listener. A healthy, singly-connected listener never receives one.
@@ -120,10 +161,8 @@ async fn soft_restart_does_not_leak_a_dueling_websocket() {
     )
     .await
     .expect("start service generation 1");
-    service1
-        .wait_connected(LISTENER_ID, Duration::from_secs(15))
-        .await
-        .expect("service 1 connects to mediator");
+    let mut events1 = service1.subscribe();
+    wait_connected_or_dump_events(&service1, &mut events1, "1").await;
 
     // Soft restart: tear the first service down. With the fix this stops the
     // websocket; without it, the socket is orphaned and keeps reconnecting.
@@ -139,10 +178,8 @@ async fn soft_restart_does_not_leak_a_dueling_websocket() {
     )
     .await
     .expect("start service generation 2");
-    service2
-        .wait_connected(LISTENER_ID, Duration::from_secs(15))
-        .await
-        .expect("service 2 connects to mediator");
+    let mut events2 = service2.subscribe();
+    wait_connected_or_dump_events(&service2, &mut events2, "2").await;
 
     // Give any orphaned socket several reconnect cycles (initial backoff is
     // 1s, capped at 2s) to start a duplicate-channel war. Poll so the test

--- a/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_live_stream.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_live_stream.rs
@@ -28,9 +28,12 @@ use tokio_util::sync::CancellationToken;
 
 const LISTENER_ID: &str = "svc";
 
+/// `(payload, sender_vid)` pairs recorded by [`RecordingTspHandler`].
+type ReceivedFrames = Arc<Mutex<Vec<(Vec<u8>, String)>>>;
+
 /// Records every TSP payload + sender the service receives.
 struct RecordingTspHandler {
-    received: Arc<Mutex<Vec<(Vec<u8>, String)>>>,
+    received: ReceivedFrames,
 }
 
 #[async_trait]
@@ -87,7 +90,10 @@ async fn tsp_frame_is_delivered_over_the_multiplexed_live_stream() {
     .await
     .expect("start service");
     service_handle
-        .wait_connected(LISTENER_ID, Duration::from_secs(15))
+        // 60s, not 15s: one connect attempt can spend 10s in the service's
+        // `profile_add` timeout on a loaded CI runner, so a flat 15s budget
+        // fits barely one retry (#611). Returns immediately when healthy.
+        .wait_connected(LISTENER_ID, Duration::from_secs(60))
         .await
         .expect("service connects to mediator");
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.18.55] - 2026-07-17
+
+- **Fix a connect-path deadlock introduced by the truthful-send change in
+  0.18.52** (#611). The websocket transport's connection setup enables live
+  delivery *from the transport task itself*; since 0.18.52 that call — routed
+  through `ATM::send_message` — enqueued a `SendMessage` command into the
+  transport's **own** command channel and awaited the write-outcome reply that
+  only the (busy) transport task could produce. Every websocket connect
+  attempt therefore hung until the caller's timeout, deterministically:
+  `profile_add(_, true)` timed out at 10s, and the didcomm-service
+  `soft_restart_websocket` CI test failed on every run after 0.18.52 (it was
+  mis-filed as a flake). The live-delivery-change frame is now packed via the
+  new internal `MessagePickup::packed_live_delivery_change` and written
+  directly to the socket the setup code already holds — same message, same
+  packing, no round-trip through the command channel. `toggle_live_delivery`
+  is unchanged for external callers and still sends through the normal
+  (truthful) transport path.
+
 ## [0.18.54] - 2026-07-16
 
 - `DidCommTransport` gains outbox-drain delivery evidence (D1 Phase 2, §5a):

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.54"
+version = "0.18.55"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -188,40 +188,62 @@ impl MessagePickup {
         let _span = span!(Level::DEBUG, "toggle_live_delivery",);
         async move {
             debug!("Setting live_delivery to ({})", live_delivery);
-            let (profile_did, mediator_did) = profile.dids()?;
+            let (packed, msg_id) =
+                Self::packed_live_delivery_change(atm, profile, live_delivery).await?;
 
-            let now = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-
-            let mut msg = Message::build(
-                Uuid::new_v4().to_string(),
-                "https://didcomm.org/messagepickup/3.0/live-delivery-change".to_owned(),
-                json!({"live_delivery": live_delivery}),
-            )
-            .created_time(now)
-            .expires_time(now + 300)
-            .from(profile_did.into())
-            .to(mediator_did.into())
-            .finalize();
-            msg.extra
-                .insert("return_route".to_string(), Value::String("all".into()));
-            let msg_id = msg.id.clone();
-
-            // Pack the message
-            let (msg, _) = atm
-                .inner
-                .pack_encrypted(&msg, mediator_did, Some(profile_did))
-                .await
-                .map_err(|e| ATMError::MsgSendError(format!("Error packing message: {e}")))?;
-
-            atm.send_message(profile, &msg, &msg_id, false, false)
+            atm.send_message(profile, &packed, &msg_id, false, false)
                 .await?;
             Ok(msg_id)
         }
         .instrument(_span)
         .await
+    }
+
+    /// Build and pack a Message Pickup 3.0 `live-delivery-change` message
+    /// without sending it. Returns `(packed_message, msg_id)`.
+    ///
+    /// Exists so the websocket transport's connection setup can write the
+    /// frame **directly** to the socket it is holding: that code runs *on*
+    /// the transport task, and routing it through [`ATM::send_message`] would
+    /// enqueue a `SendMessage` command into the transport's own channel and
+    /// then await a reply that only the (currently busy) transport task could
+    /// produce — a deadlock that made every connect attempt time out (#611).
+    /// All other callers should use
+    /// [`toggle_live_delivery`](Self::toggle_live_delivery), which sends
+    /// through the normal transport path.
+    pub(crate) async fn packed_live_delivery_change(
+        atm: &ATM,
+        profile: &Arc<ATMProfile>,
+        live_delivery: bool,
+    ) -> Result<(String, String), ATMError> {
+        let (profile_did, mediator_did) = profile.dids()?;
+
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let mut msg = Message::build(
+            Uuid::new_v4().to_string(),
+            "https://didcomm.org/messagepickup/3.0/live-delivery-change".to_owned(),
+            json!({"live_delivery": live_delivery}),
+        )
+        .created_time(now)
+        .expires_time(now + 300)
+        .from(profile_did.into())
+        .to(mediator_did.into())
+        .finalize();
+        msg.extra
+            .insert("return_route".to_string(), Value::String("all".into()));
+        let msg_id = msg.id.clone();
+
+        let (packed, _) = atm
+            .inner
+            .pack_encrypted(&msg, mediator_did, Some(profile_did))
+            .await
+            .map_err(|e| ATMError::MsgSendError(format!("Error packing message: {e}")))?;
+
+        Ok((packed, msg_id))
     }
 
     /// Waits for the next message to be received via websocket live delivery

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -640,12 +640,29 @@ impl WebSocketTransport {
             self.awaiting_pong = false;
             Some(web_socket)
         } else {
-            match atm
-                .message_pickup()
-                .toggle_live_delivery(&self.profile, true)
+            // Pack the live-delivery-change frame and write it DIRECTLY to the
+            // socket we are holding. This code runs on the transport task
+            // itself, so it must not go through `ATM::send_message`: that
+            // enqueues a `SendMessage` command into this task's own channel and
+            // awaits a reply that only this (currently busy) task could
+            // produce — a deadlock that timed out every connect attempt (#611).
+            let send_result =
+                match crate::protocols::message_pickup::MessagePickup::packed_live_delivery_change(
+                    atm,
+                    &self.profile,
+                    true,
+                )
                 .await
-            {
-                Ok(_) => {
+                {
+                    Ok((frame, _msg_id)) => {
+                        web_socket.send(Message::text(frame)).await.map_err(|e| {
+                            ATMError::TransportError(format!("websocket write failed: {e}"))
+                        })
+                    }
+                    Err(e) => Err(e),
+                };
+            match send_result {
+                Ok(()) => {
                     debug!("Live streaming enabled");
                     self.connect_delay = 0;
                     self.connect_delay_timer = None;


### PR DESCRIPTION
## Summary

Issue #611 diagnosed `soft_restart_does_not_leak_a_dueling_websocket` as a CI timing flake. **It isn't — it's a deterministic deadlock introduced by the truthful-send change in `affinidi-messaging-sdk` 0.18.52 (#605), and it fails 100% of the time on every machine since #605 merged.**

### Root cause (bisected)

Green at `72d2412` (#603), broken at `a4124da` (#605).

The websocket transport's connection setup (`_handle_connection`, which runs **on the transport task itself**) enables live delivery via `toggle_live_delivery` → `ATM::send_message`. Since #605, `send_message` enqueues a `SendMessage` command into the transport's **own** command channel and then awaits the write-outcome `oneshot` — a reply only the (currently busy) transport task could produce. Pre-#605 the enqueue was fire-and-forget, so the command was simply processed after setup returned; post-#605 it's a self-deadlock:

```
transport task ── _handle_connection ── toggle_live_delivery ── send_message
      ▲                                                              │
      └──── the only consumer of the command channel ◄── SendMessage(…, reply_tx) + await reply_rx
```

Every connect attempt hangs until `profile_add`'s 10s timeout, the listener restart loop retries into the same wall, and `wait_connected(15s)` expires. The new event-dump diagnostics (below) show exactly this: `Disconnected { error: "Timeout: deadline has elapsed" }` × 5.

### Fix (sdk 0.18.55)

Pack the `live-delivery-change` frame via the new internal `MessagePickup::packed_live_delivery_change` and write it **directly to the socket the setup code already holds** — same message, same packing, no round-trip through the command channel. `toggle_live_delivery` is unchanged for external callers and still sends through the normal (truthful) transport path. The transport task now never sends through its own command channel.

### Test hardening (test-only, no version bump per repo convention)

- `soft_restart_websocket`: connect gate raised from a flat 15s to 60s (one attempt may legitimately spend 10s inside `profile_add` on a loaded runner — 15s fit barely one retry), and on timeout the test now panics with the listener's collected lifecycle events, so a future failure names the actual connect error instead of an opaque `Timeout(Elapsed(()))`. This diagnostic is what exposed the deadlock.
- `tsp_live_stream`: same 60s connect budget; also factored the recorder field into a `ReceivedFrames` alias (pre-existing `clippy::type_complexity` under `--all-features`).

## Testing

- `cargo test -p affinidi-messaging-sdk -p affinidi-messaging-didcomm-service --all-features` — all green, incl. #605's own `send_message_errors_when_websocket_disconnected` regression test (the truthful-send contract still holds).
- `soft_restart_websocket`: fails deterministically on main (60s, 5 timed-out attempts), passes in 8.3s with this fix.
- `cargo fmt --check` and `clippy --all-features --tests -D warnings` clean on both crates.

Closes #611