### PR TITLE
feat: MessagingService::request_via for correlated request over a specific transport

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.11] - 2026-07-18
+
+- Add **`MessagingService::request_via(transport_id, …)`** — a correlated
+  request/reply over a **specific** installed transport instead of the primary.
+  The reply is awaited on the same merged inbound dispatcher (matched by thread
+  id), so a service can round-trip-prove a **secondary** transport — e.g.
+  trust-ping the VTA via a newly-added-but-not-yet-promoted mediator and await
+  the pong — **before** `promote`ing it. `request` is refactored to share the
+  same `request_over` core; behaviour unchanged. Additive; 1 new test (45 total).
+
 ## [0.1.10] - 2026-07-18
 
 - **`MessagingService` is now multi-transport.** It holds N transports with

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -421,6 +421,54 @@ impl MessagingService {
         correlation_thid: &str,
         timeout: Duration,
     ) -> Result<ReceivedMessage, MessagingError> {
+        let transport = self
+            .inner
+            .primary_transport()
+            .ok_or_else(|| MessagingError::Transport("no primary transport".into()))?;
+        self.request_over(transport, to, packed, correlation_thid, timeout)
+            .await
+    }
+
+    /// Like [`request`](Self::request), but sends over a **specific** installed
+    /// transport (by id) rather than the primary, while still awaiting the reply
+    /// on the same merged inbound dispatcher (matched by `correlation_thid`).
+    ///
+    /// This is what lets a service round-trip-prove a **secondary** transport —
+    /// e.g. trust-ping the VTA via a newly-added-but-not-yet-promoted mediator and
+    /// await the pong — **before** [`promote`](Self::promote)ing it. The reply
+    /// arrives on the same dispatcher as any other transport's inbound and is
+    /// demuxed to this waiter by thread id, so no separate correlation channel is
+    /// needed. `Err` if `transport_id` is not currently installed.
+    pub async fn request_via(
+        &self,
+        transport_id: &str,
+        to: &str,
+        packed: Vec<u8>,
+        correlation_thid: &str,
+        timeout: Duration,
+    ) -> Result<ReceivedMessage, MessagingError> {
+        let transport = self.inner.transport_by_id(transport_id).ok_or_else(|| {
+            MessagingError::Transport(format!(
+                "cannot request via unknown transport: {transport_id}"
+            ))
+        })?;
+        self.request_over(transport, to, packed, correlation_thid, timeout)
+            .await
+    }
+
+    /// Shared core of [`request`](Self::request) and
+    /// [`request_via`](Self::request_via): register a waiter keyed by
+    /// `correlation_thid` **before** sending (so a fast reply can't race ahead),
+    /// send over the already-resolved `transport`, then await the reply the merged
+    /// dispatcher fans back to this waiter, up to `timeout`.
+    async fn request_over(
+        &self,
+        transport: Arc<dyn MessageTransport>,
+        to: &str,
+        packed: Vec<u8>,
+        correlation_thid: &str,
+        timeout: Duration,
+    ) -> Result<ReceivedMessage, MessagingError> {
         let (tx, rx) = oneshot::channel();
         // Register the waiter BEFORE sending so a fast reply can't race ahead.
         self.inner
@@ -428,14 +476,6 @@ impl MessagingService {
             .lock()
             .expect("waiters mutex")
             .insert(correlation_thid.to_string(), tx);
-
-        let transport = match self.inner.primary_transport() {
-            Some(transport) => transport,
-            None => {
-                self.remove_waiter(correlation_thid);
-                return Err(MessagingError::Transport("no primary transport".into()));
-            }
-        };
 
         if let Err(e) = transport.send(to, packed).await {
             self.remove_waiter(correlation_thid);
@@ -1305,6 +1345,63 @@ mod tests {
 
         // Promoting an unknown transport is a truthful error.
         assert!(svc.promote("nope").is_err());
+    }
+
+    #[tokio::test]
+    async fn request_via_proves_a_secondary_before_promotion() {
+        let h1 = mock();
+        let svc = Arc::new(MessagingService::new(
+            h1.transport.clone(),
+            Arc::new(InMemoryOutboxStore::new()),
+        ));
+        // A newly-added secondary (NOT the primary yet) — the mediator being proven.
+        let h2 = mock();
+        svc.add_transport("candidate".into(), h2.transport.clone());
+
+        // Trust-ping the peer over the CANDIDATE transport and await the pong.
+        let svc2 = svc.clone();
+        let req = tokio::spawn(async move {
+            svc2.request_via(
+                "candidate",
+                "did:example:bob",
+                b"ping".to_vec(),
+                "ping-thread",
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        // Let the request register its waiter + send, then the pong arrives on the
+        // candidate transport (its forwarder feeds the same merged dispatcher).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The ping went out over the candidate, NOT the primary.
+        assert_eq!(h2.transport.sent.lock().unwrap().len(), 1);
+        assert!(h1.transport.sent.lock().unwrap().is_empty());
+
+        h2.inbound_tx
+            .send(inbound("pong", Some("ping-thread"), "q-pong"))
+            .unwrap();
+
+        let pong = req.await.unwrap().unwrap();
+        assert_eq!(pong.id, "pong");
+        // The candidate is still a secondary — proving it did NOT promote it.
+        assert_eq!(
+            svc.primary_transport().map(|t| t.kind()),
+            Some(TransportKind::Didcomm)
+        );
+
+        // Requesting via an unknown transport is a truthful error, no waiter leak.
+        assert!(
+            svc.request_via(
+                "nope",
+                "did:x",
+                b"x".to_vec(),
+                "t",
+                Duration::from_millis(100)
+            )
+            .await
+            .is_err()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `MessagingService::request_via(transport_id, to, packed, correlation_thid, timeout)` — a correlated request/reply routed over a **named installed transport** instead of the primary, with the reply awaited on the same merged inbound dispatcher (matched by thread id).

`request` is refactored to share a private `request_over` core; its behaviour is unchanged.

## Why

The multi-transport `MessagingService` (#625) lets a service hold a not-yet-promoted **secondary** transport, but every correlated round-trip (`request`) went over the **primary** only. A mediator migration needs to *prove* a new mediator — trust-ping the VTA via the new mediator's socket and await the pong — **before** `promote`ing it, so it never advertises a mediator that connected but can't actually round-trip deliver.

`request_via` is exactly that primitive: send over the candidate transport, await the correlated pong on the shared dispatcher, then `promote`. This unblocks the VTA messaging cut-over (D2) without weakening the migration handshake.

## Scope

- Additive, backward-compatible. No change to `request`/`send`/`promote` semantics.
- One new test: `request_via_proves_a_secondary_before_promotion` (45 total, all green).
- Bumps `affinidi-messaging-delivery` → 0.1.11.