### PR TITLE
fix: accept vta-sdk 0.20

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Changelog history
 
+## 26th July 2026
+
+### 0.17.10 — accept `vta-sdk` 0.20
+
+`vta-sdk` 0.20 is a breaking release (`VtaEndpoint` gained a `Tsp` variant and
+became `#[non_exhaustive]`; `ResolvedVta` gained two fields) shipped for TSP
+client enablement — OpenVTC/verifiable-trust-infrastructure#765/#766/#767.
+
+Our `vta-sdk = "0.19.0"` requirement excluded it. Under 0.x semver `^0.19` does
+not match 0.20, so a workspace that depends on both this crate and `vta-sdk`
+0.20 could not resolve a single copy: it kept a second, stale 0.19 node purely
+to satisfy us. That is not cosmetic — `cargo publish --locked` verifies
+dependent crates against the pinned registry copy, so a dependent would be
+built against 0.19 source while the workspace built against 0.20.
+
+No source change was needed here: the mediator does not touch either broken
+type. This is the requirement bump only.
+
 ## 23rd July 2026
 
 ### 0.17.9 — streaming Start/Stop act only for the session that owns the DID's slot

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.9"
+version = "0.17.10"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -107,7 +107,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.19.0", features = ["integration"] }
+vta-sdk = { version = "0.20.0", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog history
 
+## 26th July 2026
+
+### 0.1.23 — accept `vta-sdk` 0.20
+
+Requirement bump to match `affinidi-messaging-mediator` 0.17.10; see its
+changelog for why `^0.19` had to move.
+
+`vta-sdk` 0.20 added TSP discovery, so `ResolvedVta` grew a
+`tsp_mediator_did` field. Two test fixtures that build the struct by literal
+now set it to `None` — these cover the DIDComm/REST fallback ladder, so the
+VTA under test advertises no `#tsp` service. No behaviour change.
+
 ## 16th July 2026
 
 ### 0.1.22 — publish the did:webvh log, and a read-only probe for AWS-managed backends

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.22"
+version = "0.1.23"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.19.14", features = ["provision-client"] }
+vta-sdk = { version = "0.20.0", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -162,7 +162,7 @@ aws-sdk-s3 = { version = "1", optional = true }
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.19.14", features = ["test-support"] }
+vta-sdk = { version = "0.20.0", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/cli.rs
@@ -428,6 +428,10 @@ mod tests {
     fn resolved(mediator_did: Option<&str>, rest_url: Option<&str>) -> ResolvedVta {
         ResolvedVta {
             vta_did: "did:webvh:vta.test".into(),
+            // vta-sdk 0.20 added TSP discovery. These fixtures cover the
+            // DIDComm/REST fallback ladder, so the VTA under test advertises
+            // no `#tsp` service.
+            tsp_mediator_did: None,
             mediator_did: mediator_did.map(str::to_string),
             rest_url: rest_url.map(str::to_string),
         }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
@@ -523,6 +523,10 @@ mod tests {
     fn resolved(mediator_did: Option<&str>, rest_url: Option<&str>) -> ResolvedVta {
         ResolvedVta {
             vta_did: "did:webvh:vta.test".into(),
+            // vta-sdk 0.20 added TSP discovery. These fixtures cover the
+            // DIDComm/REST fallback ladder, so the VTA under test advertises
+            // no `#tsp` service.
+            tsp_mediator_did: None,
             mediator_did: mediator_did.map(str::to_string),
             rest_url: rest_url.map(str::to_string),
         }


### PR DESCRIPTION
## Why

`vta-sdk` 0.20.0 is a breaking release shipped for TSP client enablement (OpenVTC/verifiable-trust-infrastructure#765/#766/#767): `VtaEndpoint` gained a `Tsp` variant and became `#[non_exhaustive]`, and `ResolvedVta` gained two fields.

Our `vta-sdk = "0.19.0"` requirement excludes it. Under 0.x semver `^0.19` does not match `0.20`, so a workspace depending on **both** this crate and `vta-sdk` 0.20 cannot resolve to a single copy — it keeps a second, stale `vta-sdk 0.19.28` node in `Cargo.lock` purely to satisfy us, even when that workspace `[patch.crates-io]`-es `vta-sdk` to a local path.

That is a real hazard rather than untidiness. `cargo publish --locked` verifies dependent crates against the pinned registry copy, so a dependent gets **built against 0.19 source while the workspace builds against 0.20** — and it only surfaces at publish time. The VTI workspace has a CI guard for exactly this (`check-lockfile-self-pins.sh`, added after `pnm-cli` 0.11.2 shipped verified against stale `vta-sdk`), and it is currently red on their `main` with no fix available on their side: `cargo update --precise 0.20.0` fails because no published mediator version accepts 0.20.

## What changed

- `affinidi-messaging-mediator` **0.17.9 → 0.17.10** — requirement bump only. It touches neither broken type, so no source change was needed.
- `affinidi-messaging-mediator-setup` **0.1.22 → 0.1.23** — uses the `provision-client` feature, so two test fixtures that build `ResolvedVta` by struct literal now set `tsp_mediator_did: None`. Those fixtures cover the DIDComm/REST fallback ladder, so the VTA under test advertising no `#tsp` service is the correct value, not a placeholder.

No behaviour change in either crate.

## Verification

`cargo check --all-targets` clean for both. `cargo clippy --all-targets` clean for both. `cargo fmt --check` clean. Tests: 402 passed (mediator-setup), 162 passed (mediator). Both repo guards pass — `check-version-bumps.sh` and `check-changelogs.sh`.

Once `affinidi-messaging-mediator` 0.17.10 is on crates.io, the VTI side refreshes its lockfile pin and its self-pin guard goes green again.
