### PR TITLE
chore: bump didwebvh-rs to 0.6 + fix the vta-sdk MessageTransport failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ affinidi-tsp = { path = "crates/messaging/affinidi-tsp" }
 affinidi-did-web = { path = "crates/identity/did-methods/did-web" }
 did-scid = { path = "crates/identity/did-methods/did-scid" }
 did-example = { path = "crates/identity/did-methods/did-example" }
+affinidi-messaging-core = { path = "crates/messaging/affinidi-messaging-core" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ## 19th July 2026
 
+### 0.8.14 — didwebvh-rs 0.6
+
+- Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
+
+  0.6.0 requires `affinidi-did-common "0.4"`. Until now `didwebvh-rs 0.5.7`
+  still required `"0.3"`, so the workspace carried **two** copies of
+  `affinidi-did-common` (0.3.9 and 0.4.0); it compiled only because no types
+  cross the `didwebvh-rs` boundary — `WebvhResolver` builds its own `Document`
+  via `serde_json::from_value`. This collapses the graph back to a single
+  `affinidi-did-common 0.4.0`.
+
+  0.6.0 is a breaking release (`DIDWebVHError`, `URLType` and
+  `LogEntryValidationStatus` became `#[non_exhaustive]`), but no code change was
+  needed here: the only use is a `#[from] DIDWebVHError` conversion in
+  `did-scid`'s error type, not an exhaustive `match`.
+
+## 19th July 2026
+
 ### 0.8.13 — affinidi-did-common 0.4
 
 - Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.13"
+version = "0.8.14"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -64,7 +64,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
-didwebvh-rs = { version = "0.5", optional = true }
+didwebvh-rs = { version = "0.6", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ## 19th July 2026
 
+### 0.9.4 — didwebvh-rs 0.6
+
+- Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
+
+  0.6.0 requires `affinidi-did-common "0.4"`. Until now `didwebvh-rs 0.5.7`
+  still required `"0.3"`, so the workspace carried **two** copies of
+  `affinidi-did-common` (0.3.9 and 0.4.0); it compiled only because no types
+  cross the `didwebvh-rs` boundary — `WebvhResolver` builds its own `Document`
+  via `serde_json::from_value`. This collapses the graph back to a single
+  `affinidi-did-common 0.4.0`.
+
+  0.6.0 is a breaking release (`DIDWebVHError`, `URLType` and
+  `LogEntryValidationStatus` became `#[non_exhaustive]`), but no code change was
+  needed here: the only use is a `#[from] DIDWebVHError` conversion in
+  `did-scid`'s error type, not an exhaustive `match`.
+
+## 19th July 2026
+
 ### 0.9.3 — affinidi-did-common 0.4
 
 - Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.3"
+version = "0.9.4"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -27,7 +27,7 @@ affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.6"
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ## 19th July 2026
 
+### 0.1.12 — didwebvh-rs 0.6
+
+- Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
+
+  0.6.0 requires `affinidi-did-common "0.4"`. Until now `didwebvh-rs 0.5.7`
+  still required `"0.3"`, so the workspace carried **two** copies of
+  `affinidi-did-common` (0.3.9 and 0.4.0); it compiled only because no types
+  cross the `didwebvh-rs` boundary — `WebvhResolver` builds its own `Document`
+  via `serde_json::from_value`. This collapses the graph back to a single
+  `affinidi-did-common 0.4.0`.
+
+  0.6.0 is a breaking release (`DIDWebVHError`, `URLType` and
+  `LogEntryValidationStatus` became `#[non_exhaustive]`), but no code change was
+  needed here: the only use is a `#[from] DIDWebVHError` conversion in
+  `did-scid`'s error type, not an exhaustive `match`.
+
+## 19th July 2026
+
 ### 0.1.11 — affinidi-did-common 0.4
 
 - Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.11"
+version = "0.1.12"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -32,7 +32,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
-didwebvh-rs = { version = "0.5", optional = true }
+didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ## 19th July 2026
 
+### 0.17.4 — didwebvh-rs 0.6
+
+- Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
+
+  0.6.0 requires `affinidi-did-common "0.4"`. Until now `didwebvh-rs 0.5.7`
+  still required `"0.3"`, so the workspace carried **two** copies of
+  `affinidi-did-common` (0.3.9 and 0.4.0); it compiled only because no types
+  cross the `didwebvh-rs` boundary — `WebvhResolver` builds its own `Document`
+  via `serde_json::from_value`. This collapses the graph back to a single
+  `affinidi-did-common 0.4.0`.
+
+  0.6.0 is a breaking release (`DIDWebVHError`, `URLType` and
+  `LogEntryValidationStatus` became `#[non_exhaustive]`), but no code change was
+  needed here: the only use is a `#[from] DIDWebVHError` conversion in
+  `did-scid`'s error type, not an exhaustive `match`.
+
+## 19th July 2026
+
 ### 0.17.3 — affinidi-did-common 0.4
 
 - Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.3"
+version = "0.17.4"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -133,7 +133,7 @@ redis = { version = "1.2", features = [
 fjall = { version = "3.1", optional = true }
 
 # ── DID Infrastructure ───────────────────────────────────────────────────
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.6"
 
 # ── AWS Integration (optional, behind `aws` feature) ────────────────────
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator
 ] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
-didwebvh-rs = "0.5"
+didwebvh-rs = "0.6"
 
 # ── VTA Integration ──────────────────────────────────────────────────────
 ## provision-client: orchestration layer that drives setup-key minting,


### PR DESCRIPTION
## What

Two things, both about duplicate crate versions silently entering the graph.

1. Moves the workspace's `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
2. Adds `affinidi-messaging-core` to `[patch.crates-io]` — which turns out to be
   the actual cause of the long-standing `vta-sdk` CI failure.

## 1. didwebvh-rs 0.6

After [#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629), `main`
resolved **two** copies of `affinidi-did-common` — 0.3.9 pulled in by
`didwebvh-rs 0.5.7`, and 0.4.0 for everything else. It compiled only by luck of
interface shape: `WebvhResolver` builds its own `Document` via
`serde_json::from_value`, so no types crossed the boundary. The moment any
`didwebvh-rs` API returned a `Document`, that becomes a hard `E0308`.

`didwebvh-rs 0.6.0` requires `affinidi-did-common "0.4"`, collapsing it:

```
$ cargo tree -p affinidi-did-resolver-cache-sdk --all-features \
    | grep -oE 'affinidi-did-common v[0-9.]*|didwebvh-rs v[0-9.]*' | sort -u
affinidi-did-common v0.4.0
didwebvh-rs v0.6.0
```

0.6.0 is a breaking release (`DIDWebVHError`, `URLType` and
`LogEntryValidationStatus` became `#[non_exhaustive]`), but **no code change was
needed**: the only use here is a `#[from] DIDWebVHError` conversion in
`did-scid/src/errors.rs:14`, not an exhaustive `match`.

## 2. The `vta-sdk` failure was never a vta-sdk bug

`cargo check --workspace` has been failing on `DidCommTransport: MessageTransport
is not satisfied` for some time, and was being written off as an external
problem. It isn't. The error points at two files:

```
registry/affinidi-messaging-core-0.1.5/src/transport.rs:114
crates/messaging/affinidi-messaging-core/src/transport.rs:114
```

`affinidi-messaging-core` is a workspace member that was **missing from
`[patch.crates-io]`**. Every internal reference uses a `path` dependency, so the
gap was invisible locally — until external `vta-sdk` pulled
`affinidi-messaging-core 0.1.5` from the registry. `MessageTransport` then
existed twice, and the local `DidCommTransport` could not satisfy the registry
copy's bound.

One line fixes it. **`cargo check --workspace --all-targets` is now clean.**

This is the same class of bug as the `did-example` entry added in #629: *a
workspace member that an external consumer also reaches by version must be in
`[patch.crates-io]`, or the registry copy silently joins the graph.* That is now
two instances, which suggests a lint rather than vigilance — filed as a
follow-up thought below.

## Remaining duplicates (documented, not fixed here)

Both are contained inside the external `vta-sdk` subtree and are harmless today
because no types cross the boundary:

- `vta-sdk` pulls `didwebvh-rs 0.5.7`, hence `affinidi-did-common 0.3.9`.
- `vta-sdk` itself resolves at **two** versions — 0.18.21 via `mediator-setup`,
  0.19.11 via `mediator`.

Collapsing these needs `vta-sdk` to move to `didwebvh-rs "0.6"`, which is a
change in another repo.

## Verification

- `cargo check --workspace --all-targets` — clean, no errors.
- `did-scid`, `affinidi-did-resolver-cache-sdk`, `affinidi-did-resolver-cache-server`
  all compile against **published** `didwebvh-rs 0.6.0` (no path patches) and
  their tests pass (62 in cache-sdk).
- `cargo fmt --check` clean; `scripts/check-version-bumps.sh` passes for all four
  bumped crates.

### Pre-existing failure, still present

`affinidi-did-resolver-cache-server` `integration_test::test_cache_server` fails
with `NetworkTimeout` — it starts a server and resolves DIDs over the real
network. Reproduces identically on unmodified `main`; unrelated to this PR.

## Follow-up worth considering

A CI guard that cross-references `[workspace] members` against
`[patch.crates-io]` and flags any member reachable by version but not patched
would have caught both `did-example` and `affinidi-messaging-core` at PR time,
instead of as mysterious duplicate-type errors months apart.