### PR TITLE
fix: scope streaming Start/Stop to the session that owns the DID's slot

### DIFF
--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -8,6 +8,64 @@ we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our
 tooling.
 
+## 23rd July 2026
+
+### Mediator (0.17.9) / SDK (0.18.63) / Test Mediator (0.2.41)
+
+Raw-TSP WebSocket delivery: one outright delivery failure, one delivery
+guarantee that was documented but not implemented, and one silent
+stop-delivering bug. All three were invisible from both ends of the wire —
+the sender saw success and the recipient saw nothing.
+
+- **FIX: TSP frames arriving after the socket was open were never
+  delivered** (#646, mediator 0.17.7 / SDK 0.18.62). Two independent
+  faults. (1) A raw-TSP websocket was only ever `Registered`, never
+  `Live`: only `Start` promotes a client, and `Start` came solely from
+  the DIDComm `messagepickup/3.0/live-delivery-change` message, which a
+  binary-only raw-TSP socket cannot send. With the client not live,
+  `store_message` skipped the streaming publish, so the socket's re-drain
+  never fired and **flush-on-connect was the only delivery it ever got** —
+  everything arriving afterwards was stored and left in the inbox. (2) The
+  SDK dropped packed frames (all TSP frames) that arrived with no `Next`
+  request outstanding and no direct channel attached: the DIDComm branch
+  caches an unmatched message, the packed branch had nowhere to put one, so
+  a polling consumer lost any frame landing between polls. Also: a
+  `Deregister` from a replaced session evicted its successor's channel
+  (closing a healthy socket with "streaming task unavailable"), and
+  `TspWebSocket::recv` collapsed close frames to `Ok(None)`, discarding the
+  reason the mediator gave for closing.
+
+  *Reproduced at 0 of 10 frames delivered between two local accounts; 10 of
+  10 after the fix.*
+
+- **FEAT: opt-in delete-to-ack for raw-TSP (`tsp-ack`)** (#651, mediator
+  0.17.8 / SDK 0.18.63). Raw-TSP deleted a message the moment it was
+  written to the socket and documented that as at-least-once. It wasn't: a
+  successful send means the frame reached the mediator's local sink, not
+  the peer, so a connection dropping in between lost the message with
+  nothing left to redeliver. A client offering the `tsp-ack` subprotocol
+  now gets send-and-keep, acknowledging via the ordinary authenticated
+  delete once it holds the frame; anything un-acked when the connection
+  dies is redelivered on reconnect. No new wire protocol — the delete key
+  is `sha256` of the stored body, which is the base64url of exactly the
+  bytes on the wire, so the client derives the id itself.
+
+  **Opt-in on purpose.** Plain `tsp` keeps delete-on-send byte for byte, so
+  no deployed client changes behaviour. Clients that opt in **must be
+  idempotent**: at-least-once means a frame may arrive twice. Note the
+  subprotocol ordering is load-bearing — clients list `tsp` before
+  `tsp-ack`, because an older mediator reflects the client's list and would
+  otherwise echo `tsp-ack` without implementing it.
+
+- **FIX: streaming `Start`/`Stop` acted on the wrong connection** (#653,
+  mediator 0.17.9). `clients` is keyed by DID hash, not by connection, so a
+  `live-delivery-change` from a session that had already been replaced
+  flipped delivery for its *successor*. A stale `Stop` cleared both
+  `active` and the stored `Live` state, leaving a healthy socket connected
+  and silently no longer receiving pushes. Both variants now carry their
+  `session_id` and are applied only when that session still owns the slot —
+  completing the same fix made for `Deregister` in #646.
+
 ## 24th May 2026
 
 ### Mediator (0.15.5)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.8"
+version = "0.17.9"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -464,7 +464,9 @@ async fn handle_socket(
             if tsp_mode {
                 let live = StreamingUpdate {
                     did_hash: session.did_hash.clone(),
-                    state: StreamingUpdateState::Start,
+                    state: StreamingUpdateState::Start {
+                        session_id: session.session_id.clone(),
+                    },
                 };
                 match streaming.channel.send(live).await {
                     Ok(_) => {

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/message_pickup.rs
@@ -239,7 +239,9 @@ pub(crate) async fn toggle_live_delivery(
                     .channel
                     .send(StreamingUpdate {
                         did_hash: session.did_hash.clone(),
-                        state: StreamingUpdateState::Start,
+                        state: StreamingUpdateState::Start {
+                            session_id: session.session_id.clone(),
+                        },
                     })
                     .await
                     .map_err(|e| {
@@ -264,7 +266,9 @@ pub(crate) async fn toggle_live_delivery(
                     .channel
                     .send(StreamingUpdate {
                         did_hash: session.did_hash.clone(),
-                        state: StreamingUpdateState::Stop,
+                        state: StreamingUpdateState::Stop {
+                            session_id: session.session_id.clone(),
+                        },
                     })
                     .await
                     .map_err(|e| {

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -98,16 +98,21 @@ pub enum StreamingUpdateState {
         session_id: String,
         did: String,
     },
-    Start,
-    Stop,
+    /// Enable live delivery for the socket owned by `session_id`.
+    ///
+    /// Session-scoped for the same reason [`Deregister`](Self::Deregister) is:
+    /// `clients` is keyed by DID hash, so an update that doesn't name its
+    /// session acts on whichever connection currently holds the slot — which
+    /// may not be the one that sent it.
+    Start { session_id: String },
+    /// Disable live delivery for the socket owned by `session_id`.
+    Stop { session_id: String },
     /// Remove the map entry for this DID — but only if it is still *this*
     /// session's entry. `clients` is keyed by DID hash, not by connection, so a
     /// deregistration must name the session it belongs to: a socket that has
     /// already been replaced (one DID, one slot) would otherwise evict its
     /// successor on the way out. See the session-id check in the handler.
-    Deregister {
-        session_id: String,
-    },
+    Deregister { session_id: String },
 }
 
 /// Used to send commands from the streaming task to the websocket handler
@@ -310,26 +315,11 @@ impl StreamingTask {
                                 StreamingUpdateState::Register { .. } => {
                                     self._handle_registration(&database, &mut clients, &replay_in_progress, value).await;
                                 },
-                                StreamingUpdateState::Start => {
-                                    if let Some(entry) = clients.get_mut(&value.did_hash) {
-                                        info!("Starting streaming for DID: ({})", value.did_hash);
-                                        entry.active = true;
-                                    };
-
-                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Live).await {
-                                        error!("Error starting streaming to client ({}) streaming: {}",value.did_hash, err);
-                                    }
+                                StreamingUpdateState::Start { session_id } => {
+                                    self._handle_activation(&database, &mut clients, &value.did_hash, session_id, true).await;
                                 },
-                                StreamingUpdateState::Stop => {
-                                    // Set active to false
-                                    if let Some(entry) = clients.get_mut(&value.did_hash) {
-                                        info!("Stopping streaming for DID: ({})", value.did_hash);
-                                        entry.active = false;
-                                    };
-
-                                    if let Err(err) = database.streaming_set_state(&value.did_hash, &self.uuid, StreamingClientState::Registered).await {
-                                        error!("Error stopping streaming for client ({}): {}",value.did_hash, err);
-                                    }
+                                StreamingUpdateState::Stop { session_id } => {
+                                    self._handle_activation(&database, &mut clients, &value.did_hash, session_id, false).await;
                                 },
                                 StreamingUpdateState::Deregister { session_id } => {
                                     // Only the session that currently owns the slot may
@@ -445,6 +435,72 @@ impl StreamingTask {
                     "pub/sub msg received for did_hash({did_hash}) but it doesn't exist in clients HashMap"
                 );
             }
+        }
+    }
+
+    /// Turn live delivery on or off for **the session that owns the DID's slot**.
+    ///
+    /// `clients` is keyed by DID hash, not by connection, so an update that
+    /// doesn't name its session acts on whoever holds the slot now. That is a
+    /// real hazard for a DID whose sessions overlap: a `live-delivery-change`
+    /// from a connection that has since been replaced would otherwise flip
+    /// delivery for its *successor* — and a stale `Stop` is the bad one,
+    /// because it clears both `active` and the stored `Live` state, so the
+    /// healthy socket stays connected and simply stops receiving pushes. That
+    /// is the same silent stop-delivering failure as the `Deregister` bug, and
+    /// just as hard to see from either end.
+    ///
+    /// An update whose session no longer owns the slot — or that arrives when
+    /// there is no slot at all — is dropped. A slot-less `Start` is worth
+    /// dropping in its own right: marking a DID `Live` with no channel to
+    /// deliver on only produces "not in clients HashMap" warnings when messages
+    /// arrive. Ordering makes this safe for legitimate traffic: `Register` and
+    /// `Start` travel the same FIFO channel, so a live session's own `Start`
+    /// always finds its entry.
+    async fn _handle_activation(
+        &self,
+        database: &Arc<dyn MediatorStore>,
+        clients: &mut HashMap<String, ClientEntry>,
+        did_hash: &str,
+        session_id: &str,
+        active: bool,
+    ) {
+        match clients.get_mut(did_hash) {
+            Some(entry) if entry.session_id == session_id => {
+                entry.active = active;
+            }
+            Some(entry) => {
+                debug!(
+                    did_hash = %did_hash,
+                    requesting_session = %session_id,
+                    current_session = %entry.session_id,
+                    active,
+                    "Ignoring a live-delivery change from a session that no longer owns this DID's slot",
+                );
+                return;
+            }
+            None => {
+                debug!(
+                    did_hash = %did_hash,
+                    requesting_session = %session_id,
+                    active,
+                    "Ignoring a live-delivery change for a DID with no registered client",
+                );
+                return;
+            }
+        }
+
+        let (state, verb) = if active {
+            (StreamingClientState::Live, "Starting")
+        } else {
+            (StreamingClientState::Registered, "Stopping")
+        };
+        info!("{verb} streaming for DID: ({did_hash})");
+        if let Err(err) = database
+            .streaming_set_state(did_hash, &self.uuid, state)
+            .await
+        {
+            error!("Error changing streaming state for client ({did_hash}): {err}");
         }
     }
 
@@ -775,6 +831,152 @@ mod tests {
             // buffer exhaustion (which `ws_budget` covers directly).
             send_budget: WsSendBudget::new(16 * 1024 * 1024),
         }
+    }
+
+    /// Build a client map holding one entry, owned by `session_id`.
+    fn clients_with(
+        did_hash: &str,
+        session_id: &str,
+        active: bool,
+    ) -> HashMap<String, ClientEntry> {
+        let (tx, _rx) = mpsc::channel(5);
+        let mut clients = HashMap::new();
+        clients.insert(
+            did_hash.to_string(),
+            ClientEntry {
+                tx,
+                session_id: session_id.to_string(),
+                active,
+                registered_at: Instant::now(),
+                churn_streak: 0,
+            },
+        );
+        clients
+    }
+
+    /// A `Stop` from a session that has already been replaced must not switch
+    /// live delivery off for the connection that replaced it.
+    ///
+    /// This is the bad direction of the bug: `clients` is keyed by DID hash, so
+    /// an unscoped `Stop` clears both `active` and the stored `Live` state for
+    /// whoever holds the slot. The healthy socket stays connected and simply
+    /// stops receiving pushes — the same silent stop-delivering failure as the
+    /// `Deregister` bug, invisible from both ends.
+    #[tokio::test]
+    async fn a_stale_sessions_stop_does_not_deactivate_the_current_socket() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did_hash = digest("did:example:alice");
+        let task = streaming_task();
+
+        // Session B currently owns the slot and is live.
+        let mut clients = clients_with(&did_hash, "B", true);
+        database
+            .streaming_set_state(&did_hash, &task.uuid, StreamingClientState::Live)
+            .await
+            .expect("mark live");
+
+        // Session A — long since replaced — disables live delivery on its way out.
+        task._handle_activation(&database, &mut clients, &did_hash, "A", false)
+            .await;
+
+        assert!(
+            clients.get(&did_hash).expect("entry still present").active,
+            "a replaced session must not deactivate its successor"
+        );
+        assert!(
+            database
+                .streaming_is_client_live(&did_hash, false)
+                .await
+                .is_some(),
+            "the stored Live state belongs to the owning session and must survive"
+        );
+    }
+
+    /// The mirror: a stale `Start` must not switch delivery on for a socket
+    /// that deliberately turned it off.
+    #[tokio::test]
+    async fn a_stale_sessions_start_does_not_activate_the_current_socket() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did_hash = digest("did:example:bob");
+        let task = streaming_task();
+
+        let mut clients = clients_with(&did_hash, "B", false);
+
+        task._handle_activation(&database, &mut clients, &did_hash, "A", true)
+            .await;
+
+        assert!(
+            !clients.get(&did_hash).expect("entry still present").active,
+            "a replaced session must not activate its successor"
+        );
+        assert!(
+            database
+                .streaming_is_client_live(&did_hash, false)
+                .await
+                .is_none(),
+            "no Live state may be written on behalf of a session that does not own the slot"
+        );
+    }
+
+    /// The owning session still works — without this, "ignore everything" would
+    /// satisfy the two tests above.
+    #[tokio::test]
+    async fn the_owning_sessions_activation_is_applied() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did_hash = digest("did:example:carol");
+        let task = streaming_task();
+
+        let mut clients = clients_with(&did_hash, "B", false);
+
+        task._handle_activation(&database, &mut clients, &did_hash, "B", true)
+            .await;
+        assert!(
+            clients.get(&did_hash).expect("entry").active,
+            "the owning session's start must apply"
+        );
+        assert!(
+            database
+                .streaming_is_client_live(&did_hash, false)
+                .await
+                .is_some(),
+            "and must be reflected in the stored streaming state"
+        );
+
+        task._handle_activation(&database, &mut clients, &did_hash, "B", false)
+            .await;
+        assert!(
+            !clients.get(&did_hash).expect("entry").active,
+            "and its stop must apply too"
+        );
+        assert!(
+            database
+                .streaming_is_client_live(&did_hash, false)
+                .await
+                .is_none(),
+            "stopping must clear the stored Live state"
+        );
+    }
+
+    /// An activation for a DID with no registered client is dropped. Marking a
+    /// DID `Live` with no channel to deliver on only produces "not in clients
+    /// HashMap" warnings when messages arrive for it.
+    #[tokio::test]
+    async fn an_activation_without_a_registered_client_is_ignored() {
+        let database: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+        let did_hash = digest("did:example:dave");
+        let task = streaming_task();
+
+        let mut clients: HashMap<String, ClientEntry> = HashMap::new();
+        task._handle_activation(&database, &mut clients, &did_hash, "A", true)
+            .await;
+
+        assert!(
+            database
+                .streaming_is_client_live(&did_hash, false)
+                .await
+                .is_none(),
+            "a DID with no socket must not be marked live"
+        );
     }
 
     /// Issue #374: a duplicate connect for a DID with an in-flight (stored but


### PR DESCRIPTION
Closes #648.

#646 fixed `Deregister` acting on the wrong connection: `clients` is keyed by
DID hash, **not** by connection, so an update that doesn't name its session acts
on whoever holds the slot at that moment — which may not be the sender. `Start`
and `Stop` had the same shape and were deliberately left alone to keep that PR
focused on the delivery bug.

## The failure

A stale `Stop` is the bad direction. A `live-delivery-change(false)` from a
connection that has since been replaced clears both `active` and the stored
`Live` state for its **successor**, so the healthy socket stays connected and
simply stops receiving pushes.

That is the same silent stop-delivering failure as the `Deregister` bug, and
just as hard to see from either end: the client is connected, the mediator is
dutifully storing its messages, and nothing reports an error. It needs a client
toggling live delivery while racing its own reconnect, which is narrower than
the `Deregister` case — but the consequence is identical.

A stale `Start` is the milder mirror: it re-enables delivery for a live session
that deliberately turned it off.

## The fix

Both variants now carry their `session_id`, and both go through one
`_handle_activation` helper that applies the change only when the slot belongs
to the requesting session. Extracting the helper is also what makes the guard
testable — the arms were previously inline in the task's `select!` loop, which
is why this went untested in the first place.

One deliberate behaviour change beyond the session check: an activation for a
DID with **no** registered client is dropped rather than written through to the
store. Marking a DID `Live` with no channel to deliver on only produces "not in
clients HashMap" warnings when messages arrive. Ordering keeps this safe for
legitimate traffic — `Register` and `Start` travel the same FIFO channel, so a
live session's own `Start` always finds its entry.

## Tests

Unit tests against the in-memory store:

- `a_stale_sessions_stop_does_not_deactivate_the_current_socket`
- `a_stale_sessions_start_does_not_activate_the_current_socket`
- `the_owning_sessions_activation_is_applied` — so "ignore everything" cannot
  pass the two above
- `an_activation_without_a_registered_client_is_ignored`

Both stale-session tests were confirmed to fail with the session guard removed.
They assert on the in-memory `active` flag **and** the stored streaming state,
because the bug corrupts both and either alone would let a partial fix through.

Full mediator and test-mediator suites pass; zero clippy warnings.

affinidi-messaging-mediator 0.17.9.
