### PR TITLE
feat: support the agent name community form `example.com/@`

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 23rd July 2026
 
+### 0.8.21 — `resolve_any` accepts a community name
+
+`resolve_any("example.com/@")` now classifies as an agent name and resolves,
+where it previously failed as malformed. The agent name FAQ gives a name with
+an empty local part to the verifiable trust community that owns the domain,
+and `agent-names` 0.1.3 parses it — this release raises the floor to that
+version so the behaviour is guaranteed rather than incidental.
+
+`example.com/@/path` is still rejected: the community name takes no path.
+
+No API change. `AgentName::is_community()` distinguishes the form for callers
+that key storage by local name and need to route it elsewhere.
+
 ### 0.8.20 — a display name for a resolved DID
 
 `ResolveResponse::display_name()` returns the verified human name for a DID

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -9,8 +9,9 @@
 `resolve_any("example.com/@")` now classifies as an agent name and resolves,
 where it previously failed as malformed. The agent name FAQ gives a name with
 an empty local part to the verifiable trust community that owns the domain,
-and `agent-names` 0.1.3 parses it — this release raises the floor to that
-version so the behaviour is guaranteed rather than incidental.
+and `agent-names` 0.1.3 parses it. Requires that version or later — the
+manifest requirement stays `0.1` because both crates release together, so a
+`0.1.3` floor would not resolve at publish time.
 
 `example.com/@/path` is still rejected: the community name takes no path.
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -67,9 +67,11 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
-# 0.1.3 is the floor: it is the first release that parses the community name
-# (`example.com/@`), which `resolve_any` now accepts.
-agent-names = { version = "0.1.3", optional = true }
+# Community-name support (`example.com/@`) needs agent-names >= 0.1.3. The
+# requirement stays at `0.1` rather than pinning that floor: both crates
+# release from the same commit, so a `0.1.3` floor cannot resolve against the
+# registry at publish time. Cargo picks the newest 0.1.x anyway.
+agent-names = { version = "0.1", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.20"
+version = "0.8.21"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -67,7 +67,9 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 ahash = "0.8"
 base64 = { version = "0.22", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
-agent-names = { version = "0.1", optional = true }
+# 0.1.3 is the floor: it is the first release that parses the community name
+# (`example.com/@`), which `resolve_any` now accepts.
+agent-names = { version = "0.1.3", optional = true }
 highway = "1"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.10"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/agent_names.rs
@@ -436,7 +436,17 @@ mod tests {
     #[test]
     fn rejects_a_malformed_agent_name() {
         // Contains the marker, so it is treated as a name — and is invalid.
-        assert!(Identifier::parse("example.com/@").is_err());
+        // A community name takes no path, so this is not a qualified `/@`.
+        assert!(Identifier::parse("example.com/@/path").is_err());
+    }
+
+    /// `example.com/@` is the domain's community name, not a truncation.
+    #[test]
+    fn parses_a_community_name_as_an_agent_name() {
+        let Identifier::AgentName(name) = Identifier::parse("example.com/@").unwrap() else {
+            panic!("the community name should classify as an agent name");
+        };
+        assert!(name.is_community());
     }
 
     #[test]

--- a/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/tests/agent_names.rs
@@ -379,7 +379,9 @@ async fn backends_are_tried_in_order() {
 async fn a_malformed_agent_name_is_rejected_before_any_lookup() {
     let (client, calls) = client_with(IMMUTABLE_DID, &[], &[], 300).await;
 
-    assert!(client.resolve_any("example.com/@").await.is_err());
+    // A community name takes no path, so this is malformed rather than a
+    // context-qualified `example.com/@`.
+    assert!(client.resolve_any("example.com/@/path").await.is_err());
     assert_eq!(
         calls.load(Ordering::SeqCst),
         0,

--- a/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/tests/agent_name_endpoint.rs
@@ -82,8 +82,8 @@ async fn route_exists_when_enabled() {
 
 #[tokio::test]
 async fn rejects_a_malformed_agent_name() {
-    // Reaches the route (contains '/@') but has an empty local name.
-    let (status, body) = get(app(true).await, "/did/v1/resolve-name/example.com/@").await;
+    // Reaches the route (contains '/@'), but the community name takes no path.
+    let (status, body) = get(app(true).await, "/did/v1/resolve-name/example.com/@/path").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert!(body.contains("error"), "got {body}");
 }

--- a/crates/identity/shortcuts/agent-names/CHANGELOG.md
+++ b/crates/identity/shortcuts/agent-names/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `agent-names` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-07-23
+
+### Added
+
+- Support for the **community name** — an agent name with an empty local part,
+  `example.com/@`, which the agent name FAQ defines as the name of the
+  verifiable trust community (VTC) owning the domain and which resolves to that
+  community's VTA. It was previously rejected as an "empty local name", so no
+  conforming implementation built on this crate could parse, resolve or verify
+  one.
+
+- `AgentName::is_community()` — true for `example.com/@`. Preferred over
+  testing `local_name()` for emptiness: consumers that key per-agent storage by
+  local name generally need to route the community case to the domain's own
+  identity instead of writing an empty key.
+
+### Changed
+
+- `example.com/@/path` is still rejected, now with the reason "the community
+  name '/@' must not be followed by a path" rather than "empty local name after
+  '@'". The FAQ admits the community form "without adding any path except the @
+  sign", so a trailing path is malformed rather than a context-qualified
+  community name.
+
+The community name is an ordinary agent name otherwise: it canonicalises by the
+same rules, and Layer-1 `alsoKnownAs` verification applies unchanged. It is
+**not** a prefix of the names beneath it — a document claiming `example.com/@`
+does not answer for `example.com/@alice`, nor the reverse.
+
 ## [0.1.2] - 2026-07-19
 
 ### Added

--- a/crates/identity/shortcuts/agent-names/Cargo.toml
+++ b/crates/identity/shortcuts/agent-names/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-names"
-version = "0.1.2"
+version = "0.1.3"
 description = "Agent Name (DID shortcut) parsing, resolution and verification for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/shortcuts/agent-names/README.md
+++ b/crates/identity/shortcuts/agent-names/README.md
@@ -10,7 +10,15 @@ example.com/@alice
 connect.me/@bob
 names.somewhere.info/@john-smith
 firstperson.network/@drummond/h2hsummit   # trailing path adds context
+example.com/@                             # the domain's own community
 ```
+
+A name with an empty local part is the **community name**: it belongs to the
+verifiable trust community (VTC) owning the domain and resolves to that
+community's VTA. It takes no path — `example.com/@/anything` is malformed — and
+`AgentName::is_community()` identifies it. It is otherwise an ordinary agent
+name, and is **not** a prefix of the names beneath it: claiming `example.com/@`
+does not let a document answer for `example.com/@alice`.
 
 An agent name is **not** a DID method. It is a shortcut layer in front of DID
 resolution, and the specification anticipates other shortcut kinds later — hence

--- a/crates/identity/shortcuts/agent-names/src/lib.rs
+++ b/crates/identity/shortcuts/agent-names/src/lib.rs
@@ -9,10 +9,24 @@
  * connect.me/@bob
  * names.somewhere.info/@john-smith
  * firstperson.network/@drummond/h2hsummit   # trailing path adds context
+ * example.com/@                             # the domain's own community
  * ```
  *
  * An agent name is **not** a DID method. It is a shortcut layer in front of DID
  * resolution, and the specification anticipates other shortcut kinds later.
+ *
+ * # The community name
+ *
+ * A name with an empty local part — `example.com/@` — is the agent name of the
+ * verifiable trust community (VTC) that owns the domain, and resolves to that
+ * community's VTA. It carries no path: `example.com/@/anything` is malformed,
+ * not a context-qualified community name. Test for it with
+ * [`AgentName::is_community`] rather than checking `local_name()` for emptiness.
+ *
+ * The community name is an ordinary agent name in every other respect — same
+ * canonicalisation, and the same mandatory Layer-1 check below. In particular
+ * it is **not** a prefix of the names under it: a document claiming
+ * `example.com/@` does not thereby answer for `example.com/@alice`.
  *
  * # Resolution is two-stage, and the second stage is the important one
  *

--- a/crates/identity/shortcuts/agent-names/src/name.rs
+++ b/crates/identity/shortcuts/agent-names/src/name.rs
@@ -18,7 +18,24 @@ pub const AGENT_NAME_MARKER: &str = "/@";
 /// connect.me/@bob
 /// names.somewhere.info/@john-smith
 /// firstperson.network/@drummond/h2hsummit
+/// example.com/@                             # the community name
 /// ```
+///
+/// # The community name
+///
+/// A name whose local part is empty — `example.com/@` — belongs to the
+/// verifiable trust community (VTC) that owns the domain, and resolves to that
+/// community's VTA. The FAQ puts it as "exactly the same syntax — only without
+/// adding any path except the @ sign".
+///
+/// "Except the @ sign" is load-bearing: the community name carries **no** path,
+/// so `example.com/@/anything` is rejected rather than read as a context-
+/// qualified community name. Distinguish the form with [`AgentName::is_community`].
+///
+/// Whether a given domain lets anyone *claim* its community name is the issuing
+/// host's policy, not this crate's business — parsing says the string is
+/// well-formed, and Layer-1 verification still decides whether the DID it
+/// resolves to genuinely claims it back.
 ///
 /// # Canonicalisation
 ///
@@ -116,8 +133,19 @@ impl AgentName {
             .ok_or_else(|| invalid("path does not begin with '/@'"))?
             .to_string();
 
-        if local_name.is_empty() {
-            return Err(invalid("empty local name after '@'"));
+        // An empty local part is the community name (`example.com/@`) — the VTC
+        // that owns the domain. It is the one case where "no local name" is
+        // meaningful rather than a truncated `example.com/@alice`.
+        //
+        // The FAQ allows it "without adding any path except the @ sign", so a
+        // trailing path is not a context-qualified community name, it is
+        // malformed. Rejecting here also keeps `/@` unambiguous: without this,
+        // `example.com/@/alice` and `example.com/@alice` would differ only by a
+        // slash while looking near-identical in a URL bar.
+        if local_name.is_empty() && !segments.is_empty() {
+            return Err(invalid(
+                "the community name '/@' must not be followed by a path",
+            ));
         }
         // Only the first segment may carry the marker; `a/@b/@c` is ambiguous.
         if segments.iter().any(|s| s.starts_with('@')) {
@@ -162,8 +190,23 @@ impl AgentName {
     }
 
     /// The local name, without its `@`: `alice`.
+    ///
+    /// Empty for the community name (`example.com/@`); prefer
+    /// [`is_community`](Self::is_community) over testing this for emptiness, so
+    /// the intent is legible at the call site.
     pub fn local_name(&self) -> &str {
         &self.local_name
+    }
+
+    /// Is this the domain's community name — `example.com/@`?
+    ///
+    /// Such a name resolves to the VTA of the verifiable trust community that
+    /// owns the authority, rather than to an individual agent under it. Callers
+    /// that map names onto per-agent storage usually need to route this case
+    /// somewhere else (the domain's own identity), so it is worth branching on
+    /// rather than letting an empty key fall through.
+    pub fn is_community(&self) -> bool {
+        self.local_name.is_empty()
     }
 
     /// Trailing context path segments, if any: `["h2hsummit"]`.
@@ -276,6 +319,81 @@ mod tests {
         assert_eq!(n.path_segments(), ["can", "include", "paths"]);
     }
 
+    // --- the community name ---
+
+    /// The FAQ's three worked examples of a VTC name.
+    #[test]
+    fn parses_community_names() {
+        for (input, expected) in [
+            ("example.com/@", "https://example.com/@"),
+            ("connect.me/@", "https://connect.me/@"),
+            ("firstperson.network/@", "https://firstperson.network/@"),
+        ] {
+            let n = AgentName::parse(input).unwrap();
+            assert_eq!(n.as_str(), expected);
+            assert_eq!(n.local_name(), "");
+            assert!(n.is_community(), "{input} should be a community name");
+            assert!(n.path_segments().is_empty());
+        }
+    }
+
+    #[test]
+    fn community_name_keeps_its_authority() {
+        let n = AgentName::parse("https://example.com:8443/@").unwrap();
+        assert_eq!(n.authority(), "example.com:8443");
+        assert_eq!(n.as_str(), "https://example.com:8443/@");
+    }
+
+    #[test]
+    fn community_name_writes_without_scheme_as_the_faq_does() {
+        let n = AgentName::parse("https://example.com/@").unwrap();
+        assert_eq!(n.without_scheme(), "example.com/@");
+    }
+
+    /// A named agent is not the community, and vice versa.
+    #[test]
+    fn community_and_named_agents_are_distinct() {
+        let community = AgentName::parse("example.com/@").unwrap();
+        let alice = AgentName::parse("example.com/@alice").unwrap();
+        assert!(community.is_community());
+        assert!(!alice.is_community());
+        assert_ne!(community, alice);
+    }
+
+    /// Same convergence guarantee as a named agent — Layer-1 compares strings.
+    #[test]
+    fn all_spellings_of_a_community_name_converge() {
+        let forms = [
+            "example.com/@",
+            "https://example.com/@",
+            "https://EXAMPLE.com/@",
+            "https://example.com:443/@",
+            "https://example.com/@/",
+            "  example.com/@  ",
+        ];
+        let canonical: Vec<_> = forms
+            .iter()
+            .map(|f| {
+                AgentName::parse(f)
+                    .unwrap_or_else(|e| panic!("{f} should parse: {e}"))
+                    .as_str()
+                    .to_string()
+            })
+            .collect();
+        assert!(
+            canonical.windows(2).all(|w| w[0] == w[1]),
+            "spellings diverged: {canonical:?}"
+        );
+    }
+
+    #[test]
+    fn community_name_round_trips_through_display_and_from_str() {
+        let n: AgentName = "example.com/@".parse().unwrap();
+        assert_eq!(n.to_string(), "https://example.com/@");
+        let again: AgentName = n.to_string().parse().unwrap();
+        assert_eq!(n, again);
+    }
+
     // --- canonicalisation: the load-bearing cases for Layer-1 ---
 
     #[test]
@@ -357,10 +475,11 @@ mod tests {
         assert!(AgentName::parse("did:web:example.com").is_err());
     }
 
+    /// The community name is well-formed, but a path after `/@` is not.
     #[test]
-    fn rejects_empty_local_name() {
-        assert!(AgentName::parse("example.com/@").is_err());
+    fn rejects_community_name_with_a_path() {
         assert!(AgentName::parse("example.com/@/path").is_err());
+        assert!(AgentName::parse("example.com/@/alice/deeper").is_err());
     }
 
     #[test]

--- a/crates/identity/shortcuts/agent-names/src/verify.rs
+++ b/crates/identity/shortcuts/agent-names/src/verify.rs
@@ -178,6 +178,41 @@ mod tests {
         assert!(verify_also_known_as(&doc, &name("firstperson.network/@drummond")).is_err());
     }
 
+    // --- the community name ---
+
+    #[test]
+    fn accepts_community_name_claimed_by_the_document() {
+        let doc = doc_with(&["https://example.com/@"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@")).is_ok());
+    }
+
+    #[test]
+    fn accepts_scheme_less_community_entry() {
+        let doc = doc_with(&["example.com/@"]);
+        assert!(verify_also_known_as(&doc, &name("https://example.com/@")).is_ok());
+    }
+
+    /// The community name is not a prefix of the names under it: holding
+    /// `example.com/@` must not let a document answer for `@alice`.
+    #[test]
+    fn rejects_community_entry_for_a_named_agent_request() {
+        let doc = doc_with(&["https://example.com/@"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@alice")).is_err());
+    }
+
+    /// …and the reverse: an agent under the domain does not answer for the VTC.
+    #[test]
+    fn rejects_named_agent_entry_for_a_community_request() {
+        let doc = doc_with(&["https://example.com/@alice"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@")).is_err());
+    }
+
+    #[test]
+    fn rejects_community_name_of_a_different_domain() {
+        let doc = doc_with(&["https://evil.com/@"]);
+        assert!(verify_also_known_as(&doc, &name("example.com/@")).is_err());
+    }
+
     /// A near-miss that a naive `contains()` would wrongly accept.
     #[test]
     fn rejects_substring_near_miss() {


### PR DESCRIPTION
## Why

The agent name FAQ defines a name with an empty local part as belonging to the **verifiable trust community (VTC)** that owns the domain, resolving to that community's VTA:

> Yes! VTC agent names use exactly the same syntax—only without adding any path except the @ sign.
> `example.com/@` · `connect.me/@` · `firstperson.network/@`
> An agent name that ends with a "/@" will connect with a community VTA.

`AgentName::parse` rejected that form as `empty local name after '@'`. Because this crate is the shared parse/canonicalise/verify half — consumed over FFI precisely so implementations don't diverge — the rejection propagated to everything downstream: a hosting service could serve a perfectly good redirect for `/@` and no conforming client would ever request it, because parsing fails locally before any network access.

## What

Accept an empty local part when — and only when — no path follows it.

`example.com/@/path` **stays rejected**. "Except the @ sign" is load-bearing, so a trailing path is malformed rather than a context-qualified community name; it now reports that reason instead of the empty-local-name one. Keeping it out also avoids `example.com/@/alice` and `example.com/@alice` differing by a single slash while looking near-identical in a URL bar.

The community name is otherwise ordinary — same canonicalisation, Layer-1 `alsoKnownAs` verification unchanged. In particular it is **not a prefix** of the names beneath it: a document claiming `example.com/@` does not answer for `example.com/@alice`, nor the reverse. That falls out of the existing canonical-equality check, but both directions are now pinned by tests since it's the property most worth a regression guard.

Adds `AgentName::is_community()`. Consumers that key per-agent storage by local name generally need to route this case to the domain's own identity rather than write an empty key, and `local_name().is_empty()` at the call site doesn't say that.

## Note for reviewers

Three downstream tests used `example.com/@` as their stock *malformed* example. They now use `example.com/@/path`, which still exercises the "contains the marker but is invalid" branch they were written for. Worth knowing this was load-bearing behaviour rather than a dormant edge case.

No `+` capability-suffix work here — `connect.me/@alice+calendar` and `example.com/@+concierge` already parse, since the local part is opaque. `@+concierge` yields `local_name = "+concierge"` and `is_community() == false`, which is correct: the community's concierge agent is not the community. I deliberately did not add `base_name()`/`capability()` accessors — the FAQ only says the DTGWG *could* define that dictionary, so splitting on `+` would be inventing semantics ahead of the spec.

## Testing

- `agent-names`: 69 lib + 16 integration tests, clean clippy. New coverage for the FAQ's three worked examples, canonicalisation convergence for the community form (host case, default port, trailing slash, whitespace), and Layer-1 in both directions.
- `affinidi-did-resolver-cache-sdk` (with `agent-names`): 62 + 20 + 2 pass.
- `affinidi-did-resolver-cache-server`: 6 + 9 pass. `test_cache_server` fails, but identically on a clean tree — it needs a live websocket cache server.
- Verified against a real consumer (`affinidi-webvh-service`) via a temporary path patch: it degrades safely without a coordinated release. Its `extract_agent_names` now yields `""`, its own validator rejects it on a 2-char minimum, and reconciliation skips it with a debug log — no bad index write. 18 of its agent-name tests pass unchanged.

Version bumped to 0.1.3 with a changelog entry; the `^0.1.2` requirements downstream already admit it.