### PR TITLE
chore: move mediator-setup to vta-sdk 0.19 and clear the duplicate allowlist

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.18", features = ["provision-client"] }
+vta-sdk = { version = "0.19.14", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -162,7 +162,7 @@ aws-sdk-s3 = { version = "1", optional = true }
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.18", features = ["test-support"] }
+vta-sdk = { version = "0.19.14", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/scripts/workspace-duplicates-allow.txt
+++ b/scripts/workspace-duplicates-allow.txt
@@ -7,18 +7,12 @@
 # Only add an entry when the duplicate cannot be fixed from this repository.
 # A missing `[patch.crates-io]` entry is fixable here and does not belong.
 #
+#
 # ---------------------------------------------------------------------------
 #
-# affinidi-did-common
-#   Pulled in at 0.3.9 by `vta-sdk` -> `didwebvh-rs 0.5.x`, which still requires
-#   affinidi-did-common "0.3"; our local copy is 0.4.x, so the patch redirect
-#   does not satisfy that range and cargo falls back to the registry.
+# (empty)
 #
-#   Harmless today only by luck of interface shape: no `Document` crosses the
-#   didwebvh-rs boundary (`WebvhResolver` builds its own via
-#   `serde_json::from_value`). The moment any didwebvh-rs API returns a
-#   `Document`, this becomes a hard E0308.
-#
-#   Clears when `vta-sdk` moves to `didwebvh-rs 0.6` (which requires
-#   affinidi-did-common "0.4"). That is a change in the OpenVTC repository.
-affinidi-did-common
+# The affinidi-did-common entry that lived here was cleared on 2026-07-20:
+# vta-sdk 0.19.14 shipped on didwebvh-rs 0.6, which requires
+# affinidi-did-common "0.4", so the registry copy at 0.3.9 no longer enters the
+# graph.


### PR DESCRIPTION
The workspace now resolves to a **single** `affinidi-did-common`, `didwebvh-rs`
and `vta-sdk`. The allowlist added alongside the duplicate guard in
[#635](https://github.com/affinidi/affinidi-tdk-rs/pull/635) is empty for the
first time.

## Before / after

```
before                          after
------                          -----
affinidi-did-common v0.3.9      affinidi-did-common v0.4.0
affinidi-did-common v0.4.0
didwebvh-rs v0.5.6              didwebvh-rs v0.6.0
didwebvh-rs v0.6.0
vta-sdk v0.18.16                vta-sdk v0.19.14
vta-sdk v0.19.x
```

```
$ bash scripts/check-workspace-duplicates.sh
  ok     no workspace member is shadowed by a crates.io copy
```

## What was holding it

`mediator-setup` was the last crate on `vta-sdk 0.18`, whose line still depends on
`didwebvh-rs 0.5` — and therefore on `affinidi-did-common "0.3"`, which is what
kept the second copy in the graph.

That chain needed three things, in order:

1. `didwebvh-rs 0.6` requiring `affinidi-did-common "0.4"` — already published
2. `vta-sdk` republished on it —
   [OpenVTC/verifiable-trust-infrastructure#713](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/713),
   `0.19.14`
3. this PR

## No code changes

`mediator-setup` uses vta-sdk only through the `provision-client` and
`test-support` features, so the 0.18 → 0.19 move compiles untouched. It is
`publish = false`, so widening the range has no release implications.

## Why it mattered

The allowlist entry recorded this as debt rather than an accepted state, and said
why: the duplicate was harmless **only by luck of interface shape** — no
`Document` crossed the `didwebvh-rs` boundary, because `WebvhResolver` builds its
own via `serde_json::from_value`. The moment any didwebvh-rs API returned a
`Document`, it would have become a hard `E0308` pointing anywhere but at the
cause. That is now closed rather than deferred.

## Verification

- `cargo check --workspace --all-targets` clean.
- `scripts/check-workspace-duplicates.sh` passes **with an empty allowlist**.
- `scripts/check-version-bumps.sh` — `mediator-setup` is `publish = false`, so no
  bump required.