### PR TITLE
feat: opt-in delete-to-ack for raw-TSP delivery (`tsp-ack`)

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.7"
+version = "0.17.8"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -242,7 +242,48 @@ pub async fn websocket_handler(
     // subprotocol, not the bearer entry), so the client learns the mode was
     // accepted from the 101 response's `Sec-WebSocket-Protocol` header.
     #[cfg(feature = "tsp")]
-    let tsp_mode = app_protocols.iter().any(|p| p == "tsp");
+    let tsp_mode = app_protocols.iter().any(|p| p == "tsp" || p == "tsp-ack");
+
+    // `tsp-ack` opts into DELETE-TO-ACK delivery. Plain `tsp` keeps the
+    // original delete-on-send contract, which is at-most-once past the socket
+    // write: the frame is deleted as soon as it has been handed to the local
+    // sink, so a connection that dies before the peer reads it loses the
+    // message with nothing left to redeliver. That is fine for a liveness probe
+    // and wrong for anything that matters.
+    //
+    // In `tsp-ack` mode the mediator sends and keeps. The client acknowledges
+    // by deleting the message through the ordinary authenticated delete path
+    // once it has taken the frame — the id is `sha256` of the stored body,
+    // which is exactly the bytes on the wire, so the client can derive it
+    // without the mediator sending ids and without any change to the frame
+    // format. An un-acked message is simply still there on the next connect.
+    //
+    // Opt-in on purpose: flipping every client at once would trade silent loss
+    // for silent duplication, since a client that never acks would be
+    // redelivered its whole inbox on every reconnect.
+    #[cfg(feature = "tsp")]
+    let tsp_ack_mode = app_protocols.iter().any(|p| p == "tsp-ack");
+
+    // The echo has to be a HONEST capability signal, and by default it isn't:
+    // the offered list is just the client's own list reflected back, so a
+    // mediator that has never heard of a subprotocol still echoes it. A client
+    // asking for `tsp-ack` against an older mediator would therefore be told
+    // "yes" and silently get delete-on-send — the exact silent downgrade
+    // delete-to-ack exists to prevent.
+    //
+    // Fixed by ordering. Clients offer `tsp` BEFORE `tsp-ack`, and axum selects
+    // the first client-requested protocol that the server also lists:
+    //   * older mediator — reflects the client's list, so it selects the
+    //     client's first entry, `tsp`. The client sees no ack support. Correct.
+    //   * this mediator — narrows the offer to `tsp-ack` alone, so that is what
+    //     gets selected despite being second. The client sees ack support, and
+    //     only a mediator that implements it can produce that answer.
+    #[cfg(feature = "tsp")]
+    let app_protocols = if tsp_ack_mode {
+        vec!["tsp-ack".to_string()]
+    } else {
+        app_protocols
+    };
 
     let ws = if app_protocols.is_empty() {
         ws
@@ -258,9 +299,13 @@ pub async fn websocket_handler(
 
     #[cfg(feature = "tsp")]
     {
-        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session, tsp_mode)) }
-            .instrument(_span)
-            .await
+        async move {
+            ws.on_upgrade(move |socket| {
+                handle_socket(socket, state, session, tsp_mode, tsp_ack_mode)
+            })
+        }
+        .instrument(_span)
+        .await
     }
     #[cfg(not(feature = "tsp"))]
     {
@@ -318,6 +363,7 @@ async fn handle_socket(
     state: SharedData,
     session: Session,
     #[cfg(feature = "tsp")] tsp_mode: bool,
+    #[cfg(feature = "tsp")] tsp_ack_mode: bool,
 ) {
     let _span = span!(
         tracing::Level::INFO,
@@ -458,11 +504,31 @@ async fn handle_socket(
         let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
         ping_interval.reset(); // Skip the immediate first tick
 
-        // Flush-on-connect for raw-TSP delivery: drain whatever is already queued
-        // for this DID straight onto the socket (delete-on-send) before entering
-        // the live-delivery loop. If the socket is already gone, exit cleanly.
+        // Sent-but-not-yet-acked message ids, for `tsp-ack` mode only.
+        //
+        // In ack mode the mediator no longer deletes on send, so every drain
+        // re-fetches the same un-acked messages and would re-send them on each
+        // live-delivery wake-up — turning "may see a duplicate after a
+        // reconnect" into "sees duplicates constantly". This set is what makes
+        // redelivery a *recovery* mechanism rather than the steady state:
+        // within one connection a frame is sent once, and the set dies with the
+        // connection, so a reconnect legitimately re-sends whatever was never
+        // acked.
+        //
+        // Bounded implicitly: it only ever holds ids the inbox still contains,
+        // and it is pruned against each completed drain, so client acks remove
+        // entries. The inbox itself is capped by
+        // `queued_receive_messages_hard` and message expiry.
         #[cfg(feature = "tsp")]
-        if tsp_mode && drain_tsp_inbox(&state, &session, &mut socket).await.is_break() {
+        let mut tsp_inflight: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        // Flush-on-connect for raw-TSP delivery: drain whatever is already queued
+        // for this DID straight onto the socket before entering the live-delivery
+        // loop. If the socket is already gone, exit cleanly.
+        #[cfg(feature = "tsp")]
+        if tsp_mode && drain_tsp_inbox(&state, &session, &mut socket, tsp_ack_mode, &mut tsp_inflight)
+            .await
+            .is_break() {
             if let Some(streaming) = &state.streaming_task {
                 let stop = StreamingUpdate {
                     did_hash: session.did_hash.clone(),
@@ -613,7 +679,9 @@ async fn handle_socket(
                                 #[cfg(feature = "tsp")]
                                 if tsp_mode {
                                     let _ = &msg; // body intentionally ignored in TSP mode
-                                    if drain_tsp_inbox(&state, &session, &mut socket).await.is_break() {
+                                    if drain_tsp_inbox(&state, &session, &mut socket, tsp_ack_mode, &mut tsp_inflight)
+            .await
+            .is_break() {
                                         close_reason = (close_code::GOING_AWAY, "client disconnected");
                                         break;
                                     }
@@ -692,15 +760,37 @@ const TSP_DRAIN_PAGE: usize = 50;
 const TSP_DRAIN_MAX: usize = 1000;
 
 /// Drain the recipient's undelivered inbox to a **raw TSP** WebSocket,
-/// inline on the connection, with a *delete-on-successful-send* contract.
+/// inline on the connection. Each stored message is decoded to its raw qb2
+/// bytes and sent as a `Binary` frame; what happens next depends on the mode
+/// the client negotiated at the upgrade.
 ///
-/// This is the outbound (delivery) half of the TSP WebSocket mode. Unlike
-/// the DIDComm message-pickup path (delete-to-ack) or the streaming
-/// redelivery (notification re-cover with `DoNotDelete`), here the socket
-/// itself is the ack: each stored TSP message is decoded to its raw qb2
-/// bytes, sent as a `Binary` frame, and only then deleted. If the send
-/// fails the socket is gone — the message (and the rest of the inbox) is
-/// left intact for the next connection, so delivery is at-least-once.
+/// ## `ack_mode = false` (subprotocol `tsp`) — delete-on-send, at-most-once
+///
+/// The socket write itself is treated as the ack: the message is deleted the
+/// moment `send` returns. A successful `send` means the frame was accepted by
+/// the local sink, **not** that the peer received it, so a connection that
+/// drops between the write and the peer reading it loses the message with
+/// nothing left to redeliver — the mediator has already forgotten it. This is
+/// the historical behaviour and is kept for compatibility. It is appropriate
+/// for a liveness probe and not for anything that matters.
+///
+/// (If the *send* fails, the socket is gone and the message and the rest of
+/// the inbox are left intact for the next connection.)
+///
+/// ## `ack_mode = true` (subprotocol `tsp-ack`) — delete-to-ack, at-least-once
+///
+/// The mediator sends and keeps. The client acknowledges out of band, by
+/// deleting the message through the ordinary authenticated delete path once it
+/// has actually taken the frame; the id is `sha256` of the stored body, which
+/// is exactly the bytes on the wire, so the client derives it without the
+/// mediator sending ids and without any change to the frame format. A message
+/// the client never acks is simply still in the inbox on the next connect and
+/// is redelivered — so a consumer may see a duplicate, and must be idempotent,
+/// which is the standard trade for not losing messages.
+///
+/// Un-acked messages are bounded by the same limits as any other queued
+/// message (`queued_receive_messages_hard`, message expiry); nothing new can
+/// grow without limit here.
 ///
 /// Returns:
 /// - [`ControlFlow::Break`] when the socket send failed (caller should
@@ -712,9 +802,15 @@ async fn drain_tsp_inbox(
     state: &SharedData,
     session: &Session,
     socket: &mut WebSocket,
+    ack_mode: bool,
+    inflight: &mut std::collections::HashSet<String>,
 ) -> ControlFlow<(), ()> {
     let mut start_id: Option<String> = None;
     let mut total: usize = 0;
+    // Every id this drain walked past (ack mode only) — used to prune `inflight`
+    // once the walk completes, so ids the client has since acked (and which the
+    // inbox therefore no longer returns) stop occupying the set.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     loop {
         let options = FetchOptions {
@@ -751,6 +847,14 @@ async fn drain_tsp_inbox(
             // optimistic-delete fetch path uses; `receive_id` is only the stream
             // cursor, not a valid delete key.
             let id = element.msg_id;
+            if ack_mode {
+                seen.insert(id.clone());
+                // Already on the wire for this connection and not yet acked —
+                // sending it again would duplicate within a single session.
+                if inflight.contains(&id) {
+                    continue;
+                }
+            }
 
             // Stored body is base64url(qb2). Decode back to raw qb2 bytes for
             // the wire. A malformed entry is skipped (not deleted) so it can be
@@ -774,9 +878,20 @@ async fn drain_tsp_inbox(
                 return ControlFlow::Break(());
             }
 
-            // Delivered — delete it. A delete error is logged but not fatal: the
-            // message was already delivered, so we continue.
-            if let Err(err) = state
+            if ack_mode {
+                // Delete-to-ack: the write is not the acknowledgement, so keep
+                // the message. The client deletes it once it has taken the
+                // frame; until then it stays recoverable across a reconnect.
+                inflight.insert(id.clone());
+                debug!(
+                    did_hash = %session.did_hash,
+                    message_id = %id,
+                    "Sent TSP message, awaiting client ack (tsp-ack mode)"
+                );
+            } else if let Err(err) = state
+                // Delete-on-send: delivered as far as this mode is concerned. A
+                // delete error is logged but not fatal — the frame is already
+                // on the wire, so we continue.
                 .database
                 .delete_message(
                     &id,
@@ -800,13 +915,28 @@ async fn drain_tsp_inbox(
                     max = TSP_DRAIN_MAX,
                     "TSP inbox drain hit its safety cap; remaining messages left for the next drain"
                 );
+                // Returns WITHOUT pruning `inflight` below, deliberately: only a
+                // complete walk proves an absent id was acked, and pruning
+                // against a walk cut short by the cap would resurrect
+                // still-in-flight messages as duplicates.
                 return ControlFlow::Continue(());
             }
         }
     }
 
+    if ack_mode {
+        // Anything no longer in the inbox has been acked (or expired): drop it
+        // so the set tracks only what is genuinely outstanding.
+        inflight.retain(|id| seen.contains(id));
+    }
+
     if total > 0 {
-        debug!(did_hash = %session.did_hash, total, "TSP inbox drain complete");
+        debug!(
+            did_hash = %session.did_hash,
+            total,
+            awaiting_ack = inflight.len(),
+            "TSP inbox drain complete"
+        );
     }
     ControlFlow::Continue(())
 }

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.62"
+version = "0.18.63"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1282,6 +1282,40 @@ impl TspOps<'_> {
         &self,
         profile: &Arc<ATMProfile>,
     ) -> Result<TspWebSocket, ATMError> {
+        self.connect_websocket_inner(profile, false).await
+    }
+
+    /// Open the mediator's raw-TSP WebSocket in **delete-to-ack** mode
+    /// (subprotocol `tsp-ack`).
+    ///
+    /// Identical to [`connect_websocket`](Self::connect_websocket) except that
+    /// the mediator does not delete a message when it writes it to the socket.
+    /// It keeps it until this client acknowledges, via
+    /// [`TspWebSocket::ack`], which you call once the frame is safely in your
+    /// hands.
+    ///
+    /// Use this whenever losing a message matters. Plain `connect_websocket`
+    /// is at-most-once past the socket write: a successful write means the
+    /// frame reached the mediator's local sink, so a connection that dies
+    /// before your process reads it takes the message with it — the mediator
+    /// has already forgotten it.
+    ///
+    /// The trade is the usual one. Anything sent but not acked when the
+    /// connection drops is redelivered on the next connect, so a consumer
+    /// **must be idempotent**: it may see a frame twice. Within a single
+    /// connection the mediator will not re-send an un-acked frame.
+    pub async fn connect_websocket_acked(
+        &self,
+        profile: &Arc<ATMProfile>,
+    ) -> Result<TspWebSocket, ATMError> {
+        self.connect_websocket_inner(profile, true).await
+    }
+
+    async fn connect_websocket_inner(
+        &self,
+        profile: &Arc<ATMProfile>,
+        ack: bool,
+    ) -> Result<TspWebSocket, ATMError> {
         use tokio_tungstenite::tungstenite::{ClientRequestBuilder, http::Uri};
 
         let (profile_did, mediator_did) = profile.dids()?;
@@ -1341,10 +1375,30 @@ impl TspOps<'_> {
                 80
             });
 
-        // Offer `bearer.<jwt>` (auth) + `tsp` (raw-TSP mode) subprotocols.
-        let builder = ClientRequestBuilder::new(uri)
-            .with_sub_protocol(format!("bearer.{access_token}"))
-            .with_sub_protocol("tsp");
+        // Offer `bearer.<jwt>` (auth) + the raw-TSP mode subprotocol(s).
+        //
+        // `tsp` is offered BEFORE `tsp-ack`, and the order is load-bearing.
+        //
+        // A mediator that predates `tsp-ack` echoes the client's subprotocol
+        // list back unchanged, so it would happily echo `tsp-ack` without
+        // implementing it — and we would believe we had delete-to-ack while it
+        // deleted on send, silently losing the very guarantee we asked for.
+        //
+        // Selection takes the first client-listed protocol the server also
+        // offers. An older mediator offers back our own list and so selects our
+        // first entry, `tsp`; a mediator that supports the mode narrows its
+        // offer to `tsp-ack` and so selects that despite it being second. Only
+        // a mediator that implements delete-to-ack can answer `tsp-ack`, which
+        // is what makes the echoed value trustworthy.
+        let builder =
+            ClientRequestBuilder::new(uri).with_sub_protocol(format!("bearer.{access_token}"));
+        let builder = if ack {
+            builder
+                .with_sub_protocol("tsp")
+                .with_sub_protocol("tsp-ack")
+        } else {
+            builder.with_sub_protocol("tsp")
+        };
 
         let (ws, response) =
             crate::transports::websockets::proxy::connect_websocket(builder, &host, port)
@@ -1359,19 +1413,41 @@ impl TspOps<'_> {
         // The 101 should echo `tsp`, confirming the mode was accepted.
         // tokio-tungstenite already enforces subprotocol agreement, so a
         // mismatch here is informational only — warn, don't hard-fail.
-        match response
+        let echoed = response
             .headers()
             .get("sec-websocket-protocol")
             .and_then(|v| v.to_str().ok())
-        {
-            Some("tsp") => {}
-            other => tracing::warn!(
-                "TSP websocket did not echo the `tsp` subprotocol (got {other:?}); \
-                 raw-TSP mode may not be active"
-            ),
-        }
+            .map(str::to_string);
+        let acked = match echoed.as_deref() {
+            Some("tsp-ack") => true,
+            Some("tsp") => {
+                // A downgrade is silent otherwise, and silently losing the
+                // delivery guarantee you asked for is exactly the failure this
+                // mode exists to prevent — say so loudly.
+                if ack {
+                    tracing::warn!(
+                        "requested `tsp-ack` but the mediator echoed `tsp`: it predates \
+                         delete-to-ack, so delivery on this socket is at-most-once past \
+                         the write and `ack()` will not be honoured"
+                    );
+                }
+                false
+            }
+            other => {
+                tracing::warn!(
+                    "TSP websocket did not echo a known subprotocol (got {other:?}); \
+                     raw-TSP mode may not be active"
+                );
+                false
+            }
+        };
 
-        Ok(TspWebSocket { ws })
+        Ok(TspWebSocket {
+            ws,
+            ack_mode: acked,
+            atm: self.atm.clone(),
+            profile: profile.clone(),
+        })
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────
@@ -1451,6 +1527,15 @@ pub struct TspWebSocket {
     ws: tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
+    /// Whether the mediator agreed to `tsp-ack` (delete-to-ack). False for a
+    /// plain `tsp` socket, including when a `tsp-ack` request was downgraded by
+    /// an older mediator.
+    ack_mode: bool,
+    /// Held so [`ack`](TspWebSocket::ack) can reach the delete path; the ack
+    /// travels over the SDK's ordinary authenticated deletion channel, not over
+    /// this socket.
+    atm: ATM,
+    profile: Arc<ATMProfile>,
 }
 
 impl TspWebSocket {
@@ -1516,6 +1601,52 @@ impl TspWebSocket {
             .send(Message::Binary(tsp_message.to_vec().into()))
             .await
             .map_err(|e| ATMError::TransportError(format!("TSP websocket send error: {e}")))
+    }
+
+    /// Whether this socket negotiated `tsp-ack` (delete-to-ack delivery).
+    ///
+    /// False on a plain `tsp` socket **and** when a `tsp-ack` request was
+    /// downgraded by a mediator that predates the mode — check this if you need
+    /// to know whether the guarantee you asked for is actually in force.
+    pub fn is_acked(&self) -> bool {
+        self.ack_mode
+    }
+
+    /// Acknowledge a frame returned by [`recv`](TspWebSocket::recv), releasing
+    /// the mediator's copy.
+    ///
+    /// Call this once the frame is safely handled — persisted, dispatched,
+    /// whatever "received" means for you — not merely once it has been read off
+    /// the socket. Everything not acked when the connection drops is
+    /// redelivered on the next connect, which is the entire point: that window
+    /// is what makes this at-least-once instead of at-most-once.
+    ///
+    /// The message id is derived, not transmitted: the mediator keys deletion on
+    /// `sha256` of the stored body, and the stored body for a TSP message is the
+    /// base64url encoding of exactly these bytes. So the ack needs no id from
+    /// the mediator and no change to the frame format.
+    ///
+    /// Deletion is queued on the SDK's background deletion handler, so this does
+    /// not block on a round trip.
+    ///
+    /// Returns an error on a socket that did not negotiate `tsp-ack` — there,
+    /// the mediator deleted the message when it sent it and there is nothing to
+    /// acknowledge. Guard with [`is_acked`](TspWebSocket::is_acked) in code that
+    /// handles both modes.
+    pub async fn ack(&self, qb2: &[u8]) -> Result<(), ATMError> {
+        if !self.ack_mode {
+            return Err(ATMError::ConfigError(
+                "ack() on a socket that did not negotiate `tsp-ack`: the mediator already \
+                 deleted this message when it sent it. Open the socket with \
+                 `connect_websocket_acked` to use delete-to-ack."
+                    .into(),
+            ));
+        }
+        let stored = BASE64_URL_SAFE_NO_PAD.encode(qb2);
+        let message_id = sha256::digest(stored.as_str());
+        self.atm
+            .delete_message_background(&self.profile, &message_id)
+            .await
     }
 
     /// Close the socket gracefully.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.40"
+version = "0.2.41"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
@@ -297,3 +297,291 @@ async fn tsp_websocket_delivers_messages_that_arrive_after_connect() {
     ws.close().await.ok();
     env.shutdown().await.expect("shutdown");
 }
+
+/// Poll Bob's mailbox until it is empty, or give up. Deletion is queued on the
+/// SDK's background handler, so the ack is not synchronous with the delete.
+async fn wait_for_empty_inbox(env: &TestEnvironment, user: &TestUser) -> bool {
+    for _ in 0..40 {
+        let fetched = env
+            .atm
+            .fetch_messages(&user.profile, &FetchOptions::default())
+            .await
+            .expect("fetch messages");
+        if fetched.success.is_empty() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+/// **`tsp-ack`: send and keep.** The mediator must NOT delete the message when
+/// it writes it to the socket — only when the client acknowledges.
+///
+/// Plain `tsp` deletes on send, which is at-most-once past the write: a
+/// successful write means the frame reached the local sink, so a connection
+/// that dies before the peer reads it loses the message with nothing left to
+/// redeliver. That is fine for a liveness probe and wrong for anything that
+/// matters, so `tsp-ack` moves the delete to the ack.
+#[tokio::test]
+async fn tsp_ack_mode_keeps_the_message_until_the_client_acks() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"a TSP message that must survive until acked";
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    let mut ws = env
+        .atm
+        .tsp()
+        .connect_websocket_acked(&bob.profile)
+        .await
+        .expect("bob opens the TSP websocket in ack mode");
+    assert!(
+        ws.is_acked(),
+        "the mediator must negotiate `tsp-ack`; a silent downgrade would leave \
+         delivery at-most-once while the caller believes otherwise"
+    );
+
+    let qb2 = timeout(Duration::from_secs(5), ws.recv())
+        .await
+        .expect("a frame arrives within the timeout")
+        .expect("recv succeeds")
+        .expect("a flushed frame");
+
+    let (recovered, sender) = env
+        .atm
+        .tsp()
+        .unpack_bytes(&bob.profile, &qb2)
+        .await
+        .expect("bob unpacks the message");
+    assert_eq!(recovered, payload, "payload round-trips");
+    assert_eq!(sender, alice.did, "sender VID is recovered");
+
+    // THE POINT: delivered to the socket, still held by the mediator.
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("bob fetches messages");
+    assert_eq!(
+        fetched.success.len(),
+        1,
+        "in tsp-ack mode the message must still be held until acked — deleting on \
+         send is what loses it when the socket dies mid-flight"
+    );
+
+    // Ack, and only now may it go.
+    ws.ack(&qb2).await.expect("ack succeeds");
+    assert!(
+        wait_for_empty_inbox(&env, &bob).await,
+        "the acked message must be deleted"
+    );
+
+    ws.close().await.ok();
+    env.shutdown().await.expect("shutdown");
+}
+
+/// The recovery this buys: a frame that was sent but never acked is still there
+/// on the next connection. Under delete-on-send it would be gone for good.
+#[tokio::test]
+async fn an_unacked_tsp_message_is_redelivered_on_reconnect() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let payload = b"a TSP message the client never acknowledges";
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, payload)
+        .await
+        .expect("alice sends a TSP message to bob");
+
+    // First connection: receive it, then walk away without acking — standing in
+    // for a consumer that crashed between reading the frame and handling it.
+    {
+        let mut ws = env
+            .atm
+            .tsp()
+            .connect_websocket_acked(&bob.profile)
+            .await
+            .expect("bob connects in ack mode");
+        let first = timeout(Duration::from_secs(5), ws.recv())
+            .await
+            .expect("a frame arrives")
+            .expect("recv succeeds")
+            .expect("a flushed frame");
+        assert!(!first.is_empty(), "a non-empty frame");
+        ws.close().await.ok();
+    }
+
+    // Second connection: it is still ours to collect.
+    let mut ws = env
+        .atm
+        .tsp()
+        .connect_websocket_acked(&bob.profile)
+        .await
+        .expect("bob reconnects in ack mode");
+    let again = timeout(Duration::from_secs(5), ws.recv())
+        .await
+        .expect(
+            "the un-acked message must be redelivered on reconnect — this is the \
+             at-most-once loss window that tsp-ack closes",
+        )
+        .expect("recv succeeds")
+        .expect("a redelivered frame");
+
+    let (recovered, _) = env
+        .atm
+        .tsp()
+        .unpack_bytes(&bob.profile, &again)
+        .await
+        .expect("bob unpacks the redelivered message");
+    assert_eq!(recovered, payload, "the same message came back");
+
+    ws.ack(&again).await.expect("ack succeeds");
+    assert!(
+        wait_for_empty_inbox(&env, &bob).await,
+        "the acked message must be deleted"
+    );
+
+    ws.close().await.ok();
+    env.shutdown().await.expect("shutdown");
+}
+
+/// Redelivery is for *recovery*, not the steady state: within one connection an
+/// un-acked frame must not be sent again. Without the in-flight set, every
+/// live-delivery wake-up re-walks the inbox and re-sends everything not yet
+/// acked, so a consumer that acks a moment later sees constant duplicates.
+#[tokio::test]
+async fn an_unacked_message_is_not_resent_within_the_same_connection() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let mut ws = env
+        .atm
+        .tsp()
+        .connect_websocket_acked(&bob.profile)
+        .await
+        .expect("bob connects in ack mode");
+
+    // Two messages, neither acked. Each must arrive exactly once.
+    for round in 0..2u8 {
+        let payload = format!("unacked message {round}").into_bytes();
+        env.atm
+            .tsp()
+            .send(&alice.profile, &bob.did, &payload)
+            .await
+            .expect("alice sends");
+
+        let qb2 = timeout(Duration::from_secs(5), ws.recv())
+            .await
+            .unwrap_or_else(|_| panic!("frame {round} arrives"))
+            .expect("recv succeeds")
+            .expect("a pushed frame");
+        let (recovered, _) = env
+            .atm
+            .tsp()
+            .unpack_bytes(&bob.profile, &qb2)
+            .await
+            .expect("unpack");
+        assert_eq!(recovered, payload, "frame {round} is the one just sent");
+    }
+
+    // Nothing further: no re-send of the two outstanding frames.
+    let extra = timeout(Duration::from_secs(2), ws.recv()).await;
+    assert!(
+        extra.is_err(),
+        "an un-acked frame must not be re-sent on the same connection — \
+         redelivery is a reconnect-time recovery, not the steady state"
+    );
+
+    ws.close().await.ok();
+    env.shutdown().await.expect("shutdown");
+}
+
+/// **The negotiation must be an honest capability signal.**
+///
+/// By default the mediator echoes the client's subprotocol list back unchanged,
+/// which means a mediator that has never heard of a subprotocol still echoes
+/// it. Left alone, a client asking for `tsp-ack` against an older mediator
+/// would be told "yes" and silently get delete-on-send — the same silent loss
+/// delete-to-ack exists to remove.
+///
+/// The fix is ordering: clients list `tsp` first, and selection picks the first
+/// client-listed protocol the server also offers. An older mediator reflects
+/// the client's list and so lands on `tsp`; this mediator narrows its offer to
+/// `tsp-ack` and so lands on `tsp-ack` despite it being second. This test pins
+/// that override — if the mediator ever goes back to plain reflection, a client
+/// would read `tsp` here and correctly (if unhelpfully) conclude there is no
+/// ack support, but the *positive* signal must keep working.
+#[tokio::test]
+async fn tsp_ack_is_selected_even_though_the_client_lists_it_second() {
+    init_tracing();
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &bob).await;
+
+    // Client order mirrors the SDK: `tsp` first, `tsp-ack` second.
+    let request = ClientRequestBuilder::new(ws_uri.clone())
+        .with_sub_protocol(format!("bearer.{access_token}"))
+        .with_sub_protocol("tsp")
+        .with_sub_protocol("tsp-ack");
+    let (stream, response) = connect_async(request)
+        .await
+        .expect("bob upgrades offering tsp + tsp-ack");
+    assert_eq!(
+        response
+            .headers()
+            .get("sec-websocket-protocol")
+            .and_then(|v| v.to_str().ok()),
+        Some("tsp-ack"),
+        "a mediator that supports delete-to-ack must answer `tsp-ack`, or the \
+         client cannot tell support from mere reflection"
+    );
+    drop(stream);
+
+    // And a plain `tsp` client still negotiates plain `tsp`.
+    let (access_token, ws_uri) = token_and_ws_uri(&env, &bob).await;
+    let request = ClientRequestBuilder::new(ws_uri)
+        .with_sub_protocol(format!("bearer.{access_token}"))
+        .with_sub_protocol("tsp");
+    let (stream, response) = connect_async(request)
+        .await
+        .expect("bob upgrades offering tsp only");
+    assert_eq!(
+        response
+            .headers()
+            .get("sec-websocket-protocol")
+            .and_then(|v| v.to_str().ok()),
+        Some("tsp"),
+        "a client that did not ask for delete-to-ack must not be given it"
+    );
+    drop(stream);
+
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
Closes #649.

Raw-TSP delivery deletes a message the moment it is written to the socket, and
documents that as at-least-once. It isn't. A successful `socket.send().await`
means the frame was accepted by the mediator's local sink, **not** that the peer
received it — so a connection dropping between the write and the peer reading it
loses the message with nothing left to redeliver, because the mediator has
already forgotten it.

That is at-most-once, and it is the shape R1.1 warns about: never resolve a send
as delivered for a frame that was merely handed to the transport. Fine for a
liveness probe, wrong for anything that matters, and invisible when it happens —
the sender sees success and the receiver sees nothing.

## `tsp-ack`

A client opts in by offering the `tsp-ack` subprotocol. The mediator then sends
and keeps; the client acknowledges once it actually has the frame, and only then
is the message dropped. Anything un-acked when the connection dies is
redelivered on the next connect.

**No new wire protocol.** The delete key is `sha256` of the stored body, and the
stored body for a TSP message is the base64url encoding of exactly the bytes on
the wire — so the client derives the id itself. The mediator sends no ids, the
frame format is unchanged, and the ack rides the existing authenticated delete
path via the SDK's background deletion handler.

```rust
let mut ws = atm.tsp().connect_websocket_acked(&profile).await?;
assert!(ws.is_acked());              // did we actually get the guarantee?
let frame = ws.recv().await?.unwrap();
handle(&frame)?;                     // do the work first
ws.ack(&frame).await?;               // then release the mediator's copy
```

**Opt-in on purpose.** Flipping every client at once would trade silent loss for
silent duplication — a client that never acks would be redelivered its whole
inbox on every reconnect. Plain `tsp` keeps delete-on-send byte for byte; the
three pre-existing raw-TSP tests are unchanged and still pass.

## Redelivery is recovery, not the steady state

Not deleting on send means each drain re-walks the same un-acked messages, so a
naive version re-sends them on every live-delivery wake-up and a consumer that
acks a moment later sees constant duplicates. A per-connection in-flight set
makes a frame go out once per connection; the set dies with the connection, so a
reconnect legitimately re-sends whatever was never acked. It is pruned against
each *completed* drain — never one cut short by the safety cap, which would
resurrect in-flight messages as duplicates.

## The negotiation has to be honest (I got this wrong first)

Worth flagging for review. The mediator echoes the client's subprotocol list
back unchanged, so **an older mediator would echo `tsp-ack` without implementing
it** — the client would believe it had delete-to-ack while the mediator deleted
on send, silently losing the exact guarantee it asked for. My first version had
this bug.

Fixed by ordering. Clients list `tsp` first and `tsp-ack` second, and selection
takes the first client-listed protocol the server also offers:

- **older mediator** — reflects the client's list, so it lands on `tsp`. The
  client correctly sees no ack support.
- **this mediator** — narrows its offer to `tsp-ack` alone, so it lands on
  `tsp-ack` despite it being second. Only a mediator that implements the mode
  can produce that answer.

`is_acked()` reports what was actually negotiated, and a downgrade warns loudly
instead of passing silently. `tsp_ack_is_selected_even_though_the_client_lists_it_second`
pins it.

## Tests

- `tsp_ack_mode_keeps_the_message_until_the_client_acks` — still in the inbox
  after delivery, gone after the ack.
- `an_unacked_tsp_message_is_redelivered_on_reconnect` — the loss window closed;
  under delete-on-send that frame is gone for good.
- `an_unacked_message_is_not_resent_within_the_same_connection` — redelivery
  stays a reconnect-time recovery.
- `tsp_ack_is_selected_even_though_the_client_lists_it_second` — the negotiation
  override, without which support is indistinguishable from reflection.

Full test-mediator, mediator and sdk suites pass; zero clippy warnings.

## Versions

mediator 0.17.8, sdk 0.18.63, test-mediator 0.2.41.

Behavioural note for downstream (R3.6): nothing changes unless a client asks for
`tsp-ack`. Those that do must be **idempotent** — at-least-once means a frame may
arrive twice.
