### PR TITLE
feat!: enforce explicit_allow mediator ACL mode at authentication

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ## 29th July 2026
 
+### 0.18.0 — BREAKING: `explicit_allow` now closes the mediator at authentication (#669)
+
+`mediator_acl_mode = "explicit_allow"` now does what its name always
+promised: an unknown DID is rejected at `/authenticate/challenge` with
+`403 authentication.blocked`, and no account record is created for it. Only
+DIDs pre-registered by an admin (via `account_add`) may authenticate.
+Previously the mode never gated authentication — in *either* mode, any DID
+completing the challenge was auto-registered with `global_acl_default` and
+issued a session.
+
+- The unknown-DID rejection is deliberately identical to the blocked-DID
+  rejection (same status, error code, and problem report — only the
+  per-request session id differs), so the unauthenticated challenge
+  endpoint cannot be used to probe which DIDs hold accounts.
+- The response-step backstop applies the same policy: an account deleted
+  between the challenge and the response is treated as a revocation and
+  rejected, not silently re-registered.
+- `explicit_deny` (the shipped default) is unchanged: any DID may
+  authenticate and unknown DIDs are auto-registered with
+  `global_acl_default`.
+- **Migration:** deployments running `explicit_allow` that relied on
+  unknown DIDs self-registering must either pre-register their DIDs or
+  switch to `explicit_deny` with a restrictive `global_acl_default`.
+- `docs/acls.md`, the README ACL summary, and the `conf/mediator.toml`
+  template are rewritten for the new semantics; the new
+  `explicit_allow_auth_gate.rs` e2e suite pins both modes and the
+  indistinguishability property.
+
 ### 0.17.13 — messaging/* trust-task family rationalized: 19 → 9 tasks, clean cutover (#667)
 
 The mediator's Trust Task consumer now speaks the rationalized `messaging/*`

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.17.13"
+version = "0.18.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -329,7 +329,7 @@ Access control is four independent layers:
 
 | Layer | Scope | What it decides |
 |---|---|---|
-| `mediator_acl_mode` | mediator-wide | Who may pre-register *other* DIDs via `account_add` |
+| `mediator_acl_mode` | mediator-wide | Whether unknown DIDs may authenticate; who may pre-register other DIDs via `account_add` |
 | `global_acl_default` | mediator-wide | The ACL set given to every new/unknown DID |
 | `MediatorACLSet` | per DID | What that DID may do |
 | Access list | per DID | Which senders that DID accepts messages from |
@@ -338,15 +338,13 @@ Access control is four independent layers:
 
 | Value | Meaning |
 |---|---|
-| `explicit_allow` | Only admins may add accounts via `account_add` |
-| `explicit_deny` | Any authenticated DID may add accounts (always with `global_acl_default`) |
+| `explicit_allow` | **Closed.** Only pre-registered DIDs may authenticate — unknown DIDs are rejected at the challenge step. Only admins may add accounts via `account_add`. |
+| `explicit_deny` | **Open.** Any DID may authenticate; unknown DIDs are auto-registered with `global_acl_default`. Any authenticated DID may add accounts (always with `global_acl_default`). |
 
-> **This mode does not gate authentication.** In either mode, any DID that
-> completes the challenge is auto-registered with `global_acl_default` and
-> issued a session. `global_acl_default` — not this mode — is what controls
-> a public mediator. Earlier revisions of this table described
-> `explicit_allow` as "deny all DIDs except those explicitly allowed"; the
-> mediator has never behaved that way.
+> On an open (`explicit_deny`) mediator, `global_acl_default` is what
+> controls what an arbitrary DID may do. Before mediator 0.18.0,
+> `explicit_allow` did not gate authentication — see the historical note in
+> `docs/acls.md` §2.
 
 ### DID-level ACLs
 

--- a/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
+++ b/crates/messaging/affinidi-messaging-mediator/conf/mediator.toml
@@ -134,15 +134,18 @@ database_timeout = "2"
 ### ****************************************************************************************************************************
 [security]
 ### Env: MEDIATOR_ACL_MODE
-### Who may pre-register OTHER DIDs via the account_add admin protocol:
-###   explicit_deny  — any authenticated DID may add accounts (they are always
-###                    created with global_acl_default, never wider)
-###   explicit_allow — only admin accounts may add accounts
+### Whether the mediator is open or closed to unknown DIDs:
+###   explicit_deny  — OPEN. Any DID may authenticate; unknown DIDs are
+###                    auto-registered with global_acl_default. Any
+###                    authenticated DID may also pre-register other DIDs via
+###                    account_add (always created with global_acl_default,
+###                    never wider).
+###   explicit_allow — CLOSED. Only DIDs pre-registered by an admin may
+###                    authenticate; an unknown DID is rejected at the
+###                    challenge step. Only admin accounts may add accounts.
 ###
-### IMPORTANT: this mode does NOT gate authentication. Any DID that completes
-### the challenge is auto-registered with global_acl_default, in either mode.
-### `global_acl_default` is the setting that controls what an arbitrary DID
-### can do on this mediator. See docs/acls.md.
+### In explicit_deny mode, `global_acl_default` is the setting that controls
+### what an arbitrary self-registered DID may do. See docs/acls.md.
 mediator_acl_mode = "explicit_deny"
 
 ### Env: GLOBAL_DEFAULT_ACL

--- a/crates/messaging/affinidi-messaging-mediator/docs/acls.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/acls.md
@@ -4,9 +4,11 @@ How the Affinidi mediator decides whether a DID may connect, send, receive,
 forward, or administer. This is the reference for operators configuring a
 deployment and for developers adding a permission check.
 
-**The one thing to take away:** `global_acl_default` is the setting that
-controls a public mediator. `mediator_acl_mode` is much narrower than its
-name suggests and does **not** gate who may connect.
+**The one thing to take away:** `mediator_acl_mode` decides whether the
+mediator is open (`explicit_deny` — any DID may authenticate) or closed
+(`explicit_allow` — only pre-registered DIDs may authenticate). On an open
+mediator, `global_acl_default` is the setting that controls what an
+arbitrary DID may then do.
 
 ---
 
@@ -18,41 +20,46 @@ meaning entirely different things.
 
 | # | Layer | Scope | Set by | What it decides |
 |---|-------|-------|--------|-----------------|
-| 1 | `mediator_acl_mode` | mediator-wide | `mediator.toml` | Who may **pre-register other DIDs** via `account_add`. Nothing else. |
+| 1 | `mediator_acl_mode` | mediator-wide | `mediator.toml` | Whether **unknown DIDs may authenticate**, and who may pre-register other DIDs via `account_add`. |
 | 2 | `global_acl_default` | mediator-wide | `mediator.toml` | The ACL set handed to every new or unknown DID. |
 | 3 | `MediatorACLSet` | per DID | admin, or the DID itself where delegated | What that DID may do (19 permission bits). |
 | 4 | Access list | per DID | the DID (if delegated) or an admin | Which **senders** that DID accepts messages from. |
 
 Layers 1 and 4 both use `AccessListModeType`. They are unrelated:
 
-- **Layer 1** (`mediator_acl_mode`): `ExplicitAllow` = only admins may add
-  accounts. `ExplicitDeny` = any authenticated DID may.
+- **Layer 1** (`mediator_acl_mode`): `ExplicitAllow` = closed mediator —
+  only pre-registered DIDs may authenticate, only admins may add accounts.
+  `ExplicitDeny` = open mediator — any DID may authenticate and any
+  authenticated DID may add accounts.
 - **Layer 4** (a DID's own `access_list_mode` bit): `ExplicitAllow` = the
   access list is an **allowlist** (empty list ⇒ nobody may send to me).
   `ExplicitDeny` = it is a **denylist** (empty list ⇒ anybody may).
 
-Note the inversion: for layer 4, `ExplicitAllow` is the *closed*, secure
-posture, and it is `MediatorACLSet::default()`.
+In both layers `ExplicitAllow` is the *closed*, secure posture; for layer 4
+it is also `MediatorACLSet::default()`.
 
 ---
 
-## 2. `mediator_acl_mode` — what it does and does not do
+## 2. `mediator_acl_mode` — open or closed
 
 ```toml
 [security]
 mediator_acl_mode = "explicit_deny"   # or "explicit_allow"
 ```
 
-It has exactly two effects, both on the `account_add` operation:
+It has two effects: who may authenticate, and who may add accounts.
 
-| Mode | Effect on `messaging/account/add` (DIDComm admin protocol and Trust Tasks) |
-|------|---------------------------------------------------------------------------|
-| `explicit_allow` | Only `Admin` / `RootAdmin` accounts may add accounts. |
-| `explicit_deny` | Any authenticated DID may add accounts. |
+| Mode | Authentication | `messaging/account/add` (DIDComm admin protocol and Trust Tasks) |
+|------|----------------|------------------------------------------------------------------|
+| `explicit_allow` | **Closed.** Only DIDs that already hold an account record may authenticate. An unknown DID is rejected at `/authenticate/challenge` with `403 authentication.blocked` and no account is created for it. | Only `Admin` / `RootAdmin` accounts may add accounts. |
+| `explicit_deny` | **Open.** Any DID may authenticate; an unknown DID is auto-registered with `global_acl_default` when it requests a challenge. | Any authenticated DID may add accounts. |
 
-**It does not gate authentication.** In *either* mode, any DID that completes
-the authentication challenge is auto-registered and issued a session. There
-is no allowlist of DIDs permitted to connect.
+In `explicit_allow`, the unknown-DID rejection is deliberately identical to
+the blocked-DID rejection (same status, error code, and problem report):
+`/authenticate/challenge` is unauthenticated, and a distinguishable error
+would let anyone probe which DIDs hold accounts. The response step applies
+the same policy — an account deleted between the challenge and the response
+is treated as a revocation, not re-registered.
 
 **It does not affect message delivery.** No send, receive, forward, or
 pickup decision reads it.
@@ -62,18 +69,20 @@ pickup decision reads it.
 `global_acl_default`; any ACLs it supplies are ignored. Only admins may
 specify custom ACLs. So in `explicit_deny` the worst a non-admin can do is
 create account records that would have been created anyway on first
-authentication — consider `explicit_allow` if you want to deny even that
-(it is a minor storage-growth vector on an open mediator).
+authentication.
 
-> **Historical note.** Older documentation described `explicit_allow` as
-> "deny all DIDs except those explicitly allowed". The mediator has never
-> implemented that. If you need a genuinely closed mediator, use a denying
-> `global_acl_default` (§7) — an unknown DID then authenticates but can do
-> nothing until an admin grants it capabilities.
+> **Historical note.** Before mediator 0.18.0, `explicit_allow` did **not**
+> gate authentication — any DID completing the challenge was auto-registered
+> in either mode, and the only closed-ish posture was a denying
+> `global_acl_default` (unknown DIDs authenticated but could do nothing).
+> 0.18.0 made the mode enforce what its name always promised. If you run
+> `explicit_allow` and *relied* on unknown DIDs being able to
+> self-register, switch to `explicit_deny` with a restrictive
+> `global_acl_default` (§3).
 
 ---
 
-## 3. `global_acl_default` — the real control
+## 3. `global_acl_default` — the open-mediator control
 
 ```toml
 [security]
@@ -82,8 +91,10 @@ global_acl_default = "DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES"
 
 This is the ACL set applied to every DID the mediator has not seen before,
 and the fallback whenever a permission check runs against a DID with no
-stored record. It therefore decides what an arbitrary DID off the internet
-can do with your mediator.
+stored record. On an open mediator (`explicit_deny`) it therefore decides
+what an arbitrary DID off the internet can do; on a closed mediator
+(`explicit_allow`) unknown DIDs never authenticate, and this setting only
+matters as the account_add default and the no-record fallback.
 
 It is consumed in four places:
 
@@ -130,15 +141,15 @@ Five paths, and they do **not** all grant the same ACLs:
 
 | Path | Trigger | ACLs granted |
 |------|---------|--------------|
-| Authentication challenge | Any DID completing `/authenticate/challenge` | `global_acl_default` |
-| Authentication response | Backstop if the record vanished mid-flow | `global_acl_default` |
+| Authentication challenge | Any DID requesting `/authenticate/challenge` — `explicit_deny` mode only (`explicit_allow` rejects unknown DIDs instead) | `global_acl_default` |
+| Authentication response | Backstop if the record vanished mid-flow — `explicit_deny` mode only (`explicit_allow` rejects instead) | `global_acl_default` |
 | `account_add` by an admin | Admin protocol or Trust Task | Admin's choice, else `global_acl_default` |
 | `account_add` by a non-admin | Only in `explicit_deny` mode | Always `global_acl_default` |
 | Forward routing | An unseen DID relays a forward through the mediator | **Least privilege**: `DENY_ALL` + `SEND_FORWARDED`, and only if `global_acl_default` grants `SEND_FORWARDED`. A DID that has only ever relayed a forward does not get `LOCAL`, `RECEIVE_*`, invites, or self-management. |
 
-The first path is the one that surprises people: **registration is
-automatic and unconditional.** There is no approval step and no mode that
-turns it off.
+The first path is the one that surprises people: in `explicit_deny` mode,
+**registration is automatic and unconditional** — there is no approval
+step. `explicit_allow` is the mode that turns it off.
 
 ---
 
@@ -166,11 +177,12 @@ DID may flip it without an admin.
 
 Bits 19–63 are unassigned and must stay zero.
 
-`did_blocked` is the only bit checked at authentication. Everything else is
-checked at the point of use, which means **a DID with `DENY_ALL` still
-authenticates successfully** — it just cannot do anything afterwards. That
-is by design, but it does mean "the DID connected fine" tells you nothing
-about its permissions.
+`did_blocked` is the only *bit* checked at authentication (plus the
+mediator-wide `explicit_allow` known-DID gate, which is not a bit).
+Everything else is checked at the point of use, which means **a registered
+DID with `DENY_ALL` still authenticates successfully** — it just cannot do
+anything afterwards. That is by design, but it does mean "the DID connected
+fine" tells you nothing about its permissions.
 
 ### Two classes of bit
 
@@ -196,12 +208,14 @@ it.
   ├─ DID is `did:`-shaped?                      else 400
   ├─ resolve ACLs: stored, else global_acl_default
   ├─ blocked?                                   else 403 authentication.blocked
-  ├─ unknown? → register with global_acl_default
+  ├─ unknown?
+  │    ├─ explicit_allow → reject               403 authentication.blocked
+  │    └─ explicit_deny  → register with global_acl_default
   └─ issue challenge
 ```
 
-`mediator_acl_mode` is not consulted. Neither is any capability bit other
-than `blocked`.
+No capability bit other than `blocked` is consulted. The two 403s are
+deliberately identical (§2).
 
 ### Direct delivery (DIDComm and TSP)
 
@@ -250,7 +264,7 @@ blunt instrument for cutting a DID off from its inbox.
 | **Open, consent-based** | `global_acl_default = "ALLOW_ALL,MODE_EXPLICIT_ALLOW"`. Anyone may register and send, but each DID's inbox is an allowlist, so nobody receives until they add senders. Add `SELF_MANAGE_LIST` so users can curate it themselves. |
 | **Direct messaging only, no relay** | `global_acl_default = "DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES"` (the shipped default). No forwarding, no invites, no self-management. |
 | **Relay only** | `global_acl_default = "DENY_ALL,SEND_FORWARDED,RECEIVE_FORWARDED"` plus `enable_inter_mediator_relay = "true"`. No inboxes: nothing is stored, nothing is picked up. |
-| **Closed / invitation-only** | `mediator_acl_mode = "explicit_allow"` and `global_acl_default = "DENY_ALL"`. Unknown DIDs still authenticate but can do nothing; an admin must grant capabilities per DID. This is the closest the mediator gets to an allowlist. |
+| **Closed / allowlist** | `mediator_acl_mode = "explicit_allow"`. Unknown DIDs cannot authenticate; an admin pre-registers each DID via `account_add` (with the ACLs it should have, else `global_acl_default`). Keep a restrictive `global_acl_default` anyway — it remains the no-record fallback for permission checks. |
 | **Let users manage their own privacy** | Add `MODE_SELF_CHANGE,SELF_MANAGE_LIST` and the `_CHANGE` variants of whichever capabilities you want users to control. |
 
 ---
@@ -297,13 +311,14 @@ is set.
 
 | Symptom | Likely cause |
 |---------|--------------|
-| DID authenticates fine but every operation is 403 | `global_acl_default` is `DENY_ALL`, or too narrow. Authentication only checks `blocked`. |
+| DID authenticates fine but every operation is 403 | `global_acl_default` is `DENY_ALL`, or too narrow. Authentication only checks `blocked` and (in `explicit_allow`) that the DID is registered. |
 | `authorization.local` on fetch/list/WebSocket | The DID lacks `LOCAL`. |
 | `authorization.receive` on delivery | The **recipient** lacks `RECEIVE_MESSAGES`. |
 | `authorization.send` on delivery | The **sender** lacks `SEND_MESSAGES`. |
 | `authorization.access_list.denied` | Recipient's access list rejects the sender. Check the recipient's `access_list_mode`: in `ExplicitAllow` an *empty* list denies everyone. |
 | Messages silently not received, no error | Recipient's inbox mode is `ExplicitAllow` with an empty list, or `anon_receive` is unset for an anonymous sender. |
-| Setting `explicit_allow` did not stop unknown DIDs connecting | Expected. The mode does not gate authentication (§2). |
+| Setting `explicit_allow` did not stop unknown DIDs connecting | You are running mediator < 0.18.0 — the mode only gates authentication from 0.18.0 on (§2). |
+| DID gets `403 authentication.blocked` but was never blocked | `mediator_acl_mode = explicit_allow` and the DID has no account. The rejection deliberately reuses the blocked problem report (§2); pre-register the DID via `account_add`. |
 | `acl/set` rejected with "admin-only" | You tried to change `blocked`, `local`, or a `self_manage_*` flag as a non-admin. |
 | Every new DID is blocked | `BLOCKED` was included in `global_acl_default`. |
 
@@ -316,7 +331,8 @@ Every permission decision resolves through `src/common/authz.rs`:
 - `require_capability` / `grants` — the capability gate
 - `check_access_list` — the sender↔recipient verdict
 - `effective_acls` — stored ACLs, else `global_acl_default`
-- `authentication_check` — the pre-auth blocked gate
+- `authentication_check` — the pre-auth blocked gate (the `explicit_allow`
+  known-DID gate consumes its `known` result in the challenge handler)
 - `acl_change_ok` — non-admin self-service rules
 
 The `Capability` enum deliberately carries no `#[allow(dead_code)]`: an

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/challenge.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/challenge.rs
@@ -8,7 +8,10 @@ use crate::{
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
 use affinidi_messaging_sdk::{
     messages::problem_report::{ProblemReportScope, ProblemReportSorter},
-    protocols::mediator::{accounts::AccountType, acls::MediatorACLSet},
+    protocols::mediator::{
+        accounts::AccountType,
+        acls::{AccessListModeType, MediatorACLSet},
+    },
 };
 use axum::{Json, extract::State};
 use http::StatusCode;
@@ -64,16 +67,17 @@ pub async fn authentication_challenge(
     async move {
         // ACL checks at the door:
         // 1. Do we know this DID? If so, is it blocked?
-        // 2. If we don't know it, register it with `global_acl_default`.
+        // 2. If we don't know it, `mediator_acl_mode` decides:
+        //    - `explicit_allow`: reject. Only DIDs pre-registered by an
+        //      admin (via `account_add`) may authenticate.
+        //    - `explicit_deny`: register it with `global_acl_default`,
+        //      which decides what the new account may then do — including
+        //      `DENY_ALL`, which authenticates fine but can do nothing.
         //
-        // Note what is deliberately NOT here: `mediator_acl_mode` plays no
-        // part in authentication. Any DID that can complete the challenge
-        // gets an account, and `global_acl_default` decides what that
-        // account may then do — including `DENY_ALL`, which authenticates
-        // fine but can do nothing. The mode governs who may *pre-register
-        // other* DIDs (see the account_add handlers), not who may connect.
-        // `global_acl_default` is the control that gates a public mediator;
-        // see docs/acls.md.
+        // The unknown-DID rejection reuses the `authentication.blocked`
+        // problem report verbatim: this endpoint is unauthenticated, and a
+        // distinguishable error would let anyone probe whether an arbitrary
+        // DID holds an account here. See docs/acls.md §2.
 
         // Check if DID is allowed to connect
         let (allowed, known) = authz::authentication_check(&state, &session.did_hash, None).await?;
@@ -93,6 +97,25 @@ pub async fn authentication_challenge(
             )
             .into());
         } else if !known {
+            if state.config.security.mediator_acl_mode == AccessListModeType::ExplicitAllow {
+                info!(
+                    "DID({}) is unknown and mediator_acl_mode is explicit_allow — rejecting",
+                    session.did
+                );
+                return Err(MediatorError::problem(
+                    25,
+                    session.session_id,
+                    None,
+                    ProblemReportSorter::Error,
+                    ProblemReportScope::Protocol,
+                    "authentication.blocked",
+                    "DID is blocked",
+                    vec![],
+                    StatusCode::FORBIDDEN,
+                )
+                .into());
+            }
+
             // Register the DID as a local DID
             state
                 .database

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
@@ -13,6 +13,7 @@ use affinidi_messaging_sdk::messages::{
     known::MessageType,
     problem_report::{ProblemReportScope, ProblemReportSorter},
 };
+use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
 use axum::{Json, extract::State};
 use http::StatusCode;
 use sha256::digest;
@@ -413,21 +414,40 @@ pub async fn authentication_response(
 /// account record.
 ///
 /// In the normal flow this is a no-op: `/authenticate/challenge` already
-/// registered the DID with `global_acl_default` (unconditionally — see the
-/// note there), and a session must exist to get this far, so
-/// `account_exists` is true every time. It is kept as a backstop in case the
-/// account is removed between the two auth steps.
+/// registered the DID with `global_acl_default` (or, in `explicit_allow`
+/// mode, rejected it — see the note there), and a session must exist to get
+/// this far, so `account_exists` is true every time. It is kept as a
+/// backstop in case the account is removed between the two auth steps.
 ///
-/// Registration here uses the same ACLs and the same unconditional policy as
-/// the challenge step. It previously registered only when
-/// `global_acl_default` granted `LOCAL`, which could never actually differ
-/// from the challenge step's behaviour but read as though the two steps
-/// disagreed about who gets an account.
+/// The backstop applies the same policy as the challenge step. In
+/// `explicit_allow` mode a missing account at this point means an admin
+/// deleted it after the challenge was issued — that is a revocation, and
+/// re-registering here would silently resurrect the account, so the
+/// response is rejected instead (with the same problem report the challenge
+/// step uses, keeping the two steps indistinguishable to a prober).
 async fn _register_did_and_setup(state: &SharedData, did_hash: &str) -> Result<(), MediatorError> {
     // Do we already know about this DID?
     if state.database.account_exists(did_hash).await? {
         debug!("DID({}) already registered", did_hash);
         return Ok(());
+    }
+
+    if state.config.security.mediator_acl_mode == AccessListModeType::ExplicitAllow {
+        info!(
+            "DID({}) has no account and mediator_acl_mode is explicit_allow — rejecting",
+            did_hash
+        );
+        return Err(MediatorError::problem(
+            25,
+            "",
+            None,
+            ProblemReportSorter::Error,
+            ProblemReportScope::Protocol,
+            "authentication.blocked",
+            "DID is blocked",
+            vec![],
+            StatusCode::FORBIDDEN,
+        ));
     }
 
     state

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 29th July 2026
 
+### 0.2.44 — track mediator 0.18 (explicit_allow authentication gate) (#669)
+
+Dependency pin bump for mediator 0.18.0, which makes
+`mediator_acl_mode = "explicit_allow"` reject unknown DIDs at
+authentication. The fixture's own behaviour is unchanged — `add_user`
+pre-registers every user DID, so existing suites run identically in either
+mode. New e2e suite `explicit_allow_auth_gate.rs` covers the gate.
+
 ### 0.2.43 — trust-task integration tests follow the rationalized messaging/* family
 
 The `trust_tasks.rs` integration suite now drives the rationalized surface

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.43"
+version = "0.2.44"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -30,7 +30,7 @@ tsp = ["affinidi-messaging-mediator/tsp", "affinidi-messaging-sdk/tsp"]
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.17", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.18", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/explicit_allow_auth_gate.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/explicit_allow_auth_gate.rs
@@ -1,0 +1,221 @@
+//! End-to-end coverage for the `mediator_acl_mode = explicit_allow`
+//! authentication gate.
+//!
+//! Until mediator 0.18.0 the mode never gated authentication: any DID that
+//! completed `/authenticate/challenge` was auto-registered with
+//! `global_acl_default` and issued a session, in *either* mode. The mode now
+//! closes the mediator — an unknown DID is rejected at the challenge step and
+//! no account record is created for it.
+//!
+//! Both directions are covered deliberately. The rejection test alone would
+//! pass against a mediator that rejects everyone, so
+//! [`preregistered_did_authenticates_in_explicit_allow_mode`] is the control
+//! proving the gate admits known DIDs through the *full* auth flow, and
+//! [`unknown_did_registered_and_authenticated_in_explicit_deny_mode`] pins
+//! the open behaviour of `explicit_deny` so the gate cannot silently widen
+//! to both modes.
+//!
+//! The rejection is also asserted to be byte-indistinguishable (modulo the
+//! per-request session id) from the blocked-DID rejection:
+//! `/authenticate/challenge` is unauthenticated, and a distinguishable error
+//! would let anyone probe whether an arbitrary DID holds an account here.
+
+mod common;
+
+use std::{sync::Arc, time::Duration};
+
+use affinidi_messaging_mediator::store::MemoryStore;
+use affinidi_messaging_mediator_common::store::MediatorStore;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::{
+    AccessListModeType, TestEnvironment, TestMediator, TestMediatorHandle, acl,
+};
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use common::init_tracing;
+use serde_json::Value as JsonValue;
+
+/// A fresh `did:peer:2.*` that has never been registered on `mediator`.
+/// The secrets are discarded — these tests only exercise the challenge
+/// step, which needs no signature.
+fn unknown_did(mediator: &TestMediatorHandle) -> String {
+    let (did, _secrets) = DID::generate_did_peer(
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ],
+        Some(mediator.did().to_string()),
+    )
+    .expect("generate did:peer");
+    did
+}
+
+/// POST `did` to `/authenticate/challenge` and return (status, JSON body).
+async fn challenge(mediator: &TestMediatorHandle, did: &str) -> (u16, JsonValue) {
+    let url = format!("{}authenticate/challenge", mediator.endpoint());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client");
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({ "did": did }))
+        .send()
+        .await
+        .expect("challenge request");
+    let status = resp.status().as_u16();
+    let body: JsonValue = resp.json().await.expect("json body");
+    (status, body)
+}
+
+/// Spawn an `explicit_allow` mediator around a store the test keeps a
+/// handle on, so account side-effects can be asserted directly.
+async fn spawn_explicit_allow() -> (TestMediatorHandle, Arc<MemoryStore>) {
+    let store = Arc::new(MemoryStore::new());
+    let mediator = TestMediator::builder()
+        .store(store.clone())
+        .acl_mode(AccessListModeType::ExplicitAllow)
+        .spawn()
+        .await
+        .expect("spawn explicit_allow mediator");
+    (mediator, store)
+}
+
+/// An unknown DID must be rejected at the challenge step with 403, and —
+/// just as importantly — must NOT leave an account record behind. Before
+/// 0.18.0 this request auto-registered the DID with `global_acl_default`.
+#[tokio::test]
+async fn unknown_did_challenge_rejected_in_explicit_allow_mode() {
+    init_tracing();
+
+    let (mediator, store) = spawn_explicit_allow().await;
+    let did = unknown_did(&mediator);
+
+    let (status, body) = challenge(&mediator, &did).await;
+    assert_eq!(
+        status, 403,
+        "unknown DID must be rejected in explicit_allow mode, got {status}: {body}"
+    );
+    assert_eq!(
+        body["errorCode"].as_u64(),
+        Some(25),
+        "rejection must carry the authentication.blocked error code: {body}"
+    );
+
+    assert!(
+        !store
+            .account_exists(&sha256::digest(&did))
+            .await
+            .expect("account_exists"),
+        "a rejected DID must not be auto-registered"
+    );
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// Control: a DID an admin pre-registered completes the FULL auth flow
+/// (challenge + signed response, via the SDK) and can use its session.
+/// Without this, the rejection test would pass against a mediator that
+/// rejects everyone.
+#[tokio::test]
+async fn preregistered_did_authenticates_in_explicit_allow_mode() {
+    init_tracing();
+
+    let (mediator, _store) = spawn_explicit_allow().await;
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire the SDK to the mediator");
+
+    // `add_user` pre-registers the DID on the mediator (the admin path),
+    // so it is "known" before the SDK ever authenticates.
+    let alice = env.add_user("Alice").await.expect("add Alice");
+
+    // First SDK operation triggers the full challenge/response auth flow.
+    let fetched = env
+        .atm
+        .fetch_messages(&alice.profile, &FetchOptions::default())
+        .await
+        .expect("pre-registered DID must authenticate and fetch in explicit_allow mode");
+    assert!(fetched.success.is_empty(), "fresh mailbox should be empty");
+
+    env.shutdown().await.expect("env shutdown");
+}
+
+/// The unknown-DID rejection must be indistinguishable from the blocked-DID
+/// rejection (same status, error code, and problem report), so the
+/// unauthenticated challenge endpoint cannot be used to probe which DIDs
+/// hold accounts. Only the per-request `sessionId` may differ.
+#[tokio::test]
+async fn unknown_did_rejection_indistinguishable_from_blocked() {
+    init_tracing();
+
+    let (mediator, store) = spawn_explicit_allow().await;
+
+    // A registered-but-blocked DID.
+    let blocked_did = unknown_did(&mediator);
+    let mut blocked_acls = acl::allow_all();
+    blocked_acls.set_blocked(true);
+    store
+        .account_add(&sha256::digest(&blocked_did), &blocked_acls, None)
+        .await
+        .expect("register blocked DID");
+
+    let (blocked_status, mut blocked_body) = challenge(&mediator, &blocked_did).await;
+    let (unknown_status, mut unknown_body) = challenge(&mediator, &unknown_did(&mediator)).await;
+
+    assert_eq!(blocked_status, 403);
+    assert_eq!(unknown_status, 403);
+
+    // The session id is random per request; everything else must match.
+    for body in [&mut blocked_body, &mut unknown_body] {
+        body.as_object_mut()
+            .expect("error body is an object")
+            .remove("sessionId");
+    }
+    assert_eq!(
+        blocked_body, unknown_body,
+        "blocked and unknown DIDs must receive identical rejections"
+    );
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}
+
+/// `explicit_deny` keeps the historical open behaviour: an unknown DID gets
+/// a challenge and is auto-registered with `global_acl_default`.
+#[tokio::test]
+async fn unknown_did_registered_and_authenticated_in_explicit_deny_mode() {
+    init_tracing();
+
+    let store = Arc::new(MemoryStore::new());
+    let mediator = TestMediator::builder()
+        .store(store.clone())
+        .acl_mode(AccessListModeType::ExplicitDeny)
+        .spawn()
+        .await
+        .expect("spawn explicit_deny mediator");
+    let did = unknown_did(&mediator);
+
+    let (status, body) = challenge(&mediator, &did).await;
+    assert_eq!(
+        status, 200,
+        "unknown DID must get a challenge in explicit_deny mode, got {status}: {body}"
+    );
+    assert!(
+        body["data"]["challenge"]
+            .as_str()
+            .is_some_and(|c| !c.is_empty()),
+        "challenge body must contain the challenge string: {body}"
+    );
+
+    assert!(
+        store
+            .account_exists(&sha256::digest(&did))
+            .await
+            .expect("account_exists"),
+        "explicit_deny must auto-register the DID at the challenge step"
+    );
+
+    mediator.shutdown();
+    let _ = mediator.join().await;
+}


### PR DESCRIPTION
## Summary

`mediator_acl_mode = "explicit_allow"` now does what its name always promised: it **closes the mediator at authentication**. An unknown DID is rejected at `/authenticate/challenge` with `403 authentication.blocked` and no account record is created for it — only DIDs pre-registered by an admin (via `account_add`) may authenticate. Previously the mode never gated authentication: in *either* mode, any DID completing the challenge was auto-registered with `global_acl_default` and issued a session (documented as a historical divergence in `docs/acls.md` §2).

## Changes

- **`handlers/authenticate/challenge.rs`** — unknown DID + `ExplicitAllow` ⇒ 403. The rejection reuses the blocked-DID problem report verbatim (same status/code/report; only the per-request session id differs) so the unauthenticated endpoint cannot be used to probe which DIDs hold accounts.
- **`handlers/authenticate/response.rs`** — the backstop no longer re-registers an account that vanished between the two auth steps in `ExplicitAllow` mode: mid-flow deletion is a revocation and now rejects with the same report.
- **`explicit_deny` (shipped default) unchanged** — any DID may authenticate; unknown DIDs auto-register with `global_acl_default`.
- **No lockout risk** — admin/mediator DIDs are seeded at startup via `setup_admin_account` in every store backend.
- **Docs** — `docs/acls.md` (§1–§7, §9, §10), README ACL summary, and the `conf/mediator.toml` template rewritten; the old behaviour is preserved as a historical note with migration guidance.
- **Tests** — new `explicit_allow_auth_gate.rs` e2e suite: unknown-DID rejection (incl. no account side-effect), full-auth control for a pre-registered DID, blocked-vs-unknown indistinguishability, and the open `explicit_deny` behaviour.
- **Versions** — mediator 0.17.13 → **0.18.0** (breaking behaviour change), test-mediator 0.2.43 → 0.2.44 (dep pin).

## Migration

Deployments running `explicit_allow` that relied on unknown DIDs self-registering must either pre-register their DIDs or switch to `explicit_deny` with a restrictive `global_acl_default`.

## Verification

- `cargo fmt --check` clean; clippy clean on redis (default), `didcomm,memory-backend`, and `didcomm,memory-backend,tsp` feature sets (`--all-targets`).
- Mediator unit + store-conformance suites green (168 + conformance).
- Full test-mediator e2e suite green on default features and with `tsp,fjall-backend` (all suites, incl. the 4 new tests).
- `cargo deny check`: bans/licenses/sources ok; the advisories failure is pre-existing/transitive (crossbeam-epoch RUSTSEC-2026-0204 via the ssi-jwk chain) and unrelated — no dependency changes in this PR.
