### PR TITLE
feat: DidCommTransport surfaces inbound TSP frames alongside DIDComm

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.18.58] - 2026-07-17
+
+- **`DidCommTransport` now surfaces inbound TSP frames as well as DIDComm.**
+  `inbound()` polled `live_stream_next` (DIDComm-only), so a mediator that
+  multiplexes DIDComm **and** TSP to one DID (e.g. the VTA) had its inbound TSP
+  silently dropped once it moved to the delivery layer. It now polls
+  `live_stream_next_frame` and maps each `InboundFrame`: a DIDComm frame as
+  before, and a TSP frame (unpacked via `atm.tsp().unpack_bytes`, which
+  authenticates the sender VID) into a neutral `Inbound` with
+  `protocol = Protocol::TSP`, `sender` = the authenticated VID, `verified =
+  true`. The consumer routes by `message.protocol`. TSP unpacking is behind the
+  `tsp` feature (a DIDComm-only build skips a stray TSP frame rather than
+  dropping the stream). Additive; the DIDComm path and `SendReceipt`/ack
+  contract are unchanged. Unblocks the multi-protocol VTA cut-over.
+
 ## [0.18.57] - 2026-07-17
 
 - **Fix `DidCommTransport::send` to actually deliver.** It called

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.57"
+version = "0.18.58"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
@@ -19,6 +19,7 @@ use tokio::sync::watch;
 
 use crate::messages::Folder;
 use crate::messages::compat::UnpackMetadata;
+use crate::protocols::message_pickup::InboundFrame;
 use crate::{ATM, profiles::ATMProfile};
 
 /// How long each inbound `live_stream_next` poll waits for a message before
@@ -129,20 +130,26 @@ impl MessageTransport for DidCommTransport {
         // Own the ATM + profile so the stream is `'static`; re-borrow per poll.
         // `auto_delete = false` so the mediator keeps its copy until the caller
         // acks after a durable handoff (never ack-before-handoff).
+        //
+        // The **frame** variant surfaces BOTH DIDComm and TSP frames off the one
+        // socket — a mediator multiplexes both to a single DID, and a consumer
+        // (e.g. the VTA) receives both. `Inbound.message.protocol` tags which, so
+        // the delivery layer routes each frame to its handler; without this a
+        // DIDComm-only `live_stream_next` would silently drop inbound TSP.
         Box::pin(stream::unfold(
             (atm, profile),
             |(atm, profile)| async move {
                 loop {
                     match atm
                         .message_pickup()
-                        .live_stream_next(&profile, Some(INBOUND_POLL_WAIT), false)
+                        .live_stream_next_frame(&profile, Some(INBOUND_POLL_WAIT), false)
                         .await
                     {
-                        Ok(Some((message, meta))) => {
-                            if let Some(inbound) = to_inbound(message, &meta) {
+                        Ok(Some(frame)) => {
+                            if let Some(inbound) = frame_to_inbound(&atm, &profile, frame).await {
                                 return Some((inbound, (atm, profile)));
                             }
-                            // Un-mappable frame: skip and keep polling.
+                            // Un-mappable / unsupported frame: skip and keep polling.
                         }
                         // Poll window elapsed with no message — poll again.
                         Ok(None) => {}
@@ -176,6 +183,64 @@ impl MessageTransport for DidCommTransport {
             .map_err(|e| MessagingError::Transport(format!("list outbox failed: {e}")))?;
         Ok(Some(list.into_iter().map(|m| m.msg_id).collect()))
     }
+}
+
+/// Map an [`InboundFrame`] (DIDComm or TSP, multiplexed on the one socket) to
+/// the neutral [`Inbound`]. A DIDComm frame arrives already unpacked; a TSP
+/// frame is unpacked here (see [`tsp_to_inbound`]).
+async fn frame_to_inbound(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    frame: InboundFrame,
+) -> Option<Inbound> {
+    match frame {
+        InboundFrame::DidComm(message, meta) => to_inbound(*message, &meta),
+        InboundFrame::Tsp(packed) => tsp_to_inbound(atm, profile, &packed).await,
+    }
+}
+
+/// Map an inbound TSP frame to the neutral [`Inbound`]. `atm.tsp().unpack_bytes`
+/// authenticates the sender (resolves + verifies the VID), so `sender` is the
+/// cryptographically-authenticated VID and `verified` is `true`. `protocol` is
+/// [`Protocol::TSP`] so the consumer routes it to its TSP handler.
+#[cfg(feature = "tsp")]
+async fn tsp_to_inbound(atm: &ATM, profile: &Arc<ATMProfile>, packed: &str) -> Option<Inbound> {
+    // The mediator keys a stored TSP frame on `sha256(packed)` — the id the frame
+    // stream would delete on ack, so it is the ack handle here too.
+    let ack = digest(packed);
+    let (payload, sender) = match atm.tsp().unpack_bytes(profile, packed.as_bytes()).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to unpack inbound TSP frame — skipping");
+            return None;
+        }
+    };
+    let received = ReceivedMessage {
+        // TSP frames carry no DIDComm message id; the frame hash is a stable id.
+        id: ack.clone(),
+        sender: Some(sender),
+        recipient: profile.inner.did.clone(),
+        payload,
+        protocol: Protocol::TSP,
+        verified: true,
+        encrypted: true,
+    };
+    Some(Inbound {
+        message: received,
+        // TSP correlation is out of band, not the DIDComm `thid` demux.
+        thread_id: None,
+        ack: InboundAck(ack),
+    })
+}
+
+/// Fallback when the `tsp` feature is off: an inbound TSP frame can't be
+/// unpacked (no `atm.tsp()`), so it is skipped rather than dropping the whole
+/// stream. A DIDComm-only build never advertises TSP, so this is unreachable in
+/// practice.
+#[cfg(not(feature = "tsp"))]
+async fn tsp_to_inbound(_atm: &ATM, _profile: &Arc<ATMProfile>, _packed: &str) -> Option<Inbound> {
+    tracing::warn!("received an inbound TSP frame but the `tsp` feature is disabled — skipping it");
+    None
 }
 
 /// Map a DIDComm plaintext message + unpack metadata to the neutral [`Inbound`]


### PR DESCRIPTION
## What

`DidCommTransport::inbound()` polled `live_stream_next`, which is **DIDComm-only**.
A mediator multiplexes DIDComm **and** TSP to one DID (the VTA does exactly
this), so the moment such a service moves onto the delivery layer, its **inbound
TSP is silently dropped** — a real regression.

`inbound()` now polls `live_stream_next_frame` and maps each `InboundFrame`:
- **DIDComm** frame → as before.
- **TSP** frame → unpacked via `atm.tsp().unpack_bytes` (which resolves +
  authenticates the sender VID) into a neutral `Inbound` with
  `protocol = Protocol::TSP`, `sender` = the authenticated VID, `verified =
  true`. The consumer routes by `message.protocol`.

TSP unpacking is behind the **`tsp` feature** — a DIDComm-only build skips a
stray TSP frame rather than dropping the stream.

## Why

Found scoping the D1 Phase-3 VTA cut-over (P2): unlike the VTC (no TSP), the VTA
actively receives + processes TSP on its shared socket (`vta-service`'s
`tsp_inbound::dispatch_one`). This makes the delivery-layer transport genuinely
multi-protocol so the VTA can cut over without regressing TSP receive.

## Verification

Compiles + `clippy --all-targets` clean **both** with and without `tsp`; the 3
`to_inbound` DIDComm tests pass; `fmt` clean; `cargo publish --dry-run` green
(`0.18.58`); version guard green. Additive — DIDComm path + `SendReceipt`/ack
contract unchanged.

Unblocks P2/P3 (the VTA cut-over). Plan:
`../design-docs/vti-phase3-cutover-plan.md`.