### PR TITLE
feat: agent name lookup endpoint on the DID cache server

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,54 @@
 
 ## 19th July 2026
 
+### 0.9.5 — agent name lookup endpoint
+
+Adds `GET /did/v1/resolve-name/{*name}`, mapping an agent name
+(`example.com/@alice`) to a DID.
+
+**Off by default.** Set `enable_agent_names = "true"` to enable it.
+
+#### Scope: it returns a DID, not a document
+
+Following the redirect is the network-facing, cacheable half of agent name
+resolution and is worth centralising; turning the resulting DID into a document
+is already served by `/resolve/{did}`.
+
+More importantly it keeps the trust model honest. The mandatory Layer-1 check —
+that the resolved document's `alsoKnownAs` claims the name — must be performed
+by the **client**, against a document the client resolved itself. A server
+answering "here is the name, the DID, and the document, and I promise they
+agree" would be asking to be trusted as an authority. It is a cache, never a
+trust anchor, matching how clients re-verify `did:webvh` logs rather than
+believing the server.
+
+#### Why it is off by default
+
+The name is entirely caller-supplied, so this endpoint makes the server issue an
+HTTP request to a host of the caller's choosing. Mitigations:
+
+- the flag itself, defaulting to off (and to off on a parse failure, so an
+  unreadable config value cannot silently enable a network-facing fetch);
+- the resolver refuses non-public addresses — loopback, private, link-local,
+  cloud metadata — on **every** redirect hop.
+
+Neither is complete: the address check and the request resolve DNS separately,
+so DNS rebinding remains possible. Note also that this server still has **no
+rate limiting**, so an enabled endpoint is an unmetered outbound fetch primitive.
+Enable it only if you accept that.
+
+#### Also
+
+- Statistics gain `agent_name_success` / `agent_name_error`, reported in the
+  periodic log line.
+- Response shape: `200 {"name": "<canonical>", "did": "<did>"}`. The canonical
+  name is echoed so callers can see what normalisation did. Errors are `400`
+  (malformed / oversize), `404` (no backend resolved it), `502` (upstream
+  failure, including a blocked address) and `504` (timeout).
+- The route uses a wildcard capture because an agent name contains slashes,
+  which a single path segment cannot match. `/resolve/{did}` is untouched.
+## 19th July 2026
+
 ### 0.9.4 — didwebvh-rs 0.6
 
 - Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.4"
+version = "0.9.5"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -28,6 +28,7 @@ affinidi-did-common = "0.4"
 affinidi-task-utils = "0.1"
 
 didwebvh-rs = "0.6"
+agent-names = "0.1.2"
 
 # External Crates
 ahash = "0.8"
@@ -54,6 +55,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 affinidi-secrets-resolver = "0.5"
+tower = { version = "0.5", features = ["util"] }
 
 [lints]
 workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
@@ -32,6 +32,15 @@ enable_http_endpoint = "${ENABLE_HTTP_ENDPOINT:true}"
 ### Default: true
 ### If true, the server will make available /resolve endpoint for websocket requests
 ### that will resolve a DID Document from the cache.
+# Agent name (DID shortcut) lookup: GET /did/v1/resolve-name/{*name}
+#
+# OFF BY DEFAULT. Enabling it lets callers make this server issue HTTP requests
+# to hosts of their choosing. The resolver refuses non-public addresses
+# (loopback, private, link-local, cloud metadata) on every redirect hop, but
+# that is not complete SSRF protection: DNS rebinding remains possible, and this
+# server has no rate limiting. Enable only if you accept that.
+enable_agent_names = "${ENABLE_AGENT_NAMES:false}"
+
 enable_websocket_endpoint = "${ENABLE_WEBSOCKET_ENDPOINT:true}"
 
 [cache]

--- a/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
@@ -36,6 +36,10 @@ struct ConfigRaw {
     pub listen_address: String,
     pub enable_http_endpoint: String,
     pub enable_websocket_endpoint: String,
+    /// Agent name (DID shortcut) lookup endpoint. Defaults to **off**: it makes
+    /// the server fetch caller-supplied URLs. See handlers/agent_names.rs.
+    #[serde(default = "default_enable_agent_names")]
+    pub enable_agent_names: String,
     pub statistics_interval: String,
     #[serde(default = "default_resolve_timeout")]
     pub resolve_timeout: String,
@@ -56,11 +60,19 @@ fn default_max_did_size() -> String {
     "1024".into()
 }
 
+/// Agent name lookup defaults to **off**. Enabling it lets callers make this
+/// server issue HTTP requests to hosts of their choosing; see
+/// `handlers/agent_names.rs` for the SSRF considerations.
+fn default_enable_agent_names() -> String {
+    "false".into()
+}
+
 pub struct Config {
     pub log_level: LevelFilter,
     pub listen_address: String,
     pub enable_http_endpoint: bool,
     pub enable_websocket_endpoint: bool,
+    pub enable_agent_names: bool,
     pub statistics_interval: Duration,
     /// Maximum time a single upstream DID resolution may take before the
     /// request path gives up and returns an error instead of blocking.
@@ -78,6 +90,7 @@ impl fmt::Debug for Config {
             .field("log_level", &self.log_level)
             .field("listen_address", &self.listen_address)
             .field("enable_http_endpoint", &self.enable_http_endpoint)
+            .field("enable_agent_names", &self.enable_agent_names)
             .field("enable_websocket_endpoint", &self.enable_websocket_endpoint)
             .field(
                 "statistics_interval",
@@ -101,6 +114,7 @@ impl Default for Config {
             listen_address: "".into(),
             enable_http_endpoint: true,
             enable_websocket_endpoint: true,
+            enable_agent_names: false,
             statistics_interval: Duration::from_secs(60),
             resolve_timeout: Duration::from_secs(30),
             max_did_size: 1024,
@@ -129,6 +143,9 @@ impl TryFrom<ConfigRaw> for Config {
             listen_address: raw.listen_address,
             enable_http_endpoint: raw.enable_http_endpoint.parse().unwrap_or(true),
             enable_websocket_endpoint: raw.enable_websocket_endpoint.parse().unwrap_or(true),
+            // Defaults to false on a parse failure too: an unreadable value must
+            // not silently turn on a network-facing fetch.
+            enable_agent_names: raw.enable_agent_names.parse().unwrap_or(false),
             statistics_interval: Duration::from_secs(raw.statistics_interval.parse().unwrap_or(60)),
             resolve_timeout: Duration::from_secs(raw.resolve_timeout.parse().unwrap_or(30)),
             max_did_size: raw.max_did_size.parse().unwrap_or(1024),

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/agent_name.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/agent_name.rs
@@ -1,0 +1,128 @@
+//! Agent name (DID shortcut) lookup: `GET /did/v1/resolve-name/{*name}`.
+//!
+//! # Scope: this endpoint maps a name to a DID, and stops there
+//!
+//! It deliberately does **not** return a DID Document. Following the redirect is
+//! the expensive, network-facing, cacheable half of agent name resolution and is
+//! worth centralising; turning the resulting DID into a document is already
+//! served by `/resolve/{did}`.
+//!
+//! More importantly it keeps the trust model honest. The mandatory Layer-1 check
+//! — that the resolved document's `alsoKnownAs` claims the name — **must** be
+//! performed by the client against a document the client resolved itself. A
+//! server that returned "here is the name, the DID, and the document, and I
+//! promise they agree" would be asking to be trusted as an authority. It is a
+//! cache, never a trust anchor. This mirrors `verify_network_response`, where the
+//! client independently re-verifies webvh logs rather than believing the server.
+//!
+//! # SSRF
+//!
+//! The name is entirely caller-supplied, so this endpoint makes the server issue
+//! an HTTP request to an arbitrary host. Two mitigations:
+//!
+//! - It is **off by default** (`enable_agent_names` in the config).
+//! - The resolver refuses non-public addresses (loopback, private, link-local,
+//!   cloud metadata) on every redirect hop.
+//!
+//! Neither is complete — see `agent_names::HttpRedirectResolver::allow_private_addresses`
+//! on the residual DNS-rebinding exposure. Enable this only if you accept that
+//! your cache server will fetch caller-chosen URLs.
+
+use agent_names::{AgentName, AgentNameResolver};
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use http::StatusCode;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::SharedData;
+
+/// `GET /did/v1/resolve-name/{*name}`
+///
+/// The wildcard capture is required because an agent name contains slashes
+/// (`example.com/@alice`), which a single `{name}` segment cannot match.
+///
+/// Success is `200 {"name": "<canonical>", "did": "<did>"}`. The canonical name
+/// is echoed so the caller can see exactly what was resolved after
+/// normalisation.
+pub async fn resolve_name_handler(
+    State(state): State<SharedData>,
+    Path(name): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    if name.len() > state.max_did_size {
+        state.stats.lock().await.increment_agent_name_error();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "Agent name exceeds maximum length of {} bytes",
+                    state.max_did_size
+                )
+            })),
+        );
+    }
+
+    let parsed = match AgentName::parse(&name) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            state.stats.lock().await.increment_agent_name_error();
+            debug!("rejecting malformed agent name '{name}': {e}");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let Some(resolver) = state.agent_name_resolver.as_ref() else {
+        // Route is only registered when enabled, so this is unreachable in
+        // practice; answer honestly rather than panicking if it ever is not.
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Agent name resolution is not enabled on this server" })),
+        );
+    };
+
+    let outcome = tokio::time::timeout(state.resolve_timeout, resolver.resolve(&parsed)).await;
+
+    match outcome {
+        Ok(Some(Ok(did))) => {
+            state.stats.lock().await.increment_agent_name_success();
+            debug!("resolved agent name '{parsed}' -> '{did}'");
+            (
+                StatusCode::OK,
+                Json(json!({ "name": parsed.as_str(), "did": did })),
+            )
+        }
+        Ok(Some(Err(e))) => {
+            state.stats.lock().await.increment_agent_name_error();
+            warn!("failed to resolve agent name '{parsed}': {e}");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": e.to_string() })),
+            )
+        }
+        Ok(None) => {
+            state.stats.lock().await.increment_agent_name_error();
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": format!("No resolver could resolve '{parsed}'") })),
+            )
+        }
+        Err(_elapsed) => {
+            state.stats.lock().await.increment_agent_name_error();
+            warn!("timed out resolving agent name '{parsed}'");
+            (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(json!({
+                    "error": format!(
+                        "Timed out after {} seconds resolving agent name",
+                        state.resolve_timeout.as_secs()
+                    )
+                })),
+            )
+        }
+    }
+}

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::time::Duration;
 use tracing::{info, warn};
 
+pub(crate) mod agent_name;
 pub(crate) mod http;
 #[cfg(feature = "network")]
 pub(crate) mod websocket;
@@ -156,6 +157,16 @@ pub fn application_routes(shared_data: &SharedData, config: &Config) -> Router {
     if config.enable_http_endpoint {
         info!("Enabling HTTP Resolver endpoint");
         app = app.route("/resolve/{did}", get(http::resolver_handler));
+    }
+
+    if config.enable_agent_names {
+        // A wildcard capture is required: an agent name contains slashes
+        // (`example.com/@alice`), which a single path segment cannot match.
+        info!("Enabling Agent Name resolution endpoint (server will fetch caller-supplied URLs)");
+        app = app.route(
+            "/resolve-name/{*name}",
+            get(agent_name::resolve_name_handler),
+        );
     }
 
     Router::new()

--- a/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
@@ -31,6 +31,9 @@ pub struct SharedData {
     /// Shared HTTP client for did:webvh log fetches, built once at startup so
     /// connections are pooled instead of a fresh client per request.
     pub webvh_client: reqwest::Client,
+    /// Present only when `enable_agent_names` is set. `None` means the feature
+    /// is off and the route is not registered.
+    pub agent_name_resolver: Option<Arc<agent_names::HttpRedirectResolver>>,
 }
 
 impl<S> FromRequestParts<S> for SharedData

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -101,6 +101,16 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
             DIDCacheError::ConfigError(format!("Failed to build WebVH HTTP client: {e}"))
         })?;
 
+    // Agent name resolution is off unless explicitly enabled: it makes this
+    // server issue HTTP requests to caller-supplied hosts. The resolver keeps
+    // its default hardening (HTTPS only, non-public addresses refused on every
+    // redirect hop).
+    let agent_name_resolver = if config.enable_agent_names {
+        Some(Arc::new(agent_names::HttpRedirectResolver::new()))
+    } else {
+        None
+    };
+
     // Create the shared application State
     let shared_state = SharedData {
         service_start_timestamp: chrono::Utc::now(),
@@ -109,6 +119,7 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
         resolve_timeout: config.resolve_timeout,
         max_did_size: config.max_did_size,
         webvh_client,
+        agent_name_resolver,
     };
 
     // Supervise the statistics task through the shared TaskSupervisor: a

--- a/crates/identity/affinidi-did-resolver-cache-server/src/statistics.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/statistics.rs
@@ -32,6 +32,8 @@ pub struct Statistics {
     resolver_error: u64,
     cache_hit: u64,
     method: HashMap<DIDMethod, u64>,
+    agent_name_success: u64,
+    agent_name_error: u64,
 }
 
 impl Display for Statistics {
@@ -54,6 +56,7 @@ impl Display for Statistics {
     Connections: ws_open({}) ws_close({}) ws_current({})
     Resolver: total({}) success({}) error({})
     Methods (METHOD: COUNT): {}
+    Agent Names: success({}) error({})
             "#,
             self.cache_size,
             self.cache_hit,
@@ -68,7 +71,9 @@ impl Display for Statistics {
                 .iter()
                 .map(|(k, v)| format!("({k}: {v})"))
                 .collect::<Vec<String>>()
-                .join(", ")
+                .join(", "),
+            self.agent_name_success,
+            self.agent_name_error
         )
     }
 }
@@ -87,7 +92,19 @@ impl Statistics {
                 .iter()
                 .map(|(k, v)| (k.clone(), v - previous.method.get(k).unwrap_or(&(0))))
                 .collect(),
+            agent_name_success: self.agent_name_success - previous.agent_name_success,
+            agent_name_error: self.agent_name_error - previous.agent_name_error,
         }
+    }
+
+    /// Increments the number of successful agent name lookups
+    pub fn increment_agent_name_success(&mut self) {
+        self.agent_name_success += 1;
+    }
+
+    /// Increments the number of failed agent name lookups
+    pub fn increment_agent_name_error(&mut self) {
+        self.agent_name_error += 1;
     }
 
     /// Increments the number of opened websocket connections

--- a/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
@@ -1,0 +1,129 @@
+//! `GET /did/v1/resolve-name/{*name}` — the agent name lookup endpoint.
+//!
+//! Exercises the router directly rather than binding a port, so these run
+//! without the fixed-8080 assumption the main integration test makes.
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_did_resolver_cache_server::{
+    SharedData, config::Config, handlers::application_routes, statistics::Statistics,
+};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+/// A router with agent name resolution either on or off.
+async fn app(enable_agent_names: bool) -> axum::Router {
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .unwrap();
+
+    let config = Config {
+        enable_agent_names,
+        ..Default::default()
+    };
+
+    let state = SharedData {
+        service_start_timestamp: chrono::Utc::now(),
+        stats: Arc::new(Mutex::new(Statistics::default())),
+        resolver,
+        resolve_timeout: Duration::from_secs(5),
+        max_did_size: 1024,
+        webvh_client: reqwest::Client::new(),
+        agent_name_resolver: if enable_agent_names {
+            Some(Arc::new(agent_names::HttpRedirectResolver::new()))
+        } else {
+            None
+        },
+    };
+
+    application_routes(&state, &config)
+}
+
+async fn get(app: axum::Router, uri: &str) -> (StatusCode, String) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, String::from_utf8_lossy(&bytes).to_string())
+}
+
+/// The endpoint must not exist unless explicitly switched on — it makes the
+/// server fetch caller-supplied URLs.
+#[tokio::test]
+async fn route_is_absent_when_disabled() {
+    let (status, _) = get(app(false).await, "/did/v1/resolve-name/example.com/@alice").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn route_exists_when_enabled() {
+    let (status, _) = get(app(true).await, "/did/v1/resolve-name/example.com/@alice").await;
+    assert_ne!(
+        status,
+        StatusCode::NOT_FOUND,
+        "route should be registered when enabled"
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_malformed_agent_name() {
+    // Reaches the route (contains '/@') but has an empty local name.
+    let (status, body) = get(app(true).await, "/did/v1/resolve-name/example.com/@").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("error"), "got {body}");
+}
+
+#[tokio::test]
+async fn rejects_a_name_without_the_marker() {
+    let (status, body) = get(app(true).await, "/did/v1/resolve-name/example.com/alice").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("error"), "got {body}");
+}
+
+/// A name pointing at a loopback address must be refused rather than fetched —
+/// this is the SSRF guard, exercised through the real endpoint.
+#[tokio::test]
+async fn refuses_a_name_resolving_to_a_private_address() {
+    let (status, body) = get(app(true).await, "/did/v1/resolve-name/127.0.0.1/@alice").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_GATEWAY,
+        "a private-address name should fail upstream, got body {body}"
+    );
+    assert!(
+        body.contains("non-public") || body.contains("127.0.0.1"),
+        "expected a blocked-address error, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn path_qualified_names_reach_the_handler() {
+    let (status, _) = get(
+        app(true).await,
+        "/did/v1/resolve-name/127.0.0.1/@alice/h2hsummit",
+    )
+    .await;
+    // Blocked upstream rather than 404, proving the wildcard captured all the
+    // segments instead of failing to match the route.
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+}
+
+/// The DID endpoint must be unaffected by the new route.
+#[tokio::test]
+async fn did_resolution_still_works() {
+    let (status, body) = get(
+        app(true).await,
+        "/did/v1/resolve/did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("did:key:"), "got {body}");
+}

--- a/crates/identity/shortcuts/agent-names/CHANGELOG.md
+++ b/crates/identity/shortcuts/agent-names/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `agent-names` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-07-19
+
+### Added
+
+- `CacheServerResolver` — an `AgentNameResolver` backend that asks an
+  `affinidi-did-resolver-cache-server` to map a name to a DID, instead of
+  following the redirect locally. Centralising the fetch means it happens once
+  for many clients, and the SSRF exposure of fetching caller-supplied URLs sits
+  on one hardened host rather than on every client.
+
+  It returns **only a DID**. The mandatory Layer-1 `alsoKnownAs` check is still
+  performed by the client against a document the client resolved itself — the
+  server is a cache, never a trust anchor. This mirrors how the SDK re-verifies
+  `did:webvh` logs locally rather than believing the server's document.
+
+- `AgentNameError::CacheServer { name, status, message }`.
+
+### Fixed
+
+- The cache-server backend now reads the response body as text and parses it
+  deliberately, rather than deserializing before checking the status. A server
+  without the endpoint (an older build, or `enable_agent_names = false`) answers
+  404, and an intermediary may answer with HTML; parsing first turned all of
+  those into an opaque deserialization error instead of surfacing the status.
+
 ## [0.1.1] - 2026-07-19
 
 ### Security

--- a/crates/identity/shortcuts/agent-names/Cargo.toml
+++ b/crates/identity/shortcuts/agent-names/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-names"
-version = "0.1.1"
+version = "0.1.2"
 description = "Agent Name (DID shortcut) parsing, resolution and verification for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -21,7 +21,9 @@ reqwest = { version = "0.13", default-features = false, features = [
   "rustls",
   "charset",
   "http2",
+  "json",
 ] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["net"] }
 tracing = "0.1"

--- a/crates/identity/shortcuts/agent-names/src/cache_server.rs
+++ b/crates/identity/shortcuts/agent-names/src/cache_server.rs
@@ -1,0 +1,195 @@
+//! Resolve agent names through a shared DID cache server.
+
+use std::{future::Future, pin::Pin, time::Duration};
+
+use tracing::debug;
+use url::Url;
+
+use crate::{
+    error::AgentNameError,
+    name::AgentName,
+    resolver::{AgentNameResolver, DEFAULT_TIMEOUT, NameResolution},
+};
+
+/// Asks an `affinidi-did-resolver-cache-server` to map a name to a DID.
+///
+/// # Why point at a server at all
+///
+/// Following an agent name's redirect is the network-facing, cacheable half of
+/// resolution. Centralising it on a cache server means the fetch is done once
+/// for many clients, and — more usefully — that the SSRF exposure of fetching
+/// caller-supplied URLs lives on one hardened host you control rather than on
+/// every client.
+///
+/// # The server is a cache, never a trust anchor
+///
+/// This backend returns **only a DID**. The mandatory Layer-1 check — that the
+/// resolved document's `alsoKnownAs` claims the name — is still performed by the
+/// client, against a document the client resolved itself. A server that answered
+/// "here is the name, the DID, and the document, and I promise they agree" would
+/// be asking to be trusted; nothing here does.
+///
+/// This mirrors how the SDK re-verifies `did:webvh` logs locally rather than
+/// believing the cache server's document.
+#[derive(Debug, Clone)]
+pub struct CacheServerResolver {
+    client: reqwest::Client,
+    base_url: Url,
+}
+
+impl CacheServerResolver {
+    /// Point at a cache server's base URL, e.g. `https://resolver.example`.
+    ///
+    /// The `/did/v1/resolve-name/` path is appended, so pass the host root, not
+    /// the endpoint itself.
+    pub fn new(base_url: &str) -> Result<Self, AgentNameError> {
+        let client = reqwest::Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .map_err(AgentNameError::Http)?;
+        Self::with_client(client, base_url)
+    }
+
+    /// Use a caller-supplied client.
+    pub fn with_client(client: reqwest::Client, base_url: &str) -> Result<Self, AgentNameError> {
+        let base_url = Url::parse(base_url).map_err(|e| AgentNameError::InvalidName {
+            input: base_url.to_string(),
+            reason: format!("not a URL: {e}"),
+        })?;
+        Ok(Self { client, base_url })
+    }
+
+    /// Override the request timeout by supplying a preconfigured client.
+    pub fn with_timeout(timeout: Duration, base_url: &str) -> Result<Self, AgentNameError> {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(AgentNameError::Http)?;
+        Self::with_client(client, base_url)
+    }
+
+    fn endpoint(&self, name: &AgentName) -> Result<Url, AgentNameError> {
+        // The server route is `/did/v1/resolve-name/{*name}`, and the name is
+        // sent scheme-less (`example.com/@alice`) because the wildcard captures
+        // path segments. `Url::join` would treat a leading `//` as an authority,
+        // so build the path by hand and let `Url` percent-encode it.
+        let path = format!("did/v1/resolve-name/{}", name.without_scheme());
+        self.base_url
+            .join(&path)
+            .map_err(|e| AgentNameError::InvalidName {
+                input: path,
+                reason: format!("could not build request URL: {e}"),
+            })
+    }
+
+    async fn resolve_inner(&self, name: &AgentName) -> Result<String, AgentNameError> {
+        let url = self.endpoint(name)?;
+        debug!(%url, "resolving agent name via cache server");
+
+        let response = self.client.get(url).send().await?;
+        let status = response.status();
+
+        // Read as text and parse deliberately. A server that does not have this
+        // endpoint — an older build, or one with `enable_agent_names = false` —
+        // answers 404, and an intermediary may answer with HTML rather than
+        // JSON. Parsing first would turn all of those into an opaque
+        // deserialization error instead of the status the caller needs to see.
+        let body = response.text().await?;
+        let json: Option<serde_json::Value> = serde_json::from_str(&body).ok();
+
+        if !status.is_success() {
+            let message = json
+                .as_ref()
+                .and_then(|b| b.get("error"))
+                .and_then(|e| e.as_str())
+                .unwrap_or("cache server returned an error")
+                .to_string();
+            return Err(AgentNameError::CacheServer {
+                name: name.as_str().to_string(),
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let did = json
+            .as_ref()
+            .and_then(|b| b.get("did"))
+            .and_then(|d| d.as_str())
+            .ok_or_else(|| AgentNameError::CacheServer {
+                name: name.as_str().to_string(),
+                status: status.as_u16(),
+                message: "response contained no 'did' field".to_string(),
+            })?;
+
+        Ok(did.to_string())
+    }
+}
+
+impl AgentNameResolver for CacheServerResolver {
+    fn name(&self) -> &str {
+        "cache-server"
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        name: &'a AgentName,
+    ) -> Pin<Box<dyn Future<Output = NameResolution> + Send + 'a>> {
+        Box::pin(async move { Some(self.resolve_inner(name).await) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn name(s: &str) -> AgentName {
+        AgentName::parse(s).unwrap()
+    }
+
+    #[test]
+    fn builds_the_endpoint_url() {
+        let r = CacheServerResolver::new("https://resolver.example").unwrap();
+        assert_eq!(
+            r.endpoint(&name("example.com/@alice")).unwrap().as_str(),
+            "https://resolver.example/did/v1/resolve-name/example.com/@alice"
+        );
+    }
+
+    #[test]
+    fn builds_the_endpoint_url_for_a_path_qualified_name() {
+        let r = CacheServerResolver::new("https://resolver.example").unwrap();
+        assert_eq!(
+            r.endpoint(&name("firstperson.network/@drummond/h2hsummit"))
+                .unwrap()
+                .as_str(),
+            "https://resolver.example/did/v1/resolve-name/firstperson.network/@drummond/h2hsummit"
+        );
+    }
+
+    /// A base URL with a trailing path must not silently drop it.
+    #[test]
+    fn respects_a_base_url_with_a_trailing_slash() {
+        let r = CacheServerResolver::new("https://resolver.example/").unwrap();
+        assert!(
+            r.endpoint(&name("example.com/@alice"))
+                .unwrap()
+                .as_str()
+                .starts_with("https://resolver.example/did/v1/resolve-name/")
+        );
+    }
+
+    #[test]
+    fn rejects_a_malformed_base_url() {
+        assert!(CacheServerResolver::new("not a url").is_err());
+    }
+
+    #[test]
+    fn reports_its_name() {
+        assert_eq!(
+            CacheServerResolver::new("https://resolver.example")
+                .unwrap()
+                .name(),
+            "cache-server"
+        );
+    }
+}

--- a/crates/identity/shortcuts/agent-names/src/error.rs
+++ b/crates/identity/shortcuts/agent-names/src/error.rs
@@ -56,6 +56,14 @@ pub enum AgentNameError {
     )]
     BlockedAddress { name: String, address: String },
 
+    /// A cache server rejected or could not answer the lookup.
+    #[error("Cache server returned HTTP {status} resolving '{name}': {message}")]
+    CacheServer {
+        name: String,
+        status: u16,
+        message: String,
+    },
+
     /// No registered backend could resolve the name.
     #[error("No agent name resolver could resolve '{0}'")]
     Unresolvable(String),

--- a/crates/identity/shortcuts/agent-names/src/lib.rs
+++ b/crates/identity/shortcuts/agent-names/src/lib.rs
@@ -66,11 +66,13 @@
  * resolution cache. This crate is the standalone, dependency-light half.
  */
 
+pub mod cache_server;
 pub mod error;
 pub mod name;
 pub mod resolver;
 pub mod verify;
 
+pub use cache_server::CacheServerResolver;
 pub use error::AgentNameError;
 pub use name::{AGENT_NAME_MARKER, AgentName};
 pub use resolver::{

--- a/crates/identity/shortcuts/agent-names/tests/cache_server.rs
+++ b/crates/identity/shortcuts/agent-names/tests/cache_server.rs
@@ -1,0 +1,111 @@
+//! `CacheServerResolver` against a mock cache server.
+
+use agent_names::{AgentName, AgentNameError, AgentNameResolver, CacheServerResolver};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+const DID: &str = "did:webvh:QmScid:example.com";
+const ROUTE: &str = "/did/v1/resolve-name/example.com/@alice";
+
+async fn resolve(server: &MockServer, name: &str) -> Result<String, AgentNameError> {
+    let resolver = CacheServerResolver::new(&server.uri()).unwrap();
+    resolver
+        .resolve(&AgentName::parse(name).unwrap())
+        .await
+        .expect("the cache-server backend always claims the name")
+}
+
+#[tokio::test]
+async fn resolves_a_name_via_the_cache_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ROUTE))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "https://example.com/@alice",
+            "did": DID,
+        })))
+        .mount(&server)
+        .await;
+
+    assert_eq!(resolve(&server, "example.com/@alice").await.unwrap(), DID);
+}
+
+/// The client sends the name scheme-less, so all spellings hit one route.
+#[tokio::test]
+async fn canonicalises_the_name_before_requesting() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ROUTE))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "did": DID })))
+        .mount(&server)
+        .await;
+
+    for spelling in [
+        "example.com/@alice",
+        "https://example.com/@alice",
+        "https://EXAMPLE.com/@alice",
+        "https://example.com:443/@alice",
+        "https://example.com/@alice/",
+    ] {
+        assert_eq!(
+            resolve(&server, spelling).await.unwrap(),
+            DID,
+            "spelling {spelling} should reach the same route"
+        );
+    }
+}
+
+#[tokio::test]
+async fn surfaces_a_server_error_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ROUTE))
+        .respond_with(
+            ResponseTemplate::new(502)
+                .set_body_json(serde_json::json!({ "error": "upstream refused the redirect" })),
+        )
+        .mount(&server)
+        .await;
+
+    let err = resolve(&server, "example.com/@alice").await.unwrap_err();
+    match err {
+        AgentNameError::CacheServer {
+            status, message, ..
+        } => {
+            assert_eq!(status, 502);
+            assert!(message.contains("upstream refused"), "got {message}");
+        }
+        other => panic!("expected a CacheServer error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_a_success_response_with_no_did() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ROUTE))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "name": "whatever" })),
+        )
+        .mount(&server)
+        .await;
+
+    let err = resolve(&server, "example.com/@alice").await.unwrap_err();
+    assert!(
+        matches!(err, AgentNameError::CacheServer { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn reports_a_404_from_a_server_without_the_endpoint() {
+    // An older cache server, or one with `enable_agent_names = false`.
+    let server = MockServer::start().await;
+    let err = resolve(&server, "example.com/@alice").await.unwrap_err();
+    match err {
+        AgentNameError::CacheServer { status, .. } => assert_eq!(status, 404),
+        other => panic!("expected a CacheServer error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
PR 4b, the last of the agent-names series.
**Stacked on [#633](https://github.com/affinidi/affinidi-tdk-rs/pull/633)** (SSRF
hardening) — based on that branch, so merge #633 first. The diff shown here is
just this change.

## What

- **Server**: `GET /did/v1/resolve-name/{*name}` maps an agent name
  (`example.com/@alice`) to a DID.
- **Client**: `CacheServerResolver`, an `AgentNameResolver` backend that uses it.

Register it like any other backend:

```rust
client.set_agent_name_resolvers(vec![
    Box::new(CacheServerResolver::new("https://resolver.example")?),
]);
```

## It returns a DID, not a document — deliberately

Following the redirect is the network-facing, cacheable half of resolution and is
worth centralising. Turning the DID into a document is already served by
`/resolve/{did}`.

More importantly it keeps the trust model honest. The mandatory Layer-1 check —
that the resolved document's `alsoKnownAs` claims the name — **must** be performed
by the *client*, against a document the client resolved itself. A server answering
*"here is the name, the DID, and the document, and I promise they agree"* would be
asking to be trusted as an authority. It is a cache, never a trust anchor — the
same stance as clients re-verifying `did:webvh` logs rather than believing the
server's document.

## :warning: Off by default, and here is what you are accepting if you enable it

The name is **entirely caller-supplied**, so this endpoint makes the server issue
an HTTP request to a host of the caller's choosing.

- `enable_agent_names` defaults to `false`, and parses to `false` on a config
  parse failure too — an unreadable value must not silently enable a
  network-facing fetch.
- The resolver refuses non-public addresses (loopback, private, link-local, cloud
  metadata) on every redirect hop — #633.

**Neither is complete.** DNS rebinding remains possible (#633 explains why), and
this server still has **no rate limiting** of any kind, so an enabled endpoint is
an unmetered outbound fetch primitive. That is documented in the config file and
the CHANGELOG rather than left for someone to discover.

## No wire-protocol change

`/resolve/{did}` and the entire WebSocket surface are untouched. The new route
uses a wildcard capture because an agent name contains slashes, which a single
path segment cannot match.

**WebSocket support is deliberately deferred.** Response correlation there is by a
hash the server echoes back, matched against `hash_did(&request.did)` inserted
client-side; making that correct for a non-DID identifier — and keeping old
servers, which *drop the connection* on an unparseable request, working — deserves
its own change rather than riding along here.

## Response shape

`200 {"name": "<canonical>", "did": "<did>"}` — the canonical name is echoed so
callers can see what normalisation did. Errors: `400` malformed/oversize, `404` no
backend resolved it, `502` upstream failure (including a blocked address), `504`
timeout.

## Verification

- **agent-names: 75 tests** (58 unit + 16 integration + 1 doctest).
- **cache-server: 7 new endpoint tests**, driving the real router via `oneshot`
  rather than binding a port: route absent when disabled, present when enabled,
  malformed name, missing `/@` marker, **private-address refusal through the live
  endpoint**, path-qualified names reaching the handler (proving the wildcard
  captures every segment), and `/resolve/{did}` still working.
- `clippy --all-targets -D warnings` clean on both crates;
  `--no-default-features` clean; `cargo fmt --check` clean;
  `cargo check --workspace --all-targets` clean.

### Bug the tests caught

The client parsed the response body as JSON *before* checking the status, so a 404
from a server without the endpoint (an older build, or `enable_agent_names =
false`) surfaced as an opaque deserialization error instead of the status. The
body is now read as text and parsed deliberately. Found by
`reports_a_404_from_a_server_without_the_endpoint`; fixed in the code rather than
the test.

### Pre-existing failure, unchanged

`integration_test::test_cache_server` fails with `NetworkTimeout` — it binds a
fixed port 8080 and resolves DIDs over the real network. Reproduces identically on
unmodified `main`.