### PR TITLE
fix: recognise layer receipts carried in a DIDComm message body

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.8] - 2026-07-18
+
+- **Fix: layer receipts carried over DIDComm are now recognised.** `receipt_key`
+  parsed the transport `payload` directly as a `Receipt`, but the DIDComm
+  transport sets `ReceivedMessage.payload` to the FULL plaintext message JSON
+  (`Message::to_json()`), where the receipt lives under `body` — so the whole
+  message never parsed as a `Receipt` and a layer receipt was silently ignored
+  (§5a confirmation via `with_receipts` never fired). `receipt_key` now tries the
+  payload as a receipt directly (a transport that surfaces the body, e.g. TSP)
+  and falls back to extracting the DIDComm message `body`. Additive; 2 new tests.
+
 ## [0.1.7] - 2026-07-17
 
 - Derive `Serialize`/`Deserialize` on `OutboxEntry` and `OutboxState` so a

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/receipt.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/receipt.rs
@@ -87,7 +87,27 @@ impl Receipt {
 /// non-JSON), so a caller can cheaply tell layer traffic from application
 /// traffic without a separate type channel.
 pub fn receipt_key(payload: &[u8]) -> Option<Key> {
-    let receipt: Receipt = serde_json::from_slice(payload).ok()?;
+    // Two wire shapes a transport can surface as `payload`:
+    // (1) the Receipt JSON **directly** — a transport whose payload is the
+    //     message body (e.g. TSP surfaces the unpacked payload).
+    if let Some(key) = parse_receipt(payload) {
+        return Some(key);
+    }
+    // (2) a **full DIDComm plaintext message** whose `body` is the Receipt — the
+    //     DIDComm transport sets `ReceivedMessage.payload = message.to_json()`,
+    //     so the receipt lives under `body`, not at the top level. Without this
+    //     a layer receipt over DIDComm is never recognised (the whole message
+    //     JSON is not a `Receipt`).
+    let message: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    let body = message.get("body")?;
+    parse_receipt(&serde_json::to_vec(body).ok()?)
+}
+
+/// Parse `bytes` as a [`Receipt`], returning its confirmed key iff the body
+/// carries the [`RECEIPT_TYPE`] marker (so application JSON that merely happens
+/// to be an object is not mistaken for a receipt).
+fn parse_receipt(bytes: &[u8]) -> Option<Key> {
+    let receipt: Receipt = serde_json::from_slice(bytes).ok()?;
     (receipt.kind == RECEIPT_TYPE).then_some(receipt.confirms)
 }
 
@@ -141,6 +161,42 @@ mod tests {
         let bytes = Receipt::new(key).encode();
         assert_eq!(receipt_key(&bytes).as_deref(), Some(key));
         assert_eq!(receipt_of(&message_with(bytes)).as_deref(), Some(key));
+    }
+
+    #[test]
+    fn recognises_a_receipt_carried_as_a_didcomm_message_body() {
+        // The DIDComm transport sets `payload` = the FULL plaintext message JSON
+        // (`Message::to_json()`), so the Receipt lives under `body`, not at the
+        // top level. This is the shape `to_inbound` produces — it must be
+        // recognised. (Regression: `receipt_key` used to parse the whole message
+        // as a `Receipt`, which never matched, so DIDComm layer receipts were
+        // silently ignored.)
+        let key = "did:example:bob:1737000000000:7";
+        let receipt_body =
+            serde_json::from_slice::<serde_json::Value>(&Receipt::new(key).encode()).unwrap();
+        let full_message = serde_json::json!({
+            "id": "urn:uuid:msg-1",
+            "typ": "application/didcomm-plain+json",
+            "from": "did:example:alice",
+            "to": ["did:example:bob"],
+            "body": receipt_body,
+        });
+        let payload = serde_json::to_vec(&full_message).unwrap();
+        assert_eq!(receipt_key(&payload).as_deref(), Some(key));
+        assert_eq!(receipt_of(&message_with(payload)).as_deref(), Some(key));
+    }
+
+    #[test]
+    fn a_didcomm_message_with_a_non_receipt_body_is_not_a_receipt() {
+        let full_message = serde_json::json!({
+            "id": "urn:uuid:msg-2",
+            "typ": "application/didcomm-plain+json",
+            "from": "did:example:alice",
+            "body": { "hello": "world" },
+        });
+        let payload = serde_json::to_vec(&full_message).unwrap();
+        assert_eq!(receipt_key(&payload), None);
+        assert_eq!(receipt_of(&message_with(payload)), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

A latent bug in the §5a layer-receipt feature: `receipt_key` parsed the
transport `payload` **directly** as a `Receipt`, but the DIDComm transport
(`to_inbound`) sets `ReceivedMessage.payload` to the **full plaintext message
JSON** (`Message::to_json()`), where the receipt lives under `body`. So the whole
message never deserialised as a `Receipt`, and **a layer receipt over DIDComm was
silently ignored** — `with_receipts` §5a confirmation would never fire.

It's latent (nothing wires `with_receipts` over a real transport yet), but it
must be fixed before the VTA cut-over uses layer receipts for VTA↔VTC.

**Fix:** `receipt_key` now (1) tries the payload as a `Receipt` directly (a
transport that surfaces the message body as payload, e.g. TSP), then (2) falls
back to extracting the DIDComm message `body` and parsing that.

## Verification

- **2 new tests**: a receipt carried in a DIDComm message `body` is recognised
  (the regression); a message with a non-receipt body is not. Existing receipt
  tests unchanged — 37 in the delivery crate.
- `clippy --all-targets` / `fmt` clean; `cargo publish --dry-run` green
  (`0.1.8`); version-bump guard green. Additive.