### PR TITLE
fix: mediator ACL audit - self-service escalation and unenforced RECEIVE_MESSAGES

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,79 @@
 
 ## Changelog history
 
+## 27th July 2026
+
+### 0.17.11 — ACL audit: privilege-escalation fix, `RECEIVE_MESSAGES` now enforced, ACL guide
+
+A full review of every ACL call site in the mediator. Three behavioural
+changes, all tightening; read the first two before upgrading.
+
+**SECURITY — a non-admin could grant itself admin-only ACL flags.**
+`messaging/acls/set` validated only the seven capability bits that carry a
+self-change flag. The five flags that have *no* self-change bit —
+`blocked`, `local`, `self_manage_list`, `self_manage_send_queue_limit`,
+`self_manage_receive_queue_limit` — were not checked at all, and
+`check_permissions` lets a Standard account target its own DID. A standard
+DID could therefore grant itself `LOCAL` (an inbox, message storage and
+WebSocket access) on a mediator whose default withholds it, grant itself
+`self_manage_list` to curate its own access list, grant itself the
+queue-limit overrides, or clear its own `blocked` bit while holding a valid
+session. The equivalent Trust Task path (`ensure_self_manageable`) already
+refused all five and documented itself as "faithful to the legacy `acls_set`
+rules" — the DIDComm path was the outlier. Both paths now enforce the same
+rule. `acl_change_ok` is table-driven over the two classes of bit, with an
+exhaustiveness test (`every_acl_field_is_classified`) that fails if any
+future ACL field is left unclassified, since an unclassified field silently
+becomes self-service.
+
+**BEHAVIOURAL — `RECEIVE_MESSAGES` is now enforced.** The bit was settable,
+shipped in the default ACL string, reported over the wire, gated for
+self-change and documented as "DID can receive messages" — but no code path
+ever read it. Clearing it did nothing. Direct delivery now checks the
+recipient's `RECEIVE_MESSAGES` (DIDComm and TSP alike), mirroring the
+existing sender-side `SEND_MESSAGES` gate, and rejects with
+`authorization.receive` / problem code 74. **Any local DID whose stored ACL
+omits `RECEIVE_MESSAGES` stops receiving directly-delivered messages.** The
+shipped defaults include the bit, so a default deployment is unaffected;
+audit any account provisioned with a custom ACL. Forwarded delivery is
+unchanged — it is governed by `RECEIVE_FORWARDED`, which was already
+enforced.
+
+**CONFIG — the shipped `mediator_acl_mode` default is now `explicit_deny`.**
+`conf/mediator.toml` and `docker/conf/mediator.toml` shipped
+`explicit_allow`, which reads as a closed allowlist but is not one: the mode
+governs only who may pre-register *other* DIDs via `account_add`, and never
+gates authentication. `explicit_deny` is an honest description of what an
+out-of-the-box mediator does, and matches the built-in code default and what
+the setup wizard already emits for its default "Open" profile. The
+consequence of the change itself is that non-admins may now call
+`account_add` — bounded, because a non-admin's `account_add` always applies
+`global_acl_default`, which is what the target DID would have received by
+self-registering anyway. Set `explicit_allow` explicitly to keep the old
+restriction.
+
+Also in this release:
+
+- Every handler, routing and storage ACL gate now resolves through
+  `common::authz` rather than reading ACL bits inline. The `Capability` enum
+  lost its `#[allow(dead_code)]`, so a capability nothing enforces now shows
+  up as a dead-code warning — that allow is how `RECEIVE_MESSAGES` stayed
+  inert unnoticed.
+- New `authz::effective_acls` centralises "stored ACLs, else
+  `global_acl_default`", which was inlined at three call sites.
+- The authentication-response registration backstop no longer applies a
+  different condition (`global_acl_default` grants `LOCAL`) from the
+  challenge step, which registers unconditionally. The condition could never
+  actually fire — a session must exist to reach it — but it read as though
+  the two steps disagreed about who gets an account.
+- Corrected the README's ACL section, which described `explicit_allow` as
+  "deny all DIDs except those explicitly allowed". The mediator has never
+  behaved that way.
+- New [`docs/acls.md`](./docs/acls.md): the four layers, every permission
+  bit and where it is enforced, all five registration paths, the
+  decision walkthroughs, deployment recipes, and a symptom→cause
+  troubleshooting table.
+
 ## 26th July 2026
 
 ### 0.17.10 — accept `vta-sdk` 0.20

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.10"
+version = "0.17.11"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -90,7 +90,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.30", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.31", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.2", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -323,44 +323,62 @@ mediator rotate-admin                # actually rotate
 
 ## Access Control Lists (ACLs)
 
-The mediator provides granular access control at both the mediator and DID level.
+**See [`docs/acls.md`](./docs/acls.md) for the full guide.** Summary below.
 
-### Mediator-level ACLs
+Access control is four independent layers:
 
-| Flag | Description |
+| Layer | Scope | What it decides |
+|---|---|---|
+| `mediator_acl_mode` | mediator-wide | Who may pre-register *other* DIDs via `account_add` |
+| `global_acl_default` | mediator-wide | The ACL set given to every new/unknown DID |
+| `MediatorACLSet` | per DID | What that DID may do |
+| Access list | per DID | Which senders that DID accepts messages from |
+
+### `mediator_acl_mode`
+
+| Value | Meaning |
 |---|---|
-| `explicit_allow` | Deny all DIDs except those explicitly allowed |
-| `explicit_deny` | Allow all DIDs unless explicitly denied |
-| `local_direct_delivery_allowed` | Allow direct messaging to local DIDs |
+| `explicit_allow` | Only admins may add accounts via `account_add` |
+| `explicit_deny` | Any authenticated DID may add accounts (always with `global_acl_default`) |
+
+> **This mode does not gate authentication.** In either mode, any DID that
+> completes the challenge is auto-registered with `global_acl_default` and
+> issued a session. `global_acl_default` — not this mode — is what controls
+> a public mediator. Earlier revisions of this table described
+> `explicit_allow` as "deny all DIDs except those explicitly allowed"; the
+> mediator has never behaved that way.
 
 ### DID-level ACLs
 
 | Flag | Description |
 |---|---|
-| `ALLOW_ALL` | Allow all operations (default) |
-| `DENY_ALL` | Deny all operations |
-| `LOCAL` | Store messages for this DID |
+| `ALLOW_ALL` | Every capability, every self-change bit, open inbox (denylist) |
+| `DENY_ALL` | No capability, no self-management, closed inbox (allowlist) |
+| `LOCAL` | DID has an inbox — required for fetch/list/delete and WebSocket |
 | `SEND_MESSAGES` | DID can send messages |
-| `RECEIVE_MESSAGES` | DID can receive messages |
+| `RECEIVE_MESSAGES` | DID can receive directly-delivered messages |
 | `SEND_FORWARDED` | DID can send forwarded messages |
 | `RECEIVE_FORWARDED` | DID can receive forwarded messages |
 | `ANON_RECEIVE` | DID can receive anonymous messages |
 | `CREATE_INVITES` | DID can create OOB invites |
+| `BLOCKED` | DID cannot authenticate at all |
 
-Self-change flags (e.g., `SEND_MESSAGES_CHANGE`, `SELF_MANAGE_LIST`) allow users
-to update their own ACLs when permitted by the administrator.
+Self-change flags (e.g. `SEND_MESSAGES_CHANGE`) let a DID flip that one
+capability itself. `LOCAL`, `BLOCKED` and the `SELF_MANAGE_*` flags are
+admin-only and have no self-change variant.
 
 ## Operating Modes
 
-| Mode | Mediator ACL | DID ACL | Direct Delivery | Use Case |
-|---|---|---|---|---|
-| **Private Closed** | `explicit_allow` | `DENY_ALL + LOCAL + SEND + RECEIVE` | Yes | Restricted corporate network |
-| **Private Open** | `explicit_allow` | `ALLOW_ALL` | Yes | Internal company messaging |
-| **Public Closed** | `explicit_deny` | `ALLOW_ALL + MODE_EXPLICIT_ALLOW` | No | Consent-based messaging |
-| **Public Open** | `explicit_deny` | `ALLOW_ALL` | No | Unrestricted relay |
-| **Public Mixed** | `explicit_deny` | `ALLOW_ALL + MODE_EXPLICIT_ALLOW` | No | Discovery + private channels |
+| Mode | `mediator_acl_mode` | `global_acl_default` | Use Case |
+|---|---|---|---|
+| **Open** | `explicit_deny` | `ALLOW_ALL` | Unrestricted public mediator |
+| **Consent-based** | `explicit_deny` | `ALLOW_ALL + MODE_EXPLICIT_ALLOW` | Anyone may register; each inbox is an allowlist |
+| **Direct messaging** | `explicit_deny` | `DENY_ALL + LOCAL + SEND + RECEIVE` | Shipped default — no relay, no invites |
+| **Relay only** | `explicit_deny` | `DENY_ALL + SEND_FORWARDED + RECEIVE_FORWARDED` | Pure inter-mediator relay, no inboxes |
+| **Closed** | `explicit_allow` | `DENY_ALL` | Unknown DIDs authenticate but can do nothing until an admin grants capabilities |
 
-See the `mediator.toml` configuration file for details on each mode.
+See [`docs/acls.md`](./docs/acls.md) for the reasoning behind each, and
+`mediator.toml` for the settings.
 
 ## Sub-crates
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Changelog history
 
+## 27th July 2026
+
+### 0.15.31 — `MediatorACLSet` documentation + one renamed getter
+
+Documentation and naming only; no behaviour change. Part of the mediator's
+ACL audit — see `affinidi-messaging-mediator` 0.17.11.
+
+- `get_access_list_mode_admin_change` is **deprecated** in favour of
+  `get_access_list_mode_self_change`. The old name read as "do you need
+  admin rights to change the mode?", which is the inverse of what bit 1
+  means: it returns `true` when the DID *may* change the mode itself. Same
+  bit, same return value — the alias is kept and delegates, so this is not
+  a breaking change.
+- `MediatorACLSet` now documents the model it implements: the two classes
+  of bit (capability + self-change pair vs. the admin-only `did_blocked`,
+  `did_local` and `self_manage_*` flags), and the fact that the packed
+  `acl: u64` is the source of truth while the named fields are a
+  denormalized mirror maintained by the setters and `from_u64`. Getters
+  read bits, never the fields; writing a field directly desynchronises the
+  two. The bit map is now a doc comment rather than an inline block, and
+  labels which bits are admin-only.
+
 ## 14th July 2026
 
 ### 0.15.30 — shared `s3://` target parser

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.30"
+version = "0.15.31"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/types/acls.rs
@@ -59,31 +59,62 @@ impl Display for AccessListModeType {
     }
 }
 
-/// The ACL Set for a DID
+/// The ACL Set for a single DID — what that DID may do on the mediator, and
+/// which of those permissions it may change itself.
+///
+/// # The two classes of bit
+///
+/// Most permissions occupy a *pair* of bits: the capability itself, and a
+/// `_change` (self-change) bit saying whether the DID may flip that
+/// capability without an admin. `set_*` takes `(value, self_change, admin)`
+/// and enforces this: a non-admin caller is refused unless the self-change
+/// bit is already set, and only an admin may modify the self-change bit
+/// itself. So a DID can never widen its own authority — only exercise
+/// authority an admin delegated to it.
+///
+/// The remaining flags (`did_blocked`, `did_local`, and the three
+/// `self_manage_*` bits) have **no** self-change bit: they are admin-only,
+/// always. `did_blocked` and `did_local` are the mediator's own gates, and
+/// the `self_manage_*` bits are what delegate self-service in the first
+/// place. `crate::store` consumers and the mediator's
+/// `authz::acl_change_ok` both depend on this split.
+///
+/// # Representation
+///
+/// `acl` (the packed `u64`) is the **source of truth**: every getter reads
+/// its bits, `PartialEq` compares it alone, and it is what gets persisted
+/// (as hex) and sent on the wire. The named fields are a denormalized
+/// mirror kept in sync by the setters and by [`from_u64`](Self::from_u64),
+/// present so the struct serializes to a self-describing JSON object.
+/// Never set a named field directly — write through the setters, or the
+/// mirror and the bits will disagree.
+///
+/// ```text
+/// Bit position mapping                       class
+///     0: access_list_mode (0 = explicit_allow, 1 = explicit_deny)
+///     1: access_list_mode_change (0 = admin_only, 1 = self)
+///     2: did_blocked (0 = allow, 1 = blocked)          admin-only
+///     3: did_local (0 = false, 1 = true/local)         admin-only
+///     4: send_messages (0 = false, 1 = true)
+///     5: send_messages_change (0 = admin_only, 1 = self)
+///     6: receive_messages (0 = false, 1 = true)
+///     7: receive_messages_change (0 = admin_only, 1 = self)
+///     8: send_forwarded (0 = no, 1 = yes)
+///     9: send_forwarded_change (0 = admin_only, 1 = self)
+///    10: receive_forwarded (0 = no, 1 = yes)
+///    11: receive_forwarded_change (0 = admin_only, 1 = self)
+///    12: create_invites (0 = no, 1 = yes)
+///    13: create_invites_change (0 = admin_only, 1 = self)
+///    14: anon_receive (0 = no, 1 = yes)
+///    15: anon_receive_change (0 = admin_only, 1 = self)
+///    16: self_manage_list (0 = admin_only, 1 = self)    admin-only
+///    17: self_manage_send_queue_limit                   admin-only
+///    18: self_manage_receive_queue_limit                admin-only
+/// ```
+///
+/// Bits 19-63 are unassigned and must stay zero.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct MediatorACLSet {
-    /*
-    Bit position mapping
-        0: access_list_mode (0 = explicit_allow, 1 = explicit_deny)
-        1: access_list_mode_change (0 = admin_only, 1 = self)
-        2: did_blocked (0 = allow, 1 = blocked)
-        3: did_local (0 = false, 1 = true/local)
-        4: send_messages (0 = false, 1 = true)
-        5: send_messages_change (0 = admin_only, 1 = self)
-        6: receive_messages (0 = false, 1 = true)
-        7: receive_messages_change (0 = admin_only, 1 = self)
-        8: send_forwarded (0 = no, 1 = yes)
-        9: send_forwarded_change (0 = admin_only, 1 = self)
-       10: receive_forwarded (0 = no, 1 = yes)
-       11: receive_forwarded_change (0 = admin_only, 1 = self)
-       12: create_invites (0 = no, 1 = yes)
-       13: create_invites_change (0 = admin_only, 1 = self)
-       14: anon_receive (0 = no, 1 = yes)
-       15: anon_receive_change (0 = admin_only, 1 = self)
-       16: self_manage_list (0 = admin_only, 1 = self)
-       17: self_manage_send_queue_limit
-       18: self_manage_receive_queue_limit
-    */
     access_list_mode: AccessListModeType,
     access_list_mode_self_change: bool,
     did_blocked: bool,
@@ -229,14 +260,14 @@ impl MediatorACLSet {
                 "mode_explicit_allow" => {
                     default_acl.set_access_list_mode(
                         AccessListModeType::ExplicitAllow,
-                        default_acl.get_access_list_mode_admin_change(),
+                        default_acl.get_access_list_mode_self_change(),
                         true,
                     )?;
                 }
                 "mode_explicit_deny" => {
                     default_acl.set_access_list_mode(
                         AccessListModeType::ExplicitDeny,
-                        default_acl.get_access_list_mode_admin_change(),
+                        default_acl.get_access_list_mode_self_change(),
                         true,
                     )?;
                 }
@@ -357,7 +388,7 @@ impl MediatorACLSet {
         };
 
         acls.access_list_mode = acls.get_access_list_mode().0;
-        acls.access_list_mode_self_change = acls.get_access_list_mode_admin_change();
+        acls.access_list_mode_self_change = acls.get_access_list_mode_self_change();
         acls.did_blocked = acls.get_blocked();
         acls.did_local = acls.get_local();
         acls.send_messages = acls.get_send_messages().0;
@@ -437,7 +468,7 @@ impl MediatorACLSet {
         // BIT 0 :: DID access list Mode (0 = explicit_allow, 1 = explicit_deny)
         // BIT 1 :: DID access list Mode Change (0 = admin_only, 1 = self)
 
-        let change = self.get_access_list_mode_admin_change();
+        let change = self.get_access_list_mode_self_change();
 
         if !change && !admin {
             Err(ACLError::Denied(
@@ -460,10 +491,27 @@ impl MediatorACLSet {
         }
     }
 
-    /// Do you need to have admin rights to change the access list Mode?
-    pub fn get_access_list_mode_admin_change(&self) -> bool {
+    /// May the DID change its own access list Mode?
+    ///
+    /// `true` = the DID may change it itself; `false` = admin only. This is
+    /// the same self-change bit returned as the second element of
+    /// [`get_access_list_mode`](Self::get_access_list_mode).
+    pub fn get_access_list_mode_self_change(&self) -> bool {
         // BIT Position 1
         self._generic_get(1)
+    }
+
+    /// Renamed to [`get_access_list_mode_self_change`](Self::get_access_list_mode_self_change).
+    ///
+    /// The old name read as "do you need admin rights to change the mode?",
+    /// which is the inverse of what the bit means: it returns `true` when
+    /// the DID *may* change the mode itself. The behaviour is unchanged.
+    #[deprecated(
+        since = "0.15.31",
+        note = "misleading name — the bit is a self-change grant, not an admin requirement. Use `get_access_list_mode_self_change`"
+    )]
+    pub fn get_access_list_mode_admin_change(&self) -> bool {
+        self.get_access_list_mode_self_change()
     }
 
     /// Is this DID blocked from the mediator?
@@ -829,7 +877,7 @@ mod tests {
             acl.get_access_list_mode(),
             (AccessListModeType::ExplicitAllow, false)
         ));
-        assert!(!acl.get_access_list_mode_admin_change());
+        assert!(!acl.get_access_list_mode_self_change());
     }
 
     #[test]
@@ -845,7 +893,7 @@ mod tests {
             acl.get_access_list_mode(),
             (AccessListModeType::ExplicitDeny, true)
         ));
-        assert!(acl.get_access_list_mode_admin_change());
+        assert!(acl.get_access_list_mode_self_change());
 
         // Test that we can flip back to the default
         assert!(
@@ -856,7 +904,7 @@ mod tests {
             acl.get_access_list_mode(),
             (AccessListModeType::ExplicitAllow, false)
         ));
-        assert!(!acl.get_access_list_mode_admin_change());
+        assert!(!acl.get_access_list_mode_self_change());
     }
 
     #[test]
@@ -872,7 +920,7 @@ mod tests {
             acl.get_access_list_mode(),
             (AccessListModeType::ExplicitAllow, false)
         ));
-        assert!(!acl.get_access_list_mode_admin_change());
+        assert!(!acl.get_access_list_mode_self_change());
     }
 
     #[test]
@@ -894,7 +942,7 @@ mod tests {
             acl.get_access_list_mode(),
             (AccessListModeType::ExplicitDeny, true)
         ));
-        assert!(acl.get_access_list_mode_admin_change());
+        assert!(acl.get_access_list_mode_self_change());
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -134,11 +134,21 @@ database_timeout = "2"
 ### ****************************************************************************************************************************
 [security]
 ### Env: MEDIATOR_ACL_MODE
-### ACL logic mode: explicit_deny | explicit_allow
-mediator_acl_mode = "explicit_allow"
+### Who may pre-register OTHER DIDs via the account_add admin protocol:
+###   explicit_deny  — any authenticated DID may add accounts (they are always
+###                    created with global_acl_default, never wider)
+###   explicit_allow — only admin accounts may add accounts
+###
+### IMPORTANT: this mode does NOT gate authentication. Any DID that completes
+### the challenge is auto-registered with global_acl_default, in either mode.
+### `global_acl_default` is the setting that controls what an arbitrary DID
+### can do on this mediator. See docs/acls.md.
+mediator_acl_mode = "explicit_deny"
 
 ### Env: GLOBAL_DEFAULT_ACL
-### Default ACL applied to new/unknown DIDs
+### Default ACL applied to new/unknown DIDs. THIS is the real access control
+### for a public mediator: it decides what every self-registered DID may do,
+### and seeds each DID's own access-list mode.
 ### NOTE: ALLOW_ALL or DENY_ALL must always be first, followed by comma-separated flags
 ### Flags: LOCAL, SEND_MESSAGES, RECEIVE_MESSAGES, SEND_FORWARDED, RECEIVE_FORWARDED,
 ###        CREATE_INVITES, ANON_RECEIVE, SELF_MANAGE_LIST, SELF_MANAGE_SEND_QUEUE_LIMIT,

--- a/crates/messaging/affinidi-messaging-mediator/docs/acls.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/acls.md
@@ -1,0 +1,329 @@
+# Mediator Access Control Guide
+
+How the Affinidi mediator decides whether a DID may connect, send, receive,
+forward, or administer. This is the reference for operators configuring a
+deployment and for developers adding a permission check.
+
+**The one thing to take away:** `global_acl_default` is the setting that
+controls a public mediator. `mediator_acl_mode` is much narrower than its
+name suggests and does **not** gate who may connect.
+
+---
+
+## 1. The four layers
+
+Access control is four independent mechanisms. They are often confused
+because two of them use the same `ExplicitAllow` / `ExplicitDeny` enum while
+meaning entirely different things.
+
+| # | Layer | Scope | Set by | What it decides |
+|---|-------|-------|--------|-----------------|
+| 1 | `mediator_acl_mode` | mediator-wide | `mediator.toml` | Who may **pre-register other DIDs** via `account_add`. Nothing else. |
+| 2 | `global_acl_default` | mediator-wide | `mediator.toml` | The ACL set handed to every new or unknown DID. |
+| 3 | `MediatorACLSet` | per DID | admin, or the DID itself where delegated | What that DID may do (19 permission bits). |
+| 4 | Access list | per DID | the DID (if delegated) or an admin | Which **senders** that DID accepts messages from. |
+
+Layers 1 and 4 both use `AccessListModeType`. They are unrelated:
+
+- **Layer 1** (`mediator_acl_mode`): `ExplicitAllow` = only admins may add
+  accounts. `ExplicitDeny` = any authenticated DID may.
+- **Layer 4** (a DID's own `access_list_mode` bit): `ExplicitAllow` = the
+  access list is an **allowlist** (empty list ⇒ nobody may send to me).
+  `ExplicitDeny` = it is a **denylist** (empty list ⇒ anybody may).
+
+Note the inversion: for layer 4, `ExplicitAllow` is the *closed*, secure
+posture, and it is `MediatorACLSet::default()`.
+
+---
+
+## 2. `mediator_acl_mode` — what it does and does not do
+
+```toml
+[security]
+mediator_acl_mode = "explicit_deny"   # or "explicit_allow"
+```
+
+It has exactly two effects, both on the `account_add` operation:
+
+| Mode | Effect on `messaging/account/add` (DIDComm admin protocol and Trust Tasks) |
+|------|---------------------------------------------------------------------------|
+| `explicit_allow` | Only `Admin` / `RootAdmin` accounts may add accounts. |
+| `explicit_deny` | Any authenticated DID may add accounts. |
+
+**It does not gate authentication.** In *either* mode, any DID that completes
+the authentication challenge is auto-registered and issued a session. There
+is no allowlist of DIDs permitted to connect.
+
+**It does not affect message delivery.** No send, receive, forward, or
+pickup decision reads it.
+
+**It does not let a non-admin grant privileges.** A non-admin using
+`account_add` in `explicit_deny` mode always creates the account with
+`global_acl_default`; any ACLs it supplies are ignored. Only admins may
+specify custom ACLs. So in `explicit_deny` the worst a non-admin can do is
+create account records that would have been created anyway on first
+authentication — consider `explicit_allow` if you want to deny even that
+(it is a minor storage-growth vector on an open mediator).
+
+> **Historical note.** Older documentation described `explicit_allow` as
+> "deny all DIDs except those explicitly allowed". The mediator has never
+> implemented that. If you need a genuinely closed mediator, use a denying
+> `global_acl_default` (§7) — an unknown DID then authenticates but can do
+> nothing until an admin grants it capabilities.
+
+---
+
+## 3. `global_acl_default` — the real control
+
+```toml
+[security]
+global_acl_default = "DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES"
+```
+
+This is the ACL set applied to every DID the mediator has not seen before,
+and the fallback whenever a permission check runs against a DID with no
+stored record. It therefore decides what an arbitrary DID off the internet
+can do with your mediator.
+
+It is consumed in four places:
+
+1. **Registration.** Written verbatim as the new account's ACL set on every
+   auto-registration path (§4).
+2. **Fallback.** Any check on a DID with no account record uses it
+   (`authz::effective_acls`).
+3. **Seeding the inbox mode.** Its `access_list_mode` bit becomes each new
+   DID's own allowlist/denylist mode (layer 4).
+4. **Implicit relay.** If it grants `SEND_FORWARDED`, the mediator accepts
+   anonymous inter-mediator relay on `/inbound` even without
+   `enable_inter_mediator_relay = "true"`. This is deprecated and warns at
+   boot; a future release will require the explicit flag.
+
+### Ruleset syntax
+
+A comma-separated string. `ALLOW_ALL` or `DENY_ALL` must come **first** if
+present; later flags layer on top.
+
+| Keyword | Effect |
+|---------|--------|
+| `ALLOW_ALL` | Every capability, every self-change bit, every `self_manage_*`, and `access_list_mode = ExplicitDeny` (open inbox). |
+| `DENY_ALL` | No capability, no self-change, no self-management, and `access_list_mode = ExplicitAllow` (closed inbox). |
+| `ALLOW_ALL_SELF_CHANGE` / `DENY_ALL_SELF_CHANGE` | Set/clear every self-change bit, leaving the capability values alone. |
+| `MODE_EXPLICIT_ALLOW` / `MODE_EXPLICIT_DENY` | This DID's own access-list mode (layer 4). |
+| `MODE_SELF_CHANGE` | Let the DID change its own access-list mode. |
+| `LOCAL` | Grant an inbox (message storage). No `_CHANGE` variant — admin-only. |
+| `SEND_MESSAGES`, `RECEIVE_MESSAGES`, `SEND_FORWARDED`, `RECEIVE_FORWARDED`, `CREATE_INVITES`, `ANON_RECEIVE` | Grant that capability. Each has a `_CHANGE` variant granting the DID the right to flip it itself. |
+| `SELF_MANAGE_LIST` | Let the DID edit its own access list. Admin-only to set. |
+| `SELF_MANAGE_SEND_QUEUE_LIMIT`, `SELF_MANAGE_RECEIVE_QUEUE_LIMIT` | Let the DID set its own queue limits. Admin-only to set. |
+| `BLOCKED` | Marks the DID blocked. **Never put this in `global_acl_default`** — it blocks every new DID from authenticating. |
+
+Watch the mode inversion: `ALLOW_ALL` gives every new DID an *open* inbox
+(denylist), while `DENY_ALL` gives a *closed* one (allowlist). Boot-time
+validation warns when `mediator_acl_mode = explicit_deny` is combined with
+`global_acl_default = ALLOW_ALL`, since that combination accepts everything
+from everyone.
+
+---
+
+## 4. How a DID gets an account
+
+Five paths, and they do **not** all grant the same ACLs:
+
+| Path | Trigger | ACLs granted |
+|------|---------|--------------|
+| Authentication challenge | Any DID completing `/authenticate/challenge` | `global_acl_default` |
+| Authentication response | Backstop if the record vanished mid-flow | `global_acl_default` |
+| `account_add` by an admin | Admin protocol or Trust Task | Admin's choice, else `global_acl_default` |
+| `account_add` by a non-admin | Only in `explicit_deny` mode | Always `global_acl_default` |
+| Forward routing | An unseen DID relays a forward through the mediator | **Least privilege**: `DENY_ALL` + `SEND_FORWARDED`, and only if `global_acl_default` grants `SEND_FORWARDED`. A DID that has only ever relayed a forward does not get `LOCAL`, `RECEIVE_*`, invites, or self-management. |
+
+The first path is the one that surprises people: **registration is
+automatic and unconditional.** There is no approval step and no mode that
+turns it off.
+
+---
+
+## 5. The permission bits
+
+A DID's `MediatorACLSet` is a packed `u64`. Most permissions occupy a
+*pair* of bits — the capability, and a self-change bit saying whether the
+DID may flip it without an admin.
+
+| Bit | Flag | Enforced at |
+|-----|------|-------------|
+| 0 | `access_list_mode` | Access-list evaluation on every delivery (§6) |
+| 1 | `access_list_mode_change` | Self-service gate for bit 0 |
+| 2 | `did_blocked` | Authentication (both steps), session load, token refresh |
+| 3 | `did_local` | Inbox fetch, message list, message delete, outbound, WebSocket upgrade |
+| 4 / 5 | `send_messages` (+change) | Inbound handler (session), direct-delivery sender check |
+| 6 / 7 | `receive_messages` (+change) | Direct-delivery recipient check (DIDComm and TSP) |
+| 8 / 9 | `send_forwarded` (+change) | Forward gate (sender); anonymous inter-mediator relay |
+| 10 / 11 | `receive_forwarded` (+change) | Forward gate (next hop) |
+| 12 / 13 | `create_invites` (+change) | OOB invite handler |
+| 14 / 15 | `anon_receive` (+change) | Anonymous senders in access-list evaluation; anonymous forward next hop |
+| 16 | `self_manage_list` | Access-list add / remove / clear |
+| 17 | `self_manage_send_queue_limit` | Setting one's own send queue limit |
+| 18 | `self_manage_receive_queue_limit` | Setting one's own receive queue limit |
+
+Bits 19–63 are unassigned and must stay zero.
+
+`did_blocked` is the only bit checked at authentication. Everything else is
+checked at the point of use, which means **a DID with `DENY_ALL` still
+authenticates successfully** — it just cannot do anything afterwards. That
+is by design, but it does mean "the DID connected fine" tells you nothing
+about its permissions.
+
+### Two classes of bit
+
+- **Self-changeable** (bits 0, 4, 6, 8, 10, 12, 14): the DID may flip the
+  value when the paired `_change` bit is set. It may **never** flip the
+  `_change` bit itself.
+- **Admin-only** (bits 2, 3, 16, 17, 18): no self-change bit exists.
+  `blocked` and `local` are the mediator's own gates; the `self_manage_*`
+  bits are what delegate self-service in the first place, so a DID that
+  could set them would be granting itself the authority you withheld.
+
+A DID can therefore only ever *exercise* delegated authority, never widen
+it.
+
+---
+
+## 6. Decision walkthroughs
+
+### Authentication
+
+```
+/authenticate/challenge
+  ├─ DID is `did:`-shaped?                      else 400
+  ├─ resolve ACLs: stored, else global_acl_default
+  ├─ blocked?                                   else 403 authentication.blocked
+  ├─ unknown? → register with global_acl_default
+  └─ issue challenge
+```
+
+`mediator_acl_mode` is not consulted. Neither is any capability bit other
+than `blocked`.
+
+### Direct delivery (DIDComm and TSP)
+
+```
+├─ local_direct_delivery_allowed?               else 403 direct_delivery.denied
+├─ recipient has an account?                    else 403 direct_delivery.recipient.unknown
+├─ force_session_did_match: envelope sender == session DID?
+├─ sender has SEND_MESSAGES?                    else 403 authorization.send
+│    (anonymous sender: local_direct_delivery_allow_anon?)
+├─ recipient has RECEIVE_MESSAGES?              else 403 authorization.receive
+└─ recipient's access list admits the sender?   else 403 authorization.access_list.denied
+```
+
+### Forwarding
+
+```
+├─ sender has SEND_FORWARDED?                   else 403
+├─ next hop has RECEIVE_FORWARDED?              else 403
+├─ anonymous envelope → next hop has ANON_RECEIVE? else 403
+└─ access list check
+```
+
+### Access-list evaluation
+
+The single decision, applied on every delivery:
+
+| Sender | Recipient's mode | Verdict |
+|--------|------------------|---------|
+| Anonymous | (irrelevant) | Allowed iff `anon_receive` |
+| Known | `ExplicitAllow` (allowlist) | Allowed iff on the list |
+| Known | `ExplicitDeny` (denylist) | Allowed iff **not** on the list |
+
+### Pickup and streaming
+
+Inbox fetch, message list, message delete, outbound, and the WebSocket
+upgrade all require `LOCAL` and nothing else. Clearing `LOCAL` is the
+blunt instrument for cutting a DID off from its inbox.
+
+---
+
+## 7. Recipes
+
+| Goal | Configuration |
+|------|---------------|
+| **Open public mediator** | `mediator_acl_mode = "explicit_deny"`, `global_acl_default = "ALLOW_ALL"`. Anyone may do anything; deny per-DID afterwards. Boot warns — this accepts everything from everyone. |
+| **Open, consent-based** | `global_acl_default = "ALLOW_ALL,MODE_EXPLICIT_ALLOW"`. Anyone may register and send, but each DID's inbox is an allowlist, so nobody receives until they add senders. Add `SELF_MANAGE_LIST` so users can curate it themselves. |
+| **Direct messaging only, no relay** | `global_acl_default = "DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES"` (the shipped default). No forwarding, no invites, no self-management. |
+| **Relay only** | `global_acl_default = "DENY_ALL,SEND_FORWARDED,RECEIVE_FORWARDED"` plus `enable_inter_mediator_relay = "true"`. No inboxes: nothing is stored, nothing is picked up. |
+| **Closed / invitation-only** | `mediator_acl_mode = "explicit_allow"` and `global_acl_default = "DENY_ALL"`. Unknown DIDs still authenticate but can do nothing; an admin must grant capabilities per DID. This is the closest the mediator gets to an allowlist. |
+| **Let users manage their own privacy** | Add `MODE_SELF_CHANGE,SELF_MANAGE_LIST` and the `_CHANGE` variants of whichever capabilities you want users to control. |
+
+---
+
+## 8. Administration
+
+### Account types
+
+`Standard`, `Admin`, `RootAdmin`, `Mediator`. Admin and RootAdmin may
+operate on any DID; a Standard account may only target its own DID hash.
+Creating an Admin requires admin rights; creating a RootAdmin requires
+RootAdmin.
+
+### Admin message hardening
+
+- `block_remote_admin_msgs = "true"` (default) requires admin messages to
+  be signed by a key belonging to the session DID, so admin operations
+  cannot be relayed in from elsewhere.
+- `admin_messages_expiry` bounds replay of captured admin messages. It is
+  enforced for every admin account regardless of the setting above, and
+  rejects future-dated `created_time` as well as stale ones.
+
+### Changing ACLs
+
+Two equivalent surfaces, with identical rules:
+
+- DIDComm admin protocol: `messaging/acls/set`
+- Trust Task: `messaging/account/acl-set`
+
+An admin may set anything. A non-admin may only target its own DID, may
+only change capabilities whose self-change bit is set, may never change a
+self-change bit, and may never change an admin-only flag (§5).
+
+### Limits
+
+`access_list_limit` and `local_max_acl` cap per-DID list growth;
+`queued_send_messages_*` / `queued_receive_messages_*` cap queue depth,
+overridable per DID only when the matching `self_manage_*_queue_limit` bit
+is set.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| DID authenticates fine but every operation is 403 | `global_acl_default` is `DENY_ALL`, or too narrow. Authentication only checks `blocked`. |
+| `authorization.local` on fetch/list/WebSocket | The DID lacks `LOCAL`. |
+| `authorization.receive` on delivery | The **recipient** lacks `RECEIVE_MESSAGES`. |
+| `authorization.send` on delivery | The **sender** lacks `SEND_MESSAGES`. |
+| `authorization.access_list.denied` | Recipient's access list rejects the sender. Check the recipient's `access_list_mode`: in `ExplicitAllow` an *empty* list denies everyone. |
+| Messages silently not received, no error | Recipient's inbox mode is `ExplicitAllow` with an empty list, or `anon_receive` is unset for an anonymous sender. |
+| Setting `explicit_allow` did not stop unknown DIDs connecting | Expected. The mode does not gate authentication (§2). |
+| `acl/set` rejected with "admin-only" | You tried to change `blocked`, `local`, or a `self_manage_*` flag as a non-admin. |
+| Every new DID is blocked | `BLOCKED` was included in `global_acl_default`. |
+
+---
+
+## 10. Implementation notes
+
+Every permission decision resolves through `src/common/authz.rs`:
+
+- `require_capability` / `grants` — the capability gate
+- `check_access_list` — the sender↔recipient verdict
+- `effective_acls` — stored ACLs, else `global_acl_default`
+- `authentication_check` — the pre-auth blocked gate
+- `acl_change_ok` — non-admin self-service rules
+
+The `Capability` enum deliberately carries no `#[allow(dead_code)]`: an
+unused variant means a permission bit the mediator advertises but never
+enforces, and the dead-code warning is the tripwire for that.
+
+The backend-agnostic parts of the access-list decision live in
+`affinidi-messaging-mediator-common/src/store/ops.rs` so the Fjall and
+memory backends cannot drift; the Redis backend implements the equivalent
+logic in Lua and is kept aligned by the store conformance suite.

--- a/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/authz.rs
@@ -6,13 +6,20 @@
 //!
 //! - [`require_capability`] — does a DID's [`MediatorACLSet`] grant a given
 //!   [`Capability`]? The single source for per-capability gating.
+//! - [`check_access_list`] — may a given sender deliver to a given
+//!   recipient, under that recipient's allowlist/denylist mode?
+//! - [`effective_acls`] — the ACL set governing a DID: its stored ACLs, or
+//!   the configured `global_acl_default` when it has no account record.
 //! - [`authentication_check`] — the pre-auth "can this DID connect?" check
 //!   (resolves the ACL set from the session, the store, or the configured
 //!   default, then applies the blocked gate).
+//! - [`acl_change_ok`] — may a non-admin apply this ACL change to itself?
 //!
-//! Access-list (sender↔recipient) checks and the remaining handler/routing
-//! ACL sites migrate here in the following tasks; the capability vocabulary
-//! below is intentionally complete ahead of every call site adopting it.
+//! Every handler, routing and storage ACL gate now resolves through this
+//! module; see `docs/acls.md` for the operator-facing model these functions
+//! implement. Keep it that way — the capability enum below has no
+//! `#[allow(dead_code)]` precisely so a capability that nothing enforces
+//! shows up as a warning rather than as a silently inert permission bit.
 
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_mediator_common::store::MediatorStore;
@@ -26,10 +33,12 @@ use crate::{SharedData, common::session::Session};
 /// Mirrors the capability bits in `MediatorACLSet` (the `*_change`
 /// self-management flags are not gating capabilities and are handled by the
 /// admin-protocol layer, not here).
-// Not every variant is wired to a call site yet — the handler/routing ACL
-// checks adopt them in tasks T8/T9. Defining the full vocabulary now keeps
-// the authz surface in one place.
-#[allow(dead_code)]
+///
+/// Every variant is wired to at least one call site, and there is
+/// deliberately no `#[allow(dead_code)]` here: an unused variant means a
+/// capability the mediator advertises but never enforces. That is precisely
+/// how `ReceiveMessages` stayed inert — settable, reported over the wire and
+/// documented, but consulted by nothing. Let the dead-code warning fire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Capability {
     /// The DID is not blocked from the mediator.
@@ -107,6 +116,24 @@ pub(crate) async fn check_access_list(
     }
 }
 
+/// The ACL set that actually governs `did_hash`: its stored ACLs, or the
+/// mediator's `global_acl_default` when the DID has no account record.
+///
+/// Every ACL decision about a DID the mediator may not have registered yet
+/// must resolve it this way — an unknown DID is governed by the default,
+/// not by "no permissions". Centralised here so the fallback can't drift
+/// between the sender-side, recipient-side and routing gates.
+pub(crate) async fn effective_acls(
+    shared: &SharedData,
+    did_hash: &str,
+) -> Result<MediatorACLSet, MediatorError> {
+    Ok(shared
+        .database
+        .get_did_acl(did_hash)
+        .await?
+        .unwrap_or_else(|| shared.config.security.global_acl_default.clone()))
+}
+
 /// Pre-authentication check: is `did_hash` allowed to connect to the
 /// mediator, and is it already known?
 ///
@@ -148,11 +175,54 @@ pub(crate) async fn authentication_check(
     Ok((grants(&acls, Capability::NotBlocked), known))
 }
 
+/// A capability whose ACL entry is a `(value, self_change)` pair.
+type CapabilityPair = (&'static str, fn(&MediatorACLSet) -> (bool, bool));
+
+/// A flag with no self-change bit of its own — admin-only, always.
+type AdminOnlyFlag = (&'static str, fn(&MediatorACLSet) -> bool);
+
+/// The capabilities a DID may change itself when the matching `self_change`
+/// bit is set. `access_list_mode` is the same shape but its value is an enum
+/// rather than a `bool`, so it is checked separately below.
+const SELF_CHANGEABLE: &[CapabilityPair] = &[
+    ("send_messages", |a| a.get_send_messages()),
+    ("receive_messages", |a| a.get_receive_messages()),
+    ("send_forwarded", |a| a.get_send_forwarded()),
+    ("receive_forwarded", |a| a.get_receive_forwarded()),
+    ("create_invites", |a| a.get_create_invites()),
+    ("anon_receive", |a| a.get_anon_receive()),
+];
+
+/// Flags with no `self_change` bit of their own: only an admin may ever
+/// change them. `blocked` and `local` are the mediator's own gates (a DID
+/// must not be able to unblock itself or grant itself an inbox), and the
+/// `self_manage_*` flags are what *delegate* self-service in the first
+/// place — a DID that could set them would be granting itself the authority
+/// the operator withheld.
+const ADMIN_ONLY: &[AdminOnlyFlag] = &[
+    ("blocked", |a| a.get_blocked()),
+    ("local", |a| a.get_local()),
+    ("self_manage_list", |a| a.get_self_manage_list()),
+    ("self_manage_send_queue_limit", |a| {
+        a.get_self_manage_send_queue_limit()
+    }),
+    ("self_manage_receive_queue_limit", |a| {
+        a.get_self_manage_receive_queue_limit()
+    }),
+];
+
 /// Validate a self-initiated ACL change: for each capability, a DID may
-/// only flip the value when its `self_change` flag is set, and may never
-/// flip the `self_change` flag itself (only an admin can). Returns `None`
-/// when the change is permitted, or `Some(errors)` describing each
-/// disallowed modification.
+/// only flip the value when its `self_change` flag is set, may never flip
+/// the `self_change` flag itself, and may never touch an admin-only flag
+/// (only an admin can do either). Returns `None` when the change is
+/// permitted, or `Some(errors)` describing each disallowed modification.
+///
+/// The tables above are deliberately exhaustive over `MediatorACLSet`: every
+/// field is either self-changeable under its own bit or admin-only. The
+/// `every_acl_field_is_classified` test pins that, because an unclassified
+/// field silently becomes self-service — which is exactly how `local`,
+/// `blocked` and the three `self_manage_*` flags went unchecked here while
+/// the Trust Task path (`ensure_self_manageable`) refused them.
 ///
 /// (Relocated from the mediator admin-protocol handler so every permission
 /// decision — capability gates and self-change authorization alike — lives
@@ -163,74 +233,31 @@ pub(crate) fn acl_change_ok(
 ) -> Option<Vec<String>> {
     let mut errors = Vec::new();
 
-    if (current_acls.get_access_list_mode().0 != new_acls.get_access_list_mode().0)
-        && !current_acls.get_access_list_mode().1
-    {
-        errors.push("access_list_mode not allowed to change".to_string());
+    for (name, get) in SELF_CHANGEABLE {
+        let (current_value, current_self_change) = get(current_acls);
+        let (new_value, new_self_change) = get(new_acls);
+
+        if current_value != new_value && !current_self_change {
+            errors.push(format!("{name} not allowed to change"));
+        }
+        if current_self_change != new_self_change {
+            errors.push(format!("{name}:self_change can't modify!"));
+        }
     }
 
-    if current_acls.get_access_list_mode().1 != new_acls.get_access_list_mode().1 {
+    let (current_mode, current_mode_self_change) = current_acls.get_access_list_mode();
+    let (new_mode, new_mode_self_change) = new_acls.get_access_list_mode();
+    if current_mode != new_mode && !current_mode_self_change {
+        errors.push("access_list_mode not allowed to change".to_string());
+    }
+    if current_mode_self_change != new_mode_self_change {
         errors.push("access_list_mode:self_change can't modify!".to_string());
     }
 
-    if (current_acls.get_send_messages().0 != new_acls.get_send_messages().0)
-        && !current_acls.get_send_messages().1
-    {
-        errors.push("send_messages not allowed to change".to_string());
-    }
-
-    if current_acls.get_send_messages().1 != new_acls.get_send_messages().1 {
-        errors.push("send_messages:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_receive_messages().0 != new_acls.get_receive_messages().0)
-        && !current_acls.get_receive_messages().1
-    {
-        errors.push("receive_messages not allowed to change".to_string());
-    }
-
-    if current_acls.get_receive_messages().1 != new_acls.get_receive_messages().1 {
-        errors.push("receive_messages:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_send_forwarded().0 != new_acls.get_send_forwarded().0)
-        && !current_acls.get_send_forwarded().1
-    {
-        errors.push("send_forwarded not allowed to change".to_string());
-    }
-
-    if current_acls.get_send_forwarded().1 != new_acls.get_send_forwarded().1 {
-        errors.push("send_forwarded:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_receive_forwarded().0 != new_acls.get_receive_forwarded().0)
-        && !current_acls.get_receive_forwarded().1
-    {
-        errors.push("get_receive_forwarded not allowed to change".to_string());
-    }
-
-    if current_acls.get_receive_forwarded().1 != new_acls.get_receive_forwarded().1 {
-        errors.push("get_receive_forwarded:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_create_invites().0 != new_acls.get_create_invites().0)
-        && !current_acls.get_create_invites().1
-    {
-        errors.push("create_invites not allowed to change".to_string());
-    }
-
-    if current_acls.get_create_invites().1 != new_acls.get_create_invites().1 {
-        errors.push("create_invites:self_change can't modify!".to_string());
-    }
-
-    if (current_acls.get_anon_receive().0 != new_acls.get_anon_receive().0)
-        && !current_acls.get_anon_receive().1
-    {
-        errors.push("anon_receive not allowed to change".to_string());
-    }
-
-    if current_acls.get_anon_receive().1 != new_acls.get_anon_receive().1 {
-        errors.push("anon_receive:self_change can't modify!".to_string());
+    for (name, get) in ADMIN_ONLY {
+        if get(current_acls) != get(new_acls) {
+            errors.push(format!("{name} is admin-only and can't be changed"));
+        }
     }
 
     if errors.is_empty() {
@@ -275,6 +302,7 @@ pub(crate) fn admin_message_ttl_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 
     #[test]
     fn admin_ttl_accepts_fresh_and_rejects_stale_future_and_missing() {
@@ -391,6 +419,149 @@ mod tests {
         // Blocking does not clear the other capability bits — `NotBlocked`
         // is the gate that must be checked separately.
         assert!(grants(&acls, Capability::SendMessages));
+    }
+
+    // ─── acl_change_ok (non-admin self-service) ──────────────────────────────
+
+    /// The highest bit position `MediatorACLSet` assigns a meaning to
+    /// (`self_manage_receive_queue_limit`).
+    const HIGHEST_ACL_BIT: u32 = 18;
+
+    #[test]
+    fn identical_acls_are_never_a_change() {
+        let acls = MediatorACLSet::from_u64(0);
+        assert_eq!(acl_change_ok(&acls, &acls), None);
+        let allow = allow_all();
+        assert_eq!(acl_change_ok(&allow, &allow), None);
+    }
+
+    /// Every meaningful bit must be refused for an account holding no
+    /// self-change rights. This is the exhaustiveness guard: a field that
+    /// falls out of both `SELF_CHANGEABLE` and `ADMIN_ONLY` becomes silently
+    /// self-service, which is the bug this test exists to prevent.
+    #[test]
+    fn every_acl_field_is_classified() {
+        // Base: all bits clear — no capability, no self-change right.
+        let current = MediatorACLSet::from_u64(0);
+        for bit in 0..=HIGHEST_ACL_BIT {
+            let new_acls = MediatorACLSet::from_u64(1_u64 << bit);
+            assert!(
+                acl_change_ok(&current, &new_acls).is_some(),
+                "bit {bit} is not gated for a non-admin — it is in neither \
+                 SELF_CHANGEABLE nor ADMIN_ONLY"
+            );
+        }
+    }
+
+    /// A non-admin may never change `blocked`, `local`, or the three
+    /// `self_manage_*` flags: none of them has a self-change bit, so the
+    /// only authority that can flip them is an admin. Regression test —
+    /// these five were unchecked here while the Trust Task path refused
+    /// them, letting a standard DID grant itself an inbox (`local`), the
+    /// right to edit its own access list (`self_manage_list`), or clear its
+    /// own `blocked` bit.
+    #[test]
+    fn non_admin_cannot_change_admin_only_flags() {
+        // Start from ALLOW_ALL so every *self-change* bit is set: the only
+        // thing that can refuse these flags is the admin-only rule itself.
+        let current = allow_all();
+
+        for (name, get) in ADMIN_ONLY {
+            let mut new_acls = current.clone();
+            match *name {
+                "blocked" => new_acls.set_blocked(!get(&current)),
+                "local" => new_acls.set_local(!get(&current)),
+                "self_manage_list" => new_acls.set_self_manage_list(!get(&current)),
+                "self_manage_send_queue_limit" => {
+                    new_acls.set_self_manage_send_queue_limit(!get(&current))
+                }
+                "self_manage_receive_queue_limit" => {
+                    new_acls.set_self_manage_receive_queue_limit(!get(&current))
+                }
+                other => panic!("unclassified admin-only flag: {other}"),
+            }
+
+            let errors = acl_change_ok(&current, &new_acls)
+                .unwrap_or_else(|| panic!("{name} must be refused for a non-admin"));
+            assert!(
+                errors.iter().any(|e| e.contains(name)),
+                "expected an error naming {name}, got {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn capability_flips_only_when_its_self_change_bit_is_set() {
+        // ALLOW_ALL grants every capability *and* every self-change bit, so
+        // revoking a capability from oneself is permitted.
+        let current = allow_all();
+        let mut new_acls = current.clone();
+        new_acls.set_send_messages(false, true, false).unwrap();
+        assert_eq!(acl_change_ok(&current, &new_acls), None);
+
+        // The shipped default grants capabilities but no self-change bits,
+        // so the same flip is refused.
+        let current =
+            MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
+                .expect("shipped default ruleset");
+        let mut new_acls = current.clone();
+        new_acls.set_send_messages(false, false, true).unwrap();
+        let errors = acl_change_ok(&current, &new_acls).expect("must be refused");
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "send_messages not allowed to change"),
+            "got {errors:?}"
+        );
+    }
+
+    /// A DID may never widen its own authority by setting the self-change
+    /// bits, even when it currently holds them.
+    #[test]
+    fn self_change_bits_are_never_self_modifiable() {
+        let current = allow_all();
+        let mut new_acls = current.clone();
+        // Keep the value, drop the self-change right.
+        new_acls
+            .set_receive_messages(current.get_receive_messages().0, false, true)
+            .unwrap();
+        let errors = acl_change_ok(&current, &new_acls).expect("must be refused");
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "receive_messages:self_change can't modify!"),
+            "got {errors:?}"
+        );
+    }
+
+    /// The access-list mode is a self-changeable capability like the others,
+    /// but its value is an enum rather than a `bool` so it is checked on its
+    /// own path — cover it explicitly.
+    #[test]
+    fn access_list_mode_follows_its_self_change_bit() {
+        let current = MediatorACLSet::from_u64(0);
+        let mut new_acls = current.clone();
+        new_acls
+            .set_access_list_mode(AccessListModeType::ExplicitDeny, false, true)
+            .unwrap();
+        let errors = acl_change_ok(&current, &new_acls).expect("must be refused");
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "access_list_mode not allowed to change"),
+            "got {errors:?}"
+        );
+
+        // With the self-change bit set, the same flip is allowed.
+        let mut current = MediatorACLSet::from_u64(0);
+        current
+            .set_access_list_mode(AccessListModeType::ExplicitAllow, true, true)
+            .unwrap();
+        let mut new_acls = current.clone();
+        new_acls
+            .set_access_list_mode(AccessListModeType::ExplicitDeny, true, true)
+            .unwrap();
+        assert_eq!(acl_change_ok(&current, &new_acls), None);
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/challenge.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/challenge.rs
@@ -62,11 +62,18 @@ pub async fn authentication_challenge(
         did_hash = session.did_hash.clone()
     );
     async move {
-        // ACL Checks to be done
-        // 1. Do we know this DID?
-        //   1.1 If yes, then is it blocked?
-        // 2. If not known, then does the mediator acl_mode allow for new accounts?
-        // 3. If yes, then add the account and continue
+        // ACL checks at the door:
+        // 1. Do we know this DID? If so, is it blocked?
+        // 2. If we don't know it, register it with `global_acl_default`.
+        //
+        // Note what is deliberately NOT here: `mediator_acl_mode` plays no
+        // part in authentication. Any DID that can complete the challenge
+        // gets an account, and `global_acl_default` decides what that
+        // account may then do — including `DENY_ALL`, which authenticates
+        // fine but can do nothing. The mode governs who may *pre-register
+        // other* DIDs (see the account_add handlers), not who may connect.
+        // `global_acl_default` is the control that gates a public mediator;
+        // see docs/acls.md.
 
         // Check if DID is allowed to connect
         let (allowed, known) = authz::authentication_check(&state, &session.did_hash, None).await?;

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
@@ -409,20 +409,31 @@ pub async fn authentication_response(
     .await
 }
 
-/// Check if the DID is already registered and set up (as needed)
-/// A DID is only registered if local accounts are enabled via ACL
+/// Backstop registration for a DID that reached the response step without an
+/// account record.
+///
+/// In the normal flow this is a no-op: `/authenticate/challenge` already
+/// registered the DID with `global_acl_default` (unconditionally — see the
+/// note there), and a session must exist to get this far, so
+/// `account_exists` is true every time. It is kept as a backstop in case the
+/// account is removed between the two auth steps.
+///
+/// Registration here uses the same ACLs and the same unconditional policy as
+/// the challenge step. It previously registered only when
+/// `global_acl_default` granted `LOCAL`, which could never actually differ
+/// from the challenge step's behaviour but read as though the two steps
+/// disagreed about who gets an account.
 async fn _register_did_and_setup(state: &SharedData, did_hash: &str) -> Result<(), MediatorError> {
     // Do we already know about this DID?
     if state.database.account_exists(did_hash).await? {
         debug!("DID({}) already registered", did_hash);
         return Ok(());
-    } else if state.config.security.global_acl_default.get_local() {
-        // Register the DID as a local DID
-        state
-            .database
-            .account_add(did_hash, &state.config.security.global_acl_default, None)
-            .await?;
     }
+
+    state
+        .database
+        .account_add(did_hash, &state.config.security.global_acl_default, None)
+        .await?;
 
     Ok(())
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/inbox_fetch.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/inbox_fetch.rs
@@ -1,4 +1,8 @@
-use crate::{SharedData, common::session::Session};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+};
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::messages::{
     GetMessagesResponse,
@@ -33,7 +37,7 @@ pub async fn inbox_fetch_handler(
     );
     async move {
         // ACL Check
-        if !session.acls.get_local() {
+        if authz::require_capability(&session.acls, Capability::Local).is_err() {
             return Err(MediatorError::problem(
                 40, session.session_id, None,
                 ProblemReportSorter::Error, ProblemReportScope::Protocol,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_delete.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_delete.rs
@@ -1,4 +1,8 @@
-use crate::{SharedData, common::session::Session};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+};
 use affinidi_messaging_mediator_common::{
     errors::{AppError, MediatorError, SuccessResponse},
     store::DeletionAuthority,
@@ -36,7 +40,7 @@ pub async fn message_delete_handler(
     );
     async move {
         // ACL Check
-        if !session.acls.get_local() {
+        if authz::require_capability(&session.acls, Capability::Local).is_err() {
             return Err(MediatorError::problem(
                 40,
                 session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_list.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_list.rs
@@ -1,4 +1,8 @@
-use crate::{SharedData, common::session::Session};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+};
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::{
@@ -42,7 +46,7 @@ pub async fn message_list_handler(
     );
     async move {
         // ACL Check
-        if !session.acls.get_local() {
+        if authz::require_capability(&session.acls, Capability::Local).is_err() {
             return Err(MediatorError::problem(
                 40,
                 session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_outbound.rs
@@ -10,7 +10,11 @@ use axum::{Json, extract::State};
 use http::StatusCode;
 use tracing::{Instrument, Level, debug, span};
 
-use crate::{SharedData, common::session::Session};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+};
 
 /// Delivers messages to the client for given message_ids
 /// outbound refers to outbound from the mediator perspective
@@ -28,7 +32,7 @@ pub async fn message_outbound_handler(
     );
     async move {
         // ACL Check
-        if !session.acls.get_local() {
+        if authz::require_capability(&session.acls, Capability::Local).is_err() {
             return Err(MediatorError::problem(
                 40,
                 session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/oob_discovery.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/oob_discovery.rs
@@ -13,7 +13,11 @@
  Alice and Bob then swap messages and create a confidential communication channel between themselves.
 */
 
-use crate::{SharedData, common::session::Session};
+use crate::{
+    SharedData,
+    common::authz::{self, Capability},
+    common::session::Session,
+};
 use affinidi_messaging_didcomm::message::Message;
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::{
@@ -44,7 +48,7 @@ pub async fn oob_invite_handler(
     Json(body): Json<Message>,
 ) -> Result<(StatusCode, Json<SuccessResponse<OOBInviteResponse>>), AppError> {
     // ACL Check
-    if !session.acls.get_create_invites().0 {
+    if authz::require_capability(&session.acls, Capability::CreateInvites).is_err() {
         return Err(MediatorError::problem(
             45,
             session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -5,6 +5,7 @@ use crate::didcomm_compat;
 use crate::messages::inbound::handle_inbound_tsp;
 use crate::{
     SharedData,
+    common::authz::{self, Capability},
     common::config::{CorsOriginPolicy, origin_matches},
     common::jwt_auth::{AuthError, authenticate_token},
     common::session::Session,
@@ -211,7 +212,7 @@ pub async fn websocket_handler(
     );
 
     // 3. ACL Check (websockets only work on local DID's).
-    if !session.acls.get_local() {
+    if authz::require_capability(&session.acls, Capability::Local).is_err() {
         let error: AppError = MediatorError::problem(
             40,
             session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -316,9 +316,20 @@ async fn deliver_opaque(
         ));
     }
 
-    // Access-list check (sender → recipient), mirroring DIDComm direct delivery.
-    // The mediator routes on the authenticated sender and the recipient verifies
+    // Recipient-side ACL checks, mirroring DIDComm direct delivery. The
+    // mediator routes on the authenticated sender and the recipient verifies
     // the (opaque) message end-to-end on pickup.
+    let to_acls = authz::effective_acls(state, &to_hash).await?;
+    if authz::require_capability(&to_acls, Capability::ReceiveMessages).is_err() {
+        return Err(tsp_problem(
+            session,
+            74,
+            "authorization.receive",
+            "Recipient DID is not authorized to receive messages through this mediator".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
     let from_hash = digest(from_vid.as_bytes());
     if authz::check_access_list(state.database.as_ref(), &to_hash, Some(&from_hash))
         .await
@@ -699,14 +710,7 @@ async fn handle_inbound_didcomm(
                     let from_hash = envelope.from_did.as_ref().map(digest);
                     // Check if the message will pass ACL Checks
                     if let Some(from) = &envelope.from_did {
-                        let from_acls = if let Some(acl) = state
-                            .database
-                            .get_did_acl(&digest(from))
-                            .await? {
-                                acl
-                        } else {
-                            state.config.security.global_acl_default.clone()
-                        };
+                        let from_acls = authz::effective_acls(state, &digest(from)).await?;
 
                         if authz::require_capability(&from_acls, Capability::SendMessages).is_err() {
                             return Err(MediatorError::problem(
@@ -734,6 +738,26 @@ async fn handle_inbound_didcomm(
                             StatusCode::FORBIDDEN,
                         ));
                     }
+                    // Recipient-side gate, mirroring the sender's SEND_MESSAGES
+                    // check above: a DID whose ACLs withhold RECEIVE_MESSAGES
+                    // does not accept directly-delivered messages at all,
+                    // regardless of who the sender is. Checked before the access
+                    // list because it is the coarser of the two.
+                    let to_acls = authz::effective_acls(state, &digest(to_did)).await?;
+                    if authz::require_capability(&to_acls, Capability::ReceiveMessages).is_err() {
+                        return Err(MediatorError::problem(
+                            74,
+                            &session.session_id,
+                            None,
+                            ProblemReportSorter::Error,
+                            ProblemReportScope::Protocol,
+                            "authorization.receive",
+                            "Recipient DID is not authorized to receive messages through this mediator",
+                            vec![],
+                            StatusCode::FORBIDDEN,
+                        ));
+                    }
+
                     if authz::check_access_list(
                         state.database.as_ref(),
                         &digest(to_did),

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -428,7 +428,9 @@ async fn deliver_forward(
         }
     };
 
-    if next_envelope.from_did.is_none() && !next_acls.get_anon_receive().0 {
+    if next_envelope.from_did.is_none()
+        && authz::require_capability(next_acls, Capability::AnonReceive).is_err()
+    {
         return Err(MediatorError::problem(
             69,
             &session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Changelog history
 
+## 27th July 2026
+
+### 0.1.24 — correct the Closed network-mode help text
+
+The wizard described Closed mode as "`mediator_acl_mode = explicit_allow`
+… every cross-DID exchange requires an explicit ACL grant". The mode does
+not do that — it governs only who may pre-register other DIDs via
+`account_add`, and never gates authentication. What actually makes Closed
+mode closed is the denying `global_acl_default` the wizard emits alongside
+it. The help text now says so. Emitted config is unchanged.
+
+See `affinidi-messaging-mediator` 0.17.11 and its `docs/acls.md`.
+
 ## 26th July 2026
 
 ### 0.1.23 — accept `vta-sdk` 0.20

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.23"
+version = "0.1.24"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -2746,7 +2746,7 @@ impl WizardApp {
                 } else if self.security_phase == Some(SecurityPhase::NetworkMode) {
                     match self.selection_index {
                         0 => "Open mode emits `mediator_acl_mode = \"explicit_deny\"`, `global_acl_default = \"ALLOW_ALL\"`, and `local_direct_delivery_allowed = \"true\"`. Any DID may reach any other by default; use the ACL to deny on a per-DID basis.".into(),
-                        1 => "Closed mode keeps the historical posture: `mediator_acl_mode = \"explicit_allow\"` with a denying default ACL. Every cross-DID exchange requires an explicit ACL grant. Pick this for restricted or invitation-only deployments.".into(),
+                        1 => "Closed mode emits `mediator_acl_mode = \"explicit_allow\"` (only admins may pre-register other DIDs) with a denying default ACL, so a DID that self-registers gets no capabilities until an admin grants them. Note that neither mode blocks authentication itself — the denying default ACL is what makes this closed. Pick this for restricted or invitation-only deployments.".into(),
                         _ => String::new(),
                     }
                 } else if self.security_phase == Some(SecurityPhase::JwtMode) {

--- a/docker/conf/mediator.toml
+++ b/docker/conf/mediator.toml
@@ -59,7 +59,9 @@ database_url = "redis://redis:6379/"
 database_timeout = "2"
 
 [security]
-mediator_acl_mode = "explicit_allow"
+### Governs who may pre-register other DIDs, NOT who may authenticate.
+### global_acl_default below is what gates an arbitrary DID. See docs/acls.md.
+mediator_acl_mode = "explicit_deny"
 global_acl_default = "DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES"
 local_direct_delivery_allowed = "true"
 local_direct_delivery_allow_anon = "false"


### PR DESCRIPTION
Review of every ACL call site in the mediator, prompted by a question about whether the observed behaviour of `mediator_acl_mode` was intended. It largely was not documented accurately anywhere.

**Three behavioural changes, all tightening. Please read the first two before merging.**

## 🔒 A non-admin could grant itself admin-only ACL flags

`authz::acl_change_ok`, which gates `messaging/acls/set`, validated only the seven capability bits that carry a self-change flag. The five flags with **no** self-change bit — `blocked`, `local`, `self_manage_list`, `self_manage_send_queue_limit`, `self_manage_receive_queue_limit` — were not checked at all, and `check_permissions` lets a Standard account target its own DID.

A standard DID could therefore:

- grant itself `LOCAL` — an inbox, message storage and WebSocket access — on a mediator whose default withholds it
- grant itself `self_manage_list` and curate its own access list
- grant itself the queue-limit overrides
- clear its own `blocked` bit while holding a valid session

The Trust Task path (`ensure_self_manageable`) already refused all five, and its doc comment claims to be "faithful to the legacy `acls_set` rules" — so the DIDComm path was the outlier and the intent was unambiguous.

`acl_change_ok` is now table-driven over the two classes of bit, with an exhaustiveness test that fails if a future ACL field is left unclassified. An unclassified field silently becomes self-service, which is exactly how these five were missed.

## ⚠️ `RECEIVE_MESSAGES` is now enforced

The bit was settable, shipped in the default ACL string, reported over the wire, gated for self-change, and documented as "DID can receive messages" — and **read by no code path**. Clearing it did nothing. The only commit that has ever mentioned `Capability::ReceiveMessages` is the one that defined the vocabulary with `#[allow(dead_code)]`.

Direct delivery now checks the recipient's `RECEIVE_MESSAGES` (DIDComm and TSP), mirroring the existing sender-side `SEND_MESSAGES` gate, rejecting with `authorization.receive` / problem code 74.

**Upgrade impact:** a local DID whose stored ACL omits the bit stops receiving directly-delivered messages. Shipped defaults include it, so default deployments are unaffected — audit any account provisioned with a custom ACL. Forwarded delivery is unchanged; `RECEIVE_FORWARDED` was already enforced.

## ⚙️ Shipped `mediator_acl_mode` default is now `explicit_deny`

`explicit_allow` reads as a closed allowlist but is not one: the mode governs only who may pre-register *other* DIDs via `account_add`, and never gates authentication. `explicit_deny` honestly describes an out-of-the-box mediator, and matches both the built-in code default (`security.rs`) and the setup wizard's default profile.

Consequence: non-admins may now call `account_add`. Bounded — a non-admin's `account_add` always applies `global_acl_default`, which the target DID would have received by self-registering anyway. Set `explicit_allow` explicitly to keep the old restriction.

## The model, for reviewers

`mediator_acl_mode` does **not** gate authentication. Any DID that completes the challenge is auto-registered with `global_acl_default`, unconditionally, in either mode. `global_acl_default` is the real access control for a public mediator. The README previously described `explicit_allow` as "deny all DIDs except those explicitly allowed"; the mediator has never behaved that way.

Also note two layers share `AccessListModeType` while meaning different things: the mediator-wide mode (who may add accounts) and a DID's own `access_list_mode` bit (allowlist vs denylist of senders). For the latter, `ExplicitAllow` is the *closed* posture.

## Also in this PR

- Every handler, routing and storage ACL gate now resolves through `common::authz`. The `Capability` enum lost its `#[allow(dead_code)]`, so a capability nothing enforces surfaces as a dead-code warning — that allow is how `RECEIVE_MESSAGES` stayed inert.
- New `authz::effective_acls` centralises "stored ACLs, else `global_acl_default`", previously inlined at three call sites.
- `get_access_list_mode_admin_change` returned the *self-change* bit despite its name and doc saying the inverse. Deprecated in favour of `get_access_list_mode_self_change`; the alias delegates, so not breaking.
- `MediatorACLSet` now documents its two classes of bit, and that the packed `acl: u64` is the source of truth while the named fields are a mirror kept in sync by the setters.
- The auth-response registration backstop no longer applies a different condition from the challenge step (it could never fire, but read as though the two steps disagreed).
- Corrected the README ACL section and the setup wizard's Closed-mode help text.
- **New [`docs/acls.md`](https://github.com/affinidi/affinidi-tdk-rs/blob/fix/mediator-acl-audit/crates/messaging/affinidi-messaging-mediator/docs/acls.md)** — the four layers, every permission bit and where it is enforced, all five registration paths (they do not grant the same ACLs), decision walkthroughs, deployment recipes, and a symptom-to-cause troubleshooting table.

## Testing

- 168 mediator lib tests, 194 mediator-common, 402 mediator-setup — all pass
- clippy clean (`--all-targets`), `cargo fmt --check` clean
- changelog + version-bump guards pass
- The regression tests were confirmed **non-vacuous**: temporarily reverting the fix makes both fail, naming the exact unguarded bit (`bit 2 is not gated for a non-admin`)

**Gap:** the integration suite requires Redis, which was unavailable in the dev environment (no Docker either), so only fjall-backed tests could run locally. The new `RECEIVE_MESSAGES` gate has unit coverage at the decision layer but **no end-to-end test** — it mirrors the adjacent, already-tested `SEND_MESSAGES` gate, but was not exercised. Worth adding in CI where Redis is present.

## Coordination

Per R3.6: the `RECEIVE_MESSAGES` enforcement is a delivery-semantics change affecting every service that pins this mediator loosely. Both behavioural changes are called out prominently in the mediator CHANGELOG. Worth confirming no deployment provisions accounts with a custom ACL omitting `RECEIVE_MESSAGES` before publishing.

Versions: mediator 0.17.10 → 0.17.11, mediator-common 0.15.30 → 0.15.31, mediator-setup 0.1.23 → 0.1.24.