### PR TITLE
feat!: rationalize the messaging/* trust-task family 19 → 9, clean cutover

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.21] - 2026-07-29
+
+### Changed
+
+- Startup ACL-mode configuration now sends `messaging/account/update` (the
+  `acl` member) instead of the retired `messaging/acl/set`, following the
+  `messaging/*` trust-task rationalization (affinidi/affinidi-tdk-rs#667;
+  affinidi-messaging-sdk 0.18.65). Same partial-update semantics — only
+  `accessListMode` is set, everything else is left unchanged.
+
 ## [0.3.20] - 2026-07-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.20"
+version = "0.3.21"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -24,7 +24,7 @@ affinidi-tdk-common = "0.6"
 affinidi-messaging-sdk = "0.18"
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.2"
+trust-tasks-rs = "0.2.46"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -7,7 +7,7 @@ use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use sha256::digest;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
-use trust_tasks_rs::specs::messaging::acl;
+use trust_tasks_rs::specs::messaging::account;
 
 use super::listener::Listener;
 use crate::error::{DIDCommServiceError, StartupError};
@@ -33,18 +33,24 @@ impl Listener {
         // self-service gating applies it (the rest of the ACL is left unchanged).
         let mode = match acl_mode {
             AccessListModeType::ExplicitAllow => {
-                acl::set::v0_1::MediatorAclAccessListMode::ExplicitAllow
+                account::update::v0_1::MediatorAclAccessListMode::ExplicitAllow
             }
             AccessListModeType::ExplicitDeny => {
-                acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny
+                account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny
             }
         };
-        let acl = acl::set::v0_1::MediatorAcl {
+        let acl = account::update::v0_1::MediatorAcl {
             access_list_mode: Some(mode),
             ..Default::default()
         };
         atm.trust_tasks()
-            .acl_set(profile, digest(&profile.inner.did), acl)
+            .account_update(
+                profile,
+                Some(digest(&profile.inner.did)),
+                None,
+                Some(acl),
+                None,
+            )
             .await
             .map_err(StartupError::AclApply)?;
 

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/mediator_administration/main.rs"
 ## SDK for connecting to and communicating with a running mediator
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.2"
+trust-tasks-rs = "0.2.46"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/alice_bob.rs
@@ -111,12 +111,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob is added to Alice explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_alice,
+                None,
+                false,
+                vec![bob_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Bob is removed from Alice explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_alice,
+                None,
+                false,
+                vec![],
+                vec![bob_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Alice Access Lists reset");
@@ -125,12 +137,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Bob is added to Bob explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![alice_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Bob is removed from Bob explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![],
+                vec![alice_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Bob Access Lists reset");

--- a/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/cross_mediator_forwarding.rs
@@ -384,13 +384,25 @@ async fn apply_access(
         party
             .atm
             .trust_tasks()
-            .access_list_add(&party.profile, None, vec![peer_hash.to_string()])
+            .access_list_update(
+                &party.profile,
+                None,
+                false,
+                vec![peer_hash.to_string()],
+                vec![],
+            )
             .await?;
     } else {
         party
             .atm
             .trust_tasks()
-            .access_list_remove(&party.profile, None, vec![peer_hash.to_string()])
+            .access_list_update(
+                &party.profile,
+                None,
+                false,
+                vec![],
+                vec![peer_hash.to_string()],
+            )
             .await?;
     }
     Ok(())

--- a/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/delete_test.rs
@@ -108,12 +108,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob is added to Alice explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_alice,
+                None,
+                false,
+                vec![bob_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Bob is removed from Alice explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_alice, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_alice,
+                None,
+                false,
+                vec![],
+                vec![bob_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Alice Access Lists reset");
@@ -122,12 +134,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Bob is added to Bob explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![alice_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Bob is removed from Bob explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_bob, None, vec![alice_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![],
+                vec![alice_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Bob Access Lists reset");

--- a/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/hijack_admin.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<(), ATMError> {
     info!("Trying to access an admin function with Mallory");
     match atm
         .trust_tasks()
-        .account_list(&atm_mallory, None, None)
+        .account_list(&atm_mallory, None, None, None)
         .await
     {
         Ok(_) => {

--- a/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
+++ b/crates/messaging/affinidi-messaging-helpers/examples/spoof_test.rs
@@ -137,22 +137,26 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = alice_acl_mode {
         // Ensure Bob and Mallory are removed from explicit allow list
         atm.trust_tasks()
-            .access_list_remove(
+            .access_list_update(
                 &atm_alice,
                 None,
+                false,
+                vec![],
                 vec![mallory_info.did.as_str().to_string()],
             )
             .await?;
     } else {
         // Ensure Mallory is removed from Bob explicit deny list
         atm.trust_tasks()
-            .access_list_add(
+            .access_list_update(
                 &atm_alice,
                 None,
+                false,
                 vec![
                     bob_info.did.as_str().to_string(),
                     mallory_info.did.as_str().to_string(),
                 ],
+                vec![],
             )
             .await?;
     }
@@ -162,12 +166,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = bob_acl_mode {
         // Ensure Mallory is added to Bob explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_bob, None, vec![mallory_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![mallory_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Mallory is removed from Bob explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_bob, None, vec![mallory_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_bob,
+                None,
+                false,
+                vec![],
+                vec![mallory_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Bob Access Lists reset");
@@ -176,12 +192,24 @@ async fn main() -> Result<(), ATMError> {
     if let Some(MediatorAclAccessListMode::ExplicitAllow) = mallory_acl_mode {
         // Ensure Bob is added to Mallory explicit allow list
         atm.trust_tasks()
-            .access_list_add(&atm_mallory, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_mallory,
+                None,
+                false,
+                vec![bob_info.did.as_str().to_string()],
+                vec![],
+            )
             .await?;
     } else {
         // Ensure Bob is removed from Mallory explicit deny list
         atm.trust_tasks()
-            .access_list_remove(&atm_mallory, None, vec![bob_info.did.as_str().to_string()])
+            .access_list_update(
+                &atm_mallory,
+                None,
+                false,
+                vec![],
+                vec![bob_info.did.as_str().to_string()],
+            )
             .await?;
     }
     info!("Mallory Access Lists reset");

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
@@ -259,10 +259,10 @@ async fn _change_account_type(
     account: &account::get::v0_1::Account,
 ) -> Result<account::get::v0_1::Account, Box<dyn std::error::Error>> {
     let options = [
-        account::change_type::v0_1::AccountType::Standard,
-        account::change_type::v0_1::AccountType::Admin,
-        account::change_type::v0_1::AccountType::RootAdmin,
-        account::change_type::v0_1::AccountType::Mediator,
+        account::update::v0_1::AccountType::Standard,
+        account::update::v0_1::AccountType::Admin,
+        account::update::v0_1::AccountType::RootAdmin,
+        account::update::v0_1::AccountType::Mediator,
     ];
 
     let mut selections = options
@@ -295,7 +295,13 @@ async fn _change_account_type(
     } else {
         let updated = atm
             .trust_tasks()
-            .account_change_type(profile, account.did.as_str().to_string(), new_type)
+            .account_update(
+                profile,
+                Some(account.did.as_str().to_string()),
+                Some(new_type),
+                None,
+                None,
+            )
             .await
             .map_err(|e| e.to_string())?;
         println!("{}", style("Account type changed successfully").green());
@@ -397,11 +403,15 @@ async fn _change_account_queue_limit(
 
     let updated = atm
         .trust_tasks()
-        .account_change_queue_limits(
+        .account_update(
             profile,
             Some(account.did.as_str().to_string()),
-            send_queue_limit,
-            receive_queue_limit,
+            None,
+            None,
+            Some(account::update::v0_1::QueueLimits {
+                send_queue_limit,
+                receive_queue_limit,
+            }),
         )
         .await
         .map_err(|e| e.to_string())?;
@@ -473,7 +483,7 @@ async fn _select_from_existing_dids(
 ) -> Result<Option<account::get::v0_1::Account>, Box<dyn std::error::Error>> {
     let dids = atm
         .trust_tasks()
-        .account_list(profile, cursor, Some(2))
+        .account_list(profile, cursor, Some(2), None)
         .await?;
 
     if dids.accounts.is_empty() {

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
@@ -8,7 +8,7 @@ use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use console::style;
 use dialoguer::{MultiSelect, Select, theme::ColorfulTheme};
 use std::sync::Arc;
-use trust_tasks_rs::specs::messaging::{account, acl};
+use trust_tasks_rs::specs::messaging::account;
 
 /// Convert a partial / per-module `MediatorAcl` into the canonical
 /// `account::get::v0_1::MediatorAcl` we hold on the account across the screen.
@@ -179,11 +179,11 @@ async fn _modify_acl_flags(
     }
 
     // Build a full ACL set from the chosen flags.
-    let new_acl = acl::set::v0_1::MediatorAcl {
+    let new_acl = account::update::v0_1::MediatorAcl {
         access_list_mode: Some(if flags[0] {
-            acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny
+            account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny
         } else {
-            acl::set::v0_1::MediatorAclAccessListMode::ExplicitAllow
+            account::update::v0_1::MediatorAclAccessListMode::ExplicitAllow
         }),
         blocked: Some(flags[1]),
         local: Some(flags[2]),
@@ -209,12 +209,18 @@ async fn _modify_acl_flags(
 
     match atm
         .trust_tasks()
-        .acl_set(profile, account.did.as_str().to_string(), new_acl.clone())
+        .account_update(
+            profile,
+            Some(account.did.as_str().to_string()),
+            None,
+            Some(new_acl.clone()),
+            None,
+        )
         .await
     {
         Ok(updated) => {
             println!("{}", style("ACLs updated").green());
-            Ok(to_get_acl(&updated))
+            Ok(to_get_acl(&updated.acl))
         }
         Err(e) => {
             println!("{}", style(format!("Error updating ACLs: {e}")).red());
@@ -236,6 +242,7 @@ async fn _access_list_list(
                 profile,
                 Some(account.did.as_str().to_string()),
                 cursor,
+                None,
                 None,
             )
             .await?;
@@ -261,10 +268,12 @@ async fn _access_list_add(
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     if let Some(hash) = manually_enter_did_or_hash(theme) {
         atm.trust_tasks()
-            .access_list_add(
+            .access_list_update(
                 profile,
                 Some(account.did.as_str().to_string()),
+                false,
                 vec![hash.clone()],
+                vec![],
             )
             .await?;
         Ok(Some(hash))
@@ -282,7 +291,13 @@ async fn _access_list_remove(
     if let Some(hash) = manually_enter_did_or_hash(theme) {
         let response = atm
             .trust_tasks()
-            .access_list_remove(profile, Some(account.did.as_str().to_string()), vec![hash])
+            .access_list_update(
+                profile,
+                Some(account.did.as_str().to_string()),
+                false,
+                vec![],
+                vec![hash],
+            )
             .await?;
         Ok(response.removed.len())
     } else {
@@ -299,14 +314,20 @@ async fn _access_list_get(
     if let Some(hash) = manually_enter_did_or_hash(theme) {
         let result = atm
             .trust_tasks()
-            .access_list_get(profile, Some(account.did.as_str().to_string()), vec![hash])
+            .access_list_list(
+                profile,
+                Some(account.did.as_str().to_string()),
+                None,
+                None,
+                Some(vec![hash]),
+            )
             .await?;
 
         println!("{}", style("DID Hashes Found:").blue());
-        for hash in &result.present {
+        for hash in &result.entries {
             println!("  {}", style(hash.as_str()).blue());
         }
-        if result.present.is_empty() {
+        if result.entries.is_empty() {
             println!("{}", style("No DID Hashes found").yellow());
         }
     }
@@ -319,7 +340,13 @@ async fn _access_list_clear(
     account: &account::get::v0_1::Account,
 ) -> Result<(), Box<dyn std::error::Error>> {
     atm.trust_tasks()
-        .access_list_clear(profile, Some(account.did.as_str().to_string()))
+        .access_list_update(
+            profile,
+            Some(account.did.as_str().to_string()),
+            true,
+            vec![],
+            vec![],
+        )
         .await?;
     Ok(())
 }

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/main.rs
@@ -240,10 +240,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", style("Admin account connected...").green());
 
     println!("{}", style("Fetching Mediator Configuration...").blue());
-    let config_response = atm.trust_tasks().admin_config(&admin).await?;
+    // Generic `config/show` (replacing the retired admin/config): the version is
+    // the `mediator.version` key; every other field re-forms the config object.
+    let config_response = atm.trust_tasks().config_show(&admin, None).await?;
+    let mut version = Value::Null;
+    let mut config_object = serde_json::Map::new();
+    for field in &config_response.fields {
+        if (*field.key).as_str() == "mediator.version" {
+            version = field.value.clone();
+        } else {
+            config_object.insert((*field.key).clone(), field.value.clone());
+        }
+    }
     let shared_config: HashMap<String, Value> = serde_json::from_value(serde_json::json!({
-        "version": config_response.version,
-        "config": config_response.config,
+        "version": version,
+        "config": Value::Object(config_object),
     }))?;
     let mut mediator_config = SharedConfig::new(shared_config)?;
     println!(

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/ui.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/ui.rs
@@ -1,11 +1,14 @@
 //! UI Related functions
+use affinidi_messaging_sdk::errors::ATMError;
 use affinidi_messaging_sdk::{ATM, profiles::ATMProfile};
 use console::style;
 use dialoguer::{Confirm, Input, MultiSelect, Select, theme::ColorfulTheme};
 use regex::Regex;
 use sha256::digest;
 use std::sync::Arc;
-use trust_tasks_rs::specs::messaging::admin::list::v0_1::AccountType;
+use trust_tasks_rs::specs::messaging::account;
+use trust_tasks_rs::specs::messaging::account::list::v0_1::AccountType;
+use trust_tasks_rs::specs::messaging::account::update::v0_1::AccountType as UpdateAccountType;
 
 use crate::SharedConfig;
 
@@ -46,16 +49,34 @@ pub(crate) async fn administration_accounts_menu(
     }
 }
 
+/// The mediator's administrator accounts — `account/list` filtered per admin
+/// role (`rootAdmin`, then `admin`), replacing the retired `admin/list` task.
+async fn admin_accounts(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+) -> Result<Vec<account::list::v0_1::Account>, ATMError> {
+    let mut accounts = Vec::new();
+    for role in [AccountType::RootAdmin, AccountType::Admin] {
+        accounts.extend(
+            atm.trust_tasks()
+                .account_list(profile, None, None, Some(role))
+                .await?
+                .accounts,
+        );
+    }
+    Ok(accounts)
+}
+
 /// List first 100 Administration DIDs
 pub(crate) async fn list_admins(atm: &ATM, profile: &Arc<ATMProfile>, config: &SharedConfig) {
-    match atm.trust_tasks().admin_list(profile, None, None).await {
-        Ok(response) => {
+    match admin_accounts(atm, profile).await {
+        Ok(admins) => {
             println!(
                 "{}",
                 style("Listing Administration DIDs (SHA256 Hashed DID's). NOTE: Will only list first 100 admin accounts!").green()
             );
 
-            for (idx, admin) in response.admins.iter().enumerate() {
+            for (idx, admin) in admins.iter().enumerate() {
                 print!(
                     "  {}",
                     style(format!("{}: {}", idx, admin.did.as_str())).yellow(),
@@ -108,10 +129,16 @@ pub(crate) async fn add_admin(atm: &ATM, profile: &Arc<ATMProfile>, theme: &Colo
     {
         match atm
             .trust_tasks()
-            .admin_add(profile, vec![input.clone()])
+            .account_update(
+                profile,
+                Some(digest(&input)),
+                Some(UpdateAccountType::Admin),
+                None,
+                None,
+            )
             .await
         {
-            Ok(_admins) => {
+            Ok(_account) => {
                 println!(
                     "{}",
                     style(format!("DID ({}) is now an administrator", &input)).green()
@@ -135,11 +162,10 @@ pub(crate) async fn strip_admins(
     config: &SharedConfig,
     theme: &ColorfulTheme,
 ) {
-    match atm.trust_tasks().admin_list(profile, None, None).await {
+    match admin_accounts(atm, profile).await {
         Ok(response) => {
             // remove the mediator administrator account from the list
             let admins: Vec<String> = response
-                .admins
                 .iter()
                 .filter_map(|x| {
                     if x.did.as_str() != config.our_admin_hash.as_str()
@@ -187,15 +213,33 @@ pub(crate) async fn strip_admins(
                     .iter()
                     .map(|&idx| admins[idx].clone())
                     .collect::<Vec<_>>();
-                match atm.trust_tasks().admin_strip(profile, admins).await {
-                    Ok(result) => {
-                        println!(
-                            "{}",
-                            style(format!("Stripped admin rights from {} DIDs", result.len()))
-                                .green()
-                        );
+                // One `account/update` per DID — each demotion is its own
+                // signed, auditable document (the batched admin/strip is retired).
+                let mut stripped = 0usize;
+                let mut errors: Vec<String> = Vec::new();
+                for did in &admins {
+                    match atm
+                        .trust_tasks()
+                        .account_update(
+                            profile,
+                            Some(did.clone()),
+                            Some(UpdateAccountType::Standard),
+                            None,
+                            None,
+                        )
+                        .await
+                    {
+                        Ok(_) => stripped += 1,
+                        Err(e) => errors.push(format!("{did}: {e}")),
                     }
-                    Err(e) => {
+                }
+                if errors.is_empty() {
+                    println!(
+                        "{}",
+                        style(format!("Stripped admin rights from {stripped} DIDs")).green()
+                    );
+                } else {
+                    for e in &errors {
                         println!("{}", style(format!("Error: {e}")).red());
                     }
                 }

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Changelog history
 
+## 29th July 2026
+
+### 0.17.13 — messaging/* trust-task family rationalized: 19 → 9 tasks, clean cutover (#667)
+
+The mediator's Trust Task consumer now speaks the rationalized `messaging/*`
+surface (trust-tasks-rs 0.2.46). This is a **clean cutover** — the retired URIs
+are no longer accepted and answer `protocol.trust_task.unsupported`:
+
+- `messaging/account/update` replaces `account/change-type`,
+  `account/change-queue-limits`, and `acl/set` — one partial update for role +
+  capabilities + queue limits, with the same per-member guards (root-admin
+  gating, self-manage gating, hard queue caps) ported from the three retired
+  handlers. Guards run before anything is applied.
+- `messaging/access-list/update` replaces `access-list/{add,remove,clear}` —
+  applied in the spec's fixed order `clear`, `add`, `remove`.
+- `messaging/account/list` gains the `accountType` role filter (per page),
+  replacing `admin/list`; `admin/add` / `admin/strip` are `account/update`
+  with `accountType: admin` / `standard`.
+- `messaging/access-list/list` gains the `entries` membership filter,
+  replacing `access-list/get`.
+- The generic `audit/list` replaces `admin/audit-log` (entries as
+  `AuditEnvelope`s with a minted content-digest `eventId`; `action` / `actor` /
+  `from` / `to` filters applied per page; the log tracks neither `outcome` nor
+  `contextId`, so those filters match nothing).
+- The generic `config/show` replaces `admin/config` (one `ConfigField` per
+  top-level config member, `source: mediator`, `requiresRestart: true`; the
+  software version is the `mediator.version` key).
+
+Removed (no longer accepted) URIs, for consumer sweeps:
+`messaging/account/change-type/0.1`, `messaging/account/change-queue-limits/0.1`,
+`messaging/acl/set/0.1`, `messaging/access-list/add/0.1`,
+`messaging/access-list/remove/0.1`, `messaging/access-list/clear/0.1`,
+`messaging/access-list/get/0.1`, `messaging/admin/add/0.1`,
+`messaging/admin/strip/0.1`, `messaging/admin/list/0.1`,
+`messaging/admin/audit-log/0.1`, `messaging/admin/config/0.1`.
+
 ## 27th July 2026 (2)
 
 ### 0.17.12 — direct delivery does one recipient lookup instead of three

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.12"
+version = "0.17.13"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -75,12 +75,12 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18.61" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18.65" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.2", optional = true }
+trust-tasks-rs = { version = "0.2.46", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -9,7 +9,15 @@
 //! through the mediator's existing outbound path — exactly like the trust-ping
 //! pong — so no separate binding/agent plumbing is needed here.
 //!
-//! This first cut handles `messaging/ping`; account / acl / access-list follow.
+//! This consumes the **rationalized** `messaging/*` surface (19 → 9 active
+//! tasks, affinidi/affinidi-tdk-rs#667): `account/update` replaces the retired
+//! `change-type` / `change-queue-limits` / `acl/set` / `admin/add` /
+//! `admin/strip`; `access-list/update` replaces `access-list/{add,remove,clear}`;
+//! the role-filtered `account/list` replaces `admin/list`; the `entries`
+//! membership filter on `access-list/list` replaces `access-list/get`; and the
+//! generic `audit/list` / `config/show` tasks replace `admin/audit-log` /
+//! `admin/config`. The retired URIs are **not** dual-accepted — they answer
+//! `protocol.trust_task.unsupported` like any other unknown type.
 //!
 //! [Trust Task]: https://trusttasks.org
 
@@ -19,7 +27,6 @@ use affinidi_messaging_mediator_common::types::accounts::{Account, AccountType};
 use affinidi_messaging_mediator_common::types::acls::{
     ACLError, AccessListModeType, MediatorACLSet,
 };
-use affinidi_messaging_mediator_common::types::administration::AdminAccount as MediatorAdminAccount;
 use affinidi_messaging_mediator_common::types::audit::{AuditAction, AuditLogEntry};
 use affinidi_messaging_sdk::messages::compat::UnpackMetadata;
 use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
@@ -29,7 +36,8 @@ use sha256::digest;
 use std::collections::HashSet;
 use std::str::FromStr;
 use subtle::ConstantTimeEq;
-use trust_tasks_rs::specs::messaging::{access_list, account, acl, admin, ping};
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
+use trust_tasks_rs::specs::{audit, config};
 use trust_tasks_rs::{
     ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
     TrustTask, TypeUri, VerificationError, consume_inbound,
@@ -145,12 +153,12 @@ pub(crate) async fn process(
         .await?
     } else if doc.type_uri == type_uri_of::<account::list::v0_1::Payload>() {
         consume_account_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
-    } else if doc.type_uri == type_uri_of::<account::change_queue_limits::v0_1::Payload>() {
-        consume_account_change_queue_limits(
+    } else if doc.type_uri == type_uri_of::<account::update::v0_1::Payload>() {
+        consume_account_update(
             downcast(&doc, session)?,
             state,
             session,
-            &Some(sender_kid.clone()),
+            &sk,
             &mediator_did,
             now,
         )
@@ -165,9 +173,6 @@ pub(crate) async fn process(
             now,
         )
         .await?
-    } else if doc.type_uri == type_uri_of::<account::change_type::v0_1::Payload>() {
-        consume_account_change_type(downcast(&doc, session)?, state, session, &mediator_did, now)
-            .await?
     } else if doc.type_uri == type_uri_of::<account::add::v0_1::Payload>() {
         consume_account_add(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else if doc.type_uri == type_uri_of::<acl::get::v0_1::Payload>() {
@@ -180,48 +185,8 @@ pub(crate) async fn process(
             now,
         )
         .await?
-    } else if doc.type_uri == type_uri_of::<acl::set::v0_1::Payload>() {
-        consume_acl_set(
-            downcast(&doc, session)?,
-            state,
-            session,
-            &sk,
-            &mediator_did,
-            now,
-        )
-        .await?
-    } else if doc.type_uri == type_uri_of::<access_list::add::v0_1::Payload>() {
-        consume_access_list_add(
-            downcast(&doc, session)?,
-            state,
-            session,
-            &sk,
-            &mediator_did,
-            now,
-        )
-        .await?
-    } else if doc.type_uri == type_uri_of::<access_list::remove::v0_1::Payload>() {
-        consume_access_list_remove(
-            downcast(&doc, session)?,
-            state,
-            session,
-            &sk,
-            &mediator_did,
-            now,
-        )
-        .await?
-    } else if doc.type_uri == type_uri_of::<access_list::clear::v0_1::Payload>() {
-        consume_access_list_clear(
-            downcast(&doc, session)?,
-            state,
-            session,
-            &sk,
-            &mediator_did,
-            now,
-        )
-        .await?
-    } else if doc.type_uri == type_uri_of::<access_list::get::v0_1::Payload>() {
-        consume_access_list_get(
+    } else if doc.type_uri == type_uri_of::<access_list::update::v0_1::Payload>() {
+        consume_access_list_update(
             downcast(&doc, session)?,
             state,
             session,
@@ -240,17 +205,10 @@ pub(crate) async fn process(
             now,
         )
         .await?
-    } else if doc.type_uri == type_uri_of::<admin::add::v0_1::Payload>() {
-        consume_admin_add(downcast(&doc, session)?, state, session, &mediator_did, now).await?
-    } else if doc.type_uri == type_uri_of::<admin::strip::v0_1::Payload>() {
-        consume_admin_strip(downcast(&doc, session)?, state, session, &mediator_did, now).await?
-    } else if doc.type_uri == type_uri_of::<admin::list::v0_1::Payload>() {
-        consume_admin_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
-    } else if doc.type_uri == type_uri_of::<admin::audit_log::v0_1::Payload>() {
-        consume_admin_audit_log(downcast(&doc, session)?, state, session, &mediator_did, now)
-            .await?
-    } else if doc.type_uri == type_uri_of::<admin::config::v0_1::Payload>() {
-        consume_admin_config(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<audit::list::v0_1::Payload>() {
+        consume_audit_list(downcast(&doc, session)?, state, session, &mediator_did, now).await?
+    } else if doc.type_uri == type_uri_of::<config::show::v0_1::Payload>() {
+        consume_config_show(downcast(&doc, session)?, state, session, &mediator_did, now).await?
     } else {
         return Err(tt_problem(
             session,
@@ -361,6 +319,10 @@ async fn consume_account_get(
 
 /// Handle `messaging/account/list`: admin-only, read-only. Returns one page of the
 /// mediator's accounts (with an opaque continuation cursor) as a `TrustTask<Response>`.
+/// An `accountType` filter restricts the page to one role — filtering on `admin` /
+/// `rootAdmin` enumerates the administrators (this subsumes the retired
+/// `messaging/admin/list`). The filter applies per page, so a filtered page may
+/// hold fewer than `limit` entries while `nextCursor` still advances.
 async fn consume_account_list(
     typed: TrustTask<account::list::v0_1::Payload>,
     state: &SharedData,
@@ -399,10 +361,22 @@ async fn consume_account_list(
         .unwrap_or(0);
     let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
 
+    // Optional role filter (subsumes the retired `messaging/admin/list`).
+    let type_filter = typed.payload.account_type.as_ref().map(|t| {
+        use account::list::v0_1::AccountType as WireType;
+        match t {
+            WireType::Standard => AccountType::Standard,
+            WireType::Admin => AccountType::Admin,
+            WireType::RootAdmin => AccountType::RootAdmin,
+            WireType::Mediator => AccountType::Mediator,
+        }
+    });
+
     let page = state.database.account_list(cursor, limit).await?;
     let accounts = page
         .accounts
         .iter()
+        .filter(|a| type_filter.as_ref().is_none_or(|t| a._type == *t))
         .map(to_wire_account::<account::list::v0_1::Account>)
         .collect();
     // The store returns cursor 0 when the listing is exhausted.
@@ -427,86 +401,47 @@ async fn consume_account_list(
     serde_json::to_value(&response_doc).map_err(serialize_err)
 }
 
-/// Handle `messaging/account/change-queue-limits`: self-or-admin. A standard account
-/// may only change a limit it is permitted to self-manage, and its values are capped
-/// at the mediator's hard maximum; an admin sets any value. Returns the updated view.
-async fn consume_account_change_queue_limits(
-    typed: TrustTask<account::change_queue_limits::v0_1::Payload>,
+/// Handle `messaging/account/update`: one partial update of a served account's
+/// role, capabilities, and queue limits — the merge of the retired
+/// `change-type` / `change-queue-limits` / `acl/set` handlers, with their guards
+/// applied per member:
+///
+/// - `accountType` — admin only; only a root admin may assign the root-admin
+///   role, and only a root admin may update an account that currently holds it.
+/// - `acl` — self-or-admin; a non-admin may only change flags it self-manages.
+/// - `queueLimits` — self-or-admin; a standard account may only change limits it
+///   self-manages, capped at the mediator's hard maximum.
+///
+/// Guards run before anything is applied so a refused member refuses the whole
+/// update. Returns the account's realized view after the change.
+async fn consume_account_update(
+    typed: TrustTask<account::update::v0_1::Payload>,
     state: &SharedData,
     session: &Session,
     sender_kid: &Option<String>,
     mediator_did: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, MediatorError> {
-    typed.validate_basic(now, mediator_did).map_err(|reason| {
-        tt_problem(
-            session,
-            "message.trust_task.rejected",
-            format!("Trust Task failed basic validation: {reason:?}"),
-            StatusCode::BAD_REQUEST,
-        )
-    })?;
+    use account::update::v0_1::AccountType as WireType;
+
+    validate_tt_basic(&typed, session, mediator_did, now)?;
 
     let target_hash = typed.payload.did.to_string();
-    if !check_permissions(
-        session,
-        std::slice::from_ref(&target_hash),
-        state.config.security.block_remote_admin_msgs,
-        sender_kid,
-    ) {
-        return Err(tt_problem(
+    let is_admin = matches!(
+        session.account_type,
+        AccountType::Admin | AccountType::RootAdmin
+    );
+    let denied = |reason: &str| {
+        tt_problem(
             session,
-            "authorization.account.denied",
-            format!("not permitted to change queue limits for account {target_hash}"),
+            "authorization.permission",
+            reason.to_string(),
             StatusCode::FORBIDDEN,
-        ));
-    }
-
-    // The wire carries i64; the store works in i32. A member omitted is unchanged.
-    let req_send = typed
-        .payload
-        .queue_limits
-        .send_queue_limit
-        .map(|v| v as i32);
-    let req_receive = typed
-        .payload
-        .queue_limits
-        .receive_queue_limit
-        .map(|v| v as i32);
-
-    // A standard account may only touch limits it self-manages, capped at the hard
-    // maximum; an admin sets any value.
-    let (send_queue_limit, receive_queue_limit) = if session.account_type == AccountType::Standard {
-        (
-            gate_self_managed_limit(
-                req_send,
-                session.acls.get_self_manage_send_queue_limit(),
-                state.config.limits.queued_send_messages_hard,
-            ),
-            gate_self_managed_limit(
-                req_receive,
-                session.acls.get_self_manage_receive_queue_limit(),
-                state.config.limits.queued_receive_messages_hard,
-            ),
         )
-    } else {
-        (req_send, req_receive)
     };
 
-    state
-        .database
-        .account_change_queue_limits(&target_hash, send_queue_limit, receive_queue_limit)
-        .await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::AccountChangeQueueLimits,
-        format!("send={send_queue_limit:?} receive={receive_queue_limit:?}"),
-    )
-    .await;
-
-    let account = state
+    // The task updates; it does not create.
+    let current = state
         .database
         .account_get(&target_hash)
         .await?
@@ -518,7 +453,183 @@ async fn consume_account_change_queue_limits(
                 StatusCode::NOT_FOUND,
             )
         })?;
-    let response = account::change_queue_limits::v0_1::Response {
+
+    // ---- Guards first, so a refused member refuses the whole update. ----
+
+    // Only a root admin may touch an account that currently holds root-admin.
+    if current._type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin {
+        return Err(denied(
+            "root-admin access is required to modify a root-admin account",
+        ));
+    }
+
+    let new_type = typed.payload.account_type.as_ref().map(|t| match t {
+        WireType::Standard => AccountType::Standard,
+        WireType::Admin => AccountType::Admin,
+        WireType::RootAdmin => AccountType::RootAdmin,
+        WireType::Mediator => AccountType::Mediator,
+    });
+    if let Some(new_type) = &new_type {
+        // Must be an admin to change roles at all.
+        if !state
+            .database
+            .check_admin_account(&session.did_hash)
+            .await?
+        {
+            return Err(denied("admin access is required to change account types"));
+        }
+        // Only a root admin may assign the root-admin role.
+        if *new_type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin {
+            return Err(denied(
+                "root-admin access is required to assign the root-admin role",
+            ));
+        }
+    }
+
+    // Capabilities and queue limits are self-or-admin.
+    let acl_value = match &typed.payload.acl {
+        Some(acl) => Some(serde_json::to_value(acl).map_err(serialize_err)?),
+        None => None,
+    };
+    if (acl_value.is_some() || typed.payload.queue_limits.is_some())
+        && !check_permissions(
+            session,
+            std::slice::from_ref(&target_hash),
+            state.config.security.block_remote_admin_msgs,
+            sender_kid,
+        )
+    {
+        return Err(tt_problem(
+            session,
+            "authorization.account.denied",
+            format!("not permitted to update account {target_hash}"),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+    if let Some(acl_value) = &acl_value {
+        // A non-admin may only change flags it is permitted to self-manage.
+        if !is_admin {
+            ensure_self_manageable(acl_value, &MediatorACLSet::from_u64(current.acls), session)?;
+        }
+    }
+
+    // ---- Apply: capabilities, then queue limits, then the role. ----
+
+    if let Some(acl_value) = acl_value {
+        let base = state
+            .database
+            .get_did_acl(&target_hash)
+            .await?
+            .unwrap_or_default();
+        let merged = merge_wire_acl(acl_value, base)?;
+        let stored = state.database.set_did_acl(&target_hash, &merged).await?;
+        record_audit(
+            state,
+            session,
+            &target_hash,
+            AuditAction::SetAcl,
+            format!("acl -> {:#018x}", stored.to_u64()),
+        )
+        .await;
+    }
+
+    if let Some(limits) = &typed.payload.queue_limits {
+        // The wire carries i64; the store works in i32. A member omitted is unchanged.
+        let req_send = limits.send_queue_limit.map(|v| v as i32);
+        let req_receive = limits.receive_queue_limit.map(|v| v as i32);
+
+        // A standard account may only touch limits it self-manages, capped at the
+        // hard maximum; an admin sets any value.
+        let (send_queue_limit, receive_queue_limit) =
+            if session.account_type == AccountType::Standard {
+                (
+                    gate_self_managed_limit(
+                        req_send,
+                        session.acls.get_self_manage_send_queue_limit(),
+                        state.config.limits.queued_send_messages_hard,
+                    ),
+                    gate_self_managed_limit(
+                        req_receive,
+                        session.acls.get_self_manage_receive_queue_limit(),
+                        state.config.limits.queued_receive_messages_hard,
+                    ),
+                )
+            } else {
+                (req_send, req_receive)
+            };
+
+        state
+            .database
+            .account_change_queue_limits(&target_hash, send_queue_limit, receive_queue_limit)
+            .await?;
+        record_audit(
+            state,
+            session,
+            &target_hash,
+            AuditAction::AccountChangeQueueLimits,
+            format!("send={send_queue_limit:?} receive={receive_queue_limit:?}"),
+        )
+        .await;
+    }
+
+    if let Some(new_type) = new_type {
+        // A faithful port of the legacy admin-set transitions (promote / demote /
+        // switch); the guards above already authorized the change.
+        if current._type != new_type {
+            if current._type.is_admin() && !new_type.is_admin() {
+                // Demotion — strip admin rights first, then set the plain role.
+                state
+                    .database
+                    .strip_admin_accounts(vec![target_hash.clone()])
+                    .await?;
+                state
+                    .database
+                    .account_set_role(&target_hash, &new_type)
+                    .await?;
+            } else if !current._type.is_admin() && new_type.is_admin() {
+                // Promotion — add admin rights, carrying the account's current ACL
+                // set (re-read so an `acl` member in this same update is honoured).
+                let acls = state
+                    .database
+                    .account_get(&target_hash)
+                    .await?
+                    .map(|a| a.acls)
+                    .unwrap_or(current.acls);
+                state
+                    .database
+                    .setup_admin_account(&target_hash, new_type, &MediatorACLSet::from_u64(acls))
+                    .await?;
+            } else {
+                // Switching between admin roles is a plain set-role.
+                state
+                    .database
+                    .account_set_role(&target_hash, &new_type)
+                    .await?;
+            }
+            record_audit(
+                state,
+                session,
+                &target_hash,
+                AuditAction::AccountChangeType,
+                format!("type -> {new_type}"),
+            )
+            .await;
+        }
+    }
+
+    let account = state
+        .database
+        .account_get(&target_hash)
+        .await?
+        .ok_or_else(|| {
+            tt_problem(
+                session,
+                "account.not_found",
+                format!("account {target_hash} not found after update"),
+                StatusCode::NOT_FOUND,
+            )
+        })?;
+    let response = account::update::v0_1::Response {
         account: to_wire_account(&account),
         ext: None,
     };
@@ -617,150 +728,6 @@ async fn consume_account_remove(
     };
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
-}
-
-/// Handle `messaging/account/change-type`: admin-only, with root-admin guards —
-/// only a root admin may assign root-admin or modify a root-admin account. A
-/// faithful port of the legacy admin-set transitions (promote / demote / switch).
-/// Returns the account's realized view after the change.
-async fn consume_account_change_type(
-    typed: TrustTask<account::change_type::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    use account::change_type::v0_1::AccountType as WireType;
-
-    typed.validate_basic(now, mediator_did).map_err(|reason| {
-        tt_problem(
-            session,
-            "message.trust_task.rejected",
-            format!("Trust Task failed basic validation: {reason:?}"),
-            StatusCode::BAD_REQUEST,
-        )
-    })?;
-
-    let target_hash = typed.payload.did.to_string();
-    let new_type = match typed.payload.account_type {
-        WireType::Standard => AccountType::Standard,
-        WireType::Admin => AccountType::Admin,
-        WireType::RootAdmin => AccountType::RootAdmin,
-        WireType::Mediator => AccountType::Mediator,
-    };
-
-    let denied = |reason: &str| {
-        tt_problem(
-            session,
-            "authorization.permission",
-            reason.to_string(),
-            StatusCode::FORBIDDEN,
-        )
-    };
-
-    // Must be an admin to change types at all.
-    if !state
-        .database
-        .check_admin_account(&session.did_hash)
-        .await?
-    {
-        return Err(denied("admin access is required to change account types"));
-    }
-    // Only a root admin may assign the root-admin role.
-    if new_type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin {
-        return Err(denied(
-            "root-admin access is required to assign the root-admin role",
-        ));
-    }
-
-    let current = state.database.account_get(&target_hash).await?;
-    if let Some(current) = &current {
-        if current._type == AccountType::RootAdmin && session.account_type != AccountType::RootAdmin
-        {
-            return Err(denied(
-                "root-admin access is required to modify a root-admin account",
-            ));
-        } else if current._type == new_type {
-            // No change — report the account as-is.
-            return change_type_response(&typed, current);
-        } else if current._type.is_admin() && new_type.is_admin() {
-            // Switching between admin roles is a plain set-role (below).
-        } else if current._type.is_admin() && !new_type.is_admin() {
-            // Demotion — strip admin rights first.
-            state
-                .database
-                .strip_admin_accounts(vec![target_hash.clone()])
-                .await?;
-        } else if !current._type.is_admin() && new_type.is_admin() {
-            // Promotion — add admin rights, carrying the existing ACL set.
-            state
-                .database
-                .setup_admin_account(
-                    &target_hash,
-                    new_type,
-                    &MediatorACLSet::from_u64(current.acls),
-                )
-                .await?;
-            record_audit(
-                state,
-                session,
-                &target_hash,
-                AuditAction::AccountChangeType,
-                format!("type -> {new_type}"),
-            )
-            .await;
-            return change_type_fetch_response(&typed, state, session, &target_hash).await;
-        }
-    }
-
-    state
-        .database
-        .account_set_role(&target_hash, &new_type)
-        .await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::AccountChangeType,
-        format!("type -> {new_type}"),
-    )
-    .await;
-    change_type_fetch_response(&typed, state, session, &target_hash).await
-}
-
-/// Build a `change-type` response from an account.
-fn change_type_response(
-    typed: &TrustTask<account::change_type::v0_1::Payload>,
-    account: &Account,
-) -> Result<Value, MediatorError> {
-    let response = account::change_type::v0_1::Response {
-        account: to_wire_account(account),
-        ext: None,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Re-read the account after a change and build the `change-type` response.
-async fn change_type_fetch_response(
-    typed: &TrustTask<account::change_type::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    target_hash: &str,
-) -> Result<Value, MediatorError> {
-    let account = state
-        .database
-        .account_get(target_hash)
-        .await?
-        .ok_or_else(|| {
-            tt_problem(
-                session,
-                "account.not_found",
-                format!("account {target_hash} not found after change"),
-                StatusCode::NOT_FOUND,
-            )
-        })?;
-    change_type_response(typed, &account)
 }
 
 /// Handle `messaging/account/add`. In `ExplicitAllow` mode only an admin may add
@@ -927,74 +894,6 @@ async fn consume_acl_get(
         .map_err(serialize_err)
 }
 
-/// Handle `messaging/acl/set`: admin-only. Applies the wire ACL as a partial update
-/// onto the account's current ACL (the reverse map preserves the per-capability
-/// change bits) and returns the realized ACL. Non-admin self-service ACL changes are
-/// not supported here — they are refused.
-async fn consume_acl_set(
-    typed: TrustTask<acl::set::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    sender_kid: &Option<String>,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-
-    let target_hash = typed.payload.did.to_string();
-    let is_admin = matches!(
-        session.account_type,
-        AccountType::Admin | AccountType::RootAdmin
-    );
-
-    // Self-or-admin: a non-admin may only set its own ACL.
-    if !check_permissions(
-        session,
-        std::slice::from_ref(&target_hash),
-        state.config.security.block_remote_admin_msgs,
-        sender_kid,
-    ) {
-        return Err(tt_problem(
-            session,
-            "authorization.account.denied",
-            format!("not permitted to set the ACL for {target_hash}"),
-            StatusCode::FORBIDDEN,
-        ));
-    }
-
-    let base = state
-        .database
-        .get_did_acl(&target_hash)
-        .await?
-        .unwrap_or_default();
-    let acl_value = serde_json::to_value(&typed.payload.acl).map_err(serialize_err)?;
-
-    // A non-admin may only change flags it is permitted to self-manage.
-    if !is_admin {
-        ensure_self_manageable(&acl_value, &base, session)?;
-    }
-
-    let merged = merge_wire_acl(acl_value, base)?;
-
-    let stored = state.database.set_did_acl(&target_hash, &merged).await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::SetAcl,
-        format!("acl -> {:#018x}", stored.to_u64()),
-    )
-    .await;
-
-    let response = acl::set::v0_1::Response {
-        acl: to_wire_acl(&stored),
-        did: typed.payload.did.clone(),
-        ext: None,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
 /// Access-list authz: self-or-admin for the target, plus the `self_manage_list`
 /// capability for a standard account performing a write.
 fn authorize_access_list(
@@ -1133,102 +1032,91 @@ fn ensure_self_manageable(
     Ok(())
 }
 
-/// Handle `messaging/access-list/add`: self-or-admin (+ `self_manage_list` for a
-/// standard account). Adds entries (truncated at the mediator limit); reports those
-/// actually inserted and the new count.
-async fn consume_access_list_add(
-    typed: TrustTask<access_list::add::v0_1::Payload>,
+/// Handle `messaging/access-list/update`: self-or-admin (+ `self_manage_list` for
+/// a standard account). One write task for the whole access list — the merge of
+/// the retired `access-list/add` / `remove` / `clear` handlers. Members apply in
+/// the spec's fixed order **`clear`, `add`, `remove`**, so `clear + add` replaces
+/// the list wholesale. Reports the entries actually added and removed plus the
+/// resulting count.
+async fn consume_access_list_update(
+    typed: TrustTask<access_list::update::v0_1::Payload>,
     state: &SharedData,
     session: &Session,
     sender_kid: &Option<String>,
     mediator_did: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, MediatorError> {
-    use access_list::add::v0_1::{Response, Vid};
+    use access_list::update::v0_1::{Response, Vid};
     validate_tt_basic(&typed, session, mediator_did, now)?;
     let target_hash = typed.payload.did.to_string();
     authorize_access_list(state, session, sender_kid, &target_hash, true)?;
 
-    let hashes: Vec<String> = typed
-        .payload
-        .entries
-        .iter()
-        .map(|v| v.to_string())
-        .collect();
-    let result = state
-        .database
-        .access_list_add(state.config.limits.access_list_limit, &target_hash, &hashes)
-        .await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::AccessListAdd,
-        format!("added {} entries", result.did_hashes.len()),
-    )
-    .await;
+    // 1. `clear` empties the list before any additions.
+    if typed.payload.clear == Some(true) {
+        state.database.access_list_clear(&target_hash).await?;
+        record_audit(
+            state,
+            session,
+            &target_hash,
+            AuditAction::AccessListClear,
+            "access list cleared".to_string(),
+        )
+        .await;
+    }
 
-    let added = result
-        .did_hashes
-        .iter()
-        .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
-        .collect();
+    // 2. `add` — idempotent at the set level, truncated at the mediator limit.
+    let mut added: Vec<Vid> = Vec::new();
+    if !typed.payload.add.is_empty() {
+        let hashes: Vec<String> = typed.payload.add.iter().map(|v| v.to_string()).collect();
+        let result = state
+            .database
+            .access_list_add(state.config.limits.access_list_limit, &target_hash, &hashes)
+            .await?;
+        record_audit(
+            state,
+            session,
+            &target_hash,
+            AuditAction::AccessListAdd,
+            format!("added {} entries", result.did_hashes.len()),
+        )
+        .await;
+        added = result
+            .did_hashes
+            .iter()
+            .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
+            .collect();
+    }
+
+    // 3. `remove` — those present before removal are exactly those removed.
+    let mut removed: Vec<Vid> = Vec::new();
+    if !typed.payload.remove.is_empty() {
+        let hashes: Vec<String> = typed.payload.remove.iter().map(|v| v.to_string()).collect();
+        let present = state
+            .database
+            .access_list_get(&target_hash, &hashes)
+            .await?
+            .did_hashes;
+        state
+            .database
+            .access_list_remove(&target_hash, &hashes)
+            .await?;
+        record_audit(
+            state,
+            session,
+            &target_hash,
+            AuditAction::AccessListRemove,
+            format!("removed {} entries", present.len()),
+        )
+        .await;
+        removed = present
+            .iter()
+            .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
+            .collect();
+    }
+
     let response = Response {
         access_list_count: access_list_count(state, &target_hash).await,
         added,
-        did: typed.payload.did.clone(),
-        ext: None,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Handle `messaging/access-list/remove`: self-or-admin (+ `self_manage_list`).
-/// Reports which of the requested entries were present (and thus removed).
-async fn consume_access_list_remove(
-    typed: TrustTask<access_list::remove::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    sender_kid: &Option<String>,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    use access_list::remove::v0_1::{Response, Vid};
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    let target_hash = typed.payload.did.to_string();
-    authorize_access_list(state, session, sender_kid, &target_hash, true)?;
-
-    let hashes: Vec<String> = typed
-        .payload
-        .entries
-        .iter()
-        .map(|v| v.to_string())
-        .collect();
-    // Those present before removal are exactly those removed.
-    let present = state
-        .database
-        .access_list_get(&target_hash, &hashes)
-        .await?
-        .did_hashes;
-    state
-        .database
-        .access_list_remove(&target_hash, &hashes)
-        .await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::AccessListRemove,
-        format!("removed {} entries", present.len()),
-    )
-    .await;
-
-    let removed = present
-        .iter()
-        .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
-        .collect();
-    let response = Response {
-        access_list_count: access_list_count(state, &target_hash).await,
         did: typed.payload.did.clone(),
         ext: None,
         removed,
@@ -1237,88 +1125,11 @@ async fn consume_access_list_remove(
         .map_err(serialize_err)
 }
 
-/// Handle `messaging/access-list/clear`: self-or-admin (+ `self_manage_list`).
-async fn consume_access_list_clear(
-    typed: TrustTask<access_list::clear::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    sender_kid: &Option<String>,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    let target_hash = typed.payload.did.to_string();
-    authorize_access_list(state, session, sender_kid, &target_hash, true)?;
-
-    state.database.access_list_clear(&target_hash).await?;
-    record_audit(
-        state,
-        session,
-        &target_hash,
-        AuditAction::AccessListClear,
-        "access list cleared".to_string(),
-    )
-    .await;
-
-    let response = access_list::clear::v0_1::Response {
-        access_list_count: access_list_count(state, &target_hash).await,
-        did: typed.payload.did.clone(),
-        ext: None,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Handle `messaging/access-list/get`: self-or-admin, read-only. Partitions the
-/// requested entries into those present in the list and those absent.
-async fn consume_access_list_get(
-    typed: TrustTask<access_list::get::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    sender_kid: &Option<String>,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    use access_list::get::v0_1::Response;
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    let target_hash = typed.payload.did.to_string();
-    authorize_access_list(state, session, sender_kid, &target_hash, false)?;
-
-    let hashes: Vec<String> = typed
-        .payload
-        .entries
-        .iter()
-        .map(|v| v.to_string())
-        .collect();
-    let present: HashSet<String> = state
-        .database
-        .access_list_get(&target_hash, &hashes)
-        .await?
-        .did_hashes
-        .into_iter()
-        .collect();
-
-    let mut present_vids = Vec::new();
-    let mut absent_vids = Vec::new();
-    for v in &typed.payload.entries {
-        if present.contains(v.as_str()) {
-            present_vids.push(v.clone());
-        } else {
-            absent_vids.push(v.clone());
-        }
-    }
-
-    let response = Response {
-        absent: absent_vids,
-        did: typed.payload.did.clone(),
-        ext: None,
-        present: present_vids,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
 /// Handle `messaging/access-list/list`: self-or-admin, read-only, cursor-paged.
+/// An `entries` filter turns the enumeration into a membership check (subsuming
+/// the retired `messaging/access-list/get`): only the supplied DIDs present in
+/// the list are returned, unpaged, with `accessListCount` still the whole-list
+/// total.
 async fn consume_access_list_list(
     typed: TrustTask<access_list::list::v0_1::Payload>,
     state: &SharedData,
@@ -1331,6 +1142,42 @@ async fn consume_access_list_list(
     validate_tt_basic(&typed, session, mediator_did, now)?;
     let target_hash = typed.payload.did.to_string();
     authorize_access_list(state, session, sender_kid, &target_hash, false)?;
+
+    // Membership check (subsumes the retired `messaging/access-list/get`): return
+    // exactly the supplied entries that are present; a supplied DID absent from
+    // the response is not a member.
+    if !typed.payload.entries.is_empty() {
+        let hashes: Vec<String> = typed
+            .payload
+            .entries
+            .iter()
+            .map(|v| v.to_string())
+            .collect();
+        let present: HashSet<String> = state
+            .database
+            .access_list_get(&target_hash, &hashes)
+            .await?
+            .did_hashes
+            .into_iter()
+            .collect();
+        let entries = typed
+            .payload
+            .entries
+            .iter()
+            .filter(|v| present.contains(v.as_str()))
+            .cloned()
+            .collect();
+
+        let response = Response {
+            access_list_count: access_list_count(state, &target_hash).await,
+            did: typed.payload.did.clone(),
+            entries,
+            ext: None,
+            next_cursor: None,
+        };
+        return serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
+            .map_err(serialize_err);
+    }
 
     let cursor: u64 = typed
         .payload
@@ -1384,86 +1231,26 @@ fn require_admin(session: &Session, task: &str) -> Result<(), MediatorError> {
     }
 }
 
-/// Handle `messaging/admin/add`: admin-only. Grants admin rights to the named
-/// accounts (with the mediator's default ACL) and echoes the now-admin set.
-async fn consume_admin_add(
-    typed: TrustTask<admin::add::v0_1::Payload>,
+/// Handle the generic `audit/list`: admin-only. Pages the mediator's
+/// privileged-change log, newest first, as `AuditEnvelope`s — the messaging
+/// profile of the generic task that replaces the retired
+/// `messaging/admin/audit-log` (request `limit` → `pageSize`; response
+/// `nextCursor` → `cursor` + `truncated`).
+///
+/// Filter support is per page: `action` / `actor` / `from` / `to` are applied to
+/// the fetched page (the cursor still advances page-by-page). The mediator's log
+/// tracks neither `outcome` nor `contextId`, so a filter on those matches
+/// nothing.
+async fn consume_audit_list(
+    typed: TrustTask<audit::list::v0_1::Payload>,
     state: &SharedData,
     session: &Session,
     mediator_did: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, MediatorError> {
+    use audit::list::v0_1::Response;
     validate_tt_basic(&typed, session, mediator_did, now)?;
-    require_admin(session, "admin/add")?;
-
-    let dids: Vec<String> = typed.payload.dids.iter().map(|v| v.to_string()).collect();
-    state
-        .database
-        .add_admin_accounts(dids.clone(), &state.config.security.global_acl_default)
-        .await?;
-    for did in &dids {
-        record_audit(
-            state,
-            session,
-            did,
-            AuditAction::AdminAdd,
-            "promoted to admin".to_string(),
-        )
-        .await;
-    }
-
-    let response = admin::add::v0_1::Response {
-        admins: typed.payload.dids.clone(),
-        ext: None,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Handle `messaging/admin/strip`: admin-only. Removes admin rights from the named
-/// accounts (demoting them to standard) and echoes the stripped set.
-async fn consume_admin_strip(
-    typed: TrustTask<admin::strip::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    require_admin(session, "admin/strip")?;
-
-    let dids: Vec<String> = typed.payload.dids.iter().map(|v| v.to_string()).collect();
-    state.database.strip_admin_accounts(dids.clone()).await?;
-    for did in &dids {
-        record_audit(
-            state,
-            session,
-            did,
-            AuditAction::AdminStrip,
-            "admin rights stripped".to_string(),
-        )
-        .await;
-    }
-
-    let response = admin::strip::v0_1::Response {
-        ext: None,
-        stripped: typed.payload.dids.clone(),
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Handle `messaging/admin/list`: admin-only. Pages the mediator's admin accounts.
-async fn consume_admin_list(
-    typed: TrustTask<admin::list::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    use admin::list::v0_1::{Response, ResponseNextCursor};
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    require_admin(session, "admin/list")?;
+    require_admin(session, "audit/list")?;
 
     let cursor: u32 = typed
         .payload
@@ -1471,125 +1258,173 @@ async fn consume_admin_list(
         .as_ref()
         .and_then(|c| c.parse().ok())
         .unwrap_or(0);
-    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
-
-    let page = state.database.list_admin_accounts(cursor, limit).await?;
-    let admins = page.accounts.iter().map(map_admin_account).collect();
-    let next_cursor = (page.cursor != 0)
-        .then(|| ResponseNextCursor::from_str(&page.cursor.to_string()))
-        .transpose()
-        .map_err(|e| serialize_err_msg(format!("cursor: {e}")))?;
-
-    let response = Response {
-        admins,
-        ext: None,
-        next_cursor,
-    };
-    serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
-        .map_err(serialize_err)
-}
-
-/// Handle `messaging/admin/audit-log`: admin-only. Pages the privileged-change log.
-async fn consume_admin_audit_log(
-    typed: TrustTask<admin::audit_log::v0_1::Payload>,
-    state: &SharedData,
-    session: &Session,
-    mediator_did: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Value, MediatorError> {
-    use admin::audit_log::v0_1::{Response, ResponseNextCursor};
-    validate_tt_basic(&typed, session, mediator_did, now)?;
-    require_admin(session, "admin/audit-log")?;
-
-    let cursor: u32 = typed
+    let limit: u32 = typed
         .payload
-        .cursor
-        .as_ref()
-        .and_then(|c| c.parse().ok())
-        .unwrap_or(0);
-    let limit: u32 = typed.payload.limit.map(|n| n.get() as u32).unwrap_or(100);
+        .page_size
+        .map(|n| n.get() as u32)
+        .unwrap_or(100);
 
     let page = state.database.audit_log_list(cursor, limit).await?;
-    let entries = page.entries.iter().map(map_audit_entry).collect();
-    let next_cursor = (page.cursor != 0)
-        .then(|| ResponseNextCursor::from_str(&page.cursor.to_string()))
-        .transpose()
-        .map_err(|e| serialize_err_msg(format!("cursor: {e}")))?;
+    let entries = page
+        .entries
+        .iter()
+        .filter(|e| audit_filters_match(&typed.payload, e))
+        .map(map_audit_envelope)
+        .collect::<Result<Vec<_>, _>>()?;
+    let truncated = page.cursor != 0;
 
     let response = Response {
+        cursor: truncated.then(|| page.cursor.to_string()),
         entries,
         ext: None,
-        next_cursor,
+        truncated,
     };
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
 
-/// Handle `messaging/admin/config`: admin-only. Returns the mediator's software
-/// version and current configuration.
-async fn consume_admin_config(
-    typed: TrustTask<admin::config::v0_1::Payload>,
+/// Apply the generic `audit/list` filters to one internal log entry.
+fn audit_filters_match(payload: &audit::list::v0_1::Payload, e: &AuditLogEntry) -> bool {
+    // The mediator's log tracks neither outcome nor context: a filter on them
+    // matches nothing (honest emptiness rather than a silently ignored filter).
+    if payload.outcome.is_some() || payload.context_id.is_some() {
+        return false;
+    }
+    if let Some(action) = &payload.action
+        && **action != audit_action_name(e.action)
+    {
+        return false;
+    }
+    if let Some(actor) = &payload.actor
+        && **actor != e.actor_did_hash
+    {
+        return false;
+    }
+    let recorded = e.timestamp as i64;
+    if let Some(from) = &payload.from
+        && recorded < from.timestamp()
+    {
+        return false;
+    }
+    if let Some(to) = &payload.to
+        && recorded >= to.timestamp()
+    {
+        return false;
+    }
+    true
+}
+
+/// Map one internal audit record onto the generic `AuditEnvelope` profile:
+/// `timestamp` → `recordedAt`, `actor`/`target` hashes → `actor`/`target`,
+/// the action's shared-schema name → `action`, and the free-text detail →
+/// `detail.detail`. The mediator's log has no native event id, so a stable one
+/// is minted as the digest of the entry's content.
+fn map_audit_envelope(
+    e: &AuditLogEntry,
+) -> Result<audit::list::v0_1::AuditEnvelope, MediatorError> {
+    use audit::list::v0_1::{AuditEnvelope, AuditEnvelopeAction, AuditEnvelopeEventId};
+
+    let action = audit_action_name(e.action);
+    let event_id = digest(format!(
+        "{}:{}:{}:{}:{}",
+        e.timestamp, e.actor_did_hash, e.target_did_hash, action, e.detail
+    ));
+    let mut detail = serde_json::Map::new();
+    detail.insert("detail".to_string(), Value::String(e.detail.clone()));
+
+    Ok(AuditEnvelope {
+        action: AuditEnvelopeAction::from_str(action)
+            .map_err(|err| serialize_err_msg(format!("audit action: {err}")))?,
+        actor: Some(e.actor_did_hash.clone()),
+        context_id: None,
+        detail,
+        entry_hash: None,
+        event_id: AuditEnvelopeEventId::from_str(&event_id)
+            .map_err(|err| serialize_err_msg(format!("audit event id: {err}")))?,
+        ext: None,
+        outcome: None,
+        prev_hash: None,
+        recorded_at: chrono::DateTime::from_timestamp(e.timestamp as i64, 0)
+            .unwrap_or_else(chrono::Utc::now),
+        schema_version: None,
+        target: Some(e.target_did_hash.clone()),
+    })
+}
+
+/// The shared-schema (`messaging.schema.json#/$defs/AuditAction`) name of an
+/// internal audit action — the maintainer-defined action vocabulary this
+/// mediator reports through the generic `audit/list`.
+fn audit_action_name(a: AuditAction) -> &'static str {
+    match a {
+        AuditAction::SetAcl => "setAcl",
+        AuditAction::AccessListAdd => "accessListAdd",
+        AuditAction::AccessListRemove => "accessListRemove",
+        AuditAction::AccessListClear => "accessListClear",
+        AuditAction::AccountAdd => "accountAdd",
+        AuditAction::AccountRemove => "accountRemove",
+        AuditAction::AccountChangeType => "accountChangeType",
+        AuditAction::AccountChangeQueueLimits => "accountChangeQueueLimits",
+        AuditAction::AdminAdd => "adminAdd",
+        AuditAction::AdminStrip => "adminStrip",
+    }
+}
+
+/// Handle the generic `config/show`: admin-only. Returns the mediator's
+/// configuration as per-key `ConfigField`s — the messaging profile of the
+/// generic task that replaces the retired `messaging/admin/config` (each
+/// top-level member of the old opaque `config` blob becomes a field; the old
+/// `version` member is the `mediator.version` key). The mediator loads its
+/// configuration at startup, so every key reports `requiresRestart: true` with
+/// source `mediator`.
+async fn consume_config_show(
+    typed: TrustTask<config::show::v0_1::Payload>,
     state: &SharedData,
     session: &Session,
     mediator_did: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, MediatorError> {
+    use config::show::v0_1::{ConfigField, ConfigFieldKey, ConfigFieldSource, Response};
     validate_tt_basic(&typed, session, mediator_did, now)?;
-    require_admin(session, "admin/config")?;
+    require_admin(session, "config/show")?;
 
-    let config = serde_json::to_value(&state.config)
+    let config_object = serde_json::to_value(&state.config)
         .map_err(serialize_err)?
         .as_object()
         .cloned()
         .unwrap_or_default();
-    let response = admin::config::v0_1::Response {
-        config,
-        ext: None,
-        version: env!("CARGO_PKG_VERSION").to_string(),
+
+    // Optional `keys` filter: return only the requested keys.
+    let wanted: Option<HashSet<String>> = typed
+        .payload
+        .keys
+        .as_ref()
+        .map(|ks| ks.iter().map(|k| (**k).clone()).collect());
+
+    let mut fields = Vec::new();
+    let mut push_field = |key: String, value: Value| -> Result<(), MediatorError> {
+        if wanted.as_ref().is_none_or(|w| w.contains(&key)) {
+            fields.push(ConfigField {
+                key: ConfigFieldKey::from_str(&key)
+                    .map_err(|e| serialize_err_msg(format!("config key: {e}")))?,
+                requires_restart: true,
+                source: ConfigFieldSource::from_str("mediator")
+                    .map_err(|e| serialize_err_msg(format!("config source: {e}")))?,
+                value,
+            });
+        }
+        Ok(())
     };
+    push_field(
+        "mediator.version".to_string(),
+        Value::String(env!("CARGO_PKG_VERSION").to_string()),
+    )?;
+    for (key, value) in config_object {
+        push_field(key, value)?;
+    }
+
+    let response = Response { ext: None, fields };
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
-}
-
-fn map_admin_account(a: &MediatorAdminAccount) -> admin::list::v0_1::AdminAccount {
-    use admin::list::v0_1::{AccountType as WireType, AdminAccount as Wire, Vid};
-    Wire {
-        account_type: match a._type {
-            AccountType::Standard => WireType::Standard,
-            AccountType::Admin => WireType::Admin,
-            AccountType::RootAdmin => WireType::RootAdmin,
-            AccountType::Mediator => WireType::Mediator,
-            AccountType::Unknown => WireType::Standard,
-        },
-        did: Vid::from_str(&a.did_hash).expect("an account hash is a valid Vid"),
-    }
-}
-
-fn map_audit_entry(e: &AuditLogEntry) -> admin::audit_log::v0_1::AuditEntry {
-    use admin::audit_log::v0_1::{AuditEntry as Wire, Vid};
-    Wire {
-        action: map_audit_action(e.action),
-        actor: Vid::from_str(&e.actor_did_hash).expect("an account hash is a valid Vid"),
-        detail: Some(e.detail.clone()),
-        target: Vid::from_str(&e.target_did_hash).expect("an account hash is a valid Vid"),
-        timestamp: e.timestamp,
-    }
-}
-
-fn map_audit_action(a: AuditAction) -> admin::audit_log::v0_1::AuditAction {
-    use admin::audit_log::v0_1::AuditAction as W;
-    match a {
-        AuditAction::SetAcl => W::SetAcl,
-        AuditAction::AccessListAdd => W::AccessListAdd,
-        AuditAction::AccessListRemove => W::AccessListRemove,
-        AuditAction::AccessListClear => W::AccessListClear,
-        AuditAction::AccountAdd => W::AccountAdd,
-        AuditAction::AccountRemove => W::AccountRemove,
-        AuditAction::AccountChangeType => W::AccountChangeType,
-        AuditAction::AccountChangeQueueLimits => W::AccountChangeQueueLimits,
-        AuditAction::AdminAdd => W::AdminAdd,
-        AuditAction::AdminStrip => W::AdminStrip,
-    }
 }
 
 /// Map the mediator's internal [`Account`] to the wire `account/get` shape.

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.18.65] - 2026-07-29
+
+### Changed
+
+- **BREAKING (`trust_tasks()` surface): the `messaging/*` Trust Task family is
+  rationalized 19 → 9 tasks** (affinidi/affinidi-tdk-rs#667, trust-tasks-rs
+  0.2.46), matching the mediator's clean cutover in 0.17.13 — the retired URIs
+  are no longer accepted server-side, so the superseded senders are removed
+  rather than deprecated:
+  - `account_update(profile, did_hash, account_type, acl, queue_limits)`
+    replaces `account_change_type`, `account_change_queue_limits`, `acl_set`,
+    `admin_add`, and `admin_strip` (one `account/update` per DID for the old
+    batched admin grant/strip).
+  - `access_list_update(profile, did_hash, clear, add, remove)` replaces
+    `access_list_add`, `access_list_remove`, and `access_list_clear`.
+  - `account_list` gains an `account_type: Option<AccountType>` role-filter
+    parameter, replacing `admin_list`.
+  - `access_list_list` gains an `entries: Option<Vec<String>>` membership-filter
+    parameter, replacing `access_list_get` (returned `entries` = the old
+    `present`; the remainder of the supplied set = the old `absent`).
+  - `audit_list(profile, cursor, page_size)` (generic `audit/list`) replaces
+    `admin_audit_log`; `config_show(profile, keys)` (generic `config/show`)
+    replaces `admin_config` (the mediator version is the `mediator.version`
+    key).
+
 ## [0.18.64] - 2026-07-23
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.18.64"
+version = "0.18.65"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.5" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.2"
+trust-tasks-rs = "0.2.46"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -6,9 +6,15 @@
 //! `type` is the [`ENVELOPE_TYPE`] and whose `body` is the document). The mediator
 //! consumes it through the Trust Tasks framework and returns a `TrustTask<R>`.
 //!
-//! This exposes `ping` and `account_get`; the rest of the account / acl /
-//! access-list families follow, and the legacy `atm.mediator()` / `atm.trust_ping()`
-//! methods will route through this same core.
+//! This is the **rationalized** `messaging/*` surface (19 → 9 active tasks,
+//! affinidi/affinidi-tdk-rs#667): partial updates go through `account_update`
+//! (role + capabilities + queue limits in one task, superseding
+//! `change-type` / `change-queue-limits` / `acl/set` / `admin/add` / `admin/strip`)
+//! and `access_list_update` (`clear` → `add` → `remove`, superseding the three
+//! single-verb writers); role-filtered `account_list` supersedes `admin/list`;
+//! the `entries` membership filter on `access_list_list` supersedes
+//! `access-list/get`; and the generic `audit/list` / `config/show` tasks replace
+//! `admin/audit-log` / `admin/config`.
 //!
 //! [Trust Tasks]: https://trusttasks.org
 
@@ -22,7 +28,8 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use sha256::digest;
 use trust_tasks_rs::TrustTask;
-use trust_tasks_rs::specs::messaging::{access_list, account, acl, admin, ping};
+use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
+use trust_tasks_rs::specs::{audit, config};
 use uuid::Uuid;
 
 use crate::{ATM, errors::ATMError, profiles::ATMProfile, transports::SendMessageResponse};
@@ -80,11 +87,15 @@ impl TrustTasksOps<'_> {
     /// Send a `messaging/account/list` Trust Task (admin only) and return one page
     /// of accounts plus an opaque `next_cursor` (present only when more remain).
     /// Pass the previous page's cursor to continue; `None` starts from the top.
+    /// `account_type` filters the enumeration to one role — `Some(Admin)` /
+    /// `Some(RootAdmin)` enumerates the mediator's administrators (this supersedes
+    /// the retired `messaging/admin/list`).
     pub async fn account_list(
         &self,
         profile: &Arc<ATMProfile>,
         cursor: Option<String>,
         limit: Option<u32>,
+        account_type: Option<account::list::v0_1::AccountType>,
     ) -> Result<account::list::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
 
@@ -97,6 +108,7 @@ impl TrustTasksOps<'_> {
         let mut task = TrustTask::for_payload(
             new_id(),
             account::list::v0_1::Payload {
+                account_type,
                 cursor,
                 ext: None,
                 limit,
@@ -110,38 +122,47 @@ impl TrustTasksOps<'_> {
         Ok(response.payload)
     }
 
-    /// Send a `messaging/account/change-queue-limits` Trust Task and return the
-    /// updated account view. `did_hash` names the target; `None` is the caller's own
-    /// account. Each limit is an `Option`: `Some(-1)` = unlimited, `Some(n)` = a cap,
-    /// `None` = leave that limit unchanged. A standard account may only change limits
-    /// it self-manages (others are silently left unchanged).
-    pub async fn account_change_queue_limits(
+    /// Send a `messaging/account/update` Trust Task — one partial update for a
+    /// served account's role, capabilities, and queue limits (superseding the
+    /// retired `change-type` / `change-queue-limits` / `acl/set` /
+    /// `admin/add` / `admin/strip`). `did_hash` names the target; `None` is the
+    /// caller's own account. Every member is optional and an omitted member leaves
+    /// that facet unchanged:
+    /// - `account_type` — admin only; assigning or touching `rootAdmin` requires a
+    ///   root admin.
+    /// - `acl` — partial capability update; a non-admin may only change flags it
+    ///   self-manages.
+    /// - `queue_limits` — `Some(-1)` = unlimited, `None` member = unchanged; a
+    ///   standard account may only change limits it self-manages.
+    ///
+    /// Returns the account's realized view after the update.
+    pub async fn account_update(
         &self,
         profile: &Arc<ATMProfile>,
         did_hash: Option<String>,
-        send_queue_limit: Option<i64>,
-        receive_queue_limit: Option<i64>,
-    ) -> Result<account::change_queue_limits::v0_1::Account, ATMError> {
+        account_type: Option<account::update::v0_1::AccountType>,
+        acl: Option<account::update::v0_1::MediatorAcl>,
+        queue_limits: Option<account::update::v0_1::QueueLimits>,
+    ) -> Result<account::update::v0_1::Account, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
         let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
 
-        let did = account::change_queue_limits::v0_1::Vid::from_str(&target)
+        let did = account::update::v0_1::Vid::from_str(&target)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
         let mut task = TrustTask::for_payload(
             new_id(),
-            account::change_queue_limits::v0_1::Payload {
+            account::update::v0_1::Payload {
+                account_type,
+                acl,
                 did,
                 ext: None,
-                queue_limits: account::change_queue_limits::v0_1::QueueLimits {
-                    receive_queue_limit,
-                    send_queue_limit,
-                },
+                queue_limits,
             },
         );
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
-        let response: TrustTask<account::change_queue_limits::v0_1::Response> =
+        let response: TrustTask<account::update::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload.account)
     }
@@ -169,36 +190,6 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.removed)
     }
 
-    /// Send a `messaging/account/change-type` Trust Task (admin only) and return the
-    /// account's realized view after the role change. Only a root admin may assign the
-    /// root-admin role or modify a root-admin account. `account_type` is the
-    /// [`account::change_type::v0_1::AccountType`] to set.
-    pub async fn account_change_type(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hash: String,
-        account_type: account::change_type::v0_1::AccountType,
-    ) -> Result<account::change_type::v0_1::Account, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-
-        let did = account::change_type::v0_1::Vid::from_str(&did_hash)
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            account::change_type::v0_1::Payload {
-                account_type,
-                did,
-                ext: None,
-            },
-        );
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-
-        let response: TrustTask<account::change_type::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response.payload.account)
-    }
-
     /// Send a `messaging/acl/get` Trust Task (self-or-admin) for one or more accounts.
     /// Returns the per-DID ACL entries plus the DIDs the mediator didn't recognise.
     pub async fn acl_get(
@@ -220,36 +211,6 @@ impl TrustTasksOps<'_> {
 
         let response: TrustTask<acl::get::v0_1::Response> = self.exchange(profile, &task).await?;
         Ok(response.payload)
-    }
-
-    /// Send a `messaging/acl/set` Trust Task. The `acl` is applied as a partial update
-    /// — flags present are set, flags absent are left unchanged — and the realized ACL
-    /// is returned. An admin may set any account's ACL; a non-admin may set its own,
-    /// but only the capabilities it is permitted to self-manage (the admin-only flags
-    /// `blocked` / `local` / `selfManage*` are refused).
-    pub async fn acl_set(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hash: String,
-        acl: acl::set::v0_1::MediatorAcl,
-    ) -> Result<acl::set::v0_1::MediatorAcl, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-
-        let did = acl::set::v0_1::Vid::from_str(&did_hash)
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            acl::set::v0_1::Payload {
-                acl,
-                did,
-                ext: None,
-            },
-        );
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-
-        let response: TrustTask<acl::set::v0_1::Response> = self.exchange(profile, &task).await?;
-        Ok(response.payload.acl)
     }
 
     /// Send a `messaging/account/add` Trust Task and return the created account's view.
@@ -276,7 +237,7 @@ impl TrustTasksOps<'_> {
                 did,
                 ext: None,
                 // Initial queue limits use the mediator default; adjust with
-                // `account_change_queue_limits` after creation.
+                // `account_update` after creation.
                 queue_limits: None,
             },
         );
@@ -288,132 +249,59 @@ impl TrustTasksOps<'_> {
         Ok(response.payload.account)
     }
 
-    /// `messaging/access-list/add` — add entries to an account's access list (self-or-
-    /// admin; `None` = own list). Returns the inserted entries and the new count.
-    pub async fn access_list_add(
+    /// `messaging/access-list/update` — modify an account's access list in one
+    /// task (self-or-admin; `None` = own list), superseding the retired
+    /// `access-list/add` / `remove` / `clear`. Members are applied in the fixed
+    /// order **`clear`, `add`, `remove`**, so `clear + add` replaces the list
+    /// wholesale. Returns the entries actually added and removed plus the new count.
+    pub async fn access_list_update(
         &self,
         profile: &Arc<ATMProfile>,
         did_hash: Option<String>,
-        entries: Vec<String>,
-    ) -> Result<access_list::add::v0_1::Response, ATMError> {
+        clear: bool,
+        add: Vec<String>,
+        remove: Vec<String>,
+    ) -> Result<access_list::update::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
         let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
-        let did = access_list::add::v0_1::Vid::from_str(&target)
+        let did = access_list::update::v0_1::Vid::from_str(&target)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let entries = entries
-            .iter()
-            .map(|e| access_list::add::v0_1::Vid::from_str(e))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
+        let to_vids = |entries: Vec<String>| {
+            entries
+                .iter()
+                .map(|e| access_list::update::v0_1::Vid::from_str(e))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))
+        };
         let mut task = TrustTask::for_payload(
             new_id(),
-            access_list::add::v0_1::Payload {
+            access_list::update::v0_1::Payload {
+                add: to_vids(add)?,
+                clear: clear.then_some(true),
                 did,
-                entries,
                 ext: None,
+                remove: to_vids(remove)?,
             },
         );
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<access_list::add::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response.payload)
-    }
-
-    /// `messaging/access-list/remove` — remove entries (self-or-admin; `None` = own
-    /// list). Returns which of the requested entries were present (and so removed).
-    pub async fn access_list_remove(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hash: Option<String>,
-        entries: Vec<String>,
-    ) -> Result<access_list::remove::v0_1::Response, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
-        let did = access_list::remove::v0_1::Vid::from_str(&target)
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let entries = entries
-            .iter()
-            .map(|e| access_list::remove::v0_1::Vid::from_str(e))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            access_list::remove::v0_1::Payload {
-                did,
-                entries,
-                ext: None,
-            },
-        );
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<access_list::remove::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response.payload)
-    }
-
-    /// `messaging/access-list/clear` — drop the entire access list (self-or-admin;
-    /// `None` = own list).
-    pub async fn access_list_clear(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hash: Option<String>,
-    ) -> Result<access_list::clear::v0_1::Response, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
-        let did = access_list::clear::v0_1::Vid::from_str(&target)
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            access_list::clear::v0_1::Payload { did, ext: None },
-        );
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<access_list::clear::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response.payload)
-    }
-
-    /// `messaging/access-list/get` — partition the queried entries into those present
-    /// in the list and those absent (self-or-admin; `None` = own list).
-    pub async fn access_list_get(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hash: Option<String>,
-        entries: Vec<String>,
-    ) -> Result<access_list::get::v0_1::Response, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
-        let did = access_list::get::v0_1::Vid::from_str(&target)
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let entries = entries
-            .iter()
-            .map(|e| access_list::get::v0_1::Vid::from_str(e))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            access_list::get::v0_1::Payload {
-                did,
-                entries,
-                ext: None,
-            },
-        );
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<access_list::get::v0_1::Response> =
+        let response: TrustTask<access_list::update::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload)
     }
 
     /// `messaging/access-list/list` — page through an account's access list (self-or-
     /// admin; `None` = own list). Returns entries plus an opaque `next_cursor`.
+    /// `entries` turns the enumeration into a **membership check** (superseding the
+    /// retired `access-list/get`): only the supplied DIDs present in the list are
+    /// returned, so a supplied DID absent from the response is not a member.
     pub async fn access_list_list(
         &self,
         profile: &Arc<ATMProfile>,
         did_hash: Option<String>,
         cursor: Option<String>,
         limit: Option<u32>,
+        entries: Option<Vec<String>>,
     ) -> Result<access_list::list::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
         let target = did_hash.unwrap_or_else(|| digest(&profile.inner.did));
@@ -424,11 +312,18 @@ impl TrustTasksOps<'_> {
             .transpose()
             .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
         let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
+        let entries = entries
+            .unwrap_or_default()
+            .iter()
+            .map(|e| access_list::list::v0_1::Vid::from_str(e))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
         let mut task = TrustTask::for_payload(
             new_id(),
             access_list::list::v0_1::Payload {
                 cursor,
                 did,
+                entries,
                 ext: None,
                 limit,
             },
@@ -440,126 +335,59 @@ impl TrustTasksOps<'_> {
         Ok(response.payload)
     }
 
-    /// `messaging/admin/add` (admin only) — grant admin rights to the named accounts.
-    /// Returns the now-admin account identifiers.
-    pub async fn admin_add(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hashes: Vec<String>,
-    ) -> Result<Vec<String>, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let dids = did_hashes
-            .iter()
-            .map(|d| admin::add::v0_1::Vid::from_str(d))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), admin::add::v0_1::Payload { dids, ext: None });
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<admin::add::v0_1::Response> = self.exchange(profile, &task).await?;
-        Ok(response
-            .payload
-            .admins
-            .iter()
-            .map(|v| v.to_string())
-            .collect())
-    }
-
-    /// `messaging/admin/strip` (admin only) — revoke admin rights from the named
-    /// accounts. Returns the stripped account identifiers.
-    pub async fn admin_strip(
-        &self,
-        profile: &Arc<ATMProfile>,
-        did_hashes: Vec<String>,
-    ) -> Result<Vec<String>, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let dids = did_hashes
-            .iter()
-            .map(|d| admin::strip::v0_1::Vid::from_str(d))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), admin::strip::v0_1::Payload { dids, ext: None });
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<admin::strip::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response
-            .payload
-            .stripped
-            .iter()
-            .map(|v| v.to_string())
-            .collect())
-    }
-
-    /// `messaging/admin/list` (admin only) — page the mediator's admin accounts.
-    pub async fn admin_list(
+    /// Generic `audit/list` (admin only) — page the mediator's privileged-change
+    /// audit log, newest first (superseding the retired `messaging/admin/audit-log`).
+    pub async fn audit_list(
         &self,
         profile: &Arc<ATMProfile>,
         cursor: Option<String>,
-        limit: Option<u32>,
-    ) -> Result<admin::list::v0_1::Response, ATMError> {
+        page_size: Option<u32>,
+    ) -> Result<audit::list::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
-        let cursor = cursor
-            .map(|c| admin::list::v0_1::PayloadCursor::from_str(&c))
-            .transpose()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
-        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
         let mut task = TrustTask::for_payload(
             new_id(),
-            admin::list::v0_1::Payload {
+            audit::list::v0_1::Payload {
+                action: None,
+                actor: None,
+                context_id: None,
                 cursor,
                 ext: None,
-                limit,
+                from: None,
+                outcome: None,
+                page_size: page_size.and_then(|l| std::num::NonZeroU64::new(l as u64)),
+                to: None,
             },
         );
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<admin::list::v0_1::Response> =
+        let response: TrustTask<audit::list::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload)
     }
 
-    /// `messaging/admin/audit-log` (admin only) — page the privileged-change log,
-    /// newest first.
-    pub async fn admin_audit_log(
+    /// Generic `config/show` (admin only) — read the mediator's effective runtime
+    /// configuration as per-key fields (superseding the retired
+    /// `messaging/admin/config`; the software version is the `mediator.version` key).
+    /// `keys` narrows the result; `None` returns every key.
+    pub async fn config_show(
         &self,
         profile: &Arc<ATMProfile>,
-        cursor: Option<String>,
-        limit: Option<u32>,
-    ) -> Result<admin::audit_log::v0_1::Response, ATMError> {
+        keys: Option<Vec<String>>,
+    ) -> Result<config::show::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
-        let cursor = cursor
-            .map(|c| admin::audit_log::v0_1::PayloadCursor::from_str(&c))
+        let keys = keys
+            .map(|ks| {
+                ks.iter()
+                    .map(|k| config::show::v0_1::PayloadKeysItem::from_str(k))
+                    .collect::<Result<Vec<_>, _>>()
+            })
             .transpose()
-            .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
-        let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            admin::audit_log::v0_1::Payload {
-                cursor,
-                ext: None,
-                limit,
-            },
-        );
+            .map_err(|e| ATMError::MsgSendError(format!("invalid configuration key: {e}")))?;
+        let mut task =
+            TrustTask::for_payload(new_id(), config::show::v0_1::Payload { ext: None, keys });
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<admin::audit_log::v0_1::Response> =
-            self.exchange(profile, &task).await?;
-        Ok(response.payload)
-    }
-
-    /// `messaging/admin/config` (admin only) — read the mediator's version + config.
-    pub async fn admin_config(
-        &self,
-        profile: &Arc<ATMProfile>,
-    ) -> Result<admin::config::v0_1::Response, ATMError> {
-        let (profile_did, mediator_did) = profile.dids()?;
-        let mut task = TrustTask::for_payload(new_id(), admin::config::v0_1::Payload { ext: None });
-        task.issuer = Some(profile_did.to_string());
-        task.recipient = Some(mediator_did.to_string());
-        let response: TrustTask<admin::config::v0_1::Response> =
+        let response: TrustTask<config::show::v0_1::Response> =
             self.exchange(profile, &task).await?;
         Ok(response.payload)
     }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog history
 
+## 29th July 2026
+
+### 0.2.43 — trust-task integration tests follow the rationalized messaging/* family
+
+The `trust_tasks.rs` integration suite now drives the rationalized surface
+(affinidi/affinidi-tdk-rs#667; sdk 0.18.65 / mediator 0.17.13): queue-limit,
+role, and ACL tests go through `account/update`; the access-list lifecycle
+goes through `access-list/update` and the `entries` membership filter on
+`access-list/list`; the admin-only-reader denial test covers the generic
+`audit/list` / `config/show`. No harness changes.
+
 ## 23rd July 2026
 
 ### 0.2.42 — a slow consumer must not lose packed frames

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.42"
+version = "0.2.43"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -90,7 +90,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.22"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.2"
+trust-tasks-rs = "0.2.46"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -97,13 +97,15 @@ async fn account_list_denies_a_non_admin() {
     let denied = env
         .atm
         .trust_tasks()
-        .account_list(&alice.profile, None, None)
+        .account_list(&alice.profile, None, None, None)
         .await;
     assert!(denied.is_err(), "a non-admin must not list accounts");
 }
 
 #[tokio::test]
-async fn account_change_queue_limits_self_applies_caps_and_persists() {
+async fn account_update_queue_limits_self_applies_caps_and_persists() {
+    use trust_tasks_rs::specs::messaging::account::update::v0_1::QueueLimits;
+
     let env = TestEnvironment::spawn()
         .await
         .expect("spawn test environment");
@@ -119,7 +121,16 @@ async fn account_change_queue_limits_self_applies_caps_and_persists() {
     let updated = env
         .atm
         .trust_tasks()
-        .account_change_queue_limits(&alice.profile, None, Some(42), Some(-1))
+        .account_update(
+            &alice.profile,
+            None,
+            None,
+            None,
+            Some(QueueLimits {
+                send_queue_limit: Some(42),
+                receive_queue_limit: Some(-1),
+            }),
+        )
         .await
         .expect("alice changes her own queue limits");
     let q = updated.queue_limits.expect("queue limits present");
@@ -142,7 +153,16 @@ async fn account_change_queue_limits_self_applies_caps_and_persists() {
     let capped = env
         .atm
         .trust_tasks()
-        .account_change_queue_limits(&alice.profile, None, Some(5000), None)
+        .account_update(
+            &alice.profile,
+            None,
+            None,
+            None,
+            Some(QueueLimits {
+                send_queue_limit: Some(5000),
+                receive_queue_limit: None,
+            }),
+        )
         .await
         .expect("over-limit request is accepted but capped");
     assert_eq!(
@@ -185,10 +205,11 @@ async fn account_remove_self_removes_the_account() {
 }
 
 #[tokio::test]
-async fn account_change_type_denies_a_non_admin() {
-    use trust_tasks_rs::specs::messaging::account::change_type::v0_1::AccountType;
+async fn account_update_role_denies_a_non_admin() {
+    use trust_tasks_rs::specs::messaging::account::update::v0_1::AccountType;
 
-    // `account/change-type` is admin-only. A standard account must be refused.
+    // A role change through `account/update` is admin-only. A standard account
+    // must be refused.
     // (The admin happy-path — promotion/demotion across the admin set — isn't driven
     // here: an admin authenticates by DID resolution but isn't a streaming-registered
     // account, so the synchronous WebSocket response can't be established on the
@@ -207,7 +228,13 @@ async fn account_change_type_denies_a_non_admin() {
     let denied = env
         .atm
         .trust_tasks()
-        .account_change_type(&alice.profile, bob.did_hash(), AccountType::Admin)
+        .account_update(
+            &alice.profile,
+            Some(bob.did_hash()),
+            Some(AccountType::Admin),
+            None,
+            None,
+        )
         .await;
     assert!(denied.is_err(), "a non-admin must not change account types");
 }
@@ -240,8 +267,8 @@ async fn acl_get_self_returns_the_decoded_acl() {
 }
 
 #[tokio::test]
-async fn acl_set_denies_a_non_admin() {
-    use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
+async fn account_update_acl_denies_a_non_admin() {
+    use trust_tasks_rs::specs::messaging::account::update::v0_1::MediatorAcl;
 
     // A non-admin may set its *own* ACL (self-service, covered below), but never
     // another account's. (The reverse mapping is covered by the mediator's
@@ -264,7 +291,7 @@ async fn acl_set_denies_a_non_admin() {
     let denied = env
         .atm
         .trust_tasks()
-        .acl_set(&alice.profile, bob.did_hash(), acl)
+        .account_update(&alice.profile, Some(bob.did_hash()), None, Some(acl), None)
         .await;
     assert!(denied.is_err(), "a non-admin must not set ACLs");
 }
@@ -349,31 +376,41 @@ async fn access_list_self_lifecycle() {
     let added = env
         .atm
         .trust_tasks()
-        .access_list_add(&alice.profile, None, vec![bob.did_hash(), carol.did_hash()])
+        .access_list_update(
+            &alice.profile,
+            None,
+            false,
+            vec![bob.did_hash(), carol.did_hash()],
+            vec![],
+        )
         .await
         .expect("add to access list");
     assert_eq!(added.added.len(), 2);
     assert_eq!(added.access_list_count, 2);
 
-    // Get: bob is present, an unknown hash is absent.
+    // Membership filter (the retired access-list/get): bob is present, an unknown
+    // hash is absent from the filtered entries.
     let got = env
         .atm
         .trust_tasks()
-        .access_list_get(
+        .access_list_list(
             &alice.profile,
             None,
-            vec![bob.did_hash(), "not-in-the-list".to_string()],
+            None,
+            None,
+            Some(vec![bob.did_hash(), "not-in-the-list".to_string()]),
         )
         .await
-        .expect("query access list");
-    assert!(got.present.iter().any(|v| v.as_str() == bob.did_hash()));
-    assert!(got.absent.iter().any(|v| v.as_str() == "not-in-the-list"));
+        .expect("query access list membership");
+    assert!(got.entries.iter().any(|v| v.as_str() == bob.did_hash()));
+    assert!(!got.entries.iter().any(|v| v.as_str() == "not-in-the-list"));
+    assert_eq!(got.access_list_count, 2, "count stays the whole-list total");
 
     // List: both entries, single page.
     let listed = env
         .atm
         .trust_tasks()
-        .access_list_list(&alice.profile, None, None, None)
+        .access_list_list(&alice.profile, None, None, None, None)
         .await
         .expect("list access list");
     assert_eq!(listed.access_list_count, 2);
@@ -384,7 +421,7 @@ async fn access_list_self_lifecycle() {
     let removed = env
         .atm
         .trust_tasks()
-        .access_list_remove(&alice.profile, None, vec![bob.did_hash()])
+        .access_list_update(&alice.profile, None, false, vec![], vec![bob.did_hash()])
         .await
         .expect("remove from access list");
     assert_eq!(removed.removed.len(), 1);
@@ -394,18 +431,19 @@ async fn access_list_self_lifecycle() {
     let cleared = env
         .atm
         .trust_tasks()
-        .access_list_clear(&alice.profile, None)
+        .access_list_update(&alice.profile, None, true, vec![], vec![])
         .await
         .expect("clear access list");
     assert_eq!(cleared.access_list_count, 0);
 }
 
 #[tokio::test]
-async fn admin_family_denies_a_non_admin() {
-    // Every messaging/admin/* task is admin-only. A standard account must be refused
-    // for all of them. (The admin happy paths aren't exercised: an add_admin identity
-    // isn't a streaming-registered account, so admin-over-WS doesn't run on the
-    // in-memory harness — the handlers mirror the legacy admin-management protocol.)
+async fn audit_and_config_readers_deny_a_non_admin() {
+    // The generic audit/list and config/show consumers (which replaced the
+    // retired messaging/admin/* readers) are admin-only. A standard account must
+    // be refused for both. (Role grants/strips are account/update, whose
+    // non-admin denial is covered above; admin/list is the accountType filter on
+    // account/list, whose non-admin denial is covered above too.)
     let env = TestEnvironment::spawn()
         .await
         .expect("spawn test environment");
@@ -415,53 +453,28 @@ async fn admin_family_denies_a_non_admin() {
         .profile_add(&alice.profile, true)
         .await
         .expect("enable websocket for alice");
-    let bob = env.add_user("bob").await.expect("add bob");
 
     assert!(
         env.atm
             .trust_tasks()
-            .admin_add(&alice.profile, vec![bob.did_hash()])
+            .audit_list(&alice.profile, None, None)
             .await
             .is_err(),
-        "non-admin admin/add must be refused"
+        "non-admin audit/list must be refused"
     );
     assert!(
         env.atm
             .trust_tasks()
-            .admin_strip(&alice.profile, vec![bob.did_hash()])
+            .config_show(&alice.profile, None)
             .await
             .is_err(),
-        "non-admin admin/strip must be refused"
-    );
-    assert!(
-        env.atm
-            .trust_tasks()
-            .admin_list(&alice.profile, None, None)
-            .await
-            .is_err(),
-        "non-admin admin/list must be refused"
-    );
-    assert!(
-        env.atm
-            .trust_tasks()
-            .admin_audit_log(&alice.profile, None, None)
-            .await
-            .is_err(),
-        "non-admin admin/audit-log must be refused"
-    );
-    assert!(
-        env.atm
-            .trust_tasks()
-            .admin_config(&alice.profile)
-            .await
-            .is_err(),
-        "non-admin admin/config must be refused"
+        "non-admin config/show must be refused"
     );
 }
 
 #[tokio::test]
-async fn acl_set_self_service_changes_a_self_manageable_flag() {
-    use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
+async fn account_update_acl_self_service_changes_a_self_manageable_flag() {
+    use trust_tasks_rs::specs::messaging::account::update::v0_1::MediatorAcl;
 
     let env = TestEnvironment::spawn()
         .await
@@ -482,10 +495,10 @@ async fn acl_set_self_service_changes_a_self_manageable_flag() {
     let updated = env
         .atm
         .trust_tasks()
-        .acl_set(&alice.profile, alice.did_hash(), acl)
+        .account_update(&alice.profile, None, None, Some(acl), None)
         .await
         .expect("alice self-manages her own ACL");
-    assert_eq!(updated.anon_receive, Some(false));
+    assert_eq!(updated.acl.anon_receive, Some(false));
 
     // Persisted across a fresh read.
     let got = env
@@ -498,8 +511,8 @@ async fn acl_set_self_service_changes_a_self_manageable_flag() {
 }
 
 #[tokio::test]
-async fn acl_set_self_service_refuses_an_admin_only_flag() {
-    use trust_tasks_rs::specs::messaging::acl::set::v0_1::MediatorAcl;
+async fn account_update_acl_self_service_refuses_an_admin_only_flag() {
+    use trust_tasks_rs::specs::messaging::account::update::v0_1::MediatorAcl;
 
     let env = TestEnvironment::spawn()
         .await
@@ -519,7 +532,7 @@ async fn acl_set_self_service_refuses_an_admin_only_flag() {
     let denied = env
         .atm
         .trust_tasks()
-        .acl_set(&alice.profile, alice.did_hash(), acl)
+        .account_update(&alice.profile, None, None, Some(acl), None)
         .await;
     assert!(
         denied.is_err(),

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -18,7 +18,7 @@ affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.18" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.2"
+trust-tasks-rs = "0.2.46"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
@@ -18,8 +18,8 @@ use std::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
+use trust_tasks_rs::specs::messaging::account;
 use trust_tasks_rs::specs::messaging::account::get::v0_1::MediatorAclAccessListMode;
-use trust_tasks_rs::specs::messaging::acl;
 use uuid::Uuid;
 
 use crate::state_store::{
@@ -221,7 +221,13 @@ pub async fn send_invitation_accept(
         // Add the invite DID to this profile's ACL
         match atm
             .trust_tasks()
-            .access_list_add(&accept_temp_profile, None, vec![digest(&invite_did)])
+            .access_list_update(
+                &accept_temp_profile,
+                None,
+                false,
+                vec![digest(&invite_did)],
+                vec![],
+            )
             .await
         {
             Ok(_) => {}
@@ -496,15 +502,21 @@ pub async fn create_invitation(
                             // Flip the access-list mode to explicit_deny. This is a
                             // self-service change; the mediator refuses it if this account
                             // may not self-manage its access-list mode.
-                            let new_acl = acl::set::v0_1::MediatorAcl {
+                            let new_acl = account::update::v0_1::MediatorAcl {
                                 access_list_mode: Some(
-                                    acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny,
+                                    account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny,
                                 ),
                                 ..Default::default()
                             };
                             if let Err(e) = atm
                                 .trust_tasks()
-                                .acl_set(&profile, digest(&profile.inner.did), new_acl)
+                                .account_update(
+                                    &profile,
+                                    Some(digest(&profile.inner.did)),
+                                    None,
+                                    Some(new_acl),
+                                    None,
+                                )
                                 .await
                             {
                                 state.invite_popup.messages.push(Line::from(Span::styled(

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/manual_connect.rs
@@ -57,7 +57,7 @@ pub async fn manual_connect_setup(
         // Add the remote secure DID to our secure DID
         if let Err(e) = atm
             .trust_tasks()
-            .access_list_add(&profile, None, vec![digest(remote_did)])
+            .access_list_update(&profile, None, false, vec![digest(remote_did)], vec![])
             .await
         {
             warn!(

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/inbound_messages.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/inbound_messages.rs
@@ -209,7 +209,13 @@ async fn _handle_connection_setup(
         // Add the new remote secure DID to our new secure DID
         match atm
             .trust_tasks()
-            .access_list_add(&our_new_profile, None, vec![digest(&remote_secure_did)])
+            .access_list_update(
+                &our_new_profile,
+                None,
+                false,
+                vec![digest(&remote_secure_did)],
+                vec![],
+            )
             .await
         {
             Ok(_) => {}
@@ -691,7 +697,13 @@ pub async fn handle_message(
                 // Add the remote secure DID to this profile's ACL
                 match atm
                     .trust_tasks()
-                    .access_list_add(&our_secure_profile, None, vec![digest(&remote_secure_did)])
+                    .access_list_update(
+                        &our_secure_profile,
+                        None,
+                        false,
+                        vec![digest(&remote_secure_did)],
+                        vec![],
+                    )
                     .await
                 {
                     Ok(_) => {


### PR DESCRIPTION
Closes #667. Spec-side PR (registry + bindings): trustoverip/dtgwg-trust-tasks-tf#158 — **merge that first**; this PR compiles once `trust-tasks-rs 0.2.46` is published (automatic on that PR's merge to main).

Implements the `messaging/*` rationalization (19 → 9 active tasks) as a **clean cutover** per the pre-production consolidation policy: the new canonical URIs are implemented and the superseded URIs are removed outright (no dual-accept) — an old URI now answers `protocol.trust_task.unsupported`.

## Removed (no longer accepted) URIs — for consumer sweeps

`messaging/account/change-type/0.1`, `messaging/account/change-queue-limits/0.1`, `messaging/acl/set/0.1`, `messaging/access-list/add/0.1`, `messaging/access-list/remove/0.1`, `messaging/access-list/clear/0.1`, `messaging/access-list/get/0.1`, `messaging/admin/add/0.1`, `messaging/admin/strip/0.1`, `messaging/admin/list/0.1`, `messaging/admin/audit-log/0.1`, `messaging/admin/config/0.1`.

## What changed

**Mediator 0.17.13** (`src/messages/protocols/trust_tasks.rs`)
- `consume_account_update` — full merge of the three retired partial-updaters, not just routing: the root-admin gates, self-manage ACL gating, and hard queue caps are ported per member, and **all guards run before anything is applied** so a refused member refuses the whole update. Role transitions keep the legacy promote/demote/switch store logic.
- `consume_access_list_update` — applies `clear` → `add` → `remove` in the spec's fixed order; reports `added` / `removed` / `accessListCount`.
- `account/list` gains the `accountType` role filter (per fetched page — a filtered page may be short while the cursor still advances; documented in the handler).
- `access-list/list` gains the `entries` membership filter (returns exactly the supplied DIDs that are present, unpaged).
- Generic **`audit/list`** consumer: entries as `AuditEnvelope`s (`timestamp→recordedAt`, hashes→`actor`/`target`, shared-schema action names, minted content-digest `eventId`); `action`/`actor`/`from`/`to` filters applied per page; `outcome`/`contextId` filters match nothing (the log doesn't track them — honest emptiness, noted in the handler doc).
- Generic **`config/show`** consumer: one `ConfigField` per top-level config member (`source: mediator`, `requiresRestart: true`), version as the `mediator.version` key, `keys` filter supported.

**SDK 0.18.65 (breaking on `trust_tasks()`)** — superseded senders removed; added `account_update`, `access_list_update`, `audit_list`, `config_show`; `account_list` / `access_list_list` gain filter params. Changelog documents the full old→new mapping.

**didcomm-service 0.3.21** — startup ACL-mode config sends `account/update` (acl member) instead of `acl/set`.

**test-mediator 0.2.43** — the trust-task integration suite rewritten against the new tasks (queue-limit caps, role denial, ACL self-service allow/deny, access-list lifecycle incl. the membership filter, audit/config admin gating).

**helpers / text-client** (publish = false, no bumps) — all call sites migrated: `mediator_administration` admin screens use role-filtered `account_list` + per-DID `account_update` grants/strips + `config_show`; access-list screens and the examples use `access_list_update` / filtered `access_list_list`.

## Behavioral notes a reviewer should weigh

1. **Admin add via UI now requires an existing account**: the retired `admin/add` implicitly created the account; `account/update` is update-only (`account.not_found` otherwise). Pre-production this is the intended tightening (creation is `account/add`), but it is a flow change for `mediator_administration`.
2. **Batched admin grant/strip is gone** — the UI issues one `account/update` per DID (each grant its own signed, auditable document) and reports per-DID errors.
3. The old `admin/add` accepted raw DIDs where other paths took hashes; the UI now digests the DID before sending (consistent with the rest of the surface).

## Validation evidence

- `cargo check --workspace --all-targets` — clean (against trust-tasks-rs 0.2.46 via a local, uncommitted path patch; nothing else changed).
- `cargo clippy` on mediator/sdk/helpers/didcomm-service `--all-targets` — no warnings.
- `cargo test -p affinidi-messaging-mediator --lib` — **168 passed**.
- `cargo test -p affinidi-messaging-sdk --lib` — **74 passed**.
- `cargo test -p affinidi-messaging-test-mediator --test trust_tasks` — **14 passed** end-to-end (in-memory mediator over the DIDComm envelope).
- Release guards: version-bump ✓ (4 crates), changelog ✓ (4 entries), toolchain-sync ✓, workspace-duplicates ✓.

## Reviewer checklist

- [ ] `consume_account_update` guard ordering (all checks before any write) and root-admin gates match the retired handlers.
- [ ] `access-list/update` order `clear` → `add` → `remove` matches the spec.
- [ ] Removed-URI list above is complete and acceptable to cut over now.
- [ ] Crate version bumps + changelogs (mediator 0.17.13, sdk 0.18.65, didcomm-service 0.3.21, test-mediator 0.2.43); `trust-tasks-rs` pinned to `0.2.46` in the six messaging crates.
- [ ] Merge order: spec PR first (publishes trust-tasks-rs 0.2.46), then re-run CI here.
