### PR TITLE
feat: make MessagingService usable multi-identity

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [0.1.12] - 2026-07-26
+
+- **`MessagingService` is now usable multi-identity**, where each transport *is* a
+  sender identity (one per persona / agent DID) rather than an alternative wire to
+  the same peer. The multi-transport core from 0.1.10 already supported holding N
+  of them; what was missing was outbound selection, drain routing, and a truthful
+  per-transport status. Additive; 11 new tests (58 total).
+  - **`send_via(transport_id, to, packed, delivery)`** — the outbound counterpart
+    of 0.1.11's `request_via`. `send` routes to the primary, which is correct when
+    transports are interchangeable wires and wrong when the transport determines
+    the proven sender. `BestEffort` sends over the named transport; `Guaranteed`
+    pins the outbox entry to it.
+  - **`OutboxEntry::via: Option<String>`** (+ `with_via`) — the transport an entry
+    **must** drain over. `None` keeps today's behaviour and is what makes mediator
+    migration work: an unbound entry follows `promote` to the new primary rather
+    than being pinned to the mediator current when it was enqueued. `Some(id)` is
+    for the identity case, where draining entry A over identity B's socket would
+    send it from the wrong sender — which the recipient authenticates and the
+    mediator ACL judges.
+  - **`drain_once_via` / `drain_loop_via`** — the per-identity drain. Over one
+    shared store, every entry is claimed by **exactly one** drain: an unbound entry
+    by `drain_once`, a pinned entry by the `_via` drain naming it. Nothing
+    double-sends and nothing is orphaned.
+  - **`transport_states()` / `transport_state(id)`** — per-transport live
+    `ConnState`. `status()`'s aggregate assumes transports are alternative wires to
+    one peer, so its `Degraded` means "a standby is down"; under multi-identity the
+    same value would mean "one identity is offline", which is a different operator
+    action. Rather than redefine `status()`, the per-identity view is its own
+    accessor, and `status()` now documents the assumption it makes.
+- **Behavioural change to `drain_once`, called out per R3.6:** it now **skips**
+  entries with `via` set, leaving them to `drain_once_via`. No consumer is affected
+  today — `via` is new and defaults to `None`, so every existing entry is still
+  claimed by `drain_once` exactly as before — but a consumer that starts setting
+  `via` must run a `_via` drain for those entries or they will sit queued until
+  their delivery window settles them.
+- `OutboxEntry` gains a field. `#[serde(default)]` keeps entries persisted by
+  earlier versions loading (as unbound), and every known consumer constructs via
+  `OutboxEntry::new`, so no `OutboxStore` implementation needs changing.
+
 ## [0.1.11] - 2026-07-18
 
 - Add **`MessagingService::request_via(transport_id, …)`** — a correlated

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/drain.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/drain.rs
@@ -40,7 +40,8 @@ pub struct DrainReport {
     pub failed: usize,
 }
 
-/// One drain pass at logical time `now_ms`: attempt every due entry once.
+/// One drain pass at logical time `now_ms`: attempt every due **unbound** entry
+/// once.
 ///
 /// - **window expired** (`now_ms >= deliver_by_ms`) while still `Queued`: the
 ///   entry never hop-accepted in time and delivery was expected → `Failed`
@@ -50,15 +51,59 @@ pub struct DrainReport {
 ///   (`Sent → Delivered`) is a separate step.
 /// - **`Err`** (transport down / send failed): stay `Queued`, bump `attempts`,
 ///   schedule `next_attempt_at_ms` with [`backoff_ms`].
+///
+/// Entries with [`OutboxEntry::via`](crate::OutboxEntry::via) set are **skipped**:
+/// they are pinned to a named transport and belong to
+/// [`drain_once_via`]. `via` is `None` unless a caller sets it, so a
+/// single-identity service sees no change.
 pub async fn drain_once(
     store: &dyn OutboxStore,
     transport: &dyn MessageTransport,
     now_ms: u64,
 ) -> Result<DrainReport, OutboxError> {
+    drain_filtered(store, transport, now_ms, |entry_via| entry_via.is_none()).await
+}
+
+/// [`drain_once`] for the entries pinned to **one** transport: only entries whose
+/// [`via`](crate::OutboxEntry::via) equals `transport_id` are attempted.
+///
+/// This is the multi-identity drain. A service holding one transport per identity
+/// runs one of these per transport over a shared store, and every entry is
+/// claimed by exactly one of them — an unbound entry by [`drain_once`], a pinned
+/// entry by the `drain_once_via` whose id it names. Nothing is drained twice, and
+/// nothing goes out over the wrong identity.
+///
+/// A pinned entry whose transport is not currently installed is simply not due
+/// for this drain; it waits rather than being re-routed, because re-routing it
+/// would send it from the wrong identity — the exact thing the pin prevents. Its
+/// `deliver_by_ms` still settles it visibly if the transport never returns.
+pub async fn drain_once_via(
+    store: &dyn OutboxStore,
+    transport_id: &str,
+    transport: &dyn MessageTransport,
+    now_ms: u64,
+) -> Result<DrainReport, OutboxError> {
+    drain_filtered(store, transport, now_ms, |entry_via| {
+        entry_via == Some(transport_id)
+    })
+    .await
+}
+
+/// Shared body of [`drain_once`] and [`drain_once_via`]; `claims` decides which
+/// entries this drain owns, from an entry's `via`.
+async fn drain_filtered(
+    store: &dyn OutboxStore,
+    transport: &dyn MessageTransport,
+    now_ms: u64,
+    claims: impl Fn(Option<&str>) -> bool,
+) -> Result<DrainReport, OutboxError> {
     let due = store.due(now_ms).await?;
     let mut report = DrainReport::default();
 
     for mut entry in due {
+        if !claims(entry.via.as_deref()) {
+            continue;
+        }
         if now_ms >= entry.deliver_by_ms {
             entry.state = OutboxState::Failed;
             store.put(entry).await?;
@@ -109,6 +154,49 @@ pub async fn drain_loop(
             }
             Ok(_) => {}
             Err(e) => tracing::warn!(error = %e, "outbox drain pass failed; retrying next tick"),
+        }
+    }
+}
+
+/// [`drain_loop`] for one named transport — the multi-identity drain loop, running
+/// [`drain_once_via`] on each tick.
+///
+/// One of these per identity, over a shared store. The transport is passed as a
+/// concrete handle rather than resolved from the id on each tick: an identity's
+/// socket is not interchangeable, so following a `promote` (as
+/// `MessagingService::primary_handle` deliberately does) would be wrong here.
+pub async fn drain_loop_via(
+    store: Arc<dyn OutboxStore>,
+    transport_id: String,
+    transport: Arc<dyn MessageTransport>,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    loop {
+        ticker.tick().await;
+        match drain_once_via(
+            store.as_ref(),
+            &transport_id,
+            transport.as_ref(),
+            now_unix_ms(),
+        )
+        .await
+        {
+            Ok(report) if report != DrainReport::default() => {
+                tracing::debug!(
+                    transport = %transport_id,
+                    sent = report.sent,
+                    retried = report.retried,
+                    failed = report.failed,
+                    "outbox drain pass",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                transport = %transport_id,
+                error = %e,
+                "outbox drain pass failed; retrying next tick"
+            ),
         }
     }
 }
@@ -253,5 +341,123 @@ mod tests {
             transport.sent.lock().unwrap().is_empty(),
             "expired entry is not sent"
         );
+    }
+
+    /// The safety property the pin exists for: an entry bound to an identity must
+    /// not go out over the primary, which is a different sender.
+    #[tokio::test]
+    async fn drain_once_skips_a_pinned_entry() {
+        let store = InMemoryOutboxStore::new();
+        store
+            .put(queued("k1", 1_000).with_via("persona-a"))
+            .await
+            .unwrap();
+        let transport = MockTransport::new(false);
+
+        let report = drain_once(&store, &transport, 1_000).await.unwrap();
+        assert_eq!(report, DrainReport::default(), "nothing was claimed");
+        assert!(transport.sent.lock().unwrap().is_empty());
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Queued,
+            "still waiting for its own transport"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_once_via_claims_only_its_own_id() {
+        let store = InMemoryOutboxStore::new();
+        store
+            .put(queued("mine", 1_000).with_via("persona-a"))
+            .await
+            .unwrap();
+        store
+            .put(queued("theirs", 1_000).with_via("persona-b"))
+            .await
+            .unwrap();
+        let transport = MockTransport::new(false);
+
+        let report = drain_once_via(&store, "persona-a", &transport, 1_000)
+            .await
+            .unwrap();
+        assert_eq!(report.sent, 1);
+        assert_eq!(
+            store.get("mine").await.unwrap().unwrap().state,
+            OutboxState::Sent
+        );
+        assert_eq!(
+            store.get("theirs").await.unwrap().unwrap().state,
+            OutboxState::Queued,
+            "another identity's entry is untouched"
+        );
+    }
+
+    /// The whole point of the split: over one shared store, every entry is claimed
+    /// by exactly one drain. Nothing double-sends, nothing is orphaned.
+    #[tokio::test]
+    async fn every_entry_is_claimed_exactly_once_across_drains() {
+        let store = InMemoryOutboxStore::new();
+        store.put(queued("unbound", 1_000)).await.unwrap();
+        store
+            .put(queued("a", 1_000).with_via("persona-a"))
+            .await
+            .unwrap();
+        store
+            .put(queued("b", 1_000).with_via("persona-b"))
+            .await
+            .unwrap();
+
+        let primary = MockTransport::new(false);
+        let a = MockTransport::new(false);
+        let b = MockTransport::new(false);
+
+        let unbound_report = drain_once(&store, &primary, 1_000).await.unwrap();
+        let a_report = drain_once_via(&store, "persona-a", &a, 1_000)
+            .await
+            .unwrap();
+        let b_report = drain_once_via(&store, "persona-b", &b, 1_000)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            (unbound_report.sent, a_report.sent, b_report.sent),
+            (1, 1, 1)
+        );
+        for transport in [&primary, &a, &b] {
+            assert_eq!(
+                transport.sent.lock().unwrap().len(),
+                1,
+                "each transport sent exactly its own entry"
+            );
+        }
+        for key in ["unbound", "a", "b"] {
+            assert_eq!(
+                store.get(key).await.unwrap().unwrap().state,
+                OutboxState::Sent,
+                "{key} was drained"
+            );
+        }
+    }
+
+    /// A pinned entry still settles visibly when its transport never returns —
+    /// the window is what stops it waiting forever.
+    #[tokio::test]
+    async fn a_pinned_entry_still_expires_on_its_own_drain() {
+        let store = InMemoryOutboxStore::new();
+        store
+            .put(queued("k1", 1_000).with_via("persona-a"))
+            .await
+            .unwrap();
+        let transport = MockTransport::new(false);
+
+        let report = drain_once_via(&store, "persona-a", &transport, 1_000 + 60_000)
+            .await
+            .unwrap();
+        assert_eq!(report.failed, 1);
+        assert_eq!(
+            store.get("k1").await.unwrap().unwrap().state,
+            OutboxState::Failed
+        );
+        assert!(transport.sent.lock().unwrap().is_empty());
     }
 }

--- a/crates/messaging/affinidi-messaging-delivery/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/lib.rs
@@ -34,7 +34,7 @@ pub use confirm::{
     confirmation_loop, confirmation_loop_with, outbox_drain_loop, poll_outbox_drain,
     sweep_confirmations, sweep_confirmations_with,
 };
-pub use drain::{DrainReport, drain_loop, drain_once};
+pub use drain::{DrainReport, drain_loop, drain_loop_via, drain_once, drain_once_via};
 pub use outbox::{InMemoryOutboxStore, Key, OutboxEntry, OutboxError, OutboxState, OutboxStore};
 pub use receipt::{RECEIPT_TYPE, Receipt, ReceiptPacker, receipt_key, receipt_of};
 pub use service::{Delivery, MessagingService, MessagingStatus, Sent};

--- a/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/outbox.rs
@@ -47,7 +47,9 @@ impl OutboxState {
 /// A durable, transport-independent unit of delivery-critical work.
 ///
 /// The entry records **who** the message is for (`dest_did`), not which wire —
-/// the transport is resolved at drain time. Timestamps are Unix milliseconds;
+/// the transport is resolved at drain time. The one exception is
+/// [`via`](Self::via), which pins an entry to a specific transport when the
+/// sending *identity* matters; see its docs. Timestamps are Unix milliseconds;
 /// the drain takes the clock as a parameter so it stays deterministic in tests.
 ///
 /// `Serialize`/`Deserialize` so a durable [`OutboxStore`] can persist entries
@@ -64,6 +66,26 @@ pub struct OutboxEntry {
     /// `None` = drain in parallel; `Some(k)` = per-`k` FIFO (an entry is due only
     /// if no earlier-enqueued entry with the same key is still non-terminal).
     pub ordering_key: Option<Key>,
+    /// The transport (by `MessagingService` transport id) this entry **must** go
+    /// out over, or `None` for "whichever transport is primary at drain time".
+    ///
+    /// `None` is the right default for a single-identity service, and is what
+    /// makes mediator migration work: a queued entry follows `promote` to the new
+    /// primary rather than being pinned to the mediator that was current when it
+    /// was enqueued.
+    ///
+    /// `Some(id)` exists for the case where the transport *is* the identity — a
+    /// service holding one transport per DID (per persona, per agent). There the
+    /// wire is not interchangeable: draining a message enqueued for identity A
+    /// over identity B's socket sends it from the wrong sender, which the
+    /// recipient authenticates and the mediator ACL judges. Such an entry is
+    /// drained only by [`drain_once_via`](crate::drain_once_via) for the matching
+    /// id, never by [`drain_once`](crate::drain_once).
+    ///
+    /// `#[serde(default)]` so entries persisted before this field existed load as
+    /// unbound.
+    #[serde(default)]
+    pub via: Option<String>,
     /// The already-packed message to hand to `MessageTransport::send`.
     pub packed: Vec<u8>,
     /// Lifecycle state.
@@ -103,6 +125,7 @@ impl OutboxEntry {
             idempotency_key: idempotency_key.into(),
             dest_did: dest_did.into(),
             ordering_key: None,
+            via: None,
             packed,
             state: OutboxState::Queued,
             attempts: 0,
@@ -117,6 +140,12 @@ impl OutboxEntry {
     /// Builder-style: set the ordering key (per-key FIFO drain).
     pub fn with_ordering_key(mut self, key: impl Into<Key>) -> Self {
         self.ordering_key = Some(key.into());
+        self
+    }
+
+    /// Builder-style: pin this entry to one transport (see [`via`](Self::via)).
+    pub fn with_via(mut self, transport_id: impl Into<String>) -> Self {
+        self.via = Some(transport_id.into());
         self
     }
 }
@@ -351,5 +380,34 @@ mod tests {
         let due = store.due(1_000).await.unwrap();
         let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
         assert_eq!(keys, vec!["c", "b"]);
+    }
+
+    #[test]
+    fn a_fresh_entry_is_unbound() {
+        assert_eq!(entry("k1", 1_000).via, None);
+    }
+
+    #[test]
+    fn with_via_pins_the_entry() {
+        assert_eq!(
+            entry("k1", 1_000).with_via("persona-a").via.as_deref(),
+            Some("persona-a")
+        );
+    }
+
+    /// A durable store holds entries written before `via` existed. They must load
+    /// as unbound rather than failing the whole store open.
+    #[test]
+    fn an_entry_persisted_without_via_loads_as_unbound() {
+        let mut without_via = serde_json::to_value(entry("k1", 1_000)).unwrap();
+        without_via
+            .as_object_mut()
+            .expect("entry serialises as an object")
+            .remove("via")
+            .expect("the current struct serialises via");
+
+        let loaded: OutboxEntry = serde_json::from_value(without_via).unwrap();
+        assert_eq!(loaded.via, None);
+        assert_eq!(loaded.idempotency_key, "k1");
     }
 }

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -211,6 +211,25 @@ impl ServiceInner {
             .map(|slot| slot.transport.clone())
     }
 
+    /// Every transport's id and live connection state.
+    fn transport_states(&self) -> Vec<(TransportId, ConnState)> {
+        self.transports
+            .lock()
+            .expect("transports mutex")
+            .iter()
+            .map(|(id, slot)| (id.clone(), *slot.transport.connection_state().borrow()))
+            .collect()
+    }
+
+    /// One transport's live connection state, or `None` if not installed.
+    fn transport_state(&self, id: &str) -> Option<ConnState> {
+        self.transports
+            .lock()
+            .expect("transports mutex")
+            .get(id)
+            .map(|slot| *slot.transport.connection_state().borrow())
+    }
+
     /// Aggregate connectivity across all transports (see [`MessagingStatus`]).
     fn status(&self) -> MessagingStatus {
         let Some(primary_id) = self.primary.lock().expect("primary mutex").clone() else {
@@ -407,6 +426,63 @@ impl MessagingService {
         }
     }
 
+    /// Like [`send`](Self::send), but over a **specific** installed transport
+    /// rather than the primary.
+    ///
+    /// This is the outbound half of multi-identity operation, and the counterpart
+    /// of [`request_via`](Self::request_via). Where the service holds one transport
+    /// per identity — one per persona, one per agent DID — the wire is not
+    /// interchangeable: the transport determines the proven sender, so "send as
+    /// this identity" is a different question from "send over whatever is
+    /// primary".
+    ///
+    /// `BestEffort` sends over `transport_id` directly. `Guaranteed` pins the
+    /// outbox entry to it ([`OutboxEntry::via`](crate::OutboxEntry::via)), so the
+    /// retry lands on the same identity that the first attempt would have — drain
+    /// it with [`drain_loop_via`](crate::drain_loop_via) for the same id.
+    ///
+    /// `Err` if `transport_id` is not currently installed. A `Guaranteed` send
+    /// still enqueues in that case only if the id resolves; an unknown id is
+    /// rejected up front rather than queueing work nothing will drain.
+    pub async fn send_via(
+        &self,
+        transport_id: &str,
+        to: &str,
+        packed: Vec<u8>,
+        delivery: Delivery,
+    ) -> Result<Sent, MessagingError> {
+        let transport = self.inner.transport_by_id(transport_id).ok_or_else(|| {
+            MessagingError::Transport(format!("cannot send via unknown transport: {transport_id}"))
+        })?;
+        match delivery {
+            Delivery::BestEffort => {
+                transport.send(to, packed).await?;
+                Ok(Sent::Accepted)
+            }
+            Delivery::Guaranteed {
+                idempotency_key,
+                ordering_key,
+                deliver_by,
+            } => {
+                let now = now_unix_ms();
+                let key = idempotency_key.unwrap_or_else(|| default_key(to, now));
+                let mut entry = OutboxEntry::new(
+                    key,
+                    to,
+                    packed,
+                    now,
+                    now.saturating_add(deliver_by.as_millis() as u64),
+                );
+                entry.ordering_key = ordering_key;
+                entry.via = Some(transport_id.to_string());
+                self.inner.outbox.put(entry).await.map_err(|e| {
+                    MessagingError::Transport(format!("outbox enqueue failed: {e}"))
+                })?;
+                Ok(Sent::Accepted)
+            }
+        }
+    }
+
     /// Send `packed` over the primary and await a reply correlated by
     /// `correlation_thid` — the thread id the caller minted on the outgoing
     /// message — up to `timeout`.
@@ -516,8 +592,35 @@ impl MessagingService {
 
     /// The one status a health endpoint reads, aggregated across all transports
     /// off their live connection signals (see [`MessagingStatus`]).
+    ///
+    /// **This aggregate assumes the transports are alternative wires to the same
+    /// peer** — the mediator-lifecycle case it was written for, where
+    /// [`Degraded`](MessagingStatus::Degraded) means "outbound is fine, a standby
+    /// is down". Where instead each transport *is* an identity, the same value
+    /// means "one identity is offline", which is a different fact and a different
+    /// operator action. Read [`transport_states`](Self::transport_states) for that
+    /// case rather than reinterpreting this one.
     pub fn status(&self) -> MessagingStatus {
         self.inner.status()
+    }
+
+    /// Every installed transport's id paired with its live connection state.
+    ///
+    /// The per-transport view [`status`](Self::status) deliberately does not try to
+    /// express. A multi-identity service needs to report *which* identity is
+    /// offline — collapsing that into one tri-state loses the only thing the
+    /// operator can act on.
+    ///
+    /// Read off each transport's live `connection_state()`, never a boot-time
+    /// latch (R6.2). Order is unspecified.
+    pub fn transport_states(&self) -> Vec<(TransportId, ConnState)> {
+        self.inner.transport_states()
+    }
+
+    /// One installed transport's live connection state, or `None` if `id` is not
+    /// installed.
+    pub fn transport_state(&self, id: &str) -> Option<ConnState> {
+        self.inner.transport_state(id)
     }
 
     /// Record end-to-end delivery evidence for a `Guaranteed` send:
@@ -1447,5 +1550,137 @@ mod tests {
         handle.send("did:x", b"b".to_vec()).await.unwrap();
         assert_eq!(h2.transport.sent.lock().unwrap().len(), 1);
         assert_eq!(h1.transport.sent.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_via_uses_the_named_transport_not_the_primary() {
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let h2 = mock();
+        svc.add_transport("persona-a".into(), h2.transport.clone());
+
+        svc.send_via("persona-a", "did:x", b"a".to_vec(), Delivery::BestEffort)
+            .await
+            .unwrap();
+
+        assert_eq!(h2.transport.sent.lock().unwrap().len(), 1);
+        assert!(
+            h1.transport.sent.lock().unwrap().is_empty(),
+            "the primary must not carry an identity-bound send"
+        );
+    }
+
+    /// A promote must not silently move an identity-bound send onto another
+    /// identity's wire — the pin outranks the primary.
+    #[tokio::test]
+    async fn send_via_ignores_the_primary_after_a_promote() {
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let h2 = mock();
+        svc.add_transport("persona-a".into(), h2.transport.clone());
+        svc.promote("persona-a").unwrap();
+
+        svc.send_via("default", "did:x", b"a".to_vec(), Delivery::BestEffort)
+            .await
+            .unwrap();
+
+        assert_eq!(h1.transport.sent.lock().unwrap().len(), 1);
+        assert!(h2.transport.sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_via_pins_a_guaranteed_entry_to_that_transport() {
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), outbox.clone());
+        svc.add_transport("persona-a".into(), mock().transport);
+
+        svc.send_via(
+            "persona-a",
+            "did:x",
+            b"a".to_vec(),
+            Delivery::Guaranteed {
+                idempotency_key: Some("k1".into()),
+                ordering_key: None,
+                deliver_by: Duration::from_secs(60),
+            },
+        )
+        .await
+        .unwrap();
+
+        let entry = outbox.get("k1").await.unwrap().expect("entry was enqueued");
+        assert_eq!(entry.via.as_deref(), Some("persona-a"));
+        assert!(
+            h1.transport.sent.lock().unwrap().is_empty(),
+            "a Guaranteed send queues rather than sending inline"
+        );
+    }
+
+    /// Rejected up front rather than queueing work no drain would ever claim.
+    #[tokio::test]
+    async fn send_via_an_unknown_transport_errors_without_enqueueing() {
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), outbox.clone());
+
+        assert!(
+            svc.send_via(
+                "nope",
+                "did:x",
+                b"a".to_vec(),
+                Delivery::Guaranteed {
+                    idempotency_key: Some("k1".into()),
+                    ordering_key: None,
+                    deliver_by: Duration::from_secs(60),
+                },
+            )
+            .await
+            .is_err()
+        );
+        assert!(outbox.get("k1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn transport_states_reports_each_transport_separately() {
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let h2 = mock();
+        svc.add_transport("persona-a".into(), h2.transport.clone());
+
+        let mut states = svc.transport_states();
+        states.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let ids: Vec<_> = states.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["default", "persona-a"]);
+        assert!(
+            states
+                .iter()
+                .all(|(_, state)| *state == ConnState::Connected)
+        );
+
+        assert_eq!(svc.transport_state("persona-a"), Some(ConnState::Connected));
+        assert_eq!(svc.transport_state("nope"), None);
+    }
+
+    /// The per-identity view has to distinguish *which* identity is down — the
+    /// thing the aggregate `status()` deliberately collapses.
+    #[tokio::test]
+    async fn transport_state_names_the_disconnected_identity() {
+        let h1 = mock();
+        let svc = MessagingService::new(h1.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let h2 = mock();
+        svc.add_transport("persona-a".into(), h2.transport.clone());
+
+        h2.conn_tx.send(ConnState::Disconnected).unwrap();
+
+        assert_eq!(svc.transport_state("default"), Some(ConnState::Connected));
+        assert_eq!(
+            svc.transport_state("persona-a"),
+            Some(ConnState::Disconnected)
+        );
+        assert_eq!(
+            svc.status(),
+            MessagingStatus::Degraded,
+            "the aggregate says only that something is down"
+        );
     }
 }


### PR DESCRIPTION
Closes #660.

`MessagingService` has held N transports since 0.1.10, but for one shape:
**alternative wires to the same peer**, for the VTA's mediator lifecycle
(migrate / rollback / drain). Outbound routes to the primary, the drain follows the
primary, and `status()` aggregates on the assumption that a non-primary being down
only costs redundancy.

A consumer holding **one transport per identity** — one per persona, one per agent
DID — breaks all three. There the transport determines the proven sender, so the
wire is not interchangeable: draining an entry over the wrong socket sends it from
the wrong sender, which the recipient authenticates and the mediator ACL judges.

Most of what such a consumer needs already exists — N transports with runtime
add/remove, per-transport inbound forwarders merged into one dispatcher,
`ack_via_source`, `request_via`, and `ReceivedMessage.recipient` for demuxing
inbound by identity. This closes the three gaps that remained.

## Changes

**`send_via(transport_id, to, packed, delivery)`** — the outbound counterpart of
0.1.11's `request_via`. `BestEffort` sends over the named transport; `Guaranteed`
pins the outbox entry to it. An unknown id is rejected up front rather than
queueing work no drain would claim.

**`OutboxEntry::via: Option<String>`** (+ `with_via`) — the transport an entry
**must** drain over. `None` keeps today's behaviour and is what makes mediator
migration work: an unbound entry follows `promote` to the new primary rather than
being pinned to whichever mediator was current when it was enqueued. `Some(id)` is
the identity case.

**`drain_once_via` / `drain_loop_via`** — the per-identity drain. Over one shared
store every entry is claimed by **exactly one** drain: an unbound entry by
`drain_once`, a pinned entry by the `_via` drain naming it. Nothing double-sends and
nothing is orphaned. A pinned entry whose transport is not installed waits rather
than being re-routed — re-routing is the exact thing the pin prevents — and its
`deliver_by_ms` still settles it visibly.

**`transport_states()` / `transport_state(id)`** — per-transport live `ConnState`.
`status()`'s `Degraded` means "a standby is down"; under multi-identity the same
value would mean "one identity is offline", a different operator action. Rather than
redefine `status()`, the per-identity view is its own accessor and `status()` now
documents the assumption it makes. Read off the live signal, never a boot-time latch
(R6.2).

`OutboxStore` is deliberately **unchanged** — the filtering lives in the drain, so
no implementation (including `VtiOutboxStore` in `verifiable-trust-infrastructure`)
needs updating.

## Compatibility

Additive. `new` / `with_receipts` / `send` / `request` / `drain_once` signatures
unchanged.

**One behavioural change, flagged per R3.6 (also in the CHANGELOG):** `drain_once`
now **skips** entries with `via` set. No consumer is affected today — `via` is new
and defaults to `None`, so every existing entry is still claimed by `drain_once`
exactly as before — but a consumer that starts setting `via` must run a `_via` drain
for those entries or they sit queued until their delivery window settles them.

`OutboxEntry` gains a field. `#[serde(default)]` keeps entries persisted by earlier
versions loading as unbound, and every known consumer constructs through
`OutboxEntry::new` rather than a struct literal (checked in this repo and in
`verifiable-trust-infrastructure`, where `VtiOutboxStore` treats the entry as opaque
JSON), so nothing downstream needs changing.

## Tests

11 new (58 total in the crate). Beyond the obvious per-method coverage, the ones
worth reading:

- `every_entry_is_claimed_exactly_once_across_drains` — the property the whole split
  exists for: unbound + two pinned entries over one shared store, three drains, each
  transport sends exactly its own.
- `drain_once_skips_a_pinned_entry` — the safety property; a bound entry must not go
  out over the primary.
- `send_via_ignores_the_primary_after_a_promote` — the pin outranks the primary.
- `a_pinned_entry_still_expires_on_its_own_drain` — pinning does not create an entry
  that waits forever.
- `an_entry_persisted_without_via_loads_as_unbound` — the migration path for a
  durable store written by an earlier version.

## Verification

- `cargo test -p affinidi-messaging-delivery` — 58 passed, 0 failed
- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p affinidi-messaging-delivery --all-targets` — clean
- `cargo fmt --all --check` — clean
- `scripts/check-changelogs.sh origin/main` — `ok affinidi-messaging-delivery: 0.1.11 -> 0.1.12 (documented)`
- `scripts/check-version-bumps.sh origin/main` — `ok affinidi-messaging-delivery: 0.1.11 -> 0.1.12`

## Consumer context

OpenVTC builds one listener per persona DID (own mediator, own secrets) plus
relationship-DID listeners, and is still on `affinidi-messaging-didcomm-service`
while both VTI services have moved to this layer — OpenVTC/openvtc#189. Without
this it must run one `MessagingService`, outbox and drain loop per DID, or stay on
the old framework.

This is also the layer TSP arrives on (`TransportKind::Tsp` is reserved; the
contract says *"DIDComm today, TSP and REST later"*), so a multi-identity consumer
wants to be here before that lands rather than after.
