### PR TITLE
fix: drop the legacy rustls 0.21 stack from the AWS SDK path

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,11 @@ jobs:
     with:
       toolchain: "1.95.0"
       rustflags: "-D warnings --cfg tracing_unstable"
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104"
+      # RUSTSEC-2026-0098 / -0099 / -0104 (rustls-webpki) were listed here and
+      # are now genuinely fixed — the aws-sdk crates no longer pull the legacy
+      # rustls 0.21 stack. Removed from the ignore list on purpose: if the
+      # legacy stack comes back, audit must fail rather than stay quiet.
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi Messaging Mediator
 
+## 1st August 2026 (0.18.2)
+
+Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,
+removing three `rustls-webpki` advisories from any build with the AWS
+feature enabled:
+
+- **RUSTSEC-2026-0098** — name constraints for URI names incorrectly accepted
+- **RUSTSEC-2026-0099** — name constraints accepted for certificates asserting
+  a wildcard name
+- **RUSTSEC-2026-0104** — reachable panic in certificate revocation list parsing
+
+The `aws-sdk-*` crates ship **both** TLS stacks in their default feature set:
+
+```
+rustls               -> aws-smithy-runtime/tls-rustls
+                     -> aws-smithy-http-client/legacy-rustls-ring
+                     -> rustls 0.21 + rustls-webpki 0.101.7   (vulnerable)
+default-https-client -> aws-smithy-http-client/rustls-aws-lc
+                     -> rustls 0.23 + rustls-webpki 0.103.13  (patched)
+```
+
+`rustls` is pure back-compat. Selecting the default set minus that one
+feature leaves the aws-lc-rs stack — the provider this workspace prefers
+anyway — and the vulnerable copy disappears entirely. No version bump of
+any AWS crate was needed or available; the fix is feature selection.
+
+These three advisories had been suppressed via `auditIgnore` in
+`checks.yaml`; that suppression is removed in the same change, so a
+regression fails the audit instead of passing quietly.
+
 ## 31st July 2026 (0.18.1)
 
 Requires **`vta-sdk` 0.21.0**, which moved to curve25519-dalek 5. Together with

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.1"
+version = "0.18.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -142,8 +142,32 @@ didwebvh-rs = "0.6"
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)
 ## To build without: --no-default-features --features didcomm
 aws-config = { version = "1", optional = true }
-aws-sdk-ssm = { version = "1", optional = true }
-aws-sdk-s3 = { version = "1", optional = true }
+# `default-features = false` + the default set MINUS `rustls`.
+# The aws-sdk crates ship BOTH TLS stacks in their defaults:
+#   rustls               -> aws-smithy-runtime/tls-rustls
+#                        -> aws-smithy-http-client/legacy-rustls-ring
+#                        -> rustls 0.21 + rustls-webpki 0.101.7
+#   default-https-client -> aws-smithy-http-client/rustls-aws-lc
+#                        -> rustls 0.23 + rustls-webpki 0.103.13
+# The legacy stack is pure back-compat and drags three rustls-webpki
+# advisories in with it: RUSTSEC-2026-0098 / -0099 (name-constraint
+# bypasses) and RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+# Dropping `rustls` leaves the aws-lc-rs stack, which is the provider
+# this workspace prefers anyway.
+aws-sdk-ssm = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
+# `default-features = false` + the default set MINUS `rustls`.
+# The aws-sdk crates ship BOTH TLS stacks in their defaults:
+#   rustls               -> aws-smithy-runtime/tls-rustls
+#                        -> aws-smithy-http-client/legacy-rustls-ring
+#                        -> rustls 0.21 + rustls-webpki 0.101.7
+#   default-https-client -> aws-smithy-http-client/rustls-aws-lc
+#                        -> rustls 0.23 + rustls-webpki 0.103.13
+# The legacy stack is pure back-compat and drags three rustls-webpki
+# advisories in with it: RUSTSEC-2026-0098 / -0099 (name-constraint
+# bypasses) and RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+# Dropping `rustls` leaves the aws-lc-rs stack, which is the provider
+# this workspace prefers anyway.
+aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 
 # ── Cryptography & Security ─────────────────────────────────────────────
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi Messaging Mediator Common
 
+## 1st August 2026 (0.15.33)
+
+Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,
+removing three `rustls-webpki` advisories from any build with the AWS
+feature enabled:
+
+- **RUSTSEC-2026-0098** — name constraints for URI names incorrectly accepted
+- **RUSTSEC-2026-0099** — name constraints accepted for certificates asserting
+  a wildcard name
+- **RUSTSEC-2026-0104** — reachable panic in certificate revocation list parsing
+
+The `aws-sdk-*` crates ship **both** TLS stacks in their default feature set:
+
+```
+rustls               -> aws-smithy-runtime/tls-rustls
+                     -> aws-smithy-http-client/legacy-rustls-ring
+                     -> rustls 0.21 + rustls-webpki 0.101.7   (vulnerable)
+default-https-client -> aws-smithy-http-client/rustls-aws-lc
+                     -> rustls 0.23 + rustls-webpki 0.103.13  (patched)
+```
+
+`rustls` is pure back-compat. Selecting the default set minus that one
+feature leaves the aws-lc-rs stack — the provider this workspace prefers
+anyway — and the vulnerable copy disappears entirely. No version bump of
+any AWS crate was needed or available; the fix is feature selection.
+
+These three advisories had been suppressed via `auditIgnore` in
+`checks.yaml`; that suppression is removed in the same change, so a
+regression fails the audit instead of passing quietly.
+
 ## Changelog history
 
 ## 27th July 2026 (2)

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.32"
+version = "0.15.33"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -130,7 +130,19 @@ keyring = { version = "3", features = [
   "linux-native",
 ], optional = true }
 aws-config = { version = "1", optional = true }
-aws-sdk-secretsmanager = { version = "1", optional = true }
+# `default-features = false` + the default set MINUS `rustls`.
+# The aws-sdk crates ship BOTH TLS stacks in their defaults:
+#   rustls               -> aws-smithy-runtime/tls-rustls
+#                        -> aws-smithy-http-client/legacy-rustls-ring
+#                        -> rustls 0.21 + rustls-webpki 0.101.7
+#   default-https-client -> aws-smithy-http-client/rustls-aws-lc
+#                        -> rustls 0.23 + rustls-webpki 0.103.13
+# The legacy stack is pure back-compat and drags three rustls-webpki
+# advisories in with it: RUSTSEC-2026-0098 / -0099 (name-constraint
+# bypasses) and RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+# Dropping `rustls` leaves the aws-lc-rs stack, which is the provider
+# this workspace prefers anyway.
+aws-sdk-secretsmanager = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
 ## GCP Secret Manager (official googleapis/google-cloud-rust crate).
 ## gRPC client via tonic; uses rustls (via `default-rustls-provider`)
 ## so it joins the workspace TLS story without pulling native-tls.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi Messaging Mediator Setup
 
+## 1st August 2026 (0.1.27)
+
+Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,
+removing three `rustls-webpki` advisories from any build with the AWS
+feature enabled:
+
+- **RUSTSEC-2026-0098** — name constraints for URI names incorrectly accepted
+- **RUSTSEC-2026-0099** — name constraints accepted for certificates asserting
+  a wildcard name
+- **RUSTSEC-2026-0104** — reachable panic in certificate revocation list parsing
+
+The `aws-sdk-*` crates ship **both** TLS stacks in their default feature set:
+
+```
+rustls               -> aws-smithy-runtime/tls-rustls
+                     -> aws-smithy-http-client/legacy-rustls-ring
+                     -> rustls 0.21 + rustls-webpki 0.101.7   (vulnerable)
+default-https-client -> aws-smithy-http-client/rustls-aws-lc
+                     -> rustls 0.23 + rustls-webpki 0.103.13  (patched)
+```
+
+`rustls` is pure back-compat. Selecting the default set minus that one
+feature leaves the aws-lc-rs stack — the provider this workspace prefers
+anyway — and the vulnerable copy disappears entirely. No version bump of
+any AWS crate was needed or available; the fix is feature selection.
+
+These three advisories had been suppressed via `auditIgnore` in
+`checks.yaml`; that suppression is removed in the same change, so a
+regression fails the audit instead of passing quietly.
+
 ## 31st July 2026 (0.1.26)
 
 Requires **`vta-sdk` 0.21.0** (curve25519-dalek 5), matching the mediator.

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.26"
+version = "0.1.27"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -153,8 +153,32 @@ tracing = "0.1"
 ## uses `aws_parameter_store://`. Pinned to `1` to match the runtime crate's
 ## existing `aws-sdk-ssm` dependency.
 aws-config = { version = "1", optional = true }
-aws-sdk-ssm = { version = "1", optional = true }
-aws-sdk-s3 = { version = "1", optional = true }
+# `default-features = false` + the default set MINUS `rustls`.
+# The aws-sdk crates ship BOTH TLS stacks in their defaults:
+#   rustls               -> aws-smithy-runtime/tls-rustls
+#                        -> aws-smithy-http-client/legacy-rustls-ring
+#                        -> rustls 0.21 + rustls-webpki 0.101.7
+#   default-https-client -> aws-smithy-http-client/rustls-aws-lc
+#                        -> rustls 0.23 + rustls-webpki 0.103.13
+# The legacy stack is pure back-compat and drags three rustls-webpki
+# advisories in with it: RUSTSEC-2026-0098 / -0099 (name-constraint
+# bypasses) and RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+# Dropping `rustls` leaves the aws-lc-rs stack, which is the provider
+# this workspace prefers anyway.
+aws-sdk-ssm = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
+# `default-features = false` + the default set MINUS `rustls`.
+# The aws-sdk crates ship BOTH TLS stacks in their defaults:
+#   rustls               -> aws-smithy-runtime/tls-rustls
+#                        -> aws-smithy-http-client/legacy-rustls-ring
+#                        -> rustls 0.21 + rustls-webpki 0.101.7
+#   default-https-client -> aws-smithy-http-client/rustls-aws-lc
+#                        -> rustls 0.23 + rustls-webpki 0.103.13
+# The legacy stack is pure back-compat and drags three rustls-webpki
+# advisories in with it: RUSTSEC-2026-0098 / -0099 (name-constraint
+# bypasses) and RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+# Dropping `rustls` leaves the aws-lc-rs stack, which is the provider
+# this workspace prefers anyway.
+aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 
 [dev-dependencies]
 ## Test fixtures from `provision_client::test_helpers` (e.g.


### PR DESCRIPTION
Removes three `rustls-webpki` advisories from every build with an AWS feature
enabled:

| Advisory | Issue |
|---|---|
| RUSTSEC-2026-0098 | Name constraints for URI names incorrectly accepted |
| RUSTSEC-2026-0099 | Name constraints accepted for certs asserting a wildcard name |
| RUSTSEC-2026-0104 | Reachable panic in certificate revocation list parsing |

Two certificate-validation bypasses and a remote panic.

## Cause

The `aws-sdk-*` crates ship **both** TLS stacks in their default feature set, so
the vulnerable copy was linked *alongside* the patched one:

```
rustls               -> aws-smithy-runtime/tls-rustls
                     -> aws-smithy-http-client/legacy-rustls-ring
                     -> rustls 0.21 + rustls-webpki 0.101.7   (vulnerable)

default-https-client -> aws-smithy-http-client/rustls-aws-lc
                     -> rustls 0.23 + rustls-webpki 0.103.13  (patched)
```

## Fix

`rustls` is pure back-compat. Taking the default set **minus that one feature**
leaves the aws-lc-rs stack — the provider this workspace prefers anyway — and the
vulnerable copy disappears.

This is **feature selection, not a version bump**: `aws-smithy-http-client` 1.2.0
is already the latest release and offers both stacks. No AWS crate needed
updating, and none could have fixed it.

## Scope

A default mediator build never linked rustls 0.21. Only the AWS feature paths did
— which is the production AWS deployment path. Verified on all three:

```
affinidi-messaging-mediator        [aws]          rustls-webpki 0.103.13
affinidi-messaging-mediator-common [secrets-aws]  rustls-webpki 0.103.13
affinidi-messaging-mediator-setup  [publish-aws]  rustls-webpki 0.103.13
```

No source code referenced the legacy connector, so this is a dependency-graph
change only.

## Also: the suppression comes off

`checks.yaml` had these three IDs in `auditIgnore` — they were being suppressed,
not merely unnoticed. Now that they are genuinely fixed the suppression is
removed, so a regression **fails** the audit instead of passing quietly.
`release.yaml` never listed them, so the two configs now agree.

## Verification

- `cargo check --workspace --all-features --all-targets` clean
- **2958 tests pass, 0 failures**
- clippy clean on both feature sets (default redis-backend, and
  `--no-default-features --features didcomm,memory-backend`)
- `cargo fmt --all --check` clean
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` green
- `cargo deny check advisories`: the three vulnerabilities are **gone**. What
  remains is three `unmaintained` advisories (`number_prefix`, `rustls-pemfile`,
  `smallstr`) that cargo-deny itself reports as *"No safe upgrade is available!"*