### PR TITLE
perf: single-flight for concurrent agent name lookups

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,32 @@
 
 ## 20th July 2026
 
+### 0.8.17 — single-flight for concurrent agent name lookups
+
+Concurrent first-time lookups of the *same* agent name now collapse into one
+backend call, mirroring the single-flight the document cache has always had.
+
+Previously N concurrent callers made N outbound HTTP requests. That matters more
+here than for DIDs: a name lookup is an uncached fetch against somebody else's
+web server, so fanning out duplicate requests is precisely what a shared resolver
+exists to avoid. A verified regression test asserts one call where there were
+eight.
+
+The map is deliberately **separate** from the DID `inflight` map rather than
+shared. The two key spaces are different — a hashed agent name versus a hashed
+DID — and keeping them apart means a hash collision between the two can never
+make one wait on the other.
+
+The leader releases leadership and wakes its followers **regardless of outcome**.
+A leader that returned early on error would strand every waiter until its
+timeout; there is a test for that path specifically, since it is the failure mode
+that would only appear under concurrent load in production.
+
+Deferred from 0.8.15, where it was called out as an inefficiency rather than a
+correctness problem. It remains an optimisation — no behaviour changes for a
+single caller.
+## 20th July 2026
+
 ### 0.8.16 — seal `ResolveResponse`
 
 `ResolveResponse` is now `#[non_exhaustive]`, with `ResolveResponse::new(..)` as

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.16"
+version = "0.8.17"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
@@ -24,6 +24,7 @@
 //!    cache, with an unconditional TTL, makes that structurally impossible.
 
 use agent_names::{AgentName, AgentNameError, AgentNameResolver, verify_also_known_as};
+use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use crate::{DIDCacheClient, ResolveResponse, errors::DIDCacheError};
@@ -114,9 +115,7 @@ impl DIDCacheClient {
             }
             None => {
                 debug!("agent name cache miss: {name}");
-                let did = self.resolve_name_to_did(name).await?;
-                self.agent_name_cache.insert(name_hash, did.clone()).await;
-                did
+                self.resolve_name_deduplicated(name, name_hash).await?
             }
         };
 
@@ -144,6 +143,85 @@ impl DIDCacheClient {
         }
 
         Ok(response)
+    }
+
+    /// Resolve a name to a DID, collapsing concurrent lookups of the *same*
+    /// name into one backend call.
+    ///
+    /// Mirrors the document cache's single-flight in
+    /// `DIDCacheClient::resolve_uncached`: one caller becomes the leader and
+    /// does the work, the rest wait on a `watch` channel and then re-read the
+    /// mapping cache.
+    ///
+    /// Without this, N concurrent first-time lookups of one name make N
+    /// outbound HTTP requests. That matters more than the equivalent for DIDs,
+    /// because a name lookup is an uncached fetch against somebody else's web
+    /// server — the thing a shared resolver exists to avoid doing repeatedly.
+    async fn resolve_name_deduplicated(
+        &self,
+        name: &AgentName,
+        name_hash: [u64; 2],
+    ) -> Result<String, DIDCacheError> {
+        loop {
+            // Decide our role under the lock; no `.await` is held across it.
+            enum Role {
+                Leader(watch::Sender<()>),
+                Follower(watch::Receiver<()>),
+            }
+            let role = {
+                let mut map = self
+                    .agent_name_inflight
+                    .lock()
+                    .expect("agent name inflight mutex not poisoned");
+                if let Some(rx) = map.get(&name_hash) {
+                    Role::Follower(rx.clone())
+                } else {
+                    let (tx, rx) = watch::channel(());
+                    map.insert(name_hash, rx);
+                    Role::Leader(tx)
+                }
+            };
+
+            match role {
+                Role::Follower(mut rx) => {
+                    // The leader drops its sender when done, which closes the
+                    // channel and resolves `changed()`.
+                    let _ = rx.changed().await;
+                    if let Some(did) = self.agent_name_cache.get(&name_hash).await {
+                        debug!("agent name '{name}' resolved by another caller");
+                        return Ok(did);
+                    }
+                    // The leader errored and cached nothing. Loop and try to
+                    // become the leader ourselves.
+                    continue;
+                }
+                Role::Leader(tx) => {
+                    // A prior leader may have populated the mapping between our
+                    // cache miss and our acquiring leadership.
+                    if let Some(did) = self.agent_name_cache.get(&name_hash).await {
+                        self.release_name_leadership(name_hash, tx);
+                        return Ok(did);
+                    }
+
+                    let result = self.resolve_name_to_did(name).await;
+                    if let Ok(ref did) = result {
+                        self.agent_name_cache.insert(name_hash, did.clone()).await;
+                    }
+                    // Release leadership and wake followers regardless of
+                    // outcome — an early return here would hang every waiter.
+                    self.release_name_leadership(name_hash, tx);
+                    return result;
+                }
+            }
+        }
+    }
+
+    fn release_name_leadership(&self, name_hash: [u64; 2], tx: watch::Sender<()>) {
+        self.agent_name_inflight
+            .lock()
+            .expect("agent name inflight mutex not poisoned")
+            .remove(&name_hash);
+        drop(tx);
     }
 
     /// Walk the registered backends until one resolves the name.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -269,6 +269,14 @@ pub struct DIDCacheClient {
     agent_name_cache: Cache<[u64; 2], String>,
     #[cfg(feature = "agent-names")]
     agent_name_resolvers: Arc<Vec<Box<dyn ::agent_names::AgentNameResolver>>>,
+    /// Single-flight map for the name -> DID step, mirroring `inflight`.
+    ///
+    /// Deliberately separate from `inflight` rather than shared: the two key
+    /// spaces are different (a hashed agent name vs a hashed DID), and keeping
+    /// them apart means a hash collision between the two can never make one
+    /// wait on the other.
+    #[cfg(feature = "agent-names")]
+    agent_name_inflight: Arc<StdMutex<HashMap<[u64; 2], watch::Receiver<()>>>>,
     /// Single-flight map: concurrent cache misses for the same DID hash share
     /// one underlying resolution. The leader holds the `watch::Sender`; the
     /// stored `Receiver` is cloned by followers, who wake when the leader drops
@@ -296,6 +304,8 @@ impl Clone for DIDCacheClient {
             agent_name_cache: self.agent_name_cache.clone(),
             #[cfg(feature = "agent-names")]
             agent_name_resolvers: self.agent_name_resolvers.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_inflight: self.agent_name_inflight.clone(),
             inflight: self.inflight.clone(),
         }
     }
@@ -756,6 +766,8 @@ impl DIDCacheClient {
             agent_name_cache: agent_name_cache.clone(),
             #[cfg(feature = "agent-names")]
             agent_name_resolvers: agent_name_resolvers.clone(),
+            #[cfg(feature = "agent-names")]
+            agent_name_inflight: Arc::new(StdMutex::new(HashMap::new())),
             inflight: Arc::new(StdMutex::new(HashMap::new())),
         };
         #[cfg(not(feature = "network"))]
@@ -769,6 +781,8 @@ impl DIDCacheClient {
             agent_name_cache,
             #[cfg(feature = "agent-names")]
             agent_name_resolvers,
+            #[cfg(feature = "agent-names")]
+            agent_name_inflight: Arc::new(StdMutex::new(HashMap::new())),
             inflight: Arc::new(StdMutex::new(HashMap::new())),
         };
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
@@ -397,3 +397,127 @@ async fn an_email_is_not_treated_as_an_agent_name() {
     assert!(matches!(err, DIDCacheError::DIDError(_)), "got {err:?}");
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }
+
+/// A backend that blocks until released, so several callers are provably
+/// in-flight at the same moment.
+struct GatedResolver {
+    gate: Arc<tokio::sync::Notify>,
+    calls: Arc<AtomicUsize>,
+    did: String,
+}
+
+impl AgentNameResolver for GatedResolver {
+    fn name(&self) -> &str {
+        "gated"
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        _name: &'a AgentName,
+    ) -> Pin<Box<dyn Future<Output = NameResolution> + Send + 'a>> {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.gate.notified().await;
+            Some(Ok(self.did.clone()))
+        })
+    }
+}
+
+/// Concurrent first-time lookups of the *same* name must make **one** backend
+/// call, not one each.
+///
+/// This is the property that matters for a shared resolver: a name lookup is an
+/// uncached fetch against somebody else's web server, so N concurrent callers
+/// fanning out N requests is exactly what centralising resolution is meant to
+/// avoid.
+#[tokio::test]
+async fn concurrent_lookups_of_one_name_resolve_exactly_once() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+    client.set_agent_name_resolvers(vec![Box::new(GatedResolver {
+        gate: gate.clone(),
+        calls: calls.clone(),
+        did: IMMUTABLE_DID.to_string(),
+    })]);
+    client
+        .add_did_document(IMMUTABLE_DID, doc_claiming(IMMUTABLE_DID, &[CANONICAL]))
+        .await;
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let c = client.clone();
+        handles.push(tokio::spawn(async move { c.resolve_any(NAME).await }));
+    }
+
+    // Let every task reach the backend (or block behind the leader), then
+    // release the one that got through.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    gate.notify_waiters();
+
+    for handle in handles {
+        handle.await.unwrap().expect("every caller should resolve");
+    }
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "8 concurrent lookups of one name should make exactly one backend call"
+    );
+}
+
+/// Different names must not block each other — the single-flight is per name,
+/// not a global lock.
+#[tokio::test]
+async fn concurrent_lookups_of_different_names_do_not_serialise() {
+    let (resolver, calls) = MapResolver::new(&[
+        (CANONICAL, IMMUTABLE_DID),
+        ("https://example.com/@bob", IMMUTABLE_DID),
+    ]);
+
+    let config = DIDCacheConfigBuilder::default().build();
+    let mut client = DIDCacheClient::new(config).await.unwrap();
+    client.set_agent_name_resolvers(vec![Box::new(resolver)]);
+    client
+        .add_did_document(
+            IMMUTABLE_DID,
+            doc_claiming(IMMUTABLE_DID, &[CANONICAL, "https://example.com/@bob"]),
+        )
+        .await;
+
+    let (a, b) = tokio::join!(
+        client.resolve_any("example.com/@alice"),
+        client.resolve_any("example.com/@bob"),
+    );
+    assert!(a.is_ok() && b.is_ok());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "two distinct names should each be resolved"
+    );
+}
+
+/// A leader whose lookup FAILS must still wake its followers, and they must be
+/// able to retry rather than hang.
+#[tokio::test]
+async fn a_failed_leader_does_not_strand_followers() {
+    let (client, calls) = client_with(IMMUTABLE_DID, &[CANONICAL], &[], 300).await;
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let c = client.clone();
+        handles.push(tokio::spawn(async move { c.resolve_any(NAME).await }));
+    }
+
+    for handle in handles {
+        // The point is that these complete at all — a stranded follower would
+        // hang here and fail the test by timeout.
+        assert!(handle.await.unwrap().is_err());
+    }
+    assert!(
+        calls.load(Ordering::SeqCst) >= 1,
+        "at least one caller should have attempted resolution"
+    );
+}


### PR DESCRIPTION
Gap #6. **Stacked on [#639](https://github.com/affinidi/affinidi-tdk-rs/pull/639)** —
both touch `cache-sdk`, so merge #639 first. The diff shown is just this change.

## What

Concurrent first-time lookups of the *same* agent name now collapse into one
backend call, mirroring the single-flight the document cache has always had in
`resolve_uncached`.

Previously N concurrent callers made N outbound HTTP requests.

## Why it matters more here than for DIDs

A name lookup is an **uncached fetch against somebody else's web server**. Fanning
out duplicate requests for one name is precisely what centralising resolution is
meant to avoid — and with the cache-server endpoint now available, those requests
may be leaving *your* infrastructure at a third party.

## The test is verified, not assumed

Bypassing the single-flight makes the regression test report **8 backend calls
where it now reports 1**:

```
assertion `left == right` failed: 8 concurrent lookups of one name
should make exactly one backend call
  left: 8
 right: 1
```

I checked this specifically, because a concurrency test that passes for the wrong
reason — tasks not actually overlapping, say — is worse than none.

Three tests:

- `concurrent_lookups_of_one_name_resolve_exactly_once` — 8 callers, gated backend
  so they are provably in flight together, 1 call.
- `concurrent_lookups_of_different_names_do_not_serialise` — the single-flight is
  per name, not a global lock.
- `a_failed_leader_does_not_strand_followers` — see below.

## Two deliberate design choices

**A separate map, not the DID `inflight` one.** The key spaces are different — a
hashed agent name versus a hashed DID — and keeping them apart means a hash
collision between the two can never make one wait on the other. Sharing would
have saved a field and bought a class of bug nobody would ever reproduce.

**The leader releases leadership and wakes followers regardless of outcome.** A
leader returning early on error would strand every waiter until its timeout. That
is a failure mode which only appears under concurrent load in production, so
`a_failed_leader_does_not_strand_followers` covers it explicitly — the assertion
is simply that the followers *complete at all*; a stranded one fails by hanging.

## Scope

This was deferred from 0.8.15 as an inefficiency rather than a correctness
problem, and that is still true — no behaviour changes for a single caller.

74 tests pass in the crate (56 lib + 20 integration + 1 doctest).
`clippy --all-features --all-targets -D warnings`, `fmt --check`, and
`cargo check --workspace --all-targets` all clean.