### PR TITLE
fix: cover vta-sdk Protocol::Tsp across mediator-setup transport matches

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Changelog history
 
+## 29th July 2026
+
+### 0.1.25 — cover vta-sdk 0.20.26's new `Protocol::Tsp` transport (#670)
+
+vta-sdk 0.20.26 added TSP as a third provision-client transport
+(`Protocol::Tsp`, highest preference), which broke this crate's exhaustive
+matches on every fresh dependency resolve. The wizard and headless CLI now
+track TSP attempts first-class: `AttemptLog.tsp` is recorded and cleared
+like the other transports, TSP failures appear in the headless
+terminal-error report, and a TSP-only VTA routes to the recovery prompt
+(the SDK runner already degrades TSP to DIDComm/REST internally, so the
+consumer-side fallback logic is unchanged). vta-sdk pinned to `0.20.26` —
+the minimum version where `Protocol::Tsp` and `AttemptLog.tsp` exist.
+This build ships without vta-sdk's `tsp` feature, so a TSP leg reports
+"unavailable" and the runner continues on DIDComm/REST.
+
 ## 27th July 2026
 
 ### 0.1.24 — correct the Closed network-mode help text

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.24"
+version = "0.1.25"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.20.0", features = ["provision-client"] }
+vta-sdk = { version = "0.20.26", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -162,7 +162,7 @@ aws-sdk-s3 = { version = "1", optional = true }
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.20.0", features = ["test-support"] }
+vta-sdk = { version = "0.20.26", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -1536,9 +1536,11 @@ impl WizardApp {
         // about to be retried so the recovery / fallback prompts
         // don't see stale "already attempted" data.
         match force_transport {
+            Some(crate::vta::Protocol::Tsp) => st.attempted.tsp = None,
             Some(crate::vta::Protocol::DidComm) => st.attempted.didcomm = None,
             Some(crate::vta::Protocol::Rest) => st.attempted.rest = None,
             None => {
+                st.attempted.tsp = None;
                 st.attempted.didcomm = None;
                 st.attempted.rest = None;
             }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/cli.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/cli.rs
@@ -59,6 +59,7 @@ pub enum HeadlessFailureKind {
 /// it directly; the format is stable and grep-friendly for CI logs.
 #[derive(Debug)]
 pub struct HeadlessVtaError {
+    pub tsp: Option<String>,
     pub didcomm: Option<String>,
     pub rest: Option<String>,
     pub kind: HeadlessFailureKind,
@@ -67,13 +68,16 @@ pub struct HeadlessVtaError {
 impl fmt::Display for HeadlessVtaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Headless VTA setup failed.")?;
+        if let Some(reason) = &self.tsp {
+            writeln!(f, "  TSP: {reason}")?;
+        }
         if let Some(reason) = &self.didcomm {
             writeln!(f, "  DIDComm: {reason}")?;
         }
         if let Some(reason) = &self.rest {
             writeln!(f, "  REST: {reason}")?;
         }
-        if self.didcomm.is_none() && self.rest.is_none() {
+        if self.tsp.is_none() && self.didcomm.is_none() && self.rest.is_none() {
             writeln!(f, "  No transport advertised by the VTA's DID document.")?;
         }
         writeln!(f)?;
@@ -190,6 +194,7 @@ pub async fn run_phase2_connect(
     wait_for_acl: Option<u64>,
 ) -> Result<(), HeadlessVtaError> {
     let key = EphemeralSetupKey::load_from(key_path).map_err(|e| HeadlessVtaError {
+        tsp: None,
         didcomm: Some(format!("could not load setup key: {e}")),
         rest: None,
         kind: HeadlessFailureKind::NoTransport,
@@ -210,6 +215,7 @@ pub async fn run_phase2_connect(
     // auto-fallback can see what's already been tried.
     let mut force_transport: Option<Protocol> = None;
     let mut resolved: Option<ResolvedVta> = None;
+    let mut tsp_failure: Option<String> = None;
     let mut didcomm_failure: Option<String> = None;
     let mut rest_failure: Option<String> = None;
 
@@ -217,6 +223,7 @@ pub async fn run_phase2_connect(
         attempt += 1;
         if attempt > 1 {
             match force_transport {
+                Some(Protocol::Tsp) => println!("  Retrying TSP (attempt {attempt})…"),
                 Some(Protocol::Rest) => println!("  Falling back to REST (attempt {attempt})…"),
                 Some(Protocol::DidComm) => {
                     println!("  Retrying DIDComm (attempt {attempt})…")
@@ -284,6 +291,7 @@ pub async fn run_phase2_connect(
                     | AttemptResultKind::PostAuthFailure(reason) = &outcome
                     {
                         match protocol {
+                            Protocol::Tsp => tsp_failure = Some(reason.clone()),
                             Protocol::DidComm => didcomm_failure = Some(reason.clone()),
                             Protocol::Rest => rest_failure = Some(reason.clone()),
                         }
@@ -311,6 +319,7 @@ pub async fn run_phase2_connect(
             // rejection.
             if matches!(outcome, AttemptResultKind::PostAuthFailure(_)) {
                 return Err(HeadlessVtaError {
+                    tsp: tsp_failure,
                     didcomm: didcomm_failure,
                     rest: rest_failure,
                     kind: HeadlessFailureKind::PostAuthFailed,
@@ -348,9 +357,11 @@ pub async fn run_phase2_connect(
             // loop's "attempted" check doesn't block another
             // attempt. Keep the other transport's failure intact.
             match force_transport {
+                Some(Protocol::Tsp) => tsp_failure = None,
                 Some(Protocol::DidComm) => didcomm_failure = None,
                 Some(Protocol::Rest) => rest_failure = None,
                 None => {
+                    tsp_failure = None;
                     didcomm_failure = None;
                     rest_failure = None;
                 }
@@ -360,6 +371,7 @@ pub async fn run_phase2_connect(
 
         // Terminal failure. Pick the kind based on what we observed.
         return Err(HeadlessVtaError {
+            tsp: tsp_failure,
             didcomm: didcomm_failure,
             rest: rest_failure,
             kind: HeadlessFailureKind::NoTransport,
@@ -492,6 +504,7 @@ mod tests {
     #[test]
     fn headless_error_display_names_both_protocols() {
         let err = HeadlessVtaError {
+            tsp: None,
             didcomm: Some("ACL not found".into()),
             rest: Some("REST 401".into()),
             kind: HeadlessFailureKind::NoTransport,
@@ -505,12 +518,14 @@ mod tests {
     #[test]
     fn headless_error_display_no_transport_message_differs_from_post_auth() {
         let no_transport = HeadlessVtaError {
+            tsp: None,
             didcomm: Some("network".into()),
             rest: None,
             kind: HeadlessFailureKind::NoTransport,
         }
         .to_string();
         let post_auth = HeadlessVtaError {
+            tsp: None,
             didcomm: Some("template error".into()),
             rest: None,
             kind: HeadlessFailureKind::PostAuthFailed,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/vta/state.rs
@@ -314,6 +314,10 @@ impl VtaConnectState {
             return false;
         }
         match protocol {
+            // The SDK runner degrades TSP to DIDComm/REST internally, so a
+            // TSP record as the *last* attempt means the VTA was TSP-only —
+            // there is no alternate transport for the consumer to offer.
+            Protocol::Tsp => false,
             Protocol::DidComm => resolved.rest_url.is_some() && self.attempted.rest.is_none(),
             Protocol::Rest => resolved.mediator_did.is_some() && self.attempted.didcomm.is_none(),
         }
@@ -471,6 +475,7 @@ impl VtaConnectState {
                     at: Instant::now(),
                 };
                 match protocol {
+                    Protocol::Tsp => self.attempted.tsp = Some(result),
                     Protocol::DidComm => self.attempted.didcomm = Some(result),
                     Protocol::Rest => self.attempted.rest = Some(result),
                 }


### PR DESCRIPTION
## Summary

vta-sdk **0.20.26** (published this morning) added `Protocol::Tsp` as a third provision-client transport. Six exhaustive matches in mediator-setup stopped compiling (E0004) on every fresh dependency resolve — and since `Cargo.lock` is gitignored, CI resolves fresh, so **every PR is currently red** on the `setup / *` jobs (first seen on #669, which is unrelated).

## Changes

- TSP attempts tracked first-class: `AttemptLog.tsp` recorded on `AttemptCompleted` and cleared on retry, mirroring DIDComm/REST (the field already exists in vta-sdk 0.20.26).
- Headless CLI: TSP failure reason tracked and surfaced in the `HeadlessVtaError` terminal report; retry banner covers a forced-TSP loop.
- `should_route_to_fallback`: a TSP record as the *last* attempt means the VTA was TSP-only (the SDK runner degrades TSP→DIDComm/REST internally), so it routes to the recovery prompt — consumer-side fallback logic is otherwise unchanged.
- vta-sdk pinned to `0.20.26` in mediator-setup — the minimum version where `Protocol::Tsp` / `AttemptLog.tsp` exist (the new arms do not compile against 0.20.0).
- mediator-setup 0.1.24 → 0.1.25 + CHANGELOG.

Note: mediator-setup builds without vta-sdk's `tsp` feature, so at runtime a TSP leg reports "unavailable" and the runner continues on DIDComm/REST — behaviour for existing DIDComm/REST VTAs is unchanged.

## Verification

- `cargo check --workspace --all-targets` clean against vta-sdk 0.20.26 (nothing else in the workspace matches on the enum).
- clippy clean, `cargo fmt --check` clean, all 402 mediator-setup tests pass.
