### PR TITLE
fix: allow clock skew on a proof's created timestamp

### DIFF
--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Affinidi Data Integrity Changelog
 
+## 27th July 2026 Release 0.7.8
+
+### Fixed
+
+- **Verification no longer fails on ordinary clock skew.** A proof's
+  `created` is stamped by the *signer's* clock and was compared strictly
+  (`created > now`) against the *verifier's*, so a signer even
+  milliseconds ahead made acceptance a race between clock skew and
+  delivery latency: the same signed request was accepted or rejected
+  depending on how quickly it arrived, with no way to configure a
+  tolerance. Verification now allows a clock-skew window on a future
+  `created`, defaulting to 60 seconds (`DEFAULT_CLOCK_SKEW`) — matching
+  the leeway conventionally applied to JWT `iat`/`nbf`, past which a
+  signer generally fails bearer-token validation anyway. This governs
+  only how far *ahead* `created` may be; the library still does not
+  reject old proofs, so replay protection remains the surrounding
+  protocol's job.
+
+### Added
+
+- `VerifyOptions::with_clock_skew(TimeDelta)` and the `DEFAULT_CLOCK_SKEW`
+  constant. Pass `TimeDelta::zero()` for the previous strict behaviour.
+- `verify_conformance_with_skew(..)`, the explicit-tolerance form of
+  `verify_conformance` (which had the same strict check and now applies
+  `DEFAULT_CLOCK_SKEW`).
+
+Note: `VerifyOptions` no longer `#[derive]`s `Default` — it has a manual
+impl carrying the non-zero default. Behaviour of `VerifyOptions::new()` /
+`::default()` is otherwise unchanged, and the struct remains
+`#[non_exhaustive]`, so the added field is not a breaking change.
+
 ## 19th July 2026 Release 0.7.7
 
 ### Changed

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.7"
+version = "0.7.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-data-integrity/src/conformance.rs
+++ b/crates/credentials/affinidi-data-integrity/src/conformance.rs
@@ -187,9 +187,8 @@ mod tests {
         use chrono::{TimeDelta, Utc};
         let mut p = sample_proof().await;
         p.created = Some((Utc::now() + TimeDelta::seconds(5)).to_rfc3339());
-        let err =
-            verify_conformance_with_skew(&p, CryptoSuite::EddsaJcs2022, TimeDelta::zero())
-                .unwrap_err();
+        let err = verify_conformance_with_skew(&p, CryptoSuite::EddsaJcs2022, TimeDelta::zero())
+            .unwrap_err();
         assert!(matches!(err, DataIntegrityError::Conformance(_)));
     }
 

--- a/crates/credentials/affinidi-data-integrity/src/conformance.rs
+++ b/crates/credentials/affinidi-data-integrity/src/conformance.rs
@@ -13,6 +13,7 @@
 //! slightly differently.
 
 use crate::crypto_suites::CryptoSuite;
+use crate::options::DEFAULT_CLOCK_SKEW;
 use crate::{DataIntegrityError, DataIntegrityProof};
 
 /// Checks that `proof` conforms to the W3C Data Integrity spec.
@@ -25,8 +26,10 @@ use crate::{DataIntegrityError, DataIntegrityProof};
 /// 3. `proofPurpose` is present and non-empty.
 /// 4. `verificationMethod` is present and non-empty.
 /// 5. `proofValue` is present and multibase-decodable.
-/// 6. `created`, if present, parses as RFC 3339 and is not in the
-///    future.
+/// 6. `created`, if present, parses as RFC 3339 and is no further into
+///    the future than [`DEFAULT_CLOCK_SKEW`] (the signer's clock is not
+///    the verifier's; see [`verify_conformance_with_skew`] to choose the
+///    allowance).
 ///
 /// Returns `Ok(())` if all structural checks pass. The cryptographic
 /// signature is **not** verified here — use
@@ -37,6 +40,19 @@ use crate::{DataIntegrityError, DataIntegrityProof};
 pub fn verify_conformance(
     proof: &DataIntegrityProof,
     expected: CryptoSuite,
+) -> Result<(), DataIntegrityError> {
+    verify_conformance_with_skew(proof, expected, DEFAULT_CLOCK_SKEW)
+}
+
+/// [`verify_conformance`], with an explicit tolerance for a `created`
+/// timestamp in the verifier's future.
+///
+/// Pass [`chrono::TimeDelta::zero`] to reject any future timestamp
+/// outright. Negative values are treated as zero.
+pub fn verify_conformance_with_skew(
+    proof: &DataIntegrityProof,
+    expected: CryptoSuite,
+    clock_skew: chrono::TimeDelta,
 ) -> Result<(), DataIntegrityError> {
     if proof.type_ != "DataIntegrityProof" {
         return Err(DataIntegrityError::Conformance(format!(
@@ -74,16 +90,21 @@ pub fn verify_conformance(
     })?;
 
     if let Some(created) = &proof.created {
-        use chrono::{DateTime, Utc};
+        use chrono::{DateTime, TimeDelta, Utc};
         let parsed: DateTime<Utc> = created.parse().map_err(|e| {
             DataIntegrityError::Conformance(format!(
                 "created does not parse as RFC 3339 ({e}): {created}"
             ))
         })?;
-        if parsed > Utc::now() {
-            return Err(DataIntegrityError::Conformance(
-                "created timestamp is in the future".into(),
-            ));
+        let skew = clock_skew.max(TimeDelta::zero());
+        let horizon = Utc::now()
+            .checked_add_signed(skew)
+            .unwrap_or(DateTime::<Utc>::MAX_UTC);
+        if parsed > horizon {
+            return Err(DataIntegrityError::Conformance(format!(
+                "created timestamp is in the future (beyond the {}s clock-skew allowance)",
+                skew.num_seconds()
+            )));
         }
     }
 
@@ -146,6 +167,29 @@ mod tests {
         let mut p = sample_proof().await;
         p.created = Some("3000-01-01T00:00:00Z".to_string());
         let err = verify_conformance(&p, CryptoSuite::EddsaJcs2022).unwrap_err();
+        assert!(matches!(err, DataIntegrityError::Conformance(_)));
+    }
+
+    /// Ordinary signer-vs-verifier clock skew is not a conformance
+    /// failure — only a `created` beyond the allowance is.
+    #[tokio::test]
+    async fn conformance_tolerates_default_clock_skew() {
+        use chrono::{TimeDelta, Utc};
+        let mut p = sample_proof().await;
+        p.created = Some((Utc::now() + TimeDelta::seconds(5)).to_rfc3339());
+        verify_conformance(&p, CryptoSuite::EddsaJcs2022)
+            .expect("5s ahead is inside the default 60s allowance");
+    }
+
+    /// Zero skew restores the strict behaviour for callers that want it.
+    #[tokio::test]
+    async fn conformance_zero_skew_rejects_any_future_created() {
+        use chrono::{TimeDelta, Utc};
+        let mut p = sample_proof().await;
+        p.created = Some((Utc::now() + TimeDelta::seconds(5)).to_rfc3339());
+        let err =
+            verify_conformance_with_skew(&p, CryptoSuite::EddsaJcs2022, TimeDelta::zero())
+                .unwrap_err();
         assert!(matches!(err, DataIntegrityError::Conformance(_)));
     }
 

--- a/crates/credentials/affinidi-data-integrity/src/lib.rs
+++ b/crates/credentials/affinidi-data-integrity/src/lib.rs
@@ -84,7 +84,7 @@ pub mod suite_ops;
 pub mod verification_proof;
 
 pub use caching_signer::{CachingSigner, GetPrivateBytes};
-pub use conformance::verify_conformance;
+pub use conformance::{verify_conformance, verify_conformance_with_skew};
 pub use did_vm::{DidKeyResolver, ResolvedKey, VerificationMethodResolver};
 pub use multi::{MultiVerifyResult, VerifyPolicy, verify_multi};
 
@@ -104,7 +104,7 @@ pub mod bbs_2023;
 pub mod bbs_2023_transform;
 
 pub use error::{DataIntegrityError, SignatureFailure};
-pub use options::{SignOptions, VerifyOptions};
+pub use options::{DEFAULT_CLOCK_SKEW, SignOptions, VerifyOptions};
 
 /// Serialized Data Integrity proof.
 ///
@@ -432,15 +432,26 @@ where
         ));
     }
 
+    // `created` is stamped by the signer's clock and checked against
+    // ours, so a strict comparison makes acceptance a race between clock
+    // skew and delivery latency. Allow `options.clock_skew` (default 60s)
+    // of drift; a negative setting is clamped to zero rather than making
+    // the check *stricter* than exact.
     if let Some(created) = &proof_config.created {
-        let now = Utc::now();
+        let skew = options.clock_skew.max(chrono::TimeDelta::zero());
+        // `checked_add_signed` so an absurd caller-supplied skew saturates
+        // instead of panicking on overflow, as `+` would.
+        let horizon = Utc::now()
+            .checked_add_signed(skew)
+            .unwrap_or(DateTime::<Utc>::MAX_UTC);
         let created = created
             .parse::<DateTime<Utc>>()
             .map_err(|e| DataIntegrityError::Conformance(format!("Invalid created date: {e}")))?;
-        if created > now {
-            return Err(DataIntegrityError::Conformance(
-                "Created date is in the future".to_string(),
-            ));
+        if created > horizon {
+            return Err(DataIntegrityError::Conformance(format!(
+                "Created date is in the future (beyond the {}s clock-skew allowance)",
+                skew.num_seconds()
+            )));
         }
     }
 
@@ -560,9 +571,12 @@ fn format_created(dt: DateTime<Utc>) -> String {
 #[cfg(test)]
 mod tests {
     use affinidi_secrets_resolver::secrets::Secret;
+    use chrono::Utc;
     use serde_json::json;
 
-    use crate::{DataIntegrityProof, SignOptions, VerifyOptions, hashing_jcs};
+    use crate::{
+        DataIntegrityError, DataIntegrityProof, SignOptions, VerifyOptions, hashing_jcs,
+    };
 
     #[test]
     fn hashing_working() {
@@ -668,6 +682,75 @@ mod tests {
             err,
             crate::DataIntegrityError::KeyTypeMismatch { .. }
         ));
+    }
+
+    /// A signer whose clock runs slightly ahead of the verifier's stamps
+    /// `created` in the verifier's future. With zero tolerance this made
+    /// acceptance a race between clock skew and delivery latency — the
+    /// same proof verified or not depending on how fast it arrived. The
+    /// default allowance must absorb it.
+    #[tokio::test]
+    async fn verify_tolerates_default_clock_skew_on_created() {
+        let secret = Secret::generate_ed25519(Some("did:key:k#k"), Some(&[3u8; 32]));
+        let doc = json!({"skewed": true});
+        let proof = DataIntegrityProof::sign(
+            &doc,
+            &secret,
+            SignOptions::new().with_created(Utc::now() + chrono::TimeDelta::seconds(5)),
+        )
+        .await
+        .expect("sign");
+
+        proof
+            .verify_with_public_key(&doc, secret.get_public_bytes(), VerifyOptions::new())
+            .expect("a 5s-ahead signer is inside the default 60s allowance");
+    }
+
+    /// The allowance is bounded: a `created` beyond it is still rejected,
+    /// and the error names the allowance so the cause is diagnosable from
+    /// the wire message alone.
+    #[tokio::test]
+    async fn verify_rejects_created_beyond_the_allowance() {
+        let secret = Secret::generate_ed25519(Some("did:key:k#k"), Some(&[4u8; 32]));
+        let doc = json!({"skewed": "far"});
+        let proof = DataIntegrityProof::sign(
+            &doc,
+            &secret,
+            SignOptions::new().with_created(Utc::now() + chrono::TimeDelta::hours(1)),
+        )
+        .await
+        .expect("sign");
+
+        let err = proof
+            .verify_with_public_key(&doc, secret.get_public_bytes(), VerifyOptions::new())
+            .expect_err("an hour ahead is well beyond 60s");
+        let msg = format!("{err}");
+        assert!(msg.contains("future"), "unexpected message: {msg}");
+        assert!(msg.contains("60s"), "message should name the allowance: {msg}");
+    }
+
+    /// Zero skew restores the strict pre-allowance behaviour for callers
+    /// that want it.
+    #[tokio::test]
+    async fn verify_zero_skew_rejects_any_future_created() {
+        let secret = Secret::generate_ed25519(Some("did:key:k#k"), Some(&[5u8; 32]));
+        let doc = json!({"strict": true});
+        let proof = DataIntegrityProof::sign(
+            &doc,
+            &secret,
+            SignOptions::new().with_created(Utc::now() + chrono::TimeDelta::seconds(5)),
+        )
+        .await
+        .expect("sign");
+
+        let err = proof
+            .verify_with_public_key(
+                &doc,
+                secret.get_public_bytes(),
+                VerifyOptions::new().with_clock_skew(chrono::TimeDelta::zero()),
+            )
+            .expect_err("zero tolerance must reject a future created");
+        assert!(matches!(err, DataIntegrityError::Conformance(_)));
     }
 
     /// An attacker rewrites the `cryptosuite` field on a proof they

--- a/crates/credentials/affinidi-data-integrity/src/lib.rs
+++ b/crates/credentials/affinidi-data-integrity/src/lib.rs
@@ -574,9 +574,7 @@ mod tests {
     use chrono::Utc;
     use serde_json::json;
 
-    use crate::{
-        DataIntegrityError, DataIntegrityProof, SignOptions, VerifyOptions, hashing_jcs,
-    };
+    use crate::{DataIntegrityError, DataIntegrityProof, SignOptions, VerifyOptions, hashing_jcs};
 
     #[test]
     fn hashing_working() {
@@ -726,7 +724,10 @@ mod tests {
             .expect_err("an hour ahead is well beyond 60s");
         let msg = format!("{err}");
         assert!(msg.contains("future"), "unexpected message: {msg}");
-        assert!(msg.contains("60s"), "message should name the allowance: {msg}");
+        assert!(
+            msg.contains("60s"),
+            "message should name the allowance: {msg}"
+        );
     }
 
     /// Zero skew restores the strict pre-allowance behaviour for callers

--- a/crates/credentials/affinidi-data-integrity/src/options.rs
+++ b/crates/credentials/affinidi-data-integrity/src/options.rs
@@ -90,14 +90,30 @@ impl SignOptions {
     }
 }
 
+/// Default tolerance applied to a proof's `created` timestamp when it
+/// sits in the verifier's future: 60 seconds.
+///
+/// `created` is stamped by the *signer's* clock and checked against the
+/// *verifier's*. With zero tolerance, acceptance of an otherwise-valid
+/// proof becomes a race between clock skew and delivery latency — the
+/// same signed request is accepted or rejected depending on how quickly
+/// it arrives. 60s matches the leeway conventionally applied to JWT
+/// `iat`/`nbf` (and `jsonwebtoken`'s own default), so a signer skewed
+/// further than this generally fails bearer-token validation anyway.
+///
+/// This governs only how far *ahead* `created` may be. It is not a
+/// freshness window: this library does not reject old proofs, so replay
+/// protection must come from the surrounding protocol.
+pub const DEFAULT_CLOCK_SKEW: chrono::TimeDelta = chrono::TimeDelta::seconds(60);
+
 /// Options for verifying a Data Integrity proof.
 ///
 /// Currently carries the document's externally-supplied `@context` (for
-/// comparison with the proof's declared context) and an optional allowlist
-/// of acceptable cryptosuites. More fields will be added as the library
-/// grows — `#[non_exhaustive]` ensures future additions do not break
-/// callers.
-#[derive(Clone, Debug, Default)]
+/// comparison with the proof's declared context), an optional allowlist
+/// of acceptable cryptosuites, and the tolerance applied to a future
+/// `created` timestamp. More fields will be added as the library grows —
+/// `#[non_exhaustive]` ensures future additions do not break callers.
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct VerifyOptions {
     /// Expected `@context` of the signed document. When `Some`, the
@@ -109,10 +125,30 @@ pub struct VerifyOptions {
     /// accept (e.g. refuse `bbs-2023` in a context that requires full
     /// disclosure).
     pub allowed_suites: Vec<CryptoSuite>,
+
+    /// How far into the verifier's future a proof's `created` may sit
+    /// before it is rejected as non-conformant. Defaults to
+    /// [`DEFAULT_CLOCK_SKEW`]; set to zero for strict rejection of any
+    /// future timestamp. Negative values are treated as zero.
+    pub clock_skew: chrono::TimeDelta,
+}
+
+impl Default for VerifyOptions {
+    /// All checks off except a [`DEFAULT_CLOCK_SKEW`] allowance on
+    /// `created` — deliberately *not* `#[derive]`d, which would mean zero
+    /// tolerance and make verification skew-sensitive by default.
+    fn default() -> Self {
+        Self {
+            expected_context: None,
+            allowed_suites: Vec::new(),
+            clock_skew: DEFAULT_CLOCK_SKEW,
+        }
+    }
 }
 
 impl VerifyOptions {
-    /// Constructs an empty `VerifyOptions`. Equivalent to
+    /// Constructs a `VerifyOptions` with no context or cryptosuite
+    /// restrictions and the default clock-skew allowance. Equivalent to
     /// [`VerifyOptions::default`].
     #[must_use = "constructed options must be passed to sign/verify to take effect"]
     pub fn new() -> Self {
@@ -130,6 +166,15 @@ impl VerifyOptions {
     #[must_use = "chained builder call returns self; assign or chain further"]
     pub fn with_allowed_suites(mut self, suites: Vec<CryptoSuite>) -> Self {
         self.allowed_suites = suites;
+        self
+    }
+
+    /// Overrides the tolerance for a `created` timestamp in the
+    /// verifier's future. Pass [`chrono::TimeDelta::zero`] to reject any
+    /// future timestamp outright.
+    #[must_use = "chained builder call returns self; assign or chain further"]
+    pub fn with_clock_skew(mut self, skew: chrono::TimeDelta) -> Self {
+        self.clock_skew = skew;
         self
     }
 }


### PR DESCRIPTION
## The bug

A proof's `created` is stamped by the **signer's** clock and was compared strictly against the **verifier's**:

```rust
if created > now {
    return Err(DataIntegrityError::Conformance(
        "Created date is in the future".to_string(),
    ));
}
```

Zero tolerance at `DateTime<Utc>` resolution, and `VerifyOptions` carried no knob to loosen it. So a signer even milliseconds ahead of the verifier made acceptance a **race between clock skew and delivery latency**: the same signed document verified when it arrived slowly enough for the verifier's clock to catch up, and failed when it didn't.

This is not theoretical. It was reported in `affinidi-webvh-service`: a user adding an ACL entry from the Web UI got `proofInvalid` / "Created date is in the future", clicked again, and it worked. The browser signs trust-tasks with an ephemeral session key and stamps `created` locally; the control plane verifies it here.

## The fix

Verification allows a clock-skew window on a future `created`, defaulting to **60s** (`DEFAULT_CLOCK_SKEW`).

60s rather than the more common 5 minutes: it matches the leeway conventionally applied to JWT `iat`/`nbf` (and `jsonwebtoken`'s default), and callers in this ecosystem pair a proof with a bearer token. A signer skewed further than that already fails token validation, so a wider window buys nothing.

This governs only how far **ahead** `created` may be. It is **not** a freshness window — the library still does not reject old proofs — so replay protection remains the surrounding protocol's job, and widening a bound that nothing enforced costs no security.

`verify_conformance` in `conformance.rs` carried a second copy of the same strict check on a separate public entry point. It has no in-repo callers, but it is public API with the same flaw, so it gets the same default.

## API

- `VerifyOptions::with_clock_skew(TimeDelta)` + the public `DEFAULT_CLOCK_SKEW` constant. `TimeDelta::zero()` restores the strict behaviour; negatives clamp to zero rather than making the check stricter than exact.
- `verify_conformance_with_skew(proof, expected, skew)`, the explicit-tolerance form of `verify_conformance`.
- `VerifyOptions` swaps its derived `Default` for a manual impl carrying the non-zero default — a derived one would mean `TimeDelta::ZERO` and silently preserve the bug as the default. Called out in the code so it doesn't get "cleaned up" back to a derive. The struct stays `#[non_exhaustive]`, so the added field is not breaking.

`Utc::now().checked_add_signed(skew)` rather than `+`, so an absurd caller-supplied skew saturates instead of panicking on overflow.

## Tests

Four new, covering the actual failure mode and its bounds:

- `verify_tolerates_default_clock_skew_on_created` — a 5s-ahead signer verifies (this is the reported bug)
- `verify_rejects_created_beyond_the_allowance` — 1h ahead still rejected, and the message names the allowance so the cause is diagnosable from the wire text alone
- `verify_zero_skew_rejects_any_future_created` — strict mode still strict
- `conformance_tolerates_default_clock_skew` / `conformance_zero_skew_rejects_any_future_created` — same for the conformance entry point

43 tests pass, `cargo clippy --all-targets` clean, full workspace `cargo check --all-targets` clean.

Version bumped to 0.7.8 with a CHANGELOG entry.