### PR TITLE
feat: give a resolved DID a display name via extensible shortcuts

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## Changelog history
 
+## 23rd July 2026
+
+### 0.8.20 — a display name for a resolved DID
+
+`ResolveResponse::display_name()` returns the verified human name for a DID
+when one is known, and the DID itself otherwise. It is the call display code
+should make:
+
+```rust
+let resolved = client.resolve(did).await?;
+println!("{}", resolved.display_name()); // "example.com/@alice", or the DID
+```
+
+Every consumer that shows a DID to a person previously had to re-derive this:
+resolve the DID, read `alsoKnownAs`, resolve each claimed name, check it points
+back. The resolver already holds every piece.
+
+#### It cannot show an unverified name
+
+`ResolveResponse::shortcut` is only ever populated after verification, so a UI
+that routes every DID through `display_name()` degrades to the full DID rather
+than to a spoofable one. Displaying a name straight from `alsoKnownAs` is a
+phishing surface — anyone may claim `bigbank.com/@support` in their own
+document.
+
+#### Extensible by design
+
+The value is a `DidShortcut`, a `#[non_exhaustive]` enum rather than a bare
+`Option<String>`, so further shortcut schemes can be added without a breaking
+release. Agent names are the only kind today. A caller that only wants
+something printable uses `display_name()` and never matches at all.
+
+`ResolveResponse` gains a field rather than changing `new` — additive on a
+sealed struct, per ADR 0003.
+
+#### Two directions, one of them opt-in
+
+From a name (`resolve_any` / `resolve_agent_name`) the shortcut is free:
+verification has just run, and the name was previously discarded from the
+response.
+
+From a DID, `resolve` establishes one only when `with_resolve_shortcuts(true)`
+is set. **Off by default**: it costs a network round-trip to the naming host,
+which a caller that only wants a document should not pay unasked. Behaviour and
+latency for existing consumers are unchanged.
+
+#### Verification is the same three stages
+
+Entered from the DID end, `derive_shortcut` requires that the candidate come
+from this document's `alsoKnownAs`, that the document be the one just resolved,
+and that the candidate's forward resolution land back on this DID.
+
+Candidates resolve through the name backends directly rather than through
+`resolve_any` — that is what keeps it non-recursive, since `resolve_any` would
+resolve the DID again and re-enter derivation without bound. Candidates are
+capped, as a hostile document may claim hundreds. A name a document claims but
+which resolves elsewhere is logged and skipped, never displayed.
+
 ## 20th July 2026
 
 ### 0.8.19 — resolve agent names over the WebSocket connection

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.19"
+version = "0.8.20"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -107,5 +107,13 @@ num-format = "0.4"
 number_prefix = "0.4"
 rayon = "1"
 
+# Exercises `resolve_any` and `with_resolve_shortcuts`, so it only builds with
+# the feature that provides them. Without this, `cargo test` on a build that
+# does not enable `agent-names` fails compiling the example rather than running
+# the suite.
+[[example]]
+name = "agent_name_diagnose"
+required-features = ["agent-names"]
+
 [lints]
 workspace = true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/examples/agent_name_diagnose.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/examples/agent_name_diagnose.rs
@@ -1,0 +1,67 @@
+//! Diagnose the agent-name resolve/verify chain against a live DID, and show
+//! what `ResolveResponse::display_name()` returns for each entry point.
+
+use affinidi_did_resolver_cache_sdk::{
+    DIDCacheClient, config::DIDCacheConfigBuilder, errors::DIDCacheError,
+};
+use clap::Parser;
+use tracing_subscriber::filter;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// DID to diagnose
+    #[arg(short, long)]
+    did: String,
+    /// Agent name to resolve, e.g. `example.com/@alice`
+    #[arg(short, long)]
+    name: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), DIDCacheError> {
+    let args = Args::parse();
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter::EnvFilter::from_default_env())
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+
+    println!("\n=== resolve(did), shortcuts OFF (default) ===");
+    let resp = resolver.resolve(&args.did).await?;
+    println!("alsoKnownAs   = {:?}", resp.doc.also_known_as);
+    println!("shortcut      = {:?}", resp.shortcut);
+    println!("display_name  = {}", resp.display_name());
+    println!("  (no name lookup was asked for, so this is the DID)");
+
+    println!("\n=== resolve(did), shortcuts ON ===");
+    let with_shortcuts = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_resolve_shortcuts(true)
+            .build(),
+    )
+    .await?;
+    let resp = with_shortcuts.resolve(&args.did).await?;
+    println!("shortcut      = {:?}", resp.shortcut);
+    println!("display_name  = {}", resp.display_name());
+    if resp.shortcut.is_some() {
+        println!("  >>> DID -> verified agent name, from a plain resolve()");
+    }
+
+    if let Some(name) = &args.name {
+        println!("\n=== resolve_any(name) ===");
+        let resp = resolver.resolve_any(name).await?;
+        println!("did           = {}", resp.did);
+        println!("shortcut      = {:?}", resp.shortcut);
+        println!("display_name  = {}", resp.display_name());
+        assert_eq!(
+            resp.display_name(),
+            name.trim_start_matches("https://"),
+            "display_name should be the verified agent name"
+        );
+        println!("  >>> display_name() returned the verified agent name");
+    }
+
+    Ok(())
+}

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
@@ -27,7 +27,16 @@ use agent_names::{AgentName, AgentNameError, AgentNameResolver, verify_also_know
 use tokio::sync::watch;
 use tracing::{debug, warn};
 
-use crate::{DIDCacheClient, ResolveResponse, errors::DIDCacheError};
+use crate::{DIDCacheClient, DidShortcut, ResolveResponse, errors::DIDCacheError};
+
+/// How many claimed names to check before giving up establishing a shortcut.
+///
+/// Each candidate costs a request to its naming host, and a hostile document is
+/// free to list hundreds, so the work one resolve can provoke has to be capped.
+/// The first candidate that verifies wins, so a well-formed document — one name,
+/// or a few — never reaches this limit.
+#[cfg(feature = "agent-names")]
+const MAX_SHORTCUT_CANDIDATES: usize = 4;
 
 /// Either a DID or an agent name.
 ///
@@ -132,7 +141,10 @@ impl DIDCacheClient {
                 .and_then(|m| crate::DIDMethod::try_from(m).ok())
                 .unwrap_or(crate::DIDMethod::OTHER);
 
-            return Ok(ResolveResponse::new(did, method, did_hash, doc, false));
+            // Verification succeeded just above, so the name is safe to carry
+            // back as this DID's display shortcut.
+            return Ok(ResolveResponse::new(did, method, did_hash, doc, false)
+                .with_shortcut(DidShortcut::AgentName(name.without_scheme().to_string())));
         }
 
         let did = match self.agent_name_cache.get(&name_hash).await {
@@ -146,7 +158,10 @@ impl DIDCacheClient {
             }
         };
 
-        let response = match self.resolve(&did).await {
+        // `resolve_document`, not `resolve`: we already hold the name and attach
+        // it below, so letting `resolve` establish a shortcut here would repeat
+        // the same lookup we are in the middle of.
+        let response = match self.resolve_document(&did).await {
             Ok(response) => response,
             Err(e) => {
                 // The mapping points at a DID that will not resolve. Drop it so a
@@ -169,7 +184,63 @@ impl DIDCacheClient {
             return Err(DIDCacheError::from(e));
         }
 
-        Ok(response)
+        // Past verification: the caller asked by name and the DID claimed it
+        // back, so the name is this DID's display shortcut. Without this the
+        // name the caller supplied would be dropped from the response and every
+        // consumer would have to re-derive it.
+        Ok(response.with_shortcut(DidShortcut::AgentName(name.without_scheme().to_string())))
+    }
+
+    /// Establish a verified display shortcut for a document we have already
+    /// resolved, or `None` if no claimed name checks out.
+    ///
+    /// This completes the same three-stage check as [`Self::resolve_agent_name`],
+    /// just entered from the other end — from a DID rather than from a name:
+    ///
+    /// 1. the candidate names come from *this* document's `alsoKnownAs`, so the
+    ///    DID demonstrably claims them (the stage that stops anyone labelling
+    ///    someone else's DID);
+    /// 2. the document is the one just resolved for `did`;
+    /// 3. each candidate's forward resolution must land back on `did` — the
+    ///    stage that stops a document claiming a name it does not own, since
+    ///    only the name's controller decides where it points.
+    ///
+    /// Candidates are resolved through the name backends directly rather than
+    /// through [`Self::resolve_any`]. That is what keeps this non-recursive:
+    /// `resolve_any` would resolve the DID again, re-entering shortcut
+    /// derivation and recursing without bound. It also skips a redundant
+    /// document fetch, since stage 2 is already satisfied.
+    pub(crate) async fn derive_shortcut(
+        &self,
+        did: &str,
+        doc: &affinidi_did_common::Document,
+    ) -> Option<DidShortcut> {
+        for name in agent_names::extract_agent_names(doc)
+            .into_iter()
+            .take(MAX_SHORTCUT_CANDIDATES)
+        {
+            let name_hash = Self::hash_did(name.as_str());
+            let resolved = match self.agent_name_cache.get(&name_hash).await {
+                Some(cached) => Some(cached),
+                None => self
+                    .resolve_name_deduplicated(&name, name_hash)
+                    .await
+                    .map_err(|e| debug!("agent name '{name}' did not resolve: {e}"))
+                    .ok(),
+            };
+            match resolved.as_deref() {
+                Some(got) if got == did => {
+                    return Some(DidShortcut::AgentName(name.without_scheme().to_string()));
+                }
+                // Claimed, but the name belongs to someone else. Never display
+                // it, and keep looking rather than failing the whole resolve.
+                Some(other) => {
+                    warn!("agent name '{name}' claimed by {did} resolves to {other}; ignoring");
+                }
+                None => {}
+            }
+        }
+        None
     }
 
     /// Resolve a name to a DID, collapsing concurrent lookups of the *same*

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
@@ -47,6 +47,8 @@ pub struct DIDCacheConfig {
     pub(crate) agent_name_cache_capacity: u32,
     #[cfg(all(feature = "agent-names", feature = "network"))]
     pub(crate) agent_names_over_websocket: bool,
+    #[cfg(feature = "agent-names")]
+    pub(crate) resolve_shortcuts: bool,
 }
 
 /// DID Cache Config Builder to construct options required for the client.
@@ -74,6 +76,8 @@ pub struct DIDCacheConfigBuilder {
     agent_name_cache_capacity: u32,
     #[cfg(all(feature = "agent-names", feature = "network"))]
     agent_names_over_websocket: bool,
+    #[cfg(feature = "agent-names")]
+    resolve_shortcuts: bool,
 }
 
 impl Default for DIDCacheConfigBuilder {
@@ -95,6 +99,8 @@ impl Default for DIDCacheConfigBuilder {
             agent_name_cache_capacity: 1_000,
             #[cfg(all(feature = "agent-names", feature = "network"))]
             agent_names_over_websocket: false,
+            #[cfg(feature = "agent-names")]
+            resolve_shortcuts: false,
         }
     }
 }
@@ -196,6 +202,22 @@ impl DIDCacheConfigBuilder {
         self
     }
 
+    /// Populate a verified [`DidShortcut`](crate::DidShortcut) on every
+    /// [`resolve`](crate::DIDCacheClient::resolve), so
+    /// [`display_name`](crate::ResolveResponse::display_name) yields a
+    /// human-facing name instead of the DID.
+    ///
+    /// **Off by default.** Establishing a shortcut means resolving each name the
+    /// document claims, to check it points back at this DID — a network
+    /// round-trip to the naming host that a caller who only wants a document
+    /// should not pay unasked. Turn it on in an application that displays DIDs
+    /// to people; leave it off in a service that does not.
+    #[cfg(feature = "agent-names")]
+    pub fn with_resolve_shortcuts(mut self, enabled: bool) -> Self {
+        self.resolve_shortcuts = enabled;
+        self
+    }
+
     /// Build the [ClientConfig].
     pub fn build(self) -> DIDCacheConfig {
         DIDCacheConfig {
@@ -215,6 +237,8 @@ impl DIDCacheConfigBuilder {
             agent_name_cache_capacity: self.agent_name_cache_capacity,
             #[cfg(all(feature = "agent-names", feature = "network"))]
             agent_names_over_websocket: self.agent_names_over_websocket,
+            #[cfg(feature = "agent-names")]
+            resolve_shortcuts: self.resolve_shortcuts,
         }
     }
 }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -176,10 +176,15 @@ pub struct ResolveResponse {
     pub doc: Document,
     /// Whether the document came from cache rather than a fresh resolution.
     pub cache_hit: bool,
+    /// A **verified** human-facing shortcut for [`Self::did`], when one is
+    /// known. `None` means no shortcut was verified — which includes the case
+    /// where none was looked for. Read it through [`Self::display_name`] rather
+    /// than branching on it.
+    pub shortcut: Option<DidShortcut>,
 }
 
 impl ResolveResponse {
-    /// Assemble a response.
+    /// Assemble a response with no shortcut.
     ///
     /// The construction path for a `#[non_exhaustive]` struct. Mainly useful to
     /// consumers building a fixture or a mock resolver; the client returns these
@@ -197,7 +202,85 @@ impl ResolveResponse {
             did_hash,
             doc,
             cache_hit,
+            shortcut: None,
         }
+    }
+
+    /// Attach a verified shortcut.
+    ///
+    /// Separate from [`Self::new`] so adding shortcut support did not break the
+    /// existing construction sites. The caller is asserting the shortcut has
+    /// been **verified** to belong to this DID — see [`DidShortcut`].
+    #[must_use]
+    pub fn with_shortcut(mut self, shortcut: DidShortcut) -> Self {
+        self.shortcut = Some(shortcut);
+        self
+    }
+
+    /// What to show a human for this DID: the verified shortcut's label when
+    /// there is one, otherwise the DID itself.
+    ///
+    /// This is the call display code should make. It cannot show an unverified
+    /// name, because [`Self::shortcut`] is only ever populated after
+    /// verification — so a UI that routes every DID through here degrades to the
+    /// full DID rather than to a spoofable one.
+    ///
+    /// ```no_run
+    /// # use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+    /// # async fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    /// let resolved = client.resolve("did:webvh:QmScid:example.com").await?;
+    /// println!("{}", resolved.display_name()); // "example.com/@alice", or the DID
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        self.shortcut
+            .as_ref()
+            .map_or(self.did.as_str(), DidShortcut::label)
+    }
+}
+
+/// A verified human-facing shortcut standing in for a DID.
+///
+/// Agent names (`example.com/@alice`) are the only kind today. The enum is
+/// `#[non_exhaustive]` so further shortcut schemes can be added without a
+/// breaking release — a caller that matches on it must carry a wildcard arm,
+/// and one that only wants something printable should use
+/// [`ResolveResponse::display_name`] and never match at all.
+///
+/// A value of this type is a claim that verification **already happened**.
+/// Constructing one from an unverified source (a document's `alsoKnownAs`, say)
+/// defeats the guarantee [`ResolveResponse::display_name`] rests on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DidShortcut {
+    /// A verified agent name, in its scheme-less spelling
+    /// (`example.com/@alice`).
+    AgentName(String),
+}
+
+impl DidShortcut {
+    /// The label to display.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        match self {
+            DidShortcut::AgentName(name) => name,
+        }
+    }
+
+    /// A stable identifier for the kind of shortcut, for logs and metrics.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            DidShortcut::AgentName(_) => "agent-name",
+        }
+    }
+}
+
+impl std::fmt::Display for DidShortcut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
     }
 }
 
@@ -417,7 +500,37 @@ impl DIDCacheClient {
     /// Returns the initial DID, the hashed DID, and the resolved DID Document
     /// NOTE: The DID Document id may be different to the requested DID due to the DID having been updated.
     ///       The original DID should be in the `also_known_as` field of the DID Document.
+    ///
+    /// When [`resolve_shortcuts`](config::DIDCacheConfigBuilder::with_resolve_shortcuts)
+    /// is enabled, the response also carries a verified
+    /// [`DidShortcut`] where one could be established, so
+    /// [`ResolveResponse::display_name`] yields a human-facing name rather than
+    /// the DID. That option is **off by default**: establishing a shortcut costs
+    /// a network round-trip to the naming host, which callers that only want a
+    /// document should not silently pay.
     pub async fn resolve(&self, did: &str) -> Result<ResolveResponse, DIDCacheError> {
+        let response = self.resolve_document(did).await?;
+
+        #[cfg(feature = "agent-names")]
+        if self.config.resolve_shortcuts {
+            if let Some(shortcut) = self.derive_shortcut(&response.did, &response.doc).await {
+                return Ok(response.with_shortcut(shortcut));
+            }
+        }
+
+        Ok(response)
+    }
+
+    /// Resolve a DID to its document, without attempting any shortcut lookup.
+    ///
+    /// The shortcut derivation in [`Self::resolve`] is layered on top of this
+    /// rather than inside it, so that the verification path — which resolves an
+    /// agent name in order to check it points back here — can reach a document
+    /// without re-entering shortcut derivation and recursing.
+    pub(crate) async fn resolve_document(
+        &self,
+        did: &str,
+    ) -> Result<ResolveResponse, DIDCacheError> {
         // Size guard before any parsing
         if did.len() > self.config.max_did_size_in_bytes {
             return Err(DIDCacheError::DIDError(format!(
@@ -467,6 +580,7 @@ impl DIDCacheClient {
                 did_hash: hash,
                 doc: doc.clone(),
                 cache_hit: true,
+                shortcut: None,
             });
         }
 
@@ -479,6 +593,7 @@ impl DIDCacheClient {
                 did_hash: hash,
                 doc,
                 cache_hit: true,
+                shortcut: None,
             })
         } else {
             debug!("DID cache miss: {}", did);
@@ -526,6 +641,7 @@ impl DIDCacheClient {
                             did_hash: hash,
                             doc,
                             cache_hit: true,
+                            shortcut: None,
                         });
                     }
                     // Leader didn't populate the cache (it errored). Loop and
@@ -547,6 +663,7 @@ impl DIDCacheClient {
                             did_hash: hash,
                             doc,
                             cache_hit: true,
+                            shortcut: None,
                         });
                     }
 
@@ -568,6 +685,7 @@ impl DIDCacheClient {
                         did_hash: hash,
                         doc,
                         cache_hit: false,
+                        shortcut: None,
                     });
                 }
             }
@@ -892,6 +1010,77 @@ mod tests {
     use super::*;
 
     const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+
+    // -----------------------------------------------------------------------
+    // Display shortcuts
+    // -----------------------------------------------------------------------
+
+    fn response_for(did: &str) -> ResolveResponse {
+        ResolveResponse::new(
+            did.to_string(),
+            DIDMethod::WEBVH,
+            DIDCacheClient::hash_did(did),
+            Document::default(),
+            false,
+        )
+    }
+
+    /// With no shortcut established, display falls back to the DID — never to a
+    /// blank or a partial. A UI routing everything through `display_name` still
+    /// shows something addressable.
+    #[test]
+    fn display_name_falls_back_to_the_did() {
+        let did = "did:webvh:QmScid:example.com";
+        let resp = response_for(did);
+        assert_eq!(resp.shortcut, None);
+        assert_eq!(resp.display_name(), did);
+    }
+
+    /// With one established, display is the shortcut's label, not the DID.
+    #[test]
+    fn display_name_prefers_a_verified_shortcut() {
+        let resp = response_for("did:webvh:QmScid:example.com")
+            .with_shortcut(DidShortcut::AgentName("example.com/@alice".to_string()));
+        assert_eq!(resp.display_name(), "example.com/@alice");
+    }
+
+    /// The label is the scheme-less name; `kind` stays stable for logs, and
+    /// `Display` matches `label` so the type can be printed directly.
+    #[test]
+    fn shortcut_exposes_label_and_kind() {
+        let shortcut = DidShortcut::AgentName("example.com/@alice".to_string());
+        assert_eq!(shortcut.label(), "example.com/@alice");
+        assert_eq!(shortcut.kind(), "agent-name");
+        assert_eq!(shortcut.to_string(), "example.com/@alice");
+    }
+
+    /// Shortcut derivation is opt-in: a default client must not pay a naming-host
+    /// round-trip, so a plain resolve leaves the shortcut unset.
+    #[tokio::test]
+    async fn shortcuts_are_off_by_default() {
+        let client = basic_local_client().await;
+        let resp = client.resolve(DID_KEY).await.unwrap();
+        assert_eq!(
+            resp.shortcut, None,
+            "a default client must not attempt shortcut resolution"
+        );
+        assert_eq!(resp.display_name(), DID_KEY);
+    }
+
+    /// A document claiming no names yields no shortcut even with the option on —
+    /// and, importantly, does not error.
+    #[tokio::test]
+    async fn no_claimed_names_yields_no_shortcut() {
+        let config = config::DIDCacheConfigBuilder::default()
+            .with_resolve_shortcuts(true)
+            .build();
+        let client = DIDCacheClient::new(config).await.unwrap();
+        // did:key documents carry no `alsoKnownAs`, so there is nothing to check
+        // and no network request is made.
+        let resp = client.resolve(DID_KEY).await.unwrap();
+        assert_eq!(resp.shortcut, None);
+        assert_eq!(resp.display_name(), DID_KEY);
+    }
 
     async fn basic_local_client() -> DIDCacheClient {
         let config = config::DIDCacheConfigBuilder::default().build();

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -1069,6 +1069,11 @@ mod tests {
 
     /// A document claiming no names yields no shortcut even with the option on —
     /// and, importantly, does not error.
+    ///
+    /// Gated: the shortcut *type* and field exist unconditionally so callers can
+    /// use `display_name()` in any build, but establishing one — and hence
+    /// `with_resolve_shortcuts` — needs the `agent-names` feature.
+    #[cfg(feature = "agent-names")]
     #[tokio::test]
     async fn no_claimed_names_yields_no_shortcut() {
         let config = config::DIDCacheConfigBuilder::default()


### PR DESCRIPTION
Adds `ResolveResponse::display_name()` — the verified human name for a DID when there is one, the DID otherwise.

## Why here

Every consumer that shows a DID to a person has to re-derive its name: resolve the DID, pull `alsoKnownAs`, resolve each claimed name, check it points back. OpenVTC carries its own copy of exactly that. The resolver already holds every piece, and a helper that can't be forgotten is the point — forgetting it is what leaves a raw DID on screen.

```rust
let resolved = client.resolve(did).await?;
println!("{}", resolved.display_name());  // "example.com/@alice", or the DID
```

Display code calls that and nothing else. It **cannot** show an unverified name: `shortcut` is only ever populated after verification, so a UI routing every DID through it degrades to the full DID rather than to a spoofable one.

## Shape

`DidShortcut` is a `#[non_exhaustive]` enum rather than a bare `Option<String>`, so other shortcut schemes can be added without a breaking release. Agent names are the only kind today; a caller that just wants something printable uses `display_name()` and never matches at all. `ResolveResponse` gains a field rather than changing `new`, per ADR 0003.

## Two directions

- **From a name** (`resolve_any` / `resolve_agent_name`) — verification has just run and the name was previously *discarded* from the response. Free.
- **From a DID** (`resolve`) — behind the new `with_resolve_shortcuts(true)` option.

The DID direction is **off by default**: establishing a shortcut costs a network round-trip to the naming host, which a caller that only wants a document shouldn't pay unasked. Behaviour and latency for every existing consumer are unchanged.

## Non-recursive by construction

`derive_shortcut` completes the same three-stage check as `resolve_agent_name`, entered from the other end: candidates come from this document's `alsoKnownAs` (so the DID demonstrably claims them), the document is the one just resolved, and each candidate's forward resolution must land back on this DID.

It resolves candidates through the **name backends directly** rather than through `resolve_any`. That is what keeps it non-recursive — `resolve_any` would resolve the DID again, re-entering derivation without bound. It also skips a redundant document fetch, since that stage is already satisfied. Candidates are capped (a hostile document may list hundreds), and a name claimed by a document but resolving elsewhere is logged and skipped, never displayed.

## Verification

Validated against a live `did:webvh` agent name:

| | `display_name()` |
|---|---|
| `resolve`, shortcuts off (default) | the DID |
| `resolve`, shortcuts on | `webvh.storm.ws/@magic-depart` |
| `resolve_any(name)` | `webvh.storm.ws/@magic-depart` |

`cargo test --features agent-names`: 61 + 20 passed, 0 failed, doctests pass. Whole workspace builds.

The added example doubles as the diagnostic that located the fault this work started from (see OpenVTC#175 — the cause there turned out to be a cache TTL, not resolution).