### PR TITLE
fix: SSRF hardening — block non-public addresses in HttpRedirectResolver

### DIFF
--- a/crates/identity/shortcuts/agent-names/CHANGELOG.md
+++ b/crates/identity/shortcuts/agent-names/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `agent-names` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-19
+
+### Security
+
+- `HttpRedirectResolver` now refuses names that resolve to **non-public
+  addresses** — loopback, RFC1918 private, link-local (including the cloud
+  metadata address `169.254.169.254`), carrier-grade NAT, benchmarking,
+  documentation and reserved ranges, plus their IPv6 equivalents and
+  IPv4-mapped forms such as `::ffff:127.0.0.1`. Controlled by
+  `allow_private_addresses(bool)`, **off by default**; the check runs on
+  **every** redirect hop, since a public host can redirect inward.
+
+  This matters most when the resolver runs **server-side**: an agent name is
+  attacker-supplied, so without this a caller could make the DID cache server
+  issue requests from inside your network. It is a prerequisite for exposing
+  agent name resolution on the cache server.
+
+  **Limitation, stated plainly:** the check resolves the host and inspects the
+  addresses it gets *now*; the subsequent request resolves again. A hostile DNS
+  server can answer differently for the two lookups (**DNS rebinding**) and
+  reach an internal address anyway. Closing that requires pinning the checked IP
+  into the connection, which `reqwest` does not expose. This raises the cost of
+  SSRF; it does not eliminate it. Do not rely on it as the only control at an
+  untrusted network boundary.
+
+- New `AgentNameError::BlockedAddress { name, address }`.
+
+### Known gaps
+
+- The *mid-chain* address check (a public host redirecting inward) is not
+  integration-tested, for the same reason as the mid-chain HTTPS check:
+  `wiremock` binds `127.0.0.1`, so the entry point is itself private and the
+  test would pass for the wrong reason. The per-hop logic is covered by
+  `is_public` unit tests.
+
 ## [0.1.0] - 2026-07-19
 
 Initial release. Agent names — human-memorable shortcuts of the form

--- a/crates/identity/shortcuts/agent-names/Cargo.toml
+++ b/crates/identity/shortcuts/agent-names/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-names"
-version = "0.1.0"
+version = "0.1.1"
 description = "Agent Name (DID shortcut) parsing, resolution and verification for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -23,6 +23,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "http2",
 ] }
 thiserror = "2"
+tokio = { version = "1", features = ["net"] }
 tracing = "0.1"
 url = "2"
 

--- a/crates/identity/shortcuts/agent-names/README.md
+++ b/crates/identity/shortcuts/agent-names/README.md
@@ -108,6 +108,15 @@ down later should not disturb them.
   mirrors `affinidi-did-web`'s SSRF hardening.
 - Plain HTTP is refused unless `allow_insecure_http(true)` is set. That switch is
   for local development and tests only.
+- Names resolving to **non-public addresses** (loopback, private, link-local
+  including `169.254.169.254`, and their IPv6/IPv4-mapped forms) are refused
+  unless `allow_private_addresses(true)`. Checked on every hop, since a public
+  host can redirect inward. This matters most server-side, where the name is
+  attacker-supplied and the request originates inside your network.
+
+  It is **not** complete SSRF protection: the check and the request resolve DNS
+  separately, so DNS rebinding can still reach an internal address. It raises
+  the cost; it does not close the hole.
 
 ## DID → name
 

--- a/crates/identity/shortcuts/agent-names/src/error.rs
+++ b/crates/identity/shortcuts/agent-names/src/error.rs
@@ -48,6 +48,14 @@ pub enum AgentNameError {
     #[error("Response for agent name '{name}' exceeded the {limit} byte limit")]
     ResponseTooLarge { name: String, limit: usize },
 
+    /// The name resolved to a non-public address (loopback, private, link-local…).
+    ///
+    /// Almost always an SSRF attempt rather than a real agent name.
+    #[error(
+        "Agent name '{name}' resolves to the non-public address {address}; refusing to fetch it"
+    )]
+    BlockedAddress { name: String, address: String },
+
     /// No registered backend could resolve the name.
     #[error("No agent name resolver could resolve '{0}'")]
     Unresolvable(String),

--- a/crates/identity/shortcuts/agent-names/src/resolver.rs
+++ b/crates/identity/shortcuts/agent-names/src/resolver.rs
@@ -1,7 +1,13 @@
 //! Backends that turn an agent name into a DID.
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{
+    future::Future,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    pin::Pin,
+    time::Duration,
+};
 
+use tokio::net::lookup_host;
 use tracing::debug;
 use url::Url;
 
@@ -68,6 +74,7 @@ pub struct HttpRedirectResolver {
     client: reqwest::Client,
     max_hops: u8,
     allow_insecure_http: bool,
+    allow_private_addresses: bool,
 }
 
 impl HttpRedirectResolver {
@@ -82,6 +89,7 @@ impl HttpRedirectResolver {
             client,
             max_hops: DEFAULT_MAX_HOPS,
             allow_insecure_http: false,
+            allow_private_addresses: false,
         }
     }
 
@@ -95,6 +103,7 @@ impl HttpRedirectResolver {
             client,
             max_hops: DEFAULT_MAX_HOPS,
             allow_insecure_http: false,
+            allow_private_addresses: false,
         }
     }
 
@@ -115,6 +124,81 @@ impl HttpRedirectResolver {
         self
     }
 
+    /// Permit agent names that resolve to private, loopback or link-local
+    /// addresses.
+    ///
+    /// Off by default. Agent names are public-web identifiers, so a name
+    /// pointing at `127.0.0.1`, `10.0.0.0/8` or the cloud metadata address
+    /// `169.254.169.254` is almost always an SSRF attempt rather than a real
+    /// name. That matters most when this resolver runs **server-side** (the DID
+    /// cache server), where the attacker supplies the name and the server makes
+    /// the request from inside your network.
+    ///
+    /// Turn it on only for local development and tests.
+    pub fn allow_private_addresses(mut self, allow: bool) -> Self {
+        self.allow_private_addresses = allow;
+        self
+    }
+
+    /// Reject a URL whose host is, or resolves to, a non-public address.
+    ///
+    /// # Limitation
+    ///
+    /// This checks the addresses a host resolves to *now*; the subsequent
+    /// request performs its own resolution. A hostile DNS server can therefore
+    /// answer differently for the two lookups (**DNS rebinding**) and reach an
+    /// internal address anyway. Closing that hole requires pinning the checked
+    /// IP into the connection itself, which `reqwest` does not expose. Treat
+    /// this as raising the cost of SSRF, not as eliminating it, and do not rely
+    /// on it as the only control on an untrusted network boundary.
+    async fn check_address(&self, url: &Url, name: &AgentName) -> Result<(), AgentNameError> {
+        if self.allow_private_addresses {
+            return Ok(());
+        }
+        let host = url.host_str().ok_or_else(|| AgentNameError::InvalidName {
+            input: url.to_string(),
+            reason: "no host".to_string(),
+        })?;
+        let port = url.port_or_known_default().unwrap_or(443);
+
+        // An IP literal needs no DNS lookup.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return if is_public(&ip) {
+                Ok(())
+            } else {
+                Err(AgentNameError::BlockedAddress {
+                    name: name.as_str().to_string(),
+                    address: ip.to_string(),
+                })
+            };
+        }
+
+        let addrs = lookup_host((host, port))
+            .await
+            .map_err(|e| AgentNameError::InvalidName {
+                input: host.to_string(),
+                reason: format!("DNS lookup failed: {e}"),
+            })?;
+
+        let mut saw_any = false;
+        for addr in addrs {
+            saw_any = true;
+            if !is_public(&addr.ip()) {
+                return Err(AgentNameError::BlockedAddress {
+                    name: name.as_str().to_string(),
+                    address: addr.ip().to_string(),
+                });
+            }
+        }
+        if !saw_any {
+            return Err(AgentNameError::InvalidName {
+                input: host.to_string(),
+                reason: "host resolved to no addresses".to_string(),
+            });
+        }
+        Ok(())
+    }
+
     async fn resolve_inner(&self, name: &AgentName) -> Result<String, AgentNameError> {
         if !name.is_https() && !self.allow_insecure_http {
             return Err(AgentNameError::InsecureScheme(name.as_str().to_string()));
@@ -123,6 +207,8 @@ impl HttpRedirectResolver {
         let mut url = name.resolution_url()?;
 
         for hop in 0..self.max_hops {
+            // Re-checked on *every* hop: a public host can redirect inward.
+            self.check_address(&url, name).await?;
             debug!(hop, %url, "resolving agent name");
             let response = self.client.get(url.clone()).send().await?;
             let status = response.status();
@@ -216,6 +302,51 @@ fn extract_did(target: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Is this address on the public internet?
+///
+/// Conservative: anything loopback, private, link-local, unspecified,
+/// multicast, broadcast or otherwise special-purpose is treated as non-public.
+/// `Ipv4Addr::is_global` is still unstable, so the ranges are spelled out.
+fn is_public(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_public_v4(v4),
+        IpAddr::V6(v6) => is_public_v6(v6),
+    }
+}
+
+fn is_public_v4(ip: &Ipv4Addr) -> bool {
+    let [a, b, ..] = ip.octets();
+    !(ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        // 100.64.0.0/10 carrier-grade NAT
+        || (a == 100 && (64..128).contains(&b))
+        // 192.0.0.0/24 IETF protocol assignments
+        || (a == 192 && b == 0 && ip.octets()[2] == 0)
+        // 198.18.0.0/15 benchmarking
+        || (a == 198 && (18..20).contains(&b))
+        // 240.0.0.0/4 reserved
+        || a >= 240)
+}
+
+fn is_public_v6(ip: &Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return false;
+    }
+    // An IPv4-mapped address must be judged by its IPv4 rules, or
+    // ::ffff:127.0.0.1 would sail through.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_public_v4(&v4);
+    }
+    let seg = ip.segments()[0];
+    // fc00::/7 unique-local, fe80::/10 link-local
+    !((seg & 0xfe00) == 0xfc00 || (seg & 0xffc0) == 0xfe80)
 }
 
 fn is_did(s: &str) -> bool {
@@ -324,6 +455,57 @@ mod tests {
         assert_eq!(percent_decode("plain").unwrap(), "plain");
         assert!(percent_decode("%zz").is_err());
         assert!(percent_decode("truncated%4").is_err());
+    }
+
+    // --- is_public ---
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn blocks_loopback_and_private_v4() {
+        for a in [
+            "127.0.0.1",
+            "10.1.2.3",
+            "172.16.0.1",
+            "192.168.1.1",
+            "0.0.0.0",
+            "169.254.169.254", // cloud metadata — the classic SSRF target
+            "100.64.0.1",      // carrier-grade NAT
+            "198.18.0.1",      // benchmarking
+            "255.255.255.255",
+            "240.0.0.1",
+        ] {
+            assert!(!is_public(&ip(a)), "{a} must be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_v4() {
+        for a in ["1.1.1.1", "8.8.8.8", "93.184.216.34", "172.32.0.1"] {
+            assert!(is_public(&ip(a)), "{a} should be allowed");
+        }
+    }
+
+    #[test]
+    fn blocks_loopback_and_local_v6() {
+        for a in ["::1", "::", "fc00::1", "fd00::1", "fe80::1", "ff02::1"] {
+            assert!(!is_public(&ip(a)), "{a} must be blocked");
+        }
+    }
+
+    /// ::ffff:127.0.0.1 must be judged by IPv4 rules, or it bypasses the check.
+    #[test]
+    fn blocks_ipv4_mapped_loopback() {
+        assert!(!is_public(&ip("::ffff:127.0.0.1")));
+        assert!(!is_public(&ip("::ffff:10.0.0.1")));
+        assert!(is_public(&ip("::ffff:8.8.8.8")));
+    }
+
+    #[test]
+    fn allows_public_v6() {
+        assert!(is_public(&ip("2606:4700:4700::1111")));
     }
 
     #[test]

--- a/crates/identity/shortcuts/agent-names/tests/http_redirect.rs
+++ b/crates/identity/shortcuts/agent-names/tests/http_redirect.rs
@@ -12,9 +12,12 @@ use wiremock::{
 
 const DID: &str = "did:webvh:QmScid:example.com";
 
-/// The mock server speaks plain HTTP, so the resolver must opt into it.
+/// The mock server speaks plain HTTP on 127.0.0.1, so the resolver must opt out
+/// of both the HTTPS requirement and the private-address block.
 fn resolver() -> HttpRedirectResolver {
-    HttpRedirectResolver::new().allow_insecure_http(true)
+    HttpRedirectResolver::new()
+        .allow_insecure_http(true)
+        .allow_private_addresses(true)
 }
 
 fn name_for(server: &MockServer, local: &str) -> AgentName {
@@ -181,21 +184,49 @@ async fn refuses_plain_http_by_default() {
         .mount(&server)
         .await;
 
-    let err = resolve(&HttpRedirectResolver::new(), &name_for(&server, "alice"))
-        .await
-        .unwrap_err();
+    let err = resolve(
+        &HttpRedirectResolver::new().allow_private_addresses(true),
+        &name_for(&server, "alice"),
+    )
+    .await
+    .unwrap_err();
     assert!(
         matches!(err, AgentNameError::InsecureScheme(_)),
         "got {err:?}"
     );
 }
 
-// NOTE: the mid-chain HTTPS downgrade check (`resolver.rs`, the per-hop scheme
-// test) is NOT covered here. Exercising it needs an entry point over real HTTPS
-// that then redirects to `http://`, and `wiremock` serves plain HTTP only — with
-// a single `allow_insecure_http` flag, a plain-HTTP mock either allows every hop
-// or refuses the first one, so any test written against it would pass for the
-// wrong reason. Covering this properly needs a TLS-capable mock server.
+/// The default resolver refuses a name pointing at a loopback address, which is
+/// what stops an agent name being used to make a *server* fetch its own network.
+#[tokio::test]
+async fn refuses_a_loopback_address_by_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/@alice"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", DID))
+        .mount(&server)
+        .await;
+
+    // Allow plain HTTP so the *address* check is what rejects this, not the scheme.
+    let err = resolve(
+        &HttpRedirectResolver::new().allow_insecure_http(true),
+        &name_for(&server, "alice"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::BlockedAddress { .. }),
+        "got {err:?}"
+    );
+}
+
+// NOTE: the *mid-chain* address check (a public host redirecting inward to a
+// private address) is NOT covered here, for the same reason as the mid-chain
+// HTTPS check below: `wiremock` binds 127.0.0.1, so the entry point is itself a
+// private address. With a single `allow_private_addresses` flag the mock either
+// allows every hop or is blocked at hop 0 — a test written against it passes for
+// the wrong reason. Covering this needs a mock reachable on a public address.
+// The per-hop check itself is exercised by the `is_public` unit tests.
 
 #[tokio::test]
 async fn honours_a_custom_hop_cap_of_one() {


### PR DESCRIPTION
Prerequisite for PR 4 (agent name resolution on the cache server), split out
because it is a distinct concern and independently valuable.

## Why

An agent name is **attacker-supplied** and resolves to an arbitrary URL that
`HttpRedirectResolver` then fetches. Client-side that only affects the caller.
**Server-side — which is where PR 4 is heading — it is an SSRF pivot:** a caller
could make the DID cache server issue requests from inside your network, at
`169.254.169.254`, `10.0.0.0/8`, or anything else it can reach.

The cache server today has **no rate limiting and no host allowlist**, so I did
not want to hand it a name-fetching endpoint without this in place first.

## What

`HttpRedirectResolver` refuses names resolving to non-public addresses:

- loopback, RFC1918 private, link-local (incl. cloud metadata `169.254.169.254`),
  unspecified, multicast, broadcast, documentation
- carrier-grade NAT `100.64.0.0/10`, benchmarking `198.18.0.0/15`,
  IETF `192.0.0.0/24`, reserved `240.0.0.0/4`
- IPv6 loopback/unspecified/multicast, unique-local `fc00::/7`,
  link-local `fe80::/10`
- **IPv4-mapped IPv6** — `::ffff:127.0.0.1` is judged by IPv4 rules, which a
  naive IPv6 check would let straight through

Off by default; `allow_private_addresses(true)` opts out for dev and tests. The
check runs on **every hop**, since a public host can redirect inward.

`Ipv4Addr::is_global` is still unstable, so the ranges are spelled out and
unit-tested.

New `AgentNameError::BlockedAddress { name, address }`.

## :warning: This is not complete SSRF protection

Stated in the rustdoc, README and CHANGELOG rather than glossed over:

> The check resolves the host and inspects the addresses it gets *now*; the
> subsequent request resolves again. A hostile DNS server can answer differently
> for the two lookups (**DNS rebinding**) and reach an internal address anyway.

Closing that requires pinning the checked IP into the connection itself, which
`reqwest` does not expose. This **raises the cost** of SSRF; it does not
eliminate it, and it should not be the only control at an untrusted network
boundary. PR 4 will additionally gate the server endpoint behind a
default-off config flag.

## Verification

- **65 tests** pass (53 unit + 11 integration + 1 doctest).
- New unit coverage for `is_public` across both families, including the
  IPv4-mapped bypass and each special-purpose range.
- New integration test `refuses_a_loopback_address_by_default`.
- `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean,
  `cargo check --workspace --all-targets` clean.
- `cache-sdk` (which embeds this resolver by default) still passes its 17
  `agent_names` integration tests.

### Test gap, named rather than papered over

The **mid-chain** address check (a public host redirecting inward) is not
integration-tested. `wiremock` binds `127.0.0.1`, so the entry point is itself a
private address: with a single flag the mock either allows every hop or is
blocked at hop 0, and a test written against it passes for the wrong reason. I
wrote that test, saw it was passing for the wrong reason, and removed it in
favour of a comment naming the gap — same call as the mid-chain HTTPS check in
#631. The per-hop logic is covered by the `is_public` unit tests.