### PR TITLE
ci: cover the tsp feature, which no job ever built or ran

### DIFF
--- a/.github/workflows/checks-storage.yaml
+++ b/.github/workflows/checks-storage.yaml
@@ -1,5 +1,6 @@
 name: checks-storage
-# Matrix check for the mediator's swappable storage backends.
+# Matrix check for the mediator's swappable storage backends, plus the
+# dual-protocol (DIDComm / TSP) axis.
 #
 # `redis-backend` is the default and is exercised by `checks.yaml`
 # (which spins up a Redis service container via `useRedis: true`).
@@ -14,8 +15,14 @@ name: checks-storage
 #                --lib store::<short>_store
 #
 # Plus a "kitchen sink" job that compiles the mediator with every
-# backend feature enabled at once. Catches accidental name collisions
-# between feature-gated modules.
+# backend feature enabled at once (and `tsp`). Catches accidental name
+# collisions between feature-gated modules.
+#
+# The e2e jobs cover the fixture on both stores (`test-mediator (memory)`
+# / `(fjall)`) and on the TSP protocol (`test-mediator (tsp)`). The last
+# one matters because `tsp` is not a default feature: without it every
+# `#[cfg(feature = "tsp")]` test compiles out, so an all-green CI run said
+# nothing whatsoever about the TSP transport.
 #
 # `storage-secrets-matrix` adds a representative storage x secrets
 # cross-check. `checks.yaml` exercises the default (redis + keyring) and
@@ -252,12 +259,56 @@ jobs:
             --features fjall-backend \
             --tests
 
+  test-mediator-e2e-tsp:
+    # The dual-protocol axis. `tsp` is not a default feature of
+    # `affinidi-messaging-test-mediator`, so the two jobs above compile
+    # every `#[cfg(feature = "tsp")]` test out — which left the whole TSP
+    # e2e suite (TSP delivery, auth, websocket, pickup, federation,
+    # cross-mediator routing, capability discovery, and the recipient-side
+    # ACL gates) passing unobserved: green CI said nothing about any of it.
+    #
+    # The mediator ships TSP as a first-class transport alongside DIDComm,
+    # so the protocol axis deserves the same standing coverage the storage
+    # backends get.
+    name: test-mediator (tsp)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libdbus-1-dev libssl-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+
+      - name: Cache cargo registry + build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: test-mediator-e2e-tsp
+
+      - name: cargo test -p affinidi-messaging-test-mediator --features tsp --tests
+        run: |
+          cargo test \
+            -p affinidi-messaging-test-mediator \
+            --features tsp \
+            --tests
+
   all-backends-compile:
     # Compile the mediator with every backend feature enabled at
-    # once. Doesn't run any tests — the test commands per-backend
-    # above already do that — but a successful build here proves
-    # the feature-gated modules don't conflict (duplicate symbols,
-    # incompatible deps, etc.) when bundled together.
+    # once, plus `tsp`. Doesn't run any tests — the test commands
+    # per-backend above already do that — but a successful build here
+    # proves the feature-gated modules don't conflict (duplicate
+    # symbols, incompatible deps, etc.) when bundled together.
+    #
+    # `tsp` is in the list because it gates ~39 sites in the mediator
+    # source and was previously compiled by no job in any workflow: the
+    # only `tsp` in CI was a `cargo check` on the `affinidi-tdk` facade,
+    # which does not pull the mediator's TSP code. A type error behind
+    # that gate could reach a release unseen.
     name: all-backends compile
     runs-on: ubuntu-latest
     steps:
@@ -278,9 +329,9 @@ jobs:
         with:
           key: all-backends-compile
 
-      - name: cargo check --features redis-backend,fjall-backend,memory-backend
+      - name: cargo check --features tsp,redis-backend,fjall-backend,memory-backend
         run: |
           cargo check \
             -p affinidi-messaging-mediator \
             --no-default-features \
-            --features "didcomm,redis-backend,fjall-backend,memory-backend"
+            --features "didcomm,tsp,redis-backend,fjall-backend,memory-backend"

--- a/crates/messaging/affinidi-messaging-test-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/README.md
@@ -337,6 +337,33 @@ that need different semantics:
   for tests that exercise multi-mediator coordination, but requires
   a reachable Redis instance.
 
+## Feature flags and what CI runs
+
+`default = []`, so the two optional features have to be asked for
+explicitly — and a plain `cargo test` silently compiles their tests
+*out* rather than failing:
+
+| Feature | Enables |
+|---|---|
+| `fjall-backend` | `FjallStore` + the tests gated on it |
+| `tsp` | mediator TSP support, `atm.tsp()`, and every `#[cfg(feature = "tsp")]` test (TSP delivery, auth, websocket, pickup, federation, cross-mediator routing, capability discovery) |
+
+To run everything locally:
+
+```sh
+cargo test -p affinidi-messaging-test-mediator --features tsp,fjall-backend --tests
+```
+
+CI covers all three axes as separate jobs in `checks-storage.yaml` —
+`test-mediator (memory)`, `(fjall)` and `(tsp)`. The `tsp` job was
+added after the feature spent a long time uncovered: because `tsp`
+isn't default, a fully green CI run had been saying nothing at all
+about the TSP transport. If you add a test behind a new feature gate,
+add the matching job too, or it will not run.
+
+Note that no part of this suite requires Redis. `skip_if_no_redis()`
+in `tests/common` is a retained no-op that always returns `false`.
+
 ## Cross-workspace consumption
 
 When using this crate from outside the `affinidi-tdk-rs` workspace


### PR DESCRIPTION
Found while checking that #664's new tests actually execute in CI. **They don't** — and neither does anything else behind the `tsp` gate.

## The gap

`affinidi-messaging-test-mediator` has `default = []`, and `checks-storage.yaml` ran only:

```
cargo test -p affinidi-messaging-test-mediator --tests
cargo test -p affinidi-messaging-test-mediator --features fjall-backend --tests
```

Neither enables `tsp`, so every `#[cfg(feature = "tsp")]` test **compiled out**. That silently excluded ten e2e files — TSP delivery, auth, websocket, pickup, federation, cross-mediator routing, capability discovery, `send_to`, and the recipient-side ACL gates added in #664.

A fully green CI run was saying nothing whatsoever about the TSP transport, which the mediator ships as a first-class transport alongside DIDComm.

The mediator's own source was equally uncovered: **~39 `cfg(feature = "tsp")` sites, compiled by no job in any workflow.** The only `tsp` anywhere in CI was `cargo check -p affinidi-tdk --features trust,tsp`, which exercises the *facade* and does not pull the mediator's TSP code. A type error behind that gate could have reached a release unseen.

This is the failure mode where the absence of a signal looks exactly like a passing signal.

## Changes

- **New `test-mediator (tsp)` job** running the e2e suite with `--features tsp`. Takes CI from **70 to 101** e2e tests — 31 that had never run.
- **`all-backends compile` now includes `tsp`**, so the mediator's TSP-gated modules are type-checked alongside every storage backend.
- **Workflow header and job comments** explain the protocol axis and why the tsp job exists, so the next person adding a feature-gated test knows a matching job is required.
- **test-mediator README** documents both optional features, the command that runs everything, and the property that let this hide: a plain `cargo test` compiles their tests *out* rather than failing.

## Nothing needed fixing

All ten previously dark files already pass — this is purely additive coverage, no production code changed. That's the good outcome, but it was not knowable in advance; the tests could equally have been rotting for months.

Verified by running the exact commands the runner will, with the workflow's `RUSTFLAGS`:

| Command | Result |
|---|---|
| `--features tsp --tests` | 101 tests, exit 0 |
| `--features tsp,fjall-backend --tests` | 105 tests, exit 0 (the README command) |
| `all-backends` check `+tsp` | exit 0, no warnings |
| clippy, mediator + test-mediator with `tsp`, `-D warnings` | clean |

## No other feature is dark

I checked the whole surface rather than just `tsp`: `jemalloc` is in the mediator's default set, and `aws` arrives via `secrets-aws`, which `checks-features.yaml` already sweeps. Every other mediator feature is covered by an existing job.

## One correction

The README now records that this suite needs **no** Redis — `skip_if_no_redis()` is a retained no-op that always returns `false`. I claimed the opposite on #662 when explaining why the e2e gap there went unfilled; that claim was wrong, and the gap could have been closed at the time.

## Note for the repo owner

If branch protection has a required-checks list, `test-mediator (tsp)` needs adding to it — otherwise the job runs but cannot block a merge.

No version bump or changelog: CI and docs only, per `scripts/check-version-bumps.sh`. Both guards confirm nothing to check.