### PR TITLE
chore: move the workspace to curve25519-dalek 5

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Affinidi Crypto Changelog
 
+## 31st July 2026 (0.2.6)
+
+**`PrivateKeyAgreement::X25519` now holds `[u8; 32]` instead of an
+`x25519_dalek::StaticSecret`.** Holding the dalek type put the x25519-dalek
+major version in this crate's *public API*, so every dalek bump was a breaking
+change for every consumer — the reason this upgrade needed cross-repo
+coordination at all. Raw bytes make the API dalek-agnostic, and unlike the
+`#[zeroize(skip)]` `StaticSecret` it replaces, the scalar is now actually
+zeroized on drop. The `StaticSecret` is rebuilt at the point of use, so ECDH is
+bit-identical — locked by the existing `ecdh_1pu_x25519_kek_golden` KAT.
+
+`PublicKeyAgreement::X25519` already held raw bytes and is unchanged.
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 16th July 2026 (0.2.5)
 
 Adds `jose::signing::verify_secp256k1` — ECDSA secp256k1 signature verification

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.5"
+version = "0.2.6"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -23,8 +23,8 @@ ed25519 = ["dep:ed25519-dalek"]
 # `post-quantum` is the umbrella flag; `ml-dsa` and `slh-dsa` can be enabled
 # individually. Off by default.
 post-quantum = ["ml-dsa", "slh-dsa"]
-ml-dsa = ["dep:ml-dsa", "dep:rand_10"]
-slh-dsa = ["dep:slh-dsa", "dep:rand_10"]
+ml-dsa = ["dep:ml-dsa"]
+slh-dsa = ["dep:slh-dsa"]
 # JOSE primitives (#327): ECDH-ES / ECDH-1PU Concat KDF, A256KW key wrap,
 # A256CBC-HS512 content encryption, EdDSA signing. Pulls in EdDSA via the
 # `ed25519` feature. Key agreement (curves) lands separately in a later PR.
@@ -39,7 +39,7 @@ affinidi-encoding = "0.1.4"
 base58 = "0.2"
 base64 = "0.22"
 multibase = "0.9"
-ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
+ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 k256 = { version = "0.13", features = [
   "ecdsa-core",
   "ecdsa",
@@ -71,13 +71,13 @@ slh-dsa = { version = "=0.2.0-rc.5", features = ["zeroize"], optional = true }
 # PQC crates (ml-dsa, slh-dsa) pull rand_core 0.10 transitively via
 # `signature` v3. A second copy coexists with the 0.6 one used by other
 # primitives; we never import it directly, so no explicit dep is needed.
-rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "sys_rng"], optional = true }
+rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "sys_rng", "thread_rng"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 zeroize = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/core/affinidi-crypto/src/ed25519.rs
+++ b/crates/core/affinidi-crypto/src/ed25519.rs
@@ -4,7 +4,6 @@ use affinidi_encoding::{ED25519_PUB, MultiEncoded, MultiEncodedBuf, X25519_PUB};
 use base58::{FromBase58, ToBase58};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use rand_core::OsRng;
 use sha2::{Digest, Sha512};
 use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -40,7 +39,7 @@ impl KeyPair {
 pub fn generate(seed: Option<&[u8; 32]>) -> KeyPair {
     let signing_key = match seed {
         Some(seed) => SigningKey::from_bytes(seed),
-        None => SigningKey::generate(&mut OsRng),
+        None => SigningKey::generate(&mut rand_10::rng()),
     };
 
     let private_bytes = signing_key.to_bytes().to_vec();

--- a/crates/core/affinidi-crypto/src/jose/key_agreement.rs
+++ b/crates/core/affinidi-crypto/src/jose/key_agreement.rs
@@ -259,7 +259,15 @@ fn ec_point_from_jwk(jwk: &Value) -> Result<Vec<u8>, CryptoError> {
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 #[non_exhaustive]
 pub enum PrivateKeyAgreement {
-    X25519(#[zeroize(skip)] x25519_dalek::StaticSecret),
+    /// Raw 32-byte X25519 scalar.
+    ///
+    /// Deliberately **not** an `x25519_dalek::StaticSecret`: holding the
+    /// dalek type here put the x25519-dalek major version in this crate's
+    /// public API, so every dalek bump became a breaking change for every
+    /// consumer. Raw bytes keep the API dalek-agnostic, and — unlike the
+    /// `#[zeroize(skip)]` `StaticSecret` this replaces — they are actually
+    /// zeroized on drop. The `StaticSecret` is rebuilt at the point of use.
+    X25519([u8; 32]),
     P256(#[zeroize(skip)] p256::SecretKey),
     K256(#[zeroize(skip)] k256::SecretKey),
     P384(#[zeroize(skip)] p384::SecretKey),
@@ -289,9 +297,7 @@ impl PrivateKeyAgreement {
                 let arr: [u8; 32] = bytes.try_into().map_err(|_| {
                     CryptoError::KeyAgreement("X25519 private key must be 32 bytes".into())
                 })?;
-                Ok(PrivateKeyAgreement::X25519(
-                    x25519_dalek::StaticSecret::from(arr),
-                ))
+                Ok(PrivateKeyAgreement::X25519(arr))
             }
             Curve::P256 => {
                 let sk = p256::SecretKey::from_slice(bytes).map_err(|e| {
@@ -323,9 +329,9 @@ impl PrivateKeyAgreement {
     /// Generate a new random private key on the given curve.
     pub fn generate(curve: Curve) -> Self {
         match curve {
-            Curve::X25519 => {
-                PrivateKeyAgreement::X25519(x25519_dalek::StaticSecret::random_from_rng(OsRng))
-            }
+            Curve::X25519 => PrivateKeyAgreement::X25519(
+                x25519_dalek::StaticSecret::random_from_rng(&mut rand_10::rng()).to_bytes(),
+            ),
             Curve::P256 => PrivateKeyAgreement::P256(p256::SecretKey::random(&mut OsRng)),
             Curve::K256 => PrivateKeyAgreement::K256(k256::SecretKey::random(&mut OsRng)),
             Curve::P384 => PrivateKeyAgreement::P384(p384::SecretKey::random(&mut OsRng)),
@@ -336,9 +342,9 @@ impl PrivateKeyAgreement {
     /// Derive the public key.
     pub fn public_key(&self) -> PublicKeyAgreement {
         match self {
-            PrivateKeyAgreement::X25519(sk) => {
-                PublicKeyAgreement::X25519(x25519_dalek::PublicKey::from(sk).to_bytes())
-            }
+            PrivateKeyAgreement::X25519(sk) => PublicKeyAgreement::X25519(
+                x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(*sk)).to_bytes(),
+            ),
             PrivateKeyAgreement::P256(sk) => PublicKeyAgreement::P256(sk.public_key()),
             PrivateKeyAgreement::K256(sk) => PublicKeyAgreement::K256(sk.public_key()),
             PrivateKeyAgreement::P384(sk) => PublicKeyAgreement::P384(sk.public_key()),
@@ -364,6 +370,7 @@ impl PrivateKeyAgreement {
     ) -> Result<Vec<u8>, CryptoError> {
         match (self, their_public) {
             (PrivateKeyAgreement::X25519(sk), PublicKeyAgreement::X25519(pk)) => {
+                let sk = x25519_dalek::StaticSecret::from(*sk);
                 let pk = x25519_dalek::PublicKey::from(*pk);
                 Ok(sk.diffie_hellman(&pk).as_bytes().to_vec())
             }

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi Secrets Manager
 
+## 31st July 2026 (0.5.9)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 13th June 2026 (0.5.8)
 
 Semver wave (W7 — release W11). `SecretsResolverError` is now `#[non_exhaustive]`

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.8"
+version = "0.5.9"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -39,7 +39,7 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 thiserror = "2"
 unsigned-varint = "0.8"
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 zeroize = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Affinidi Data Integrity Changelog
 
+## 31st July 2026 (0.7.9)
+
+The Ed25519 signing path takes the signature through the inherent
+`Signature::to_bytes()` rather than the `SignatureEncoding` trait, which needs
+`alloc` and does not resolve under every feature unification.
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 27th July 2026 Release 0.7.8
 
 ### Fixed

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.8"
+version = "0.7.9"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -32,7 +32,7 @@ ciborium = { version = "0.2", optional = true }
 
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 multibase = "0.9"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/crates/credentials/affinidi-data-integrity/src/signer.rs
+++ b/crates/credentials/affinidi-data-integrity/src/signer.rs
@@ -22,7 +22,7 @@
 
 use affinidi_secrets_resolver::secrets::{KeyType, Secret};
 use async_trait::async_trait;
-use ed25519_dalek::{SigningKey, ed25519::signature::SignerMut};
+use ed25519_dalek::{Signer as _, SigningKey};
 use zeroize::Zeroizing;
 
 use crate::DataIntegrityError;
@@ -106,8 +106,8 @@ impl Signer for Secret {
                             reason: "Ed25519 private key must be exactly 32 bytes".to_string(),
                         }
                     })?);
-                let mut signing_key = SigningKey::from_bytes(&private_bytes);
-                Ok(signing_key.sign(data).to_vec())
+                let signing_key = SigningKey::from_bytes(&private_bytes);
+                Ok(signing_key.sign(data).to_bytes().to_vec())
             }
             #[cfg(feature = "ml-dsa")]
             KeyType::MlDsa44 => {

--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi mdoc Changelog
 
+## 31st July 2026 (0.2.4)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 14th June 2026 Release 0.2.3
 
 - **Fix (build):** `session.rs` no longer calls the now-deprecated

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -40,7 +40,7 @@ serde_bytes = "0.11"
 serde_json = "1"
 p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
 p384 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
-ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
+ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 sha2 = "0.10"
 hmac = "0.12"
 hkdf = "0.12"

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 31st July 2026 (0.4.1)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 All notable changes to `affinidi-did-common` are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.4.0"
+version = "0.4.1"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true
@@ -33,7 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 url = { version = "2", features = ["serde"] }
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [lints]

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 31st July 2026 (0.15.6)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 All notable changes to `affinidi-messaging-didcomm` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this crate follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.5"
+version = "0.15.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -32,7 +32,7 @@ p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 k256 = { version = "0.13", features = ["ecdh", "jwk"] }
 
 # Ed25519 — test helpers generate keys directly.
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+ed25519-dalek = { version = "3", features = ["rand_core"] }
 sha2 = "0.10"
 
 # Encoding / serialization
@@ -45,6 +45,7 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 # Misc
 rand_core = { version = "0.6", features = ["getrandom"] }
+rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 
 # Optional — messaging-core trait integration
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1", optional = true }

--- a/crates/messaging/affinidi-messaging-didcomm/fuzz/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 serde_json = "1"
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 # `arbitrary` feature provides Arbitrary for the wire types (the message_structured target).
 affinidi-messaging-didcomm = { path = "..", features = ["arbitrary"] }

--- a/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/identity.rs
@@ -43,7 +43,7 @@ impl PrivateIdentity {
         let sig_kid = format!("{did}#key-signing-1");
 
         let ka_private = PrivateKeyAgreement::generate(Curve::X25519);
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
 
         Self {
             did,
@@ -61,7 +61,7 @@ impl PrivateIdentity {
         let sig_kid = format!("{did}#key-signing-1");
 
         let ka_private = PrivateKeyAgreement::generate(curve);
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
 
         Self {
             did,

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/sign.rs
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn sign_produces_valid_jws() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
 
         let jws_str = sign_ed25519(
             b"{\"type\":\"test\"}",

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn sign_verify_roundtrip() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
 
         let payload = b"{\"type\":\"test\",\"body\":{}}";
@@ -149,8 +149,8 @@ mod tests {
 
     #[test]
     fn wrong_key_fails() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
-        let wrong_pk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng)
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
+        let wrong_pk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng())
             .verifying_key()
             .to_bytes();
 
@@ -166,7 +166,7 @@ mod tests {
     /// from the unprotected header.
     #[test]
     fn signer_kid_from_unprotected_header() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
         let payload = b"{\"type\":\"test\",\"body\":{}}";
 
@@ -209,7 +209,7 @@ mod tests {
     /// (it's integrity-protected).
     #[test]
     fn protected_kid_takes_precedence_over_unprotected() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
 
         // sign_ed25519 puts kid in the protected header.
@@ -292,7 +292,7 @@ mod tests {
     /// algorithm-confusion attempt.
     #[test]
     fn es256_rejects_eddsa_alg() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let jws_str = sign::sign_ed25519(b"x", "did:example:alice#key-1", &sk.to_bytes()).unwrap();
 
         let dummy_pub = [0x04u8; 65];
@@ -357,7 +357,7 @@ mod tests {
     /// the polymorphic `EdDSA`.
     #[test]
     fn ed25519_alg_accepted_alongside_eddsa() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
         let payload = b"{\"type\":\"test\"}";
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/message/pack.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/message/pack.rs
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn pack_signed_roundtrip() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
 
         let msg =
             Message::new("test-type", serde_json::json!({"data": 42})).from("did:example:alice");
@@ -245,7 +245,7 @@ mod tests {
     /// as an attachment in a wrapper message.
     #[test]
     fn pack_signed_then_authcrypt() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let sender_ka = PrivateKeyAgreement::generate(Curve::X25519);
         let recipient_ka = PrivateKeyAgreement::generate(Curve::X25519);
 

--- a/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/message/unpack.rs
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn unpack_signed() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
 
         let msg = Message::new("test", serde_json::json!({}));
@@ -222,7 +222,7 @@ mod tests {
     /// the inner signer kid.
     #[test]
     fn unpack_sign_then_encrypt() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let signer_pk = sk.verifying_key().to_bytes();
         let sender = PrivateKeyAgreement::generate(Curve::X25519);
         let recipient = PrivateKeyAgreement::generate(Curve::X25519);
@@ -273,7 +273,7 @@ mod tests {
     /// rather than returning an unverified message.
     #[test]
     fn unpack_sign_then_encrypt_requires_signer_public() {
-        let sk = ed25519_dalek::SigningKey::generate(&mut rand_core::OsRng);
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand_10::rng());
         let sender = PrivateKeyAgreement::generate(Curve::X25519);
         let recipient = PrivateKeyAgreement::generate(Curve::X25519);
 

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi Messaging Mediator
 
+## 31st July 2026 (0.18.1)
+
+Requires **`vta-sdk` 0.21.0**, which moved to curve25519-dalek 5. Together with
+the workspace dalek upgrade this removes the last `curve25519-dalek` 4 node from
+the graph — the mediator now links a single curve25519 implementation.
+
+No behavioural change to send/ack/reconnect semantics.
+
 ## Changelog history
 
 ## 29th July 2026

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.0"
+version = "0.18.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -107,7 +107,7 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.20.0", features = ["integration"] }
+vta-sdk = { version = "0.21.0", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Affinidi Messaging Mediator Setup
 
+## 31st July 2026 (0.1.26)
+
+Requires **`vta-sdk` 0.21.0** (curve25519-dalek 5), matching the mediator.
+
+No behavioural change.
+
 ## Changelog history
 
 ## 29th July 2026

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.25"
+version = "0.1.26"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.20.26", features = ["provision-client"] }
+vta-sdk = { version = "0.21.0", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -162,7 +162,7 @@ aws-sdk-s3 = { version = "1", optional = true }
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.20.26", features = ["test-support"] }
+vta-sdk = { version = "0.21.0", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi TSP Changelog
 
+## 31st July 2026 (0.1.14)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 19th July 2026
 
 ### 0.1.13 — affinidi-did-common 0.4

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -33,13 +33,14 @@ affinidi-did-common = { path = "../../identity/affinidi-did-common", version = "
 affinidi-encoding = { path = "../../core/affinidi-encoding", version = "0.1", optional = true }
 
 # Crypto
-ed25519-dalek = { version = "2", features = ["rand_core"] }
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+ed25519-dalek = { version = "3", features = ["rand_core"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 hkdf = "0.12"
 sha2 = "0.10"
 ## TSP mandates ChaCha20Poly1305 as the HPKE AEAD (spec Rev 2); see docs/tsp/interop.md.
 chacha20poly1305 = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
+rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 zeroize = { version = "1", features = ["derive"] }
 blake2 = "0.10"
 

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -8,7 +8,6 @@
 
 use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, KeyInit, aead::generic_array::GenericArray};
 use hkdf::Hkdf;
-use rand_core::OsRng;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::Zeroize;
@@ -129,7 +128,7 @@ fn auth_encap(
     sk_s: &StaticSecret,
 ) -> Result<([u8; N_SECRET], [u8; 32]), TspError> {
     // Generate ephemeral keypair
-    let sk_e = StaticSecret::random_from_rng(OsRng);
+    let sk_e = StaticSecret::random_from_rng(&mut rand_10::rng());
     let pk_e = PublicKey::from(&sk_e);
 
     // Two DH operations
@@ -312,9 +311,9 @@ mod tests {
 
     #[test]
     fn seal_open_roundtrip() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let sender_pk = PublicKey::from(&sender_sk);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let plaintext = b"Hello, TSP!";
@@ -348,10 +347,10 @@ mod tests {
 
     #[test]
     fn wrong_recipient_key_fails() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
-        let wrong_sk = StaticSecret::random_from_rng(OsRng);
+        let wrong_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
 
         let sealed = seal(
             b"secret",
@@ -377,8 +376,8 @@ mod tests {
 
     #[test]
     fn wrong_sender_key_fails() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let sealed = seal(
@@ -391,7 +390,7 @@ mod tests {
         .unwrap();
 
         // Try to open with wrong sender public key
-        let wrong_pk = PublicKey::from(&StaticSecret::random_from_rng(OsRng));
+        let wrong_pk = PublicKey::from(&StaticSecret::random_from_rng(&mut rand_10::rng()));
         let result = open(
             &sealed.ciphertext,
             b"aad",
@@ -406,9 +405,9 @@ mod tests {
 
     #[test]
     fn tampered_aad_fails() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let sender_pk = PublicKey::from(&sender_sk);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let sealed = seal(
@@ -434,9 +433,9 @@ mod tests {
 
     #[test]
     fn tampered_ciphertext_fails() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let sender_pk = PublicKey::from(&sender_sk);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let sealed = seal(
@@ -465,9 +464,9 @@ mod tests {
 
     #[test]
     fn empty_plaintext() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let sender_pk = PublicKey::from(&sender_sk);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let sealed = seal(
@@ -496,9 +495,9 @@ mod tests {
 
     #[test]
     fn large_plaintext() {
-        let sender_sk = StaticSecret::random_from_rng(OsRng);
+        let sender_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let sender_pk = PublicKey::from(&sender_sk);
-        let recipient_sk = StaticSecret::random_from_rng(OsRng);
+        let recipient_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let recipient_pk = PublicKey::from(&recipient_sk);
 
         let plaintext = vec![0x42u8; 65536];

--- a/crates/messaging/affinidi-tsp/src/crypto/signing.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/signing.rs
@@ -33,11 +33,10 @@ pub fn public_key_from_private(private_key: &[u8; 32]) -> [u8; 32] {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use rand_core::OsRng;
 
     #[test]
     fn sign_verify_roundtrip() {
-        let sk = SigningKey::generate(&mut OsRng);
+        let sk = SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
         let data = b"test message for TSP signing";
 
@@ -47,8 +46,10 @@ mod tests {
 
     #[test]
     fn wrong_key_fails() {
-        let sk = SigningKey::generate(&mut OsRng);
-        let wrong_pk = SigningKey::generate(&mut OsRng).verifying_key().to_bytes();
+        let sk = SigningKey::generate(&mut rand_10::rng());
+        let wrong_pk = SigningKey::generate(&mut rand_10::rng())
+            .verifying_key()
+            .to_bytes();
         let data = b"test";
 
         let sig = sign(data, &sk.to_bytes()).unwrap();
@@ -57,7 +58,7 @@ mod tests {
 
     #[test]
     fn tampered_data_fails() {
-        let sk = SigningKey::generate(&mut OsRng);
+        let sk = SigningKey::generate(&mut rand_10::rng());
         let pk = sk.verifying_key().to_bytes();
 
         let sig = sign(b"original", &sk.to_bytes()).unwrap();
@@ -66,7 +67,7 @@ mod tests {
 
     #[test]
     fn public_key_derivation() {
-        let sk = SigningKey::generate(&mut OsRng);
+        let sk = SigningKey::generate(&mut rand_10::rng());
         let expected_pk = sk.verifying_key().to_bytes();
         let derived_pk = public_key_from_private(&sk.to_bytes());
         assert_eq!(expected_pk, derived_pk);

--- a/crates/messaging/affinidi-tsp/src/message/direct.rs
+++ b/crates/messaging/affinidi-tsp/src/message/direct.rs
@@ -517,7 +517,6 @@ pub fn message_digest(packed: &PackedMessage) -> [u8; 32] {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use rand_core::OsRng;
     use x25519_dalek::{PublicKey, StaticSecret};
 
     struct TestKeys {
@@ -530,9 +529,9 @@ mod tests {
     }
 
     fn gen_keys() -> TestKeys {
-        let sender_sign = SigningKey::generate(&mut OsRng);
-        let sender_enc = StaticSecret::random_from_rng(OsRng);
-        let receiver_enc = StaticSecret::random_from_rng(OsRng);
+        let sender_sign = SigningKey::generate(&mut rand_10::rng());
+        let sender_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
+        let receiver_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
 
         TestKeys {
             sender_sign_sk: sender_sign.to_bytes(),
@@ -609,7 +608,7 @@ mod tests {
     #[test]
     fn wrong_receiver_key_fails() {
         let keys = gen_keys();
-        let wrong_sk = StaticSecret::random_from_rng(OsRng);
+        let wrong_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let packed = pack(
             b"secret",
             MessageType::Direct,

--- a/crates/messaging/affinidi-tsp/src/message/meta.rs
+++ b/crates/messaging/affinidi-tsp/src/message/meta.rs
@@ -81,13 +81,12 @@ mod tests {
     use super::*;
     use crate::message::direct;
     use ed25519_dalek::SigningKey;
-    use rand_core::OsRng;
     use x25519_dalek::{PublicKey, StaticSecret};
 
     fn packed() -> direct::PackedMessage {
-        let sign = SigningKey::generate(&mut OsRng);
-        let sender_enc = StaticSecret::random_from_rng(OsRng);
-        let recv_enc = StaticSecret::random_from_rng(OsRng);
+        let sign = SigningKey::generate(&mut rand_10::rng());
+        let sender_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
+        let recv_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
         direct::pack(
             b"payload",
             MessageType::Direct,
@@ -136,9 +135,9 @@ mod tests {
     fn meta_envelope_reads_addressing_for_routed_message() {
         // In the interop format the kind is encrypted, so a keys-free parse only
         // recovers addressing (and reports Direct as a placeholder kind).
-        let sign = SigningKey::generate(&mut OsRng);
-        let sender_enc = StaticSecret::random_from_rng(OsRng);
-        let recv_enc = StaticSecret::random_from_rng(OsRng);
+        let sign = SigningKey::generate(&mut rand_10::rng());
+        let sender_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
+        let recv_enc = StaticSecret::random_from_rng(&mut rand_10::rng());
         let msg = direct::pack(
             b"routing-layer",
             MessageType::Routed,

--- a/crates/messaging/affinidi-tsp/src/message/routed.rs
+++ b/crates/messaging/affinidi-tsp/src/message/routed.rs
@@ -142,7 +142,6 @@ mod tests {
     use super::*;
     use crate::message::direct::unpack;
     use ed25519_dalek::SigningKey;
-    use rand_core::OsRng;
     use x25519_dalek::{PublicKey, StaticSecret};
 
     struct Party {
@@ -154,8 +153,8 @@ mod tests {
     }
 
     fn party(vid: &str) -> Party {
-        let sign = SigningKey::generate(&mut OsRng);
-        let enc = StaticSecret::random_from_rng(OsRng);
+        let sign = SigningKey::generate(&mut rand_10::rng());
+        let enc = StaticSecret::random_from_rng(&mut rand_10::rng());
         Party {
             vid: vid.to_string(),
             sign_sk: sign.to_bytes(),

--- a/crates/messaging/affinidi-tsp/src/vid/mod.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/mod.rs
@@ -68,13 +68,12 @@ impl PrivateVid {
     /// Create a new PrivateVid with generated keys.
     pub fn generate(id: impl Into<String>) -> Self {
         use ed25519_dalek::SigningKey;
-        use rand_core::OsRng;
         use x25519_dalek::{PublicKey, StaticSecret};
 
-        let ed_sk = SigningKey::generate(&mut OsRng);
+        let ed_sk = SigningKey::generate(&mut rand_10::rng());
         let ed_pk = ed_sk.verifying_key().to_bytes();
 
-        let x_sk = StaticSecret::random_from_rng(OsRng);
+        let x_sk = StaticSecret::random_from_rng(&mut rand_10::rng());
         let x_pk = PublicKey::from(&x_sk);
 
         PrivateVid {
@@ -180,9 +179,8 @@ mod tests {
     #[test]
     fn from_keys_derives_public_correctly() {
         use ed25519_dalek::SigningKey;
-        use rand_core::OsRng;
 
-        let sk = SigningKey::generate(&mut OsRng);
+        let sk = SigningKey::generate(&mut rand_10::rng());
         let expected_pk = sk.verifying_key().to_bytes();
 
         let vid = PrivateVid::from_keys("test", sk.to_bytes(), [0u8; 32]);

--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi OID4VC Core Changelog
 
+## 31st July 2026 (0.1.6)
+
+`EddsaSigner::generate_with_rng` now bounds `R: rand::CryptoRng` (rand 0.10)
+instead of the rand_core 0.6 traits. Callers passing a rand 0.8-era RNG must
+update. `Es256Signer` is unchanged — p256 is still on elliptic-curve 0.13, so
+this crate carries both rand generations.
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## 14th June 2026 Release 0.1.5
 
 - `JwtError` and `OAuthError` are now `#[non_exhaustive]` (ADR-0003) so new

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -16,13 +16,13 @@ rust-version.workspace = true
 default = ["es256", "eddsa"]
 _test-utils = []
 es256 = ["dep:p256"]
-eddsa = ["dep:ed25519-dalek", "dep:rand_core"]
+eddsa = ["dep:ed25519-dalek", "dep:rand_10"]
 
 [dependencies]
 base64 = "0.22"
-ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
+ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
-rand_core = { version = "0.6", features = ["getrandom"], optional = true }
+rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/eddsa.rs
@@ -42,7 +42,7 @@ impl EdDsaSigner {
 
     /// Generate a new random Ed25519 key pair using the OS RNG.
     pub fn generate() -> Self {
-        Self::generate_with_rng(&mut rand_core::OsRng)
+        Self::generate_with_rng(&mut rand_10::rng())
     }
 
     /// Generate a new Ed25519 key pair using a caller-supplied RNG.
@@ -50,7 +50,7 @@ impl EdDsaSigner {
     /// Useful for tests that need deterministic keys via a seeded RNG.
     pub fn generate_with_rng<R>(rng: &mut R) -> Self
     where
-        R: rand_core::CryptoRng + rand_core::RngCore,
+        R: rand_10::CryptoRng,
     {
         Self {
             signing_key: SigningKey::generate(rng),

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi TDK Test Support
 
+## 31st July 2026 (0.8.2)
+
+Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),
+which brings rand_core 0.10 and signature 3 with it. rand 0.10 renamed `OsRng`
+to `SysRng` *and* made it fallible (`TryRng<Error = SysError>`), so it no longer
+satisfies dalek's `CryptoRng` bound; key generation moves to `rand::rng()`.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through
+`[patch.crates-io]`, and a minor bump would break the redirect and pull a second
+copy from crates.io.
+
 ## Changelog history
 
 ## 19th July 2026

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.8.1"
+version = "0.8.2"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ affinidi-messaging-didcomm = { version = "0.15", path = "../../messaging/affinid
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 ## EdDSA signer/verifier backing the scenario's JWS signing (the workspace
 ## sd-jwt crate ships only an HMAC test signer).
-ed25519-dalek = { version = "2" }
+ed25519-dalek = { version = "3" }
 base64 = "0.22"
 
 # ── TI5b: mdoc (COSE sign_mso/verify_issuer_auth) + OID4VP present/verify ──

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -22,8 +22,8 @@ affinidi-tsp = { path = "../crates/messaging/affinidi-tsp", default-features = f
 # The ToIP reference, built WITHOUT `resolve` (no didwebvh diamond) so it can
 # share one dependency graph with affinidi-tsp.
 tsp_sdk = { path = "../../tsp-sdk", default-features = false, features = ["serialize"] }
-ed25519-dalek = { version = "2", features = ["rand_core"] }
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+ed25519-dalek = { version = "3", features = ["rand_core"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde_json = "1"
 base64ct = { version = "1", features = ["alloc"] }

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -35,8 +35,8 @@ struct Keys {
 }
 
 fn gen_keys() -> Keys {
-    let sign = SigningKey::generate(&mut OsRng);
-    let enc = StaticSecret::random_from_rng(OsRng);
+    let sign = SigningKey::generate(&mut rand_10::rng());
+    let enc = StaticSecret::random_from_rng(&mut rand_10::rng());
     Keys {
         sign_sk: sign.to_bytes(),
         sign_pk: sign.verifying_key().to_bytes(),


### PR DESCRIPTION
Takes `ed25519-dalek` 2 → 3 and `x25519-dalek` 2 → 3 across the workspace, and the
mediator's `vta-sdk` requirement to 0.21.0. Together these remove the last
`curve25519-dalek` 4 node — the workspace now links a **single** curve25519
implementation.

```
before:  curve25519-dalek v4.1.3  +  curve25519-dalek v5.0.0
after:   curve25519-dalek v5.0.0
```

## Why

`vta-sdk` was the reason dalek 4 could not leave this graph. It pinned
`curve25519-dalek = "4"` directly plus ed25519-dalek 2, x25519-dalek 2 and
hpke 0.13, and the mediator inherits all of it. OpenVTC/verifiable-trust-infrastructure#887
moved that side (vta-sdk 0.21.0, published); this is the other half.

## `affinidi-crypto`: the public API stops leaking the dalek version

`PrivateKeyAgreement::X25519` now holds `[u8; 32]` instead of an
`x25519_dalek::StaticSecret`. Holding the dalek type put the x25519-dalek **major
version in the crate's public API**, which is precisely why this upgrade needed
cross-repo coordination at all — de-leaking it makes the next dalek bump an
internal detail.

It also fixes a real defect: that variant was `#[zeroize(skip)]`, so the X25519
scalar was **never zeroized**. Raw bytes are. The `StaticSecret` is rebuilt at the
point of use, so ECDH is bit-identical — locked by the existing
`ecdh_1pu_x25519_kek_golden` KAT. `PublicKeyAgreement::X25519` already held raw
bytes and is unchanged.

## Patch bumps, per ADR 0003

All bumps are patch-within-minor, per [ADR 0003](docs/adr/0003-public-api-semver-policy.md)
point 3: `vta-sdk` and `didwebvh-rs` pin these crates through `[patch.crates-io]`,
and a minor bump breaks the redirect so cargo pulls a second copy from crates.io.

This is not theoretical — I wrote it as `affinidi-crypto` 0.3.0 first and the
workspace stopped compiling in exactly that way:

```
error[E0433]: cannot find `jose` in `affinidi_crypto`
  --> vta-sdk-0.21.0/src/didcomm_light.rs:65:26
note: found an item that was configured out
  --> affinidi-crypto-0.2.5/src/lib.rs:40:9   # registry fallback, jose gated off
```

with `curve25519-dalek` 4 back in the graph alongside two `affinidi-crypto`
copies. `scripts/check-workspace-duplicates.sh` confirms no member is shadowed
under the shipped versions.

## Migration notes

- **rand 0.10 renamed `OsRng` → `SysRng` *and* made it fallible**
  (`TryRng<Error = SysError>`), so it no longer satisfies dalek's `CryptoRng`
  bound. Key generation moves to `rand::rng()`. `rand_core` 0.10 has no `OsRng`
  at all. Crates that also use P-256 carry both rand generations, since
  elliptic-curve 0.13 is still on rand_core 0.6.
- **`affinidi-oid4vc-core`**: `EddsaSigner::generate_with_rng` now bounds
  `R: rand::CryptoRng` instead of the rand_core 0.6 traits. Callers passing a
  rand 0.8-era RNG must update. `Es256Signer` is unchanged.
- **`affinidi-data-integrity`**: the Ed25519 signing path uses the inherent
  `Signature::to_bytes()` rather than the `SignatureEncoding` trait, which needs
  `alloc` and does not resolve under every feature unification.

## Verification

- `cargo check --workspace --all-features --all-targets` clean
- **2958 tests pass, 0 failures** (`--workspace --all-features --no-fail-fast`)
- clippy clean on **both** feature sets: default (redis-backend), and
  `--no-default-features --features didcomm,memory-backend`
- `cargo fmt --all --check` clean
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` all green
- `cargo deny`: bans/licenses/sources ok. `advisories` fails, but it **already
  fails on `main`** — and this branch carries one *fewer* advisory
  (RUSTSEC-2026-0204, crossbeam-epoch, drops out via the newer transitive graph).
  Remaining 6 are all pre-existing.

## Follow-up (not in this PR)

`ed25519-dalek-bip32` 0.3 (last released 2023-08) still pins ed25519-dalek 2 with
no v3, so it keeps a dalek-2 subtree inside VTI's `vta-service`/`vta-keys`. It is
absent from `vta-sdk`'s tree, so it does **not** reach this repo. Replacing it
means reimplementing SLIP-0010 ed25519 derivation — security-sensitive, tracked
separately.