### PR TITLE
perf: one recipient lookup per direct delivery instead of three

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Changelog history
 
+## 27th July 2026 (2)
+
+### 0.17.12 — direct delivery does one recipient lookup instead of three
+
+Performance follow-up to the ACL audit in 0.17.11. No behavioural change to
+who may deliver to whom; the same gates run in the same order and return the
+same problem codes.
+
+Direct delivery asked the store three separate questions about the *same*
+recipient record:
+
+- `account_exists` — does the account exist?
+- `get_did_acl` — what are its ACL bits? (added by 0.17.11's
+  `RECEIVE_MESSAGES` gate)
+- `access_list_allowed` — does its access list admit this sender? (which
+  internally re-reads the ACL bits to get the mode)
+
+All three are derivable from one read. The new
+`MediatorStore::delivery_decision` returns them together — `None` for an
+unknown recipient, otherwise the ACL set plus the already-interpreted
+access-list verdict — taking the DIDComm and TSP direct-delivery paths from
+four store round trips to two (sender ACL, then recipient decision). On
+Redis the recipient half is a single pipelined `SISMEMBER` + `HGET` that was
+already there; it now serves all three answers instead of one.
+
+The trait method ships with a default implementation in terms of the
+existing calls, so third-party backends keep compiling unchanged. Redis,
+Fjall and Memory each override it, and a new
+`delivery_decision_matches_access_list` conformance check pins every
+backend's optimised version against `access_list_allowed` on the same store
+— including the anonymous-sender branch, where the verdict comes from
+`anon_receive` rather than the list.
+
+Also:
+
+- `digest(to_did)` was being recomputed three times per message on the
+  DIDComm direct-delivery path (a SHA-256 over the DID string each time).
+  Hoisted to one, matching what the TSP path already did.
+- The Redis `access_list_allowed` is now expressed in terms of
+  `delivery_decision`, and applies the allowlist/denylist rule via the
+  shared `store::ops::access_list_allowed` rather than its own inline copy —
+  removing the third implementation of that rule. Fail-closed behaviour on a
+  missing account or backend error is unchanged.
+- Edge-case note: a corrupt account record that exists but has no `ACLS`
+  field now reports `direct_delivery.recipient.unknown` (72) where it
+  previously reported `authorization.access_list.denied` (73). Both deny
+  delivery; only the problem code differs.
+
 ## 27th July 2026
 
 ### 0.17.11 — ACL audit: privilege-escalation fix, `RECEIVE_MESSAGES` now enforced, ACL guide

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.11"
+version = "0.17.12"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -90,7 +90,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.31", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.32", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.2", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Changelog history
 
+## 27th July 2026 (2)
+
+### 0.15.32 — `MediatorStore::delivery_decision`
+
+New trait method plus the `DeliveryDecision` type it returns. Additive: it
+carries a default implementation written in terms of the existing
+`get_did_acl` + `access_list_allowed`, so existing backends outside this
+workspace keep compiling and behaving identically.
+
+It exists so a backend can answer the three questions the recipient side of
+direct delivery asks — does this account exist, what are its ACL bits, does
+its access list admit this sender — from one read of the single record they
+all derive from, instead of three. Backends that can batch should override
+it; `RedisStore` does, serving all three from the pipelined `SISMEMBER` +
+`HGET` it already issued.
+
+`RedisStore::access_list_allowed` is now expressed in terms of the new
+method and applies the allowlist/denylist rule via the shared
+`store::ops::access_list_allowed` instead of its own inline copy, so that
+rule now has one implementation rather than three. Its fail-closed contract
+(missing account or backend error ⇒ `false`) is unchanged.
+
+See `affinidi-messaging-mediator` 0.17.12.
+
 ## 27th July 2026
 
 ### 0.15.31 — `MediatorACLSet` documentation + one renamed getter

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.31"
+version = "0.15.32"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -67,9 +67,9 @@ pub mod ops;
 pub mod redis;
 
 pub use types::{
-    DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MessageMetaData,
-    MetadataStats, PubSubRecord, Session, SessionClaims, SessionState, SessionSweepReport,
-    StatCounter, StoreHealth, StreamingClientState,
+    DeletionAuthority, DeliveryDecision, ExpiryReport, ForwardQueueEntry, InboxStatusReply,
+    MessageMetaData, MetadataStats, PubSubRecord, Session, SessionClaims, SessionState,
+    SessionSweepReport, StatCounter, StoreHealth, StreamingClientState,
 };
 
 /// Fail-closed session rename used by the default
@@ -364,6 +364,37 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
     /// ExplicitDeny). For anonymous senders (`from_hash = None`),
     /// consults `to_hash`'s `anon_receive` ACL bit.
     async fn access_list_allowed(&self, to_hash: &str, from_hash: Option<&str>) -> bool;
+
+    /// Everything the recipient-side delivery gate needs about `to_hash`, in
+    /// as few round trips as the backend can manage. Returns `None` when the
+    /// account does not exist.
+    ///
+    /// The direct-delivery path needs three facts about one recipient — does
+    /// the account exist, does it grant `RECEIVE_MESSAGES`, and does its
+    /// access list admit this sender — which are all derivable from the same
+    /// stored record. Fetching them via `account_exists` + `get_did_acl` +
+    /// `access_list_allowed` costs three reads of that record; this method
+    /// exists so a backend can serve all three from one.
+    ///
+    /// The default implementation is the unoptimised two-call version, so
+    /// third-party backends keep working unchanged. Backends that can batch
+    /// should override it — [`RedisStore`] already pipelines the membership
+    /// probe and the ACL read into a single round trip, and the in-process
+    /// backends read one record.
+    async fn delivery_decision(
+        &self,
+        to_hash: &str,
+        from_hash: Option<&str>,
+    ) -> Result<Option<DeliveryDecision>, MediatorError> {
+        let Some(acls) = self.get_did_acl(to_hash).await? else {
+            return Ok(None);
+        };
+        let access_list_allows = self.access_list_allowed(to_hash, from_hash).await;
+        Ok(Some(DeliveryDecision {
+            acls,
+            access_list_allows,
+        }))
+    }
 
     /// Page through a DID's access list using a server-side cursor. Pass `0` to
     /// start; feed the returned `cursor` back in for the next page.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/acls.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/acls.rs
@@ -1,5 +1,6 @@
 use super::Database;
 use crate::errors::MediatorError;
+use crate::store::{DeliveryDecision, ops};
 use crate::types::{
     acls::{AccessListModeType, MediatorACLSet},
     acls_handler::{
@@ -143,14 +144,41 @@ impl Database {
     /// - `from_hash` - Hash of the DID we are checking for (typically the FROM address)
     ///
     /// Returns true if it exists, false otherwise
+    ///
+    /// Expressed in terms of [`Self::delivery_decision`] so the mode
+    /// interpretation lives in exactly one place. Preserves the fail-closed
+    /// contract: a missing account or a backend error is `false`.
     pub async fn access_list_allowed(&self, to_hash: &str, from_hash: Option<&str>) -> bool {
-        let Ok(mut con) = self.get_connection().await else {
-            warn!("Failed to get database connection");
-            return false;
-        };
+        match self.delivery_decision(to_hash, from_hash).await {
+            Ok(Some(decision)) => decision.access_list_allows,
+            Ok(None) => {
+                debug!("ACL not found for DID: {}", to_hash);
+                false
+            }
+            Err(err) => {
+                warn!("access_list_allowed failed. Reason: {}", err);
+                false
+            }
+        }
+    }
 
-        if let Some(from_hash) = from_hash {
-            let (exists, acl): (bool, Option<String>) = match redis::pipe()
+    /// Recipient-side delivery inputs in a single round trip.
+    ///
+    /// For a known sender this is one pipelined `SISMEMBER` + `HGET`: the
+    /// access-list membership probe and the recipient's ACL bitmask come back
+    /// together, and the mode is then applied in-process by
+    /// [`ops::access_list_allowed`]. Callers that also need existence and a
+    /// capability check get them from the same result rather than issuing
+    /// `account_exists` and `get_did_acl` of their own.
+    pub(crate) async fn delivery_decision(
+        &self,
+        to_hash: &str,
+        from_hash: Option<&str>,
+    ) -> Result<Option<DeliveryDecision>, MediatorError> {
+        let mut con = self.get_connection().await?;
+
+        let (acl, sender) = if let Some(from_hash) = from_hash {
+            let (on_access_list, acl): (bool, Option<String>) = redis::pipe()
                 .atomic()
                 .cmd("SISMEMBER")
                 .arg(["ACCESS_LIST:", to_hash].concat())
@@ -164,48 +192,45 @@ impl Database {
                     MediatorError::DatabaseError(
                         14,
                         "NA".to_string(),
-                        format!("access_list_allowed failed. Reason: {err}"),
+                        format!("delivery_decision failed. Reason: {err}"),
                     )
-                }) {
-                Ok(result) => result,
-                Err(err) => {
-                    warn!("access_list_allowed failed. Reason: {}", err);
-                    return false;
-                }
-            };
+                })?;
 
-            let acl = if let Some(acl) = acl {
-                if let Ok(acls) = MediatorACLSet::from_hex_string(&acl) {
-                    acls
-                } else {
-                    warn!("Failed to parse ACL for to_hash({})", to_hash);
-                    return false;
-                }
-            } else {
-                debug!("ACL not found for DID: {}", to_hash);
-                return false;
-            };
-
-            if acl.get_access_list_mode().0 == AccessListModeType::ExplicitAllow {
-                debug!(
-                    "access_list_allowed == true for to_hash({}), from_hash({})",
-                    to_hash, from_hash
-                );
-                exists
-            } else {
-                debug!(
-                    "access_list_allowed == false for to_hash({}), from_hash({})",
-                    to_hash, from_hash
-                );
-                !exists
-            }
+            (acl, ops::Sender::Known { on_access_list })
         } else {
-            // Anonymous Message
-            match self.get_did_acl(to_hash).await {
-                Ok(Some(acl)) => acl.get_anon_receive().0,
-                _ => false,
-            }
-        }
+            // Anonymous sender: the access list is irrelevant, only the
+            // recipient's anon_receive bit matters — so skip the membership
+            // probe and read the ACL alone.
+            let acl: Option<String> = Cmd::hget(["DID:", to_hash].concat(), "ACLS")
+                .query_async(&mut con)
+                .await
+                .map_err(|err| {
+                    MediatorError::DatabaseError(
+                        14,
+                        "NA".to_string(),
+                        format!("delivery_decision failed. Reason: {err}"),
+                    )
+                })?;
+
+            (acl, ops::Sender::Anonymous)
+        };
+
+        let Some(acl) = acl else {
+            return Ok(None);
+        };
+        let acls = MediatorACLSet::from_hex_string(&acl)
+            .map_err(|e| MediatorError::InternalError(26, to_hash.into(), e.to_string()))?;
+        let access_list_allows = ops::access_list_allowed(&acls, sender);
+
+        debug!(
+            to_hash,
+            access_list_allows, "delivery_decision resolved for recipient"
+        );
+
+        Ok(Some(DeliveryDecision {
+            acls,
+            access_list_allows,
+        }))
     }
 
     /// Retrieves DID hashes from the Access List

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -13,6 +13,7 @@
 //! subscribers can share one Redis pubsub bridge.
 
 use crate::circuit_breaker::CircuitBreaker;
+use crate::store::DeliveryDecision;
 use crate::store::redis::database::{
     forwarding::ForwardQueueEntry as InnerForwardEntry, stats::MetadataStats as InnerMetadataStats,
     store::MessageMetaData as InnerMessageMetaData,
@@ -706,6 +707,14 @@ impl MediatorStore for RedisStore {
 
     async fn access_list_allowed(&self, to_hash: &str, from_hash: Option<&str>) -> bool {
         self.access_list_allowed(to_hash, from_hash).await
+    }
+
+    async fn delivery_decision(
+        &self,
+        to_hash: &str,
+        from_hash: Option<&str>,
+    ) -> Result<Option<DeliveryDecision>, MediatorError> {
+        self.delivery_decision(to_hash, from_hash).await
     }
 
     async fn access_list_list(

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/types.rs
@@ -317,6 +317,23 @@ impl DeletionAuthority {
     }
 }
 
+/// The recipient-side facts a delivery gate needs, resolved in one lookup.
+///
+/// Returned by [`MediatorStore::delivery_decision`]. Existence is carried by
+/// the `Option` around this struct, so a caller that would otherwise call
+/// `account_exists` separately does not need to.
+///
+/// [`MediatorStore::delivery_decision`]: crate::store::MediatorStore::delivery_decision
+#[derive(Clone, Debug)]
+pub struct DeliveryDecision {
+    /// The recipient's stored ACL set — check capabilities against this.
+    pub acls: MediatorACLSet,
+    /// Whether the recipient's access list admits this particular sender,
+    /// already interpreted per the recipient's allowlist/denylist mode (and,
+    /// for an anonymous sender, per its `anon_receive` bit).
+    pub access_list_allows: bool,
+}
+
 // ─── Live streaming state ───────────────────────────────────────────────────
 
 /// State of a live-streaming subscriber, set by the WebSocket task as

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -304,8 +304,17 @@ async fn deliver_opaque(
     bytes: &[u8],
 ) -> Result<InboundMessageResponse, MediatorError> {
     let to_hash = digest(to_vid.as_bytes());
+    let from_hash = digest(from_vid.as_bytes());
 
-    if !state.database.account_exists(&to_hash).await? {
+    // Recipient-side ACL checks, mirroring DIDComm direct delivery: existence,
+    // RECEIVE_MESSAGES and the access-list verdict all come from one lookup.
+    // The mediator routes on the authenticated sender and the recipient
+    // verifies the (opaque) message end-to-end on pickup.
+    let Some(recipient) = state
+        .database
+        .delivery_decision(&to_hash, Some(&from_hash))
+        .await?
+    else {
         return Err(tsp_problem(
             session,
             58,
@@ -314,13 +323,9 @@ async fn deliver_opaque(
                 .to_string(),
             StatusCode::NOT_FOUND,
         ));
-    }
+    };
 
-    // Recipient-side ACL checks, mirroring DIDComm direct delivery. The
-    // mediator routes on the authenticated sender and the recipient verifies
-    // the (opaque) message end-to-end on pickup.
-    let to_acls = authz::effective_acls(state, &to_hash).await?;
-    if authz::require_capability(&to_acls, Capability::ReceiveMessages).is_err() {
+    if authz::require_capability(&recipient.acls, Capability::ReceiveMessages).is_err() {
         return Err(tsp_problem(
             session,
             74,
@@ -330,11 +335,7 @@ async fn deliver_opaque(
         ));
     }
 
-    let from_hash = digest(from_vid.as_bytes());
-    if authz::check_access_list(state.database.as_ref(), &to_hash, Some(&from_hash))
-        .await
-        .is_err()
-    {
+    if !recipient.access_list_allows {
         return Err(tsp_problem(
             session,
             73,
@@ -670,8 +671,17 @@ async fn handle_inbound_didcomm(
                         ));
                     }
 
-                    // Check that the recipient account is local to the mediator
-                    if !state.database.account_exists(&digest(to_did)).await? {
+                    // Everything the recipient side needs — existence, ACL bits
+                    // and the access-list verdict — comes from one lookup. The
+                    // three facts all derive from the same stored record, so
+                    // asking for them separately cost three reads of it.
+                    let to_hash = digest(to_did);
+                    let from_hash = envelope.from_did.as_ref().map(digest);
+                    let Some(recipient) = state
+                        .database
+                        .delivery_decision(&to_hash, from_hash.as_deref())
+                        .await?
+                    else {
                         return Err(MediatorError::problem(
                             72,
                             &session.session_id,
@@ -683,7 +693,7 @@ async fn handle_inbound_didcomm(
                             vec![],
                             StatusCode::FORBIDDEN,
                         ));
-                    }
+                    };
 
                     // The mediator cannot decrypt a direct-delivery envelope, so the
                     // claimed sender (JWE `skid` header) is unverified. When
@@ -707,10 +717,9 @@ async fn handle_inbound_didcomm(
                         ));
                     }
 
-                    let from_hash = envelope.from_did.as_ref().map(digest);
                     // Check if the message will pass ACL Checks
-                    if let Some(from) = &envelope.from_did {
-                        let from_acls = authz::effective_acls(state, &digest(from)).await?;
+                    if let Some(from_hash) = from_hash.as_deref() {
+                        let from_acls = authz::effective_acls(state, from_hash).await?;
 
                         if authz::require_capability(&from_acls, Capability::SendMessages).is_err() {
                             return Err(MediatorError::problem(
@@ -738,13 +747,15 @@ async fn handle_inbound_didcomm(
                             StatusCode::FORBIDDEN,
                         ));
                     }
-                    // Recipient-side gate, mirroring the sender's SEND_MESSAGES
-                    // check above: a DID whose ACLs withhold RECEIVE_MESSAGES
-                    // does not accept directly-delivered messages at all,
-                    // regardless of who the sender is. Checked before the access
-                    // list because it is the coarser of the two.
-                    let to_acls = authz::effective_acls(state, &digest(to_did)).await?;
-                    if authz::require_capability(&to_acls, Capability::ReceiveMessages).is_err() {
+                    // Recipient-side gates, both answered from the single
+                    // lookup above. RECEIVE_MESSAGES mirrors the sender's
+                    // SEND_MESSAGES check: a DID whose ACLs withhold it does
+                    // not accept directly-delivered messages at all, whoever
+                    // the sender is. Checked before the access list because it
+                    // is the coarser of the two.
+                    if authz::require_capability(&recipient.acls, Capability::ReceiveMessages)
+                        .is_err()
+                    {
                         return Err(MediatorError::problem(
                             74,
                             &session.session_id,
@@ -758,14 +769,7 @@ async fn handle_inbound_didcomm(
                         ));
                     }
 
-                    if authz::check_access_list(
-                        state.database.as_ref(),
-                        &digest(to_did),
-                        from_hash.as_deref(),
-                    )
-                    .await
-                    .is_err()
-                    {
+                    if !recipient.access_list_allows {
                         return Err(MediatorError::problem(
                             73,
                             &session.session_id,

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -57,9 +57,9 @@ use affinidi_messaging_mediator_common::{
     circuit_breaker::CircuitBreaker,
     errors::MediatorError,
     store::{
-        DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
-        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionState, SessionSweepReport,
-        StatCounter, StoreHealth, StreamingClientState, ops,
+        DeletionAuthority, DeliveryDecision, ExpiryReport, ForwardQueueEntry, InboxStatusReply,
+        MediatorStore, MessageMetaData, MetadataStats, PubSubRecord, Session, SessionState,
+        SessionSweepReport, StatCounter, StoreHealth, StreamingClientState, ops,
     },
     types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditLogEntry, MediatorAuditLogList},
 };
@@ -1875,12 +1875,26 @@ impl MediatorStore for FjallStore {
     }
 
     async fn access_list_allowed(&self, to_hash: &str, from_hash: Option<&str>) -> bool {
+        matches!(
+            self.delivery_decision(to_hash, from_hash).await,
+            Ok(Some(decision)) if decision.access_list_allows
+        )
+    }
+
+    /// One account-partition read serves the ACL set and existence; the
+    /// membership probe is a separate prefix lookup only when the sender is
+    /// known.
+    async fn delivery_decision(
+        &self,
+        to_hash: &str,
+        from_hash: Option<&str>,
+    ) -> Result<Option<DeliveryDecision>, MediatorError> {
         let Ok(Some(raw)) = self.accounts.get(to_hash.as_bytes()) else {
-            return false;
+            return Ok(None);
         };
         let acc: StoredAccount = match Self::decode(&raw) {
             Ok(a) => a,
-            Err(_) => return false,
+            Err(_) => return Ok(None),
         };
         let acls = MediatorACLSet::from_u64(acc.acls);
         let sender = match from_hash {
@@ -1889,7 +1903,11 @@ impl MediatorStore for FjallStore {
             },
             None => ops::Sender::Anonymous,
         };
-        ops::access_list_allowed(&acls, sender)
+        let access_list_allows = ops::access_list_allowed(&acls, sender);
+        Ok(Some(DeliveryDecision {
+            acls,
+            access_list_allows,
+        }))
     }
 
     async fn access_list_list(

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -27,9 +27,9 @@ use crate::common::time::unix_timestamp_secs;
 use affinidi_messaging_mediator_common::{
     errors::MediatorError,
     store::{
-        DeletionAuthority, ExpiryReport, ForwardQueueEntry, InboxStatusReply, MediatorStore,
-        MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport, StatCounter,
-        StoreHealth, StreamingClientState, ops,
+        DeletionAuthority, DeliveryDecision, ExpiryReport, ForwardQueueEntry, InboxStatusReply,
+        MediatorStore, MessageMetaData, MetadataStats, PubSubRecord, Session, SessionSweepReport,
+        StatCounter, StoreHealth, StreamingClientState, ops,
     },
     types::audit::{AUDIT_LOG_MAX_ENTRIES, AuditLogEntry, MediatorAuditLogList},
 };
@@ -1065,9 +1065,21 @@ impl MediatorStore for MemoryStore {
     }
 
     async fn access_list_allowed(&self, to_hash: &str, from_hash: Option<&str>) -> bool {
+        matches!(
+            self.delivery_decision(to_hash, from_hash).await,
+            Ok(Some(decision)) if decision.access_list_allows
+        )
+    }
+
+    /// One lock acquisition serves the ACL set and the membership probe.
+    async fn delivery_decision(
+        &self,
+        to_hash: &str,
+        from_hash: Option<&str>,
+    ) -> Result<Option<DeliveryDecision>, MediatorError> {
         let state = self.state.lock().await;
         let Some(account) = state.accounts.get(to_hash) else {
-            return false;
+            return Ok(None);
         };
         let sender = match from_hash {
             Some(from) => ops::Sender::Known {
@@ -1079,7 +1091,11 @@ impl MediatorStore for MemoryStore {
             },
             None => ops::Sender::Anonymous,
         };
-        ops::access_list_allowed(&account.acls, sender)
+        let access_list_allows = ops::access_list_allowed(&account.acls, sender);
+        Ok(Some(DeliveryDecision {
+            acls: account.acls.clone(),
+            access_list_allows,
+        }))
     }
 
     async fn access_list_list(

--- a/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
@@ -551,6 +551,73 @@ async fn check_access_list_mode_semantics(store: Arc<dyn MediatorStore>) {
     );
 }
 
+/// `delivery_decision` must answer exactly what the three calls it replaces
+/// would have: `None` for an unknown recipient (standing in for
+/// `account_exists`), the recipient's stored ACL set (standing in for
+/// `get_did_acl`), and a verdict identical to `access_list_allowed`.
+///
+/// The direct-delivery path now trusts this single call for all three facts,
+/// and backends are free to implement it as one batched read, so a backend
+/// whose optimised version drifts from the generic path would silently change
+/// who may deliver to whom. Pinning it against `access_list_allowed` on the
+/// same store keeps the fast path honest.
+async fn check_delivery_decision_matches_access_list(store: Arc<dyn MediatorStore>) {
+    let listed = "did_hash_dd_listed".to_string();
+    let unlisted = "did_hash_dd_unlisted";
+
+    // Unknown recipient → None. This is what replaces the `account_exists`
+    // probe, so it has to be a *distinguishable* answer, not a denying one.
+    assert!(
+        store
+            .delivery_decision("did_hash_dd_nobody", Some(&listed))
+            .await
+            .expect("delivery_decision on unknown recipient")
+            .is_none(),
+        "unknown recipient yields None"
+    );
+
+    // Both access-list modes, and for each: a listed sender, an unlisted
+    // sender, and an anonymous sender (whose verdict comes from anon_receive
+    // rather than the list).
+    for mode in [
+        AccessListModeType::ExplicitAllow,
+        AccessListModeType::ExplicitDeny,
+    ] {
+        let owner = match mode {
+            AccessListModeType::ExplicitAllow => "did_hash_dd_allow_owner",
+            AccessListModeType::ExplicitDeny => "did_hash_dd_deny_owner",
+        };
+        let acls = acls_with_mode(mode);
+        store
+            .account_add(owner, &acls, None)
+            .await
+            .expect("add delivery-decision owner");
+        store
+            .access_list_add(1000, owner, std::slice::from_ref(&listed))
+            .await
+            .expect("add to access list");
+
+        for sender in [Some(listed.as_str()), Some(unlisted), None] {
+            let decision = store
+                .delivery_decision(owner, sender)
+                .await
+                .expect("delivery_decision")
+                .expect("known recipient yields Some");
+
+            assert_eq!(
+                decision.acls.to_u64(),
+                acls.to_u64(),
+                "returns the recipient's stored ACL set (owner={owner}, sender={sender:?})"
+            );
+            assert_eq!(
+                decision.access_list_allows,
+                store.access_list_allowed(owner, sender).await,
+                "verdict matches access_list_allowed (owner={owner}, sender={sender:?})"
+            );
+        }
+    }
+}
+
 // ─── Backend instantiation + test generation ────────────────────────────────
 
 /// A constructed backend plus anything that must outlive it (Fjall's temp dir).
@@ -833,6 +900,10 @@ macro_rules! conformance_for {
             async fn oob_discovery_roundtrip() {
                 check_oob_discovery_roundtrip(ready($ctor).await).await;
             }
+            #[tokio::test]
+            async fn delivery_decision_matches_access_list() {
+                check_delivery_decision_matches_access_list(ready($ctor).await).await;
+            }
         }
     };
 }
@@ -878,4 +949,5 @@ conformance_for_redis!(redis,
     access_list_mode_semantics => check_access_list_mode_semantics @ 10,
     audit_log_lifecycle      => check_audit_log_lifecycle      @ 11,
     oob_discovery_roundtrip  => check_oob_discovery_roundtrip  @ 12,
+    delivery_decision_matches_access_list => check_delivery_decision_matches_access_list @ 13,
 );


### PR DESCRIPTION
Follow-up to the ACL audit (#662). **No behavioural change to who may deliver to whom** — the same gates run in the same order and return the same problem codes. This is purely about how many times the store gets asked.

## The problem

Direct delivery asked three separate questions about the *same* recipient record:

| Call | Question |
|---|---|
| `account_exists` | does the account exist? |
| `get_did_acl` | what are its ACL bits? *(added by the `RECEIVE_MESSAGES` gate in #662)* |
| `access_list_allowed` | does its access list admit this sender? *(internally re-reads the ACL bits to get the mode)* |

All three are derivable from one read. I introduced the middle one in #662, so this pays that back and then some.

## The change

`MediatorStore::delivery_decision` returns them together — `None` for an unknown recipient, otherwise the ACL set plus the already-interpreted access-list verdict.

**DIDComm and TSP direct delivery go from four store round trips to two** (sender ACL, then recipient decision). On Redis the recipient half is a single pipelined `SISMEMBER` + `HGET` that was *already being issued* — it now answers all three questions instead of one, so the win costs nothing extra on the wire.

Error precedence is deliberately unchanged: `72` (recipient unknown) → `52` (session mismatch) → `44`/`50` (sender) → `74` (`RECEIVE_MESSAGES`) → `73` (access list).

## Not breaking for third-party backends

The trait method carries a default implementation written in terms of the existing `get_did_acl` + `access_list_allowed`, so a backend outside this workspace compiles and behaves identically without touching it. Redis, Fjall and Memory each override it.

## Keeping the fast path honest

New `delivery_decision_matches_access_list` conformance check pins **every** backend's optimised version against `access_list_allowed` on the same store — across both access-list modes, and including the anonymous-sender branch where the verdict comes from `anon_receive` rather than the list. A backend whose optimised implementation drifts fails as a named test instead of silently changing who can deliver.

## Also

- `digest(to_did)` was recomputed **three times per message** on the DIDComm direct path — a SHA-256 over the DID string each time. Hoisted to one, matching what the TSP path already did.
- Redis `access_list_allowed` now applies the allowlist/denylist rule via the shared `store::ops::access_list_allowed` instead of its own inline copy, leaving **one** implementation of that rule rather than three. Fail-closed contract (missing account or backend error ⇒ `false`) unchanged.
- **Edge case worth a look in review:** a corrupt account record that exists but carries no `ACLS` field now reports `direct_delivery.recipient.unknown` (72) where it previously reported `authorization.access_list.denied` (73). Both deny delivery; only the problem code differs. `account_exists` tests `EXISTS DID:<hash>` while the new path tests the `ACLS` field of that hash.

## Testing

- 168 mediator lib tests, 194 mediator-common
- 26 conformance checks across memory + fjall, including the new one (Redis conformance runs in CI via `REDIS_URL`)
- clippy + fmt clean on both the default and `memory-backend,fjall-backend` feature sets
- changelog + version-bump guards pass

## Not in scope

Two further items from the same analysis, deliberately left out:

1. **Per-request `get_session`** — every authenticated HTTP request loads the session from the store (WebSocket amortises it at upgrade). A short-TTL cache removes it but trades revocation latency, so it wants a deliberate decision rather than a drive-by.
2. **`MediatorACLSet` is 32 bytes but only its `u64` is ever read** — the named fields are a serialization mirror. Shrinking it to a `Copy` newtype would remove every clone, but needs a `#[serde(into/from)]` DTO to preserve the JSON wire shape. Worth folding into the next change that touches the type.

Versions: mediator 0.17.11 → 0.17.12, mediator-common 0.15.31 → 0.15.32.