### PR TITLE
fix: deliver TSP frames that arrive after the socket is open

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.6"
+version = "0.17.7"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -395,6 +395,41 @@ async fn handle_socket(
                     return;
                 }
             }
+
+            // Raw-TSP mode is live by construction — enable it here.
+            //
+            // `Register` alone leaves the client in `StreamingClientState::
+            // Registered` ("has a socket but has not enabled live delivery"),
+            // and only `Start` promotes it to `Live`. The DIDComm client gets
+            // there by sending `messagepickup/3.0/live-delivery-change`; a
+            // raw-TSP socket has no such message — it carries binary TSP frames
+            // and nothing else — so it stayed `Registered` forever. With the
+            // client not live, `store_message` skips the streaming publish
+            // entirely, so the `rx.recv()` re-drain arm below never fired and
+            // the ONLY delivery this socket ever got was flush-on-connect.
+            // Every frame that arrived after the socket came up was stored and
+            // left sitting in the inbox: the sender saw a successful send and
+            // the recipient heard nothing.
+            //
+            // Push delivery isn't an opt-in here the way it is for DIDComm —
+            // it is the raw-TSP contract (flush-on-connect + delete-on-send),
+            // so the socket declares itself live the moment it registers.
+            #[cfg(feature = "tsp")]
+            if tsp_mode {
+                let live = StreamingUpdate {
+                    did_hash: session.did_hash.clone(),
+                    state: StreamingUpdateState::Start,
+                };
+                match streaming.channel.send(live).await {
+                    Ok(_) => {
+                        debug!("Raw-TSP socket: enabled live delivery");
+                    }
+                    Err(e) => {
+                        warn!("Error enabling live delivery for raw-TSP socket: {:?}", e);
+                        return;
+                    }
+                }
+            }
         }
 
         let _ = state
@@ -431,7 +466,9 @@ async fn handle_socket(
             if let Some(streaming) = &state.streaming_task {
                 let stop = StreamingUpdate {
                     did_hash: session.did_hash.clone(),
-                    state: StreamingUpdateState::Deregister,
+                    state: StreamingUpdateState::Deregister {
+                        session_id: session.session_id.clone(),
+                    },
                 };
                 let _ = streaming.channel.send(stop).await;
             }
@@ -613,7 +650,9 @@ async fn handle_socket(
             if let Some(streaming) = &state.streaming_task  {
                 let stop = StreamingUpdate {
                     did_hash: session.did_hash.clone(),
-                    state: StreamingUpdateState::Deregister,
+                    state: StreamingUpdateState::Deregister {
+                        session_id: session.session_id.clone(),
+                    },
                 };
                 let _ = streaming.channel.send(stop).await;
             }

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -100,7 +100,14 @@ pub enum StreamingUpdateState {
     },
     Start,
     Stop,
-    Deregister,
+    /// Remove the map entry for this DID — but only if it is still *this*
+    /// session's entry. `clients` is keyed by DID hash, not by connection, so a
+    /// deregistration must name the session it belongs to: a socket that has
+    /// already been replaced (one DID, one slot) would otherwise evict its
+    /// successor on the way out. See the session-id check in the handler.
+    Deregister {
+        session_id: String,
+    },
 }
 
 /// Used to send commands from the streaming task to the websocket handler
@@ -324,18 +331,42 @@ impl StreamingTask {
                                         error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
                                     }
                                 },
-                                StreamingUpdateState::Deregister => {
-                                    let count = if !clients.is_empty() {
-                                        clients.len() - 1
-                                    } else {
-                                        warn!("Duplicate websocket channels has us off by one");
-                                        0
-                                    };
-                                    info!("Deregistered streaming for DID: ({}) registered_clients({})", value.did_hash, count);
-                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Deregistered).await {
-                                        error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
+                                StreamingUpdateState::Deregister { session_id } => {
+                                    // Only the session that currently owns the slot may
+                                    // vacate it. One DID has one entry, so a socket that
+                                    // was already replaced still runs its own teardown —
+                                    // and an unconditional remove here would take the
+                                    // *successor's* channel out with it. Dropping that
+                                    // `tx` closes the live socket's command channel, so
+                                    // its handler exits with "streaming task unavailable"
+                                    // and the client sees the connection closed for no
+                                    // reason it can act on. Common whenever one DID hands
+                                    // off between transports (a DIDComm session closing
+                                    // as a raw-TSP socket opens).
+                                    match clients.get(value.did_hash.as_str()) {
+                                        Some(entry) if entry.session_id != *session_id => {
+                                            debug!(
+                                                did_hash = %value.did_hash,
+                                                leaving_session = %session_id,
+                                                current_session = %entry.session_id,
+                                                "Ignoring deregistration from a replaced session; the slot belongs to a newer connection",
+                                            );
+                                        }
+                                        Some(_) => {
+                                            clients.remove(value.did_hash.as_str());
+                                            info!("Deregistered streaming for DID: ({}) registered_clients({})", value.did_hash, clients.len());
+                                            if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Deregistered).await {
+                                                error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
+                                            }
+                                        }
+                                        None => {
+                                            debug!(
+                                                did_hash = %value.did_hash,
+                                                leaving_session = %session_id,
+                                                "Deregistration for a DID with no registered client",
+                                            );
+                                        }
                                     }
-                                    clients.remove(value.did_hash.as_str());
                                 }
                             }
                         }

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.61"
+version = "0.18.62"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1457,9 +1457,22 @@ impl TspWebSocket {
     /// Receive the next raw qb2 TSP frame.
     ///
     /// Returns `Ok(Some(bytes))` for a delivered message (unpack it with
-    /// [`TspOps::unpack_bytes`]), or `Ok(None)` when the socket closes / the
-    /// stream ends. Control frames (`Ping`/`Pong`) and any `Text` frames are
-    /// skipped transparently.
+    /// [`TspOps::unpack_bytes`]). Control frames (`Ping`/`Pong`) and any `Text`
+    /// frames are skipped transparently.
+    ///
+    /// When the socket goes away:
+    /// - the peer sent a **close frame** → `Err`, carrying its RFC 6455 code and
+    ///   reason. The mediator always states why it closed a socket
+    ///   ("replaced by a newer connection", "authentication token expired",
+    ///   "streaming task unavailable", …) and that reason is the difference
+    ///   between an operator diagnosing the problem and guessing at it. It used
+    ///   to be discarded, collapsing every one of those into a bare `Ok(None)`
+    ///   that read, to the caller, exactly like "nothing arrived".
+    /// - the stream **ended with no close frame** (peer vanished / transport
+    ///   died) → `Ok(None)`. There is genuinely nothing to report.
+    ///
+    /// Either way the socket is finished: polling again cannot produce a
+    /// message, so callers should reconnect rather than retry.
     pub async fn recv(&mut self) -> Result<Option<Vec<u8>>, ATMError> {
         use futures_util::StreamExt;
         use tokio_tungstenite::tungstenite::Message;
@@ -1467,7 +1480,21 @@ impl TspWebSocket {
         loop {
             match self.ws.next().await {
                 Some(Ok(Message::Binary(bytes))) => return Ok(Some(bytes.to_vec())),
-                Some(Ok(Message::Close(_))) | None => return Ok(None),
+                Some(Ok(Message::Close(frame))) => {
+                    return Err(ATMError::TransportError(match frame {
+                        Some(frame) if !frame.reason.is_empty() => format!(
+                            "TSP websocket closed by the mediator: {} ({})",
+                            frame.reason, frame.code
+                        ),
+                        Some(frame) => {
+                            format!("TSP websocket closed by the mediator: code {}", frame.code)
+                        }
+                        None => {
+                            "TSP websocket closed by the mediator (no reason given)".to_string()
+                        }
+                    }));
+                }
+                None => return Ok(None),
                 Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Text(_))) => continue,
                 Some(Ok(Message::Frame(_))) => continue,
                 Some(Err(e)) => {

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -80,6 +80,20 @@ pub(crate) struct WebSocketTransport {
     next_requests: HashMap<u32, oneshot::Sender<WebSocketResponses>>,
     next_requests_list: VecDeque<u32>,
 
+    /// Inbound frames that are handed back **packed** (TSP frames, and every
+    /// frame when `skip_unpack_messages` is set) and arrived with nowhere to go.
+    ///
+    /// These cannot live in [`Self::inbound_cache`], which is keyed by unpacked
+    /// DIDComm message id. Without a home of their own they were dropped: the
+    /// packed path delivered a frame only if a `Next` request happened to be
+    /// outstanding at that instant, or a direct channel was attached. A polling
+    /// consumer (`live_stream_next_frame`) leaves microsecond-wide gaps between
+    /// one poll returning and the next being registered, and a frame landing in
+    /// that gap was gone — the send succeeded, the mediator delivered, and the
+    /// consumer waited forever. Queue them here instead and let the next `Next`
+    /// drain the queue.
+    packed_cache: VecDeque<String>,
+
     /// Skip calling toggle_live_delivery during connection setup
     skip_toggle_live_delivery: bool,
 
@@ -160,6 +174,7 @@ impl WebSocketTransport {
                 direct_channel,
                 next_requests: HashMap::new(),
                 next_requests_list: VecDeque::new(),
+                packed_cache: VecDeque::new(),
                 skip_toggle_live_delivery: false,
                 skip_unpack_messages: false,
                 conn_state_tx,
@@ -200,6 +215,7 @@ impl WebSocketTransport {
                 direct_channel,
                 next_requests: HashMap::new(),
                 next_requests_list: VecDeque::new(),
+                packed_cache: VecDeque::new(),
                 skip_toggle_live_delivery,
                 skip_unpack_messages,
                 conn_state_tx,
@@ -359,7 +375,14 @@ impl WebSocketTransport {
                             },
                             Some(WebSocketCommands::Next(id, sender)) => {
                                 debug!("Next message requested");
-                                if let Some((message, metadata)) = self.inbound_cache.next() {
+                                // Packed frames first: they are strictly older than
+                                // anything a later poll could produce, and they have no
+                                // other way out — the DIDComm cache is keyed by unpacked
+                                // message id and cannot hold them.
+                                if let Some(packed) = self.packed_cache.pop_front() {
+                                    debug!("Serving packed message from cache");
+                                    let _ = sender.send(WebSocketResponses::PackedMessageReceived(Box::new(packed)));
+                                } else if let Some((message, metadata)) = self.inbound_cache.next() {
                                     let _ = sender.send(WebSocketResponses::MessageReceived(Box::new(message), Box::new(metadata)));
                                 } else {
                                     self.next_requests.insert(id, sender);
@@ -520,27 +543,75 @@ impl WebSocketTransport {
 
         // If skip_unpack_messages is true, send the packed message directly
         if self.skip_unpack_messages || force_packed {
-            // for packed messages skip cache lookup
-            if let Some(next_request) = self.next_requests_list.pop_front() {
-                debug!("Next message found, sending to requestor packed");
-                if let Some(sender) = self.next_requests.remove(&next_request) {
-                    let _ =
-                        sender.send(WebSocketResponses::PackedMessageReceived(Box::new(message)));
-                    return;
-                } else {
+            // A packed frame has exactly three possible homes, tried in order:
+            // an outstanding `Next` request, the direct channel, or the packed
+            // cache. It must reach one of them — every arm that gives up on the
+            // frame has to hand it to the next arm rather than let it fall off
+            // the end, which is how these frames used to vanish.
+            let mut message = message;
+
+            // 1. Outstanding `Next` requests. A waiter whose receiver has gone
+            //    away (its poll timed out between our `pop_front` and this
+            //    `send`) hands the frame back, so we try the next waiter rather
+            //    than losing it to a race we just lost.
+            while let Some(next_request) = self.next_requests_list.pop_front() {
+                let Some(sender) = self.next_requests.remove(&next_request) else {
                     error!(
-                        "Next message requestor not found - bug in the SDK - inbound message may be lost"
+                        "Next message requestor ({next_request}) not found - bug in the SDK - trying the next waiter"
                     );
+                    continue;
+                };
+                match sender.send(WebSocketResponses::PackedMessageReceived(Box::new(message))) {
+                    Ok(()) => {
+                        debug!("Next message found, sending to requestor packed");
+                        return;
+                    }
+                    Err(WebSocketResponses::PackedMessageReceived(returned)) => {
+                        debug!("Next requestor ({next_request}) is gone; re-homing the frame");
+                        message = *returned;
+                    }
+                    // `send` returns the value we passed, which is the variant
+                    // constructed one line above.
+                    Err(_) => unreachable!("oneshot returns the value it was given"),
                 }
             }
 
+            // 2. The direct channel, when one is attached and has receivers.
+            //    `send` fails only when every receiver has dropped, which makes
+            //    the channel no better than no channel for this frame.
             if let Some(direct_channel) = self.direct_channel.as_mut() {
-                debug!("Sending message to direct channel packed");
-                let _ = direct_channel
-                    .send(WebSocketResponses::PackedMessageReceived(Box::new(message)));
-            } else {
-                debug!("No direct channel, should be cached");
+                match direct_channel
+                    .send(WebSocketResponses::PackedMessageReceived(Box::new(message)))
+                {
+                    Ok(_) => {
+                        debug!("Sending message to direct channel packed");
+                        return;
+                    }
+                    Err(returned) => {
+                        let WebSocketResponses::PackedMessageReceived(returned) = returned.0 else {
+                            unreachable!("broadcast returns the value it was given")
+                        };
+                        debug!("Direct channel has no receivers; caching the packed frame");
+                        message = *returned;
+                    }
+                }
             }
+
+            // 3. Cache it for the next `Next`. Bounded by the same count limit
+            //    as the DIDComm cache; at the limit the OLDEST frame is dropped
+            //    (a stalled consumer should not be able to block live traffic
+            //    indefinitely) and we say so — a silent drop here is the exact
+            //    failure this cache exists to prevent.
+            let limit = self.shared.config.fetch_cache_limit_count as usize;
+            if self.packed_cache.len() >= limit {
+                warn!(
+                    "Packed message cache is full ({limit} frames); dropping the oldest frame. \
+                     Nothing is consuming inbound frames fast enough."
+                );
+                self.packed_cache.pop_front();
+            }
+            self.packed_cache.push_back(message);
+            debug!("Cached packed message ({} queued)", self.packed_cache.len());
             return;
         }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.39"
+version = "0.2.40"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
@@ -1,0 +1,91 @@
+//! TSP frames delivered over the **message-pickup** websocket must survive the
+//! gap between polls.
+//!
+//! A TSP frame arriving on the pickup socket is handed back *packed* (it can't
+//! be DIDComm-unpacked). That path used to deliver it only if a `Next` request
+//! happened to be outstanding at that exact instant, or a direct channel was
+//! attached; otherwise it was dropped on the floor with a `debug!` line. The
+//! DIDComm branch caches an unmatched message, but a packed frame has no place
+//! in that cache, so it had nowhere to go.
+//!
+//! A polling consumer (`live_stream_next_frame` in a loop) always leaves a gap
+//! between one poll returning and the next being registered. A frame landing in
+//! that gap was silently lost — which reads to the operator as an intermittent
+//! transport: the send succeeded, the mediator delivered, and the frame simply
+//! never appeared.
+//!
+//! The sleep below is the whole point of this test: it guarantees the frame
+//! arrives with no `Next` outstanding.
+#![cfg(feature = "tsp")]
+
+use std::time::Duration;
+
+use affinidi_messaging_sdk::protocols::message_pickup::InboundFrame;
+use affinidi_messaging_test_mediator::TestEnvironment;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tsp_frame_arriving_between_polls_is_not_dropped() {
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Bob listens on the message-pickup socket (live delivery on) — NOT the
+    // raw-TSP socket.
+    env.atm
+        .profile_enable_websocket(&bob.profile)
+        .await
+        .expect("bob enables the pickup websocket");
+
+    let payload = b"a TSP frame that lands between polls";
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    // Let the frame arrive while Bob is NOT polling. This is what used to lose
+    // it: with no `Next` outstanding the packed branch had nowhere to put it.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Now poll. Enabling live delivery also produces a `messagepickup/3.0/status`
+    // DIDComm frame, so keep pulling until the TSP frame shows up rather than
+    // judging on whatever comes first.
+    let mut tsp_frame: Option<String> = None;
+    for _ in 0..5 {
+        match env
+            .atm
+            .message_pickup()
+            .live_stream_next_frame(&bob.profile, Some(Duration::from_secs(2)), true)
+            .await
+            .expect("live_stream_next_frame must not error")
+        {
+            Some(InboundFrame::Tsp(raw)) => {
+                tsp_frame = Some(*raw);
+                break;
+            }
+            Some(_other) => continue, // the status frame; keep going
+            None => continue,
+        }
+    }
+
+    let frame = tsp_frame.expect(
+        "the TSP frame was delivered by the mediator but never surfaced — it arrived while no \
+         `Next` was outstanding and was dropped",
+    );
+
+    // It really is Alice's message, not just any frame.
+    let qb2 = env.atm.tsp().decode(&frame).expect("frame decodes to qb2");
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack_bytes(&bob.profile, &qb2)
+        .await
+        .expect("bob unpacks the cached TSP frame");
+    assert_eq!(recovered, payload, "payload round-trips");
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+
+    env.shutdown().await.expect("shutdown");
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
@@ -218,3 +218,82 @@ async fn tsp_websocket_sdk_consumer_flushes_and_deletes() {
     ws.close().await.ok();
     env.shutdown().await.expect("shutdown");
 }
+
+/// **Live delivery**: a message sent while the raw-TSP socket is already open
+/// must be pushed onto it, not left in the inbox.
+///
+/// Every test above queues the message *before* Bob connects, so they all pass
+/// on flush-on-connect alone — which is exactly how this shipped broken. A
+/// raw-TSP socket registered with the streaming task but never reached
+/// `StreamingClientState::Live` (only the DIDComm `live-delivery-change`
+/// message promotes a client, and a raw-TSP socket cannot send one), so
+/// `store_message` skipped the streaming publish and the socket's re-drain
+/// never fired. Delivery worked exactly once, at connect time, and every
+/// message after that was stored and forgotten: senders saw success, receivers
+/// heard nothing, and the whole transport looked intermittent because the
+/// outcome depended on whether the frame beat the socket.
+#[tokio::test]
+async fn tsp_websocket_delivers_messages_that_arrive_after_connect() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    // Bob connects FIRST, with an empty inbox — so nothing here can be
+    // satisfied by the flush-on-connect drain.
+    let mut ws = env
+        .atm
+        .tsp()
+        .connect_websocket(&bob.profile)
+        .await
+        .expect("bob opens the TSP websocket");
+
+    // Several messages, to catch a fix that only pushes the first one.
+    for round in 0..3u8 {
+        let payload = format!("live TSP frame {round}").into_bytes();
+        env.atm
+            .tsp()
+            .send(&alice.profile, &bob.did, &payload)
+            .await
+            .unwrap_or_else(|e| panic!("alice sends live TSP message {round}: {e}"));
+
+        let qb2 = timeout(Duration::from_secs(5), ws.recv())
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "TSP frame {round} was sent successfully but never delivered — the socket is \
+                     open and the mediator is holding the message"
+                )
+            })
+            .expect("recv succeeds")
+            .expect("a pushed frame");
+
+        let (recovered, sender) = env
+            .atm
+            .tsp()
+            .unpack_bytes(&bob.profile, &qb2)
+            .await
+            .expect("bob unpacks the pushed TSP message");
+        assert_eq!(recovered, payload, "payload round-trips (frame {round})");
+        assert_eq!(sender, alice.did, "sender VID is recovered (frame {round})");
+    }
+
+    // Delete-on-send holds for pushed frames too.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    assert!(
+        fetched.success.is_empty(),
+        "pushed TSP messages must be deleted on send, got {} left in the inbox",
+        fetched.success.len()
+    );
+
+    ws.close().await.ok();
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
A TSP send reported success and the frame was never delivered. It looked
intermittent — a probe would pass once, then fail for minutes — but it was
total: the outcome depended only on whether the frame reached the mediator
before or after the recipient's socket came up.

Reproduced with two local accounts on an embedded mediator, no VTA involved:
**0 of 10 frames delivered**. With this PR, 10 of 10.

## The two faults

**1. The mediator never marked a raw-TSP websocket live.** `Register` leaves a
client in `StreamingClientState::Registered` ("has a socket but has not enabled
live delivery"); only `Start` promotes it to `Live`. A DIDComm client gets there
by sending `messagepickup/3.0/live-delivery-change` — a raw-TSP socket carries
binary TSP frames and has no such message, so it stayed `Registered` for its
whole life. With the client not live, `store_message` skipped the streaming
publish, so the socket's re-drain arm never fired and flush-on-connect was the
only delivery it ever got. Everything arriving afterwards was stored and left in
the inbox.

Log signature: `TSP/bridged message stored for local recipient` with no
`Live streaming message to UUID` following it.

Raw-TSP delivery is push by contract (flush-on-connect + delete-on-send), not an
opt-in, so the socket now declares itself live when it registers.

**2. The SDK dropped packed frames that arrived between polls.** A TSP frame is
handed back packed (it can't be DIDComm-unpacked) and was delivered only if a
`Next` request happened to be outstanding at that instant, or a direct channel
was attached — otherwise it fell off the end of the function. The DIDComm branch
caches an unmatched message; the packed branch had nowhere to put one, since
`inbound_cache` is keyed by unpacked DIDComm message id. A polling consumer
always leaves a gap between one poll returning and the next being registered, so
this was a race the consumer could only lose.

Packed frames now go to a bounded `packed_cache` that the next `Next` drains,
and every arm hands the frame onward rather than dropping it.

## Also fixed

Both of these made the fault harder to diagnose than it should have been.

- **`Deregister` didn't check whose session it was.** `clients` is keyed by DID
  hash, so a socket that had already been replaced took its successor's channel
  down on the way out — and dropping that `tx` closes the live socket's command
  channel, so its handler exits with "streaming task unavailable". One DID
  handing off between transports (a DIDComm session closing as a raw-TSP socket
  opens) hits this routinely. Deregistration now names its session and is
  ignored if the slot has moved on.

- **`TspWebSocket::recv` discarded the close reason.** The mediator always says
  why it closed a socket ("replaced by a newer connection", "authentication
  token expired", "streaming task unavailable"); the client reported all of
  them, and a socket that simply went quiet, as the same bare `Ok(None)`. A
  close frame is now an `Err` carrying code and reason; a stream that ends
  without one stays `Ok(None)`. Signature unchanged.

## Tests

Every existing raw-TSP test queued its message *before* connecting, so they all
passed on flush-on-connect alone — which is how this shipped broken.

- `tsp_websocket_delivers_messages_that_arrive_after_connect` — connects first,
  against an empty inbox, then sends three frames.
- `tsp_frame_arriving_between_polls_is_not_dropped` — sleeps before polling, so
  the frame provably lands with no `Next` outstanding.

Both were checked to fail without their fix, with the symptom named in the
assertion. Full `affinidi-messaging-test-mediator`, mediator, sdk and
didcomm-service suites pass.

## Versions

`affinidi-messaging-mediator` 0.17.7, `affinidi-messaging-sdk` 0.18.62,
`affinidi-messaging-test-mediator` 0.2.40.

Behavioural change for downstream (R3.6): a raw-TSP socket now receives live
pushes, and `TspWebSocket::recv` returns `Err` where it previously returned
`Ok(None)` for a close frame. Consumers that treated `Ok(None)` as "socket gone"
should treat `Err` the same way.

## Not in this PR

Filed separately so this stays reviewable — see the linked issues: packed-cache
backpressure, the same session-id blindness in `Start`/`Stop`, delete-on-send
vs. R1.1, and the stale messaging CHANGELOG.
