### PR TITLE
feat: resolve_any() — unified DID and agent name resolution

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,49 @@
 
 ## 19th July 2026
 
+### 0.8.15 — agent names (`resolve_any`)
+
+New optional `agent-names` feature. Off by default; nothing changes for existing
+callers when it is not enabled.
+
+- `DIDCacheClient::resolve_any(&str)` accepts **either** a DID or an agent name
+  (`example.com/@alice`) and returns the same `ResolveResponse`. A DID is passed
+  straight through to `resolve()` with identical behaviour, so switching costs
+  existing callers nothing. `resolve()` keeps its strict DID-only contract.
+- `Identifier` enum + `FromStr`, classifying an input on the `/@` marker with no
+  network access.
+- A **second** cache, `agent name -> DID`, in front of the document cache.
+  Keeping the mapping separate is deliberate:
+  - a name and its DID **share one document entry**, so neither form pays twice
+    and the two can never hold divergent copies;
+  - the mapping always carries a TTL. `DIDExpiry` derives expiry from the
+    *resolved document's* `id`, not the cache key, so a name pointing at an
+    immutable method (`did:key`) would otherwise inherit "never expires" and pin
+    a web redirect that can change at any moment. There is a regression test for
+    exactly this.
+- Layer-1 verification is enforced on every resolution: the resolved document
+  must claim the name via `alsoKnownAs`, or the call fails **and the mapping is
+  evicted** so a poisoned entry is not re-failed from cache until its TTL lapses.
+- `set_agent_name_resolvers` / `prepend_` / `append_` / `agent_name_resolver_names`
+  for the backend chain, and `remove_agent_name` to drop a cached mapping.
+  `agent_names::HttpRedirectResolver` is registered by default. As with the DID
+  resolver chain, registration must happen **before the client is cloned**.
+- Config: `with_agent_name_ttl` (default 300s) and
+  `with_agent_name_cache_capacity` (default 1000).
+- `DIDCacheError::AgentNameError`.
+
+`ResolveResponse` is deliberately **unchanged**. The plan had it gain a field
+naming the originating agent name, but the struct is not `#[non_exhaustive]`, so
+adding one is a breaking change — for marginal value, since a caller passing a
+name already knows it, and `did` reports the resolved DID either way.
+
+Not implemented: single-flight de-duplication of concurrent lookups of the *same
+name*. The expensive half (document resolution) is already de-duplicated by the
+existing `inflight` map; concurrent duplicate name lookups cost an extra backend
+call, which is an inefficiency rather than a correctness problem.
+
+## 19th July 2026
+
 ### 0.8.14 — didwebvh-rs 0.6
 
 - Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.14"
+version = "0.8.15"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -43,6 +43,8 @@ did_example = ["dep:did-example"]
 did-jwk = ["dep:did-jwk"]
 did-cheqd = ["dep:did-resolver-cheqd"]
 did-webvh = ["dep:didwebvh-rs"]
+# Agent names: human-memorable "/@" shortcuts resolvable via `resolve_any()`.
+agent-names = ["dep:agent-names"]
 did-scid = ["dep:did-scid"]
 did-ebsi = ["dep:did-ebsi"]
 
@@ -65,6 +67,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
+agent-names = { version = "0.1", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/examples/custom_resolver.rs
@@ -69,8 +69,8 @@ async fn main() -> Result<(), DIDCacheError> {
     // the cache client dispatches to our resolver.
     let response = client.resolve("did:example:alice").await?;
     println!(
-        "resolved {} via a custom resolver -> document id {}",
-        "did:example:alice", response.doc.id
+        "resolved did:example:alice via a custom resolver -> document id {}",
+        response.doc.id
     );
 
     // Custom resolvers can also override a built-in method: registering for

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
@@ -1,0 +1,278 @@
+//! Unified resolution of DIDs **and** agent names.
+//!
+//! Client code should not have to care whether it holds a DID or a human-memorable
+//! shortcut. [`DIDCacheClient::resolve_any`] takes either and returns the same
+//! [`ResolveResponse`].
+//!
+//! # Two-level cache
+//!
+//! ```text
+//! agent name --[ name cache: hash -> DID ]--> DID --[ document cache ]--> Document
+//! ```
+//!
+//! The name mapping is cached separately from the document, which matters for two
+//! reasons:
+//!
+//! 1. **A name and its DID share one document entry.** Resolving
+//!    `example.com/@alice` warms the cache for `did:webvh:…` and vice versa, so
+//!    neither form pays twice and the two can never hold divergent copies.
+//! 2. **It sidesteps a TTL trap.** `DIDExpiry` decides expiry from the *resolved
+//!    document's* `id`, not from the cache key, so a document reached via an agent
+//!    name pointing at an immutable method (`did:key`, say) would be cached
+//!    **forever** if the name were used as the key — pinning a mapping that is a
+//!    web redirect and can change at any time. Keeping the mapping in its own
+//!    cache, with an unconditional TTL, makes that structurally impossible.
+
+use agent_names::{AgentName, AgentNameError, AgentNameResolver, verify_also_known_as};
+use tracing::{debug, warn};
+
+use crate::{DIDCacheClient, ResolveResponse, errors::DIDCacheError};
+
+/// Either a DID or an agent name.
+///
+/// Parsing is a cheap syntactic test on the `/@` marker — no network access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Identifier {
+    /// A DID string, e.g. `did:webvh:QmScid:example.com`.
+    Did(String),
+    /// An agent name, e.g. `example.com/@alice`.
+    AgentName(Box<AgentName>),
+}
+
+impl Identifier {
+    /// Classify an identifier without touching the network.
+    ///
+    /// A string containing `/@` is treated as an agent name and must parse as
+    /// one; anything else is passed through as a DID for [`DIDCacheClient::resolve`]
+    /// to validate.
+    pub fn parse(input: &str) -> Result<Self, DIDCacheError> {
+        if AgentName::looks_like_agent_name(input) {
+            let name = AgentName::parse(input).map_err(DIDCacheError::from)?;
+            Ok(Identifier::AgentName(Box::new(name)))
+        } else {
+            Ok(Identifier::Did(input.to_string()))
+        }
+    }
+}
+
+impl std::str::FromStr for Identifier {
+    type Err = DIDCacheError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl DIDCacheClient {
+    /// Resolve a DID **or** an agent name.
+    ///
+    /// This is the single entry point client code should reach for when an
+    /// identifier may be either form. A DID is passed straight through to
+    /// [`DIDCacheClient::resolve`] with identical behaviour, so existing callers
+    /// lose nothing by switching.
+    ///
+    /// For an agent name the flow is:
+    ///
+    /// 1. look the name up in the name cache; on a miss, ask each registered
+    ///    [`AgentNameResolver`] in turn until one resolves it to a DID;
+    /// 2. cache the mapping with an unconditional TTL;
+    /// 3. resolve the DID through the normal path — reusing the document cache,
+    ///    the resolver chain and single-flight de-duplication;
+    /// 4. **verify** the resolved document claims the name via `alsoKnownAs`.
+    ///
+    /// Step 4 is mandatory. A failure there also **evicts** the name-cache entry,
+    /// so a poisoned mapping is not retained and re-checked forever.
+    ///
+    /// The returned [`ResolveResponse`]'s `did` is the **resolved DID**, not the
+    /// agent name that was passed in.
+    ///
+    /// # Backends
+    ///
+    /// A [`agent_names::HttpRedirectResolver`] is registered by default. Register
+    /// others with [`DIDCacheClient::set_agent_name_resolvers`] — like the DID
+    /// resolver chain, **all registration must happen before the client is
+    /// cloned**.
+    pub async fn resolve_any(&self, input: &str) -> Result<ResolveResponse, DIDCacheError> {
+        match Identifier::parse(input)? {
+            Identifier::Did(did) => self.resolve(&did).await,
+            Identifier::AgentName(name) => self.resolve_agent_name(&name).await,
+        }
+    }
+
+    /// Resolve an already-parsed agent name.
+    pub async fn resolve_agent_name(
+        &self,
+        name: &AgentName,
+    ) -> Result<ResolveResponse, DIDCacheError> {
+        let name_hash = Self::hash_did(name.as_str());
+
+        let did = match self.agent_name_cache.get(&name_hash).await {
+            Some(did) => {
+                debug!("agent name cache hit: {name}");
+                did
+            }
+            None => {
+                debug!("agent name cache miss: {name}");
+                let did = self.resolve_name_to_did(name).await?;
+                self.agent_name_cache.insert(name_hash, did.clone()).await;
+                did
+            }
+        };
+
+        let response = match self.resolve(&did).await {
+            Ok(response) => response,
+            Err(e) => {
+                // The mapping points at a DID that will not resolve. Drop it so a
+                // transient failure does not stay cached for the whole TTL; the
+                // next caller re-asks the backend.
+                debug!("dropping agent name mapping for unresolvable DID: {name} -> {did}");
+                self.agent_name_cache.remove(&name_hash).await;
+                return Err(e);
+            }
+        };
+
+        // Layer 1: the DID must claim the name back. Without this the redirect
+        // proves nothing — anyone can point a name they control at someone
+        // else's DID.
+        if let Err(e) = verify_also_known_as(&response.doc, name) {
+            warn!("agent name verification failed: {e}");
+            // Evict, so a poisoned mapping is re-fetched rather than re-failed
+            // from cache until its TTL happens to expire.
+            self.agent_name_cache.remove(&name_hash).await;
+            return Err(DIDCacheError::from(e));
+        }
+
+        Ok(response)
+    }
+
+    /// Walk the registered backends until one resolves the name.
+    async fn resolve_name_to_did(&self, name: &AgentName) -> Result<String, DIDCacheError> {
+        for resolver in self.agent_name_resolvers.iter() {
+            match resolver.resolve(name).await {
+                Some(Ok(did)) => {
+                    debug!(
+                        "agent name '{name}' resolved to '{did}' by {}",
+                        resolver.name()
+                    );
+                    return Ok(did);
+                }
+                Some(Err(e)) => {
+                    // The backend recognised the name but failed. Report rather
+                    // than silently falling through to a backend that might
+                    // answer differently.
+                    return Err(DIDCacheError::from(e));
+                }
+                None => continue,
+            }
+        }
+        Err(DIDCacheError::from(AgentNameError::Unresolvable(
+            name.as_str().to_string(),
+        )))
+    }
+
+    /// Replace the agent name resolution backends.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client has already been cloned, matching
+    /// [`DIDCacheClient::set_resolver`]. Register backends during setup.
+    pub fn set_agent_name_resolvers(&mut self, resolvers: Vec<Box<dyn AgentNameResolver>>) {
+        *std::sync::Arc::get_mut(&mut self.agent_name_resolvers)
+            .expect("Cannot modify agent name resolvers after DIDCacheClient has been cloned") =
+            resolvers;
+    }
+
+    /// Add a backend to the front of the chain (tried first).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client has already been cloned.
+    pub fn prepend_agent_name_resolver(&mut self, resolver: Box<dyn AgentNameResolver>) {
+        std::sync::Arc::get_mut(&mut self.agent_name_resolvers)
+            .expect("Cannot modify agent name resolvers after DIDCacheClient has been cloned")
+            .insert(0, resolver);
+    }
+
+    /// Add a backend to the end of the chain (tried last).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client has already been cloned.
+    pub fn append_agent_name_resolver(&mut self, resolver: Box<dyn AgentNameResolver>) {
+        std::sync::Arc::get_mut(&mut self.agent_name_resolvers)
+            .expect("Cannot modify agent name resolvers after DIDCacheClient has been cloned")
+            .push(resolver);
+    }
+
+    /// Names of the registered backends, in the order they are tried.
+    pub fn agent_name_resolver_names(&self) -> Vec<&str> {
+        self.agent_name_resolvers.iter().map(|r| r.name()).collect()
+    }
+
+    /// Drop a cached agent name mapping, forcing the next lookup to re-resolve.
+    ///
+    /// Returns the DID that was cached, if any.
+    pub async fn remove_agent_name(&self, name: &AgentName) -> Option<String> {
+        self.agent_name_cache
+            .remove(&Self::hash_did(name.as_str()))
+            .await
+    }
+}
+
+impl From<AgentNameError> for DIDCacheError {
+    fn from(err: AgentNameError) -> Self {
+        DIDCacheError::AgentNameError(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_a_did() {
+        assert_eq!(
+            Identifier::parse("did:web:example.com").unwrap(),
+            Identifier::Did("did:web:example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn classifies_an_agent_name() {
+        let id = Identifier::parse("example.com/@alice").unwrap();
+        match id {
+            Identifier::AgentName(n) => assert_eq!(n.as_str(), "https://example.com/@alice"),
+            other => panic!("expected an agent name, got {other:?}"),
+        }
+    }
+
+    /// An email has an '@' but no '/@', so it is not mistaken for a name. It is
+    /// passed through as a DID and rejected later by `resolve`.
+    #[test]
+    fn does_not_mistake_an_email_for_an_agent_name() {
+        assert!(matches!(
+            Identifier::parse("alice@example.com").unwrap(),
+            Identifier::Did(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_a_malformed_agent_name() {
+        // Contains the marker, so it is treated as a name — and is invalid.
+        assert!(Identifier::parse("example.com/@").is_err());
+    }
+
+    #[test]
+    fn from_str_works() {
+        let id: Identifier = "example.com/@alice".parse().unwrap();
+        assert!(matches!(id, Identifier::AgentName(_)));
+    }
+
+    #[test]
+    fn agent_name_error_maps_to_cache_error() {
+        let err = DIDCacheError::from(AgentNameError::Unresolvable("x".to_string()));
+        assert!(matches!(err, DIDCacheError::AgentNameError(_)));
+        assert!(err.to_string().contains('x'));
+    }
+}

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
@@ -41,6 +41,10 @@ pub struct DIDCacheConfig {
     pub(crate) network_cache_limit_count: u32,
     pub(crate) max_did_parts: usize,
     pub(crate) max_did_size_in_bytes: usize,
+    #[cfg(feature = "agent-names")]
+    pub(crate) agent_name_ttl: u32,
+    #[cfg(feature = "agent-names")]
+    pub(crate) agent_name_cache_capacity: u32,
 }
 
 /// DID Cache Config Builder to construct options required for the client.
@@ -62,6 +66,10 @@ pub struct DIDCacheConfigBuilder {
     network_cache_limit_count: u32,
     max_did_parts: usize,
     max_did_size_in_bytes: usize,
+    #[cfg(feature = "agent-names")]
+    agent_name_ttl: u32,
+    #[cfg(feature = "agent-names")]
+    agent_name_cache_capacity: u32,
 }
 
 impl Default for DIDCacheConfigBuilder {
@@ -77,6 +85,10 @@ impl Default for DIDCacheConfigBuilder {
             network_cache_limit_count: 100,
             max_did_parts: 12,
             max_did_size_in_bytes: 1_000,
+            #[cfg(feature = "agent-names")]
+            agent_name_ttl: 300,
+            #[cfg(feature = "agent-names")]
+            agent_name_cache_capacity: 1_000,
         }
     }
 }
@@ -136,6 +148,29 @@ impl DIDCacheConfigBuilder {
         self
     }
 
+    /// Set the time-to-live in seconds for cached agent name to DID mappings.
+    ///
+    /// Unlike DID documents, this **always** applies: an agent name mapping is a
+    /// web redirect and is therefore always mutable, no matter how immutable the
+    /// DID it points at happens to be.
+    /// Default: 300 (5 minutes)
+    #[cfg(feature = "agent-names")]
+    pub fn with_agent_name_ttl(mut self, ttl: u32) -> Self {
+        self.agent_name_ttl = ttl;
+        self
+    }
+
+    /// Set the capacity of the agent name to DID mapping cache.
+    ///
+    /// Entries are short strings rather than whole documents, so this can be far
+    /// larger than the document cache for the same memory.
+    /// Default: 1000 items
+    #[cfg(feature = "agent-names")]
+    pub fn with_agent_name_cache_capacity(mut self, capacity: u32) -> Self {
+        self.agent_name_cache_capacity = capacity;
+        self
+    }
+
     /// Build the [ClientConfig].
     pub fn build(self) -> DIDCacheConfig {
         DIDCacheConfig {
@@ -149,6 +184,10 @@ impl DIDCacheConfigBuilder {
             network_cache_limit_count: self.network_cache_limit_count,
             max_did_parts: self.max_did_parts,
             max_did_size_in_bytes: self.max_did_size_in_bytes,
+            #[cfg(feature = "agent-names")]
+            agent_name_ttl: self.agent_name_ttl,
+            #[cfg(feature = "agent-names")]
+            agent_name_cache_capacity: self.agent_name_cache_capacity,
         }
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/errors.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/errors.rs
@@ -29,6 +29,14 @@ pub enum DIDCacheError {
     /// String parsing error
     #[error("Parsing error: {0}")]
     ParsingError(String),
+
+    /// An agent name (DID shortcut) failed to parse, resolve, or verify.
+    ///
+    /// Notably includes the mandatory `alsoKnownAs` check: a name that resolves
+    /// to a DID whose document does not claim the name back is rejected here.
+    #[cfg(feature = "agent-names")]
+    #[error("Agent name error: {0}")]
+    AgentNameError(String),
 }
 
 // Converts DIDCacheError to JsValue which is required for propagating errors to WASM

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -42,6 +42,8 @@ use tracing::warn;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "agent-names")]
+pub mod agent_names;
 pub mod config;
 pub mod errors;
 #[cfg(feature = "network")]
@@ -218,6 +220,14 @@ pub struct DIDCacheClient {
     #[cfg(feature = "did_example")]
     did_example_cache: did_example::DiDExampleCache,
     resolvers: Arc<HashMap<MethodName, VecDeque<Box<dyn AsyncResolver>>>>,
+    /// Agent name -> DID mappings. Deliberately a *separate* cache from the
+    /// document cache: the mapping is a web redirect and is therefore always
+    /// mutable, so it always carries a TTL, whereas `DIDExpiry` would derive
+    /// "no expiry" from an immutable resolved DID. See `agent_names`.
+    #[cfg(feature = "agent-names")]
+    agent_name_cache: Cache<[u64; 2], String>,
+    #[cfg(feature = "agent-names")]
+    agent_name_resolvers: Arc<Vec<Box<dyn ::agent_names::AgentNameResolver>>>,
     /// Single-flight map: concurrent cache misses for the same DID hash share
     /// one underlying resolution. The leader holds the `watch::Sender`; the
     /// stored `Receiver` is cloned by followers, who wake when the leader drops
@@ -241,6 +251,10 @@ impl Clone for DIDCacheClient {
             #[cfg(feature = "did_example")]
             did_example_cache: self.did_example_cache.clone(),
             resolvers: self.resolvers.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_cache: self.agent_name_cache.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_resolvers: self.agent_name_resolvers.clone(),
             inflight: self.inflight.clone(),
         }
     }
@@ -672,6 +686,20 @@ impl DIDCacheClient {
 
         let resolvers = Arc::new(resolvers);
 
+        // Agent name (DID shortcut) support. The mapping cache always carries a
+        // TTL: an agent name is a web redirect and can change at any time,
+        // regardless of how immutable the DID it currently points at is.
+        #[cfg(feature = "agent-names")]
+        let agent_name_cache: Cache<[u64; 2], String> = Cache::builder()
+            .max_capacity(config.agent_name_cache_capacity.into())
+            .time_to_live(Duration::from_secs(config.agent_name_ttl.into()))
+            .build();
+        #[cfg(feature = "agent-names")]
+        let agent_name_resolvers: Arc<Vec<Box<dyn ::agent_names::AgentNameResolver>>> =
+            Arc::new(vec![
+                Box::new(::agent_names::HttpRedirectResolver::new()) as Box<_>
+            ]);
+
         #[cfg(feature = "network")]
         let mut client = Self {
             config,
@@ -683,6 +711,10 @@ impl DIDCacheClient {
             #[cfg(feature = "did_example")]
             did_example_cache: did_example::DiDExampleCache::new(),
             resolvers: resolvers.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_cache: agent_name_cache.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_resolvers: agent_name_resolvers.clone(),
             inflight: Arc::new(StdMutex::new(HashMap::new())),
         };
         #[cfg(not(feature = "network"))]
@@ -692,6 +724,10 @@ impl DIDCacheClient {
             #[cfg(feature = "did_example")]
             did_example_cache: did_example::DiDExampleCache::new(),
             resolvers,
+            #[cfg(feature = "agent-names")]
+            agent_name_cache,
+            #[cfg(feature = "agent-names")]
+            agent_name_resolvers,
             inflight: Arc::new(StdMutex::new(HashMap::new())),
         };
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
@@ -1,0 +1,399 @@
+//! `resolve_any()` — unified DID / agent name resolution and its two-level cache.
+//!
+//! These use an in-memory name backend rather than HTTP, so they exercise the
+//! cache and verification wiring without a network. The HTTP redirect backend
+//! itself is covered in the `agent-names` crate.
+
+#![cfg(feature = "agent-names")]
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use affinidi_did_common::{Document, DocumentBuilder};
+use affinidi_did_resolver_cache_sdk::{
+    DIDCacheClient, config::DIDCacheConfigBuilder, errors::DIDCacheError,
+};
+use agent_names::{AgentName, AgentNameError, AgentNameResolver, NameResolution};
+
+const NAME: &str = "example.com/@alice";
+const CANONICAL: &str = "https://example.com/@alice";
+/// `did:key` is *immutable*, so its document is cached with no expiry. That is
+/// exactly what makes it the right DID for the TTL regression test below.
+const IMMUTABLE_DID: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+/// A name backend backed by a fixed map, counting how often it is consulted.
+struct MapResolver {
+    map: HashMap<String, String>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl MapResolver {
+    fn new(pairs: &[(&str, &str)]) -> (Self, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let map = pairs
+            .iter()
+            .map(|(n, d)| (n.to_string(), d.to_string()))
+            .collect();
+        (
+            Self {
+                map,
+                calls: calls.clone(),
+            },
+            calls,
+        )
+    }
+}
+
+impl AgentNameResolver for MapResolver {
+    fn name(&self) -> &str {
+        "test-map"
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        name: &'a AgentName,
+    ) -> Pin<Box<dyn Future<Output = NameResolution> + Send + 'a>> {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.map.get(name.as_str()) {
+                Some(did) => Some(Ok(did.clone())),
+                None => Some(Err(AgentNameError::Unresolvable(name.as_str().to_string()))),
+            }
+        })
+    }
+}
+
+/// A document that claims `aka` via `alsoKnownAs`.
+fn doc_claiming(did: &str, aka: &[&str]) -> Document {
+    DocumentBuilder::new(did)
+        .unwrap()
+        .also_known_as_many(aka.iter().copied())
+        .build()
+}
+
+/// Client with a seeded document cache and a map-backed name resolver.
+async fn client_with(
+    did: &str,
+    aka: &[&str],
+    pairs: &[(&str, &str)],
+    name_ttl: u32,
+) -> (DIDCacheClient, Arc<AtomicUsize>) {
+    let config = DIDCacheConfigBuilder::default()
+        .with_agent_name_ttl(name_ttl)
+        .build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+
+    let (resolver, calls) = MapResolver::new(pairs);
+    client.set_agent_name_resolvers(vec![Box::new(resolver)]);
+    // Seed the document cache so no real DID resolution happens.
+    client.add_did_document(did, doc_claiming(did, aka)).await;
+
+    (client, calls)
+}
+
+// --- pass-through ---
+
+#[tokio::test]
+async fn a_did_passes_straight_through() {
+    let (client, calls) = client_with(IMMUTABLE_DID, &[], &[], 300).await;
+
+    let response = client.resolve_any(IMMUTABLE_DID).await.unwrap();
+    assert_eq!(response.did, IMMUTABLE_DID);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a DID must not consult the agent name backends"
+    );
+}
+
+// --- happy path ---
+
+#[tokio::test]
+async fn resolves_an_agent_name_to_its_did() {
+    let (client, calls) = client_with(
+        IMMUTABLE_DID,
+        &[CANONICAL],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+
+    let response = client.resolve_any(NAME).await.unwrap();
+    assert_eq!(
+        response.did, IMMUTABLE_DID,
+        "the response reports the resolved DID, not the name"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn accepts_a_scheme_less_also_known_as_entry() {
+    let (client, _) = client_with(
+        IMMUTABLE_DID,
+        &["example.com/@alice"],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+    assert!(client.resolve_any(NAME).await.is_ok());
+}
+
+/// All spellings of one name hit the same cache entry.
+#[tokio::test]
+async fn equivalent_spellings_share_one_mapping() {
+    let (client, calls) = client_with(
+        IMMUTABLE_DID,
+        &[CANONICAL],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+
+    for spelling in [
+        "example.com/@alice",
+        "https://example.com/@alice",
+        "https://EXAMPLE.com/@alice",
+        "https://example.com:443/@alice",
+        "https://example.com/@alice/",
+    ] {
+        client.resolve_any(spelling).await.unwrap();
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "canonicalisation should collapse every spelling onto one cached mapping"
+    );
+}
+
+// --- the mapping cache ---
+
+#[tokio::test]
+async fn a_cached_mapping_is_not_re_resolved() {
+    let (client, calls) = client_with(
+        IMMUTABLE_DID,
+        &[CANONICAL],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+
+    for _ in 0..5 {
+        client.resolve_any(NAME).await.unwrap();
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+/// Resolving via the name warms the document cache for the bare DID too, so a
+/// name and its DID never hold divergent copies of one document.
+///
+/// This deliberately does **not** pre-seed the document cache — that would make
+/// the assertion vacuous, since resolving by DID would hit the seeded entry
+/// whether or not the name path ran. Instead the name points at a real,
+/// locally-resolvable `did:key`, whose generated document has no `alsoKnownAs`
+/// and so fails Layer 1. The failure is the point: resolution still happened, so
+/// the document must now be in the shared cache.
+#[tokio::test]
+async fn a_name_and_its_did_share_one_document_entry() {
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+    let (resolver, _) = MapResolver::new(&[(CANONICAL, IMMUTABLE_DID)]);
+    client.set_agent_name_resolvers(vec![Box::new(resolver)]);
+
+    // Nothing cached yet: resolving the DID directly is a miss.
+    assert!(!client.resolve_any(IMMUTABLE_DID).await.unwrap().cache_hit);
+    client.remove(IMMUTABLE_DID).await;
+
+    // Resolve through the name. Verification fails (a did:key document claims no
+    // names), but the underlying DID resolution still populated the cache.
+    assert!(client.resolve_any(NAME).await.is_err());
+
+    let by_did = client.resolve_any(IMMUTABLE_DID).await.unwrap();
+    assert!(
+        by_did.cache_hit,
+        "resolving by name should have warmed the shared document cache for its DID"
+    );
+}
+
+#[tokio::test]
+async fn remove_agent_name_forces_re_resolution() {
+    let (client, calls) = client_with(
+        IMMUTABLE_DID,
+        &[CANONICAL],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+
+    client.resolve_any(NAME).await.unwrap();
+    let name = AgentName::parse(NAME).unwrap();
+    assert_eq!(
+        client.remove_agent_name(&name).await.as_deref(),
+        Some(IMMUTABLE_DID)
+    );
+
+    client.resolve_any(NAME).await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+/// **Regression test for the `DIDExpiry` trap.**
+///
+/// `DIDExpiry` decides expiry from the *resolved document's* `id`, not from the
+/// cache key. `did:key` is immutable, so its document is cached with **no**
+/// expiry. Had the agent name been used as a key into that same cache, the
+/// mapping would have inherited "never expires" — pinning a web redirect that
+/// can change at any moment. The separate mapping cache must expire regardless.
+#[tokio::test]
+async fn a_mapping_to_an_immutable_did_still_expires() {
+    let (client, calls) = client_with(
+        IMMUTABLE_DID,
+        &[CANONICAL],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        1,
+    )
+    .await;
+
+    client.resolve_any(NAME).await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+    client.resolve_any(NAME).await.unwrap();
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "the name->DID mapping must expire even though the DID it points at is immutable"
+    );
+
+    // …while the document itself stayed cached throughout.
+    assert!(client.resolve_any(IMMUTABLE_DID).await.unwrap().cache_hit);
+}
+
+// --- Layer-1 verification ---
+
+#[tokio::test]
+async fn rejects_a_did_that_does_not_claim_the_name() {
+    // The redirect points at a DID whose document says nothing about the name.
+    let (client, _) = client_with(IMMUTABLE_DID, &[], &[(CANONICAL, IMMUTABLE_DID)], 300).await;
+
+    let err = client.resolve_any(NAME).await.unwrap_err();
+    assert!(
+        matches!(err, DIDCacheError::AgentNameError(_)),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("alsoKnownAs"), "got {err}");
+}
+
+#[tokio::test]
+async fn rejects_a_did_that_claims_a_different_name() {
+    let (client, _) = client_with(
+        IMMUTABLE_DID,
+        &["https://example.com/@bob"],
+        &[(CANONICAL, IMMUTABLE_DID)],
+        300,
+    )
+    .await;
+    assert!(client.resolve_any(NAME).await.is_err());
+}
+
+/// A failed verification must **evict** the mapping, so a poisoned entry is
+/// re-fetched rather than re-failed from cache until its TTL happens to lapse.
+#[tokio::test]
+async fn failed_verification_evicts_the_mapping() {
+    let (client, calls) = client_with(IMMUTABLE_DID, &[], &[(CANONICAL, IMMUTABLE_DID)], 300).await;
+
+    assert!(client.resolve_any(NAME).await.is_err());
+    assert!(client.resolve_any(NAME).await.is_err());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "a rejected mapping must not stay cached"
+    );
+
+    let name = AgentName::parse(NAME).unwrap();
+    assert_eq!(
+        client.remove_agent_name(&name).await,
+        None,
+        "nothing should remain cached after a rejected verification"
+    );
+}
+
+/// A mapping pointing at a DID that will not resolve must not stay cached for
+/// the whole TTL — the next caller should re-ask the backend.
+#[tokio::test]
+async fn a_mapping_to_an_unresolvable_did_is_evicted() {
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+    let (resolver, calls) = MapResolver::new(&[(CANONICAL, "did:nosuchmethod:whatever")]);
+    client.set_agent_name_resolvers(vec![Box::new(resolver)]);
+
+    assert!(client.resolve_any(NAME).await.is_err());
+    assert!(client.resolve_any(NAME).await.is_err());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "an unresolvable mapping must be evicted, not cached"
+    );
+}
+
+// --- backends ---
+
+#[tokio::test]
+async fn reports_an_unresolvable_name() {
+    let (client, _) = client_with(IMMUTABLE_DID, &[CANONICAL], &[], 300).await;
+
+    let err = client.resolve_any("example.com/@nobody").await.unwrap_err();
+    assert!(
+        matches!(err, DIDCacheError::AgentNameError(_)),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_default_backend_is_http_redirect() {
+    let config = DIDCacheConfigBuilder::default().build();
+    let client = DIDCacheClient::new(config).await.unwrap();
+    assert_eq!(client.agent_name_resolver_names(), ["http-redirect"]);
+}
+
+#[tokio::test]
+async fn backends_are_tried_in_order() {
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+
+    let (first, _) = MapResolver::new(&[]);
+    let (second, _) = MapResolver::new(&[]);
+    client.set_agent_name_resolvers(vec![Box::new(first)]);
+    client.append_agent_name_resolver(Box::new(second));
+    assert_eq!(client.agent_name_resolver_names().len(), 2);
+}
+
+#[tokio::test]
+async fn a_malformed_agent_name_is_rejected_before_any_lookup() {
+    let (client, calls) = client_with(IMMUTABLE_DID, &[], &[], 300).await;
+
+    assert!(client.resolve_any("example.com/@").await.is_err());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a malformed name must not reach the backends"
+    );
+}
+
+/// An email address has an `@` but no `/@`, so it is not mistaken for a name;
+/// it falls through to DID parsing and is rejected there.
+#[tokio::test]
+async fn an_email_is_not_treated_as_an_agent_name() {
+    let (client, calls) = client_with(IMMUTABLE_DID, &[], &[], 300).await;
+
+    let err = client.resolve_any("alice@example.com").await.unwrap_err();
+    assert!(matches!(err, DIDCacheError::DIDError(_)), "got {err:?}");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}


### PR DESCRIPTION
PR 3 of the agent-names plan. PR 1 (typed `Document::also_known_as`) was
[#629](https://github.com/affinidi/affinidi-tdk-rs/pull/629); PR 2 (the standalone
crate) was [#631](https://github.com/affinidi/affinidi-tdk-rs/pull/631).

## What

New optional `agent-names` feature on the cache SDK. **Off by default** — nothing
changes for existing callers when it is not enabled.

```rust
// Same call, either form:
client.resolve_any("did:webvh:QmScid:example.com").await?;
client.resolve_any("example.com/@alice").await?;
```

A DID is passed straight through to `resolve()` with identical behaviour, so
switching costs existing callers nothing, and `resolve()` keeps its strict
DID-only contract. This is the "single resolver regardless of shortcut or DID"
goal from the original ask.

## The two-level cache is the design, not an implementation detail

```text
agent name --[ name cache: hash -> DID ]--> DID --[ document cache ]--> Document
```

The mapping gets its **own** cache rather than reusing the document cache, for two
reasons:

1. **A name and its DID share one document entry.** Resolving `example.com/@alice`
   warms the cache for `did:webvh:…` and vice versa, so neither form pays twice
   and the two can never hold divergent copies.

2. **It sidesteps a live TTL trap.** `DIDExpiry` (`lib.rs:171`) derives expiry from
   the *resolved document's* `id`, **not** from the cache key. A name pointing at
   an immutable method (`did:key`) would therefore have inherited "never expires"
   — pinning a web redirect that can change at any moment. The separate cache
   carries an unconditional TTL, which makes that structurally impossible.

   `a_mapping_to_an_immutable_did_still_expires` is a deliberate regression test
   for exactly this: it resolves a name to a `did:key`, waits out a 1s name TTL,
   and asserts the backend is consulted again **while the document stays cached**.

## Layer-1 verification runs on every resolution

The resolved document must claim the name via `alsoKnownAs`, or the call fails
**and the mapping is evicted** — so a poisoned entry is not re-failed from cache
until its TTL happens to lapse. A mapping pointing at an unresolvable DID is
likewise evicted rather than left to go stale.

## Deviation from the approved plan, flagged

The plan had `ResolveResponse` gain a field naming the originating agent name.
**I did not do that.** The struct is not `#[non_exhaustive]`, so adding a field is
a breaking change — for marginal value, since a caller passing a name already has
it, and `did` reports the resolved DID either way. Sealing `ResolveResponse` is
worth doing, but as its own ADR-0003 follow-up rather than smuggled in here.

## Also not implemented, deliberately

Single-flight de-duplication of concurrent lookups of the **same name**. The
expensive half (document resolution) is already de-duplicated by the existing
`inflight` map; duplicate concurrent name lookups cost one extra backend call —
an inefficiency, not a correctness problem. Adding a second inflight map is worth
doing on its own, with the deadlock topology thought through properly, rather
than bolted onto this PR.

## API

- `resolve_any(&str)`, `resolve_agent_name(&AgentName)`
- `Identifier` enum + `FromStr` — classifies on the `/@` marker, no network access
- `set_agent_name_resolvers` / `prepend_` / `append_` / `agent_name_resolver_names`,
  and `remove_agent_name`. `HttpRedirectResolver` is registered by default. As with
  the DID resolver chain, registration must happen **before the client is cloned**.
- Config: `with_agent_name_ttl` (300s), `with_agent_name_cache_capacity` (1000)
- `DIDCacheError::AgentNameError` (the enum is already `#[non_exhaustive]`)

## Verification

- **73 tests** in the crate: 55 lib + 17 integration + 1 doctest.
- Integration coverage: DID pass-through (asserting backends are *not* consulted),
  happy path, scheme-less `alsoKnownAs`, all five canonical spellings collapsing to
  one cached mapping, cached mapping not re-resolved, shared document entry,
  TTL expiry with an immutable DID, eviction on failed verification, eviction on
  unresolvable DID, unresolvable name, backend ordering, malformed name rejected
  before any lookup, and an email not being mistaken for a name.
- `clippy --all-targets -D warnings` clean in **all three** configs: feature on,
  feature off, `--all-features`.
- `cargo fmt --check` clean; `cargo check --workspace --all-targets` clean.

### On one of those tests

`a_name_and_its_did_share_one_document_entry` originally pre-seeded the document
cache, which made it vacuous — resolving by DID would hit the seeded entry whether
or not the name path ran. It now uses a real, locally-resolvable `did:key` and
asserts the cache was warmed as a side effect of a resolution that then *failed*
Layer 1. Noting it because a reviewer would reasonably wonder why that test
asserts an error.

## Drive-by

Fixes a pre-existing `clippy::print_literal` failure in
`examples/custom_resolver.rs:73`. It fails on `main` today and blocked local
clippy verification of this crate.