### PR TITLE
feat: per-IP rate limiting on the DID cache server

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,45 @@
 
 ## 20th July 2026
 
+### 0.9.7 — per-IP rate limiting
+
+The server previously had **no rate limiting of any kind**. It now applies a
+per-IP token bucket, via the shared `affinidi-rate-limit` crate extracted from
+the mediator.
+
+#### ⚠ On by default — check this before upgrading
+
+`rate_limit_per_ip` defaults to **100 req/s per IP, burst 50**, matching the
+mediator. That is generous for a resolver cache, whose whole purpose is that most
+lookups are served from memory.
+
+**But raise or disable it behind a load balancer or NAT.** The limiter keys on
+the peer address, so if you terminate TLS or route through a CDN, the only
+address this server sees is the proxy's — every client shares one bucket and
+legitimate traffic gets 429s. Set `rate_limit_per_ip = "0"` to disable.
+
+An unparseable value falls back to the default rather than to 0, so a config typo
+cannot silently remove limiting. An explicit `"0"` still disables.
+
+#### Behaviour
+
+- Over-quota requests get `429` with an accurate `Retry-After`, taken from
+  `governor`'s estimate of when the next token arrives, floored at 1 second.
+- A request whose client IP cannot be determined is **refused with 403**, not
+  exempted — failing open would make per-IP limiting trivially bypassable. The
+  server already binds with `into_make_service_with_connect_info`, so this only
+  bites if that is ever removed.
+- The layer sits outermost, so a throttled client costs nothing beyond the
+  token-bucket check. It wraps the healthcheck route too, deliberately: an
+  unlimited healthcheck is itself a cheap way to hold connections open.
+- The keyed bucket store is swept periodically. Without that it grows once per
+  source IP for the process lifetime — see the `affinidi-rate-limit` README.
+
+This complements, rather than replaces, `agent_name_concurrency` (0.9.6). Rate
+limiting bounds what any one client can ask for; the concurrency cap bounds total
+outbound fan-out however many clients ask.
+## 20th July 2026
+
 ### 0.9.6 — bound the agent name endpoint's outbound fetches
 
 Adds `agent_name_concurrency` (default **16**): a ceiling on how many agent name

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.6"
+version = "0.9.7"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -26,6 +26,7 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", default-features = true, pa
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
+affinidi-rate-limit = "0.1"
 
 didwebvh-rs = "0.6"
 agent-names = "0.1.2"

--- a/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/conf/cache-conf.toml
@@ -62,3 +62,18 @@ capacity_count = "${CACHE_CAPACITY_COUNT:1000}"
 ### expire: Cache Time To Live (TTL) for a cached entry in seconds
 ### Default: 300 (5 minutes)
 expire = "${EXPIRE:300}"
+
+# Sustained requests per second per client IP. 0 disables rate limiting.
+#
+# ⚠ RAISE OR DISABLE THIS BEHIND A LOAD BALANCER OR NAT. The limiter keys on the
+# peer address, so every client behind a proxy shares one bucket and legitimate
+# traffic gets throttled. If you terminate TLS or route through a CDN, the only
+# address this server sees is the proxy's.
+#
+# An unparseable value falls back to the default rather than to 0, so a typo
+# cannot silently disable limiting. Set "0" explicitly to disable.
+rate_limit_per_ip = "${RATE_LIMIT_PER_IP:100}"
+
+# Token-bucket depth above the sustained per-IP rate — how large a burst is
+# tolerated before 429s begin.
+rate_limit_burst = "${RATE_LIMIT_BURST:50}"

--- a/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/config.rs
@@ -44,6 +44,10 @@ struct ConfigRaw {
     /// `default_agent_name_concurrency`.
     #[serde(default = "default_agent_name_concurrency")]
     pub agent_name_concurrency: String,
+    #[serde(default = "default_rate_limit_per_ip")]
+    pub rate_limit_per_ip: String,
+    #[serde(default = "default_rate_limit_burst")]
+    pub rate_limit_burst: String,
     pub statistics_interval: String,
     #[serde(default = "default_resolve_timeout")]
     pub resolve_timeout: String,
@@ -90,6 +94,24 @@ fn default_agent_name_concurrency() -> String {
     "16".into()
 }
 
+/// Sustained requests per second per client IP; `0` disables limiting.
+///
+/// Matches the mediator's default. Generous for a resolver cache, whose whole
+/// purpose is that most lookups are served from memory.
+///
+/// **Raise or disable this behind a load balancer or NAT**, where many clients
+/// share one source address: `ConnectInfo` reports the *peer* address, so every
+/// client behind a proxy is charged to one bucket and legitimate traffic gets
+/// throttled.
+fn default_rate_limit_per_ip() -> String {
+    "100".into()
+}
+
+/// Token-bucket depth above the sustained per-IP rate.
+fn default_rate_limit_burst() -> String {
+    "50".into()
+}
+
 pub struct Config {
     pub log_level: LevelFilter,
     pub listen_address: String,
@@ -97,6 +119,8 @@ pub struct Config {
     pub enable_websocket_endpoint: bool,
     pub enable_agent_names: bool,
     pub agent_name_concurrency: usize,
+    pub rate_limit_per_ip: u32,
+    pub rate_limit_burst: u32,
     pub statistics_interval: Duration,
     /// Maximum time a single upstream DID resolution may take before the
     /// request path gives up and returns an error instead of blocking.
@@ -116,6 +140,8 @@ impl fmt::Debug for Config {
             .field("enable_http_endpoint", &self.enable_http_endpoint)
             .field("enable_agent_names", &self.enable_agent_names)
             .field("agent_name_concurrency", &self.agent_name_concurrency)
+            .field("rate_limit_per_ip", &self.rate_limit_per_ip)
+            .field("rate_limit_burst", &self.rate_limit_burst)
             .field("enable_websocket_endpoint", &self.enable_websocket_endpoint)
             .field(
                 "statistics_interval",
@@ -141,6 +167,8 @@ impl Default for Config {
             enable_websocket_endpoint: true,
             enable_agent_names: false,
             agent_name_concurrency: 16,
+            rate_limit_per_ip: 100,
+            rate_limit_burst: 50,
             statistics_interval: Duration::from_secs(60),
             resolve_timeout: Duration::from_secs(30),
             max_did_size: 1024,
@@ -180,6 +208,11 @@ impl TryFrom<ConfigRaw> for Config {
                 .ok()
                 .filter(|n: &usize| *n > 0)
                 .unwrap_or(16),
+            // An unparseable value falls back to the default rather than to 0:
+            // 0 means "disabled", and a typo must not silently remove limiting.
+            // An explicit "0" still disables, which is the documented way to.
+            rate_limit_per_ip: raw.rate_limit_per_ip.parse().unwrap_or(100),
+            rate_limit_burst: raw.rate_limit_burst.parse().unwrap_or(50),
             statistics_interval: Duration::from_secs(raw.statistics_interval.parse().unwrap_or(60)),
             resolve_timeout: Duration::from_secs(raw.resolve_timeout.parse().unwrap_or(30)),
             max_did_size: raw.max_did_size.parse().unwrap_or(1024),

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -7,6 +7,7 @@ use crate::{
 use affinidi_did_resolver_cache_sdk::{
     DIDCacheClient, config::DIDCacheConfigBuilder, errors::DIDCacheError,
 };
+use affinidi_rate_limit::{RateLimitLayer, RateLimiterState};
 use affinidi_task_utils::TaskSupervisor;
 use axum::{Router, routing::get};
 use http::Method;
@@ -145,6 +146,25 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
     }
 
     // build our application routes
+    // Per-IP rate limiting. `ConnectInfo` is attached below via
+    // `into_make_service_with_connect_info`, which the layer requires: a
+    // request it cannot attribute to an IP is refused rather than exempted.
+    let rate_limiter = RateLimiterState::new(config.rate_limit_per_ip, config.rate_limit_burst);
+    rate_limiter.spawn_gc(shutdown.clone());
+    if rate_limiter.is_enabled() {
+        event!(
+            Level::INFO,
+            "Rate limiting enabled: {} req/s per IP, burst {}",
+            config.rate_limit_per_ip,
+            config.rate_limit_burst
+        );
+    } else {
+        event!(
+            Level::WARN,
+            "Rate limiting is DISABLED (rate_limit_per_ip = 0)"
+        );
+    }
+
     let app: Router = application_routes(&shared_state, &config);
 
     // Add middleware to all routes
@@ -167,7 +187,13 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
         .route(
             "/did/healthchecker",
             get(health_checker_handler).with_state(shared_state),
-        );
+        )
+        // Outermost: rate limiting runs before routing, so a throttled client
+        // costs nothing beyond the token-bucket check. Placed after the
+        // healthcheck route in builder order, which means it wraps that too —
+        // deliberate, since an unlimited healthcheck is itself a cheap way to
+        // hold a connection open.
+        .layer(RateLimitLayer::new(rate_limiter));
 
     let listen_address = config
         .listen_address

--- a/crates/identity/affinidi-did-resolver-cache-server/tests/rate_limit.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/tests/rate_limit.rs
@@ -1,0 +1,118 @@
+//! Per-IP rate limiting on the cache server.
+//!
+//! These drive the layer directly over a trivial inner service rather than
+//! standing up the whole server, so they assert the wiring contract — which
+//! requests are charged, which are refused, and what a refusal looks like —
+//! without a socket.
+
+use affinidi_rate_limit::{RateLimitLayer, RateLimiterState};
+use axum::{Router, body::Body, extract::ConnectInfo, routing::get};
+use http::{Request, StatusCode, header};
+use std::net::SocketAddr;
+use tower::ServiceExt;
+
+fn app(per_second: u32, burst: u32) -> Router {
+    Router::new()
+        .route("/ping", get(|| async { "pong" }))
+        .layer(RateLimitLayer::new(RateLimiterState::new(
+            per_second, burst,
+        )))
+}
+
+/// Send a request carrying a client address, as `into_make_service_with_connect_info`
+/// does in the real server.
+async fn get_from(app: Router, ip: &str) -> StatusCode {
+    let mut req = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+    let addr: SocketAddr = format!("{ip}:40000").parse().unwrap();
+    req.extensions_mut().insert(ConnectInfo(addr));
+    app.oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn normal_traffic_is_served() {
+    let app = app(100, 50);
+    assert_eq!(get_from(app, "203.0.113.10").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn refuses_once_the_burst_is_spent() {
+    let app = app(1, 3);
+    for i in 0..3 {
+        assert_eq!(
+            get_from(app.clone(), "203.0.113.10").await,
+            StatusCode::OK,
+            "request {i} should be within the burst"
+        );
+    }
+    assert_eq!(
+        get_from(app, "203.0.113.10").await,
+        StatusCode::TOO_MANY_REQUESTS
+    );
+}
+
+/// One noisy client must not throttle another.
+#[tokio::test]
+async fn one_client_cannot_exhaust_anothers_quota() {
+    let app = app(1, 2);
+    while get_from(app.clone(), "203.0.113.10").await == StatusCode::OK {}
+    assert_eq!(
+        get_from(app, "198.51.100.20").await,
+        StatusCode::OK,
+        "a different IP must have its own bucket"
+    );
+}
+
+#[tokio::test]
+async fn a_refusal_carries_retry_after() {
+    let app = app(1, 1);
+    assert_eq!(get_from(app.clone(), "203.0.113.10").await, StatusCode::OK);
+
+    let mut req = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+    let addr: SocketAddr = "203.0.113.10:40000".parse().unwrap();
+    req.extensions_mut().insert(ConnectInfo(addr));
+    let response = app.oneshot(req).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry: u64 = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .expect("Retry-After must be set")
+        .to_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(retry >= 1, "Retry-After must never be 0, got {retry}");
+}
+
+/// A request with no `ConnectInfo` is refused, not waved through. Failing open
+/// would make per-IP limiting trivially bypassable.
+#[tokio::test]
+async fn a_request_without_a_client_ip_is_refused() {
+    let app = app(100, 50);
+    let req = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+    assert_eq!(
+        app.oneshot(req).await.unwrap().status(),
+        StatusCode::FORBIDDEN
+    );
+}
+
+/// `rate_limit_per_ip = 0` must be a genuine pass-through, not a silent block.
+#[tokio::test]
+async fn zero_disables_limiting_entirely() {
+    let app = app(0, 0);
+    for i in 0..200 {
+        assert_eq!(
+            get_from(app.clone(), "203.0.113.10").await,
+            StatusCode::OK,
+            "request {i} should pass with limiting disabled"
+        );
+    }
+}
+
+/// With limiting disabled the layer must not require a client IP either.
+#[tokio::test]
+async fn disabled_limiting_does_not_require_a_client_ip() {
+    let app = app(0, 0);
+    let req = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+}


### PR DESCRIPTION
Second half of "proper rate limiting", and the reason for the extraction in
[#637](https://github.com/affinidi/affinidi-tdk-rs/pull/637). Closes gap #3.

The server had **no rate limiting of any kind**. It now applies a per-IP token
bucket via the shared `affinidi-rate-limit` crate.

## :warning: On by default — check this before you upgrade

`rate_limit_per_ip` defaults to **100 req/s per IP, burst 50**, matching the
mediator. Defaulting it *off* would have left the gap open in every deployment
that doesn't go looking for it, so it is on — but that makes this a behaviour
change on upgrade, and there is one deployment shape where it will bite:

> **Raise or disable it behind a load balancer, NAT or CDN.** The limiter keys on
> the **peer** address. If you terminate TLS or route through a proxy, the only
> address this server sees is the proxy's — every client shares one bucket and
> legitimate traffic gets 429s.

`rate_limit_per_ip = "0"` disables it. An *unparseable* value falls back to the
default rather than to 0, so a config typo cannot silently remove limiting; an
explicit `"0"` still works, which is the documented way to turn it off.

100 req/s is generous for a resolver cache, whose whole purpose is that most
lookups are served from memory.

## Behaviour

- Over-quota → `429` with an accurate `Retry-After` (from `governor`'s estimate of
  when the next token arrives, floored at 1s).
- No determinable client IP → **`403`, not exempted**. Failing open would make
  per-IP limiting trivially bypassable.
- The layer sits **outermost**, so a throttled client costs nothing beyond the
  bucket check. It wraps the healthcheck route too — deliberate, since an
  unlimited healthcheck is itself a cheap way to hold connections open.
- The keyed bucket store is swept periodically; without that it grows once per
  source IP for the process lifetime.

## Tests

Seven, covering the wiring contract. The two worth a reviewer's attention are the
ones that would be *silently* wrong if the layer were misconfigured:

- `a_request_without_a_client_ip_is_refused` — failing open here defeats the whole
  mechanism, and would look like everything working.
- `disabled_limiting_does_not_require_a_client_ip` — with `0`, the layer must be a
  genuine pass-through and must **not** then demand a client IP. Getting this
  wrong turns "disabled" into "reject everything".

Plus: normal traffic served, burst then refusal, per-IP isolation, `Retry-After`
present and never 0, and `0` passing 200 consecutive requests.

## On the one failing test

`integration_test::test_cache_server` fails with `NetworkTimeout` — pre-existing,
network-dependent, fails on `main` too.

I checked this specifically rather than assuming, because this PR adds a limiter
to the very server that test starts: the failure is at the **same line with the
same error**, not a 403 or 429, so the layer is not interfering with the
WebSocket handshake. The server already binds with
`into_make_service_with_connect_info`, so `ConnectInfo` is attached.

`clippy --all-targets -D warnings`, `fmt --check`, `cargo check --workspace
--all-targets`, and the workspace-duplicate guard are all clean.

## How this fits with 0.9.6

Complementary, not overlapping. **Rate limiting bounds what any one client can
ask for. `agent_name_concurrency` bounds total outbound fan-out however many
clients ask.** An attacker with a botnet defeats the first and not the second;
a single abusive client is caught by the first before it reaches the second.