### PR TITLE
refactor: seal the WebSocket wire types

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,40 @@
 
 ## 20th July 2026
 
+### 0.8.18 — seal the WebSocket wire types
+
+`WSRequest`, `WSResponse`, `WSResponseError` and `WSResponseType` are now
+`#[non_exhaustive]`, with `WSRequest::new`, `WSResponse::new` / `with_logs` and
+`WSResponseError::new` as the construction paths.
+
+Groundwork for carrying agent names over the WebSocket transport: today a name
+lookup in network mode costs **two round trips over two transports** — HTTP to
+the cache server for name→DID, then WebSocket for DID→document. Collapsing that
+onto the connection the client already holds means growing these types, and
+growing them should not require a breaking release each time.
+
+#### The wire rule these types now document
+
+Sealing records a Rust-level constraint. The wire-level one is stricter and
+matters more, so it is written on `WSResponseType`:
+
+> **Do not add variants.** The enum is externally tagged, so a new variant
+> serializes as an unrecognised key. An older client fails to deserialize it and
+> `ws_recv` *drops the frame* — leaving the caller to wait out its full
+> `network_timeout` with no error to report.
+
+A silent hang is a far worse failure than a clean error. Protocol growth
+therefore belongs in additive optional fields (as `did_log` already does), never
+in a new variant.
+
+Eight tests pin the wire format itself: the request shape, that a minimal
+payload from an older peer still deserializes, that unknown fields are ignored
+rather than rejected, that absent logs are omitted, and that the enum really is
+externally tagged.
+
+No behaviour change — this is types and construction paths only.
+## 20th July 2026
+
 ### 0.8.17 — single-flight for concurrent agent name lookups
 
 Concurrent first-time lookups of the *same* agent name now collapse into one

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.17"
+version = "0.8.18"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
@@ -19,11 +19,29 @@ pub mod network;
 pub(crate) mod utils;
 
 mod request_queue;
-/// WSRequest is the request format to the websocket connection
-/// did: DID to resolve
+/// A resolution request sent over the WebSocket connection.
+///
+/// `#[non_exhaustive]`: build via [`WSRequest::new`]. Fields stay public for
+/// reads.
+///
+/// Sealing matters here specifically because this is a **wire type**. Growing
+/// the protocol means adding fields, and every added field must be
+/// `#[serde(default, skip_serializing_if = ...)]` so an older peer that does not
+/// know it simply ignores it — the pattern `did_log` already follows on
+/// [`WSResponse`]. Sealing makes those additions non-breaking for Rust callers
+/// too, rather than forcing a major release for each one.
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct WSRequest {
+    /// The DID to resolve.
     pub did: String,
+}
+
+impl WSRequest {
+    /// Request resolution of `did`.
+    pub fn new(did: impl Into<String>) -> Self {
+        Self { did: did.into() }
+    }
 }
 
 /// WSResponse is the response format from the websocket connection
@@ -33,7 +51,9 @@ pub struct WSRequest {
 /// did_log: Raw JSONL DID log for verifiable DID methods (e.g. did:webvh)
 ///          Enables client-side cryptographic verification of the document
 /// did_witness_log: Raw witness proofs JSON for DID methods that use witnesses
+/// `#[non_exhaustive]`: build via [`WSResponse::new`] and the `with_*` setters.
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct WSResponse {
     pub did: String,
     pub hash: [u64; 2],
@@ -44,23 +64,78 @@ pub struct WSResponse {
     pub did_witness_log: Option<String>,
 }
 
+impl WSResponse {
+    /// A response carrying a resolved document.
+    ///
+    /// `hash` must be the hash of whatever string the *client* sent, since that
+    /// is what the client matches the response against. It is not necessarily
+    /// `hash_did(&did)` — see `network.rs`, where inbound responses are
+    /// correlated by the server-supplied `hash` rather than by re-hashing `did`.
+    pub fn new(did: impl Into<String>, hash: [u64; 2], document: Document) -> Self {
+        Self {
+            did: did.into(),
+            hash,
+            document,
+            did_log: None,
+            did_witness_log: None,
+        }
+    }
+
+    /// Attach the raw `did:webvh` logs, letting the client verify the document
+    /// itself rather than trusting this server.
+    pub fn with_logs(mut self, did_log: Option<String>, did_witness_log: Option<String>) -> Self {
+        self.did_log = did_log;
+        self.did_witness_log = did_witness_log;
+        self
+    }
+}
+
 /// WSResponseError is the response format from the websocket connection if an error occurred server side.
 /// did: DID associated with the error
 /// hash: HighwayHash128 of the DID
 /// error: Error message
+/// `#[non_exhaustive]`: build via [`WSResponseError::new`].
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct WSResponseError {
     pub did: String,
     pub hash: [u64; 2],
     pub error: String,
 }
 
-/// WSResponseType is the type of response received from the websocket connection
-/// Response: A successful response
-/// Error: An error response
+impl WSResponseError {
+    /// An error response. `hash` follows the same rule as [`WSResponse::new`]:
+    /// it must match what the client sent, or the caller never sees this and
+    /// waits out its timeout instead.
+    pub fn new(did: impl Into<String>, hash: [u64; 2], error: impl Into<String>) -> Self {
+        Self {
+            did: did.into(),
+            hash,
+            error: error.into(),
+        }
+    }
+}
+
+/// What came back over the WebSocket connection.
+///
+/// # Do not add variants
+///
+/// `#[non_exhaustive]` here records a Rust-level rule, but the **wire**-level one
+/// is stricter and matters more: this is an externally-tagged enum, so a new
+/// variant serializes as an unrecognised key. An older client fails to
+/// deserialize it, and `ws_recv` in `network.rs` logs the parse failure and
+/// *drops the frame* — leaving the caller waiting out its full `network_timeout`
+/// with no error to report.
+///
+/// A silent hang is a far worse failure than a clean error, so protocol growth
+/// belongs in **additive optional fields** on [`WSResponse`] and
+/// [`WSResponseError`] (as `did_log` does), never in a new variant here.
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub enum WSResponseType {
+    /// A successful resolution.
     Response(Box<WSResponse>),
+    /// A failure attributable to a specific request.
     Error(WSResponseError),
 }
 
@@ -99,7 +174,7 @@ impl DIDCacheClient {
 
             // 1. Send the request to the network task, which will then send via websocket to the remote server
             network_task_tx
-                .send(WSCommands::Send(tx, unique_id.clone(), WSRequest { did: did.into() }))
+                .send(WSCommands::Send(tx, unique_id.clone(), WSRequest::new(did)))
                 .await
                 .map_err(|e| {
                     DIDCacheError::TransportError(format!(
@@ -212,5 +287,97 @@ impl DIDCacheClient {
         }
 
         Ok(doc)
+    }
+}
+
+#[cfg(test)]
+mod wire_tests {
+    use super::*;
+
+    fn doc() -> Document {
+        Document::new("did:example:123").unwrap()
+    }
+
+    #[test]
+    fn request_serializes_to_the_documented_shape() {
+        let json = serde_json::to_string(&WSRequest::new("did:example:123")).unwrap();
+        assert_eq!(json, r#"{"did":"did:example:123"}"#);
+    }
+
+    /// An older peer sends only `did`. That must still deserialize, or every
+    /// existing client breaks the moment this type grows a field.
+    #[test]
+    fn request_accepts_a_minimal_payload() {
+        let req: WSRequest = serde_json::from_str(r#"{"did":"did:example:123"}"#).unwrap();
+        assert_eq!(req.did, "did:example:123");
+    }
+
+    /// Unknown fields must be ignored, not rejected — this is what lets a newer
+    /// client talk to an older server without a negotiation step.
+    #[test]
+    fn request_ignores_unknown_fields() {
+        let req: WSRequest =
+            serde_json::from_str(r#"{"did":"did:example:123","future_field":"x"}"#).unwrap();
+        assert_eq!(req.did, "did:example:123");
+    }
+
+    #[test]
+    fn response_omits_absent_logs() {
+        let json =
+            serde_json::to_string(&WSResponse::new("did:example:123", [1, 2], doc())).unwrap();
+        assert!(!json.contains("did_log"), "got {json}");
+        assert!(!json.contains("did_witness_log"), "got {json}");
+    }
+
+    #[test]
+    fn response_round_trips_with_logs() {
+        let original = WSResponse::new("did:example:123", [1, 2], doc())
+            .with_logs(Some("log".into()), Some("witness".into()));
+        let back: WSResponse =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+        assert_eq!(back.did, "did:example:123");
+        assert_eq!(back.hash, [1, 2]);
+        assert_eq!(back.did_log.as_deref(), Some("log"));
+        assert_eq!(back.did_witness_log.as_deref(), Some("witness"));
+    }
+
+    /// A response from an older server carries no logs at all.
+    #[test]
+    fn response_accepts_a_payload_without_logs() {
+        let json = r#"{"did":"did:example:123","hash":[1,2],"document":{"id":"did:example:123"}}"#;
+        let response: WSResponse = serde_json::from_str(json).unwrap();
+        assert!(response.did_log.is_none());
+    }
+
+    /// The enum is externally tagged. This is pinned deliberately: the tagging
+    /// is what makes an added variant unparseable to older clients, which is why
+    /// the type documents that variants must not be added.
+    #[test]
+    fn response_type_is_externally_tagged() {
+        let json = serde_json::to_string(&WSResponseType::Error(WSResponseError::new(
+            "d",
+            [0, 0],
+            "e",
+        )))
+        .unwrap();
+        assert!(json.starts_with(r#"{"Error":"#), "got {json}");
+
+        let json = serde_json::to_string(&WSResponseType::Response(Box::new(WSResponse::new(
+            "d",
+            [0, 0],
+            doc(),
+        ))))
+        .unwrap();
+        assert!(json.starts_with(r#"{"Response":"#), "got {json}");
+    }
+
+    #[test]
+    fn error_round_trips() {
+        let original = WSResponseError::new("did:example:123", [7, 8], "boom");
+        let back: WSResponseError =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+        assert_eq!(back.did, "did:example:123");
+        assert_eq!(back.hash, [7, 8]);
+        assert_eq!(back.error, "boom");
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 20th July 2026
 
+### 0.9.8 — build WebSocket responses via constructors
+
+Follows `affinidi-did-resolver-cache-sdk 0.8.18`, which sealed the WebSocket wire
+types. `build_response` and the two error paths now use `WSResponse::new` /
+`with_logs` and `WSResponseError::new` instead of struct literals.
+
+No behaviour change; the emitted frames are byte-identical.
+## 20th July 2026
+
 ### 0.9.7 — per-IP rate limiting
 
 The server previously had **no rate limiting of any kind**. It now applies a

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -22,7 +22,9 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 
 [dependencies]
 # Affinidi Crates
-affinidi-did-resolver-cache-sdk = { version = "0.8", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
+# Requires 0.8.18 for the sealed WebSocket wire types' constructors
+# (WSResponse::new / with_logs, WSResponseError::new).
+affinidi-did-resolver-cache-sdk = { version = "0.8.18", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.7"
+version = "0.9.8"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
@@ -25,13 +25,10 @@ async fn build_response(client: &reqwest::Client, response: ResolveResponse) -> 
         (None, None)
     };
 
-    WSResponseType::Response(Box::new(WSResponse {
-        did: response.did.clone(),
-        hash: response.did_hash,
-        document: response.doc,
-        did_log,
-        did_witness_log,
-    }))
+    WSResponseType::Response(Box::new(
+        WSResponse::new(response.did.clone(), response.did_hash, response.doc)
+            .with_logs(did_log, did_witness_log),
+    ))
 }
 
 /// Serialize and send a WS response. Returns `false` if the connection should
@@ -66,11 +63,11 @@ async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: St
         let hash = DIDCacheClient::hash_did(&did);
         warn!("ws: rejecting oversized DID ({} bytes)", did.len());
         state.stats().await.increment_resolver_error();
-        let message = WSResponseType::Error(WSResponseError {
+        let message = WSResponseType::Error(WSResponseError::new(
             did,
             hash,
-            error: format!("DID exceeds maximum length of {} bytes", state.max_did_size),
-        });
+            format!("DID exceeds maximum length of {} bytes", state.max_did_size),
+        ));
         return send_response(socket, &message).await;
     }
 
@@ -96,11 +93,7 @@ async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: St
             let hash = DIDCacheClient::hash_did(&did);
             warn!("Couldn't resolve DID: ({did}) Reason: {e}");
             state.stats().await.increment_resolver_error();
-            let message = WSResponseType::Error(WSResponseError {
-                did,
-                hash,
-                error: e.to_string(),
-            });
+            let message = WSResponseType::Error(WSResponseError::new(did, hash, e.to_string()));
             send_response(socket, &message).await
         }
     }


### PR DESCRIPTION
First half of gap #7. Types and construction paths only — **no behaviour change**,
emitted frames are byte-identical. The protocol change follows separately.

## Why

Today a name lookup in network mode costs **two round trips over two transports**:
HTTP to the cache server for name→DID, then WebSocket for DID→document.
Collapsing that onto the connection the client already holds means growing these
types — and growing them should not require a breaking release each time.

`WSRequest`, `WSResponse`, `WSResponseError` and `WSResponseType` are now
`#[non_exhaustive]`, with `WSRequest::new`, `WSResponse::new` / `with_logs` and
`WSResponseError::new` as the construction paths.

## The part that matters more than the sealing

Sealing records a *Rust*-level constraint. The **wire**-level one is stricter, and
is now documented on `WSResponseType`:

> **Do not add variants.** The enum is externally tagged, so a new variant
> serializes as an unrecognised key. An older client fails to deserialize it and
> `ws_recv` **drops the frame** — leaving the caller to wait out its full
> `network_timeout` with no error to report.

A silent hang is a far worse failure than a clean error, and nothing in the type
system stops you adding a variant. Writing the rule where the next person will
read it is the real deliverable here.

Protocol growth therefore belongs in **additive optional fields** — exactly the
pattern `did_log` already follows — never a new variant.

## Sealing immediately earned its keep

It caught **two struct literals** in the cache server (`websocket.rs:66` and `:96`)
that would have broken on the first added field. Those are now constructor calls.

## Tests pin the wire format, not the Rust types

Eight tests, because the Rust API is not what compatibility depends on:

- the request serializes to exactly `{"did":"…"}`
- a **minimal payload from an older peer** still deserializes
- **unknown fields are ignored, not rejected** — this is what lets a newer client
  talk to an older server with no negotiation step
- absent logs are omitted rather than serialized as `null`
- a response with no logs at all (an older server) still parses
- the enum really is externally tagged — pinned deliberately, since that tagging
  is *why* an added variant is unparseable to older clients

## Verification

- 104 tests pass across the two crates (77 lib + 20 + 6 + 9 endpoint + 7 rate-limit
  + doctests).
- `cargo check --workspace --all-targets`, `clippy --all-features --all-targets
  -D warnings`, `fmt --check`, and the workspace-duplicate guard all clean.
- Pre-existing `integration_test::test_cache_server` still fails on
  `NetworkTimeout` — network-dependent, fails on `main` too.