### PR TITLE
test: cover DidCommTransport surfacing inbound TSP frames (regression for #627)

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -46,6 +46,8 @@ affinidi-did-common = "0.3"
 # package stays publishable while using the in-tree path for dev-builds.
 affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
 affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
+futures-util = "0.3"
 
 
 [[example]]

--- a/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/tests/tsp_transport_adapter.rs
@@ -1,0 +1,125 @@
+//! Regression test: the delivery-layer `DidCommTransport` must surface an inbound
+//! **TSP** frame off the multiplexed pickup socket.
+//!
+//! A TSP frame is handed to the adapter's `tsp_to_inbound` as the **qb64** stored
+//! string (base64url of qb2 — `-E…` *text*), so it must `atm.tsp().unpack(profile,
+//! packed)` (base64url-decodes first), NOT `unpack_bytes(packed.as_bytes())`.
+//! Before sdk 0.18.59 (#627) it did the latter, fed the ASCII `-E…` bytes into the
+//! CESR parser, failed with `missing -E envelope wrapper`, and dropped the frame —
+//! so the VTA never answered TSP trust-pings. On the old code this times out; on
+//! the fix it passes. Drives the SDK's `DidCommTransport` directly — the coverage
+//! gap that let the bug ship.
+//!
+//! Mirrors `tsp_live_stream` (the framework-path regression): receiver minted with
+//! `env.mediator.add_user` (a DIDComm-only did:peer — TSP is delivered over the
+//! mediator's pickup socket the transport reads), connected via the framework's
+//! `from_tdk_profile` + `profile_add(_, true)` sequence, and — crucially — the
+//! inbound consumer is polling BEFORE the client sends (`live_stream_next_frame`
+//! is live-only, so a frame delivered before the stream is polled is missed).
+
+#![cfg(feature = "tsp")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_messaging_core::{Inbound, MessageTransport, Protocol};
+use affinidi_messaging_sdk::DidCommTransport;
+use affinidi_messaging_test_mediator::TestEnvironment;
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::secrets_resolver::SecretsResolver;
+use affinidi_tdk_common::profiles::TDKProfile;
+use futures_util::StreamExt;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn didcomm_transport_surfaces_inbound_tsp_frame() {
+    let env = TestEnvironment::spawn().await.expect("spawn test mediator");
+    let service = env
+        .mediator
+        .add_user("service")
+        .await
+        .expect("service identity");
+    let client = env.add_user("client").await.expect("client identity");
+    let mediator_did = env.mediator.did().to_string();
+
+    // Stand the service up as the framework listener's `connect()` does (its own
+    // fresh TDK — a separate connection from `env.atm` — secrets seeded before
+    // ATM::new, profile via `from_tdk_profile` + `profile_add(_, true)`), then wrap
+    // it in `DidCommTransport`.
+    let tdk_profile = TDKProfile::new(
+        "svc",
+        &service.did,
+        Some(mediator_did.as_str()),
+        service.secrets.clone(),
+    );
+    let service_tdk = Arc::new(
+        TDKSharedState::new(TDKConfig::builder().build().expect("tdk config"))
+            .await
+            .expect("service TDK"),
+    );
+    for secret in service.secrets.clone() {
+        service_tdk.secrets_resolver().insert(secret).await;
+    }
+    let service_atm = ATM::new(
+        ATMConfig::builder().build().expect("atm config"),
+        service_tdk,
+    )
+    .await
+    .expect("service ATM");
+    let atm_profile = ATMProfile::from_tdk_profile(&service_atm, &tdk_profile)
+        .await
+        .expect("service profile from tdk profile");
+    let service_profile = service_atm
+        .profile_add(&atm_profile, true)
+        .await
+        .expect("profile_add (connect websocket)");
+    let transport = DidCommTransport::new(service_atm.clone(), service_profile.clone())
+        .await
+        .expect("bind DidCommTransport");
+
+    // Start consuming BEFORE the send: `live_stream_next_frame` is live-only, so a
+    // frame delivered before the stream is being polled would be missed. Skip the
+    // DIDComm control frames (e.g. `messagepickup/3.0/status`) and return the first
+    // TSP one. Before the qb64/qb2 unpack fix the TSP frame NEVER surfaces (dropped
+    // as "missing -E envelope wrapper") and this task never completes.
+    let recv: tokio::task::JoinHandle<Option<Inbound>> = tokio::spawn(async move {
+        let mut inbound = transport.inbound();
+        loop {
+            match inbound.next().await {
+                Some(item) if item.message.protocol == Protocol::TSP => break Some(item),
+                Some(_) => continue,
+                None => break None,
+            }
+        }
+    });
+
+    // Give the live-stream a moment to subscribe, then the client sends a TSP
+    // message to the service through the mediator.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let payload = b"hello over tsp (adapter)".to_vec();
+    env.atm
+        .tsp()
+        .send(&client.profile, &service.did, &payload)
+        .await
+        .expect("client sends TSP to the service");
+
+    let got = tokio::time::timeout(Duration::from_secs(30), recv)
+        .await
+        .expect("DidCommTransport yields the inbound TSP frame within 30s")
+        .expect("receive task panicked")
+        .expect("inbound stream ended before any TSP frame arrived");
+
+    assert_eq!(got.message.payload, payload, "payload round-trips");
+    assert_eq!(
+        got.message.sender.as_deref(),
+        Some(client.did.as_str()),
+        "authenticated sender VID is the client"
+    );
+    assert!(
+        got.message.verified,
+        "a TSP sender is cryptographically authenticated"
+    );
+}


### PR DESCRIPTION
## What

Adds an integration test driving the SDK's `DidCommTransport` TSP-receive path directly, closing the coverage gap that let the #627 unpack bug ship.

## Why

`DidCommTransport` had **no** integration coverage of inbound TSP. The existing `tsp_live_stream` test only exercises the framework listener's `dispatch_tsp` (always correct), not the SDK adapter's `tsp_to_inbound` where the bug lived: a TSP frame arrives off the multiplexed pickup socket as the **qb64** stored string but was unpacked as raw qb2 via `unpack_bytes(packed.as_bytes())`, failing with `missing -E envelope wrapper` and silently dropping every inbound TSP frame — so a VTA never answered TSP trust-pings.

## The test

`tsp_transport_adapter::didcomm_transport_surfaces_inbound_tsp_frame`:
- Receiver minted with `env.mediator.add_user` (DIDComm-only did:peer → TSP delivered over the mediator pickup socket the transport reads), connected via the framework's `from_tdk_profile` + `profile_add(_, true)` sequence, then wrapped in `DidCommTransport`.
- A client sends a TSP message; the test asserts the transport surfaces it as a `Protocol::TSP` `Inbound` with the round-tripped payload + verified sender VID.
- The consumer polls **before** the send, because `live_stream_next_frame` is live-only (a frame delivered before the stream is polled is missed) — the subtle bit that made this hard to write.

## Has teeth

Reverting the fix (`unpack` → `unpack_bytes`) makes it **time out**; with the fix it passes in ~2s. Test-only + two dev-deps (`affinidi-messaging-core`, `futures-util`); no shipped source change, so no version bump.