### PR TITLE
chore: align the messaging changelogs and enforce them in CI

### DIFF
--- a/.github/workflows/release-guards.yaml
+++ b/.github/workflows/release-guards.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
 
+      - name: Changelog guard for bumped publishable crates
+        run: bash scripts/check-changelogs.sh "${{ github.event.pull_request.base.sha }}"
+
       - name: Workspace duplicate guard (patch.crates-io coverage)
         run: bash scripts/check-workspace-duplicates.sh
 

--- a/crates/messaging/CHANGELOG.md
+++ b/crates/messaging/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Changelog history
 
+> [!IMPORTANT]
+> **This file is no longer updated.** Release notes live in each crate's own
+> `CHANGELOG.md` — a directory-level file cannot say which crate a change
+> shipped in, and every crate here versions independently. Start with:
+>
+> - [`affinidi-messaging-mediator`](affinidi-messaging-mediator/CHANGELOG.md)
+> - [`affinidi-messaging-sdk`](affinidi-messaging-sdk/CHANGELOG.md)
+> - [`affinidi-messaging-didcomm`](affinidi-messaging-didcomm/CHANGELOG.md)
+> - [`affinidi-messaging-didcomm-service`](affinidi-messaging-didcomm-service/CHANGELOG.md)
+> - [`affinidi-messaging-delivery`](affinidi-messaging-delivery/CHANGELOG.md)
+> - [`affinidi-messaging-test-mediator`](affinidi-messaging-test-mediator/CHANGELOG.md)
+> - [`affinidi-tsp`](affinidi-tsp/CHANGELOG.md)
+>
+> The history below is kept for the record and stops at Mediator 0.15.5
+> (24th May 2026). Anything after that is in the per-crate files — this file
+> being both stale and plausible is how a recent change got written to it by
+> mistake.
+
+
 Why are there skipped version numbers? Sometimes when deploying via CI/CD Pipeline
 we find little issues that only affect deployment.
 
@@ -24,64 +43,6 @@ tooling.
   that stalls stalls its own connection instead. The queue is bounded by
   the same count *and* byte limits as the DIDComm cache
   (`fetch_cache_limit_count` / `fetch_cache_limit_bytes`).
-
-## 23rd July 2026
-
-### Mediator (0.17.9) / SDK (0.18.63) / Test Mediator (0.2.41)
-
-Raw-TSP WebSocket delivery: one outright delivery failure, one delivery
-guarantee that was documented but not implemented, and one silent
-stop-delivering bug. All three were invisible from both ends of the wire —
-the sender saw success and the recipient saw nothing.
-
-- **FIX: TSP frames arriving after the socket was open were never
-  delivered** (#646, mediator 0.17.7 / SDK 0.18.62). Two independent
-  faults. (1) A raw-TSP websocket was only ever `Registered`, never
-  `Live`: only `Start` promotes a client, and `Start` came solely from
-  the DIDComm `messagepickup/3.0/live-delivery-change` message, which a
-  binary-only raw-TSP socket cannot send. With the client not live,
-  `store_message` skipped the streaming publish, so the socket's re-drain
-  never fired and **flush-on-connect was the only delivery it ever got** —
-  everything arriving afterwards was stored and left in the inbox. (2) The
-  SDK dropped packed frames (all TSP frames) that arrived with no `Next`
-  request outstanding and no direct channel attached: the DIDComm branch
-  caches an unmatched message, the packed branch had nowhere to put one, so
-  a polling consumer lost any frame landing between polls. Also: a
-  `Deregister` from a replaced session evicted its successor's channel
-  (closing a healthy socket with "streaming task unavailable"), and
-  `TspWebSocket::recv` collapsed close frames to `Ok(None)`, discarding the
-  reason the mediator gave for closing.
-
-  *Reproduced at 0 of 10 frames delivered between two local accounts; 10 of
-  10 after the fix.*
-
-- **FEAT: opt-in delete-to-ack for raw-TSP (`tsp-ack`)** (#651, mediator
-  0.17.8 / SDK 0.18.63). Raw-TSP deleted a message the moment it was
-  written to the socket and documented that as at-least-once. It wasn't: a
-  successful send means the frame reached the mediator's local sink, not
-  the peer, so a connection dropping in between lost the message with
-  nothing left to redeliver. A client offering the `tsp-ack` subprotocol
-  now gets send-and-keep, acknowledging via the ordinary authenticated
-  delete once it holds the frame; anything un-acked when the connection
-  dies is redelivered on reconnect. No new wire protocol — the delete key
-  is `sha256` of the stored body, which is the base64url of exactly the
-  bytes on the wire, so the client derives the id itself.
-
-  **Opt-in on purpose.** Plain `tsp` keeps delete-on-send byte for byte, so
-  no deployed client changes behaviour. Clients that opt in **must be
-  idempotent**: at-least-once means a frame may arrive twice. Note the
-  subprotocol ordering is load-bearing — clients list `tsp` before
-  `tsp-ack`, because an older mediator reflects the client's list and would
-  otherwise echo `tsp-ack` without implementing it.
-
-- **FIX: streaming `Start`/`Stop` acted on the wrong connection** (#653,
-  mediator 0.17.9). `clients` is keyed by DID hash, not by connection, so a
-  `live-delivery-change` from a session that had already been replaced
-  flipped delivery for its *successor*. A stale `Stop` cleared both
-  `active` and the stored `Live` state, leaving a healthy socket connected
-  and silently no longer receiving pushes. Both variants now carry their
-  `session_id` and are applied only when that session still owns the slot —
-  completing the same fix made for `Deregister` in #646.
 
 ## 24th May 2026
 

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Changelog history
 
+## 23rd July 2026
+
+### 0.17.9 — streaming Start/Stop act only for the session that owns the DID's slot
+
+`clients` is keyed by DID hash, not by connection, so a `live-delivery-change`
+from a session that had already been replaced flipped delivery for its
+*successor*. A stale `Stop` cleared both `active` and the stored `Live` state,
+leaving a healthy socket connected and silently no longer receiving pushes —
+the same shape as the `Deregister` bug fixed in 0.17.7, and just as invisible
+from either end.
+
+Both variants now carry their `session_id` and are applied only while that
+session still holds the slot. An activation for a DID with no registered client
+is dropped rather than written through to the store: marking a DID `Live` with
+no channel to deliver on only produces "not in clients HashMap" warnings later.
+(#653)
+
+### 0.17.8 — opt-in delete-to-ack for raw-TSP delivery (`tsp-ack`)
+
+Raw-TSP deleted a message the moment it was written to the socket and documented
+that as at-least-once. It was not: a successful send means the frame reached the
+mediator's local sink, not the peer, so a connection dropping in between lost the
+message with nothing left to redeliver.
+
+A client offering the `tsp-ack` subprotocol now gets send-and-keep; it
+acknowledges by deleting through the ordinary authenticated path once it holds
+the frame. Nothing is deleted on send in that mode, and anything un-acked when
+the connection dies is redelivered on reconnect.
+
+**Opt-in.** Plain `tsp` keeps delete-on-send byte for byte, so no deployed client
+changes behaviour. Clients that opt in must be **idempotent** — at-least-once
+means a frame can arrive twice. Note the subprotocol negotiation is ordering-
+sensitive by design: a mediator that predates this echoes the client's list
+unchanged, so clients list `tsp` first and this mediator narrows its offer to
+`tsp-ack`, making the echo a trustworthy capability signal. (#651)
+
+### 0.17.7 — TSP frames arriving after the socket is open are actually delivered
+
+A raw-TSP websocket was only ever `Registered`, never `Live`: only `Start`
+promotes a client, and `Start` came solely from the DIDComm
+`messagepickup/3.0/live-delivery-change` message, which a binary-only raw-TSP
+socket cannot send. With the client not live, `store_message` skipped the
+streaming publish, so the socket's re-drain never fired and **flush-on-connect
+was the only delivery it ever got** — everything arriving afterwards was stored
+and left in the inbox. Reproduced at 0 of 10 frames delivered between two local
+accounts; 10 of 10 after the fix.
+
+Also fixed: a `Deregister` from a session that had already been replaced removed
+its successor's channel from the client map, closing a healthy socket with
+"streaming task unavailable". Deregistration now names its session. (#646)
+
 ## 22nd July 2026
 
 ### 0.17.6 — stop the mediator dialling itself, and damp duplicate-socket duels

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [0.18.64] - 2026-07-23
+
+### Fixed
+
+- **A slow consumer silently lost packed (TSP) frames.** The packed-frame queue
+  added in 0.18.62 sat outside the socket-read backpressure guard, so the only
+  way to honour its bound was to discard the oldest frame — and a discarded
+  packed frame is unrecoverable, because under delete-on-send the mediator drops
+  its copy the moment it writes it. A consumer that stopped polling long enough
+  lost messages outright, with a `warn!` as the only trace. Measured: 130 frames
+  sent while the consumer idled lost exactly 30 (the amount over the 100-frame
+  default limit), oldest first.
+
+  Both inbound caches now share one policy — **back-pressure, never discard**.
+  When either queue is full the select loop stops reading the socket; a consumer
+  that has stopped consuming stalls its own connection, a visible failure,
+  rather than silently losing messages. The packed queue is bounded by the same
+  count *and* byte limits as the DIDComm cache. (#655)
+
+## [0.18.63] - 2026-07-23
+
+### Added
+
+- **`connect_websocket_acked` — opt-in delete-to-ack for raw-TSP** (`tsp-ack`
+  subprotocol). The mediator sends and keeps; `TspWebSocket::ack` releases its
+  copy once you actually hold the frame. Anything un-acked when the connection
+  dies is redelivered on reconnect, so consumers **must be idempotent**. The
+  message id is derived, not transmitted — `sha256` of the stored body, which is
+  the base64url of exactly the bytes on the wire — so no protocol change was
+  needed. `is_acked()` reports what was really negotiated: a mediator predating
+  the mode echoes the client's subprotocol list unchanged, so a downgrade is
+  detected and warned about rather than silently leaving you at-most-once.
+  Plain `connect_websocket` is unchanged. (#651)
+
+### Changed
+
+- **`TspWebSocket::recv` surfaces the close reason.** A close frame is now an
+  `Err` carrying the mediator's RFC 6455 code and reason ("replaced by a newer
+  connection", "authentication token expired", "streaming task unavailable"),
+  instead of collapsing every one of them — and a socket that merely went quiet
+  — into a bare `Ok(None)`. A stream that ends with no close frame still returns
+  `Ok(None)`. (#651)
+
+## [0.18.62] - 2026-07-23
+
+### Fixed
+
+- **Packed (TSP) frames arriving between polls were dropped.** A TSP frame is
+  handed back packed and was delivered only if a `Next` request happened to be
+  outstanding at that instant or a direct channel was attached; otherwise it fell
+  off the end of the function. The DIDComm branch caches an unmatched message,
+  but the packed branch had nowhere to put one — `inbound_cache` is keyed by
+  unpacked DIDComm message id. A polling consumer always leaves a gap between one
+  poll returning and the next being registered, so this was a race it could only
+  lose. Packed frames now go to a queue that the next `Next` drains, and every
+  arm hands the frame onward rather than dropping it. (#646)
+
 ## [0.18.61] - 2026-07-22
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Changelog history
 
+## 23rd July 2026
+
+### 0.2.42 — a slow consumer must not lose packed frames
+
+- `tsp_pickup_socket.rs`: `a_slow_consumer_does_not_lose_packed_frames` sends 130
+  frames (the SDK's default cache limit is 100) while the consumer polls for
+  nothing at all, then drains and requires every one. Under the previous
+  drop-oldest policy it fails with exactly the predicted loss — 30 frames, oldest
+  first. Sends are paced 15ms apart because the mediator rate-limits inbound at
+  100 req/s per IP with a burst of 50. (#655)
+
+### 0.2.41 — delete-to-ack coverage
+
+- `tsp_websocket.rs`: `tsp_ack_mode_keeps_the_message_until_the_client_acks` (the
+  message is still in the inbox after delivery, gone after the ack),
+  `an_unacked_tsp_message_is_redelivered_on_reconnect` (the loss window closed —
+  under delete-on-send that frame is gone for good),
+  `an_unacked_message_is_not_resent_within_the_same_connection` (redelivery stays
+  a reconnect-time recovery, not the steady state), and
+  `tsp_ack_is_selected_even_though_the_client_lists_it_second` (pins the
+  subprotocol negotiation, without which mediator support is indistinguishable
+  from the echo an older mediator gives anyway). (#651)
+
+### 0.2.40 — live raw-TSP delivery coverage
+
+- `tsp_websocket.rs`: `tsp_websocket_delivers_messages_that_arrive_after_connect`.
+  Every existing raw-TSP test queued its message *before* connecting, so all of
+  them passed on flush-on-connect alone — which is how a total delivery failure
+  shipped unnoticed. This one connects first, against an empty inbox, then sends.
+- New `tsp_pickup_socket.rs`: `tsp_frame_arriving_between_polls_is_not_dropped`
+  sleeps before polling so the frame provably lands with no `Next` outstanding.
+  (#646)
+
 ## 2nd July 2026
 
 ### 0.2.36 — TSP capability-learning e2e

--- a/crates/tdk/CHANGELOG.md
+++ b/crates/tdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi TDK Changelog
 
+> [!IMPORTANT]
+> **This file is no longer updated** (last entry: 24th March 2026). Release
+> notes live in each crate's own `CHANGELOG.md`:
+>
+> - [`affinidi-tdk`](affinidi-tdk/CHANGELOG.md)
+> - [`affinidi-tdk-common`](affinidi-tdk-common/CHANGELOG.md)
+> - [`affinidi-tdk-test-support`](affinidi-tdk-test-support/CHANGELOG.md)
+>
+> The history below is kept for the record.
+
 ## 10th March 2026
 
 - **CHORE:** Updated `affinidi-messaging-didcomm` re-export to 0.13.0

--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Guard: a published version with no changelog entry.
+#
+# Sibling to check-version-bumps.sh, which enforces the other half of the same
+# convention. That script already tells you to "bump the crate's Cargo.toml
+# version (and CHANGELOG)" — but only the version half was ever enforced, so the
+# changelog half depended on the author remembering. It stopped being
+# remembered: between them, affinidi-messaging-mediator 0.17.7/0.17.8/0.17.9,
+# affinidi-messaging-sdk 0.18.62/0.18.63/0.18.64 and
+# affinidi-messaging-test-mediator 0.2.40/0.2.41/0.2.42 all shipped to crates.io
+# with nothing written down.
+#
+# That matters beyond tidiness. CLAUDE.md (R3.6) makes the changelog part of the
+# downstream contract: services pin these crates loosely, so a behavioural change
+# to send/ack/reconnect semantics is breaking for a consumer even when no
+# signature changes, and the changelog is where they are supposed to find out.
+# An undocumented release is a silent breaking change waiting to happen.
+#
+# The rule: if a publishable crate's VERSION changed in this PR, that crate's
+# CHANGELOG.md must have changed too.
+#
+# Not circular with check-version-bumps.sh — that script explicitly excludes
+# CHANGELOG* from "source changes", so a changelog-only PR needs no bump, and a
+# bump needs a changelog. The two guards meet in the middle.
+#
+# Usage: scripts/check-changelogs.sh [base-ref]
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; CYAN=''; NC=''
+fi
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "${RED}error:${NC} base ref '$BASE' not found. Pass a reachable ref, e.g. origin/main." >&2
+  exit 2
+fi
+
+echo "=== Changelog guard (base: $BASE) ==="
+echo
+
+changed=$(git diff --name-only "$BASE"...HEAD)
+if [ -z "$changed" ]; then
+  echo "${GREEN}No changes vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+# Publishable crates as  name<TAB>relative-crate-dir. Non-publishable crates are
+# irrelevant here: nothing reaches a consumer, so there is no contract to record.
+crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | select(.publish == null or .publish == ["crates.io"])
+      | "\(.name)\t\(.manifest_path)"' \
+  | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||")
+
+fail=0
+found=0
+
+while IFS="$(printf '\t')" read -r name dir; do
+  [ -n "$name" ] || continue
+  manifest="$dir/Cargo.toml"
+
+  # Did this PR change the crate's version?
+  old_version=$(git show "$BASE:$manifest" 2>/dev/null \
+    | awk '/^\[/{ in_pkg = ($0 == "[package]") } in_pkg && /^version = / { gsub(/^version = "|"$/, ""); print; exit }')
+  new_version=$(awk '/^\[/{ in_pkg = ($0 == "[package]") } in_pkg && /^version = / { gsub(/^version = "|"$/, ""); print; exit }' "$manifest" 2>/dev/null)
+
+  # A crate that is new in this PR has no old version; it still needs an entry.
+  [ -n "$new_version" ] || continue
+  [ "$old_version" != "$new_version" ] || continue
+
+  found=1
+  if echo "$changed" | grep -qx "$dir/CHANGELOG.md"; then
+    echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (changelog updated)"
+  else
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version but $dir/CHANGELOG.md is untouched"
+    fail=1
+  fi
+done <<EOF
+$crates
+EOF
+
+echo
+if [ "$found" -eq 0 ]; then
+  echo "${GREEN}No publishable crate versions changed — nothing to check.${NC}"
+  exit 0
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "${RED}A crate is being published with no record of what changed.${NC}"
+  echo "Consumers pin these crates loosely, so a behavioural change is breaking for"
+  echo "them even when no signature changes — the changelog is where they find out."
+  echo "Add an entry for the new version to the crate's ${CYAN}CHANGELOG.md${NC}."
+  exit 1
+fi
+
+echo "${GREEN}Every version bump in this PR has a changelog entry.${NC}"

--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -17,7 +17,12 @@
 # An undocumented release is a silent breaking change waiting to happen.
 #
 # The rule: if a publishable crate's VERSION changed in this PR, that crate's
-# CHANGELOG.md must have changed too.
+# CHANGELOG.md must MENTION THE NEW VERSION.
+#
+# Deliberately not the weaker "the changelog file was touched". A PR that edits
+# a changelog for one reason and bumps a version for another would satisfy that
+# and still ship an undocumented release — which is exactly how the first draft
+# of this guard passed a version bump it should have caught.
 #
 # Not circular with check-version-bumps.sh — that script explicitly excludes
 # CHANGELOG* from "source changes", so a changelog-only PR needs no bump, and a
@@ -77,10 +82,16 @@ while IFS="$(printf '\t')" read -r name dir; do
   [ "$old_version" != "$new_version" ] || continue
 
   found=1
-  if echo "$changed" | grep -qx "$dir/CHANGELOG.md"; then
-    echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (changelog updated)"
+  changelog="$dir/CHANGELOG.md"
+  if [ ! -f "$changelog" ]; then
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version but $changelog does not exist"
+    fail=1
+  # Match the version as a whole token: a plain substring search would let
+  # `0.1.30`'s entry satisfy a bump to `0.1.3`.
+  elif grep -qE "(^|[^0-9.])$(printf '%s' "$new_version" | sed 's/\./\\./g')([^0-9.]|\$)" "$changelog"; then
+    echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (documented)"
   else
-    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version but $dir/CHANGELOG.md is untouched"
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but $new_version does not appear in $changelog"
     fail=1
   fi
 done <<EOF
@@ -97,7 +108,7 @@ if [ "$fail" -ne 0 ]; then
   echo "${RED}A crate is being published with no record of what changed.${NC}"
   echo "Consumers pin these crates loosely, so a behavioural change is breaking for"
   echo "them even when no signature changes — the changelog is where they find out."
-  echo "Add an entry for the new version to the crate's ${CYAN}CHANGELOG.md${NC}."
+  echo "Add an entry naming the new version to the crate's ${CYAN}CHANGELOG.md${NC}."
   exit 1
 fi
 


### PR DESCRIPTION
Nine published versions have no changelog entry, and I added a tenth entry to
the wrong file. Same root cause: the convention is documented and unenforced.

## What was missing

| crate | latest entry | actually shipped |
|---|---|---|
| `affinidi-messaging-mediator` | 0.17.6 | **0.17.7, 0.17.8, 0.17.9** |
| `affinidi-messaging-sdk` | 0.18.61 | **0.18.62, 0.18.63, 0.18.64** |
| `affinidi-messaging-test-mediator` | 0.2.36 | **0.2.40, 0.2.41, 0.2.42** |

That includes `tsp-ack`, which changes a delivery *guarantee* for anyone who
opts in, and the raw-TSP live-delivery fix, which changes whether messages
arrive at all.

CLAUDE.md (R3.6) makes this part of the downstream contract — services pin these
crates loosely, so a behavioural change to send/ack/reconnect semantics is
breaking for a consumer even when no signature changes, and the changelog is
where they find out.

## Why it kept happening

`check-version-bumps.sh` enforces the version half of the convention. Its own
error message says *"bump the crate's Cargo.toml version (and CHANGELOG)"* — but
nothing ever checked the changelog half. The mechanical part was guaranteed; the
part needing a human was not.

`scripts/check-changelogs.sh` closes it, mirroring the version guard's shape and
wired into the same `release guards` job:

> if a publishable crate's version changed in this PR, its `CHANGELOG.md` must
> **mention the new version**

Requiring the version *string*, not merely that the file changed, is deliberate —
and came from the guard failing its own test. The first draft checked only "was
the changelog touched", and passed a bump it should have caught, because this
very PR edits those changelogs for another reason. A PR could otherwise bump
0.18.65 while its changelog edit is about 0.18.64.

Verified in all three directions:

```
1. changelog-only PR      → No publishable crate versions changed — nothing to check.
2. bump, undocumented     → MISSING affinidi-messaging-sdk: 0.18.64 -> 0.18.65,
                            but 0.18.65 does not appear in …/CHANGELOG.md   (exit 1)
3. bump, documented       → ok   affinidi-messaging-sdk: 0.18.64 -> 0.18.65 (documented)
```

The match is token-boundaried, so a `0.1.30` entry cannot satisfy a bump to
`0.1.3`. No circularity with the version guard: that script excludes `CHANGELOG*`
from "source changes", so a changelog-only PR needs no bump and a bump needs a
changelog — the two guards meet in the middle.

## Retiring the directory-level files

`crates/messaging/CHANGELOG.md` and `crates/tdk/CHANGELOG.md` are marked as no
longer updated, pointing at the per-crate files.

These are what caused the misfiled entry. Both look plausible and are stale
(messaging stops at Mediator 0.15.5 in May; tdk at March), and a directory-level
file can't say which crate a change shipped in when every crate versions
independently. History is kept for the record, and the entry I wrote to the
messaging one is removed — it now lives in the three per-crate files where it
belongs.

This also resolves #650, which asked whether to reconstruct that file's
0.15.5 → 0.17.7 gap or retire it. Retire: the gap exists because the project
moved to per-crate changelogs, not because releases went unrecorded there by
accident.

## Not covered

`affinidi-messaging-test-mediator` 0.2.37–0.2.39 remain undocumented — they
predate this work and I would be inventing their contents.
