### PR TITLE
fix: DidCommTransport::send must forward, not just send_message

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.18.57] - 2026-07-17
+
+- **Fix `DidCommTransport::send` to actually deliver.** It called
+  `ATM::send_message`, which only pushes the packed bytes to our own mediator
+  without wrapping a DIDComm routing/2.0 `forward` envelope — so a standard
+  mediator never routes the message to the recipient and it is silently
+  undelivered. (A same-DID self-send happened to round-trip, which is why the
+  0.18.53 live check missed it.) `send` now uses `forward_and_send_message`,
+  forwarding the packed frame to `dest` (the recipient the delivery layer
+  passes) through the profile's mediator. The `SendReceipt`/`hop_id` contract is
+  unchanged, but the outbox-drain (§5a) correlation must be re-validated for a
+  forwarded frame before a `Guaranteed` flow relies on it. `dest` is no longer
+  ignored. Behavioural fix; no signature change.
+
 ## [0.18.56] - 2026-07-17
 
 - **`DidCommTransport` now yields a cryptographically-authenticated sender.**

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.56"
+version = "0.18.57"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
@@ -70,29 +70,53 @@ impl MessageTransport for DidCommTransport {
         TransportKind::Didcomm
     }
 
-    async fn send(&self, _dest: &str, packed: Vec<u8>) -> Result<SendReceipt, MessagingError> {
-        // The packed JWE already encodes the recipient; the ATM routes it via
-        // the profile's mediator, so `dest` is informational here.
+    async fn send(&self, dest: &str, packed: Vec<u8>) -> Result<SendReceipt, MessagingError> {
         let packed = String::from_utf8(packed)
             .map_err(|e| MessagingError::Transport(format!("packed message is not UTF-8: {e}")))?;
-        // Fire-and-forget at the transport: the delivery layer's outbox owns
-        // end-to-end confirmation, so we don't wait for a reply. `msg_id` is only
-        // used for reply correlation (unused when not waiting), so a fresh id is
-        // fine. `send_message` is truthful — `Err` if the frame wasn't written.
+        // Deliver to `dest` by **forwarding** the packed message through the
+        // recipient's mediator (a DIDComm routing/2.0 `forward` envelope). A bare
+        // `send_message` only pushes bytes to our own mediator and does NOT wrap a
+        // forward, so a standard mediator never routes it to the recipient — the
+        // message is silently undelivered. (`send_message` "worked" for a
+        // same-DID self-send, which is why this went unnoticed until a real
+        // cross-DID round trip.) Fire-and-forget: the delivery layer's outbox
+        // owns end-to-end confirmation, so we don't wait for a response.
+        // `forward_and_send_message` is truthful — `Err` if the frame wasn't
+        // written.
         let msg_id = uuid::Uuid::new_v4().to_string();
-        // The mediator keys a stored message on `sha256(packed bytes)` and shows
-        // that id in the sender's outbox (`Folder::Outbox`). Return it as the
-        // `hop_id` so the delivery layer can watch this exact message drain
-        // (outbox-drain evidence, §5a). Verified live against a real mediator.
+        let mediator_did = self
+            .profile
+            .inner
+            .mediator
+            .as_ref()
+            .as_ref()
+            .map(|m| m.did.clone())
+            .ok_or_else(|| {
+                MessagingError::Transport("profile has no mediator to forward through".to_string())
+            })?;
+        // `hop_id` correlates a later outbox-drain confirmation (§5a). It is the
+        // `sha256` of the inner packed frame; the outbox-drain path must key on
+        // the same value the mediator exposes in `Folder::Outbox` for a forwarded
+        // message (re-validate before Guaranteed/outbox-drain relies on it).
         let hop_id = digest(packed.as_str());
         self.atm
-            .send_message(&self.profile, &packed, &msg_id, false, false)
+            .forward_and_send_message(
+                &self.profile,
+                false,
+                &packed,
+                Some(&msg_id),
+                &mediator_did,
+                dest,
+                None,
+                None,
+                false,
+            )
             .await
             .map(|_| SendReceipt {
                 via: TransportKind::Didcomm,
                 hop_id: Some(hop_id),
             })
-            .map_err(|e| MessagingError::Transport(format!("didcomm send failed: {e}")))
+            .map_err(|e| MessagingError::Transport(format!("didcomm forward+send failed: {e}")))
     }
 
     fn connection_state(&self) -> watch::Receiver<ConnState> {


### PR DESCRIPTION
## What — a delivery bug in the transport

`DidCommTransport::send` called `ATM::send_message`, which pushes the packed
bytes to our own mediator **without wrapping a DIDComm routing/2.0 `forward`
envelope**. A standard mediator only routes messages that arrive as a `forward`
addressed to the recipient — so a bare `send_message` frame is **silently
undelivered**.

A **same-DID self-send** happens to round-trip (it lands in the sender's own
mediator queue), which is exactly why the 0.18.53 "verified live against a real
mediator" check missed this — it was a self-send. A real **cross-DID** round
trip (the VTC replying to a join applicant) times out with no reply.

**Fix:** `send()` now uses `forward_and_send_message`, forwarding the packed
frame to `dest` (the recipient the delivery layer passes — previously **ignored**)
through the profile's mediator. This is the *exact* call the SDK's own
`DIDCommSession::pack_and_forward` and every working sender already use; the
transport was the outlier.

## Impact

- Unblocks the D1 Phase-3 cut-over: without this, **no** `MessagingService::send`
  (replies, `send_to_member`, and every `Guaranteed` drain) actually delivers
  cross-DID. Found by the VTC's `join_didcomm` round-trip integration tests
  (they time out on 0.18.56).
- Truthful (`Err` on an unwritten frame); no signature change.
- The `SendReceipt`/`hop_id` contract is unchanged, but the **outbox-drain (§5a)
  correlation for a forwarded frame must be re-validated** before a `Guaranteed`
  flow relies on it — flagged in code + CHANGELOG. P1a is BestEffort, so
  unaffected.

## Verification

70 lib tests pass; `clippy`/`fmt` clean; version guard green (`0.18.57`). End-to-end
validation is the VTC `join_didcomm` suite, which I'll re-run against the published
`0.18.57` (it needs the crates.io release; a local path-patch pulls the whole
unreleased worktree and skews).