### PR TITLE
fix: drop idle pooled HTTP connections after 15s, not reqwest's 90s

### DIFF
--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -6,6 +6,26 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk-common`.
 
+## 0.6.7 — 2026-07-23
+
+### Fixed
+
+- **Idle pooled connections are dropped after 15s instead of reqwest's 90s
+  default.** The client's idle window was *wider* than the keep-alive of the
+  servers in front of our endpoints (nginx defaults to 75s, an AWS ALB to 60s),
+  which loses a race: the peer closes a connection the pool still believes is
+  good, the next request is written into it, and the caller sees the EOF as
+  `hyper::Error(IncompleteMessage)` on send.
+
+  Periodic traffic sat squarely in the danger zone — a 60s health-check leaves a
+  connection idle for about as long as a proxy will hold it, so a percentage of
+  cycles failed with no retry to cover them. It surfaced downstream as recurring
+  `Failed to send TSP reply … IncompleteMessage` warnings against the mediator's
+  `/inbound` endpoint, one dropped reply per affected cycle.
+
+  Erring short costs one extra TLS handshake; erring long costs a dropped
+  request.
+
 ## 0.6.6 — 2026-07-19
 
 ### Changed

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.6"
+version = "0.6.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/tdk/affinidi-tdk-common/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-common/src/lib.rs
@@ -107,8 +107,33 @@ pub struct TDKSharedState {
     pub(crate) authentication: AuthenticationCache,
 }
 
+/// How long an idle pooled connection may be reused before it is discarded.
+///
+/// **Deliberately shorter than any plausible server-side keep-alive.** reqwest's
+/// default is 90s, which is *longer* than the common defaults in front of our
+/// endpoints — nginx's `keepalive_timeout` is 75s and an AWS ALB's idle timeout
+/// is 60s. When the client's window is the wider one there is a race: the peer
+/// closes a connection the pool still believes is good, the next request is
+/// written into it, and the caller sees the EOF as
+/// `hyper::Error(IncompleteMessage)` on send.
+///
+/// That is not theoretical. Periodic traffic sits squarely in the danger zone:
+/// a 60s health-check leaves a connection idle for exactly as long as the proxy
+/// is willing to hold it, so a percentage of cycles fail with no retry to cover
+/// them (observed as recurring "Failed to send TSP reply" warnings).
+///
+/// 15s keeps the pool useful for bursty traffic while guaranteeing we drop a
+/// connection well before any of those servers would. The cost of being wrong
+/// in this direction is one extra TLS handshake; the cost of being wrong in the
+/// other is a dropped request.
+const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Build a reusable HTTP/HTTPS [`Client`] backed by `rustls` with the platform
 /// trust verifier, optionally extended with `extra_roots`.
+///
+/// Idle pooled connections are dropped after [`POOL_IDLE_TIMEOUT`] rather than
+/// reqwest's 90s default — see that constant for why the shorter window is the
+/// safe direction to err in.
 ///
 /// Pass an empty slice for the default behaviour (platform trust store only).
 /// Non-empty `extra_roots` are added on top of the platform store via
@@ -184,6 +209,7 @@ pub fn create_http_client(extra_roots: &[CertificateDer<'static>]) -> Result<Cli
     reqwest::ClientBuilder::new()
         .use_rustls_tls()
         .use_preconfigured_tls(tls_config)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
         .user_agent(format!(
             "Affinidi Trust Development Kit {}",
             env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
## The symptom

A `did-hosting-server` in production logs this every so often, on a fixed cadence:

```
WARN affinidi_messaging_didcomm_service::service::listener: Failed to send TSP reply
  profile=server error=ATM error: Transport (HTTP(S)) error: Could not send TSP message:
  reqwest::Error { kind: Request, url: "https://mediator.…/mediator/v1/inbound",
  source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage)) }
```

Six occurrences over two hours, every one of them at `:42.490` past the minute — a periodic task where only some cycles fail.

## The cause

`create_http_client` never set `pool_idle_timeout`, so it inherited reqwest's **90s** default. That is *wider* than the keep-alive of the servers in front of our endpoints: nginx's `keepalive_timeout` defaults to 75s, an AWS ALB's idle timeout to 60s.

When the client's window is the wider one there is a race — the peer closes a connection the pool still believes is good, the next request is written into it, and the caller sees the EOF as `hyper::Error(IncompleteMessage)` on send. The request never reached the server.

Periodic traffic sits squarely in the danger zone. A 60s health-check leaves a connection idle for about as long as a proxy is willing to hold it, so a percentage of cycles land in the race window. The TSP send path (`protocols/tsp.rs`) is a single `.send()` with no retry, so nothing covers it.

## The fix

`.pool_idle_timeout(15s)` — short enough to guarantee we discard a connection well before any of those servers would, long enough that bursty traffic still reuses connections. Erring short costs one extra TLS handshake; erring long costs a dropped request.

Chosen at the shared client rather than per-call site, because every caller through `TDKSharedState::client()` has the same exposure.

## Impact downstream

Each dropped reply is one missed health-check response. In `did-hosting-control`, `health_status_from_timestamp` marks an instance **Degraded** once `last_health_check` is more than `timeout_secs` stale — so a single missed reply could flip a perfectly healthy server to "Degraded" in the dashboard until the next successful cycle.

## Notes

No retry added. A retry would paper over the race rather than avoid it, and would need the send to be idempotent — worth considering separately, but not the fix for this.

`pool_idle_timeout` only bounds how long an **idle** connection is kept; in-flight requests are unaffected, so there is no timeout behaviour change for slow responses.

Bumped to 0.6.7 with a changelog entry. Clippy and fmt clean.