### PR TITLE
fix: support secp256k1

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi Crypto Changelog
 
+## 16th July 2026 (0.2.5)
+
+Adds `jose::signing::verify_secp256k1` — ECDSA secp256k1 signature verification
+(JWS `alg: ES256K`), accepting compressed or uncompressed SEC1 public points —
+and enables the k256 `ecdsa` feature. Additive (verify-only); locked by a
+deterministic RFC 6979 golden vector plus roundtrip KATs. Patch bump keeps the
+`[patch.crates-io]` redirect valid — see
+[ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md).
+
 ## 4th July 2026 (0.2.4)
 
 Adds `KeyType::key_agreement_curve() -> Option<Curve>` (gated on the `jose`

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.4"
+version = "0.2.5"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -42,6 +42,7 @@ multibase = "0.9"
 ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 k256 = { version = "0.13", features = [
   "ecdsa-core",
+  "ecdsa",
   "arithmetic",
   "ecdh",
 ], optional = true }

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -16,6 +16,8 @@
 //!   vector 5b deferred until key agreement landed).
 //! - `es256_p256_golden` — deterministic (RFC 6979) ECDSA P-256 sign +
 //!   `verify_p256` roundtrip, pinning the ES256 signature/public-key bytes.
+//! - `secp256k1_es256k_golden` — deterministic (RFC 6979) ECDSA secp256k1
+//!   sign + `verify_secp256k1` roundtrip, pinning the ES256K bytes.
 
 #![cfg(test)]
 
@@ -28,6 +30,9 @@ use super::{aes_kw, concat_kdf, content_encryption, signing};
 // ECDSA P-256 signing lives in the `p256` dev-dependency (this crate is
 // verify-only for ES256), used by the P-256 KAT(s) below to produce vectors.
 use p256::ecdsa::{SigningKey as P256SigningKey, signature::Signer as P256Signer};
+// Likewise ECDSA secp256k1 signing (this crate is verify-only for ES256K),
+// used by the secp256k1 KAT(s) below to produce vectors.
+use k256::ecdsa::{SigningKey as K256SigningKey, signature::Signer as K256Signer};
 
 fn hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -423,4 +428,99 @@ fn p256_compressed_and_uncompressed_pubkey_agree() {
 fn p256_invalid_public_key_errors() {
     let sig_bytes = [0u8; 64];
     assert!(signing::verify_p256(b"x", &sig_bytes, b"not-a-key").is_err());
+}
+
+// ─── ES256K (ECDSA secp256k1) ───────────────────────────────────────────────
+
+#[test]
+fn secp256k1_es256k_golden() {
+    const EXPECTED_PK: &str = "049ac20335eb38768d2052be1dbbc3c8f6178407458e51e6b4ad22f1d91758895baf102a603fa09b366705fd727757a5abd614410a6e3f802ab8da8dfe84289d64";
+    const EXPECTED_SIG: &str = "c857cd5897512aa9606ada5bc8654ec60e3b2467174a4fe8299ab1c4685233d709230fa59777d14e42934f9de78e08c22c02b0f5b30a7fcadf5cefec13ed83b7";
+
+    let sk = K256SigningKey::from_slice(&[0x55u8; 32]).expect("valid secp256k1 scalar");
+    let msg = b"DIDComm KAT message";
+
+    let pk = sk.verifying_key().to_encoded_point(false);
+    assert_eq!(
+        hex(pk.as_bytes()),
+        EXPECTED_PK,
+        "secp256k1 public key drifted"
+    );
+
+    // RustCrypto ECDSA `sign` is deterministic (RFC 6979), so these bytes pin.
+    let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert_eq!(
+        hex(&sig_bytes),
+        EXPECTED_SIG,
+        "ES256K signature drifted (RFC 6979 determinism broken)"
+    );
+
+    assert!(signing::verify_secp256k1(msg, &sig_bytes, pk.as_bytes()).is_ok());
+    assert!(signing::verify_secp256k1(b"tampered", &sig_bytes, pk.as_bytes()).is_err());
+}
+
+/// A secp256k1 signing key's public point as uncompressed SEC1 bytes (65 bytes).
+fn k256_sec1_uncompressed(sk: &K256SigningKey) -> Vec<u8> {
+    sk.verifying_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec()
+}
+
+#[test]
+fn secp256k1_sign_verify_roundtrip() {
+    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"affinidi es256k roundtrip";
+    let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(signing::verify_secp256k1(msg, &sig_bytes, &k256_sec1_uncompressed(&sk)).is_ok());
+}
+
+#[test]
+fn secp256k1_wrong_key_fails() {
+    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let other = K256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"affinidi es256k";
+    let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(signing::verify_secp256k1(msg, &sig_bytes, &k256_sec1_uncompressed(&other)).is_err());
+}
+
+#[test]
+fn secp256k1_tampered_message_fails() {
+    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, b"original");
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    assert!(
+        signing::verify_secp256k1(b"tampered", &sig_bytes, &k256_sec1_uncompressed(&sk)).is_err()
+    );
+}
+
+/// `verify_secp256k1` accepts both SEC1 encodings of the public point
+/// (compressed 33-byte and uncompressed 65-byte).
+#[test]
+fn secp256k1_compressed_and_uncompressed_pubkey_agree() {
+    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let msg = b"sec1 encodings";
+    let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
+    let sig_bytes: [u8; 64] = sig.to_bytes().into();
+    let uncompressed = sk
+        .verifying_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    let compressed = sk
+        .verifying_key()
+        .to_encoded_point(true)
+        .as_bytes()
+        .to_vec();
+    assert!(signing::verify_secp256k1(msg, &sig_bytes, &uncompressed).is_ok());
+    assert!(signing::verify_secp256k1(msg, &sig_bytes, &compressed).is_ok());
+}
+
+#[test]
+fn secp256k1_invalid_public_key_errors() {
+    let sig_bytes = [0u8; 64];
+    assert!(signing::verify_secp256k1(b"x", &sig_bytes, b"not-a-key").is_err());
 }

--- a/crates/core/affinidi-crypto/src/jose/signing.rs
+++ b/crates/core/affinidi-crypto/src/jose/signing.rs
@@ -1,5 +1,6 @@
-//! Ed25519 signing/verification (EdDSA / JWS `alg: EdDSA`) and ECDSA P-256
-//! verification (JWS `alg: ES256`).
+//! Ed25519 signing/verification (EdDSA / JWS `alg: EdDSA`), ECDSA P-256
+//! verification (JWS `alg: ES256`), and ECDSA secp256k1 verification (JWS
+//! `alg: ES256K`).
 //!
 //! Ported verbatim from `affinidi-messaging-didcomm` for the #327
 //! centralization; byte-level output is locked by [`super::kat`] (both the
@@ -44,6 +45,23 @@ pub fn verify_p256(
         .map_err(|e| CryptoError::Verification(format!("invalid P-256 public key: {e}")))?;
     let sig = p256::ecdsa::Signature::from_slice(signature)
         .map_err(|e| CryptoError::Verification(format!("invalid P-256 signature: {e}")))?;
+    verifying_key
+        .verify(data, &sig)
+        .map_err(|e| CryptoError::Verification(format!("signature verification failed: {e}")))
+}
+
+/// Verify an ECDSA secp256k1 signature (JWS `alg: ES256K`).
+pub fn verify_secp256k1(
+    data: &[u8],
+    signature: &[u8; 64],
+    public_key_sec1: &[u8],
+) -> Result<(), CryptoError> {
+    use k256::ecdsa::signature::Verifier as _;
+
+    let verifying_key = k256::ecdsa::VerifyingKey::from_sec1_bytes(public_key_sec1)
+        .map_err(|e| CryptoError::Verification(format!("invalid secp256k1 public key: {e}")))?;
+    let sig = k256::ecdsa::Signature::from_slice(signature)
+        .map_err(|e| CryptoError::Verification(format!("invalid secp256k1 signature: {e}")))?;
     verifying_key
         .verify(data, &sig)
         .map_err(|e| CryptoError::Verification(format!("signature verification failed: {e}")))

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.5] - 2026-07-16
+
+### Added
+
+- **ES256K (ECDSA secp256k1) JWS verification.** `jws::verify::verify_secp256k1`
+  verifies DIDComm signed messages whose protected header declares `alg: ES256K`,
+  alongside the existing `EdDSA` and `ES256` paths. The signer `kid` is
+  attributed from the protected header, falling back to the per-signature
+  unprotected header. Verify-only — this crate does not sign ES256K. Signer-key
+  resolution and the inner/top-level JWS dispatch live in the mediator's
+  `didcomm_compat` shim.
+
 ## [0.15.4] - 2026-06-30
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -16,6 +16,13 @@ and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html
   resolution and the inner/top-level JWS dispatch live in the mediator's
   `didcomm_compat` shim.
 
+### Changed
+
+- Internal: `verify_ed25519` / `verify_p256` / `verify_secp256k1` now share one
+  JWS parsing/dispatch skeleton instead of three copies. Public signatures and
+  behavior are unchanged (the Ed25519 wrong-length-signature error message now
+  names the accepted algs).
+
 ## [0.15.4] - 2026-06-30
 
 ### Added

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.4"
+version = "0.15.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -55,10 +55,11 @@ arbitrary = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-# ECDSA signing for ES256 JWS verification tests (the runtime dep only needs
-# `ecdh`/`jwk`; tests additionally sign with P-256). Cargo unifies the feature
-# set so this enables `ecdsa` for test builds only.
+# ECDSA signing for ES256 / ES256K JWS verification tests (the runtime deps
+# only need `ecdh`/`jwk`; tests additionally sign with P-256 / secp256k1).
+# Cargo unifies the feature set so this enables `ecdsa` for test builds only.
 p256 = { version = "0.13", features = ["ecdsa"] }
+k256 = { version = "0.13", features = ["ecdsa"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -133,6 +133,62 @@ pub fn verify_p256(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDC
     })
 }
 
+/// Verify a JWS string using an ECDSA secp256k1 (ES256K) public key.
+///
+/// # Arguments
+/// * `jws_str` - The JWS JSON string
+/// * `public_key` - The signer's SEC1-encoded secp256k1 public key (compressed 33 bytes or uncompressed 65 bytes)
+pub fn verify_secp256k1(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDCommError> {
+    let jws: Jws = serde_json::from_str(jws_str)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid JWS JSON: {e}")))?;
+
+    if jws.signatures.is_empty() {
+        return Err(DIDCommError::InvalidMessage("no signatures in JWS".into()));
+    }
+
+    // Verify the first signature
+    let sig_entry = &jws.signatures[0];
+
+    // Parse protected header
+    let header_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.protected)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid protected header: {e}")))?;
+    let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
+
+    if header.alg != "ES256K" {
+        return Err(DIDCommError::UnsupportedAlgorithm(format!(
+            "expected ES256K, got {}",
+            header.alg
+        )));
+    }
+
+    // Decode signature (raw r || s, 64 bytes)
+    let sig_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.signature)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid signature base64: {e}")))?;
+    let sig: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| DIDCommError::InvalidMessage("ES256K signature must be 64 bytes".into()))?;
+
+    // Reconstruct signing input
+    let signing_input = format!("{}.{}", sig_entry.protected, jws.payload);
+    signing::verify_secp256k1(signing_input.as_bytes(), &sig, public_key)?;
+
+    // Decode payload
+    let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
+        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid payload base64: {e}")))?;
+
+    // Signer kid: prefer the protected header, fall back to the
+    // per-signature unprotected header.
+    let signer_kid = header
+        .kid
+        .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
+
+    Ok(VerifiedJws {
+        payload,
+        signer_kid,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,6 +452,132 @@ mod tests {
         assert_eq!(
             result.signer_kid.as_deref(),
             Some("did:example:alice#key-1")
+        );
+    }
+
+    // ─── ES256K / ECDSA secp256k1 ───────────────────────────────────────────
+    // `signature::Signer` is already in scope from the ES256 block above (both
+    // curves re-export the same `signature` crate trait).
+    use k256::ecdsa::SigningKey as K256SigningKey;
+
+    /// Build an ES256K JWS (General JSON Serialization) over `payload`. `kid`
+    /// is placed in the protected header when `Some`, otherwise omitted.
+    fn build_es256k_jws(payload: &[u8], kid: Option<&str>, sk: &K256SigningKey) -> String {
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "ES256K".into(),
+            kid: kid.map(|k| k.to_string()),
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig: k256::ecdsa::Signature = sk.sign(signing_input.as_bytes());
+        let sig_bytes: [u8; 64] = sig.to_bytes().into();
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: None,
+                signature: Base64UrlUnpadded::encode_string(&sig_bytes),
+            }],
+        };
+        serde_json::to_string(&jws).unwrap()
+    }
+
+    fn k256_pub_sec1(sk: &K256SigningKey) -> Vec<u8> {
+        sk.verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn es256k_sign_verify_roundtrip() {
+        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let payload = b"{\"type\":\"test\",\"body\":{}}";
+        let jws_str = build_es256k_jws(payload, Some("did:example:alice#k256-1"), &sk);
+
+        let result = verify_secp256k1(&jws_str, &k256_pub_sec1(&sk)).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#k256-1")
+        );
+    }
+
+    #[test]
+    fn es256k_wrong_key_fails() {
+        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let other = K256SigningKey::random(&mut rand_core::OsRng);
+        let jws_str = build_es256k_jws(b"test", Some("did:example:alice#k256-1"), &sk);
+
+        assert!(verify_secp256k1(&jws_str, &k256_pub_sec1(&other)).is_err());
+    }
+
+    /// The ES256K verifier must reject a JWS that declares a different `alg`
+    /// (here ES256) before touching the signature — guards against an
+    /// algorithm-confusion attempt across the two ECDSA curves.
+    #[test]
+    fn es256k_rejects_es256_alg() {
+        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let jws_str = build_es256_jws(b"x", Some("did:example:alice#p256-1"), &sk);
+
+        let dummy_pub = [0x04u8; 65];
+        let result = verify_secp256k1(&jws_str, &dummy_pub);
+        assert!(matches!(result, Err(DIDCommError::UnsupportedAlgorithm(_))));
+    }
+
+    /// Symmetric guard: the ES256 verifier must reject an ES256K JWS.
+    #[test]
+    fn es256_rejects_es256k_alg() {
+        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let jws_str = build_es256k_jws(b"x", Some("did:example:alice#k256-1"), &sk);
+
+        let dummy_pub = [0x04u8; 65];
+        let result = verify_p256(&jws_str, &dummy_pub);
+        assert!(matches!(result, Err(DIDCommError::UnsupportedAlgorithm(_))));
+    }
+
+    /// ES256K counterpart of `es256_signer_kid_from_unprotected_header`: when
+    /// the signer `kid` lives only in the per-signature unprotected header, it
+    /// must still be attributed.
+    #[test]
+    fn es256k_signer_kid_from_unprotected_header() {
+        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let payload = b"{\"type\":\"test\"}";
+
+        let protected = JwsProtectedHeader {
+            typ: Some("application/didcomm-signed+json".into()),
+            alg: "ES256K".into(),
+            kid: None,
+            jwk: None,
+        };
+        let protected_b64 =
+            Base64UrlUnpadded::encode_string(serde_json::to_string(&protected).unwrap().as_bytes());
+        let payload_b64 = Base64UrlUnpadded::encode_string(payload);
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let sig: k256::ecdsa::Signature = sk.sign(signing_input.as_bytes());
+        let sig_bytes: [u8; 64] = sig.to_bytes().into();
+
+        let jws = Jws {
+            payload: payload_b64,
+            signatures: vec![JwsSignature {
+                protected: protected_b64,
+                header: Some(JwsUnprotectedHeader {
+                    kid: Some("did:example:alice#k256-1".into()),
+                }),
+                signature: Base64UrlUnpadded::encode_string(&sig_bytes),
+            }],
+        };
+        let jws_str = serde_json::to_string(&jws).unwrap();
+
+        let result = verify_secp256k1(&jws_str, &k256_pub_sec1(&sk)).unwrap();
+        assert_eq!(result.payload, payload);
+        assert_eq!(
+            result.signer_kid.as_deref(),
+            Some("did:example:alice#k256-1")
         );
     }
 }

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -15,16 +15,17 @@ pub struct VerifiedJws {
     pub signer_kid: Option<String>,
 }
 
-/// Verify a JWS string using an Ed25519 public key.
-///
-/// Accepts either the polymorphic `EdDSA` alg (RFC 8037) or the fully-specified
-/// `Ed25519` alg (draft-ietf-jose-fully-specified-algorithms) — both denote
-/// Ed25519 signatures.
-///
-/// # Arguments
-/// * `jws_str` - The JWS JSON string
-/// * `public_key` - The signer's Ed25519 public key (32 bytes)
-pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJws, DIDCommError> {
+/// Shared JWS verification skeleton (General JSON Serialization): parse the
+/// envelope, enforce the expected `alg` on the first signature's protected
+/// header, reconstruct the signing input, and delegate the signature check to
+/// `verify`. Only the first signature is verified (DIDComm envelopes are
+/// single-signer). `alg_expected` names the accepted alg(s) in error messages.
+fn verify_jws(
+    jws_str: &str,
+    alg_accepted: impl Fn(&str) -> bool,
+    alg_expected: &str,
+    verify: impl FnOnce(&[u8], &[u8; 64]) -> Result<(), DIDCommError>,
+) -> Result<VerifiedJws, DIDCommError> {
     let jws: Jws = serde_json::from_str(jws_str)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid JWS JSON: {e}")))?;
 
@@ -41,23 +42,24 @@ pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJw
     let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
 
-    if header.alg != "EdDSA" && header.alg != "Ed25519" {
+    if !alg_accepted(&header.alg) {
         return Err(DIDCommError::UnsupportedAlgorithm(format!(
-            "expected EdDSA or Ed25519, got {}",
+            "expected {alg_expected}, got {}",
             header.alg
         )));
     }
 
-    // Decode signature
+    // Decode signature (raw r || s for ECDSA, R || S for Ed25519 — 64 bytes
+    // either way)
     let sig_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.signature)
         .map_err(|e| DIDCommError::InvalidMessage(format!("invalid signature base64: {e}")))?;
-    let sig: [u8; 64] = sig_bytes
-        .try_into()
-        .map_err(|_| DIDCommError::InvalidMessage("signature must be 64 bytes".into()))?;
+    let sig: [u8; 64] = sig_bytes.try_into().map_err(|_| {
+        DIDCommError::InvalidMessage(format!("{alg_expected} signature must be 64 bytes"))
+    })?;
 
     // Reconstruct signing input
     let signing_input = format!("{}.{}", sig_entry.protected, jws.payload);
-    signing::verify(signing_input.as_bytes(), &sig, public_key)?;
+    verify(signing_input.as_bytes(), &sig)?;
 
     // Decode payload
     let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
@@ -77,60 +79,36 @@ pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJw
     })
 }
 
+/// Verify a JWS string using an Ed25519 public key.
+///
+/// Accepts either the polymorphic `EdDSA` alg (RFC 8037) or the fully-specified
+/// `Ed25519` alg (draft-ietf-jose-fully-specified-algorithms) — both denote
+/// Ed25519 signatures.
+///
+/// # Arguments
+/// * `jws_str` - The JWS JSON string
+/// * `public_key` - The signer's Ed25519 public key (32 bytes)
+pub fn verify_ed25519(jws_str: &str, public_key: &[u8; 32]) -> Result<VerifiedJws, DIDCommError> {
+    verify_jws(
+        jws_str,
+        |alg| alg == "EdDSA" || alg == "Ed25519",
+        "EdDSA or Ed25519",
+        |input, sig| signing::verify(input, sig, public_key).map_err(DIDCommError::from),
+    )
+}
+
 /// Verify a JWS string using an ECDSA P-256 (ES256) public key.
 ///
 /// # Arguments
 /// * `jws_str` - The JWS JSON string
 /// * `public_key` - The signer's SEC1-encoded P-256 public key (compressed 33 bytes or uncompressed 65 bytes)
 pub fn verify_p256(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDCommError> {
-    let jws: Jws = serde_json::from_str(jws_str)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid JWS JSON: {e}")))?;
-
-    if jws.signatures.is_empty() {
-        return Err(DIDCommError::InvalidMessage("no signatures in JWS".into()));
-    }
-
-    // Verify the first signature
-    let sig_entry = &jws.signatures[0];
-
-    // Parse protected header
-    let header_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.protected)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid protected header: {e}")))?;
-    let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
-
-    if header.alg != "ES256" {
-        return Err(DIDCommError::UnsupportedAlgorithm(format!(
-            "expected ES256, got {}",
-            header.alg
-        )));
-    }
-
-    // Decode signature (raw r || s, 64 bytes)
-    let sig_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.signature)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid signature base64: {e}")))?;
-    let sig: [u8; 64] = sig_bytes
-        .try_into()
-        .map_err(|_| DIDCommError::InvalidMessage("ES256 signature must be 64 bytes".into()))?;
-
-    // Reconstruct signing input
-    let signing_input = format!("{}.{}", sig_entry.protected, jws.payload);
-    signing::verify_p256(signing_input.as_bytes(), &sig, public_key)?;
-
-    // Decode payload
-    let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid payload base64: {e}")))?;
-
-    // Signer kid: prefer the protected header, fall back to the
-    // per-signature unprotected header.
-    let signer_kid = header
-        .kid
-        .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
-
-    Ok(VerifiedJws {
-        payload,
-        signer_kid,
-    })
+    verify_jws(
+        jws_str,
+        |alg| alg == "ES256",
+        "ES256",
+        |input, sig| signing::verify_p256(input, sig, public_key).map_err(DIDCommError::from),
+    )
 }
 
 /// Verify a JWS string using an ECDSA secp256k1 (ES256K) public key.
@@ -139,54 +117,12 @@ pub fn verify_p256(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDC
 /// * `jws_str` - The JWS JSON string
 /// * `public_key` - The signer's SEC1-encoded secp256k1 public key (compressed 33 bytes or uncompressed 65 bytes)
 pub fn verify_secp256k1(jws_str: &str, public_key: &[u8]) -> Result<VerifiedJws, DIDCommError> {
-    let jws: Jws = serde_json::from_str(jws_str)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid JWS JSON: {e}")))?;
-
-    if jws.signatures.is_empty() {
-        return Err(DIDCommError::InvalidMessage("no signatures in JWS".into()));
-    }
-
-    // Verify the first signature
-    let sig_entry = &jws.signatures[0];
-
-    // Parse protected header
-    let header_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.protected)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid protected header: {e}")))?;
-    let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid header JSON: {e}")))?;
-
-    if header.alg != "ES256K" {
-        return Err(DIDCommError::UnsupportedAlgorithm(format!(
-            "expected ES256K, got {}",
-            header.alg
-        )));
-    }
-
-    // Decode signature (raw r || s, 64 bytes)
-    let sig_bytes = Base64UrlUnpadded::decode_vec(&sig_entry.signature)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid signature base64: {e}")))?;
-    let sig: [u8; 64] = sig_bytes
-        .try_into()
-        .map_err(|_| DIDCommError::InvalidMessage("ES256K signature must be 64 bytes".into()))?;
-
-    // Reconstruct signing input
-    let signing_input = format!("{}.{}", sig_entry.protected, jws.payload);
-    signing::verify_secp256k1(signing_input.as_bytes(), &sig, public_key)?;
-
-    // Decode payload
-    let payload = Base64UrlUnpadded::decode_vec(&jws.payload)
-        .map_err(|e| DIDCommError::InvalidMessage(format!("invalid payload base64: {e}")))?;
-
-    // Signer kid: prefer the protected header, fall back to the
-    // per-signature unprotected header.
-    let signer_kid = header
-        .kid
-        .or_else(|| sig_entry.header.as_ref().and_then(|h| h.kid.clone()));
-
-    Ok(VerifiedJws {
-        payload,
-        signer_kid,
-    })
+    verify_jws(
+        jws_str,
+        |alg| alg == "ES256K",
+        "ES256K",
+        |input, sig| signing::verify_secp256k1(input, sig, public_key).map_err(DIDCommError::from),
+    )
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+## 16th July 2026
+
+### 0.17.2 — secp256k1 (ES256K) support + resolve sender key by JWE skid
+
+- Accept `ES256K` (secp256k1) signatures in `verify_inner_jws`, resolving the
+  signer's secp256k1 verification key from their DID document (`publicKeyMultibase`
+  multikey or `publicKeyJwk`).
+- Resolve the sender's exact key-agreement key by the JWE `skid` rather than the
+  sender's first advertised key. This fixes an ECDH-1PU
+  `curve mismatch between private and public keys` (`e.p.message.unpack`) when a
+  sender advertises key-agreement keys on multiple curves (e.g. secp256k1 before
+  P-256) and authcrypts on the shared curve.
+- `mediator-setup`: new `--key-suite secp256k1` advertises a secp256k1 signing
+  (`#key-4`) + key-agreement (`#key-5`) pair in the generated `did:webvh`
+  document, so the mediator can speak P-256 + X25519 + secp256k1.
+
 ## 14th July 2026
 
 ### 0.17.1 — read the self-hosted `did.jsonl` log from `s3://`

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -13,7 +13,9 @@
   sender's first advertised key. This fixes an ECDH-1PU
   `curve mismatch between private and public keys` (`e.p.message.unpack`) when a
   sender advertises key-agreement keys on multiple curves (e.g. secp256k1 before
-  P-256) and authcrypts on the shared curve.
+  P-256) and authcrypts on the shared curve. When the `skid` cannot be found in
+  the sender's DID document, the fallback to the first key-agreement key is
+  logged at `warn` (it can reproduce the very curve mismatch this fixes).
 - `mediator-setup`: new `--key-suite secp256k1` advertises a secp256k1 signing
   (`#key-4`) + key-agreement (`#key-5`) pair in the generated `did:webvh`
   document, so the mediator can speak P-256 + X25519 + secp256k1.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -224,6 +224,9 @@ affinidi-secrets-resolver = "0.5"
 ## `test-util` enables `tokio::time::pause/advance` so the task-supervisor
 ## backoff tests run deterministically without real sleeps.
 tokio = { workspace = true, features = ["test-util"] }
+## ES256K test signing for the `verify_inner_jws` secp256k1 path (the runtime
+## is verify-only, via affinidi-crypto / affinidi-messaging-didcomm).
+k256 = { version = "0.13", features = ["ecdsa"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.1"
+version = "0.17.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -335,9 +335,9 @@ async fn recurse_decrypted_plaintext(
 
     if value.get("payload").is_some() && value.get("signatures").is_some() {
         // Nested JWS: sign-then-encrypt. Verify the inner signature with the
-        // signer's resolved key (Ed25519/EdDSA or P-256/ES256) and attribute
-        // non-repudiation. Never trust the kid without verifying — a bad
-        // signature must error.
+        // signer's resolved key (Ed25519/EdDSA, P-256/ES256, or
+        // secp256k1/ES256K) and attribute non-repudiation. Never trust the
+        // kid without verifying — a bad signature must error.
         let jws_str = std::str::from_utf8(plaintext)
             .map_err(|e| format!("Inner JWS is not valid UTF-8: {e}"))?;
 
@@ -432,10 +432,10 @@ fn extract_jws_alg(jws: &serde_json::Value) -> Option<String> {
 }
 
 /// Verify an inner/top-level JWS, dispatching on the JOSE `alg`:
-/// `EdDSA`/`Ed25519` (Ed25519) or `ES256` (P-256). Resolves the signer's
-/// verification key from their DID document and verifies the signature. Any
-/// other `alg` (including a missing/undecodable one) is rejected rather than
-/// assumed.
+/// `EdDSA`/`Ed25519` (Ed25519), `ES256` (P-256), or `ES256K` (secp256k1).
+/// Resolves the signer's verification key from their DID document and
+/// verifies the signature. Any other `alg` (including a missing/undecodable
+/// one) is rejected rather than assumed.
 async fn verify_inner_jws(
     jws_str: &str,
     alg: &str,
@@ -611,29 +611,33 @@ async fn resolve_did_ed25519_verification(
     None
 }
 
-/// Resolve a DID's ECDSA P-256 verification (signing) public key as SEC1 bytes.
+/// Resolve a DID's ECDSA verification (signing) public key as SEC1 bytes,
+/// shared by the ES256 (P-256) and ES256K (secp256k1) paths — the curves
+/// differ only in multicodec and JOSE `crv` name.
 ///
-/// Supports `publicKeyMultibase` (multikey, `p256-pub` codec — compressed
-/// SEC1) and `publicKeyJwk` (`EC`/`P-256` — assembled into uncompressed SEC1).
-async fn resolve_did_p256_verification(
+/// Supports `publicKeyMultibase` (multikey, `multicodec` — compressed SEC1)
+/// and `publicKeyJwk` (`EC`/`jose_crv` — assembled into uncompressed SEC1).
+async fn resolve_did_ecdsa_verification(
     did: &str,
     prefer_kid: Option<&str>,
     did_resolver: &DIDCacheClient,
+    multicodec: u64,
+    jose_crv: &str,
 ) -> Option<Vec<u8>> {
     let vm = resolve_authentication_vm(did, prefer_kid, did_resolver).await?;
 
     if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
         && let Some(multibase_str) = multibase_value.as_str()
         && let Ok((codec, key_bytes)) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
-        && codec == affinidi_encoding::P256_PUB
+        && codec == multicodec
     {
-        // Multikey for P-256 is the compressed SEC1 point (33 bytes).
+        // Multikey ECDSA points are compressed SEC1 (33 bytes).
         return Some(key_bytes);
     }
 
     if let Some(jwk_value) = vm.property_set.get("publicKeyJwk")
         && jwk_value.get("kty").and_then(|v| v.as_str()) == Some("EC")
-        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some("P-256")
+        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some(jose_crv)
         && let Some(x_b64) = jwk_value.get("x").and_then(|v| v.as_str())
         && let Some(y_b64) = jwk_value.get("y").and_then(|v| v.as_str())
         && let Ok(x_bytes) = BASE64_URL_SAFE_NO_PAD.decode(x_b64)
@@ -652,46 +656,38 @@ async fn resolve_did_p256_verification(
     None
 }
 
+/// Resolve a DID's ECDSA P-256 verification (signing) public key as SEC1
+/// bytes (JWS `alg: ES256`).
+async fn resolve_did_p256_verification(
+    did: &str,
+    prefer_kid: Option<&str>,
+    did_resolver: &DIDCacheClient,
+) -> Option<Vec<u8>> {
+    resolve_did_ecdsa_verification(
+        did,
+        prefer_kid,
+        did_resolver,
+        affinidi_encoding::P256_PUB,
+        "P-256",
+    )
+    .await
+}
+
 /// Resolve a DID's ECDSA secp256k1 verification (signing) public key as SEC1
 /// bytes (JWS `alg: ES256K`).
-///
-/// Supports `publicKeyMultibase` (multikey, `secp256k1-pub` codec — compressed
-/// SEC1) and `publicKeyJwk` (`EC`/`secp256k1` — assembled into uncompressed SEC1).
 async fn resolve_did_secp256k1_verification(
     did: &str,
     prefer_kid: Option<&str>,
     did_resolver: &DIDCacheClient,
 ) -> Option<Vec<u8>> {
-    let vm = resolve_authentication_vm(did, prefer_kid, did_resolver).await?;
-
-    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
-        && let Some(multibase_str) = multibase_value.as_str()
-        && let Ok((codec, key_bytes)) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
-        && codec == affinidi_encoding::SECP256K1_PUB
-    {
-        // Multikey for secp256k1 is the compressed SEC1 point (33 bytes).
-        return Some(key_bytes);
-    }
-
-    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk")
-        && jwk_value.get("kty").and_then(|v| v.as_str()) == Some("EC")
-        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some("secp256k1")
-        && let Some(x_b64) = jwk_value.get("x").and_then(|v| v.as_str())
-        && let Some(y_b64) = jwk_value.get("y").and_then(|v| v.as_str())
-        && let Ok(x_bytes) = BASE64_URL_SAFE_NO_PAD.decode(x_b64)
-        && let Ok(y_bytes) = BASE64_URL_SAFE_NO_PAD.decode(y_b64)
-        && x_bytes.len() == 32
-        && y_bytes.len() == 32
-    {
-        // Assemble the uncompressed SEC1 point: 0x04 || x || y.
-        let mut sec1 = Vec::with_capacity(65);
-        sec1.push(0x04);
-        sec1.extend_from_slice(&x_bytes);
-        sec1.extend_from_slice(&y_bytes);
-        return Some(sec1);
-    }
-
-    None
+    resolve_did_ecdsa_verification(
+        did,
+        prefer_kid,
+        did_resolver,
+        affinidi_encoding::SECP256K1_PUB,
+        "secp256k1",
+    )
+    .await
 }
 
 /// Resolve a DID's first key agreement public key.
@@ -719,6 +715,10 @@ async fn resolve_did_key_agreement_by_skid(
     if let Some(pk) = resolve_public_key(&doc.doc, skid) {
         return Some(pk);
     }
+    tracing::warn!(
+        "JWE skid {skid} not found in the sender's DID document; falling back to the \
+         first key-agreement key (its curve may not match the authcrypt)"
+    );
     let kid = doc.doc.find_key_agreement(None).first().copied()?;
     resolve_public_key(&doc.doc, kid)
 }
@@ -1312,5 +1312,127 @@ mod tests {
 
         assert!(unpack_meta.authenticated, "authcrypt must be authenticated");
         assert_eq!(out.from.as_deref(), Some(sender));
+    }
+
+    // ---------------------------------------------------------------------
+    // ES256K inner-JWS verification: `verify_inner_jws` must resolve the
+    // signer's secp256k1 key from the DID document — both `publicKeyMultibase`
+    // (Multikey, compressed SEC1) and `publicKeyJwk` (EC/secp256k1) encodings
+    // — and actually verify the signature with it.
+    // ---------------------------------------------------------------------
+
+    /// Build an ES256K JWS (General JSON Serialization) over `payload`,
+    /// signed with `sk`, with `kid` in the protected header.
+    fn build_es256k_jws(payload: &[u8], kid: &str, sk: &k256::ecdsa::SigningKey) -> String {
+        use k256::ecdsa::signature::Signer as _;
+        let protected = protected_b64(&json!({
+            "typ": "application/didcomm-signed+json",
+            "alg": "ES256K",
+            "kid": kid,
+        }));
+        let payload_b64 = BASE64_URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{protected}.{payload_b64}");
+        let sig: k256::ecdsa::Signature = sk.sign(signing_input.as_bytes());
+        let sig_bytes: [u8; 64] = sig.to_bytes().into();
+        json!({
+            "payload": payload_b64,
+            "signatures": [{
+                "protected": protected,
+                "signature": BASE64_URL_SAFE_NO_PAD.encode(sig_bytes),
+            }]
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn verify_inner_jws_es256k_from_multikey() {
+        let signer = "did:example:k256multikey";
+        let kid = format!("{signer}#key-1");
+        let sk = k256::ecdsa::SigningKey::from_slice(&[0x42u8; 32]).unwrap();
+        // Advertise the same key as a Multikey (compressed SEC1) authentication VM.
+        let secret = Secret::generate_secp256k1(Some(&kid), Some(&[0x42u8; 32])).unwrap();
+        let doc = json!({
+            "id": signer,
+            "verificationMethod": [{
+                "id": &kid,
+                "type": "Multikey",
+                "controller": signer,
+                "publicKeyMultibase": secret.get_public_keymultibase().unwrap(),
+            }],
+            "authentication": [&kid],
+        });
+        let resolver = example_resolver(&[doc]).await;
+
+        let payload = br#"{"type":"https://didcomm.org/test/1.0/msg"}"#;
+        let jws = build_es256k_jws(payload, &kid, &sk);
+
+        let verified = verify_inner_jws(&jws, "ES256K", signer, &kid, &resolver)
+            .await
+            .expect("ES256K signer key must resolve from publicKeyMultibase");
+        assert_eq!(verified.payload, payload);
+        assert_eq!(verified.signer_kid.as_deref(), Some(kid.as_str()));
+    }
+
+    #[tokio::test]
+    async fn verify_inner_jws_es256k_from_jwk() {
+        let signer = "did:example:k256jwk";
+        let kid = format!("{signer}#key-1");
+        let sk = k256::ecdsa::SigningKey::from_slice(&[0x43u8; 32]).unwrap();
+        let point = sk.verifying_key().to_encoded_point(false);
+        let doc = json!({
+            "id": signer,
+            "verificationMethod": [{
+                "id": &kid,
+                "type": "JsonWebKey2020",
+                "controller": signer,
+                "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "secp256k1",
+                    "x": BASE64_URL_SAFE_NO_PAD.encode(&point.as_bytes()[1..33]),
+                    "y": BASE64_URL_SAFE_NO_PAD.encode(&point.as_bytes()[33..65]),
+                },
+            }],
+            "authentication": [&kid],
+        });
+        let resolver = example_resolver(&[doc]).await;
+
+        let payload = br#"{"type":"https://didcomm.org/test/1.0/msg"}"#;
+        let jws = build_es256k_jws(payload, &kid, &sk);
+
+        let verified = verify_inner_jws(&jws, "ES256K", signer, &kid, &resolver)
+            .await
+            .expect("ES256K signer key must resolve from publicKeyJwk");
+        assert_eq!(verified.payload, payload);
+    }
+
+    /// A well-formed ES256K JWS signed by a key the DID document does NOT
+    /// advertise must fail — the resolved (advertised) key won't verify it.
+    #[tokio::test]
+    async fn verify_inner_jws_es256k_wrong_key_fails() {
+        let signer = "did:example:k256wrong";
+        let kid = format!("{signer}#key-1");
+        let advertised = Secret::generate_secp256k1(Some(&kid), Some(&[0x44u8; 32])).unwrap();
+        let doc = json!({
+            "id": signer,
+            "verificationMethod": [{
+                "id": &kid,
+                "type": "Multikey",
+                "controller": signer,
+                "publicKeyMultibase": advertised.get_public_keymultibase().unwrap(),
+            }],
+            "authentication": [&kid],
+        });
+        let resolver = example_resolver(&[doc]).await;
+
+        // Sign with a DIFFERENT key than the document advertises.
+        let rogue = k256::ecdsa::SigningKey::from_slice(&[0x45u8; 32]).unwrap();
+        let jws = build_es256k_jws(b"{}", &kid, &rogue);
+
+        assert!(
+            verify_inner_jws(&jws, "ES256K", signer, &kid, &resolver)
+                .await
+                .is_err(),
+            "signature by an unadvertised key must not verify"
+        );
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -20,7 +20,7 @@ use affinidi_did_common::{
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_messaging_didcomm::{
     jwe::decrypt::decrypt,
-    jws::verify::{VerifiedJws, verify_ed25519, verify_p256},
+    jws::verify::{VerifiedJws, verify_ed25519, verify_p256, verify_secp256k1},
     message::{
         Message,
         pack::{pack_encrypted_anoncrypt, pack_encrypted_authcrypt},
@@ -49,6 +49,8 @@ pub struct MetaEnvelope {
     parsed: serde_json::Value,
     /// Pre-resolved sender DID (if authcrypt detected)
     sender_did: Option<String>,
+    /// The sender's specific key id (full `skid`) for ECDH-1PU key resolution
+    sender_kid: Option<String>,
 }
 
 /// Metadata about the envelope format
@@ -74,6 +76,7 @@ impl MetaEnvelope {
             let mut to_did = None;
             let mut from_did = None;
             let mut sender_did = None;
+            let mut sender_kid: Option<String> = None;
             let mut authenticated = false;
 
             // Extract recipient KID to determine to_did
@@ -107,6 +110,7 @@ impl MetaEnvelope {
                     };
                     from_did = Some(did.clone());
                     sender_did = Some(did);
+                    sender_kid = Some(skid.to_string());
                 }
 
                 // Fallback: try apu header for sender DID
@@ -119,6 +123,7 @@ impl MetaEnvelope {
                     let did = apu_str[..hash_pos].to_string();
                     from_did = Some(did.clone());
                     sender_did = Some(did);
+                    sender_kid = Some(apu_str.clone());
                 }
             }
 
@@ -133,6 +138,7 @@ impl MetaEnvelope {
                 },
                 parsed: value,
                 sender_did,
+                sender_kid,
             })
         } else if value.get("payload").is_some() && value.get("signatures").is_some() {
             // JWS envelope - signed but not encrypted
@@ -147,6 +153,7 @@ impl MetaEnvelope {
                 },
                 parsed: value,
                 sender_did: None,
+                sender_kid: None,
             })
         } else if value.get("type").is_some() {
             // Plaintext message
@@ -172,6 +179,7 @@ impl MetaEnvelope {
                 },
                 parsed: value,
                 sender_did: None,
+                sender_kid: None,
             })
         } else {
             Err("Cannot detect message format: expected JWE, JWS, or plaintext".to_string())
@@ -237,8 +245,14 @@ impl MetaEnvelope {
         let recipient_private =
             recipient_private.ok_or("No local secret matches any JWE recipient")?;
 
-        // Resolve sender public key using pre-extracted sender DID (no re-parsing)
-        let sender_public = if let Some(sender_did) = &self.sender_did {
+        // Resolve the sender's *specific* key-agreement key named by the JWE
+        // `skid`, not merely the sender's first advertised key. A sender that
+        // advertises e.g. secp256k1 before P-256 would otherwise pair the wrong
+        // curve here and fail ECDH-1PU with "curve mismatch between private and
+        // public keys" even though the authcrypt itself used P-256.
+        let sender_public = if let Some(skid) = &self.sender_kid {
+            resolve_did_key_agreement_by_skid(skid, did_resolver).await
+        } else if let Some(sender_did) = &self.sender_did {
             resolve_did_key_agreement(sender_did, did_resolver).await
         } else {
             None
@@ -346,9 +360,9 @@ async fn recurse_decrypted_plaintext(
         // key-agreement key (from skid/apu) so ECDH-1PU authcrypt is recovered.
         let inner_str = std::str::from_utf8(plaintext)
             .map_err(|e| format!("Inner JWE is not valid UTF-8: {e}"))?;
-        let inner_sender_did = inner_jwe_sender_did(&value);
-        let inner_sender_public = if let Some(did) = &inner_sender_did {
-            resolve_did_key_agreement(did, did_resolver).await
+        let inner_sender_kid = inner_jwe_sender_kid(&value);
+        let inner_sender_public = if let Some(skid) = &inner_sender_kid {
+            resolve_did_key_agreement_by_skid(skid, did_resolver).await
         } else {
             None
         };
@@ -452,28 +466,46 @@ async fn verify_inner_jws(
                 })?;
             verify_p256(jws_str, &pubkey).map_err(|e| e.to_string())
         }
+        "ES256K" => {
+            let pubkey =
+                resolve_did_secp256k1_verification(signer_did, Some(signer_kid), did_resolver)
+                    .await
+                    .ok_or_else(|| {
+                        format!(
+                            "Could not resolve secp256k1 verification key for signer {signer_kid}"
+                        )
+                    })?;
+            verify_secp256k1(jws_str, &pubkey).map_err(|e| e.to_string())
+        }
         other => Err(format!(
-            "Unsupported JWS signature algorithm {other:?} (expected EdDSA/Ed25519 or ES256)"
+            "Unsupported JWS signature algorithm {other:?} (expected EdDSA/Ed25519, ES256, or ES256K)"
         )),
     }
 }
 
 /// Extract the inner JWE's sender DID from its protected header (`skid`, or
 /// `apu` fallback), mirroring the outer-layer logic in `MetaEnvelope::new`.
+#[cfg(test)]
 fn inner_jwe_sender_did(jwe: &serde_json::Value) -> Option<String> {
+    inner_jwe_sender_kid(jwe).map(|kid| did_part(&kid))
+}
+
+/// Extract the inner JWE's sender key id (full `skid`, with `#fragment`, or the
+/// `apu` fallback). Used to resolve the exact sender key-agreement key.
+fn inner_jwe_sender_kid(jwe: &serde_json::Value) -> Option<String> {
     let protected_b64 = jwe.get("protected").and_then(|p| p.as_str())?;
     let bytes = BASE64_URL_SAFE_NO_PAD.decode(protected_b64).ok()?;
     let header: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
 
     if let Some(skid) = header.get("skid").and_then(|s| s.as_str()) {
-        return Some(did_part(skid));
+        return Some(skid.to_string());
     }
     if let Some(apu) = header.get("apu").and_then(|a| a.as_str())
         && let Ok(apu_bytes) = BASE64_URL_SAFE_NO_PAD.decode(apu)
         && let Ok(apu_str) = String::from_utf8(apu_bytes)
         && apu_str.contains('#')
     {
-        return Some(did_part(&apu_str));
+        return Some(apu_str);
     }
     None
 }
@@ -620,6 +652,48 @@ async fn resolve_did_p256_verification(
     None
 }
 
+/// Resolve a DID's ECDSA secp256k1 verification (signing) public key as SEC1
+/// bytes (JWS `alg: ES256K`).
+///
+/// Supports `publicKeyMultibase` (multikey, `secp256k1-pub` codec — compressed
+/// SEC1) and `publicKeyJwk` (`EC`/`secp256k1` — assembled into uncompressed SEC1).
+async fn resolve_did_secp256k1_verification(
+    did: &str,
+    prefer_kid: Option<&str>,
+    did_resolver: &DIDCacheClient,
+) -> Option<Vec<u8>> {
+    let vm = resolve_authentication_vm(did, prefer_kid, did_resolver).await?;
+
+    if let Some(multibase_value) = vm.property_set.get("publicKeyMultibase")
+        && let Some(multibase_str) = multibase_value.as_str()
+        && let Ok((codec, key_bytes)) = affinidi_encoding::decode_multikey_with_codec(multibase_str)
+        && codec == affinidi_encoding::SECP256K1_PUB
+    {
+        // Multikey for secp256k1 is the compressed SEC1 point (33 bytes).
+        return Some(key_bytes);
+    }
+
+    if let Some(jwk_value) = vm.property_set.get("publicKeyJwk")
+        && jwk_value.get("kty").and_then(|v| v.as_str()) == Some("EC")
+        && jwk_value.get("crv").and_then(|v| v.as_str()) == Some("secp256k1")
+        && let Some(x_b64) = jwk_value.get("x").and_then(|v| v.as_str())
+        && let Some(y_b64) = jwk_value.get("y").and_then(|v| v.as_str())
+        && let Ok(x_bytes) = BASE64_URL_SAFE_NO_PAD.decode(x_b64)
+        && let Ok(y_bytes) = BASE64_URL_SAFE_NO_PAD.decode(y_b64)
+        && x_bytes.len() == 32
+        && y_bytes.len() == 32
+    {
+        // Assemble the uncompressed SEC1 point: 0x04 || x || y.
+        let mut sec1 = Vec::with_capacity(65);
+        sec1.push(0x04);
+        sec1.extend_from_slice(&x_bytes);
+        sec1.extend_from_slice(&y_bytes);
+        return Some(sec1);
+    }
+
+    None
+}
+
 /// Resolve a DID's first key agreement public key.
 async fn resolve_did_key_agreement(
     did: &str,
@@ -628,6 +702,24 @@ async fn resolve_did_key_agreement(
     let doc = did_resolver.resolve(did).await.ok()?;
     let ka_kids = doc.doc.find_key_agreement(None);
     let kid = ka_kids.first()?;
+    resolve_public_key(&doc.doc, kid)
+}
+
+/// Resolve the sender's key-agreement public key named by `skid` (a full DID
+/// URL with `#fragment`). This honors the exact key the sender used for
+/// ECDH-1PU instead of assuming the sender's first advertised key-agreement
+/// key, which breaks when the sender lists keys on multiple curves (e.g.
+/// secp256k1 before P-256). Falls back to the first key-agreement key only
+/// when the exact key can't be resolved.
+async fn resolve_did_key_agreement_by_skid(
+    skid: &str,
+    did_resolver: &DIDCacheClient,
+) -> Option<PublicKeyAgreement> {
+    let doc = did_resolver.resolve(&did_part(skid)).await.ok()?;
+    if let Some(pk) = resolve_public_key(&doc.doc, skid) {
+        return Some(pk);
+    }
+    let kid = doc.doc.find_key_agreement(None).first().copied()?;
     resolve_public_key(&doc.doc, kid)
 }
 
@@ -1152,5 +1244,73 @@ mod tests {
             err.contains("no secret held"),
             "error must explain why the advertised key was unusable: {err}"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression: `unpack` must resolve the sender's key-agreement key named
+    // by the JWE `skid`, not the sender's *first* advertised key. A sender
+    // that lists secp256k1 before P-256 and authcrypts on the shared P-256
+    // curve previously failed the mediator's decrypt with
+    //   "curve mismatch between private and public keys"
+    // (ProblemReport `e.p.message.unpack`) because the mediator paired its
+    // P-256 secret with the sender's *first* (secp256k1) public key.
+    // ---------------------------------------------------------------------
+    #[tokio::test]
+    async fn unpack_authcrypt_resolves_sender_key_by_skid_not_first() {
+        // Mediator offers only P-256 key agreement.
+        let mediator = "did:example:medskid";
+        let med_p_kid = format!("{mediator}#key-p256");
+        let med_p = Secret::generate_p256(Some(&med_p_kid), None).unwrap();
+
+        // Sender advertises secp256k1 FIRST, then P-256 (the shared curve).
+        let sender = "did:example:sndskid";
+        let snd_k_kid = format!("{sender}#key-secp256k1");
+        let snd_p_kid = format!("{sender}#key-p256");
+        let snd_k = Secret::generate_secp256k1(Some(&snd_k_kid), None).unwrap();
+        let snd_p = Secret::generate_p256(Some(&snd_p_kid), None).unwrap();
+
+        let mediator_doc = json!({
+            "id": mediator,
+            "verificationMethod": [ka_vm(&med_p_kid, mediator, &med_p)],
+            "keyAgreement": [med_p_kid],
+        });
+        let sender_doc = json!({
+            "id": sender,
+            "verificationMethod": [
+                ka_vm(&snd_k_kid, sender, &snd_k), // secp256k1 first
+                ka_vm(&snd_p_kid, sender, &snd_p),
+            ],
+            "keyAgreement": [snd_k_kid.clone(), snd_p_kid.clone()],
+        });
+
+        let resolver = example_resolver(&[mediator_doc, sender_doc]).await;
+
+        // Sender packs authcrypt to the mediator; negotiation picks the shared
+        // P-256 curve, so `skid` is the sender's P-256 key (the SECOND one).
+        let sender_secrets = SimpleSecretsResolver::new(&[snd_k, snd_p]).await;
+        let msg = status_message(sender, mediator, "skid-multicurve");
+        let (packed, pack_meta) =
+            pack_encrypted(&msg, mediator, Some(sender), &resolver, &sender_secrets)
+                .await
+                .expect("sender packs authcrypt on the shared P-256 curve");
+        assert_eq!(
+            pack_meta.from_kid.as_deref(),
+            Some(snd_p_kid.as_str()),
+            "authcrypt skid must be the sender's P-256 key, not the first secp256k1 key"
+        );
+        assert_eq!(jwe_epk_crv(&packed).as_deref(), Some("P-256"));
+
+        // Mediator unpacks: it must resolve the sender's P-256 key via skid.
+        let mediator_secrets = SimpleSecretsResolver::new(&[med_p]).await;
+        let envelope = MetaEnvelope::new(&packed, &resolver)
+            .await
+            .expect("parse the JWE envelope");
+        let (out, unpack_meta) = envelope
+            .unpack(&resolver, &mediator_secrets)
+            .await
+            .expect("mediator must unpack authcrypt from a secp256k1-first sender via skid");
+
+        assert!(unpack_meta.authenticated, "authcrypt must be authenticated");
+        assert_eq!(out.from.as_deref(), Some(sender));
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/cli.rs
@@ -220,12 +220,15 @@ impl std::fmt::Display for DidMethod {
 pub enum KeySuite {
     /// NIST P-256 — ES256 signing + ECDH-ES (P-256) key agreement.
     P256,
+    /// secp256k1 — ES256K signing + ECDH-ES (secp256k1) key agreement.
+    Secp256k1,
 }
 
 impl std::fmt::Display for KeySuite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::P256 => write!(f, "p256"),
+            Self::Secp256k1 => write!(f, "secp256k1"),
         }
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -640,6 +640,43 @@ mod tests {
         assert!(!result.did_doc.contains("{DID}"));
     }
 
+    /// The secp256k1 suite alone (no P-256) keeps its suite-stable `#key-4` /
+    /// `#key-5` slots — the numbering gap at `#key-2`/`#key-3` is intentional
+    /// so the two suites never collide.
+    #[tokio::test]
+    async fn webvh_secp256k1_suite_alone_keeps_key4_key5_slots() {
+        let result = generate_did_webvh(
+            "https://mediator.example.com",
+            "https://mediator.example.com/mediator/v1",
+            &[KeySuite::Secp256k1],
+            false,
+        )
+        .await
+        .unwrap();
+
+        use affinidi_secrets_resolver::secrets::KeyType;
+        // Four runtime secrets: Ed25519 + X25519 + secp256k1(sign, KA).
+        assert_eq!(result.secrets.len(), 4);
+        assert!(result.secrets[2].id.ends_with("#key-4"));
+        assert!(result.secrets[3].id.ends_with("#key-5"));
+        assert!(matches!(
+            result.secrets[2].get_key_type(),
+            KeyType::Secp256k1
+        ));
+        assert!(matches!(
+            result.secrets[3].get_key_type(),
+            KeyType::Secp256k1
+        ));
+
+        let entry: Value = serde_json::from_str(&result.did_doc).unwrap();
+        let doc = &entry["state"];
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert_eq!(vms.len(), 4);
+        assert!(vms[2]["id"].as_str().unwrap().ends_with("#key-4"));
+        assert!(vms[3]["id"].as_str().unwrap().ends_with("#key-5"));
+        assert!(!result.did_doc.contains("{DID}"));
+    }
+
     #[tokio::test]
     async fn webvh_key_ids_match_final_did() {
         let result = generate_did_webvh(

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/generators/did_webvh.rs
@@ -102,6 +102,29 @@ pub async fn generate_did_webvh(
         None
     };
 
+    // secp256k1 suite: a signing key (`#key-4`) + a key-agreement key
+    // (`#key-5`), injected into the rendered document after templating (the
+    // embedded template has no secp256k1 slots, so we append them directly,
+    // mirroring the TSP-service injection). Numbered above the P-256 slots so
+    // the two suites never collide.
+    let include_secp256k1 = key_suites.contains(&KeySuite::Secp256k1);
+    let mut secp256k1_signing = if include_secp256k1 {
+        Some(
+            Secret::generate_secp256k1(None, None)
+                .map_err(|e| anyhow::anyhow!("Failed to generate secp256k1 signing key: {e}"))?,
+        )
+    } else {
+        None
+    };
+    let mut secp256k1_key_agreement =
+        if include_secp256k1 {
+            Some(Secret::generate_secp256k1(None, None).map_err(|e| {
+                anyhow::anyhow!("Failed to generate secp256k1 key-agreement key: {e}")
+            })?)
+        } else {
+            None
+        };
+
     // ── Render template ─────────────────────────────────────────────
     let template = load_embedded("didcomm-mediator")
         .map_err(|e| anyhow::anyhow!("Failed to load mediator template: {e}"))?;
@@ -175,6 +198,21 @@ pub async fn generate_did_webvh(
         strip_tsp_service(&mut did_document);
     }
 
+    // Inject secp256k1 verification methods (post-render; see key generation
+    // above). Uses `{DID}` sentinels so `create_did` resolves them alongside
+    // the templated methods after SCID computation.
+    if let (Some(k1_sign), Some(k1_ka)) =
+        (secp256k1_signing.as_ref(), secp256k1_key_agreement.as_ref())
+    {
+        let k1_sign_mb = k1_sign
+            .get_public_keymultibase()
+            .map_err(|e| anyhow::anyhow!("Failed to get secp256k1 signing public key: {e}"))?;
+        let k1_ka_mb = k1_ka.get_public_keymultibase().map_err(|e| {
+            anyhow::anyhow!("Failed to get secp256k1 key-agreement public key: {e}")
+        })?;
+        inject_secp256k1_vms(&mut did_document, &k1_sign_mb, &k1_ka_mb)?;
+    }
+
     // ── Authorization + pre-rotation ───────────────────────────────
     let mut auth_key = Secret::generate_ed25519(None, None);
     let auth_pubkey = auth_key
@@ -227,6 +265,17 @@ pub async fn generate_did_webvh(
         secrets.push(p256_ka);
     }
 
+    // secp256k1 runtime secrets occupy `#key-4` (signing / assertion) and
+    // `#key-5` (key agreement), matching the injected verification methods.
+    if let Some(mut k1_sign) = secp256k1_signing.take() {
+        k1_sign.id = format!("{final_did}#key-4");
+        secrets.push(k1_sign);
+    }
+    if let Some(mut k1_ka) = secp256k1_key_agreement.take() {
+        k1_ka.id = format!("{final_did}#key-5");
+        secrets.push(k1_ka);
+    }
+
     let did_doc = serde_json::to_string(result.log_entry())?;
 
     Ok(DidWebvhResult {
@@ -234,6 +283,59 @@ pub async fn generate_did_webvh(
         secrets,
         did_doc,
     })
+}
+
+/// Inject secp256k1 signing (`#key-4`) and key-agreement (`#key-5`)
+/// verification methods into a rendered (pre-SCID) mediator DID document.
+///
+/// The embedded template has no secp256k1 slots, so — as with the TSP service
+/// — the methods are appended directly. Ids keep the `{DID}` sentinel so
+/// `create_did` resolves them across the document after SCID computation. The
+/// signing key joins `authentication`/`assertionMethod`; the key-agreement key
+/// joins `keyAgreement`.
+fn inject_secp256k1_vms(
+    did_document: &mut serde_json::Value,
+    signing_mb: &str,
+    key_agreement_mb: &str,
+) -> anyhow::Result<()> {
+    use serde_json::{Value, json};
+
+    let obj = did_document
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Rendered DID document is not a JSON object"))?;
+
+    let vms = obj
+        .get_mut("verificationMethod")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            anyhow::anyhow!("Rendered DID document has no `verificationMethod` array")
+        })?;
+    vms.push(json!({
+        "id": "{DID}#key-4",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": signing_mb,
+    }));
+    vms.push(json!({
+        "id": "{DID}#key-5",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": key_agreement_mb,
+    }));
+
+    for (field, kid) in [
+        ("authentication", "{DID}#key-4"),
+        ("assertionMethod", "{DID}#key-4"),
+        ("keyAgreement", "{DID}#key-5"),
+    ] {
+        let arr = obj
+            .get_mut(field)
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| anyhow::anyhow!("Rendered DID document has no `{field}` array"))?;
+        arr.push(Value::String(kid.to_string()));
+    }
+
+    Ok(())
 }
 
 /// Inject a `TSPTransport` service into a rendered (pre-SCID) mediator DID
@@ -477,6 +579,64 @@ mod tests {
 
         // The webvh SCID sentinel must be fully resolved — no `{DID}` token
         // survives in the var-injected P-256 methods.
+        assert!(!result.did_doc.contains("{DID}"));
+    }
+
+    #[tokio::test]
+    async fn webvh_secp256k1_suite_adds_signing_and_key_agreement_keys() {
+        let result = generate_did_webvh(
+            "https://mediator.example.com",
+            "https://mediator.example.com/mediator/v1",
+            &[KeySuite::P256, KeySuite::Secp256k1],
+            false,
+        )
+        .await
+        .unwrap();
+
+        use affinidi_secrets_resolver::secrets::KeyType;
+        // Six runtime secrets: Ed25519 + X25519 + P-256(sign,KA) + secp256k1(sign,KA).
+        assert_eq!(result.secrets.len(), 6);
+        assert!(result.secrets[4].id.ends_with("#key-4"));
+        assert!(result.secrets[5].id.ends_with("#key-5"));
+        assert!(matches!(
+            result.secrets[4].get_key_type(),
+            KeyType::Secp256k1
+        ));
+        assert!(matches!(
+            result.secrets[5].get_key_type(),
+            KeyType::Secp256k1
+        ));
+
+        let entry: Value = serde_json::from_str(&result.did_doc).unwrap();
+        let doc = &entry["state"];
+
+        // Six verification methods; the secp256k1 pair are `#key-4` / `#key-5`.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert_eq!(vms.len(), 6);
+        assert!(vms[4]["id"].as_str().unwrap().ends_with("#key-4"));
+        assert!(vms[5]["id"].as_str().unwrap().ends_with("#key-5"));
+        assert_eq!(vms[5]["type"], "Multikey");
+        // secp256k1 multikeys use the `zQ3s` multibase prefix.
+        assert!(
+            vms[5]["publicKeyMultibase"]
+                .as_str()
+                .unwrap()
+                .starts_with("zQ3s")
+        );
+
+        // The secp256k1 keys join the relationship arrays.
+        let auth = doc["authentication"].as_array().unwrap();
+        assert!(auth.iter().any(|a| a.as_str().unwrap().ends_with("#key-4")));
+        let assertion = doc["assertionMethod"].as_array().unwrap();
+        assert!(
+            assertion
+                .iter()
+                .any(|a| a.as_str().unwrap().ends_with("#key-4"))
+        );
+        let ka = doc["keyAgreement"].as_array().unwrap();
+        assert!(ka.iter().any(|k| k.as_str().unwrap().ends_with("#key-5")));
+
+        // SCID sentinel fully resolved in the injected methods too.
         assert!(!result.did_doc.contains("{DID}"));
     }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -141,8 +141,9 @@ fn parse_extra_key_suites(raw: &[String]) -> anyhow::Result<Vec<crate::cli::KeyS
     raw.iter()
         .map(|s| match s.trim().to_ascii_lowercase().as_str() {
             "p256" | "p-256" | "es256" => Ok(crate::cli::KeySuite::P256),
+            "secp256k1" | "k256" | "es256k" => Ok(crate::cli::KeySuite::Secp256k1),
             other => anyhow::bail!(
-                "Invalid identity.extra_key_suites entry '{other}': supported suites are 'p256'"
+                "Invalid identity.extra_key_suites entry '{other}': supported suites are 'p256', 'secp256k1'"
             ),
         })
         .collect()


### PR DESCRIPTION
# secp256k1 (ES256K) support + resolve sender key by JWE `skid`

Adds ES256K (ECDSA secp256k1) verification end-to-end through three layers, plus a real unpack fix:

- **`affinidi-crypto` 0.2.5** — `jose::signing::verify_secp256k1` (raw 64-byte r‖s over a SEC1 point, compressed or uncompressed), enabling k256's `ecdsa` feature. Verify-only, locked by a deterministic RFC 6979 golden vector + roundtrip KATs.
- **`affinidi-messaging-didcomm` 0.15.5** — `jws::verify::verify_secp256k1` for JWS with `alg: ES256K`, with alg-confusion guards in both directions vs ES256.
- **`affinidi-messaging-mediator` 0.17.2** — `verify_inner_jws` gains an `ES256K` arm resolving the signer's key from the DID document (`publicKeyMultibase` multikey or `publicKeyJwk`); `mediator-setup` gains `--key-suite secp256k1` (`#key-4`/`#key-5` in the generated did:webvh document).
- **Fix** — `unpack` resolves the sender's key-agreement key by the JWE `skid` instead of the sender's *first* advertised key. A sender advertising secp256k1 before P-256 and authcrypting on P-256 previously failed ECDH-1PU with `curve mismatch between private and public keys` (`e.p.message.unpack`).

Follow-up polish (second commit): the three JWS verify paths in `affinidi-messaging-didcomm` and the two ECDSA DID-key resolvers in the mediator are deduplicated into shared skeletons; the skid→first-key fallback now logs at `warn`; mediator-level tests cover the ES256K key-resolution path (multikey + JWK + wrong-key negative) and the secp256k1-only key suite.

> **Note for reviewers:** the red `publish dry-run` / `verify-publish` checks are the expected multi-crate case — the registry-isolated resolve can't see the unpublished sibling crates (mediator → didcomm 0.15.5 → crypto 0.2.5). The release job publishes in dependency order; merge as one PR.

## Pre-merge checklist

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no new clients
- [x] No lock held across a network await (R1.3) — no locks touched
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — verify-only paths, no mutations
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — no retries added
- [x] Accept/poll/listen loops survive transient errors (R1.5) — no loops touched
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no new wire types; ES256K is standard JOSE (RFC 8812)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — unknown JWS `alg` is rejected, never assumed
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — skid-fallback now warn-logged
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none
