### PR TITLE
fix: bound the agent name endpoint's outbound fetches

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Changelog history
 
+## 20th July 2026
+
+### 0.9.6 — bound the agent name endpoint's outbound fetches
+
+Adds `agent_name_concurrency` (default **16**): a ceiling on how many agent name
+lookups may be fetching upstream at once.
+
+Agent name resolution turns one cheap inbound request into one outbound HTTP
+request to a host the *caller* chose. Without a ceiling that is an amplification
+primitive — a shared cache server can be driven to fan out arbitrary traffic at
+third parties, or used to scan them, at a cost to the attacker of one request
+each.
+
+The cap bounds that fan-out **however many source addresses the load arrives
+from**, which is the property per-IP rate limiting cannot give you. Requests over
+the ceiling are shed with `503` rather than queued: queueing would convert a
+fetch ceiling into an unbounded backlog of pending outbound requests, which is
+the thing being defended against.
+
+A zero or unparseable value falls back to the default rather than meaning "no
+limit", so a config typo cannot silently remove the ceiling.
+
+Note this is **not** general rate limiting — the server still has none, and that
+remains worth adding. This bounds the *outbound* amplification specifically,
+which is the harm this endpoint can do to third parties rather than to itself.
 ## 19th July 2026
 
 ### 0.9.5 — agent name lookup endpoint

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.5"
+version = "0.9.6"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
@@ -41,6 +41,17 @@ enable_http_endpoint = "${ENABLE_HTTP_ENDPOINT:true}"
 # server has no rate limiting. Enable only if you accept that.
 enable_agent_names = "${ENABLE_AGENT_NAMES:false}"
 
+# Ceiling on agent name lookups fetching upstream at once.
+#
+# Agent name resolution turns one cheap inbound request into one outbound
+# request to a host the CALLER chose. Without a ceiling that is an amplification
+# primitive: this server can be driven to fan out traffic at third parties, or
+# to scan them, at a cost of one request each. The cap bounds that fan-out
+# however many source addresses the load arrives from. Requests over it are shed
+# with 503 rather than queued, so a saturated server does not accumulate an
+# unbounded backlog of pending fetches.
+agent_name_concurrency = "${AGENT_NAME_CONCURRENCY:16}"
+
 enable_websocket_endpoint = "${ENABLE_WEBSOCKET_ENDPOINT:true}"
 
 [cache]

--- a/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
@@ -40,6 +40,10 @@ struct ConfigRaw {
     /// the server fetch caller-supplied URLs. See handlers/agent_names.rs.
     #[serde(default = "default_enable_agent_names")]
     pub enable_agent_names: String,
+    /// Ceiling on agent name lookups fetching upstream at once. See
+    /// `default_agent_name_concurrency`.
+    #[serde(default = "default_agent_name_concurrency")]
+    pub agent_name_concurrency: String,
     pub statistics_interval: String,
     #[serde(default = "default_resolve_timeout")]
     pub resolve_timeout: String,
@@ -67,12 +71,32 @@ fn default_enable_agent_names() -> String {
     "false".into()
 }
 
+/// Ceiling on agent name lookups fetching upstream at once.
+///
+/// Agent name resolution turns one cheap inbound request into one outbound HTTP
+/// request to a host the *caller* chose. Without a ceiling that is an
+/// amplification primitive: a shared cache server can be driven to fan out
+/// arbitrary traffic at third parties, or used to scan them, at a cost to the
+/// attacker of one request each.
+///
+/// The cap bounds that fan-out regardless of how many source addresses the load
+/// arrives from, which per-IP rate limiting alone cannot do. Requests beyond it
+/// are rejected immediately with 503 rather than queued, so a saturated server
+/// sheds load instead of growing an unbounded backlog of pending fetches.
+///
+/// 16 is deliberately modest: agent name lookups are cache-warming, not a hot
+/// path, and a cache server exists precisely so the fetch happens rarely.
+fn default_agent_name_concurrency() -> String {
+    "16".into()
+}
+
 pub struct Config {
     pub log_level: LevelFilter,
     pub listen_address: String,
     pub enable_http_endpoint: bool,
     pub enable_websocket_endpoint: bool,
     pub enable_agent_names: bool,
+    pub agent_name_concurrency: usize,
     pub statistics_interval: Duration,
     /// Maximum time a single upstream DID resolution may take before the
     /// request path gives up and returns an error instead of blocking.
@@ -91,6 +115,7 @@ impl fmt::Debug for Config {
             .field("listen_address", &self.listen_address)
             .field("enable_http_endpoint", &self.enable_http_endpoint)
             .field("enable_agent_names", &self.enable_agent_names)
+            .field("agent_name_concurrency", &self.agent_name_concurrency)
             .field("enable_websocket_endpoint", &self.enable_websocket_endpoint)
             .field(
                 "statistics_interval",
@@ -115,6 +140,7 @@ impl Default for Config {
             enable_http_endpoint: true,
             enable_websocket_endpoint: true,
             enable_agent_names: false,
+            agent_name_concurrency: 16,
             statistics_interval: Duration::from_secs(60),
             resolve_timeout: Duration::from_secs(30),
             max_did_size: 1024,
@@ -146,6 +172,14 @@ impl TryFrom<ConfigRaw> for Config {
             // Defaults to false on a parse failure too: an unreadable value must
             // not silently turn on a network-facing fetch.
             enable_agent_names: raw.enable_agent_names.parse().unwrap_or(false),
+            // A zero or unparseable cap would mean "no limit", which is the
+            // opposite of what this setting is for; fall back to the default.
+            agent_name_concurrency: raw
+                .agent_name_concurrency
+                .parse()
+                .ok()
+                .filter(|n: &usize| *n > 0)
+                .unwrap_or(16),
             statistics_interval: Duration::from_secs(raw.statistics_interval.parse().unwrap_or(60)),
             resolve_timeout: Duration::from_secs(raw.resolve_timeout.parse().unwrap_or(30)),
             max_did_size: raw.max_did_size.parse().unwrap_or(1024),

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/agent_name.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/agent_name.rs
@@ -23,6 +23,11 @@
 //! - It is **off by default** (`enable_agent_names` in the config).
 //! - The resolver refuses non-public addresses (loopback, private, link-local,
 //!   cloud metadata) on every redirect hop.
+//! - At most `agent_name_concurrency` lookups fetch upstream at once, so the
+//!   endpoint cannot be used to fan out arbitrary traffic at third parties (or
+//!   to scan them) faster than that. Requests over the ceiling are shed with
+//!   503 rather than queued: a saturated server must not accumulate an
+//!   unbounded backlog of pending outbound fetches.
 //!
 //! Neither is complete — see `agent_names::HttpRedirectResolver::allow_private_addresses`
 //! on the residual DNS-rebinding exposure. Enable this only if you accept that
@@ -82,6 +87,20 @@ pub async fn resolve_name_handler(
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "Agent name resolution is not enabled on this server" })),
+        );
+    };
+
+    // Take an outbound-fetch permit, or shed the request. `try_acquire` rather
+    // than `acquire` is the point: queueing here would convert a fetch ceiling
+    // into an unbounded backlog, which is the thing being defended against.
+    let Ok(_permit) = state.agent_name_permits.try_acquire() else {
+        state.stats.lock().await.increment_agent_name_error();
+        warn!("shedding agent name lookup '{parsed}': outbound fetch ceiling reached");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "Too many agent name lookups in flight; retry shortly"
+            })),
         );
     };
 

--- a/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/lib.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use session::SessionError;
 use statistics::Statistics;
 use std::{fmt::Debug, sync::Arc, time::Duration};
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard, Semaphore};
 
 pub(crate) mod common;
 pub mod config;
@@ -34,6 +34,13 @@ pub struct SharedData {
     /// Present only when `enable_agent_names` is set. `None` means the feature
     /// is off and the route is not registered.
     pub agent_name_resolver: Option<Arc<agent_names::HttpRedirectResolver>>,
+    /// Ceiling on agent name lookups fetching upstream at once.
+    ///
+    /// Agent name resolution turns one cheap inbound request into one outbound
+    /// request to a caller-chosen host. This bounds that fan-out globally —
+    /// something per-IP rate limiting cannot do, because the cap has to hold
+    /// however many source addresses the load arrives from.
+    pub agent_name_permits: Arc<Semaphore>,
 }
 
 impl<S> FromRequestParts<S> for SharedData

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -11,7 +11,7 @@ use affinidi_task_utils::TaskSupervisor;
 use axum::{Router, routing::get};
 use http::Method;
 use std::{env, net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tower_http::{
     cors::CorsLayer,
@@ -120,6 +120,7 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
         max_did_size: config.max_did_size,
         webvh_client,
         agent_name_resolver,
+        agent_name_permits: Arc::new(Semaphore::new(config.agent_name_concurrency)),
     };
 
     // Supervise the statistics task through the shared TaskSupervisor: a

--- a/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
@@ -13,10 +13,16 @@ use axum::{
 };
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
 use tower::ServiceExt;
 
 /// A router with agent name resolution either on or off.
 async fn app(enable_agent_names: bool) -> axum::Router {
+    app_with_permits(enable_agent_names, 16).await
+}
+
+/// A router with an explicit outbound-fetch ceiling.
+async fn app_with_permits(enable_agent_names: bool, permits: usize) -> axum::Router {
     let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
         .await
         .unwrap();
@@ -38,6 +44,7 @@ async fn app(enable_agent_names: bool) -> axum::Router {
         } else {
             None
         },
+        agent_name_permits: Arc::new(Semaphore::new(permits)),
     };
 
     application_routes(&state, &config)
@@ -126,4 +133,70 @@ async fn did_resolution_still_works() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("did:key:"), "got {body}");
+}
+
+/// With every outbound-fetch permit already taken, a lookup must be **shed**
+/// rather than queued. Queueing would turn the fetch ceiling into an unbounded
+/// backlog, which is precisely what the ceiling exists to prevent.
+#[tokio::test]
+async fn sheds_lookups_once_the_fetch_ceiling_is_reached() {
+    let permits = Arc::new(Semaphore::new(1));
+    let held = permits.clone().acquire_owned().await.unwrap();
+
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .unwrap();
+    let state = SharedData {
+        service_start_timestamp: chrono::Utc::now(),
+        stats: Arc::new(Mutex::new(Statistics::default())),
+        resolver,
+        resolve_timeout: Duration::from_secs(5),
+        max_did_size: 1024,
+        webvh_client: reqwest::Client::new(),
+        agent_name_resolver: Some(Arc::new(agent_names::HttpRedirectResolver::new())),
+        agent_name_permits: permits.clone(),
+    };
+    let config = Config {
+        enable_agent_names: true,
+        ..Default::default()
+    };
+
+    let (status, body) = get(
+        application_routes(&state, &config),
+        "/did/v1/resolve-name/example.com/@alice",
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "body: {body}");
+    assert!(body.contains("retry shortly"), "got {body}");
+
+    // Releasing the permit lets lookups through again — the ceiling must not
+    // latch. This one fails upstream (no such host), which is fine: anything
+    // other than 503 proves the permit was reacquired.
+    drop(held);
+    let (status, _) = get(
+        application_routes(&state, &config),
+        "/did/v1/resolve-name/127.0.0.1/@alice",
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "the ceiling should not latch after a permit is released"
+    );
+}
+
+/// A permit must be returned when a lookup fails, not leaked. A ceiling that
+/// drains on the error path would wedge the endpoint permanently.
+#[tokio::test]
+async fn a_failed_lookup_returns_its_permit() {
+    let app = app_with_permits(true, 1).await;
+    // Blocked-address failures, repeated well past the ceiling of 1.
+    for i in 0..5 {
+        let (status, _) = get(app.clone(), "/did/v1/resolve-name/127.0.0.1/@alice").await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_GATEWAY,
+            "iteration {i} should still reach the resolver, not exhaust permits"
+        );
+    }
 }


### PR DESCRIPTION
Gap #3 from the retrospective — partially. Read the scope note at the bottom.

## The problem

Agent name resolution turns **one cheap inbound request into one outbound HTTP
request to a host the caller chose**. Without a ceiling that is an amplification
primitive: a shared cache server can be driven to fan out arbitrary traffic at
third parties, or used to scan them, at a cost to the attacker of one request
each.

## The fix

`agent_name_concurrency`, default **16** — a ceiling on how many lookups may be
fetching upstream at once.

It bounds the fan-out **however many source addresses the load arrives from**.
That is the property per-IP rate limiting cannot give you, and it is why this is
the right *first* control for this endpoint even though the server has no rate
limiting at all.

Two details that are the substance rather than incidental:

- **`try_acquire`, not `acquire`.** Requests over the ceiling are shed with `503`
  rather than queued. Queueing would convert a fetch ceiling into an unbounded
  backlog of pending outbound requests — the thing being defended against.
- **A zero or unparseable value falls back to the default**, rather than meaning
  "no limit". A config typo must not silently remove the ceiling. Matches how
  `enable_agent_names` parses to `false` on error.

16 is deliberately modest: agent name lookups are cache-warming, not a hot path,
and a cache server exists precisely so the fetch happens rarely.

## Tests

The two that carry the behaviour:

- `sheds_lookups_once_the_fetch_ceiling_is_reached` — a saturated pool returns
  503, **and does not latch** once a permit is released.
- `a_failed_lookup_returns_its_permit` — five consecutive *failing* lookups
  against a ceiling of 1 all still reach the resolver. A ceiling that drained on
  the error path would wedge the endpoint permanently, and that bug would be
  invisible until production.

9 endpoint tests pass. `clippy --all-targets -D warnings`, `fmt --check`,
`cargo check --workspace --all-targets`, and the new workspace-duplicate guard
all clean.

## :warning: Scope — this is not general rate limiting

The server still has **none**, and that remains worth doing. I deliberately did
not bundle it, because it needs a decision I should not make silently:

The mediator already has a good per-IP limiter
(`affinidi-messaging-mediator/src/common/rate_limiter.rs`, 186 lines, governor-based,
including the `retain_recent()` fix for the unbounded-growth bug found during the
memory-profile work). Reusing it across crates needs a shared home, and:

- `affinidi-task-utils` is scoped to background-task supervision — a rate limiter
  does not belong there;
- a **new** shared crate means another manual first-publish, since crates.io
  Trusted Publishing cannot create crates (we hit this with `agent-names 0.1.0`);
- duplicating 186 lines is the third option, with the maintenance cost that implies.

That is a call worth making explicitly rather than as a side effect of this PR.

What this change does address is the **outbound amplification** — the harm this
endpoint can do to *third parties*. General rate limiting addresses the harm it
can do to *itself*. Both matter; this is the one that reaches outside your
network.