### PR TITLE
ci: guard against workspace members shadowed by crates.io copies

### DIFF
--- a/.github/workflows/release-guards.yaml
+++ b/.github/workflows/release-guards.yaml
@@ -10,7 +10,15 @@ name: release-guards
 #      edited-but-unbumped crate left stale source on crates.io that broke the
 #      registry-resolved publish verify build downstream.
 #
-#   3. test-clock      — the mediator-common `test-clock` feature (the
+#   3. workspace-dups  — no workspace member may ALSO be resolved from crates.io.
+#      A member depended on *by version* is only redirected to local source by a
+#      `[patch.crates-io]` entry; miss it and cargo silently builds the published
+#      copy alongside the local one, so local edits do nothing and two copies of
+#      the same types produce errors that point anywhere but at the cause. Bit us
+#      via `did-example` (#629) and `affinidi-messaging-core` (#630, long
+#      misdiagnosed as an unfixable vta-sdk failure).
+#
+#   4. test-clock      — the mediator-common `test-clock` feature (the
 #      advanceable TestClock, TI4b) must never be enabled for the mediator
 #      binary. Keeps the test-only clock out of production builds.
 #
@@ -42,6 +50,9 @@ jobs:
 
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
+
+      - name: Workspace duplicate guard (patch.crates-io coverage)
+        run: bash scripts/check-workspace-duplicates.sh
 
       - name: Test-clock isolation guard (mediator binary)
         run: bash scripts/check-test-clock-isolation.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,12 @@ did-scid = { path = "crates/identity/did-methods/did-scid" }
 did-example = { path = "crates/identity/did-methods/did-example" }
 affinidi-messaging-core = { path = "crates/messaging/affinidi-messaging-core" }
 agent-names = { path = "crates/identity/shortcuts/agent-names" }
+affinidi-vc = { path = "crates/credentials/affinidi-vc" }
+affinidi-sd-jwt = { path = "crates/credentials/affinidi-sd-jwt" }
+affinidi-oid4vc-core = { path = "crates/protocols/affinidi-oid4vc-core" }
+affinidi-openid4vci = { path = "crates/protocols/affinidi-openid4vci" }
+affinidi-openid4vp = { path = "crates/protocols/affinidi-openid4vp" }
+affinidi-messaging-delivery = { path = "crates/messaging/affinidi-messaging-delivery" }
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"

--- a/scripts/check-workspace-duplicates.sh
+++ b/scripts/check-workspace-duplicates.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Fail if a workspace member is ALSO resolved from crates.io.
+#
+# WHY THIS EXISTS
+#
+# A workspace member that another crate depends on *by version* (rather than by
+# path) is only redirected to local source if it is listed in the root
+# `[patch.crates-io]`. Miss the entry and cargo silently resolves the published
+# copy **alongside** the local one. Two things then go wrong, both quietly:
+#
+#   1. Local changes to that crate do not take effect in workspace builds. You
+#      edit source, rebuild, and nothing happens.
+#   2. Two copies of the same types exist, so a value produced by one cannot be
+#      passed to the other:
+#
+#        error[E0308]: expected `affinidi_did_common::Document`,
+#                      found a different `affinidi_did_common::Document`
+#
+#      or, more confusingly, an unsatisfied trait bound naming a type that
+#      obviously does implement the trait — because the trait came from the
+#      other copy.
+#
+# External consumers make this worse: a crates.io crate that depends on our
+# crates (e.g. `vta-sdk`) drags the registry copies in even when every internal
+# reference uses a path.
+#
+# This has bitten repeatedly, and the symptom never points at the cause:
+#   * `did-example`                (PR #629)
+#   * `affinidi-messaging-core`    (PR #630) — spent a long time written off as
+#                                   an unrelated, unfixable `vta-sdk` failure
+#   * `affinidi-vc`, `affinidi-sd-jwt`, `affinidi-oid4vc-core`,
+#     `affinidi-openid4vci`, `affinidi-openid4vp`,
+#     `affinidi-messaging-delivery` (all found by this script's first run)
+#
+# WHAT IT CHECKS
+#
+# The *symptom*, not the cause: any package whose name is a workspace member and
+# which also appears in the resolved graph with a registry source. That catches
+# both a missing `[patch.crates-io]` entry and a patch entry whose version no
+# longer satisfies an external consumer's requirement — the two ways a redirect
+# falls through — with no false positives from members nothing depends on.
+#
+# ALLOWLIST
+#
+# `scripts/workspace-duplicates-allow.txt` lists duplicates that are known and
+# cannot be fixed from this repository, one crate name per line. Keep it short
+# and keep the reason in the file; an entry is a debt marker, not a resolution.
+
+set -euo pipefail
+
+ALLOW_FILE="$(dirname "$0")/workspace-duplicates-allow.txt"
+
+echo "=== Workspace duplicate guard ==="
+echo
+
+allowed=""
+if [[ -f "$ALLOW_FILE" ]]; then
+    allowed="$(grep -vE '^\s*(#|$)' "$ALLOW_FILE" || true)"
+fi
+
+# cargo metadata resolves the full graph; a workspace member has a null source,
+# so a non-null source for a member's name means a second, registry-sourced copy.
+# NOTE: `python3 -c` (not `python3 -`), so stdin stays free for the pipe.
+read -r -d '' EXTRACT <<'PY' || true
+import json, sys
+
+meta = json.load(sys.stdin)
+members = {p["name"] for p in meta["packages"] if p["id"] in meta["workspace_members"]}
+for pkg in sorted(meta["packages"], key=lambda p: (p["name"], p["version"])):
+    if pkg["name"] in members and pkg.get("source"):
+        print(pkg["name"], pkg["version"], sep="\t")
+PY
+
+duplicates="$(cargo metadata --format-version 1 | python3 -c "$EXTRACT")"
+
+status=0
+unexpected=""
+
+while IFS=$'\t' read -r name version; do
+    [[ -z "$name" ]] && continue
+    if grep -qxF "$name" <<<"$allowed" 2>/dev/null; then
+        echo "  allow  $name $version (known, see $(basename "$ALLOW_FILE"))"
+    else
+        echo "  DUP    $name $version is resolved from crates.io as well as locally"
+        unexpected="${unexpected}${name}"$'\n'
+        status=1
+    fi
+done <<<"$duplicates"
+
+if [[ -z "$duplicates" ]]; then
+    echo "  ok     no workspace member is shadowed by a crates.io copy"
+fi
+
+echo
+if [[ $status -ne 0 ]]; then
+    cat <<EOF
+Some workspace members are ALSO being pulled from crates.io.
+
+Local edits to these crates will not take effect in workspace builds, and having
+two copies of their types in the graph produces mismatched-type or unsatisfied-
+trait errors that point anywhere but here.
+
+Fix: add each to '[patch.crates-io]' in the root Cargo.toml, e.g.
+
+  <crate-name> = { path = "crates/<group>/<crate-name>" }
+
+Then confirm with:
+
+  cargo tree --workspace -i "registry+https://github.com/rust-lang/crates.io-index#<crate>@<version>"
+
+If a duplicate genuinely cannot be resolved from this repository — an external
+consumer pinning an incompatible version range, say — add it to
+$ALLOW_FILE with a note explaining why and what would clear it.
+EOF
+else
+    echo "All workspace members resolve to local source."
+fi
+
+exit $status

--- a/scripts/workspace-duplicates-allow.txt
+++ b/scripts/workspace-duplicates-allow.txt
@@ -1,0 +1,24 @@
+# Workspace members knowingly shadowed by a crates.io copy.
+#
+# One crate name per line. Every entry is a debt marker, not a resolution:
+# it means local edits to that crate are NOT what the workspace builds against
+# in the affected subtree, and two copies of its types exist in the graph.
+#
+# Only add an entry when the duplicate cannot be fixed from this repository.
+# A missing `[patch.crates-io]` entry is fixable here and does not belong.
+#
+# ---------------------------------------------------------------------------
+#
+# affinidi-did-common
+#   Pulled in at 0.3.9 by `vta-sdk` -> `didwebvh-rs 0.5.x`, which still requires
+#   affinidi-did-common "0.3"; our local copy is 0.4.x, so the patch redirect
+#   does not satisfy that range and cargo falls back to the registry.
+#
+#   Harmless today only by luck of interface shape: no `Document` crosses the
+#   didwebvh-rs boundary (`WebvhResolver` builds its own via
+#   `serde_json::from_value`). The moment any didwebvh-rs API returns a
+#   `Document`, this becomes a hard E0308.
+#
+#   Clears when `vta-sdk` moves to `didwebvh-rs 0.6` (which requires
+#   affinidi-did-common "0.4"). That is a change in the OpenVTC repository.
+affinidi-did-common


### PR DESCRIPTION
Gap #1 from the agent-names retrospective. This is the bug that cost the most
time in that series, twice, and never once pointed at itself.

## The failure mode

A workspace member that another crate depends on **by version** is only
redirected to local source by a `[patch.crates-io]` entry. Miss it and cargo
silently resolves the published copy **alongside** the local one. Two things then
go wrong, both quietly:

1. **Local edits to that crate stop taking effect** in workspace builds. You edit
   source, rebuild, nothing happens.
2. **Two copies of its types exist**, so a value from one cannot be passed to the
   other.

The resulting errors never point at the cause:

```
error[E0308]: expected `affinidi_did_common::Document`,
              found a different `affinidi_did_common::Document`
```

or worse, an unsatisfied trait bound on a type that obviously *does* implement
the trait — because the trait came from the other copy. That second form is what
the `vta-sdk` / `MessageTransport` failure looked like, and it was written off as
an unrelated external problem for a long time before turning out to be a
**one-line** fix here.

External consumers make it worse: a crates.io crate depending on ours (`vta-sdk`)
drags the registry copies in even when every internal reference uses a path.

Prior art: `did-example` (#629), `affinidi-messaging-core` (#630).

## What the guard checks

The **symptom**, not the cause: any package whose name is a workspace member and
which also appears in the resolved graph with a registry source.

That catches both ways a redirect falls through — a missing patch entry, *and* a
patch whose version no longer satisfies an external consumer's range — with no
false positives from members that nothing happens to depend on. Cheap: pure
`cargo metadata`, no build. Runs in `release-guards.yaml` alongside the existing
toolchain / version-bump / test-clock guards.

**Verified it fails, not just that it passes.** Removing the `affinidi-vc` patch
entry produces `DUP affinidi-vc 0.2.1 …` and exit 1.

## Its first run found six more instances

All via `vta-sdk`, all fixed here:

| Crate | |
|---|---|
| `affinidi-vc` | 0.2.1 |
| `affinidi-sd-jwt` | 0.1.4 |
| `affinidi-oid4vc-core` | 0.1.5 |
| `affinidi-openid4vci` | 0.2.1 |
| `affinidi-openid4vp` | 0.1.3 |
| `affinidi-messaging-delivery` | 0.1.11 |

Which means the workspace has been building the **published** copies of those six
rather than local source. Worth knowing if anyone has been puzzled by an edit to
the OID4VC or credentials crates not taking effect.

**Local and published versions match exactly for all six**, so this changes no
behaviour: **151 test suites pass**, and the only failure is the pre-existing
network-dependent `test_cache_server`, which fails identically on `main`.

## One duplicate is allowlisted, not hidden

`affinidi-did-common 0.3.9`, via `vta-sdk` → `didwebvh-rs 0.5.x` which still
requires `"0.3"` while our local copy is 0.4.x — so the patch cannot satisfy that
range. It is harmless *today* only by luck of interface shape (no `Document`
crosses the didwebvh-rs boundary; `WebvhResolver` builds its own via
`serde_json::from_value`). The moment any didwebvh-rs API returns a `Document` it
becomes a hard E0308.

It clears when `vta-sdk` moves to `didwebvh-rs 0.6`, which is a change in the
OpenVTC repository. `scripts/workspace-duplicates-allow.txt` records why and what
would clear it, and says plainly that an entry is a debt marker rather than a
resolution.

## Related, not fixed here

The trace also confirms **`vta-sdk` resolves at two versions simultaneously**
(0.18.x via `mediator-setup`, 0.19.x via `mediator`). That is pre-existing and
separate; noting it because this PR's output makes it visible.