### PR TITLE
refactor: seal ResolveResponse against future additions

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Changelog history
 
+## 20th July 2026
+
+### 0.8.16 — seal `ResolveResponse`
+
+`ResolveResponse` is now `#[non_exhaustive]`, with `ResolveResponse::new(..)` as
+the construction path. Fields remain `pub` for reads (ADR 0003 Option B).
+
+This is a *returned* type — callers read it, they do not normally build one — so
+sealing costs nothing in practice and removes the barrier to reporting more about
+a resolution later. That barrier was real: `resolve_any()` in 0.8.15 wanted to
+report which agent name a response was resolved under, and the field was dropped
+precisely because adding it to an unsealed struct would have been breaking for
+marginal value. Sealed, such a field becomes additive whenever there is a genuine
+need for it.
+
+Released as a patch bump per ADR 0003 §3: adding `#[non_exhaustive]` is
+technically breaking, but shipping it as a minor would invalidate the
+`[patch.crates-io]` redirects held by externally-pinned consumers. Nothing in
+this workspace constructs a `ResolveResponse` outside this crate — the cache
+server only reads its fields, which sealing still permits — so nothing needed
+changing.
+
+Not done here: the WebSocket wire types (`WSRequest`, `WSResponse`,
+`WSResponseType`, `WSResponseError`) are also unsealed, and sealing them would be
+a prerequisite for evolving the protocol additively. They are *constructed* by
+the cache server, so sealing needs constructors designed alongside whatever
+protocol change actually needs them, rather than speculatively.
 ## 19th July 2026
 
 ### 0.8.15 — agent names (`resolve_any`)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.15"
+version = "0.8.16"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -151,13 +151,54 @@ impl DIDMethod {
     }
 }
 
+/// The result of resolving an identifier.
+///
+/// `#[non_exhaustive]`: build via [`ResolveResponse::new`] rather than a struct
+/// literal. Fields stay public for reads.
+///
+/// This is a *returned* type — callers read it, they do not normally construct
+/// one — so sealing it costs nothing in practice and buys the ability to report
+/// more about a resolution later without a breaking release. Per
+/// [ADR 0003](https://github.com/affinidi/affinidi-tdk-rs/blob/main/docs/adr/0003-public-api-semver-policy.md),
+/// new fields on a sealed struct are additive.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ResolveResponse {
+    /// The identifier that was resolved. For [`DIDCacheClient::resolve_any`]
+    /// given an agent name, this is the **DID the name resolved to**, not the
+    /// name.
     pub did: String,
+    /// The DID method of [`Self::did`].
     pub method: DIDMethod,
+    /// HighwayHash128 of [`Self::did`] — the document cache key.
     pub did_hash: [u64; 2],
+    /// The resolved DID Document.
     pub doc: Document,
+    /// Whether the document came from cache rather than a fresh resolution.
     pub cache_hit: bool,
+}
+
+impl ResolveResponse {
+    /// Assemble a response.
+    ///
+    /// The construction path for a `#[non_exhaustive]` struct. Mainly useful to
+    /// consumers building a fixture or a mock resolver; the client returns these
+    /// itself in normal use.
+    pub fn new(
+        did: String,
+        method: DIDMethod,
+        did_hash: [u64; 2],
+        doc: Document,
+        cache_hit: bool,
+    ) -> Self {
+        Self {
+            did,
+            method,
+            did_hash,
+            doc,
+            cache_hit,
+        }
+    }
 }
 
 /// Per-entry expiry policy for the DID document cache.
@@ -1121,6 +1162,30 @@ mod tests {
                 Some(Ok(doc))
             })
         }
+    }
+
+    /// `ResolveResponse` is `#[non_exhaustive]`, so `new` is the construction
+    /// path for anything outside this crate — a fixture or a mock resolver.
+    /// Fields stay readable.
+    #[test]
+    fn resolve_response_is_built_via_new() {
+        let doc = Document::new("did:example:123").unwrap();
+        let response = ResolveResponse::new(
+            "did:example:123".to_string(),
+            DIDMethod::EXAMPLE,
+            DIDCacheClient::hash_did("did:example:123"),
+            doc,
+            true,
+        );
+
+        assert_eq!(response.did, "did:example:123");
+        assert_eq!(response.method, DIDMethod::EXAMPLE);
+        assert_eq!(
+            response.did_hash,
+            DIDCacheClient::hash_did("did:example:123")
+        );
+        assert_eq!(response.doc.id.as_str(), "did:example:123");
+        assert!(response.cache_hit);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Gap #4. Small, and it removes a barrier that already bit once.

## What

`ResolveResponse` becomes `#[non_exhaustive]`, with `ResolveResponse::new(..)` as
the construction path. Fields stay `pub` for reads — ADR 0003 Option B.

## Why now

The barrier is not hypothetical. In
[#632](https://github.com/affinidi/affinidi-tdk-rs/pull/632), `resolve_any()`
wanted to report *which agent name* a response had been resolved under, and I
dropped the field specifically because adding it to an unsealed public struct
would have been a breaking change for marginal value.

Sealed, that field — and anything else worth reporting about a resolution — is
additive whenever there is a genuine need. I have deliberately **not** added the
agent-name field in this PR: sealing is what removes the barrier, and API surface
should follow a real use case rather than anticipate one.

## Cost: none, in practice

`ResolveResponse` is a *returned* type. Callers read it; they do not construct
one. Nothing in this workspace builds one outside the SDK — the cache server only
reads its fields, which `#[non_exhaustive]` still permits — so
`cargo check --workspace --all-targets` passes untouched.

## Versioning

Patch bump per [ADR 0003 §3](https://github.com/affinidi/affinidi-tdk-rs/blob/main/docs/adr/0003-public-api-semver-policy.md).
Adding `#[non_exhaustive]` is technically breaking, but shipping it as a minor
would invalidate the `[patch.crates-io]` redirects held by externally-pinned
consumers — the same reasoning that governed the original semver wave, and the
same trap we spent real time on with `affinidi-did-common 0.4.0`.

## Also found, deliberately not fixed here

Scanning the crate for other unsealed public types turned up the WebSocket wire
types — `WSRequest`, `WSResponse`, `WSResponseType`, `WSResponseError`. Sealing
those is a **prerequisite for evolving the WS protocol additively**, which is
exactly what agent names over WebSocket (gap #7) will need.

But unlike `ResolveResponse`, those are *constructed* by the cache server, so
sealing them requires designing constructors — and that design should be informed
by the protocol change that needs it, not guessed at now. It belongs with the
WebSocket work.

The rest of the scan is fine as-is: `DIDCacheConfig` and `DIDCacheClient` have
private fields so cannot be externally constructed anyway, and the resolver unit
structs (`WebResolver`, `EthrResolver`, …) are *meant* to be constructed by
consumers registering them.

## Verification

- 74 tests pass (56 lib + 17 agent-names integration + 1 doctest), including a new
  one pinning `new()` as the construction path with fields still readable.
- `cargo check --workspace --all-targets`, `clippy --all-features --all-targets
  -D warnings`, `fmt --check` all clean.