### PR TITLE
feat: add typed also_known_as field to Document (did-common 0.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ docs/*
 !docs/testing/
 # TSP usage cookbook is tracked.
 !docs/tsp/
+# Release runbooks for publishes that can't just be "merge and let CI run".
+!docs/release/
 
 # mediator-setup wizard generated artifacts (may land in any directory)
 **/conf/secrets.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ affinidi-meeting-place = { path = "crates/applications/affinidi-meeting-place" }
 affinidi-tsp = { path = "crates/messaging/affinidi-tsp" }
 affinidi-did-web = { path = "crates/identity/did-methods/did-web" }
 did-scid = { path = "crates/identity/did-methods/did-scid" }
+did-example = { path = "crates/identity/did-methods/did-example" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Meeting Place Changelog
 
+## 19th July 2026 (0.4.4)
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 13th June 2026 (0.4.3)
 
 - **Publish fix.** The W9 semver wave (#448) added a wildcard match arm here

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.4.3"
+version = "0.4.4"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ affinidi-did-authentication = "0.3"
 affinidi-tdk-common = "0.6"
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-resolver-cache-sdk = "0.8"
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 
 base64 = "0.22"
 chrono = "0.4"

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi Data Integrity Changelog
 
+## 19th July 2026 Release 0.7.7
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 13th June 2026 Release 0.7.6
 
 Semver wave (W10 — release W11). `DataIntegrityProof` is now `#[non_exhaustive]`

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.6"
+version = "0.7.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -25,7 +25,7 @@ slh-dsa = ["affinidi-crypto/slh-dsa", "affinidi-secrets-resolver/slh-dsa"]
 affinidi-crypto = "0.2"
 affinidi-rdf-encoding = { version = "0.1", path = "../affinidi-rdf-encoding" }
 affinidi-secrets-resolver = "0.5"
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 affinidi-bbs = { version = "0.3", path = "../../core/affinidi-bbs", optional = true }
 hmac = { version = "0.12", optional = true }
 ciborium = { version = "0.2", optional = true }

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi DID Authentication
 
+## 0.3.10 — 2026-07-19
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 4th July 2026 (0.3.9)
 
 Internal refactor: the local `_key_type_to_curve` helper is replaced by

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -16,7 +16,7 @@ rust-version.workspace = true
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-resolver-cache-sdk = "0.8"
-affinidi-did-common = { version = "0.3", features = ["key-agreement"] }
+affinidi-did-common = { version = "0.4", features = ["key-agreement"] }
 affinidi-secrets-resolver = "0.5"
 affinidi-encoding = "0.1"
 

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-19
+
+### Added
+
+- `Document::also_known_as` (`alsoKnownAs`) is now a **typed field** (`Vec<String>`)
+  rather than an untyped entry in the flattened `parameters_set` map, plus
+  `DocumentBuilder::also_known_as` / `also_known_as_many` to set it.
+
+  The DID specification defines `alsoKnownAs` as a set, so it always *serializes*
+  as a JSON array and is omitted entirely when empty. Deserialization is
+  deliberately lenient and also accepts a **bare string**, because documents in
+  the wild emit that form; a bare string normalizes to a single-element array on
+  the next serialization.
+
+  This is groundwork for agent-name (DID shortcut) resolution, where the
+  mandatory anti-spoofing check is that a resolved DID Document's `alsoKnownAs`
+  contains the agent name that was used to reach it.
+
+  The change itself is additive: `Document` is `#[non_exhaustive]`, so consumers
+  already construct it via `Document::new` / `DocumentBuilder` / deserialization
+  rather than struct literals, and no consumer code needs to change.
+
+  Note for anyone who previously read the value out of the untyped map:
+  `parameters_set["alsoKnownAs"]` is now absent — read `doc.also_known_as`.
+
+### Changed
+
+- **Minor version bump to `0.4.0`.** Although the API change above is additive,
+  this is released as a minor rather than a patch, which means every consumer
+  must move its requirement from `"0.3"` to `"0.4"`. Per ADR 0003 §3 a minor bump
+  of this crate breaks any `[patch.crates-io]` redirect held by an external
+  crates.io consumer still pinning `"0.3"`, so those consumers must be released
+  first. The one such consumer, `didwebvh-rs`, is updated in lockstep
+  (`0.5.8`, requiring `affinidi-did-common "0.4"`); it needed only the dependency
+  bump, no code changes.
+
 ## [0.3.9] - 2026-06-23
 
 ### Fixed

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.3.9"
+version = "0.4.0"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-common/src/builder.rs
+++ b/crates/identity/affinidi-did-common/src/builder.rs
@@ -14,6 +14,7 @@ use crate::{
 /// Builder for constructing a [`Document`] using a fluent API.
 pub struct DocumentBuilder {
     id: Url,
+    also_known_as: Vec<String>,
     verification_method: Vec<VerificationMethod>,
     authentication: Vec<VerificationRelationship>,
     assertion_method: Vec<VerificationRelationship>,
@@ -36,6 +37,7 @@ impl DocumentBuilder {
     pub fn from_url(id: Url) -> Self {
         Self {
             id,
+            also_known_as: Vec::new(),
             verification_method: Vec::new(),
             authentication: Vec::new(),
             assertion_method: Vec::new(),
@@ -82,6 +84,24 @@ impl DocumentBuilder {
     /// Add `https://www.w3.org/ns/did/v1.1` to `@context`.
     pub fn context_did_v1_1(self) -> Self {
         self.append_context("https://www.w3.org/ns/did/v1.1")
+    }
+
+    // --- Also Known As ---
+
+    /// Add a single `alsoKnownAs` identifier.
+    pub fn also_known_as(mut self, uri: impl Into<String>) -> Self {
+        self.also_known_as.push(uri.into());
+        self
+    }
+
+    /// Add multiple `alsoKnownAs` identifiers.
+    pub fn also_known_as_many<I, S>(mut self, uris: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.also_known_as.extend(uris.into_iter().map(Into::into));
+        self
     }
 
     /// Add a single verification method.
@@ -230,6 +250,7 @@ impl DocumentBuilder {
     pub fn build(self) -> Document {
         Document {
             id: self.id,
+            also_known_as: self.also_known_as,
             verification_method: self.verification_method,
             authentication: self.authentication,
             assertion_method: self.assertion_method,
@@ -427,6 +448,26 @@ mod tests {
         assert!(doc.capability_delegation.is_empty());
         assert!(doc.service.is_empty());
         assert!(doc.parameters_set.is_empty());
+    }
+
+    #[test]
+    fn also_known_as_single_and_many() {
+        let doc = DocumentBuilder::new("did:example:123")
+            .unwrap()
+            .also_known_as("example.com/@alice")
+            .also_known_as_many(["connect.me/@bob", "names.info/@carol"])
+            .build();
+
+        assert_eq!(
+            doc.also_known_as,
+            vec!["example.com/@alice", "connect.me/@bob", "names.info/@carol"]
+        );
+    }
+
+    #[test]
+    fn also_known_as_empty_by_default() {
+        let doc = DocumentBuilder::new("did:example:123").unwrap().build();
+        assert!(doc.also_known_as.is_empty());
     }
 
     #[test]

--- a/crates/identity/affinidi-did-common/src/did_method/resolve.rs
+++ b/crates/identity/affinidi-did-common/src/did_method/resolve.rs
@@ -112,6 +112,7 @@ fn resolve_key(did: &DID, identifier: &str) -> Result<Document, DIDError> {
 
     Ok(Document {
         id: did.url(),
+        also_known_as: vec![],
         verification_method: vms,
         authentication: vec![vm_relationship.clone()],
         assertion_method: vec![vm_relationship.clone()],
@@ -244,6 +245,7 @@ fn resolve_peer_2(did: &DID, identifier: &str) -> Result<Document, DIDError> {
 
     Ok(Document {
         id: did.url(),
+        also_known_as: vec![],
         verification_method: verification_methods,
         authentication,
         assertion_method,

--- a/crates/identity/affinidi-did-common/src/document.rs
+++ b/crates/identity/affinidi-did-common/src/document.rs
@@ -171,6 +171,7 @@ mod tests {
     fn document() -> Document {
         Document {
             id: Url::parse("did:test:1234").unwrap(),
+            also_known_as: vec![],
             verification_method: vec![VerificationMethod {
                 id: Url::parse("did:test:1234#vm").unwrap(),
                 type_: "Ed25519VerificationKey2018".to_string(),

--- a/crates/identity/affinidi-did-common/src/lib.rs
+++ b/crates/identity/affinidi-did-common/src/lib.rs
@@ -5,12 +5,13 @@
 use std::collections::HashMap;
 
 use affinidi_encoding::EncodingError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use url::Url;
 
 use crate::{
+    one_or_many::OneOrMany,
     service::Service,
     verification_method::{VerificationMethod, VerificationRelationship},
 };
@@ -67,6 +68,22 @@ pub struct Document {
     /// <https://www.w3.org/TR/cid-1.0/#subjects>
     pub id: Url,
 
+    /// Other identifiers the DID subject is also known by
+    /// <https://www.w3.org/TR/did-1.1/#also-known-as>
+    ///
+    /// The DID specification defines this as a *set*, so it always serializes as
+    /// a JSON array. Deserialization additionally accepts a bare string, because
+    /// documents in the wild emit that form.
+    ///
+    /// This is the property an agent-name resolver checks to confirm that a
+    /// human-readable shortcut is actually authorized by the DID it resolved to.
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        default,
+        deserialize_with = "deserialize_also_known_as"
+    )]
+    pub also_known_as: Vec<String>,
+
     /// https://www.w3.org/TR/cid-1.0/#verification-methods
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub verification_method: Vec<VerificationMethod>,
@@ -100,11 +117,20 @@ pub struct Document {
     pub parameters_set: HashMap<String, Value>,
 }
 
+/// Accepts either a JSON array of strings or a single bare string.
+fn deserialize_also_known_as<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(OneOrMany::<String>::deserialize(deserializer)?.into_vec())
+}
+
 impl Default for Document {
     /// Creates a default example DID Document that is blank except for the id field
     fn default() -> Self {
         Self {
             id: Url::parse("did:example:123456789abcdefghi").unwrap(),
+            also_known_as: Vec::new(),
             verification_method: Vec::new(),
             authentication: Vec::new(),
             assertion_method: Vec::new(),
@@ -163,6 +189,78 @@ mod tests {
         let doc = Document::new("did:example:456").unwrap();
         let json = serde_json::to_string(&doc).unwrap();
         let back: Document = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc, back);
+    }
+
+    // --- alsoKnownAs ---
+
+    #[test]
+    fn also_known_as_defaults_to_empty() {
+        let doc = Document::new("did:example:123").unwrap();
+        assert!(doc.also_known_as.is_empty());
+    }
+
+    #[test]
+    fn also_known_as_omitted_when_empty() {
+        let doc = Document::new("did:example:123").unwrap();
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(!json.contains("alsoKnownAs"));
+    }
+
+    #[test]
+    fn also_known_as_absent_from_json() {
+        let doc: Document = serde_json::from_str(r#"{"id":"did:example:123"}"#).unwrap();
+        assert!(doc.also_known_as.is_empty());
+    }
+
+    #[test]
+    fn also_known_as_deserializes_array() {
+        let doc: Document = serde_json::from_str(
+            r#"{"id":"did:example:123","alsoKnownAs":["example.com/@alice","connect.me/@bob"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            doc.also_known_as,
+            vec!["example.com/@alice", "connect.me/@bob"]
+        );
+    }
+
+    /// Documents in the wild emit a bare string; the DID spec says set. Accept both.
+    #[test]
+    fn also_known_as_deserializes_bare_string() {
+        let doc: Document =
+            serde_json::from_str(r#"{"id":"did:example:123","alsoKnownAs":"example.com/@alice"}"#)
+                .unwrap();
+        assert_eq!(doc.also_known_as, vec!["example.com/@alice"]);
+    }
+
+    /// Lenient on read, strict on write: a bare string normalizes to an array.
+    #[test]
+    fn also_known_as_always_serializes_as_array() {
+        let doc: Document =
+            serde_json::from_str(r#"{"id":"did:example:123","alsoKnownAs":"example.com/@alice"}"#)
+                .unwrap();
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(json.contains(r#""alsoKnownAs":["example.com/@alice"]"#));
+    }
+
+    /// Regression: alsoKnownAs used to land in the flattened `parameters_set` map.
+    /// It must now be a typed field and must NOT be duplicated into that map.
+    #[test]
+    fn also_known_as_not_captured_by_parameters_set() {
+        let doc: Document = serde_json::from_str(
+            r#"{"id":"did:example:123","alsoKnownAs":["example.com/@alice"]}"#,
+        )
+        .unwrap();
+        assert_eq!(doc.also_known_as, vec!["example.com/@alice"]);
+        assert!(!doc.parameters_set.contains_key("alsoKnownAs"));
+    }
+
+    #[test]
+    fn also_known_as_serde_roundtrip() {
+        let json = r#"{"id":"did:example:123","alsoKnownAs":["example.com/@alice"]}"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        let back: Document = serde_json::from_str(&serde_json::to_string(&doc).unwrap()).unwrap();
         assert_eq!(doc, back);
     }
 }

--- a/crates/identity/affinidi-did-common/src/service.rs
+++ b/crates/identity/affinidi-did-common/src/service.rs
@@ -154,6 +154,7 @@ mod tests {
     fn make_doc_with_services(services: Vec<Service>) -> Document {
         Document {
             id: Url::parse("did:test:1234").unwrap(),
+            also_known_as: vec![],
             verification_method: vec![],
             authentication: vec![],
             assertion_method: vec![],

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.8.13 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 17th June 2026
 
 ### 0.8.11 — `did-cheqd` is now opt-in (no forced rustls `ring` backend)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -64,7 +64,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
-didwebvh-rs = { version = "0.5.8", optional = true }
+didwebvh-rs = { version = "0.5", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.12"
+version = "0.8.13"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ did-ebsi = ["dep:did-ebsi"]
 
 [dependencies]
 # Affinidi Crates
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 affinidi-did-resolver-traits = { version = "0.1", path = "../affinidi-did-resolver-traits" }
 # Shared background-task supervision (network mode only)
 affinidi-task-utils = { version = "0.1", optional = true }
@@ -64,7 +64,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
-didwebvh-rs = { version = "0.5", optional = true }
+didwebvh-rs = { version = "0.5.8", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.9.3 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### 0.9.2 — non_exhaustive error enums (W7 sweep)

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.2"
+version = "0.9.3"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -23,11 +23,11 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 [dependencies]
 # Affinidi Crates
 affinidi-did-resolver-cache-sdk = { version = "0.8", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.5.8"
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -27,7 +27,7 @@ affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 
-didwebvh-rs = "0.5.8"
+didwebvh-rs = "0.5"
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/affinidi-did-resolver-traits/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-traits/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.1.3 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### 0.1.2 — non_exhaustive ResolverError (W7 sweep)

--- a/crates/identity/affinidi-did-resolver-traits/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-traits"
-version = "0.1.2"
+version = "0.1.3"
 description = "Resolver traits for pluggable DID resolution"
 edition.workspace = true
 authors.workspace = true
@@ -13,7 +13,7 @@ readme = "README.md"
 rust-version.workspace = true
 
 [dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/identity/did-methods/did-ebsi/CHANGELOG.md
+++ b/crates/identity/did-methods/did-ebsi/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.1.4 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### 0.1.3 — non_exhaustive EbsiError (W7 sweep)

--- a/crates/identity/did-methods/did-ebsi/Cargo.toml
+++ b/crates/identity/did-methods/did-ebsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ebsi"
-version = "0.1.3"
+version = "0.1.4"
 description = "Implementation of did:ebsi (EBSI DID method for legal entities) in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -16,7 +16,7 @@ rust-version.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 bs58 = "0.5"
 rand = "0.9"
 reqwest = { version = "0.13", features = ["rustls", "json"] }

--- a/crates/identity/did-methods/did-example/CHANGELOG.md
+++ b/crates/identity/did-methods/did-example/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.5.9 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### 0.5.8 — non_exhaustive DidExampleError (W7 sweep)

--- a/crates/identity/did-methods/did-example/Cargo.toml
+++ b/crates/identity/did-methods/did-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-example"
-version = "0.5.8"
+version = "0.5.9"
 description = "Implementation of did:example in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -16,7 +16,7 @@ rust-version.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 ahash = "0.8"
 serde_json = "1"
 thiserror = "2"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.1.11 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 17th June 2026
 
 ### 0.1.10 — drop `did-cheqd` from default features (no forced `ring` TLS)

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
-didwebvh-rs = { version = "0.5.8", optional = true }
+didwebvh-rs = { version = "0.5", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.10"
+version = "0.1.11"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -30,9 +30,9 @@ did-webvh = ["dep:didwebvh-rs"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 
-didwebvh-rs = { version = "0.5", optional = true }
+didwebvh-rs = { version = "0.5.8", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"

--- a/crates/identity/did-methods/did-web/CHANGELOG.md
+++ b/crates/identity/did-methods/did-web/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.1.3 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### Affinidi DID Web (0.1.2)

--- a/crates/identity/did-methods/did-web/Cargo.toml
+++ b/crates/identity/did-methods/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-web"
-version = "0.1.2"
+version = "0.1.3"
 description = "Minimal did:web DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -16,7 +16,7 @@ rust-version.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 percent-encoding = "2"
 reqwest = { version = "0.13", default-features = false, features = [
   "rustls",

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.20] - 2026-07-19
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## [0.3.19] - 2026-07-16
 
 - Ack (delete) live inbound messages only AFTER the handler has processed them,

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.19"
+version = "0.3.20"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.17.3 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 16th July 2026
 
 ### 0.17.2 — secp256k1 (ES256K) support + resolve sender key by JWE skid

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.2"
+version = "0.17.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -99,7 +99,7 @@ humantime = "2"
 clap = { version = "4", features = ["derive"] }
 ## DID resolution with in-memory cache (capacity: 1000 DIDs, TTL: 300s)
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
@@ -133,7 +133,7 @@ redis = { version = "1.2", features = [
 fjall = { version = "3.1", optional = true }
 
 # ── DID Infrastructure ───────────────────────────────────────────────────
-didwebvh-rs = "0.5.4"
+didwebvh-rs = "0.5.8"
 
 # ── AWS Integration (optional, behind `aws` feature) ────────────────────
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -133,7 +133,7 @@ redis = { version = "1.2", features = [
 fjall = { version = "3.1", optional = true }
 
 # ── DID Infrastructure ───────────────────────────────────────────────────
-didwebvh-rs = "0.5.8"
+didwebvh-rs = "0.5"
 
 # ── AWS Integration (optional, behind `aws` feature) ────────────────────
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator
 ] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
-didwebvh-rs = "0.5.4"
+didwebvh-rs = "0.5.8"
 
 # ── VTA Integration ──────────────────────────────────────────────────────
 ## provision-client: orchestration layer that drives setup-key minting,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator
 ] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
-didwebvh-rs = "0.5.8"
+didwebvh-rs = "0.5"
 
 # ── VTA Integration ──────────────────────────────────────────────────────
 ## provision-client: orchestration layer that drives setup-key minting,

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.60] - 2026-07-19
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## [0.18.59] - 2026-07-18
 
 - **Fix: `DidCommTransport` dropped every inbound TSP frame** (regression in

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.59"
+version = "0.18.60"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -51,7 +51,7 @@ reqwest = { version = "0.13", features = [
 ## call sites continue to resolve their old paths.
 affinidi-messaging-mediator-common = { path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", version = "0.15", default-features = false }
 affinidi-did-authentication = "0.3"
-affinidi-did-common = { version = "0.3", features = ["key-agreement"] }
+affinidi-did-common = { version = "0.4", features = ["key-agreement"] }
 affinidi-encoding = "0.1"
 affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (delete-handler restart + health)

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi TSP Changelog
 
+## 19th July 2026
+
+### 0.1.13 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 30th June 2026
 
 ### 0.1.12 — rustfmt-only

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -29,7 +29,7 @@ affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1"
 
 # Optional Affinidi crates (for DID-based VID resolution)
 affinidi-did-resolver-cache-sdk = { path = "../../identity/affinidi-did-resolver-cache-sdk", version = "0.8", optional = true }
-affinidi-did-common = { path = "../../identity/affinidi-did-common", version = "0.3", optional = true }
+affinidi-did-common = { path = "../../identity/affinidi-did-common", version = "0.4", optional = true }
 affinidi-encoding = { path = "../../core/affinidi-encoding", version = "0.1", optional = true }
 
 # Crypto

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.6 — 2026-07-19
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 0.6.5 — 2026-06-16
 
 ### Fixed

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-authentication = "0.3"
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 affinidi-secrets-resolver = "0.5"
 affinidi-data-integrity = "0.7"
 

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+## 19th July 2026
+
+### 0.8.1 — affinidi-did-common 0.4
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## 14th June 2026
 
 ### 0.7.0 — documented testing API + cookbook (TI6)

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.8.0"
+version = "0.8.1"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ publish = true
 # ── TI2: did:web/webvh mock server + StaticResolver ──────────────────────
 ## `DID`/`Document` types and the resolver traits the StaticResolver implements.
 ## Path + explicit version so the crate stays publishable once the API settles.
-affinidi-did-common = { version = "0.3", path = "../../identity/affinidi-did-common" }
+affinidi-did-common = { version = "0.4", path = "../../identity/affinidi-did-common" }
 affinidi-did-resolver-traits = { version = "0.1", path = "../../identity/affinidi-did-resolver-traits" }
 ## In-process HTTP server backing MockDidWebServer.
 axum = "0.8"

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## [0.8.4] - 2026-07-19
+
+### Changed
+
+- Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.
+  No functional change to this crate: `Document` gained a typed
+  `also_known_as` field, which is additive.
+
 ## [0.8.1] - 2026-06-13
 
 ### Added

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.3"
+version = "0.8.4"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tsp = ["dep:affinidi-tsp"]
 
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
-affinidi-did-common = "0.3"
+affinidi-did-common = "0.4"
 affinidi-messaging-sdk = { version = "0.18", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"

--- a/docs/release/did-common-0.4.0-publish-runbook.md
+++ b/docs/release/did-common-0.4.0-publish-runbook.md
@@ -3,29 +3,28 @@
 Covers affinidi-tdk-rs [#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629)
 and didwebvh-rs [#50](https://github.com/decentralized-identity/didwebvh-rs/pull/50).
 
-Read the whole thing before running anything. Steps 1–3 are manual and
-out-of-band; step 5 is the normal automated release.
+TDK crates publish **only from CI** (push to `main`). `didwebvh-rs` is published
+manually. This runbook is written around those two constraints.
 
 ## Why this one needs a runbook
 
 `affinidi-did-common` takes a **minor** bump (0.3.9 → 0.4.0). Per
 [ADR 0003 §3](../adr/0003-public-api-semver-policy.md) that invalidates the
 `[patch.crates-io]` redirect held by any **external** crates.io consumer still
-requiring `"0.3"`, so those consumers must be republished first — but they
-cannot build until 0.4.0 is on crates.io. That circularity is the entire
-problem:
+requiring `"0.3"` — but those consumers cannot build until 0.4.0 is on
+crates.io:
 
 ```
-affinidi-did-common 0.4.0  ──needs nothing new──▶  publishable immediately
-affinidi-data-integrity 0.7.7 ──needs──▶ did-common 0.4.0
-didwebvh-rs 0.5.8         ──needs──▶ did-common 0.4.0 + data-integrity 0.7.7
-everything else           ──needs──▶ didwebvh-rs 0.5.8
+affinidi-did-common 0.4.0     ──needs──▶  nothing new; publishable immediately
+affinidi-data-integrity 0.7.7 ──needs──▶  did-common 0.4.0
+didwebvh-rs 0.5.8             ──needs──▶  did-common 0.4.0 + data-integrity 0.7.7
+did-scid, cache-sdk, …        ──needs──▶  didwebvh-rs 0.5.8
 ```
 
 There are **two** external consumers in that chain, not one.
-`affinidi-data-integrity` is easy to miss because `didwebvh-rs` pulls
-`affinidi-did-common` through it transitively; bumping `didwebvh-rs` alone still
-leaves two copies of `affinidi-did-common` in the graph and fails with:
+`affinidi-data-integrity` is easy to miss because `didwebvh-rs` reaches
+`affinidi-did-common` through it transitively. Bumping `didwebvh-rs` alone still
+leaves two copies of `affinidi-did-common` in the graph:
 
 ```
 error[E0308]: expected `affinidi_did_common::Document`,
@@ -34,156 +33,169 @@ note: there are multiple different versions of crate `affinidi_did_common`
       in the dependency graph
 ```
 
+## The release pipeline resolves ordering by itself
+
+This is the key fact, and it is what makes the cycle escapable.
+`affinidi/pipeline-rust/.github/workflows/release.yaml@main` with
+`workspace_publish: false`:
+
+- **Runs no workspace build before publishing.** Quoting the workflow: *"no
+  unconditional `cargo build --release` here … a full-workspace build at release
+  time … couples every crate's fate together (one unrelated broken crate fails
+  the whole release before anything publishes)."*
+- Publishes each crate via `cargo publish -p <crate>`, which **verifies only
+  that crate's own dependency tree**. An unrelated broken crate cannot block it.
+- Retries in passes (default `release_max_retries: 10`, 15s apart). A failed
+  crate becomes a warning and is requeued; the loop stops early only when a full
+  pass makes **no** progress. Publish ordering therefore sorts itself out.
+- Skips any crate whose local version is not strictly greater than crates.io, so
+  re-running is safe and resumes rather than restarting.
+
+Consequence: **a red workspace build does not prevent publishing.** It only
+means the PR's own checks are red, which is a merge-gate question, not a
+release-pipeline one.
+
 ## Preconditions
 
-- crates.io publish rights for the `affinidi-*` crates and `didwebvh-rs`.
-- `cargo login` done.
-- affinidi-tdk-rs #629 checked out locally. **Do not merge it yet** — merging
-  before step 3 triggers the release pipeline against an unpublishable graph.
-- didwebvh-rs #50 checked out locally on `did-common-0.4`.
-
-> `didwebvh-rs` lives under the `decentralized-identity` org, not `affinidi`.
-> Confirm publish rights there before starting, not at step 3.
+- Admin/bypass rights to merge #629 with red checks.
+- crates.io publish rights for `didwebvh-rs` (org: `decentralized-identity`,
+  **not** `affinidi` — confirm before you start, not at step 3).
+- #629 keeps the `didwebvh-rs` requirement at `"0.5"`, **not** `"0.5.8"`.
+  Pinning a version that does not exist makes the workspace unresolvable, and
+  cargo then refuses to package *any* crate:
+  `error: failed to select a version for the requirement didwebvh-rs = "^0.5.8"`.
+  `"0.5"` selects 0.5.8 automatically once published.
 
 ---
 
-## Step 1 — publish `affinidi-did-common 0.4.0`
+## Step 1 — merge #629 into `main` (force past red checks)
 
-From the #629 branch:
+PR checks will be red: `did-scid`, `affinidi-did-resolver-cache-sdk` and their
+dependents cannot compile until `didwebvh-rs 0.5.8` exists. That is expected and
+is the reason for the bypass.
 
-```bash
-cargo publish -p affinidi-did-common
-```
+> **`main` is left non-compiling from here until step 2 completes.** Keep the
+> window short and tell anyone working off `main`. This is the real cost of the
+> minor-bump route; nothing else in this runbook is risky.
 
-This works because `affinidi-did-common` depends only on already-published
-crates (`affinidi-crypto 0.2`, `affinidi-encoding 0.1`).
+The release run then publishes, over several retry passes:
 
-It also depends on the workspace **resolving**, which is why #629 keeps the
-`didwebvh-rs` requirement at `"0.5"` rather than `"0.5.8"`. Pinning a version
-that does not exist yet makes the whole workspace unresolvable and cargo refuses
-to package *any* crate:
+| Pass | Publishes |
+|------|-----------|
+| 1 | `affinidi-did-common 0.4.0` — needs only `affinidi-crypto`/`affinidi-encoding`, both live |
+| 2 | `affinidi-data-integrity 0.7.7`, `affinidi-did-resolver-traits 0.1.3`, `affinidi-did-web 0.1.3`, `did-example 0.5.9`, `did-ebsi 0.1.4` |
+| 3+ | no progress — remaining crates need `didwebvh-rs 0.5.8` |
 
-```
-error: failed to select a version for the requirement `didwebvh-rs = "^0.5.8"`
-```
+The step then exits non-zero listing the unpublished crates. **That is the
+expected outcome, not a failure to fix.** Tags for what did publish are pushed
+regardless (`Push Tags` runs under `always()`).
 
-If you see that, someone has re-pinned it — revert to `"0.5"`. Cargo selects
-0.5.8 automatically once published, since it is a patch release.
-
-Verify: `cargo info affinidi-did-common` shows 0.4.0.
-
-## Step 2 — publish `affinidi-data-integrity 0.7.7`
-
-Same branch, after step 1 has propagated (usually seconds; the verify build
-resolves from the registry, so it will fail if 0.4.0 is not yet visible):
+Confirm before continuing:
 
 ```bash
-cargo publish -p affinidi-data-integrity
+cargo info affinidi-did-common      # 0.4.0
+cargo info affinidi-data-integrity  # 0.7.7
 ```
 
-## Step 3 — publish `didwebvh-rs 0.5.8`
+## Step 2 — manually publish `didwebvh-rs 0.5.8`
 
-Switch to the didwebvh-rs repo, `did-common-0.4` branch (PR #50).
-
-`Cargo.lock` is intentionally uncommitted there — it could not be regenerated
-honestly before steps 1–2. Refresh it now:
+In the didwebvh-rs repo on `did-common-0.4` (PR #50). `Cargo.lock` was
+deliberately left unrefreshed there — it could not be regenerated honestly
+before step 1. Refresh it now:
 
 ```bash
 cargo update -p affinidi-did-common --precise 0.4.0
 cargo update -p affinidi-data-integrity --precise 0.7.7
-cargo test --all-features        # expect 438 passing
+cargo tree | grep affinidi-did-common      # must show exactly one line: v0.4.0
+cargo test --all-features                  # expect 438 passing
 cargo publish
 ```
 
-Commit the refreshed `Cargo.lock` to PR #50 and merge it.
+Commit the refreshed lockfile to PR #50 and merge it.
 
 > `cargo update -p X` silently no-ops when two versions of `X` are in the graph.
-> Use the `--precise` form above, and confirm with
-> `cargo tree | grep affinidi-did-common` — you want **one** line, `v0.4.0`.
+> Use the `--precise` form above and verify with `cargo tree`.
 
-## Step 4 — confirm #629 goes green
+## Step 3 — re-run the TDK release
 
-With 0.5.8 live, affinidi-tdk-rs #629 resolves. Re-run CI. Expect green apart
-from two failures that are **pre-existing on main** and unrelated:
+Re-run the `release` workflow on `main` (or push any commit to `main`). With
+`didwebvh-rs 0.5.8` live, the remaining 12 crates publish; the 6 from step 1 are
+skipped automatically as already-published.
+
+| Crate | Version |
+|-------|---------|
+| `did-scid` | 0.1.11 |
+| `affinidi-did-resolver-cache-sdk` | 0.8.13 |
+| `affinidi-did-authentication` | 0.3.10 |
+| `affinidi-did-resolver-cache-server` | 0.9.3 |
+| `affinidi-tdk-common` | 0.6.6 |
+| `affinidi-meeting-place` | 0.4.4 |
+| `affinidi-tsp` | 0.1.13 |
+| `affinidi-messaging-sdk` | 0.18.60 |
+| `affinidi-tdk` | 0.8.4 |
+| `affinidi-messaging-didcomm-service` | 0.3.20 |
+| `affinidi-messaging-mediator` | 0.17.3 |
+| `affinidi-tdk-test-support` | 0.8.1 |
+
+(The retry loop handles ordering within this set; the table is for verification,
+not for driving anything manually. Regenerate it with `cargo metadata`.)
+
+## Step 4 — verify
+
+`main` should now compile again:
+
+```bash
+git checkout main && git pull
+cargo update -w
+cargo tree --workspace | grep -o 'affinidi-did-common v[0-9.]*' | sort -u
+# must print exactly one line: affinidi-did-common v0.4.0
+cargo test --workspace --no-fail-fast
+```
+
+Two failures are **pre-existing on main** and unrelated to this release:
 
 - `vta-sdk` — `DidCommTransport: MessageTransport` not satisfied.
 - `affinidi-did-common` under `--no-default-features` — `KeyType`/`JWK` E0599s.
 
-Sanity check locally:
-
-```bash
-cargo tree --workspace | grep -o 'affinidi-did-common v[0-9.]*' | sort -u
-# must print exactly one line: affinidi-did-common v0.4.0
-```
-
-## Step 5 — merge #629 and let the pipeline publish the rest
-
-Merging to `main` triggers
-`affinidi/pipeline-rust/.github/workflows/release.yaml@main`, which compares
-each crate's local version against crates.io and publishes those that moved.
-`workspace_publish: false` means it **skips already-published crates**, so
-`affinidi-did-common 0.4.0` and `affinidi-data-integrity 0.7.7` from steps 1–2
-are passed over rather than erroring.
-
-The remaining 16 publish in this dependency order:
-
-| # | Crate | Version |
-|---|-------|---------|
-| 3 | `affinidi-did-resolver-traits` | 0.1.3 |
-| 4 | `affinidi-did-web` | 0.1.3 |
-| 5 | `did-ebsi` | 0.1.4 |
-| 6 | `did-example` | 0.5.9 |
-| 7 | `did-scid` | 0.1.11 |
-| 8 | `affinidi-did-resolver-cache-sdk` | 0.8.13 |
-| 9 | `affinidi-did-authentication` | 0.3.10 |
-| 10 | `affinidi-did-resolver-cache-server` | 0.9.3 |
-| 11 | `affinidi-tdk-common` | 0.6.6 |
-| 12 | `affinidi-meeting-place` | 0.4.4 |
-| 13 | `affinidi-tsp` | 0.1.13 |
-| 14 | `affinidi-messaging-sdk` | 0.18.60 |
-| 15 | `affinidi-tdk` | 0.8.4 |
-| 16 | `affinidi-messaging-didcomm-service` | 0.3.20 |
-| 17 | `affinidi-messaging-mediator` | 0.17.3 |
-| 18 | `affinidi-tdk-test-support` | 0.8.1 |
-
-(Regenerate this ordering with `cargo metadata` rather than editing by hand.)
-
-## Step 6 — post-release verification
-
-```bash
-cargo update -w && cargo test --workspace --no-fail-fast
-```
-
-Confirm no `[patch.crates-io]` entry is silently masking a stale registry crate:
+Then check no `[patch.crates-io]` redirect is masking a stale registry crate:
 
 ```bash
 cargo tree --workspace | grep -o 'affinidi-[a-z-]* v[0-9.]*' | sort -u
 ```
 
-Any crate appearing at two versions means a `[patch]` redirect has fallen
-through — the failure mode this whole runbook exists to prevent.
+Any crate at two versions means a redirect has fallen through — the failure mode
+this runbook exists to prevent.
 
-## If a step fails partway
+## If something goes wrong
 
-crates.io publishes are **irreversible** — you can yank, never unpublish, and a
-yanked version still can't be republished at the same number.
+crates.io publishes are **irreversible** — yank only, and a yanked version
+cannot be republished at the same number.
 
-- **Failure at step 1 or 2** — nothing downstream has moved; fix and retry.
-- **Failure at step 3** — steps 1–2 are already live and permanent. That is
-  fine and not wasted: those versions are correct regardless. Fix `didwebvh-rs`
-  and retry. Do **not** bump `affinidi-did-common` again to work around it.
-- **Failure during step 5** — the pipeline skips already-published crates, so
-  re-running after a fix resumes rather than restarting. Any crate that needs a
-  code change to publish also needs a fresh patch bump (see
-  `scripts/check-version-bumps.sh` and ADR 0004 for why publishing changed
-  source at an existing version is what broke the 2026-06-13 release).
+- **Step 1 publishes fewer crates than expected** — read the per-crate warnings
+  in the job log. The loop only gives up after a pass with zero progress, so a
+  crate left pending has a real dependency problem, not an ordering one.
+- **Step 2 fails** — step 1's publishes are permanent, which is fine; those
+  versions are correct regardless. Fix `didwebvh-rs` and retry. Do **not** bump
+  `affinidi-did-common` again to work around it.
+- **A crate needs a code change to publish** — it also needs a fresh patch bump.
+  Publishing changed source at an already-published version is what broke the
+  2026-06-13 release; see `scripts/check-version-bumps.sh` and ADR 0004.
 
 ## Known trap for next time
 
-`did-example` was a workspace member referenced *by version* from
-`affinidi-did-resolver-cache-sdk` but **missing from `[patch.crates-io]`**, so
-cargo silently built against the published copy rather than local source. #629
-adds it. If you add a workspace crate that another member depends on by version,
-add it to `[patch.crates-io]` in the same PR, or local changes to it will not
-take effect in workspace builds and a stale registry copy will drag in old
+`did-example` is a workspace member referenced *by version* from
+`affinidi-did-resolver-cache-sdk` but was **missing from `[patch.crates-io]`**,
+so cargo silently built against the published copy instead of local source —
+which is how a second `affinidi-did-common` kept entering the graph even after
+`didwebvh-rs` was handled. #629 adds it.
+
+If you add a workspace crate that another member depends on *by version*, add it
+to `[patch.crates-io]` in the same PR. Otherwise local changes to it will not
+take effect in workspace builds, and a stale registry copy will drag in old
 transitive dependencies.
+
+Note also that `[patch.crates-io]` replaces the registry crate **unconditionally**
+for path-dependency members: a workspace crate requiring `"0.3"` while the local
+crate is at `0.4.0` fails to resolve outright rather than falling back to the
+registry. This is why there is no "bump the foundational crate on its own first"
+PR — it cannot be made to resolve.

--- a/docs/release/did-common-0.4.0-publish-runbook.md
+++ b/docs/release/did-common-0.4.0-publish-runbook.md
@@ -1,0 +1,189 @@
+# Runbook — publishing `affinidi-did-common 0.4.0`
+
+Covers affinidi-tdk-rs [#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629)
+and didwebvh-rs [#50](https://github.com/decentralized-identity/didwebvh-rs/pull/50).
+
+Read the whole thing before running anything. Steps 1–3 are manual and
+out-of-band; step 5 is the normal automated release.
+
+## Why this one needs a runbook
+
+`affinidi-did-common` takes a **minor** bump (0.3.9 → 0.4.0). Per
+[ADR 0003 §3](../adr/0003-public-api-semver-policy.md) that invalidates the
+`[patch.crates-io]` redirect held by any **external** crates.io consumer still
+requiring `"0.3"`, so those consumers must be republished first — but they
+cannot build until 0.4.0 is on crates.io. That circularity is the entire
+problem:
+
+```
+affinidi-did-common 0.4.0  ──needs nothing new──▶  publishable immediately
+affinidi-data-integrity 0.7.7 ──needs──▶ did-common 0.4.0
+didwebvh-rs 0.5.8         ──needs──▶ did-common 0.4.0 + data-integrity 0.7.7
+everything else           ──needs──▶ didwebvh-rs 0.5.8
+```
+
+There are **two** external consumers in that chain, not one.
+`affinidi-data-integrity` is easy to miss because `didwebvh-rs` pulls
+`affinidi-did-common` through it transitively; bumping `didwebvh-rs` alone still
+leaves two copies of `affinidi-did-common` in the graph and fails with:
+
+```
+error[E0308]: expected `affinidi_did_common::Document`,
+              found a different `affinidi_did_common::Document`
+note: there are multiple different versions of crate `affinidi_did_common`
+      in the dependency graph
+```
+
+## Preconditions
+
+- crates.io publish rights for the `affinidi-*` crates and `didwebvh-rs`.
+- `cargo login` done.
+- affinidi-tdk-rs #629 checked out locally. **Do not merge it yet** — merging
+  before step 3 triggers the release pipeline against an unpublishable graph.
+- didwebvh-rs #50 checked out locally on `did-common-0.4`.
+
+> `didwebvh-rs` lives under the `decentralized-identity` org, not `affinidi`.
+> Confirm publish rights there before starting, not at step 3.
+
+---
+
+## Step 1 — publish `affinidi-did-common 0.4.0`
+
+From the #629 branch:
+
+```bash
+cargo publish -p affinidi-did-common
+```
+
+This works because `affinidi-did-common` depends only on already-published
+crates (`affinidi-crypto 0.2`, `affinidi-encoding 0.1`).
+
+It also depends on the workspace **resolving**, which is why #629 keeps the
+`didwebvh-rs` requirement at `"0.5"` rather than `"0.5.8"`. Pinning a version
+that does not exist yet makes the whole workspace unresolvable and cargo refuses
+to package *any* crate:
+
+```
+error: failed to select a version for the requirement `didwebvh-rs = "^0.5.8"`
+```
+
+If you see that, someone has re-pinned it — revert to `"0.5"`. Cargo selects
+0.5.8 automatically once published, since it is a patch release.
+
+Verify: `cargo info affinidi-did-common` shows 0.4.0.
+
+## Step 2 — publish `affinidi-data-integrity 0.7.7`
+
+Same branch, after step 1 has propagated (usually seconds; the verify build
+resolves from the registry, so it will fail if 0.4.0 is not yet visible):
+
+```bash
+cargo publish -p affinidi-data-integrity
+```
+
+## Step 3 — publish `didwebvh-rs 0.5.8`
+
+Switch to the didwebvh-rs repo, `did-common-0.4` branch (PR #50).
+
+`Cargo.lock` is intentionally uncommitted there — it could not be regenerated
+honestly before steps 1–2. Refresh it now:
+
+```bash
+cargo update -p affinidi-did-common --precise 0.4.0
+cargo update -p affinidi-data-integrity --precise 0.7.7
+cargo test --all-features        # expect 438 passing
+cargo publish
+```
+
+Commit the refreshed `Cargo.lock` to PR #50 and merge it.
+
+> `cargo update -p X` silently no-ops when two versions of `X` are in the graph.
+> Use the `--precise` form above, and confirm with
+> `cargo tree | grep affinidi-did-common` — you want **one** line, `v0.4.0`.
+
+## Step 4 — confirm #629 goes green
+
+With 0.5.8 live, affinidi-tdk-rs #629 resolves. Re-run CI. Expect green apart
+from two failures that are **pre-existing on main** and unrelated:
+
+- `vta-sdk` — `DidCommTransport: MessageTransport` not satisfied.
+- `affinidi-did-common` under `--no-default-features` — `KeyType`/`JWK` E0599s.
+
+Sanity check locally:
+
+```bash
+cargo tree --workspace | grep -o 'affinidi-did-common v[0-9.]*' | sort -u
+# must print exactly one line: affinidi-did-common v0.4.0
+```
+
+## Step 5 — merge #629 and let the pipeline publish the rest
+
+Merging to `main` triggers
+`affinidi/pipeline-rust/.github/workflows/release.yaml@main`, which compares
+each crate's local version against crates.io and publishes those that moved.
+`workspace_publish: false` means it **skips already-published crates**, so
+`affinidi-did-common 0.4.0` and `affinidi-data-integrity 0.7.7` from steps 1–2
+are passed over rather than erroring.
+
+The remaining 16 publish in this dependency order:
+
+| # | Crate | Version |
+|---|-------|---------|
+| 3 | `affinidi-did-resolver-traits` | 0.1.3 |
+| 4 | `affinidi-did-web` | 0.1.3 |
+| 5 | `did-ebsi` | 0.1.4 |
+| 6 | `did-example` | 0.5.9 |
+| 7 | `did-scid` | 0.1.11 |
+| 8 | `affinidi-did-resolver-cache-sdk` | 0.8.13 |
+| 9 | `affinidi-did-authentication` | 0.3.10 |
+| 10 | `affinidi-did-resolver-cache-server` | 0.9.3 |
+| 11 | `affinidi-tdk-common` | 0.6.6 |
+| 12 | `affinidi-meeting-place` | 0.4.4 |
+| 13 | `affinidi-tsp` | 0.1.13 |
+| 14 | `affinidi-messaging-sdk` | 0.18.60 |
+| 15 | `affinidi-tdk` | 0.8.4 |
+| 16 | `affinidi-messaging-didcomm-service` | 0.3.20 |
+| 17 | `affinidi-messaging-mediator` | 0.17.3 |
+| 18 | `affinidi-tdk-test-support` | 0.8.1 |
+
+(Regenerate this ordering with `cargo metadata` rather than editing by hand.)
+
+## Step 6 — post-release verification
+
+```bash
+cargo update -w && cargo test --workspace --no-fail-fast
+```
+
+Confirm no `[patch.crates-io]` entry is silently masking a stale registry crate:
+
+```bash
+cargo tree --workspace | grep -o 'affinidi-[a-z-]* v[0-9.]*' | sort -u
+```
+
+Any crate appearing at two versions means a `[patch]` redirect has fallen
+through — the failure mode this whole runbook exists to prevent.
+
+## If a step fails partway
+
+crates.io publishes are **irreversible** — you can yank, never unpublish, and a
+yanked version still can't be republished at the same number.
+
+- **Failure at step 1 or 2** — nothing downstream has moved; fix and retry.
+- **Failure at step 3** — steps 1–2 are already live and permanent. That is
+  fine and not wasted: those versions are correct regardless. Fix `didwebvh-rs`
+  and retry. Do **not** bump `affinidi-did-common` again to work around it.
+- **Failure during step 5** — the pipeline skips already-published crates, so
+  re-running after a fix resumes rather than restarting. Any crate that needs a
+  code change to publish also needs a fresh patch bump (see
+  `scripts/check-version-bumps.sh` and ADR 0004 for why publishing changed
+  source at an existing version is what broke the 2026-06-13 release).
+
+## Known trap for next time
+
+`did-example` was a workspace member referenced *by version* from
+`affinidi-did-resolver-cache-sdk` but **missing from `[patch.crates-io]`**, so
+cargo silently built against the published copy rather than local source. #629
+adds it. If you add a workspace crate that another member depends on by version,
+add it to `[patch.crates-io]` in the same PR, or local changes to it will not
+take effect in workspace builds and a stale registry copy will drag in old
+transitive dependencies.


### PR DESCRIPTION
## What

Promotes `alsoKnownAs` from an untyped entry in `Document`'s flattened
`parameters_set` map to a typed `Vec<String>` field, plus
`DocumentBuilder::also_known_as` / `also_known_as_many`.

Groundwork for agent-name (DID shortcut) resolution, where the mandatory
Layer-1 anti-spoofing check is that a resolved DID Document's `alsoKnownAs`
contains the agent name used to reach it. PR 1 of 4.

### Serde behaviour: lenient read, strict write

The DID spec defines `alsoKnownAs` as a set, so it always **serializes** as a
JSON array and is omitted when empty. Deserialization also accepts a **bare
string**, because documents in the wild emit that form; a bare string normalizes
to a single-element array on the next write. Reuses the crate's existing
`OneOrMany` rather than a hand-rolled visitor.

## :warning: Do not merge before `didwebvh-rs 0.5.8` is on crates.io

This ships as a **minor** bump (`0.3.9` -> `0.4.0`), which is what makes this PR
large: all 17 dependent workspace crates move their requirement from `"0.3"` to
`"0.4"` and take a patch bump.

Per [ADR 0003 §3](docs/adr/0003-public-api-semver-policy.md), a minor bump of
`affinidi-did-common` invalidates the `[patch.crates-io]` redirect held by any
**external** crates.io consumer still requiring `"0.3"`. `didwebvh-rs` is the
only such consumer. Left unaddressed, cargo resolves a second copy of
`affinidi-did-common` from the registry and the build dies with:

```
error[E0308]: expected `affinidi_did_common::Document`,
              found a different `affinidi_did_common::Document`
note: there are multiple different versions of crate `affinidi_did_common`
      in the dependency graph
```

`didwebvh-rs` needed **only a dependency bump, no code changes** (it neither
struct-literal-constructs `Document` nor re-exports it). Companion release:
`didwebvh-rs 0.5.8`.

### Required ordering

There is a genuine circular constraint: `didwebvh-rs 0.5.8` requires
`affinidi-did-common "0.4"`, which does not exist on crates.io yet.

1. Publish `affinidi-did-common 0.4.0` (builds standalone, no didwebvh-rs dep).
2. Publish `didwebvh-rs 0.5.8`.
3. This PR then resolves and goes green; merge normally.

**CI on this PR will be red until steps 1-2 are done** — `didwebvh-rs = "0.5.8"`
cannot resolve. This is a dependency-resolution failure, not a code failure.

## Drive-by fix

Adds `did-example` to `[patch.crates-io]`. It is a workspace member referenced
*by version* from `cache-sdk`, but was missing from the patch list, so cargo
silently used the published copy from the registry — which is how a second
`affinidi-did-common` kept entering the graph even after `didwebvh-rs` was
handled.

## Verification

- `affinidi-did-common`: 214 tests pass, incl. 10 new (array form, bare-string
  form, absent, empty-omitted, round-trip, and a regression test asserting
  `alsoKnownAs` no longer lands in `parameters_set`).
- `cache-sdk` 62, `did-web` 9, `did-scid`, `data-integrity` 26, `tdk-common` — all green.
- `cargo tree --workspace` shows a **single** `affinidi-did-common v0.4.0`.
- `cargo fmt --check` clean; `clippy --all-features -D warnings` clean.
- `scripts/check-version-bumps.sh` passes for all 18 crates.

Verified locally with `--config patch.crates-io.didwebvh-rs.path=<local 0.5.8>`.

### Pre-existing failures (not from this PR)

Both confirmed by stashing and re-running against the base commit:

- `vta-sdk` fails workspace-wide (`DidCommTransport: MessageTransport` not
  satisfied), blocking a full `cargo check --workspace` on main today.
- `affinidi-did-common` does not compile with `--no-default-features`
  (`KeyType`/`JWK` E0599s).