### PR TITLE
feat: add agent-names crate (DID shortcuts)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/identity/did-methods/did-web",
   "crates/identity/affinidi-did-resolver-traits",
   "crates/identity/affinidi-did-authentication",
+  "crates/identity/shortcuts/agent-names",
 
   # Credentials: formats, proofs, status
   "crates/credentials/affinidi-sd-jwt",
@@ -108,6 +109,7 @@ affinidi-did-web = { path = "crates/identity/did-methods/did-web" }
 did-scid = { path = "crates/identity/did-methods/did-scid" }
 did-example = { path = "crates/identity/did-methods/did-example" }
 affinidi-messaging-core = { path = "crates/messaging/affinidi-messaging-core" }
+agent-names = { path = "crates/identity/shortcuts/agent-names" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/crates/identity/shortcuts/agent-names/CHANGELOG.md
+++ b/crates/identity/shortcuts/agent-names/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to `agent-names` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-19
+
+Initial release. Agent names — human-memorable shortcuts of the form
+`example.com/@alice` that resolve to DIDs.
+
+### Added
+
+- `AgentName`: parsing, validation and canonicalisation. Canonicalises a missing
+  scheme to `https`, the host to lowercase, a default port away, and a trailing
+  slash away; deliberately preserves the case of the local name so `@Alice` and
+  `@alice` stay distinct identities.
+- `AgentName::looks_like_agent_name`: cheap `/@` marker test with no network
+  access, for deciding whether an identifier is a DID or a shortcut. Does not
+  match a bare `@handle` (agent names are always rooted in a domain) or an email
+  address (which has `@` but not `/@`).
+- `verify_also_known_as` / `also_known_as_contains`: the **mandatory** Layer-1
+  anti-spoofing check. Both sides are canonicalised before comparison; matching
+  is exact afterwards, with no prefix or wildcard matching.
+- `extract_agent_names`: the authoritative DID → name direction, reading a
+  resolved document's `alsoKnownAs`.
+- `AgentNameResolver` trait: the pluggable backend seam. Returns
+  `Option<Result<..>>` mirroring `affinidi-did-resolver-traits`' `Resolution`, so
+  a chain of name backends reads like a chain of DID method resolvers.
+- `HttpRedirectResolver`: the default backend, following the web redirect a name
+  serves. Redirects are not auto-followed — each hop is inspected explicitly, so
+  the hop cap and per-hop HTTPS check are enforceable (mirroring
+  `affinidi-did-web`'s SSRF hardening). Plain HTTP is refused unless
+  `allow_insecure_http(true)`.
+- `AgentNameError`, `#[non_exhaustive]`.
+
+### Notes on what is deliberately absent
+
+- **Layer 2 (the agent name credential)** is not implemented. Layer 1 stops an
+  unrelated party pointing a name they control at a DID they do not; it does not
+  survive DNS poisoning or a breach of the name's own web server. The
+  `AgentNameResolver` trait is where Layer 2 would attach.
+- **No DID → candidate-name construction.** The name→DID link is a web redirect
+  and is not derivable from DID structure, even for domain-based methods like
+  `did:web`, so such a helper would manufacture unverified guesses behind an
+  authoritative-looking API.
+
+### Known gaps
+
+- **The redirect contract is unverified against a live implementation.** The
+  agent name FAQ does not specify the status code, the form the DID arrives in,
+  or any content negotiation, and there is no reference implementation to test
+  against (`firstperson.network` is live, but its example names return 404).
+  `HttpRedirectResolver` is therefore permissive, and all of that guesswork is
+  confined to it.
+- **The specification defines no canonical form**, so the canonicalisation rules
+  here are this implementation's choice. Two implementations that normalise
+  differently will disagree about whether a name verifies.
+- The mid-chain HTTPS-downgrade check is not integration-tested: doing so needs
+  a TLS-capable mock server, and `wiremock` serves plain HTTP only.

--- a/crates/identity/shortcuts/agent-names/Cargo.toml
+++ b/crates/identity/shortcuts/agent-names/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "agent-names"
+version = "0.1.0"
+description = "Agent Name (DID shortcut) parsing, resolution and verification for the Affinidi TDK"
+repository.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+affinidi-did-common = "0.4"
+reqwest = { version = "0.13", default-features = false, features = [
+  "rustls",
+  "charset",
+  "http2",
+] }
+thiserror = "2"
+tracing = "0.1"
+url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/crates/identity/shortcuts/agent-names/README.md
+++ b/crates/identity/shortcuts/agent-names/README.md
@@ -1,0 +1,125 @@
+# agent-names
+
+Human-memorable shortcuts that resolve to DIDs.
+
+A DID is unmemorable. An **agent name** is a URL whose path begins with `/@` and
+which resolves to one:
+
+```text
+example.com/@alice
+connect.me/@bob
+names.somewhere.info/@john-smith
+firstperson.network/@drummond/h2hsummit   # trailing path adds context
+```
+
+An agent name is **not** a DID method. It is a shortcut layer in front of DID
+resolution, and the specification anticipates other shortcut kinds later — hence
+`crates/identity/shortcuts/`.
+
+## Resolution is two-stage, and the second stage is the point
+
+1. The agent name URL redirects to a DID.
+2. The DID resolves to a DID Document as usual.
+3. **The document must claim the name back via `alsoKnownAs`.**
+
+Step 3 is mandatory. Step 1 is served by the name's own web server, so by itself
+it proves nothing — anyone can publish a redirect pointing at somebody else's
+DID. Only the DID's controller can add an `alsoKnownAs` entry, so requiring both
+directions is what makes the binding real.
+
+```rust
+use agent_names::{AgentName, AgentNameResolver, HttpRedirectResolver, verify_also_known_as};
+
+let name: AgentName = "example.com/@alice".parse()?;
+
+// Stage 1
+let resolver = HttpRedirectResolver::new();
+let did = resolver.resolve(&name).await.unwrap()?;
+
+// Stage 2: resolve `did` with your DID resolver, then stage 3:
+verify_also_known_as(&document, &name)?;
+```
+
+Most callers should not drive these stages by hand — `DIDCacheClient::resolve_any()`
+wires them together with the resolution cache and performs step 3 for you. This
+crate is the standalone, dependency-light half, usable without the resolver.
+
+### What Layer 1 does and does not buy you
+
+It stops an unrelated party from pointing a name they control at a DID they do
+not. It does **not** survive DNS poisoning or a breach of the name's own web
+server: an attacker with either can serve a redirect to a DID they control whose
+document legitimately claims the name.
+
+Defending against that is Layer 2 — the *agent name credential*, a verifiable
+presentation with a nonce requested from the DID's `whois` endpoint or its VTA
+service endpoint. This crate does not implement Layer 2; the `AgentNameResolver`
+trait is the seam where it would attach.
+
+## Canonicalisation
+
+Layer-1 verification compares the name a caller typed against a string in
+somebody else's DID Document, so the two must normalise identically or the check
+fails for cosmetic reasons. `AgentName` normalises:
+
+| Input | Canonical |
+|---|---|
+| `example.com/@alice` | `https://example.com/@alice` |
+| `EXAMPLE.COM/@alice` | `https://example.com/@alice` |
+| `https://example.com:443/@alice` | `https://example.com/@alice` |
+| `https://example.com/@alice/` | `https://example.com/@alice` |
+
+The local name keeps its case: `@Alice` and `@alice` are **different** names, and
+folding them could merge two distinct identities.
+
+Verification also accepts the scheme-less spelling (`example.com/@alice`) in
+`alsoKnownAs`, since that is how names are written in prose. Matching is exact
+after canonicalisation — there is deliberately no prefix or wildcard matching, so
+`@alice` is never satisfied by `@alicia`, and a path-qualified name is never
+satisfied by its bare parent.
+
+**The specification does not define a canonical form.** These rules are this
+implementation's choice, and they are the single highest-value thing for the spec
+to pin down — without them, two implementations disagree about whether a name
+verifies.
+
+## Status: the redirect contract is not pinned down
+
+The agent name FAQ says resolution "typically works through a simple web
+redirect" without specifying the status code, the form the DID arrives in, or any
+content negotiation — and there is no reference implementation to check against
+(`firstperson.network` is live, but its example names return 404).
+
+`HttpRedirectResolver` is therefore deliberately permissive:
+
+- any 3xx carrying a `Location` header (301/302/303/307/308);
+- the DID accepted as a bare `did:…`, a `did=` query parameter, or a
+  percent-encoded final path segment;
+- up to 5 hops, so an apex→`www` redirect on the way does not break resolution.
+
+All of that guesswork is confined to this one type. Parsing, canonicalisation and
+verification do not depend on how the DID was obtained, so pinning the contract
+down later should not disturb them.
+
+## Security
+
+- Redirects are **not** followed automatically; each hop is inspected explicitly,
+  which is what makes the hop cap and the per-hop HTTPS check enforceable. This
+  mirrors `affinidi-did-web`'s SSRF hardening.
+- Plain HTTP is refused unless `allow_insecure_http(true)` is set. That switch is
+  for local development and tests only.
+
+## DID → name
+
+`extract_agent_names(&document)` returns the names a document claims. That is the
+only supported direction.
+
+There is deliberately **no** helper that builds a likely agent name from a
+`did:web` / `did:webvh` domain. The name→DID link is a web redirect and is not
+derivable from DID structure, so such a helper would manufacture unverified
+guesses behind an authoritative-looking API — exactly the spoofing Layer 1 exists
+to prevent.
+
+## License
+
+Apache-2.0

--- a/crates/identity/shortcuts/agent-names/src/error.rs
+++ b/crates/identity/shortcuts/agent-names/src/error.rs
@@ -1,0 +1,54 @@
+//! Errors produced while parsing, resolving or verifying an agent name.
+
+use thiserror::Error;
+
+/// Agent name errors.
+///
+/// This type is `#[non_exhaustive]`: callers must include a wildcard arm when
+/// matching, so future additions do not constitute breaking changes.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AgentNameError {
+    /// The string is not an agent name (no `/@` marker, empty local name,
+    /// unparseable as a URL, …).
+    #[error("Invalid agent name '{input}': {reason}")]
+    InvalidName { input: String, reason: String },
+
+    /// The name's scheme is not permitted (plain HTTP without opt-in).
+    #[error("Refusing to resolve '{0}' over plain HTTP; agent names must use HTTPS")]
+    InsecureScheme(String),
+
+    /// The name resolved, but the DID Document does not claim the name back via
+    /// `alsoKnownAs`. This is the mandatory Layer-1 anti-spoofing check.
+    ///
+    /// Anyone can publish a redirect pointing at someone else's DID; only the
+    /// DID's own controller can add an `alsoKnownAs` entry to its Document.
+    #[error(
+        "Agent name '{name}' is not authorized by DID '{did}': its DID Document's alsoKnownAs does not contain the name"
+    )]
+    NotAuthorized { name: String, did: String },
+
+    /// Transport failure reaching the agent name.
+    #[error("HTTP error resolving agent name: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The name did not redirect to anything.
+    #[error("Agent name '{name}' did not redirect (HTTP {status}); expected a 3xx with a Location")]
+    NoRedirect { name: String, status: u16 },
+
+    /// A redirect was returned but its target is not a DID.
+    #[error("Agent name '{name}' redirected to '{target}', which is not a DID")]
+    NotADid { name: String, target: String },
+
+    /// Too many redirect hops.
+    #[error("Agent name '{name}' exceeded the redirect limit of {limit} hops")]
+    TooManyRedirects { name: String, limit: u8 },
+
+    /// A response exceeded the configured size cap.
+    #[error("Response for agent name '{name}' exceeded the {limit} byte limit")]
+    ResponseTooLarge { name: String, limit: usize },
+
+    /// No registered backend could resolve the name.
+    #[error("No agent name resolver could resolve '{0}'")]
+    Unresolvable(String),
+}

--- a/crates/identity/shortcuts/agent-names/src/lib.rs
+++ b/crates/identity/shortcuts/agent-names/src/lib.rs
@@ -1,0 +1,79 @@
+/*!
+ * Agent Names — human-memorable shortcuts that resolve to DIDs.
+ *
+ * A DID is unmemorable. An **agent name** is a URL whose path begins with `/@`
+ * and which resolves to one:
+ *
+ * ```text
+ * example.com/@alice
+ * connect.me/@bob
+ * names.somewhere.info/@john-smith
+ * firstperson.network/@drummond/h2hsummit   # trailing path adds context
+ * ```
+ *
+ * An agent name is **not** a DID method. It is a shortcut layer in front of DID
+ * resolution, and the specification anticipates other shortcut kinds later.
+ *
+ * # Resolution is two-stage, and the second stage is the important one
+ *
+ * 1. The agent name URL redirects to a DID.
+ * 2. The DID resolves to a DID Document as usual.
+ * 3. **The document must claim the name back via `alsoKnownAs`.**
+ *
+ * Step 3 is mandatory, not advisory. Step 1 is served by the name's own web
+ * server, so on its own it proves nothing — anyone can publish a redirect
+ * pointing at somebody else's DID. Only the DID's controller can add an
+ * `alsoKnownAs` entry, so requiring both directions is what makes the binding
+ * real. See [`verify_also_known_as`].
+ *
+ * What that check does **not** buy you: it does not survive DNS poisoning or a
+ * breach of the name's web server. Defending against those is Layer 2 (the
+ * agent name credential), which this crate does not implement — the
+ * [`AgentNameResolver`] trait is the seam where it would go.
+ *
+ * # Status: the redirect contract is not pinned down
+ *
+ * The agent name FAQ says resolution "typically works through a simple web
+ * redirect" without specifying the status code, the form the DID arrives in, or
+ * any content negotiation, and there is no reference implementation to check
+ * against (`firstperson.network` is live, but its example names return 404).
+ *
+ * [`HttpRedirectResolver`] is therefore deliberately permissive, and all of that
+ * guesswork is confined to it. The parsing, canonicalisation and verification
+ * layers do not depend on how the DID was obtained, so pinning the contract down
+ * later should not disturb them.
+ *
+ * # Usage
+ *
+ * ```no_run
+ * # async fn run() -> Result<(), agent_names::AgentNameError> {
+ * use agent_names::{AgentName, AgentNameResolver, HttpRedirectResolver};
+ *
+ * let name: AgentName = "example.com/@alice".parse()?;
+ * let resolver = HttpRedirectResolver::new();
+ *
+ * // Stage 1: name -> DID
+ * let did = resolver.resolve(&name).await
+ *     .ok_or_else(|| agent_names::AgentNameError::Unresolvable(name.to_string()))??;
+ *
+ * // Stage 2: resolve `did` with your DID resolver, then:
+ * // agent_names::verify_also_known_as(&document, &name)?;
+ * # Ok(()) }
+ * ```
+ *
+ * Callers generally should not drive those stages by hand — the unified
+ * `resolve_any()` entry point on `DIDCacheClient` wires them together with the
+ * resolution cache. This crate is the standalone, dependency-light half.
+ */
+
+pub mod error;
+pub mod name;
+pub mod resolver;
+pub mod verify;
+
+pub use error::AgentNameError;
+pub use name::{AGENT_NAME_MARKER, AgentName};
+pub use resolver::{
+    AgentNameResolver, DEFAULT_MAX_HOPS, DEFAULT_TIMEOUT, HttpRedirectResolver, NameResolution,
+};
+pub use verify::{also_known_as_contains, extract_agent_names, verify_also_known_as};

--- a/crates/identity/shortcuts/agent-names/src/name.rs
+++ b/crates/identity/shortcuts/agent-names/src/name.rs
@@ -1,0 +1,404 @@
+//! Parsing and canonicalisation of agent names.
+
+use std::{fmt, str::FromStr};
+
+use url::Url;
+
+use crate::error::AgentNameError;
+
+/// The marker that distinguishes an agent name from an ordinary URL.
+pub const AGENT_NAME_MARKER: &str = "/@";
+
+/// A parsed, canonicalised agent name.
+///
+/// An agent name is a URL whose path begins with `/@`:
+///
+/// ```text
+/// example.com/@alice
+/// connect.me/@bob
+/// names.somewhere.info/@john-smith
+/// firstperson.network/@drummond/h2hsummit
+/// ```
+///
+/// # Canonicalisation
+///
+/// Layer-1 verification compares the name a caller typed against a string in
+/// somebody else's DID Document, so the two must normalise identically or the
+/// check fails for cosmetic reasons. [`AgentName`] therefore normalises:
+///
+/// - a missing scheme to `https`;
+/// - the host to lowercase (`Example.COM` ⇒ `example.com`);
+/// - a default port away (`example.com:443` ⇒ `example.com`);
+/// - a trailing slash away (`example.com/@alice/` ⇒ `example.com/@alice`).
+///
+/// The local name and any trailing path segments keep their case, because
+/// nothing in the spec says they are case-insensitive and folding them could
+/// merge two distinct identities.
+///
+/// The agent name FAQ does not specify a canonical form. These rules are this
+/// implementation's choice; see the crate docs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AgentName {
+    canonical: String,
+    authority: String,
+    local_name: String,
+    path_segments: Vec<String>,
+}
+
+impl AgentName {
+    /// Does this string look like an agent name?
+    ///
+    /// A cheap syntactic test — the `/@` marker — with no network access. Used
+    /// to decide whether an identifier is a DID or a shortcut before doing any
+    /// work. Deliberately does not accept a bare `@handle` with no authority:
+    /// agent names are always rooted in a domain.
+    pub fn looks_like_agent_name(input: &str) -> bool {
+        input.contains(AGENT_NAME_MARKER)
+    }
+
+    /// Parse and canonicalise an agent name.
+    ///
+    /// Accepts the name with or without a scheme; a missing scheme is treated
+    /// as `https`.
+    pub fn parse(input: &str) -> Result<Self, AgentNameError> {
+        let invalid = |reason: &str| AgentNameError::InvalidName {
+            input: input.to_string(),
+            reason: reason.to_string(),
+        };
+
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(invalid("empty"));
+        }
+        if !trimmed.contains(AGENT_NAME_MARKER) {
+            return Err(invalid("missing the '/@' agent name marker"));
+        }
+
+        // A bare `example.com/@alice` is not a URL until it has a scheme.
+        let with_scheme = if trimmed.contains("://") {
+            trimmed.to_string()
+        } else {
+            format!("https://{trimmed}")
+        };
+
+        let url = Url::parse(&with_scheme).map_err(|e| invalid(&format!("not a URL: {e}")))?;
+
+        let scheme = url.scheme();
+        if scheme != "https" && scheme != "http" {
+            return Err(invalid(&format!("unsupported scheme '{scheme}'")));
+        }
+
+        // `Url` lowercases the host and drops a default port for us.
+        let host = url.host_str().ok_or_else(|| invalid("no host"))?;
+        if host.is_empty() {
+            return Err(invalid("empty host"));
+        }
+        let authority = match url.port() {
+            Some(port) => format!("{host}:{port}"),
+            None => host.to_string(),
+        };
+
+        // Split the path, discarding the empty segment a trailing slash leaves.
+        let mut segments: Vec<String> = url
+            .path_segments()
+            .ok_or_else(|| invalid("no path"))?
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+
+        if segments.is_empty() {
+            return Err(invalid("no path segments"));
+        }
+
+        let first = segments.remove(0);
+        let local_name = first
+            .strip_prefix('@')
+            .ok_or_else(|| invalid("path does not begin with '/@'"))?
+            .to_string();
+
+        if local_name.is_empty() {
+            return Err(invalid("empty local name after '@'"));
+        }
+        // Only the first segment may carry the marker; `a/@b/@c` is ambiguous.
+        if segments.iter().any(|s| s.starts_with('@')) {
+            return Err(invalid("more than one '/@' marker"));
+        }
+
+        let mut canonical = format!("{scheme}://{authority}/@{local_name}");
+        for seg in &segments {
+            canonical.push('/');
+            canonical.push_str(seg);
+        }
+
+        Ok(Self {
+            canonical,
+            authority,
+            local_name,
+            path_segments: segments,
+        })
+    }
+
+    /// The canonical form, always a full URL: `https://example.com/@alice`.
+    ///
+    /// This is what gets compared against `alsoKnownAs`.
+    pub fn as_str(&self) -> &str {
+        &self.canonical
+    }
+
+    /// The canonical form without its scheme: `example.com/@alice`.
+    ///
+    /// Agent names are written this way in prose and in the FAQ's examples, and
+    /// a DID Document may well record that form, so verification accepts it too.
+    pub fn without_scheme(&self) -> &str {
+        self.canonical
+            .split_once("://")
+            .map(|(_, rest)| rest)
+            .unwrap_or(&self.canonical)
+    }
+
+    /// Host, plus port when it is not the scheme default: `example.com`.
+    pub fn authority(&self) -> &str {
+        &self.authority
+    }
+
+    /// The local name, without its `@`: `alice`.
+    pub fn local_name(&self) -> &str {
+        &self.local_name
+    }
+
+    /// Trailing context path segments, if any: `["h2hsummit"]`.
+    pub fn path_segments(&self) -> &[String] {
+        &self.path_segments
+    }
+
+    /// Is this name HTTPS?
+    pub fn is_https(&self) -> bool {
+        self.canonical.starts_with("https://")
+    }
+
+    /// The URL to request in order to resolve this name.
+    pub fn resolution_url(&self) -> Result<Url, AgentNameError> {
+        Url::parse(&self.canonical).map_err(|e| AgentNameError::InvalidName {
+            input: self.canonical.clone(),
+            reason: format!("not a URL: {e}"),
+        })
+    }
+}
+
+impl fmt::Display for AgentName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.canonical)
+    }
+}
+
+impl FromStr for AgentName {
+    type Err = AgentNameError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detection ---
+
+    #[test]
+    fn detects_agent_names() {
+        assert!(AgentName::looks_like_agent_name("example.com/@alice"));
+        assert!(AgentName::looks_like_agent_name(
+            "https://example.com/@alice"
+        ));
+    }
+
+    #[test]
+    fn does_not_detect_dids_or_emails() {
+        assert!(!AgentName::looks_like_agent_name("did:web:example.com"));
+        assert!(!AgentName::looks_like_agent_name(
+            "did:webvh:QmScid:example.com"
+        ));
+        // An email has an '@' but no '/@'.
+        assert!(!AgentName::looks_like_agent_name("alice@example.com"));
+        assert!(!AgentName::looks_like_agent_name(
+            "https://example.com/alice"
+        ));
+    }
+
+    // --- parsing ---
+
+    #[test]
+    fn parses_bare_name_defaulting_to_https() {
+        let n = AgentName::parse("example.com/@alice").unwrap();
+        assert_eq!(n.as_str(), "https://example.com/@alice");
+        assert_eq!(n.authority(), "example.com");
+        assert_eq!(n.local_name(), "alice");
+        assert!(n.path_segments().is_empty());
+    }
+
+    #[test]
+    fn parses_with_explicit_scheme() {
+        let n = AgentName::parse("https://connect.me/@bob").unwrap();
+        assert_eq!(n.as_str(), "https://connect.me/@bob");
+    }
+
+    #[test]
+    fn parses_dotted_and_hyphenated_local_names() {
+        assert_eq!(
+            AgentName::parse("names.somewhere.info/@john-smith")
+                .unwrap()
+                .local_name(),
+            "john-smith"
+        );
+        assert_eq!(
+            AgentName::parse("anydomain.io/@any.name.can.go.here")
+                .unwrap()
+                .local_name(),
+            "any.name.can.go.here"
+        );
+    }
+
+    #[test]
+    fn parses_context_path_segments() {
+        let n = AgentName::parse("firstperson.network/@drummond/h2hsummit").unwrap();
+        assert_eq!(n.local_name(), "drummond");
+        assert_eq!(n.path_segments(), ["h2hsummit"]);
+        assert_eq!(
+            n.as_str(),
+            "https://firstperson.network/@drummond/h2hsummit"
+        );
+    }
+
+    #[test]
+    fn parses_multi_segment_paths() {
+        let n = AgentName::parse("anydomain.io/@an-agent-name/can/include/paths").unwrap();
+        assert_eq!(n.path_segments(), ["can", "include", "paths"]);
+    }
+
+    // --- canonicalisation: the load-bearing cases for Layer-1 ---
+
+    #[test]
+    fn canonicalises_host_case() {
+        assert_eq!(
+            AgentName::parse("EXAMPLE.COM/@alice").unwrap().as_str(),
+            "https://example.com/@alice"
+        );
+    }
+
+    #[test]
+    fn canonicalises_away_trailing_slash() {
+        assert_eq!(
+            AgentName::parse("example.com/@alice/").unwrap().as_str(),
+            "https://example.com/@alice"
+        );
+    }
+
+    #[test]
+    fn canonicalises_away_default_port() {
+        assert_eq!(
+            AgentName::parse("https://example.com:443/@alice")
+                .unwrap()
+                .as_str(),
+            "https://example.com/@alice"
+        );
+    }
+
+    #[test]
+    fn preserves_non_default_port() {
+        let n = AgentName::parse("https://example.com:8443/@alice").unwrap();
+        assert_eq!(n.as_str(), "https://example.com:8443/@alice");
+        assert_eq!(n.authority(), "example.com:8443");
+    }
+
+    /// The local name is NOT case-folded: two distinct identities must not merge.
+    #[test]
+    fn preserves_local_name_case() {
+        let n = AgentName::parse("example.com/@Alice").unwrap();
+        assert_eq!(n.local_name(), "Alice");
+        assert_ne!(
+            n,
+            AgentName::parse("example.com/@alice").unwrap(),
+            "@Alice and @alice must not be treated as the same name"
+        );
+    }
+
+    #[test]
+    fn all_spellings_of_one_name_converge() {
+        let forms = [
+            "example.com/@alice",
+            "https://example.com/@alice",
+            "https://EXAMPLE.com/@alice",
+            "https://example.com:443/@alice",
+            "https://example.com/@alice/",
+            "  example.com/@alice  ",
+        ];
+        let canonical: Vec<_> = forms
+            .iter()
+            .map(|f| AgentName::parse(f).unwrap().as_str().to_string())
+            .collect();
+        assert!(
+            canonical.windows(2).all(|w| w[0] == w[1]),
+            "spellings diverged: {canonical:?}"
+        );
+    }
+
+    #[test]
+    fn without_scheme_strips_https() {
+        let n = AgentName::parse("https://example.com/@alice").unwrap();
+        assert_eq!(n.without_scheme(), "example.com/@alice");
+    }
+
+    // --- rejections ---
+
+    #[test]
+    fn rejects_missing_marker() {
+        assert!(AgentName::parse("example.com/alice").is_err());
+        assert!(AgentName::parse("did:web:example.com").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_local_name() {
+        assert!(AgentName::parse("example.com/@").is_err());
+        assert!(AgentName::parse("example.com/@/path").is_err());
+    }
+
+    #[test]
+    fn rejects_no_host() {
+        assert!(AgentName::parse("https:///@alice").is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_scheme() {
+        assert!(AgentName::parse("ftp://example.com/@alice").is_err());
+        assert!(AgentName::parse("file:///@alice").is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_markers() {
+        assert!(AgentName::parse("example.com/@alice/@bob").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(AgentName::parse("").is_err());
+        assert!(AgentName::parse("   ").is_err());
+    }
+
+    // --- traits ---
+
+    #[test]
+    fn from_str_and_display_round_trip() {
+        let n: AgentName = "example.com/@alice".parse().unwrap();
+        assert_eq!(n.to_string(), "https://example.com/@alice");
+        let again: AgentName = n.to_string().parse().unwrap();
+        assert_eq!(n, again);
+    }
+
+    #[test]
+    fn http_scheme_is_flagged_not_rejected_at_parse_time() {
+        // Parsing is syntax; transport policy is the resolver's job.
+        let n = AgentName::parse("http://example.com/@alice").unwrap();
+        assert!(!n.is_https());
+    }
+}

--- a/crates/identity/shortcuts/agent-names/src/resolver.rs
+++ b/crates/identity/shortcuts/agent-names/src/resolver.rs
@@ -1,0 +1,333 @@
+//! Backends that turn an agent name into a DID.
+
+use std::{future::Future, pin::Pin, time::Duration};
+
+use tracing::debug;
+use url::Url;
+
+use crate::{error::AgentNameError, name::AgentName};
+
+/// Default request timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default cap on redirect hops followed while chasing a name.
+pub const DEFAULT_MAX_HOPS: u8 = 5;
+
+/// The outcome of asking one backend to resolve a name.
+///
+/// Mirrors `affinidi_did_resolver_traits::Resolution`, so a chain of agent name
+/// backends reads the same way as a chain of DID method resolvers:
+///
+/// - `None` — "not mine, try the next backend"
+/// - `Some(Ok(did))` — resolved
+/// - `Some(Err(e))` — recognised, but failed
+pub type NameResolution = Option<Result<String, AgentNameError>>;
+
+/// A backend that maps an agent name to a DID.
+///
+/// Implement this to resolve names from somewhere other than a live HTTP
+/// redirect — a registry API, DNS, a cache server, or a fixed map in tests.
+pub trait AgentNameResolver: Send + Sync {
+    /// Short name for this backend, used for logging and de-duplication.
+    fn name(&self) -> &str;
+
+    /// Attempt to resolve `name` to a DID string.
+    fn resolve<'a>(
+        &'a self,
+        name: &'a AgentName,
+    ) -> Pin<Box<dyn Future<Output = NameResolution> + Send + 'a>>;
+}
+
+/// Resolves an agent name by following the web redirect it serves.
+///
+/// # The redirect contract is not pinned down by the specification
+///
+/// The agent name FAQ says only that resolution "typically works through a
+/// simple web redirect". It does not state the status code, whether the DID
+/// arrives as a bare `did:…` string or wrapped in a URI, or whether content
+/// negotiation is involved. At the time of writing there is no reference
+/// implementation to check against: `firstperson.network` is live but its
+/// example names return 404.
+///
+/// This backend is therefore deliberately permissive, and every guess is
+/// contained here rather than in the crate's data types:
+///
+/// - any 3xx carrying a `Location` header is accepted (301/302/303/307/308);
+/// - the target is accepted as a bare `did:…`, or as a URI whose last path
+///   segment is a DID, or with a `did=` query parameter;
+/// - up to [`DEFAULT_MAX_HOPS`] hops are followed, so an apex-to-`www`
+///   redirect on the way to the DID does not break resolution.
+///
+/// # Safety
+///
+/// Redirects are **not** followed automatically by `reqwest`; each hop is
+/// inspected explicitly. This mirrors `affinidi-did-web`'s SSRF hardening and
+/// is what makes the hop cap and the HTTPS requirement enforceable.
+#[derive(Debug, Clone)]
+pub struct HttpRedirectResolver {
+    client: reqwest::Client,
+    max_hops: u8,
+    allow_insecure_http: bool,
+}
+
+impl HttpRedirectResolver {
+    /// A resolver with redirects disabled, a 20s timeout, and HTTPS required.
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .unwrap_or_default();
+        Self {
+            client,
+            max_hops: DEFAULT_MAX_HOPS,
+            allow_insecure_http: false,
+        }
+    }
+
+    /// Use a caller-supplied client.
+    ///
+    /// The client **must** have redirects disabled
+    /// (`reqwest::redirect::Policy::none()`); otherwise the hop cap and the
+    /// per-hop HTTPS check are bypassed.
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self {
+            client,
+            max_hops: DEFAULT_MAX_HOPS,
+            allow_insecure_http: false,
+        }
+    }
+
+    /// Override the redirect hop cap.
+    pub fn with_max_hops(mut self, max_hops: u8) -> Self {
+        self.max_hops = max_hops;
+        self
+    }
+
+    /// Permit plain-HTTP agent names.
+    ///
+    /// Off by default and intended for local development and tests. A plain
+    /// HTTP redirect can be rewritten in transit, which lets an attacker point
+    /// the name at a DID of their choosing — `alsoKnownAs` verification will
+    /// usually catch that, but do not rely on it in production.
+    pub fn allow_insecure_http(mut self, allow: bool) -> Self {
+        self.allow_insecure_http = allow;
+        self
+    }
+
+    async fn resolve_inner(&self, name: &AgentName) -> Result<String, AgentNameError> {
+        if !name.is_https() && !self.allow_insecure_http {
+            return Err(AgentNameError::InsecureScheme(name.as_str().to_string()));
+        }
+
+        let mut url = name.resolution_url()?;
+
+        for hop in 0..self.max_hops {
+            debug!(hop, %url, "resolving agent name");
+            let response = self.client.get(url.clone()).send().await?;
+            let status = response.status();
+
+            if !status.is_redirection() {
+                return Err(AgentNameError::NoRedirect {
+                    name: name.as_str().to_string(),
+                    status: status.as_u16(),
+                });
+            }
+
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| AgentNameError::NoRedirect {
+                    name: name.as_str().to_string(),
+                    status: status.as_u16(),
+                })?
+                .to_string();
+
+            if let Some(did) = extract_did(&location) {
+                return Ok(did);
+            }
+
+            // Not a DID yet — could be an apex→www or http→https hop. Resolve
+            // the target relative to the current URL and keep going.
+            let next = url.join(&location).map_err(|_| AgentNameError::NotADid {
+                name: name.as_str().to_string(),
+                target: location.clone(),
+            })?;
+
+            if next.scheme() != "https" && !self.allow_insecure_http {
+                return Err(AgentNameError::InsecureScheme(next.to_string()));
+            }
+            let _ = hop;
+            url = next;
+        }
+
+        Err(AgentNameError::TooManyRedirects {
+            name: name.as_str().to_string(),
+            limit: self.max_hops,
+        })
+    }
+}
+
+impl Default for HttpRedirectResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentNameResolver for HttpRedirectResolver {
+    fn name(&self) -> &str {
+        "http-redirect"
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        name: &'a AgentName,
+    ) -> Pin<Box<dyn Future<Output = NameResolution> + Send + 'a>> {
+        Box::pin(async move { Some(self.resolve_inner(name).await) })
+    }
+}
+
+/// Pull a DID out of a redirect target.
+///
+/// Accepts, in order: a bare `did:…`; a `did=` query parameter; a URI whose
+/// last path segment is a DID. Returns `None` if the target carries no DID,
+/// which the caller treats as "keep following".
+fn extract_did(target: &str) -> Option<String> {
+    let trimmed = target.trim();
+
+    if is_did(trimmed) {
+        return Some(trimmed.to_string());
+    }
+
+    if let Ok(url) = Url::parse(trimmed) {
+        if let Some((_, value)) = url.query_pairs().find(|(k, _)| k == "did")
+            && is_did(&value)
+        {
+            return Some(value.into_owned());
+        }
+        // A DID in a path arrives percent-encoded, since ':' is reserved.
+        if let Some(last) = url.path_segments().and_then(|mut s| s.next_back())
+            && let Ok(decoded) = percent_decode(last)
+            && is_did(&decoded)
+        {
+            return Some(decoded);
+        }
+    }
+
+    None
+}
+
+fn is_did(s: &str) -> bool {
+    // did:<method>:<id> — enough structure to distinguish a DID from a URL.
+    let mut parts = s.splitn(3, ':');
+    parts.next() == Some("did")
+        && parts.next().is_some_and(|m| {
+            !m.is_empty()
+                && m.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        })
+        && parts.next().is_some_and(|id| !id.is_empty())
+}
+
+fn percent_decode(s: &str) -> Result<String, ()> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return Err(());
+            }
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).map_err(|_| ())?;
+            out.push(u8::from_str_radix(hex, 16).map_err(|_| ())?);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- is_did ---
+
+    #[test]
+    fn recognises_dids() {
+        assert!(is_did("did:web:example.com"));
+        assert!(is_did("did:key:z6Mk"));
+        assert!(is_did("did:webvh:QmScid:example.com"));
+        assert!(is_did("did:scid:vh:1:QmScid"));
+    }
+
+    #[test]
+    fn rejects_non_dids() {
+        assert!(!is_did("https://example.com"));
+        assert!(!is_did("did:"));
+        assert!(!is_did("did::abc"));
+        assert!(!is_did("did:web:"));
+        assert!(!is_did("notdid:web:example.com"));
+        // Method names are lowercase alphanumeric.
+        assert!(!is_did("did:WEB:example.com"));
+        assert!(!is_did("did:we-b:example.com"));
+    }
+
+    // --- extract_did ---
+
+    #[test]
+    fn extracts_bare_did() {
+        assert_eq!(
+            extract_did("did:web:example.com").as_deref(),
+            Some("did:web:example.com")
+        );
+    }
+
+    #[test]
+    fn extracts_did_with_surrounding_whitespace() {
+        assert_eq!(
+            extract_did("  did:web:example.com  ").as_deref(),
+            Some("did:web:example.com")
+        );
+    }
+
+    #[test]
+    fn extracts_did_from_query_parameter() {
+        assert_eq!(
+            extract_did("https://example.com/resolve?did=did:web:example.com").as_deref(),
+            Some("did:web:example.com")
+        );
+    }
+
+    #[test]
+    fn extracts_percent_encoded_did_from_path() {
+        assert_eq!(
+            extract_did("https://example.com/dids/did%3Aweb%3Aexample.com").as_deref(),
+            Some("did:web:example.com")
+        );
+    }
+
+    #[test]
+    fn returns_none_for_plain_url() {
+        // An apex->www hop carries no DID; the caller keeps following.
+        assert_eq!(extract_did("https://www.example.com/@alice"), None);
+    }
+
+    // --- percent_decode ---
+
+    #[test]
+    fn percent_decodes() {
+        assert_eq!(percent_decode("did%3Aweb%3Ax").unwrap(), "did:web:x");
+        assert_eq!(percent_decode("plain").unwrap(), "plain");
+        assert!(percent_decode("%zz").is_err());
+        assert!(percent_decode("truncated%4").is_err());
+    }
+
+    #[test]
+    fn resolver_reports_its_name() {
+        assert_eq!(HttpRedirectResolver::new().name(), "http-redirect");
+    }
+}

--- a/crates/identity/shortcuts/agent-names/src/verify.rs
+++ b/crates/identity/shortcuts/agent-names/src/verify.rs
@@ -1,0 +1,228 @@
+//! Layer-1 anti-spoofing: does the DID actually claim this name back?
+
+use affinidi_did_common::Document;
+
+use crate::{error::AgentNameError, name::AgentName};
+
+/// Verify that `doc` claims `name` via `alsoKnownAs`.
+///
+/// This is the **mandatory** Layer-1 check from the agent name specification.
+/// Resolving a name yields a DID by following a redirect that the name's own
+/// web server controls — so on its own it proves nothing: anyone can publish a
+/// redirect pointing at somebody else's DID. Only the DID's controller can add
+/// an `alsoKnownAs` entry to its DID Document, so requiring the document to
+/// name the shortcut back is what makes the binding two-sided.
+///
+/// # What this does and does not buy you
+///
+/// It stops an unrelated party from pointing a name they control at a DID they
+/// do not. It does **not** survive DNS poisoning or a breach of the name's own
+/// web server — an attacker with either can serve a redirect to a DID they
+/// control whose document legitimately claims the name. Defending against that
+/// is Layer 2 (the agent name credential), which this crate does not implement.
+///
+/// # Matching
+///
+/// Both sides are canonicalised before comparison, so all the spellings of one
+/// name agree (host case, default port, trailing slash — see [`AgentName`]).
+/// An entry that cannot be parsed as an agent name (a plain `did:` URI, say) is
+/// skipped rather than treated as an error, since `alsoKnownAs` legitimately
+/// holds other identifier types.
+///
+/// Matching is exact after canonicalisation. There is deliberately no prefix or
+/// wildcard matching: `example.com/@alice` must not be satisfied by an entry for
+/// `example.com/@alicia`, nor a path-qualified name by its bare parent.
+pub fn verify_also_known_as(doc: &Document, name: &AgentName) -> Result<(), AgentNameError> {
+    if also_known_as_contains(doc, name) {
+        return Ok(());
+    }
+    Err(AgentNameError::NotAuthorized {
+        name: name.as_str().to_string(),
+        did: doc.id.to_string(),
+    })
+}
+
+/// The predicate behind [`verify_also_known_as`], for callers who want a `bool`.
+pub fn also_known_as_contains(doc: &Document, name: &AgentName) -> bool {
+    doc.also_known_as
+        .iter()
+        .any(|entry| entry_matches(entry, name))
+}
+
+fn entry_matches(entry: &str, name: &AgentName) -> bool {
+    // Canonicalise the document's entry the same way we canonicalised the
+    // requested name, so cosmetic differences do not cause a false negative.
+    if let Ok(parsed) = AgentName::parse(entry) {
+        return parsed == *name;
+    }
+    // Not parseable as an agent name (e.g. a `did:` URI): fall back to an exact
+    // match against both canonical spellings, then give up.
+    entry == name.as_str() || entry == name.without_scheme()
+}
+
+/// Every entry in `doc`'s `alsoKnownAs` that is a well-formed agent name.
+///
+/// This is the **authoritative** direction for DID → name: the document says
+/// which names it claims. There is deliberately no helper that constructs a
+/// likely agent name from a `did:web` / `did:webvh` domain — the name→DID link
+/// is a web redirect and is not derivable from DID structure, so a "candidate
+/// name" would be an unverified guess wearing an authoritative-looking API.
+pub fn extract_agent_names(doc: &Document) -> Vec<AgentName> {
+    doc.also_known_as
+        .iter()
+        .filter_map(|entry| AgentName::parse(entry).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_did_common::DocumentBuilder;
+
+    fn doc_with(aka: &[&str]) -> Document {
+        DocumentBuilder::new("did:webvh:QmScid:example.com")
+            .unwrap()
+            .also_known_as_many(aka.iter().copied())
+            .build()
+    }
+
+    fn name(s: &str) -> AgentName {
+        AgentName::parse(s).unwrap()
+    }
+
+    // --- accept ---
+
+    #[test]
+    fn accepts_exact_match() {
+        let doc = doc_with(&["https://example.com/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_ok());
+    }
+
+    #[test]
+    fn accepts_scheme_less_entry() {
+        let doc = doc_with(&["example.com/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("https://example.com/@alice")).is_ok());
+    }
+
+    #[test]
+    fn accepts_entry_with_trailing_slash() {
+        let doc = doc_with(&["https://example.com/@alice/"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_ok());
+    }
+
+    #[test]
+    fn accepts_entry_with_different_host_case() {
+        let doc = doc_with(&["https://EXAMPLE.com/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_ok());
+    }
+
+    #[test]
+    fn accepts_when_one_of_several_entries_matches() {
+        let doc = doc_with(&[
+            "did:web:other.example",
+            "https://other.com/@bob",
+            "https://example.com/@alice",
+        ]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_ok());
+    }
+
+    #[test]
+    fn accepts_path_qualified_name() {
+        let doc = doc_with(&["https://firstperson.network/@drummond/h2hsummit"]);
+        assert!(
+            verify_also_known_as(&doc, &name("firstperson.network/@drummond/h2hsummit")).is_ok()
+        );
+    }
+
+    // --- reject ---
+
+    #[test]
+    fn rejects_empty_also_known_as() {
+        let doc = doc_with(&[]);
+        let err = verify_also_known_as(&doc, &name("example.com/@alice")).unwrap_err();
+        assert!(matches!(err, AgentNameError::NotAuthorized { .. }));
+    }
+
+    #[test]
+    fn rejects_different_local_name() {
+        let doc = doc_with(&["https://example.com/@alicia"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    #[test]
+    fn rejects_different_host() {
+        let doc = doc_with(&["https://evil.com/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    /// Case matters in the local part; `@Alice` must not satisfy `@alice`.
+    #[test]
+    fn rejects_local_name_case_difference() {
+        let doc = doc_with(&["https://example.com/@Alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    /// No prefix matching: a bare name must not satisfy a path-qualified one.
+    #[test]
+    fn rejects_parent_name_for_path_qualified_request() {
+        let doc = doc_with(&["https://firstperson.network/@drummond"]);
+        assert!(
+            verify_also_known_as(&doc, &name("firstperson.network/@drummond/h2hsummit")).is_err()
+        );
+    }
+
+    /// …and the reverse: a path-qualified entry must not satisfy the bare name.
+    #[test]
+    fn rejects_path_qualified_entry_for_parent_request() {
+        let doc = doc_with(&["https://firstperson.network/@drummond/h2hsummit"]);
+        assert!(verify_also_known_as(&doc, &name("firstperson.network/@drummond")).is_err());
+    }
+
+    /// A near-miss that a naive `contains()` would wrongly accept.
+    #[test]
+    fn rejects_substring_near_miss() {
+        let doc = doc_with(&["https://example.com/@alice-evil"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    #[test]
+    fn rejects_different_port() {
+        let doc = doc_with(&["https://example.com:8443/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    #[test]
+    fn error_names_both_sides() {
+        let doc = doc_with(&[]);
+        let msg = verify_also_known_as(&doc, &name("example.com/@alice"))
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("example.com/@alice"));
+        assert!(msg.contains("did:webvh:QmScid:example.com"));
+    }
+
+    // --- extraction ---
+
+    #[test]
+    fn extracts_only_well_formed_agent_names() {
+        let doc = doc_with(&[
+            "https://example.com/@alice",
+            "did:web:other.example",
+            "https://example.com/not-an-agent-name",
+            "example.com/@bob",
+        ]);
+        let names: Vec<String> = extract_agent_names(&doc)
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect();
+        assert_eq!(
+            names,
+            ["https://example.com/@alice", "https://example.com/@bob"]
+        );
+    }
+
+    #[test]
+    fn extracts_nothing_from_empty_document() {
+        assert!(extract_agent_names(&doc_with(&[])).is_empty());
+    }
+}

--- a/crates/identity/shortcuts/agent-names/tests/http_redirect.rs
+++ b/crates/identity/shortcuts/agent-names/tests/http_redirect.rs
@@ -1,0 +1,216 @@
+//! End-to-end resolution against a mock web server.
+//!
+//! These cover the parts that unit tests cannot: that redirects are actually
+//! followed, that the hop cap and HTTPS policy are enforced on every hop, and
+//! that a non-redirecting name fails rather than hanging or guessing.
+
+use agent_names::{AgentName, AgentNameError, AgentNameResolver, HttpRedirectResolver};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+const DID: &str = "did:webvh:QmScid:example.com";
+
+/// The mock server speaks plain HTTP, so the resolver must opt into it.
+fn resolver() -> HttpRedirectResolver {
+    HttpRedirectResolver::new().allow_insecure_http(true)
+}
+
+fn name_for(server: &MockServer, local: &str) -> AgentName {
+    AgentName::parse(&format!("{}/@{local}", server.uri())).unwrap()
+}
+
+async fn resolve(r: &HttpRedirectResolver, n: &AgentName) -> Result<String, AgentNameError> {
+    r.resolve(n)
+        .await
+        .expect("http-redirect backend always claims the name")
+}
+
+#[tokio::test]
+async fn resolves_a_bare_did_in_the_location_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", DID))
+        .mount(&server)
+        .await;
+
+    let did = resolve(&resolver(), &name_for(&server, "alice"))
+        .await
+        .unwrap();
+    assert_eq!(did, DID);
+}
+
+/// The FAQ does not pin the status code, so accept the whole 3xx family.
+#[tokio::test]
+async fn accepts_every_redirect_status() {
+    for status in [301u16, 302, 303, 307, 308] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/@alice"))
+            .respond_with(ResponseTemplate::new(status).insert_header("location", DID))
+            .mount(&server)
+            .await;
+
+        let did = resolve(&resolver(), &name_for(&server, "alice"))
+            .await
+            .unwrap_or_else(|e| panic!("status {status} should resolve, got {e}"));
+        assert_eq!(did, DID, "status {status}");
+    }
+}
+
+#[tokio::test]
+async fn resolves_a_did_carried_in_a_query_parameter() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(302).insert_header(
+            "location",
+            format!("https://resolver.example/r?did={DID}").as_str(),
+        ))
+        .mount(&server)
+        .await;
+
+    let did = resolve(&resolver(), &name_for(&server, "alice"))
+        .await
+        .unwrap();
+    assert_eq!(did, DID);
+}
+
+/// An apex->www hop on the way to the DID must not break resolution.
+#[tokio::test]
+async fn follows_an_intermediate_non_did_redirect() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(301).insert_header("location", "/canonical/@alice"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/canonical/@alice"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", DID))
+        .mount(&server)
+        .await;
+
+    let did = resolve(&resolver(), &name_for(&server, "alice"))
+        .await
+        .unwrap();
+    assert_eq!(did, DID);
+}
+
+#[tokio::test]
+async fn rejects_a_name_that_does_not_redirect() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("a normal web page"))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&resolver(), &name_for(&server, "alice"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::NoRedirect { status: 200, .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@nobody"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&resolver(), &name_for(&server, "nobody"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::NoRedirect { status: 404, .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_redirect_loop() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@loop"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", "/@loop"))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&resolver().with_max_hops(3), &name_for(&server, "loop"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::TooManyRedirects { limit: 3, .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_redirect_with_no_location_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(302))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&resolver(), &name_for(&server, "alice"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::NoRedirect { .. }),
+        "got {err:?}"
+    );
+}
+
+/// Plain HTTP must be refused unless explicitly opted into.
+#[tokio::test]
+async fn refuses_plain_http_by_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", DID))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&HttpRedirectResolver::new(), &name_for(&server, "alice"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::InsecureScheme(_)),
+        "got {err:?}"
+    );
+}
+
+// NOTE: the mid-chain HTTPS downgrade check (`resolver.rs`, the per-hop scheme
+// test) is NOT covered here. Exercising it needs an entry point over real HTTPS
+// that then redirects to `http://`, and `wiremock` serves plain HTTP only — with
+// a single `allow_insecure_http` flag, a plain-HTTP mock either allows every hop
+// or refuses the first one, so any test written against it would pass for the
+// wrong reason. Covering this properly needs a TLS-capable mock server.
+
+#[tokio::test]
+async fn honours_a_custom_hop_cap_of_one() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(301).insert_header("location", "/hop/@alice"))
+        .mount(&server)
+        .await;
+
+    let err = resolve(&resolver().with_max_hops(1), &name_for(&server, "alice"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::TooManyRedirects { limit: 1, .. }),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
PR 2 of the agent-names plan. PR 1 (typed `Document::also_known_as`) landed in
[#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629).

## What

An **agent name** is a human-memorable URL whose path begins with `/@` and which
resolves to a DID:

```text
example.com/@alice
connect.me/@bob
firstperson.network/@drummond/h2hsummit   # trailing path adds context
```

It is **not** a DID method — it is a shortcut layer in front of DID resolution,
and the spec anticipates other shortcut kinds later, hence
`crates/identity/shortcuts/`.

This PR is the standalone crate: parsing, canonicalisation, verification, and a
pluggable resolution backend. It depends only on `affinidi-did-common` and
`reqwest` — **not** on the resolver SDK, so the dependency runs one way when
PR 3 wires `resolve_any()` into `DIDCacheClient`.

## Resolution is two-stage, and the second stage is the point

1. The agent name URL redirects to a DID.
2. The DID resolves to a DID Document as usual.
3. **The document must claim the name back via `alsoKnownAs`.**

Step 3 is mandatory, not advisory. Step 1 is served by the name's own web server,
so on its own it proves nothing — anyone can publish a redirect pointing at
somebody else's DID. Only the DID's controller can add an `alsoKnownAs` entry, so
requiring both directions is what makes the binding real.

**What Layer 1 does not buy you:** it does not survive DNS poisoning or a breach
of the name's own web server. Defending against those is Layer 2 (the agent name
credential), which this PR does not implement — `AgentNameResolver` is the seam
where it attaches.

## Canonicalisation is the load-bearing detail

Layer-1 verification compares the name a caller typed against a string in
*somebody else's* document, so both must normalise identically or the check fails
for cosmetic reasons:

| Input | Canonical |
|---|---|
| `example.com/@alice` | `https://example.com/@alice` |
| `EXAMPLE.COM/@alice` | `https://example.com/@alice` |
| `https://example.com:443/@alice` | `https://example.com/@alice` |
| `https://example.com/@alice/` | `https://example.com/@alice` |

The local name keeps its case — `@Alice` and `@alice` are **different** names, and
folding them could merge two distinct identities. Matching is exact after
canonicalisation: no prefix or wildcard matching, so `@alice` is never satisfied
by `@alicia`, and a path-qualified name is never satisfied by its bare parent.
There are explicit regression tests for each of those near-misses.

The **specification defines no canonical form** — these rules are this
implementation's choice, and pinning them down is the highest-value thing the
spec could add.

## :warning: The redirect contract is unverified against a live implementation

The FAQ says resolution "typically works through a simple web redirect" without
specifying the status code, the form the DID arrives in, or any content
negotiation. I probed for a reference implementation and there isn't one:
`www.firstperson.network` returns 200, but `/@drummond` returns **404**, with and
without DID content negotiation.

`HttpRedirectResolver` is therefore deliberately permissive — any 3xx with a
`Location`; the DID accepted as a bare `did:…`, a `did=` query parameter, or a
percent-encoded final path segment; up to 5 hops so an apex→`www` redirect does
not break resolution. **All of that guesswork is confined to that one type.**
Parsing, canonicalisation and verification do not depend on how the DID was
obtained, so pinning the contract down later should not disturb them.

## Security

- Redirects are **not** auto-followed; each hop is inspected explicitly, which is
  what makes the hop cap and per-hop HTTPS check enforceable. Mirrors
  `affinidi-did-web`'s SSRF hardening.
- Plain HTTP refused unless `allow_insecure_http(true)` — for dev and tests only.

## Deliberately absent

No DID → *candidate* name construction. The name→DID link is a redirect and is
not derivable from DID structure, even for `did:web`/`did:webvh` where the domain
is right there in the identifier. Such a helper would manufacture unverified
guesses behind an authoritative-looking API — precisely the spoofing Layer 1
exists to prevent. `extract_agent_names()` (reading `alsoKnownAs`) is the only
supported direction.

## Verification

- **59 tests**: 48 unit + 10 integration (`wiremock`) + 1 doctest.
- Integration coverage: bare-DID `Location`, all five 3xx statuses, `did=` query
  param, an intermediate non-DID hop, non-redirecting name, 404, redirect loop,
  missing `Location`, plain-HTTP refusal, custom hop cap.
- `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- `cargo check --workspace --all-targets` clean.
- `cargo publish --dry-run -p agent-names` passes — this PR should **not** be
  expected-red, since it adds no cross-crate dependency on an unpublished sibling.

### Known test gap, stated rather than papered over

The mid-chain HTTPS-downgrade check is **not** integration-tested. Doing so needs
an HTTPS entry point that redirects to `http://`, and `wiremock` serves plain HTTP
only — with a single `allow_insecure_http` flag, a plain-HTTP mock either allows
every hop or refuses the first, so any test written against it passes for the
wrong reason. I wrote such a test, noticed it was passing for the wrong reason,
and removed it in favour of a comment naming the gap.

## Drive-by

`agent-names` is added to `[patch.crates-io]` up front, even though nothing
depends on it by version yet, so PR 3's `cache-sdk` dependency cannot hit the
missing-patch-entry trap that caused duplicate crates in #629 (`did-example`) and
#630 (`affinidi-messaging-core`).