### PR TITLE
fix: DidCommTransport dropped every inbound TSP frame (unpack qb64, not qb2)

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.18.59] - 2026-07-18
+
+- **Fix: `DidCommTransport` dropped every inbound TSP frame** (regression in
+  0.18.58's TSP surfacing). The multiplexed pickup socket
+  (`live_stream_next_frame`) hands a TSP frame to `tsp_to_inbound` as the
+  **qb64** stored string (base64url of qb2 — `-E…` *text*), but the adapter called
+  `unpack_bytes(packed.as_bytes())`, which expects raw qb2 and so pushed the ASCII
+  `'-','E',…` bytes straight into the CESR parser — failing with `missing -E
+  envelope wrapper` and skipping the frame. Every inbound TSP message (e.g. a
+  trust-ping) was silently dropped and never answered. Now calls
+  `atm.tsp().unpack(profile, packed)`, which base64url-decodes first — matching the
+  framework listener's `dispatch_tsp`. TSP-only; the DIDComm path was unaffected.
+
 ## [0.18.58] - 2026-07-17
 
 - **`DidCommTransport` now surfaces inbound TSP frames as well as DIDComm.**

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.58"
+version = "0.18.59"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
@@ -199,7 +199,7 @@ async fn frame_to_inbound(
     }
 }
 
-/// Map an inbound TSP frame to the neutral [`Inbound`]. `atm.tsp().unpack_bytes`
+/// Map an inbound TSP frame to the neutral [`Inbound`]. `atm.tsp().unpack`
 /// authenticates the sender (resolves + verifies the VID), so `sender` is the
 /// cryptographically-authenticated VID and `verified` is `true`. `protocol` is
 /// [`Protocol::TSP`] so the consumer routes it to its TSP handler.
@@ -208,7 +208,16 @@ async fn tsp_to_inbound(atm: &ATM, profile: &Arc<ATMProfile>, packed: &str) -> O
     // The mediator keys a stored TSP frame on `sha256(packed)` — the id the frame
     // stream would delete on ack, so it is the ack handle here too.
     let ack = digest(packed);
-    let (payload, sender) = match atm.tsp().unpack_bytes(profile, packed.as_bytes()).await {
+    // The multiplexed pickup socket (`live_stream_next_frame`) surfaces a TSP
+    // frame as the **qb64** stored string — base64url of qb2, i.e. `-E…` *text* —
+    // NOT raw qb2. Use `unpack`, which base64url-decodes first. Feeding
+    // `packed.as_bytes()` to `unpack_bytes` (which expects raw qb2) would push the
+    // ASCII `'-','E',…` bytes straight into the CESR parser and fail with "missing
+    // -E envelope wrapper", so every inbound TSP frame — e.g. a trust-ping — is
+    // silently skipped and never answered. Mirrors the framework listener's
+    // `dispatch_tsp` (the raw-TSP `connect_websocket` path yields already-decoded
+    // qb2 and correctly uses `unpack_bytes`; this DIDComm-multiplexed path does not).
+    let (payload, sender) = match atm.tsp().unpack(profile, packed).await {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(error = %e, "failed to unpack inbound TSP frame — skipping");


### PR DESCRIPTION
## Symptom

A VTA on the delivery-layer `DidCommTransport` (D2/P2a) never answers TSP trust-pings. Observed live:

```
WARN affinidi_messaging_sdk::transport_adapter: failed to unpack inbound TSP frame — skipping
  error=... couldn't parse TSP envelope: invalid message: missing -E envelope wrapper
```
…and the peer (PNM) reports `TSP ping failed: TSP websocket closed before reply`.

## Root cause

0.18.58 (#622) taught `DidCommTransport::inbound()` to surface inbound TSP frames off the multiplexed pickup socket, but `tsp_to_inbound` unpacked them with the wrong call. `MessagePickup::live_stream_next_frame` hands a TSP frame over as the **qb64 stored string** — base64url of qb2, i.e. `-E…` *text* — but the adapter called:

```rust
atm.tsp().unpack_bytes(profile, packed.as_bytes())  // expects RAW qb2
```

feeding the ASCII `'-','E',…` bytes straight into the CESR parser → `missing -E envelope wrapper` → frame skipped. So **every** inbound TSP message (trust-ping included) was silently dropped and never answered.

The framework listener's `dispatch_tsp` already documents this exact pitfall and does it correctly.

## Fix

```rust
atm.tsp().unpack(profile, packed)  // base64url-decodes first, then unpack_bytes on the qb2
```

One-line change + a comment explaining qb64-vs-qb2 (mirroring `dispatch_tsp`). TSP-only; the DIDComm path was unaffected. `unpack` internally base64url-decodes and delegates to `unpack_bytes` on the raw qb2, so the sender authentication (verified VID) is unchanged.

## Testing

- `cargo build/clippy -p affinidi-messaging-sdk --features tsp` — clean.
- Verified against the framework's `dispatch_tsp` (whose behaviour is covered by `affinidi-messaging-didcomm-service/tests/tsp_live_stream.rs`) — the adapter now matches it.
- **Regression-test gap:** `DidCommTransport` has no integration-test harness today, and a `TestEnvironment`-based test can't live in this crate without an SDK↔test-mediator dev-dep cycle. Recommend a follow-up adapter-level TSP round-trip test (e.g. in `affinidi-messaging-didcomm-service/tests/`, which already has the harness).

## Downstream

Consumers on the `tsp` feature (the VTA) must bump to **0.18.59** to pick this up.