### PR TITLE
feat: resolve agent names over the WebSocket connection

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,45 @@
 
 ## 20th July 2026
 
+### 0.8.19 — resolve agent names over the WebSocket connection
+
+Opt in with `with_agent_names_over_websocket(true)`. **Off by default**, and
+requires `affinidi-did-resolver-cache-server` 0.9.9 or newer.
+
+A name lookup in network mode previously cost **two round trips over two
+transports**: HTTP to the cache server for name → DID, then WebSocket for
+DID → document. The server now does both in one exchange on the connection the
+client already holds.
+
+#### How it stays compatible
+
+The name travels in `WSRequest::did` *and* in a new optional `agent_name`. A
+server that predates this ignores the unknown field, tries to parse the name as a
+DID, fails, and answers with a `WSResponseError` carrying the hash of what the
+client sent — which is what the client registered its waiter under. The caller
+sees a **clean error rather than a hang**, which is the failure mode that
+mattered: `ws_recv` drops frames it cannot correlate, so a mismatched hash costs
+a full `network_timeout` with nothing to report.
+
+`WSResponse` gains an optional `agent_name` echo. No new `WSResponseType`
+variant — see the note on that type for why.
+
+#### Not auto-detected, deliberately
+
+An older server's response to a name request is a generic "failed to parse DID",
+indistinguishable from a real failure without matching on error strings. Enabling
+this against an old server is therefore safe but useless — you get an error, not
+a hang. Capability discovery is the proper answer and is not attempted here.
+
+#### Verification is unchanged
+
+`alsoKnownAs` is still checked client-side, against the document this client
+received. The server resolves and caches; it is not trusted to have verified
+anything. `WSCommands::ResponseReceived` now carries the whole `WSResponse`
+rather than picked-apart fields, so the resolved DID and echoed name are
+available without further protocol changes.
+## 20th July 2026
+
 ### 0.8.18 — seal the WebSocket wire types
 
 `WSRequest`, `WSResponse`, `WSResponseError` and `WSResponseType` are now

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.18"
+version = "0.8.19"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
@@ -108,6 +108,33 @@ impl DIDCacheClient {
     ) -> Result<ResolveResponse, DIDCacheError> {
         let name_hash = Self::hash_did(name.as_str());
 
+        // One-round-trip path: the cache server resolves name -> DID -> document
+        // in a single exchange, so there is no separate DID resolution to do.
+        // Verification still happens here, against a document this client
+        // received directly — the server is a cache, never a trust anchor.
+        #[cfg(all(feature = "agent-names", feature = "network"))]
+        if self.config.agent_names_over_websocket && self.network_task_tx.is_some() {
+            let (did, doc) = self.network_resolve_agent_name(name.as_str()).await?;
+
+            if let Err(e) = verify_also_known_as(&doc, name) {
+                warn!("agent name verification failed: {e}");
+                return Err(DIDCacheError::from(e));
+            }
+
+            let did_hash = Self::hash_did(&did);
+            // Populate the shared document cache so a later lookup by DID hits.
+            self.cache.insert(did_hash, doc.clone()).await;
+            self.agent_name_cache.insert(name_hash, did.clone()).await;
+
+            let method: crate::DIDMethod = did
+                .split(':')
+                .nth(1)
+                .and_then(|m| crate::DIDMethod::try_from(m).ok())
+                .unwrap_or(crate::DIDMethod::OTHER);
+
+            return Ok(ResolveResponse::new(did, method, did_hash, doc, false));
+        }
+
         let did = match self.agent_name_cache.get(&name_hash).await {
             Some(did) => {
                 debug!("agent name cache hit: {name}");

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
@@ -45,6 +45,8 @@ pub struct DIDCacheConfig {
     pub(crate) agent_name_ttl: u32,
     #[cfg(feature = "agent-names")]
     pub(crate) agent_name_cache_capacity: u32,
+    #[cfg(all(feature = "agent-names", feature = "network"))]
+    pub(crate) agent_names_over_websocket: bool,
 }
 
 /// DID Cache Config Builder to construct options required for the client.
@@ -70,6 +72,8 @@ pub struct DIDCacheConfigBuilder {
     agent_name_ttl: u32,
     #[cfg(feature = "agent-names")]
     agent_name_cache_capacity: u32,
+    #[cfg(all(feature = "agent-names", feature = "network"))]
+    agent_names_over_websocket: bool,
 }
 
 impl Default for DIDCacheConfigBuilder {
@@ -89,6 +93,8 @@ impl Default for DIDCacheConfigBuilder {
             agent_name_ttl: 300,
             #[cfg(feature = "agent-names")]
             agent_name_cache_capacity: 1_000,
+            #[cfg(all(feature = "agent-names", feature = "network"))]
+            agent_names_over_websocket: false,
         }
     }
 }
@@ -171,6 +177,25 @@ impl DIDCacheConfigBuilder {
         self
     }
 
+    /// Resolve agent names over the WebSocket connection instead of through the
+    /// registered backends.
+    ///
+    /// Saves a round trip and a transport: the cache server does name → DID →
+    /// document in one exchange, rather than the client making an HTTP call for
+    /// name → DID and then a WebSocket call for DID → document.
+    ///
+    /// **Requires `affinidi-did-resolver-cache-server` 0.9.9 or newer.** Off by
+    /// default, and deliberately not auto-detected: an older server answers a
+    /// name request with a generic "failed to parse DID" error, and telling that
+    /// apart from a real failure would mean matching on error strings. The
+    /// failure is at least clean — a reported error, not a hang — so enabling
+    /// this against an old server is safe, just useless.
+    #[cfg(all(feature = "agent-names", feature = "network"))]
+    pub fn with_agent_names_over_websocket(mut self, enabled: bool) -> Self {
+        self.agent_names_over_websocket = enabled;
+        self
+    }
+
     /// Build the [ClientConfig].
     pub fn build(self) -> DIDCacheConfig {
         DIDCacheConfig {
@@ -188,6 +213,8 @@ impl DIDCacheConfigBuilder {
             agent_name_ttl: self.agent_name_ttl,
             #[cfg(feature = "agent-names")]
             agent_name_cache_capacity: self.agent_name_cache_capacity,
+            #[cfg(all(feature = "agent-names", feature = "network"))]
+            agent_names_over_websocket: self.agent_names_over_websocket,
         }
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
@@ -33,14 +33,43 @@ mod request_queue;
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WSRequest {
-    /// The DID to resolve.
+    /// The identifier to resolve.
+    ///
+    /// For an agent name request this carries the **name**, not a DID. That is
+    /// deliberate: `did` is the only field an older server requires, so a name
+    /// request still deserializes there. It then fails to parse as a DID and
+    /// comes back as a clean [`WSResponseError`] whose `hash` still matches what
+    /// the client registered — an error the caller can see, rather than a frame
+    /// the client cannot correlate and a wait to `network_timeout`.
     pub did: String,
+
+    /// Set when `did` carries an agent name rather than a DID.
+    ///
+    /// Additive and optional, so an older server ignores it (see above) and an
+    /// older client never sends it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_name: Option<String>,
 }
 
 impl WSRequest {
     /// Request resolution of `did`.
     pub fn new(did: impl Into<String>) -> Self {
-        Self { did: did.into() }
+        Self {
+            did: did.into(),
+            agent_name: None,
+        }
+    }
+
+    /// Request resolution of an agent name.
+    ///
+    /// `name` must be the **canonical** form, since the server echoes its hash
+    /// back for correlation and the client matches on the hash of what it sent.
+    pub fn for_agent_name(name: impl Into<String>) -> Self {
+        let name = name.into();
+        Self {
+            did: name.clone(),
+            agent_name: Some(name),
+        }
     }
 }
 
@@ -62,6 +91,11 @@ pub struct WSResponse {
     pub did_log: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub did_witness_log: Option<String>,
+    /// Echoed when the request carried an agent name, so the client can confirm
+    /// which name this document was resolved for before verifying `alsoKnownAs`
+    /// against it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_name: Option<String>,
 }
 
 impl WSResponse {
@@ -78,7 +112,14 @@ impl WSResponse {
             document,
             did_log: None,
             did_witness_log: None,
+            agent_name: None,
         }
+    }
+
+    /// Record the agent name this document was resolved for.
+    pub fn with_agent_name(mut self, agent_name: Option<String>) -> Self {
+        self.agent_name = agent_name;
+        self
     }
 
     /// Attach the raw `did:webvh` logs, letting the client verify the document
@@ -140,6 +181,104 @@ pub enum WSResponseType {
 }
 
 impl DIDCacheClient {
+    /// Resolve an agent name via the cache server, in **one** round trip.
+    ///
+    /// Returns `(resolved DID, document)`. Without this, a name lookup in
+    /// network mode costs two round trips over two transports: HTTP to the
+    /// server for name → DID, then WebSocket for DID → document.
+    ///
+    /// # Talking to an older server
+    ///
+    /// The name travels in `WSRequest::did` with `agent_name` alongside it. A
+    /// server that predates this ignores the unknown field, tries to parse the
+    /// name as a DID, fails, and answers with a `WSResponseError` carrying the
+    /// hash of what we sent — which is what we registered against, so it
+    /// surfaces as a clean transport error rather than a frame we cannot
+    /// correlate and a wait to `network_timeout`.
+    ///
+    /// It is still gated behind `agent_names_over_websocket` rather than
+    /// attempted optimistically, because distinguishing "old server" from "real
+    /// failure" would mean matching on error strings.
+    #[cfg(feature = "agent-names")]
+    pub(crate) async fn network_resolve_agent_name(
+        &self,
+        canonical_name: &str,
+    ) -> Result<(String, Document), DIDCacheError> {
+        let _span = span!(Level::DEBUG, "network_resolve_agent_name");
+        async move {
+            let name_hash = DIDCacheClient::hash_did(canonical_name);
+            debug!("resolving agent name ({canonical_name}) via network");
+
+            let network_task_tx = self.network_task_tx.clone().unwrap();
+            let (tx, rx) = oneshot::channel::<WSCommands>();
+            let unique_id: String = rand::rng()
+                .sample_iter(&Alphanumeric)
+                .take(8)
+                .map(char::from)
+                .collect();
+
+            network_task_tx
+                .send(WSCommands::Send(
+                    tx,
+                    unique_id.clone(),
+                    WSRequest::for_agent_name(canonical_name),
+                ))
+                .await
+                .map_err(|e| {
+                    DIDCacheError::TransportError(format!(
+                        "Couldn't send request to network_task. Reason: {e}",
+                    ))
+                })?;
+
+            let sleep = tokio::time::sleep(self.config.network_timeout);
+            tokio::pin!(sleep);
+
+            select! {
+                _ = &mut sleep => {
+                    warn!("Timeout resolving agent name ({canonical_name})");
+                    network_task_tx
+                        .send(WSCommands::TimeOut(unique_id, name_hash))
+                        .await
+                        .map_err(|err| {
+                            DIDCacheError::TransportError(format!(
+                                "Could not send timeout message to ws_handler: {err:?}"
+                            ))
+                        })?;
+                    Err(DIDCacheError::NetworkTimeout)
+                }
+                value = rx => {
+                    match value {
+                        Ok(WSCommands::ResponseReceived(response)) => {
+                            let response = *response;
+                            // The server reports the DID it resolved the name to;
+                            // `response.did` is that DID, not the name we sent.
+                            let did = response.did.clone();
+                            let document = Self::verify_network_response(
+                                &did,
+                                response.document,
+                                response.did_log,
+                                response.did_witness_log,
+                            )
+                            .await?;
+                            Ok((did, document))
+                        }
+                        Ok(WSCommands::ErrorReceived(msg)) => {
+                            Err(DIDCacheError::TransportError(msg))
+                        }
+                        Ok(_) => Err(DIDCacheError::TransportError(
+                            "Unexpected response from network task".into(),
+                        )),
+                        Err(e) => Err(DIDCacheError::TransportError(format!(
+                            "Error receiving response from network task: {e:?}"
+                        ))),
+                    }
+                }
+            }
+        }
+        .instrument(_span)
+        .await
+    }
+
     /// Resolve a DID via the network
     /// Returns the resolved DID Document, or an error
     ///
@@ -198,9 +337,16 @@ impl DIDCacheClient {
                     }
                     value = rx => {
                         match value {
-                            Ok(WSCommands::ResponseReceived(doc, did_log, did_witness_log)) => {
+                            Ok(WSCommands::ResponseReceived(response)) => {
                                 debug!("Received response from network task ({:#?})", did_hash);
-                                Self::verify_network_response(did, *doc, did_log, did_witness_log).await
+                                let response = *response;
+                                Self::verify_network_response(
+                                    did,
+                                    response.document,
+                                    response.did_log,
+                                    response.did_witness_log,
+                                )
+                                .await
                             }
                             Ok(WSCommands::ErrorReceived(msg)) => {
                                 warn!("Received error response from network task");
@@ -379,5 +525,68 @@ mod wire_tests {
         assert_eq!(back.did, "did:example:123");
         assert_eq!(back.hash, [7, 8]);
         assert_eq!(back.error, "boom");
+    }
+}
+
+#[cfg(test)]
+mod agent_name_wire_tests {
+    use super::*;
+
+    /// The name travels in `did` as well as `agent_name`. That is what makes an
+    /// older server — which only knows `did` — answer with a correlatable error
+    /// rather than leaving the caller to time out.
+    #[test]
+    fn agent_name_request_also_populates_did() {
+        let req = WSRequest::for_agent_name("https://example.com/@alice");
+        assert_eq!(req.did, "https://example.com/@alice");
+        assert_eq!(
+            req.agent_name.as_deref(),
+            Some("https://example.com/@alice")
+        );
+    }
+
+    #[test]
+    fn plain_did_request_sends_no_agent_name() {
+        let json = serde_json::to_string(&WSRequest::new("did:example:123")).unwrap();
+        assert_eq!(json, r#"{"did":"did:example:123"}"#);
+    }
+
+    #[test]
+    fn agent_name_request_serializes_both_fields() {
+        let json = serde_json::to_string(&WSRequest::for_agent_name("example.com/@alice")).unwrap();
+        assert!(json.contains(r#""did":"example.com/@alice""#), "got {json}");
+        assert!(
+            json.contains(r#""agent_name":"example.com/@alice""#),
+            "got {json}"
+        );
+    }
+
+    /// An older *client* sends no `agent_name`; a newer server must still parse.
+    #[test]
+    fn request_without_agent_name_parses() {
+        let req: WSRequest = serde_json::from_str(r#"{"did":"did:example:123"}"#).unwrap();
+        assert!(req.agent_name.is_none());
+    }
+
+    /// An older *server* echoes no `agent_name`; a newer client must still parse.
+    #[test]
+    fn response_without_agent_name_parses() {
+        let json = r#"{"did":"did:example:123","hash":[1,2],"document":{"id":"did:example:123"}}"#;
+        let response: WSResponse = serde_json::from_str(json).unwrap();
+        assert!(response.agent_name.is_none());
+    }
+
+    #[test]
+    fn response_round_trips_the_agent_name() {
+        let doc = Document::new("did:example:123").unwrap();
+        let original = WSResponse::new("did:example:123", [1, 2], doc)
+            .with_agent_name(Some("https://example.com/@alice".into()));
+        let back: WSResponse =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+        assert_eq!(
+            back.agent_name.as_deref(),
+            Some("https://example.com/@alice")
+        );
+        assert_eq!(back.did, "did:example:123", "did carries the RESOLVED did");
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/network.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/networking/network.rs
@@ -8,12 +8,11 @@
 
 use affinidi_task_utils::CancellationToken;
 
-use super::{WSResponseType, request_queue::RequestList};
+use super::{WSResponse, WSResponseType, request_queue::RequestList};
 use crate::{
     DIDCacheClient, WSRequest, config::DIDCacheConfig, errors::DIDCacheError,
     networking::utils::connect,
 };
-use affinidi_did_common::Document;
 use std::{pin::Pin, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncWrite, BufReader},
@@ -34,7 +33,10 @@ use web_socket::{CloseCode, DataType, Event, MessageType, WebSocket};
 /// Connected: Signals that the websocket is connected
 /// Exit: Exits the websocket handler
 /// Send: Sends the response string to the websocket (Channel, ID, WSRequest)
-/// ResponseReceived: Response received from the websocket (Document, optional DID log, optional witness log)
+/// ResponseReceived: the full response frame from the websocket. Carrying the
+///   whole `WSResponse` rather than picked-apart fields means the agent name
+///   path can read the *resolved* DID and the echoed name, and future fields
+///   need no further change here.
 /// ErrorReceived: Error received from the remote server
 /// NotFound: Response not found in the cache
 /// TimeOut: SDK request timed out, contains ID and did_hash we were looking for
@@ -42,7 +44,7 @@ use web_socket::{CloseCode, DataType, Event, MessageType, WebSocket};
 pub(crate) enum WSCommands {
     Connected,
     Send(Responder, String, WSRequest),
-    ResponseReceived(Box<Document>, Option<String>, Option<String>),
+    ResponseReceived(Box<WSResponse>),
     ErrorReceived(String),
     TimeOut(String, [u64; 2]),
 }
@@ -320,11 +322,15 @@ impl NetworkTask {
                 if let Some(channels) = self.cache.remove(&response.hash, None) {
                     // Loop through and notify each registered channel
                     for channel in channels {
-                        let _ = channel.send(WSCommands::ResponseReceived(
-                            Box::new(response.document.clone()),
-                            response.did_log.clone(),
-                            response.did_witness_log.clone(),
-                        ));
+                        let _ = channel.send(WSCommands::ResponseReceived(Box::new(
+                            WSResponse::new(
+                                response.did.clone(),
+                                response.hash,
+                                response.document.clone(),
+                            )
+                            .with_logs(response.did_log.clone(), response.did_witness_log.clone())
+                            .with_agent_name(response.agent_name.clone()),
+                        )));
                     }
                 } else {
                     warn!("Response not found in request list: {:#?}", response.hash);

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ## 20th July 2026
 
+### 0.9.9 — agent name resolution over WebSocket
+
+A `WSRequest` carrying `agent_name` is now resolved name → DID → document in one
+exchange, matching `GET /did/v1/resolve-name/{*name}` but on the connection the
+client already holds.
+
+Gated by the same `enable_agent_names` flag and subject to the same
+`agent_name_concurrency` ceiling as the HTTP endpoint, including shedding rather
+than queueing when saturated.
+
+#### The correlation rule
+
+The response's `hash` is the hash of the **name as sent**, not of the resolved
+DID. Clients register their waiter under the hash of what they sent and
+`ws_recv` drops frames it cannot correlate — so hashing the resolved DID instead
+would leave every caller waiting out its full timeout with no error. `did`
+carries the resolved DID and `agent_name` echoes the name.
+
+#### Still a cache, not a trust anchor
+
+No `alsoKnownAs` verification is performed or claimed here. The client re-verifies
+against the document it received, exactly as it re-verifies `did:webvh` logs.
+## 20th July 2026
+
 ### 0.9.8 — build WebSocket responses via constructors
 
 Follows `affinidi-did-resolver-cache-sdk 0.8.18`, which sealed the WebSocket wire

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.8"
+version = "0.9.9"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -22,9 +22,8 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 
 [dependencies]
 # Affinidi Crates
-# Requires 0.8.18 for the sealed WebSocket wire types' constructors
-# (WSResponse::new / with_logs, WSResponseError::new).
-affinidi-did-resolver-cache-sdk = { version = "0.8.18", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
+# Requires 0.8.19 for WSRequest::agent_name / WSResponse::with_agent_name.
+affinidi-did-resolver-cache-sdk = { version = "0.8.19", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/websocket.rs
@@ -2,6 +2,7 @@ use affinidi_did_resolver_cache_sdk::{
     DIDCacheClient, DIDMethod, ResolveResponse,
     networking::{WSRequest, WSResponse, WSResponseError, WSResponseType},
 };
+use agent_names::{AgentName, AgentNameResolver};
 use axum::{
     extract::{
         State, WebSocketUpgrade,
@@ -58,6 +59,128 @@ async fn send_response(socket: &mut WebSocket, message: &WSResponseType) -> bool
 /// Resolve `did` (bounded by the configured timeout) and send the response, or
 /// an error response if resolution fails or times out. Returns `false` if the
 /// connection should be closed.
+/// Route a request to the DID path or the agent name path.
+///
+/// An agent name request carries the name in `did` *and* in `agent_name`; a
+/// server without agent name support simply never sees the latter and treats the
+/// name as a DID, which fails cleanly.
+async fn dispatch_request(socket: &mut WebSocket, state: &SharedData, request: WSRequest) -> bool {
+    match request.agent_name {
+        Some(name) => resolve_agent_name_and_respond(socket, state, name).await,
+        None => resolve_and_respond(socket, state, request.did).await,
+    }
+}
+
+/// Resolve an agent name to a DID **and** its document, in one exchange.
+///
+/// The response's `hash` is the hash of the **name as sent**, not of the
+/// resolved DID: the client registered its waiter under that hash, so anything
+/// else leaves the caller waiting out its timeout. `did` carries the resolved
+/// DID, and `agent_name` echoes the name.
+///
+/// The client re-verifies `alsoKnownAs` against the document itself — this
+/// server is a cache, not a trust anchor — so no verification is claimed here.
+async fn resolve_agent_name_and_respond(
+    socket: &mut WebSocket,
+    state: &SharedData,
+    name: String,
+) -> bool {
+    let name_hash = DIDCacheClient::hash_did(&name);
+
+    let fail = |error: String| WSResponseType::Error(WSResponseError::new(&name, name_hash, error));
+
+    if name.len() > state.max_did_size {
+        state.stats().await.increment_agent_name_error();
+        return send_response(
+            socket,
+            &fail(format!(
+                "Agent name exceeds maximum length of {} bytes",
+                state.max_did_size
+            )),
+        )
+        .await;
+    }
+
+    let Some(resolver) = state.agent_name_resolver.as_ref() else {
+        state.stats().await.increment_agent_name_error();
+        return send_response(
+            socket,
+            &fail("Agent name resolution is not enabled on this server".to_string()),
+        )
+        .await;
+    };
+
+    let parsed = match AgentName::parse(&name) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            state.stats().await.increment_agent_name_error();
+            return send_response(socket, &fail(e.to_string())).await;
+        }
+    };
+
+    // Same outbound-fetch ceiling as the HTTP endpoint: shed rather than queue.
+    let Ok(_permit) = state.agent_name_permits.try_acquire() else {
+        state.stats().await.increment_agent_name_error();
+        warn!("ws: shedding agent name lookup '{parsed}': outbound fetch ceiling reached");
+        return send_response(
+            socket,
+            &fail("Too many agent name lookups in flight; retry shortly".to_string()),
+        )
+        .await;
+    };
+
+    let did = match tokio::time::timeout(state.resolve_timeout, resolver.resolve(&parsed)).await {
+        Ok(Some(Ok(did))) => did,
+        Ok(Some(Err(e))) => {
+            state.stats().await.increment_agent_name_error();
+            return send_response(socket, &fail(e.to_string())).await;
+        }
+        Ok(None) => {
+            state.stats().await.increment_agent_name_error();
+            return send_response(
+                socket,
+                &fail(format!("No resolver could resolve '{parsed}'")),
+            )
+            .await;
+        }
+        Err(_elapsed) => {
+            state.stats().await.increment_agent_name_error();
+            return send_response(socket, &fail("Timed out resolving agent name".to_string()))
+                .await;
+        }
+    };
+
+    // Now resolve that DID exactly as a normal request would.
+    match resolve_with_timeout(&state.resolver, state.resolve_timeout, &did).await {
+        Ok(response) => {
+            {
+                let mut stats = state.stats().await;
+                stats.increment_agent_name_success();
+                stats.increment_resolver_success();
+                if response.cache_hit {
+                    stats.increment_cache_hit();
+                }
+                stats.increment_did_method_success(response.method.clone());
+            }
+            let (did_log, did_witness_log) = if response.method == DIDMethod::WEBVH {
+                fetch_webvh_log(&state.webvh_client, &response.did).await
+            } else {
+                (None, None)
+            };
+            let message = WSResponseType::Response(Box::new(
+                WSResponse::new(response.did.clone(), name_hash, response.doc)
+                    .with_logs(did_log, did_witness_log)
+                    .with_agent_name(Some(parsed.as_str().to_string())),
+            ));
+            send_response(socket, &message).await
+        }
+        Err(e) => {
+            state.stats().await.increment_agent_name_error();
+            send_response(socket, &fail(e.to_string())).await
+        }
+    }
+}
+
 async fn resolve_and_respond(socket: &mut WebSocket, state: &SharedData, did: String) -> bool {
     if !did_within_size_limit(&did, state.max_did_size) {
         let hash = DIDCacheClient::hash_did(&did);
@@ -155,7 +278,7 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData) {
                                             }
                                         };
 
-                                        if !resolve_and_respond(&mut socket, &state, request.did).await {
+                                        if !dispatch_request(&mut socket, &state, request).await {
                                             break;
                                         }
                                     }
@@ -169,7 +292,7 @@ async fn handle_socket(mut socket: WebSocket, state: SharedData) {
                                             }
                                         };
 
-                                        if !resolve_and_respond(&mut socket, &state, request.did).await {
+                                        if !dispatch_request(&mut socket, &state, request).await {
                                             break;
                                         }
                                     }


### PR DESCRIPTION
Second half of gap #7, and the last item on the list. Builds on
[#641](https://github.com/affinidi/affinidi-tdk-rs/pull/641), which sealed the
wire types so this could be additive.

## What it saves

A name lookup in network mode cost **two round trips over two transports**: HTTP
to the cache server for name→DID, then WebSocket for DID→document. The server now
does both in one exchange on the connection the client already holds.

Opt in with `with_agent_names_over_websocket(true)`. Off by default; requires
cache-server 0.9.9.

## The design is driven by one failure mode

`ws_recv` **drops frames it cannot correlate**. A response hashed against anything
other than what the client sent costs the caller a full `network_timeout` with
nothing to report — a silent hang, the worst outcome available. Everything else
follows from avoiding that:

- **The name travels in `WSRequest::did` as well as `agent_name`.** An older
  server ignores the unknown field, tries to parse the name as a DID, fails, and
  answers with a `WSResponseError` carrying the hash of what the client sent —
  which is what the client registered under. **Clean error, not a hang.**
- **The server echoes `hash_did(<name as sent>)`**, not the hash of the resolved
  DID. `did` carries the resolved DID; `agent_name` echoes the name.
- **No new `WSResponseType` variant**, per the rule documented on that type in
  #641: an added variant is unparseable to older clients, which drop the frame
  and hang.

## Not auto-detected, deliberately

An older server answers a name request with a generic *"failed to parse DID"* —
indistinguishable from a real failure without matching on error strings. That is
exactly the sort of fragility that breaks quietly two releases later.

So it is an explicit flag. Enabling it against an old server is **safe but
useless**: you get an error, not a hang. Capability discovery is the proper
long-term answer and is not attempted here.

## Verification is unchanged

`alsoKnownAs` is still checked **client-side**, against the document this client
received. The server resolves and caches; it is not trusted to have verified
anything — the same stance as client-side `did:webvh` log re-verification.

Server-side, the path reuses the existing `enable_agent_names` gate and the
`agent_name_concurrency` ceiling from 0.9.6, shedding rather than queueing when
saturated.

## Tests

Six new wire tests pin compatibility **in both directions**, which is the part
that cannot be caught by compiling:

- an older *client*'s request (no `agent_name`) parses on a new server
- an older *server*'s response (no echo) parses on a new client
- a plain DID request still serializes to exactly `{"did":"…"}` — no new field
  leaks onto the existing path
- an agent-name request populates **both** `did` and `agent_name`, which is the
  property the graceful-degradation story depends on

125 tests pass across the two crates. `clippy --all-features --all-targets
-D warnings`, `fmt --check`, `cargo check --workspace --all-targets` all clean.

Pre-existing `integration_test::test_cache_server` still fails on
`NetworkTimeout` — network-dependent, fails on `main` too.

## Expect a red publish dry-run

`cache-server 0.9.9` requires `cache-sdk 0.8.19`, which does not exist on
crates.io until this merges. The release job publishes in dependency order.