### PR TITLE
fix: back-pressure the packed-frame queue instead of discarding frames

### DIFF
--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -8,6 +8,23 @@ we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our
 tooling.
 
+## 24th July 2026
+
+### SDK (0.18.64) / Test Mediator (0.2.42)
+
+- **FIX: a slow consumer silently lost packed (TSP) frames** (#647). The
+  packed-frame queue added in #646 sat outside the socket-read
+  backpressure guard, so the only way to honour its bound was to discard
+  the oldest frame — and a discarded packed frame is unrecoverable,
+  because under delete-on-send the mediator dropped its copy the moment
+  it wrote it. A consumer that stopped polling for long enough therefore
+  lost messages outright, with only a `warn!` to show for it. Both
+  inbound caches now share one policy: when either is full the select
+  loop stops reading the socket, and nothing is discarded. A consumer
+  that stalls stalls its own connection instead. The queue is bounded by
+  the same count *and* byte limits as the DIDComm cache
+  (`fetch_cache_limit_count` / `fetch_cache_limit_bytes`).
+
 ## 23rd July 2026
 
 ### Mediator (0.17.9) / SDK (0.18.63) / Test Mediator (0.2.41)

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.63"
+version = "0.18.64"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -92,7 +92,21 @@ pub(crate) struct WebSocketTransport {
     /// that gap was gone — the send succeeded, the mediator delivered, and the
     /// consumer waited forever. Queue them here instead and let the next `Next`
     /// drain the queue.
+    ///
+    /// Bounded by the same count/byte limits as [`Self::inbound_cache`], and
+    /// with the same policy: when it fills, the socket-read arm of the select
+    /// loop stops reading (backpressure) rather than the cache discarding
+    /// anything. See [`Self::packed_cache_is_full`].
     packed_cache: VecDeque<String>,
+
+    /// Running total of `packed_cache`'s payload bytes, so fullness can be
+    /// judged without walking the queue.
+    packed_cache_bytes: u64,
+
+    /// Latched when `packed_cache` exceeds either limit; cleared once the
+    /// consumer has drained it back under both. Mirrors `MessageCache`'s
+    /// `cache_full` so the two caches behave identically.
+    packed_cache_full: bool,
 
     /// Skip calling toggle_live_delivery during connection setup
     skip_toggle_live_delivery: bool,
@@ -175,6 +189,8 @@ impl WebSocketTransport {
                 next_requests: HashMap::new(),
                 next_requests_list: VecDeque::new(),
                 packed_cache: VecDeque::new(),
+                packed_cache_bytes: 0,
+                packed_cache_full: false,
                 skip_toggle_live_delivery: false,
                 skip_unpack_messages: false,
                 conn_state_tx,
@@ -216,6 +232,8 @@ impl WebSocketTransport {
                 next_requests: HashMap::new(),
                 next_requests_list: VecDeque::new(),
                 packed_cache: VecDeque::new(),
+                packed_cache_bytes: 0,
+                packed_cache_full: false,
                 skip_toggle_live_delivery,
                 skip_unpack_messages,
                 conn_state_tx,
@@ -379,7 +397,7 @@ impl WebSocketTransport {
                                 // anything a later poll could produce, and they have no
                                 // other way out — the DIDComm cache is keyed by unpacked
                                 // message id and cannot hold them.
-                                if let Some(packed) = self.packed_cache.pop_front() {
+                                if let Some(packed) = self.pop_packed() {
                                     debug!("Serving packed message from cache");
                                     let _ = sender.send(WebSocketResponses::PackedMessageReceived(Box::new(packed)));
                                 } else if let Some((message, metadata)) = self.inbound_cache.next() {
@@ -409,7 +427,13 @@ impl WebSocketTransport {
                             None => break,
                         }
                     },
-                    Some(msg) = WebSocketTransport::conditional_websocket(&mut self.web_socket), if !self.inbound_cache.is_full() => {
+                    // Read only while BOTH inbound queues have room. The packed
+                    // queue was previously outside this guard, which left
+                    // discarding a frame as the only way to honour its bound —
+                    // unrecoverable, since delete-on-send means the mediator no
+                    // longer holds it. One policy for both caches: stop reading,
+                    // never discard.
+                    Some(msg) = WebSocketTransport::conditional_websocket(&mut self.web_socket), if !self.inbound_cache.is_full() && !self.packed_cache_is_full() => {
                         self.handle_inbound_message(&atm, msg).await;
                     }
                 }
@@ -529,6 +553,42 @@ impl WebSocketTransport {
         }
     }
 
+    /// Queue a packed frame, updating the byte total and the full latch.
+    fn push_packed(&mut self, message: String) {
+        self.packed_cache_bytes += message.len() as u64;
+        self.packed_cache.push_back(message);
+        if self.packed_cache.len() as u32 > self.shared.config.fetch_cache_limit_count
+            || self.packed_cache_bytes > self.shared.config.fetch_cache_limit_bytes
+        {
+            self.packed_cache_full = true;
+        }
+        debug!(
+            "Cached packed message ({} queued, {} bytes)",
+            self.packed_cache.len(),
+            self.packed_cache_bytes
+        );
+    }
+
+    /// Take the oldest queued packed frame, clearing the full latch once the
+    /// queue is back under both limits.
+    fn pop_packed(&mut self) -> Option<String> {
+        let message = self.packed_cache.pop_front()?;
+        self.packed_cache_bytes = self.packed_cache_bytes.saturating_sub(message.len() as u64);
+        if self.packed_cache_full
+            && (self.packed_cache.len() as u32) <= self.shared.config.fetch_cache_limit_count
+            && self.packed_cache_bytes <= self.shared.config.fetch_cache_limit_bytes
+        {
+            self.packed_cache_full = false;
+        }
+        Some(message)
+    }
+
+    /// Whether the packed queue has hit its limits and the socket should stop
+    /// being read until the consumer catches up.
+    fn packed_cache_is_full(&self) -> bool {
+        self.packed_cache_full
+    }
+
     async fn process_inbound_didcomm_message(&mut self, atm: &ATM, message: String) {
         debug!("Received text message ({})", message);
 
@@ -597,21 +657,18 @@ impl WebSocketTransport {
                 }
             }
 
-            // 3. Cache it for the next `Next`. Bounded by the same count limit
-            //    as the DIDComm cache; at the limit the OLDEST frame is dropped
-            //    (a stalled consumer should not be able to block live traffic
-            //    indefinitely) and we say so — a silent drop here is the exact
-            //    failure this cache exists to prevent.
-            let limit = self.shared.config.fetch_cache_limit_count as usize;
-            if self.packed_cache.len() >= limit {
-                warn!(
-                    "Packed message cache is full ({limit} frames); dropping the oldest frame. \
-                     Nothing is consuming inbound frames fast enough."
-                );
-                self.packed_cache.pop_front();
-            }
-            self.packed_cache.push_back(message);
-            debug!("Cached packed message ({} queued)", self.packed_cache.len());
+            // 3. Cache it for the next `Next`.
+            //
+            //    Never dropped to make room. This cache exists precisely because
+            //    a dropped packed frame is unrecoverable — under delete-on-send
+            //    the mediator has already forgotten it — so discarding here to
+            //    honour a memory bound would reintroduce the bug in a quieter
+            //    form. Instead the queue is allowed to reach its limit and the
+            //    socket-read arm stops reading, which is the same backpressure
+            //    the DIDComm cache applies. A consumer that has stopped
+            //    consuming stalls its own connection rather than silently losing
+            //    messages.
+            self.push_packed(message);
             return;
         }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.41"
+version = "0.2.42"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
@@ -89,3 +89,98 @@ async fn tsp_frame_arriving_between_polls_is_not_dropped() {
 
     env.shutdown().await.expect("shutdown");
 }
+
+/// **A consumer that falls behind must not lose frames.**
+///
+/// The packed queue holds TSP frames that arrived with no `Next` outstanding.
+/// It used to sit outside the socket-read backpressure guard, so the only way
+/// to honour its bound was to discard the oldest frame — and a discarded packed
+/// frame is unrecoverable: under delete-on-send the mediator dropped its copy
+/// the moment it wrote it, so there is nothing left to redeliver.
+///
+/// Now both caches share one policy: when either is full the select loop stops
+/// reading the socket, and nothing is ever discarded. A consumer that stalls
+/// stalls its own connection instead of silently losing messages.
+///
+/// This sends comfortably more than `fetch_cache_limit_count` (100 by default)
+/// before polling at all, so the queue provably passes its limit while the
+/// consumer is idle, then drains and checks that every frame survived.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_slow_consumer_does_not_lose_packed_frames() {
+    const FRAMES: usize = 130;
+
+    let env = TestEnvironment::spawn()
+        .await
+        .expect("spawn test environment");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    env.atm
+        .profile_enable_websocket(&bob.profile)
+        .await
+        .expect("bob enables the pickup websocket");
+
+    // Fill well past the cache limit while Bob polls for nothing at all.
+    //
+    // Paced: the mediator rate-limits inbound at 100 req/s per IP with a burst
+    // of 50, so an unthrottled loop gets a 429 around frame 58. The pause is
+    // about the sender's rate limit, not the behaviour under test — Bob is
+    // still not polling throughout.
+    for i in 0..FRAMES {
+        let payload = format!("frame-{i:04}").into_bytes();
+        env.atm
+            .tsp()
+            .send(&alice.profile, &bob.did, &payload)
+            .await
+            .unwrap_or_else(|e| panic!("alice sends frame {i}: {e}"));
+        tokio::time::sleep(Duration::from_millis(15)).await;
+    }
+
+    // Let the backlog settle so the queue is genuinely over its limit and the
+    // read arm has had to back off.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Now drain. Every frame must still be there.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for _ in 0..(FRAMES * 3) {
+        match env
+            .atm
+            .message_pickup()
+            .live_stream_next_frame(&bob.profile, Some(Duration::from_secs(5)), true)
+            .await
+            .expect("live_stream_next_frame must not error")
+        {
+            Some(InboundFrame::Tsp(raw)) => {
+                let qb2 = env.atm.tsp().decode(&raw).expect("frame decodes");
+                let (payload, _) = env
+                    .atm
+                    .tsp()
+                    .unpack_bytes(&bob.profile, &qb2)
+                    .await
+                    .expect("unpack");
+                seen.insert(String::from_utf8(payload).expect("utf8 payload"));
+            }
+            Some(_other) => continue, // the status frame
+            None => break,            // nothing left within the budget
+        }
+        if seen.len() == FRAMES {
+            break;
+        }
+    }
+
+    let missing: Vec<String> = (0..FRAMES)
+        .map(|i| format!("frame-{i:04}"))
+        .filter(|f| !seen.contains(f))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{} of {FRAMES} frames were lost while the consumer was not polling \
+         (first few: {:?}). Discarding a packed frame is unrecoverable — the \
+         mediator no longer holds it.",
+        missing.len(),
+        &missing[..missing.len().min(5)]
+    );
+
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
Closes #647.

#646 added a queue for packed (TSP) frames arriving with no `Next` outstanding,
because the alternative was dropping them. That queue was left outside the
socket-read backpressure guard:

```rust
Some(msg) = conditional_websocket(...), if !self.inbound_cache.is_full() => ...
```

So the DIDComm cache stopped the loop reading when it filled, while the packed
queue had no such protection — leaving *discard the oldest frame* as the only
way to honour its bound.

That reintroduced the original bug in a quieter form. **A discarded packed frame
is unrecoverable**: under delete-on-send the mediator dropped its copy the
instant it wrote it, so there is nothing to redeliver. A consumer that stopped
polling long enough lost messages outright, with a `warn!` as the only trace.

## The policy, chosen deliberately

The issue asked for one policy rather than two by accident. Chosen:
**back-pressure, never discard**, for both caches.

When either queue is full the select loop stops reading the socket; frames stay
in the OS/tungstenite buffers and the sender eventually feels it. A consumer
that has stopped consuming now stalls its own connection — a visible failure —
instead of silently losing messages. It also matches what the DIDComm cache
already did, so there is one rule instead of two.

**No deadlock risk:** the command-channel arm of the same `select!` keeps running
while the read arm is disabled, so `Next` requests still drain the queue and
reading resumes.

The queue is now bounded by count **and** bytes (`fetch_cache_limit_count` /
`fetch_cache_limit_bytes`), mirroring `MessageCache` with the same latch
semantics — set on exceeding a limit, cleared once back under both.

## Test

`a_slow_consumer_does_not_lose_packed_frames` sends 130 frames (default cache
limit is 100) while the consumer polls for nothing at all, then drains and
requires every one. Under the old policy it fails with exactly the predicted
loss:

```
30 of 130 frames were lost while the consumer was not polling
(first few: ["frame-0000", "frame-0001", "frame-0002", ...])
```

130 − 100 = 30, and the casualties are the oldest. Sends are paced 15ms apart
because the mediator rate-limits inbound at 100 req/s per IP with a burst of 50
(an unthrottled loop 429s around frame 58) — that pacing is about the sender's
rate limit, not the behaviour under test.

## Note for reviewers

While mirroring `MessageCache` I noticed its byte accounting uses
`size_of_val(&message)`, which is the shallow size of the `Message` struct — a
constant, independent of payload — so its **byte** limit can never meaningfully
trigger and only the count limit is doing any work. I have not touched it here
(out of scope), but it's worth a look. The new packed accounting uses the
frame's actual length.

Full test-mediator and SDK suites pass; zero clippy warnings.

affinidi-messaging-sdk 0.18.64, affinidi-messaging-test-mediator 0.2.42, plus a
changelog entry — this changes inbound flow-control behaviour for every consumer
of the pickup socket (R3.6).
