### PR TITLE
fix: stop the admin-DID websocket connection storm

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Changelog history
 
+## 22nd July 2026
+
+### 0.17.6 — stop the mediator dialling itself, and damp duplicate-socket duels
+
+Two independent faults combined into a self-inflicted connection storm: a
+mediator whose VTA routes DIDComm back through it saturated itself with
+websocket connect/close churn on its own admin DID (observed: ~40 connects/sec,
+plus a matching flood of `DELETE /mediator/v1/delete`).
+
+- **The VTA refresh task no longer opens a DIDComm session to this mediator.**
+  `vta_bootstrap` detects the self-mediated topology at boot, but
+  `tasks::vta_refresh` re-ran with `TransportPreference::Auto` on every tick
+  (every `cache_ttl/4`, clamped to 5min–1h) on the assumption that DIDComm to
+  ourselves "resolves cleanly once the listener is up". It connects — that is
+  the problem. Each tick opened a *client* websocket, authenticated as the
+  mediator's admin DID (which is also its VTA credential), back into this same
+  mediator, competing for that DID's one-socket slot. Each tick now re-checks
+  whether the VTA's advertised DIDComm mediator is us and refreshes over REST
+  when it is. Probe failures fall back to the configured preference — a probe
+  must never stop a refresh.
+
+  `VtaRefresher::with_mediator_did` supplies the DID for that check;
+  `VtaRefresher::new` is unchanged and an unset DID keeps the previous
+  behaviour.
+
+- **Duplicate-socket duels are damped instead of amplified.** Newest-wins is
+  right for an isolated duplicate — a client reconnecting after a half-open
+  socket must be able to reclaim its slot — but wrong for a sustained duel:
+  every takeover evicts a peer that immediately reconnects and takes the slot
+  straight back. After `CHURN_REFUSE_STREAK` (3) replacements inside the 5s
+  churn window, the incumbent keeps the slot and the contender is closed,
+  *provided the incumbent's channel is still alive* — a dead incumbent can
+  never lock a DID out. Self-limiting: refusals don't refresh the incumbent's
+  registration time, so once it ages past the churn window the next contender
+  is accepted normally. New counter: `websocket_churn_refused_total`.
+
+Requires `affinidi-messaging-sdk` 0.18.61, which stops client-side reconnect
+backoff from resetting on a connection that is immediately closed — the third
+leg of the same storm.
+
 ## 19th July 2026
 
 ### 0.17.4 — didwebvh-rs 0.6

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.5"
+version = "0.17.6"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -72,7 +72,10 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
+# 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
+# closed. Pinned tighter than the usual "0.18" because a mediator built against
+# an older SDK still amplifies duplicate-socket duels client-side.
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18.61" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -629,7 +629,10 @@ impl TryFrom<ConfigRaw> for Config {
                 mediator_secrets.clone(),
                 ttl_secs,
                 secrets_resolver.clone(),
-            );
+            )
+            // Our own DID, so each refresh tick can tell whether the VTA routes
+            // back through us and pick REST if it does.
+            .with_mediator_did(result.did.clone());
 
             Some((result, refresher))
         } else {

--- a/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/metrics.rs
@@ -102,6 +102,11 @@ pub mod names {
     pub const WEBSOCKET_REDELIVERED_MESSAGES_TOTAL: &str = "websocket_redelivered_messages_total";
     /// counter: Duplicate replacements occurring within the churn window (flip-flop signal)
     pub const WEBSOCKET_DUPLICATE_CHURN_TOTAL: &str = "websocket_duplicate_churn_total";
+    /// counter: New WebSocket registrations refused because the DID was in a
+    /// sustained replacement duel and the incumbent socket was still alive.
+    /// Non-zero means the duel damper is holding a DID's slot steady — pair it
+    /// with `WEBSOCKET_DUPLICATE_CHURN_TOTAL` to find the offending DID.
+    pub const WEBSOCKET_CHURN_REFUSED_TOTAL: &str = "websocket_churn_refused_total";
 
     // ── Rate limiting ───────────────────────────────────────────────────────
 

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/vta_refresh.rs
@@ -30,12 +30,15 @@ use crate::common::metrics::names;
 use affinidi_messaging_mediator_common::MediatorSecrets;
 use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secrets::Secret};
 use std::{
+    borrow::Cow,
     sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
-use vta_sdk::integration::{self, FallbackReason, SecretSource, VtaServiceConfig};
+use vta_sdk::integration::{
+    self, FallbackReason, SecretSource, TransportPreference, VtaServiceConfig,
+};
 
 /// Default refresh interval when `cache_ttl == 0` (no-expiry policy).
 /// Picks a sensible cadence so the cache still tracks the latest VTA
@@ -73,6 +76,10 @@ pub struct VtaRefresher {
     pub cache_ttl_secs: u64,
     pub secrets_resolver: Arc<ThreadedSecretsResolver>,
     pub interval: Duration,
+    /// This mediator's own DID. Compared against the VTA's advertised DIDComm
+    /// mediator each tick to detect the self-mediated topology — see
+    /// [`Self::tick_config`].
+    pub mediator_did: String,
 }
 
 impl VtaRefresher {
@@ -89,6 +96,61 @@ impl VtaRefresher {
             cache_ttl_secs,
             secrets_resolver,
             interval,
+            // Empty = "unknown", which disables the self-mediation probe and
+            // leaves the configured transport untouched. Set it with
+            // [`Self::with_mediator_did`]; `new` keeps its original signature so
+            // this stays a non-breaking addition.
+            mediator_did: String::new(),
+        }
+    }
+
+    /// Tell the refresher this mediator's own DID, enabling the self-mediation
+    /// check in [`Self::tick_config`]. Without it, refresh ticks use the
+    /// configured transport preference unchanged.
+    pub fn with_mediator_did(mut self, mediator_did: String) -> Self {
+        self.mediator_did = mediator_did;
+        self
+    }
+
+    /// Pick the transport for one refresh tick.
+    ///
+    /// [`bootstrap_vta`] detects the self-mediated topology at boot, but the
+    /// refresh path used to re-run with `Auto` every time on the assumption that
+    /// "by the time this runs the listener is up, so DIDComm to ourselves
+    /// resolves cleanly". It does connect — and that is the problem. Each tick
+    /// then opens a *client* websocket, authenticated as the mediator's admin
+    /// DID, back into this same mediator. The mediator allows one socket per
+    /// DID, so every such session competes for the admin DID's slot with any
+    /// other session that outlived its owner; the result is an eviction duel
+    /// that saturates the server with connect/close churn.
+    ///
+    /// So: when the VTA routes through us, refresh over REST. Nothing is lost —
+    /// REST is the same authenticated fetch — and the mediator never dials
+    /// itself. Probe failures fall back to the configured preference; a probe
+    /// must never be the reason a refresh doesn't happen.
+    ///
+    /// [`bootstrap_vta`]: crate::common::config::vta_bootstrap::bootstrap_vta
+    async fn tick_config(&self) -> Cow<'_, VtaServiceConfig> {
+        if self.mediator_did.is_empty() {
+            return Cow::Borrowed(&self.service_config);
+        }
+
+        let vta_did = &self.service_config.auth.credential.vta_did;
+        match vta_sdk::session::resolve_mediator_did(vta_did).await {
+            Ok(Some(vta_mediator)) if vta_mediator == self.mediator_did => {
+                debug!(
+                    mediator_did = %self.mediator_did,
+                    "VTA is self-mediated; refreshing over REST to avoid dialling ourselves"
+                );
+                let mut config = self.service_config.clone();
+                config.context.transport_preference = TransportPreference::PreferRest;
+                Cow::Owned(config)
+            }
+            Ok(_) => Cow::Borrowed(&self.service_config),
+            Err(e) => {
+                debug!("Self-mediation probe failed ({e}); using the configured transport");
+                Cow::Borrowed(&self.service_config)
+            }
         }
     }
 
@@ -113,7 +175,8 @@ impl VtaRefresher {
             }
 
             let started = Instant::now();
-            let outcome = integration::startup_with_reason(&self.service_config, &cache).await;
+            let tick_config = self.tick_config().await;
+            let outcome = integration::startup_with_reason(&tick_config, &cache).await;
             metrics::histogram!(names::VTA_REFRESH_DURATION_SECONDS)
                 .record(started.elapsed().as_secs_f64());
 

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -21,8 +21,9 @@
  Fjall's in-process broadcast, or the test MemoryStore.
 */
 use crate::common::metrics::names::{
-    WEBSOCKET_DUPLICATE_CHURN_TOTAL, WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL,
-    WEBSOCKET_REDELIVERED_MESSAGES_TOTAL, WS_LIVE_DELIVERY_DROPPED,
+    WEBSOCKET_CHURN_REFUSED_TOTAL, WEBSOCKET_DUPLICATE_CHURN_TOTAL,
+    WEBSOCKET_DUPLICATE_REPLACEMENTS_TOTAL, WEBSOCKET_REDELIVERED_MESSAGES_TOTAL,
+    WS_LIVE_DELIVERY_DROPPED,
 };
 use crate::common::ws_budget::{SendPermit, WsSendBudget};
 use crate::tasks::supervisor::TaskSupervisor;
@@ -48,6 +49,11 @@ use tracing::{Instrument, Level, debug, error, info, span, warn};
 /// registration for the same DID is counted as socket *churn* (the
 /// flip-flop signal in issue #374).
 const CHURN_WINDOW: Duration = Duration::from_secs(5);
+
+/// Consecutive in-window replacements for one DID before the duel damper in
+/// `_handle_registration` starts holding the slot for the incumbent. Two is a
+/// hand-off (A replaced by B, B replaced by A); three or more is a duel.
+const CHURN_REFUSE_STREAK: u32 = 3;
 
 /// Page size for the inbox-redelivery drain.
 const REDELIVERY_PAGE: usize = 50;
@@ -75,6 +81,10 @@ struct ClientEntry {
     active: bool,
     /// When this client registered — used to detect rapid replacement churn.
     registered_at: Instant,
+    /// Consecutive in-churn-window replacements this DID's slot has seen.
+    /// Carried across replacements and reset by any registration that arrives
+    /// outside the window. Drives the duel damper in `_handle_registration`.
+    churn_streak: u32,
 }
 
 /// Used when updating the streaming state.
@@ -449,10 +459,60 @@ impl StreamingTask {
         }
 
         // Is this replacing an existing session for the same DID?
-        let replacing = if let Some(old) = clients.get(&value.did_hash) {
+        let mut churn_streak = 0;
+        let replacing = if let Some(old) = clients.get_mut(&value.did_hash) {
             let since_last = old.registered_at.elapsed();
             let churn = since_last < CHURN_WINDOW;
             let since_last_ms = since_last.as_millis() as u64;
+            churn_streak = if churn { old.churn_streak + 1 } else { 0 };
+
+            // Duel damper. Newest-wins is the right rule for an isolated
+            // duplicate — a client that reconnected after a half-open socket
+            // must be able to take its slot back. It is the wrong rule for a
+            // *sustained* duel: with two or more live sessions for one DID,
+            // every takeover evicts a peer that immediately reconnects and
+            // takes the slot straight back, and the pair (or the pack) saturate
+            // the server with connect/close churn indefinitely.
+            //
+            // Past a short streak, hold the slot for the incumbent instead —
+            // but only while the incumbent's channel is demonstrably alive, so
+            // a stale entry can never lock a DID out. This is self-limiting:
+            // refusals don't touch the incumbent's `registered_at`, so once it
+            // ages past `CHURN_WINDOW` the next contender is accepted normally.
+            // Worst case is one takeover per window rather than one per
+            // round-trip.
+            if churn && churn_streak >= CHURN_REFUSE_STREAK && !old.tx.is_closed() {
+                old.churn_streak = churn_streak;
+                metrics::counter!(WEBSOCKET_CHURN_REFUSED_TOTAL).increment(1);
+                // Warn once as the duel starts, then stay quiet — the refusal
+                // path is hot by definition and the metric is the live signal.
+                if churn_streak == CHURN_REFUSE_STREAK {
+                    warn!(
+                        did = did,
+                        incumbent_session = old.session_id,
+                        refused_session = new_session_id,
+                        since_last_ms,
+                        churn_streak,
+                        "Sustained duplicate-WebSocket duel for this DID: holding the \
+                         incumbent session and refusing new connections for up to {}s. \
+                         Something is running more than one live session for this DID.",
+                        CHURN_WINDOW.as_secs(),
+                    );
+                } else {
+                    debug!(
+                        did = did,
+                        incumbent_session = old.session_id,
+                        refused_session = new_session_id,
+                        churn_streak,
+                        "Refusing duplicate WebSocket registration (duel damper)",
+                    );
+                }
+                let _ = client_tx
+                    .send(QueuedCommand::control(WebSocketCommands::Close))
+                    .await;
+                return;
+            }
+
             let msg = "Duplicate WebSocket connection: closing old session in favour of new one";
             // A churning DID replaces its own socket every few seconds
             // (e.g. two client sessions for the same DID dueling over the
@@ -498,12 +558,22 @@ impl StreamingTask {
             false
         };
 
+        // Count after this registration lands. A replacement swaps a map entry
+        // rather than adding one, so `len() + 1` over-reported by one on every
+        // duplicate — which reads, misleadingly, like a client leak during a
+        // duel. `clients` is keyed by DID hash, so this is the number of DIDs
+        // with a live socket, not the number of sockets.
+        let registered_clients = if replacing {
+            clients.len()
+        } else {
+            clients.len() + 1
+        };
         info!(
             did = did,
             session = new_session_id,
             "Registered streaming for DID: ({}) registered_clients({})",
             value.did_hash,
-            clients.len() + 1
+            registered_clients
         );
         clients.insert(
             value.did_hash.clone(),
@@ -512,6 +582,7 @@ impl StreamingTask {
                 session_id: new_session_id.to_string(),
                 active: false,
                 registered_at: Instant::now(),
+                churn_streak,
             },
         );
 
@@ -705,6 +776,7 @@ mod tests {
                 session_id: "A".to_string(),
                 active: true,
                 registered_at: Instant::now(),
+                churn_streak: 0,
             },
         );
 
@@ -789,6 +861,144 @@ mod tests {
                 .await
                 .is_err(),
             "fresh registration must not redeliver the inbox"
+        );
+    }
+
+    /// Newest-wins is correct for an isolated duplicate, but under a sustained
+    /// duel it makes both sides reconnect forever. Past `CHURN_REFUSE_STREAK`
+    /// in-window replacements the incumbent keeps the slot and the contender is
+    /// closed instead.
+    #[tokio::test]
+    async fn sustained_duel_holds_the_slot_for_the_incumbent() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did = "did:example:duellist";
+        let did_hash = digest(did);
+
+        let task = streaming_task();
+        let replay_in_progress: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let mut clients: HashMap<String, ClientEntry> = HashMap::new();
+
+        // Keep every receiver alive: a live incumbent channel is a precondition
+        // of the damper (see the dead-incumbent test below).
+        let mut keepalive = Vec::new();
+
+        let register = |session: &str, tx: mpsc::Sender<QueuedCommand>| StreamingUpdate {
+            did_hash: did_hash.clone(),
+            state: StreamingUpdateState::Register {
+                channel: tx,
+                session_id: session.to_string(),
+                did: did.to_string(),
+            },
+        };
+
+        // First connection takes the slot uncontested.
+        let (tx, rx) = mpsc::channel(5);
+        keepalive.push(rx);
+        task._handle_registration(
+            &database,
+            &mut clients,
+            &replay_in_progress,
+            &register("s0", tx),
+        )
+        .await;
+
+        // Contenders arrive back-to-back, well inside CHURN_WINDOW. The first
+        // few take the slot (a genuine reconnect must still be able to).
+        for i in 1..CHURN_REFUSE_STREAK {
+            let session = format!("s{i}");
+            let (tx, rx) = mpsc::channel(5);
+            keepalive.push(rx);
+            task._handle_registration(
+                &database,
+                &mut clients,
+                &replay_in_progress,
+                &register(&session, tx),
+            )
+            .await;
+            assert_eq!(
+                clients.get(&did_hash).map(|e| e.session_id.as_str()),
+                Some(session.as_str()),
+                "replacement {i} is below the streak threshold and must be accepted"
+            );
+        }
+
+        // This one crosses the threshold: it must be refused, not honoured.
+        let incumbent = clients
+            .get(&did_hash)
+            .map(|e| e.session_id.clone())
+            .expect("an incumbent is registered");
+        let (late_tx, mut late_rx) = mpsc::channel(5);
+        task._handle_registration(
+            &database,
+            &mut clients,
+            &replay_in_progress,
+            &register("refused", late_tx),
+        )
+        .await;
+
+        assert_eq!(
+            clients.get(&did_hash).map(|e| e.session_id.as_str()),
+            Some(incumbent.as_str()),
+            "the incumbent must keep the slot once the duel is detected"
+        );
+        match timeout(StdDuration::from_secs(1), late_rx.recv())
+            .await
+            .expect("the refused contender is answered")
+        {
+            Some(QueuedCommand {
+                cmd: WebSocketCommands::Close,
+                ..
+            }) => {}
+            other => panic!(
+                "expected Close on the refused socket, got {:?}",
+                other.is_some()
+            ),
+        }
+    }
+
+    /// The damper must never be able to strand a DID. If the incumbent's channel
+    /// is gone, the slot is handed over however long the streak is.
+    #[tokio::test]
+    async fn duel_damper_yields_to_a_dead_incumbent() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did = "did:example:ghost";
+        let did_hash = digest(did);
+
+        let task = streaming_task();
+        let replay_in_progress: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let mut clients: HashMap<String, ClientEntry> = HashMap::new();
+
+        // Incumbent deep in a churn streak, but its receiver is dropped — the
+        // socket behind it is gone.
+        let (dead_tx, dead_rx) = mpsc::channel(5);
+        drop(dead_rx);
+        clients.insert(
+            did_hash.clone(),
+            ClientEntry {
+                tx: dead_tx,
+                session_id: "ghost".to_string(),
+                active: true,
+                registered_at: Instant::now(),
+                churn_streak: CHURN_REFUSE_STREAK * 10,
+            },
+        );
+
+        let (tx, _rx) = mpsc::channel(5);
+        let update = StreamingUpdate {
+            did_hash: did_hash.clone(),
+            state: StreamingUpdateState::Register {
+                channel: tx,
+                session_id: "live".to_string(),
+                did: did.to_string(),
+            },
+        };
+        task._handle_registration(&database, &mut clients, &replay_in_progress, &update)
+            .await;
+
+        assert_eq!(
+            clients.get(&did_hash).map(|e| e.session_id.as_str()),
+            Some("live"),
+            "a dead incumbent must never hold the slot against a live client"
         );
     }
 }

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.18.61] - 2026-07-22
+
+### Fixed
+
+- **Reconnect backoff no longer resets on a connection that doesn't survive.**
+  `connect_delay` was zeroed the moment a socket connected and the
+  live-delivery frame was written; it only escalated on connect *failures*. A
+  socket that connects and is then closed by the mediator therefore never
+  backed off past the first step. Two clients authenticated as the same DID
+  duelling over the mediator's one-socket-per-DID slot each saw
+  "connect → success → evicted", pinning both at a ~1s reconnect loop
+  indefinitely (observed: ~40 connects/sec sustained against a production
+  mediator). A connection must now stay up for 30s — longer than the 20s
+  watchdog, so at least one ping/pong completed — before its loss earns an
+  immediate retry; anything shorter escalates 1→2→4→…→60s as a connect failure
+  always did.
+
+  **Behavioural change:** a client evicted by a duplicate session for its DID
+  now reconnects on the backoff ladder rather than instantly. Deployments
+  running a single session per DID are unaffected.
+
+- **`graceful_shutdown` now stops websockets first, and cannot hang.** The
+  Deletion Handler was stopped first, followed by an *unbounded* wait for its
+  `Exit`; the profiles' websocket transports were stopped only afterwards. A
+  handler that had already died sent no `Exit`, so shutdown could stall with
+  the websocket transports still running — and those auto-reconnect on their
+  own timer and hold the mediator's slot for the profile's DID. Callers that
+  open a session per refresh cycle accumulated orphaned, reconnecting sockets
+  this way. Websockets are now torn down first and the handler drain is bounded
+  at 5s.
+
+- **`ATMProfile::stop_websocket` clears the profile's channel slot.** It left
+  the stale `Sender` in place, so `profile_enable_websocket` saw a populated
+  slot, reported "already connected" and returned `Ok` — leaving a stopped
+  profile permanently unable to reconnect. Now idempotent, and a stopped
+  profile can be re-enabled.
+
 ## [0.18.60] - 2026-07-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.60"
+version = "0.18.61"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -203,13 +203,18 @@ use config::ATMConfig;
 use delete_handler::DeletionHandlerCommands;
 use errors::ATMError;
 use profiles::Profiles;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::{
     Mutex, RwLock, broadcast,
     mpsc::{self, Receiver, Sender},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 use transports::websockets::WebSocketResponses;
+
+/// Upper bound on how long [`ATM::graceful_shutdown`] waits for the Deletion
+/// Handler to acknowledge its stop. Generous for a live handler, bounded so a
+/// dead or wedged one cannot hold shutdown open.
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 //pub mod authentication;
 pub mod config;
@@ -285,26 +290,47 @@ impl ATM {
         Ok(atm)
     }
 
+    /// Shut the SDK down: stop every profile's websocket transport, then stop
+    /// the Deletion Handler.
+    ///
+    /// Ordering is load-bearing. The websocket transports go FIRST because they
+    /// are the only part of the SDK that keeps acting on the outside world after
+    /// a shutdown begins: each one auto-reconnects on its own timer and holds
+    /// the mediator's one-socket-per-DID slot for its profile. Stopping the
+    /// Deletion Handler first (the historical order) left a window — and, if the
+    /// handler was already gone so no `Exit` ever arrived, an unbounded wait —
+    /// in which a half-shut-down session still owned a live, reconnecting socket
+    /// that the caller believed was closed. That window is how a service that
+    /// opens a session per refresh cycle accumulates orphaned sockets which then
+    /// duel over the same DID.
+    ///
+    /// Every step is bounded: shutdown must not be able to hang on a wedged
+    /// background task.
     pub async fn graceful_shutdown(&self) {
         debug!("Shutting down ATM SDK");
 
-        // turn off incoming messages on websockets
-
-        // Send a shutdown message to the Deletion Handler
-        let _ = self.abort_deletion_handler().await;
-        {
-            let mut guard = self.inner.deletion_handler_recv_stream.lock().await;
-            let _ = guard.recv().await;
-            // Only ever send back a closing command
-            // safe to exit now
-            debug!("Deletion Handler stopped");
-        }
-
+        // 1. Stop the websocket transports. `stop_websocket` clears the
+        //    profile's channel slot, so this is idempotent across repeat calls.
         {
             let profiles = &*self.inner.profiles.read().await;
             for (_, profile) in profiles.0.iter() {
-                // Send a Stop command to each profile
                 let _ = profile.stop_websocket().await;
+            }
+        }
+
+        // 2. Stop the Deletion Handler and wait (briefly) for its `Exit`. A
+        //    handler that already died sends nothing, so this wait is bounded —
+        //    never let a dead background task hold shutdown open.
+        let _ = self.abort_deletion_handler().await;
+        {
+            let mut guard = self.inner.deletion_handler_recv_stream.lock().await;
+            match tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, guard.recv()).await {
+                Ok(_) => debug!("Deletion Handler stopped"),
+                Err(_) => warn!(
+                    "Deletion Handler did not acknowledge shutdown within {}s; \
+                     continuing (its websockets are already stopped)",
+                    SHUTDOWN_DRAIN_TIMEOUT.as_secs()
+                ),
             }
         }
     }

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -184,10 +184,25 @@ impl ATMProfile {
 
     /// Stops the WebSocket connection for this profile
     /// This will stop the WebSocket connection and any related tasks
+    ///
+    /// Takes the command sender out of the profile rather than leaving it in
+    /// place. Two reasons: the transport task only exits once every sender is
+    /// gone or it has seen `Stop`, and `profile_enable_websocket` treats a
+    /// populated `ws_channel_tx` as "already connected" — so leaving the stale
+    /// sender behind made a stopped profile impossible to restart, silently
+    /// returning `Ok` while no transport was running. Idempotent: stopping an
+    /// already-stopped profile is a no-op.
     pub async fn stop_websocket(&self) -> Result<(), ATMError> {
-        if let Some(mediator) = &*self.inner.mediator
-            && let Some(channel) = &*mediator.ws_channel_tx.read().await
-        {
+        let Some(mediator) = &*self.inner.mediator else {
+            return Ok(());
+        };
+
+        let channel = mediator.ws_channel_tx.write().await.take();
+        // Drop the connection-state receiver with the sender; a fresh one is
+        // installed by the next `WebSocketTransport::start`.
+        let _ = mediator.ws_conn_state_rx.write().await.take();
+
+        if let Some(channel) = channel {
             channel.send(WebSocketCommands::Stop).await.map_err(|err| {
                 ATMError::TransportError(format!("Could not send websocket Stop command: {err:?}"))
             })?;

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -28,6 +28,13 @@ use tracing::{Instrument, Level, debug, error, span, warn};
 
 type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
+/// How long a socket must stay up before we treat the connection as proven.
+///
+/// Longer than the 20s watchdog interval, so a "stable" connection is one that
+/// completed at least one ping/pong round-trip. See
+/// [`WebSocketTransport::on_disconnected`] for why this gate exists.
+const STABLE_CONNECTION: Duration = Duration::from_secs(30);
+
 /// A standalone task that manages the WebSocket connection to a mediator for a DID Profile
 pub(crate) struct WebSocketTransport {
     /// The ATM Profile that this WebSocket connection is associated with
@@ -49,6 +56,11 @@ pub(crate) struct WebSocketTransport {
     /// Counter tracking Websocket Ping/Pong responses
     /// Used to help with detecting when a websocket connection is lost
     awaiting_pong: bool,
+
+    /// When the current socket was established. `None` while disconnected.
+    /// Read by [`Self::on_disconnected`] to decide whether the connection
+    /// lived long enough to earn a backoff reset.
+    connected_at: Option<tokio::time::Instant>,
 
     /// Unix-seconds expiry of the access token the current socket was opened
     /// with. The mediator force-closes the socket at this time, so we use it
@@ -138,6 +150,7 @@ impl WebSocketTransport {
                 connect_delay_timer: None,
                 connect_delay: 0,
                 awaiting_pong: false,
+                connected_at: None,
                 access_expires_at: None,
                 inbound_cache: MessageCache {
                     fetch_cache_limit_count: shared.config.fetch_cache_limit_count,
@@ -177,6 +190,7 @@ impl WebSocketTransport {
                 connect_delay_timer: None,
                 connect_delay: 0,
                 awaiting_pong: false,
+                connected_at: None,
                 access_expires_at: None,
                 inbound_cache: MessageCache {
                     fetch_cache_limit_count: shared.config.fetch_cache_limit_count,
@@ -276,6 +290,10 @@ impl WebSocketTransport {
                         }
                         self.web_socket = None;
                         self.fail_pending_requests();
+                        // Self-initiated reconnect (not a failure): keep the
+                        // immediate retry, but clear the stability marker so the
+                        // fresh socket has to earn its own reset.
+                        self.connected_at = None;
                         self.connect_delay = 0;
                         self.connect_delay_timer = None;
                     },
@@ -287,7 +305,7 @@ impl WebSocketTransport {
                             }
                             self.web_socket = None;
                             self.fail_pending_requests();
-                            self.backoff_delay();
+                            self.on_disconnected();
                         } else if let Some(web_socket) = self.web_socket.as_mut() {
                             let _ = web_socket.send(Message::Ping(Bytes::new())).await;
                         }
@@ -464,7 +482,7 @@ impl WebSocketTransport {
                     debug!("WebSocket connection closed by server");
                     self.web_socket = None;
                     self.fail_pending_requests();
-                    self.backoff_delay();
+                    self.on_disconnected();
                 }
                 _ => {
                     warn!("Received unknown message type: {:?}", ws_msg);
@@ -477,13 +495,13 @@ impl WebSocketTransport {
                 warn!("WebSocket connection dropped");
                 self.web_socket = None;
                 self.fail_pending_requests();
-                self.backoff_delay();
+                self.on_disconnected();
             }
             Err(e) => {
                 error!("Generic websocket error: {:?}", e);
                 self.web_socket = None;
                 self.fail_pending_requests();
-                self.backoff_delay();
+                self.on_disconnected();
             }
         }
     }
@@ -605,15 +623,39 @@ impl WebSocketTransport {
         }
     }
 
+    /// Record that the live socket went away, and pick the next reconnect delay.
+    ///
+    /// A socket that survived [`STABLE_CONNECTION`] proved the endpoint healthy,
+    /// so its loss earns an immediate retry. A socket that died young did *not*.
+    ///
+    /// This distinction is load-bearing: resetting the backoff on connect alone
+    /// makes a connect-then-immediately-closed cycle unthrottled, because every
+    /// attempt "succeeds" before being killed. That is exactly what happens when
+    /// two clients for the same DID duel over the mediator's one-socket-per-DID
+    /// slot — each eviction is preceded by a successful connect, so the delay
+    /// never escalates past the first step and the pair reconnect at ~1 Hz
+    /// forever. Escalating on short-lived connections lets the duel decay to the
+    /// 60s cap instead.
+    fn on_disconnected(&mut self) {
+        let connected_for = self.connected_at.map(|since| since.elapsed());
+        self.connected_at = None;
+
+        let next = delay_after_disconnect(self.connect_delay, connected_for);
+        if next > self.connect_delay {
+            debug!(
+                connect_delay = next,
+                "Short-lived websocket connection; escalating reconnect backoff"
+            );
+        }
+        self.connect_delay = next;
+        self.connect_delay_timer = None;
+    }
+
     /// Calculate exponential backoff delay: 0→1→2→4→8→16→32→60s (capped).
     /// Jitter is applied separately at timer-creation time
     /// ([`jittered_backoff`]) so this base sequence stays deterministic.
     fn backoff_delay(&mut self) {
-        self.connect_delay = match self.connect_delay {
-            0 => 1,
-            d if d < 60 => (d * 2).min(60),
-            _ => 60,
-        };
+        self.connect_delay = escalate_delay(self.connect_delay);
         self.connect_delay_timer = None;
     }
 
@@ -635,8 +677,11 @@ impl WebSocketTransport {
         // Do toggle_live_delivery on this socket if not skipped
         if self.skip_toggle_live_delivery {
             debug!("Skipping toggle_live_delivery as requested");
-            self.connect_delay = 0;
+            // NB: the backoff is deliberately NOT reset here — connecting is not
+            // the same as staying connected. `on_disconnected` resets it once
+            // this socket has survived `STABLE_CONNECTION`.
             self.connect_delay_timer = None;
+            self.connected_at = Some(tokio::time::Instant::now());
             self.awaiting_pong = false;
             Some(web_socket)
         } else {
@@ -664,8 +709,10 @@ impl WebSocketTransport {
             match send_result {
                 Ok(()) => {
                     debug!("Live streaming enabled");
-                    self.connect_delay = 0;
+                    // See the sibling branch: the backoff reset belongs to
+                    // `on_disconnected`, not to a bare successful connect.
                     self.connect_delay_timer = None;
+                    self.connected_at = Some(tokio::time::Instant::now());
                     self.awaiting_pong = false;
                     Some(web_socket)
                 }
@@ -774,6 +821,28 @@ fn jittered_backoff(base_secs: u8) -> Duration {
     Duration::from_secs_f64(base_secs as f64 * factor)
 }
 
+/// Next backoff step: 0→1→2→4→8→16→32→60s (capped).
+fn escalate_delay(current: u8) -> u8 {
+    match current {
+        0 => 1,
+        d if d < 60 => (d * 2).min(60),
+        _ => 60,
+    }
+}
+
+/// Next `connect_delay` after the live socket went away.
+///
+/// `connected_for` is how long the socket that just died had been up (`None` if
+/// there was no live socket — i.e. the connect attempt itself failed). Only a
+/// connection that lasted [`STABLE_CONNECTION`] earns a reset; see
+/// [`WebSocketTransport::on_disconnected`] for why anything else must escalate.
+fn delay_after_disconnect(current: u8, connected_for: Option<Duration>) -> u8 {
+    match connected_for {
+        Some(lifetime) if lifetime >= STABLE_CONNECTION => 0,
+        _ => escalate_delay(current),
+    }
+}
+
 /// How long after connecting to proactively refresh the access token and
 /// reconnect: 80% of the token's remaining lifetime, leaving the final ~20%
 /// as budget to refresh + reconnect before the mediator force-closes the
@@ -786,6 +855,65 @@ fn refresh_after_secs(ttl_secs: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_long_lived_connection_earns_an_immediate_retry() {
+        // A socket that proved itself and then dropped should come straight
+        // back, whatever the delay had climbed to beforehand.
+        for current in [0u8, 1, 8, 60] {
+            assert_eq!(
+                delay_after_disconnect(current, Some(STABLE_CONNECTION)),
+                0,
+                "a stable connection must reset the backoff"
+            );
+        }
+        assert_eq!(
+            delay_after_disconnect(4, Some(STABLE_CONNECTION + Duration::from_secs(3600))),
+            0
+        );
+    }
+
+    #[test]
+    fn a_short_lived_connection_escalates_instead_of_resetting() {
+        // The duel case: connect succeeds, then the peer is evicted moments
+        // later. Every attempt "succeeds", so if success alone reset the delay
+        // this pair would reconnect at ~1Hz forever. Walk the full ladder to
+        // the cap to prove it decays instead.
+        let brief = Some(Duration::from_millis(200));
+        let mut delay = 0u8;
+        for expected in [1u8, 2, 4, 8, 16, 32, 60] {
+            delay = delay_after_disconnect(delay, brief);
+            assert_eq!(delay, expected, "backoff must escalate on a short session");
+        }
+        // Capped, not wrapping (u8 would overflow at 128).
+        for _ in 0..10 {
+            delay = delay_after_disconnect(delay, brief);
+            assert_eq!(delay, 60);
+        }
+    }
+
+    #[test]
+    fn a_failed_connect_attempt_escalates() {
+        // No socket ever came up, so there is nothing to have been stable.
+        assert_eq!(delay_after_disconnect(0, None), 1);
+        assert_eq!(delay_after_disconnect(16, None), 32);
+        assert_eq!(delay_after_disconnect(60, None), 60);
+    }
+
+    #[test]
+    fn stability_threshold_outlasts_the_watchdog_interval() {
+        // "Stable" must mean at least one completed ping/pong round-trip,
+        // otherwise a connection we never proved could reset the backoff.
+        assert!(
+            STABLE_CONNECTION > Duration::from_secs(20),
+            "STABLE_CONNECTION must exceed the 20s watchdog interval"
+        );
+        // Just under the threshold still escalates — no off-by-one grace.
+        assert_eq!(
+            delay_after_disconnect(2, Some(STABLE_CONNECTION - Duration::from_millis(1))),
+            4
+        );
+    }
 
     #[test]
     fn refresh_fires_before_expiry_with_budget_to_spare() {


### PR DESCRIPTION
## What happened

A production mediator was taking **~40 websocket connects/sec from its own admin DID**, plus a matching flood of `DELETE /mediator/v1/delete`. The admin DID is not just an authz principal — it is also the mediator's **VTA credential** (`config/mod.rs:488-549` hands the stored `AdminCredential` to vta-sdk). When the VTA's `DIDCommMessaging` service routes through this mediator, the mediator opens a client websocket back into itself.

Three independent faults had to line up. All three are fixed here; any one of them alone would have kept this self-limiting.

## The fixes

**1. The refresh task dialled us. `affinidi-messaging-mediator` 0.17.5 → 0.17.6**

`vta_bootstrap` detects the self-mediated topology at boot, but `tasks::vta_refresh` re-ran with `TransportPreference::Auto` (DIDComm-first) on every tick — every `cache_ttl/4`, clamped to 5min–1h — on the documented assumption that DIDComm to ourselves "resolves cleanly once the listener is up". It *does* connect; that is the problem. Each tick opened a client socket, authenticated as the admin DID, competing for that DID's one-socket slot.

Each tick now re-probes whether the VTA's advertised mediator is us, and refreshes over REST when it is (`PreferRest` maps to a hard `RestOnly` in vta-sdk — no DIDComm fallback). Probe failures fall back to the configured preference: a probe must never be why a refresh doesn't happen.

`VtaRefresher::new` is unchanged; the DID arrives via a new `with_mediator_did`, so this stays a non-breaking addition to a `pub` module.

**2. Backoff reset on connecting, not on staying connected. `affinidi-messaging-sdk` 0.18.60 → 0.18.61**

This is what turned an eviction into a storm. `connect_delay` was zeroed the moment a socket connected and the live-delivery frame was written, and escalated only on connect *failures*. So a socket that connects and is then closed by the mediator never backed off past the first step — every attempt "succeeded" before being killed, pinning a pair of duelling sessions at ~1Hz indefinitely.

A connection must now survive 30s — longer than the 20s watchdog, so at least one ping/pong completed — before its loss earns an immediate retry. Anything shorter escalates 1→2→4→…→60s exactly as a connect failure always did.

*Behavioural change:* a client evicted by a duplicate session for its DID now reconnects on the backoff ladder rather than instantly. Single-session-per-DID deployments are unaffected.

**3. Shutdowns that left live sockets running. SDK 0.18.61**

`graceful_shutdown` stopped the Deletion Handler first, then waited **unbounded** for its `Exit`, and only afterwards stopped the profiles' websocket transports. A handler that had already died sends no `Exit` — so shutdown could stall with transports still running, and those auto-reconnect on their own timer. This is the state the production logs were reporting as `failed to ack inbound message ... Deletion Handler: channel closed`: dead handler, live socket.

Websockets are now torn down first, and the handler drain is bounded at 5s.

`ATMProfile::stop_websocket` also now clears the profile's channel slot. It left the stale `Sender` behind, so `profile_enable_websocket` saw a populated slot, reported "already connected" and returned `Ok` over a dead transport — a stopped profile could never reconnect.

## Server-side damper

So that no client — ours or anyone's — can do this to a mediator again.

Newest-wins is right for an isolated duplicate: a client reconnecting after a half-open socket must be able to reclaim its slot. It is wrong for a *sustained* duel, where every takeover evicts a peer that immediately reconnects and takes the slot straight back. After `CHURN_REFUSE_STREAK` (3) replacements inside the 5s churn window, the incumbent keeps the slot and the contender is closed — **only while the incumbent's channel is demonstrably alive**, so a stale entry can never lock a DID out.

Self-limiting: refusals don't refresh the incumbent's registration time, so once it ages past the churn window the next contender is accepted normally. Worst case becomes one takeover per window instead of one per round-trip. New counter: `websocket_churn_refused_total`.

Refused connections receive `Close` from the streaming task, which sets `already_deregistered_flag` — so they cannot deregister the incumbent on their way out.

## Also

`registered_clients(N)` used `len() + 1` even on replacements, so it over-reported by one on every duplicate — which reads like a client leak during exactly the incident you'd be using it to diagnose. It counts *DIDs with a live socket*, not sockets.

## Note on the SDK pin

`affinidi-messaging-sdk` is pinned to `"0.18.61"` rather than the usual `"0.18"`: a mediator built against an older SDK still amplifies duels client-side. Expect `publish dry-run` / `verify-publish` to go red on this PR — the registry-isolated resolve can't see the unpublished sibling. The release job publishes in dependency order.

## Verification

- `cargo clippy -D warnings` clean on default and `memory-backend,tsp` feature sets
- SDK: 74 unit tests pass, including 4 new ones covering the backoff gate (stable → reset, short-lived → escalate to cap without `u8` overflow, failed attempt → escalate, threshold > watchdog interval)
- Mediator: 184 unit tests pass, including 2 new ones — a sustained duel holds the incumbent's slot, and a *dead* incumbent always yields
- Full `affinidi-messaging-test-mediator` integration suite passes (real mediator + SDK clients over websockets)

Pairs with OpenVTC/verifiable-trust-infrastructure vta-sdk 0.19.18, which fixes the fourth leak: `DIDCommSession::connect_with_secrets` never shut its ATM down on any error path.
