### PR TITLE
feat!: move to elliptic-curve 0.14 and gate the legacy ssi-backed DID methods

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Affinidi Crypto Changelog
 
+## 2nd August 2026 (0.2.7)
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## 31st July 2026 (0.2.6)
 
 **`PrivateKeyAgreement::X25519` now holds `[u8; 32]` instead of an

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.6"
+version = "0.2.7"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -40,27 +40,10 @@ base58 = "0.2"
 base64 = "0.22"
 multibase = "0.9"
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
-k256 = { version = "0.13", features = [
-  "ecdsa-core",
-  "ecdsa",
-  "arithmetic",
-  "ecdh",
-], optional = true }
-p256 = { version = "0.13", features = [
-  "ecdsa-core",
-  "ecdsa",
-  "arithmetic",
-  "ecdh",
-], optional = true }
-p384 = { version = "0.13", features = [
-  "ecdsa-core",
-  "arithmetic",
-  "ecdh",
-], optional = true }
-p521 = { version = "0.13", features = [
-  "arithmetic",
-  "ecdh",
-], optional = true }
+k256 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional = true }
+p256 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional = true }
+p384 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional = true }
+p521 = { version = "0.14", features = ["arithmetic", "ecdh"], optional = true }
 # JOSE content-encryption / key-wrap primitives (`jose` feature).
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", features = ["alloc"], optional = true }

--- a/crates/core/affinidi-crypto/src/jose/content_encryption.rs
+++ b/crates/core/affinidi-crypto/src/jose/content_encryption.rs
@@ -8,7 +8,7 @@
 use aes::Aes256;
 use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 use hmac::{Hmac, Mac};
-use rand_core::RngCore;
+use rand_10::Rng;
 use sha2::Sha512;
 use subtle::ConstantTimeEq;
 
@@ -29,14 +29,14 @@ pub const TAG_SIZE: usize = 32;
 /// Generate a random 64-byte CEK.
 pub fn generate_cek() -> [u8; CEK_SIZE] {
     let mut cek = [0u8; CEK_SIZE];
-    rand_core::OsRng.fill_bytes(&mut cek);
+    rand_10::rng().fill_bytes(&mut cek);
     cek
 }
 
 /// Generate a random 16-byte IV.
 pub fn generate_iv() -> [u8; IV_SIZE] {
     let mut iv = [0u8; IV_SIZE];
-    rand_core::OsRng.fill_bytes(&mut iv);
+    rand_10::rng().fill_bytes(&mut iv);
     iv
 }
 

--- a/crates/core/affinidi-crypto/src/jose/kat.rs
+++ b/crates/core/affinidi-crypto/src/jose/kat.rs
@@ -30,6 +30,7 @@ use super::{aes_kw, concat_kdf, content_encryption, signing};
 // ECDSA P-256 signing lives in the `p256` dev-dependency (this crate is
 // verify-only for ES256), used by the P-256 KAT(s) below to produce vectors.
 use p256::ecdsa::{SigningKey as P256SigningKey, signature::Signer as P256Signer};
+use p256::elliptic_curve::Generate;
 // Likewise ECDSA secp256k1 signing (this crate is verify-only for ES256K),
 // used by the secp256k1 KAT(s) below to produce vectors.
 use k256::ecdsa::{SigningKey as K256SigningKey, signature::Signer as K256Signer};
@@ -351,7 +352,7 @@ fn es256_p256_golden() {
     let sk = P256SigningKey::from_slice(&[0x55u8; 32]).expect("valid P-256 scalar");
     let msg = b"DIDComm KAT message";
 
-    let pk = sk.verifying_key().to_encoded_point(false);
+    let pk = sk.verifying_key().to_sec1_point(false);
     assert_eq!(hex(pk.as_bytes()), EXPECTED_PK, "P-256 public key drifted");
 
     // RustCrypto ECDSA `sign` is deterministic (RFC 6979), so these bytes pin.
@@ -369,15 +370,12 @@ fn es256_p256_golden() {
 
 /// A P-256 signing key's public point as uncompressed SEC1 bytes (65 bytes).
 fn p256_sec1_uncompressed(sk: &P256SigningKey) -> Vec<u8> {
-    sk.verifying_key()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec()
+    sk.verifying_key().to_sec1_point(false).as_bytes().to_vec()
 }
 
 #[test]
 fn p256_sign_verify_roundtrip() {
-    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let sk = P256SigningKey::generate();
     let msg = b"affinidi es256 roundtrip";
     let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
@@ -386,8 +384,8 @@ fn p256_sign_verify_roundtrip() {
 
 #[test]
 fn p256_wrong_key_fails() {
-    let sk = P256SigningKey::random(&mut rand_core::OsRng);
-    let other = P256SigningKey::random(&mut rand_core::OsRng);
+    let sk = P256SigningKey::generate();
+    let other = P256SigningKey::generate();
     let msg = b"affinidi es256";
     let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
@@ -396,7 +394,7 @@ fn p256_wrong_key_fails() {
 
 #[test]
 fn p256_tampered_message_fails() {
-    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let sk = P256SigningKey::generate();
     let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, b"original");
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
     assert!(signing::verify_p256(b"tampered", &sig_bytes, &p256_sec1_uncompressed(&sk)).is_err());
@@ -406,20 +404,12 @@ fn p256_tampered_message_fails() {
 /// (compressed 33-byte and uncompressed 65-byte).
 #[test]
 fn p256_compressed_and_uncompressed_pubkey_agree() {
-    let sk = P256SigningKey::random(&mut rand_core::OsRng);
+    let sk = P256SigningKey::generate();
     let msg = b"sec1 encodings";
     let sig: p256::ecdsa::Signature = P256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
-    let uncompressed = sk
-        .verifying_key()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec();
-    let compressed = sk
-        .verifying_key()
-        .to_encoded_point(true)
-        .as_bytes()
-        .to_vec();
+    let uncompressed = sk.verifying_key().to_sec1_point(false).as_bytes().to_vec();
+    let compressed = sk.verifying_key().to_sec1_point(true).as_bytes().to_vec();
     assert!(signing::verify_p256(msg, &sig_bytes, &uncompressed).is_ok());
     assert!(signing::verify_p256(msg, &sig_bytes, &compressed).is_ok());
 }
@@ -440,7 +430,7 @@ fn secp256k1_es256k_golden() {
     let sk = K256SigningKey::from_slice(&[0x55u8; 32]).expect("valid secp256k1 scalar");
     let msg = b"DIDComm KAT message";
 
-    let pk = sk.verifying_key().to_encoded_point(false);
+    let pk = sk.verifying_key().to_sec1_point(false);
     assert_eq!(
         hex(pk.as_bytes()),
         EXPECTED_PK,
@@ -462,15 +452,12 @@ fn secp256k1_es256k_golden() {
 
 /// A secp256k1 signing key's public point as uncompressed SEC1 bytes (65 bytes).
 fn k256_sec1_uncompressed(sk: &K256SigningKey) -> Vec<u8> {
-    sk.verifying_key()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec()
+    sk.verifying_key().to_sec1_point(false).as_bytes().to_vec()
 }
 
 #[test]
 fn secp256k1_sign_verify_roundtrip() {
-    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let sk = K256SigningKey::generate();
     let msg = b"affinidi es256k roundtrip";
     let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
@@ -479,8 +466,8 @@ fn secp256k1_sign_verify_roundtrip() {
 
 #[test]
 fn secp256k1_wrong_key_fails() {
-    let sk = K256SigningKey::random(&mut rand_core::OsRng);
-    let other = K256SigningKey::random(&mut rand_core::OsRng);
+    let sk = K256SigningKey::generate();
+    let other = K256SigningKey::generate();
     let msg = b"affinidi es256k";
     let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
@@ -489,7 +476,7 @@ fn secp256k1_wrong_key_fails() {
 
 #[test]
 fn secp256k1_tampered_message_fails() {
-    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let sk = K256SigningKey::generate();
     let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, b"original");
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
     assert!(
@@ -501,20 +488,12 @@ fn secp256k1_tampered_message_fails() {
 /// (compressed 33-byte and uncompressed 65-byte).
 #[test]
 fn secp256k1_compressed_and_uncompressed_pubkey_agree() {
-    let sk = K256SigningKey::random(&mut rand_core::OsRng);
+    let sk = K256SigningKey::generate();
     let msg = b"sec1 encodings";
     let sig: k256::ecdsa::Signature = K256Signer::sign(&sk, msg);
     let sig_bytes: [u8; 64] = sig.to_bytes().into();
-    let uncompressed = sk
-        .verifying_key()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec();
-    let compressed = sk
-        .verifying_key()
-        .to_encoded_point(true)
-        .as_bytes()
-        .to_vec();
+    let uncompressed = sk.verifying_key().to_sec1_point(false).as_bytes().to_vec();
+    let compressed = sk.verifying_key().to_sec1_point(true).as_bytes().to_vec();
     assert!(signing::verify_secp256k1(msg, &sig_bytes, &uncompressed).is_ok());
     assert!(signing::verify_secp256k1(msg, &sig_bytes, &compressed).is_ok());
 }

--- a/crates/core/affinidi-crypto/src/jose/key_agreement.rs
+++ b/crates/core/affinidi-crypto/src/jose/key_agreement.rs
@@ -10,7 +10,7 @@
 //! change. The `Curve` enum doubles as the typed JOSE `crv` wire boundary.
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use rand_core::OsRng;
+use p256::elliptic_curve::Generate;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -77,8 +77,8 @@ impl PublicKeyAgreement {
                 "x": URL_SAFE_NO_PAD.encode(bytes),
             }),
             PublicKeyAgreement::P256(pk) => {
-                use p256::elliptic_curve::sec1::ToEncodedPoint;
-                let point = pk.to_encoded_point(false);
+                use p256::elliptic_curve::sec1::ToSec1Point;
+                let point = pk.to_sec1_point(false);
                 serde_json::json!({
                     "kty": "EC",
                     "crv": "P-256",
@@ -87,8 +87,8 @@ impl PublicKeyAgreement {
                 })
             }
             PublicKeyAgreement::K256(pk) => {
-                use k256::elliptic_curve::sec1::ToEncodedPoint;
-                let point = pk.to_encoded_point(false);
+                use k256::elliptic_curve::sec1::ToSec1Point;
+                let point = pk.to_sec1_point(false);
                 serde_json::json!({
                     "kty": "EC",
                     "crv": "secp256k1",
@@ -97,8 +97,8 @@ impl PublicKeyAgreement {
                 })
             }
             PublicKeyAgreement::P384(pk) => {
-                use p384::elliptic_curve::sec1::ToEncodedPoint;
-                let point = pk.to_encoded_point(false);
+                use p384::elliptic_curve::sec1::ToSec1Point;
+                let point = pk.to_sec1_point(false);
                 serde_json::json!({
                     "kty": "EC",
                     "crv": "P-384",
@@ -107,8 +107,8 @@ impl PublicKeyAgreement {
                 })
             }
             PublicKeyAgreement::P521(pk) => {
-                use p521::elliptic_curve::sec1::ToEncodedPoint;
-                let point = pk.to_encoded_point(false);
+                use p521::elliptic_curve::sec1::ToSec1Point;
+                let point = pk.to_sec1_point(false);
                 serde_json::json!({
                     "kty": "EC",
                     "crv": "P-521",
@@ -127,20 +127,20 @@ impl PublicKeyAgreement {
         match self {
             PublicKeyAgreement::X25519(bytes) => bytes.to_vec(),
             PublicKeyAgreement::P256(pk) => {
-                use p256::elliptic_curve::sec1::ToEncodedPoint;
-                pk.to_encoded_point(true).as_bytes().to_vec()
+                use p256::elliptic_curve::sec1::ToSec1Point;
+                pk.to_sec1_point(true).as_bytes().to_vec()
             }
             PublicKeyAgreement::K256(pk) => {
-                use k256::elliptic_curve::sec1::ToEncodedPoint;
-                pk.to_encoded_point(true).as_bytes().to_vec()
+                use k256::elliptic_curve::sec1::ToSec1Point;
+                pk.to_sec1_point(true).as_bytes().to_vec()
             }
             PublicKeyAgreement::P384(pk) => {
-                use p384::elliptic_curve::sec1::ToEncodedPoint;
-                pk.to_encoded_point(true).as_bytes().to_vec()
+                use p384::elliptic_curve::sec1::ToSec1Point;
+                pk.to_sec1_point(true).as_bytes().to_vec()
             }
             PublicKeyAgreement::P521(pk) => {
-                use p521::elliptic_curve::sec1::ToEncodedPoint;
-                pk.to_encoded_point(true).as_bytes().to_vec()
+                use p521::elliptic_curve::sec1::ToSec1Point;
+                pk.to_sec1_point(true).as_bytes().to_vec()
             }
         }
     }
@@ -332,10 +332,18 @@ impl PrivateKeyAgreement {
             Curve::X25519 => PrivateKeyAgreement::X25519(
                 x25519_dalek::StaticSecret::random_from_rng(&mut rand_10::rng()).to_bytes(),
             ),
-            Curve::P256 => PrivateKeyAgreement::P256(p256::SecretKey::random(&mut OsRng)),
-            Curve::K256 => PrivateKeyAgreement::K256(k256::SecretKey::random(&mut OsRng)),
-            Curve::P384 => PrivateKeyAgreement::P384(p384::SecretKey::random(&mut OsRng)),
-            Curve::P521 => PrivateKeyAgreement::P521(p521::SecretKey::random(&mut OsRng)),
+            Curve::P256 => {
+                PrivateKeyAgreement::P256(p256::SecretKey::generate_from_rng(&mut rand_10::rng()))
+            }
+            Curve::K256 => {
+                PrivateKeyAgreement::K256(k256::SecretKey::generate_from_rng(&mut rand_10::rng()))
+            }
+            Curve::P384 => {
+                PrivateKeyAgreement::P384(p384::SecretKey::generate_from_rng(&mut rand_10::rng()))
+            }
+            Curve::P521 => {
+                PrivateKeyAgreement::P521(p521::SecretKey::generate_from_rng(&mut rand_10::rng()))
+            }
         }
     }
 

--- a/crates/core/affinidi-crypto/src/p256.rs
+++ b/crates/core/affinidi-crypto/src/p256.rs
@@ -1,12 +1,16 @@
 //! P-256 (secp256r1/prime256v1) key operations
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use p256::elliptic_curve::Generate;
 use p256::{
-    AffinePoint, EncodedPoint,
+    AffinePoint,
     ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+    elliptic_curve::sec1::{FromSec1Point, ToSec1Point},
 };
-use rand_core::OsRng;
+
+/// `elliptic-curve` 0.14 made `EncodedPoint` a generic alias for
+/// `Sec1Point<C>`; pin it to this module's curve.
+type EncodedPoint = p256::elliptic_curve::sec1::Sec1Point<p256::NistP256>;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -32,12 +36,12 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
         Some(secret) => SigningKey::from_slice(secret).map_err(|e| {
             CryptoError::KeyError(format!("P-256 secret material isn't valid: {e}"))
         })?,
-        None => SigningKey::random(&mut OsRng),
+        None => SigningKey::generate(),
     };
 
     let verifying_key = VerifyingKey::from(&signing_key);
     let private_bytes = signing_key.to_bytes().to_vec();
-    let public_bytes = verifying_key.to_encoded_point(false).to_bytes().to_vec();
+    let public_bytes = verifying_key.to_sec1_point(false).to_bytes().to_vec();
 
     Ok(KeyPair {
         key_type: KeyType::P256,
@@ -47,10 +51,8 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
             key_id: None,
             params: Params::EC(ECParams {
                 curve: "P-256".to_string(),
-                x: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).x().unwrap()),
-                y: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).y().unwrap()),
+                x: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).x().unwrap()),
+                y: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).y().unwrap()),
                 d: Some(BASE64_URL_SAFE_NO_PAD.encode(&private_bytes)),
             }),
         },
@@ -63,14 +65,14 @@ pub fn public_jwk(data: &[u8]) -> Result<JWK> {
         .map_err(|e| CryptoError::KeyError(format!("P-256 public key isn't valid: {e}")))?;
 
     // Convert to AffinePoint to validate the point is on the curve
-    let ap: AffinePoint = AffinePoint::from_encoded_point(&ep)
+    let ap: AffinePoint = AffinePoint::from_sec1_point(&ep)
         .into_option()
         .ok_or_else(|| {
             CryptoError::KeyError("Couldn't convert P-256 EncodedPoint to AffinePoint".into())
         })?;
 
     // Decompress to get x and y coordinates
-    let ep = ap.to_encoded_point(false);
+    let ep = ap.to_sec1_point(false);
 
     Ok(JWK {
         key_id: None,

--- a/crates/core/affinidi-crypto/src/p384.rs
+++ b/crates/core/affinidi-crypto/src/p384.rs
@@ -1,12 +1,16 @@
 //! P-384 (secp384r1) key operations
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use p384::elliptic_curve::Generate;
 use p384::{
-    AffinePoint, EncodedPoint,
+    AffinePoint,
     ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+    elliptic_curve::sec1::{FromSec1Point, ToSec1Point},
 };
-use rand_core::OsRng;
+
+/// `elliptic-curve` 0.14 made `EncodedPoint` a generic alias for
+/// `Sec1Point<C>`; pin it to this module's curve.
+type EncodedPoint = p384::elliptic_curve::sec1::Sec1Point<p384::NistP384>;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -32,12 +36,12 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
         Some(secret) => SigningKey::from_slice(secret).map_err(|e| {
             CryptoError::KeyError(format!("P-384 secret material isn't valid: {e}"))
         })?,
-        None => SigningKey::random(&mut OsRng),
+        None => SigningKey::generate(),
     };
 
     let verifying_key = VerifyingKey::from(&signing_key);
     let private_bytes = signing_key.to_bytes().to_vec();
-    let public_bytes = verifying_key.to_encoded_point(false).to_bytes().to_vec();
+    let public_bytes = verifying_key.to_sec1_point(false).to_bytes().to_vec();
 
     Ok(KeyPair {
         key_type: KeyType::P384,
@@ -47,10 +51,8 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
             key_id: None,
             params: Params::EC(ECParams {
                 curve: "P-384".to_string(),
-                x: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).x().unwrap()),
-                y: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).y().unwrap()),
+                x: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).x().unwrap()),
+                y: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).y().unwrap()),
                 d: Some(BASE64_URL_SAFE_NO_PAD.encode(&private_bytes)),
             }),
         },
@@ -63,14 +65,14 @@ pub fn public_jwk(data: &[u8]) -> Result<JWK> {
         .map_err(|e| CryptoError::KeyError(format!("P-384 public key isn't valid: {e}")))?;
 
     // Convert to AffinePoint to validate the point is on the curve
-    let ap: AffinePoint = AffinePoint::from_encoded_point(&ep)
+    let ap: AffinePoint = AffinePoint::from_sec1_point(&ep)
         .into_option()
         .ok_or_else(|| {
             CryptoError::KeyError("Couldn't convert P-384 EncodedPoint to AffinePoint".into())
         })?;
 
     // Decompress to get x and y coordinates
-    let ep = ap.to_encoded_point(false);
+    let ep = ap.to_sec1_point(false);
 
     Ok(JWK {
         key_id: None,

--- a/crates/core/affinidi-crypto/src/p521.rs
+++ b/crates/core/affinidi-crypto/src/p521.rs
@@ -5,11 +5,15 @@
 //! `p521` crate (P-521 key agreement, not signing, is what this stack uses).
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use p521::elliptic_curve::Generate;
 use p521::{
-    AffinePoint, EncodedPoint, SecretKey,
-    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+    AffinePoint, SecretKey,
+    elliptic_curve::sec1::{FromSec1Point, ToSec1Point},
 };
-use rand_core::OsRng;
+
+/// `elliptic-curve` 0.14 made `EncodedPoint` a generic alias for
+/// `Sec1Point<C>`; pin it to this module's curve.
+type EncodedPoint = p521::elliptic_curve::sec1::Sec1Point<p521::NistP521>;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -35,12 +39,12 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
         Some(secret) => SecretKey::from_slice(secret).map_err(|e| {
             CryptoError::KeyError(format!("P-521 secret material isn't valid: {e}"))
         })?,
-        None => SecretKey::random(&mut OsRng),
+        None => SecretKey::generate(),
     };
 
     let public_key = secret_key.public_key();
     let private_bytes = secret_key.to_bytes().to_vec();
-    let ep = public_key.to_encoded_point(false);
+    let ep = public_key.to_sec1_point(false);
     let public_bytes = ep.as_bytes().to_vec();
 
     Ok(KeyPair {
@@ -73,14 +77,14 @@ pub fn public_jwk(data: &[u8]) -> Result<JWK> {
         .map_err(|e| CryptoError::KeyError(format!("P-521 public key isn't valid: {e}")))?;
 
     // Convert to AffinePoint to validate the point is on the curve
-    let ap: AffinePoint = AffinePoint::from_encoded_point(&ep)
+    let ap: AffinePoint = AffinePoint::from_sec1_point(&ep)
         .into_option()
         .ok_or_else(|| {
             CryptoError::KeyError("Couldn't convert P-521 EncodedPoint to AffinePoint".into())
         })?;
 
     // Decompress to get x and y coordinates
-    let ep = ap.to_encoded_point(false);
+    let ep = ap.to_sec1_point(false);
 
     Ok(JWK {
         key_id: None,

--- a/crates/core/affinidi-crypto/src/secp256k1.rs
+++ b/crates/core/affinidi-crypto/src/secp256k1.rs
@@ -1,12 +1,16 @@
 //! secp256k1 key operations
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use k256::elliptic_curve::Generate;
 use k256::{
-    AffinePoint, EncodedPoint,
+    AffinePoint,
     ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+    elliptic_curve::sec1::{FromSec1Point, ToSec1Point},
 };
-use rand_core::OsRng;
+
+/// `elliptic-curve` 0.14 made `EncodedPoint` a generic alias for
+/// `Sec1Point<C>`; pin it to this module's curve.
+type EncodedPoint = k256::elliptic_curve::sec1::Sec1Point<k256::Secp256k1>;
 
 use crate::{CryptoError, ECParams, JWK, KeyType, Params, error::Result};
 
@@ -32,12 +36,12 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
         Some(secret) => SigningKey::from_slice(secret).map_err(|e| {
             CryptoError::KeyError(format!("secp256k1 secret material isn't valid: {e}"))
         })?,
-        None => SigningKey::random(&mut OsRng),
+        None => SigningKey::generate(),
     };
 
     let verifying_key = VerifyingKey::from(&signing_key);
     let private_bytes = signing_key.to_bytes().to_vec();
-    let public_bytes = verifying_key.to_encoded_point(false).to_bytes().to_vec();
+    let public_bytes = verifying_key.to_sec1_point(false).to_bytes().to_vec();
 
     Ok(KeyPair {
         key_type: KeyType::Secp256k1,
@@ -47,10 +51,8 @@ pub fn generate(secret: Option<&[u8]>) -> Result<KeyPair> {
             key_id: None,
             params: Params::EC(ECParams {
                 curve: "secp256k1".to_string(),
-                x: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).x().unwrap()),
-                y: BASE64_URL_SAFE_NO_PAD
-                    .encode(verifying_key.to_encoded_point(false).y().unwrap()),
+                x: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).x().unwrap()),
+                y: BASE64_URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_point(false).y().unwrap()),
                 d: Some(BASE64_URL_SAFE_NO_PAD.encode(&private_bytes)),
             }),
         },
@@ -63,14 +65,14 @@ pub fn public_jwk(data: &[u8]) -> Result<JWK> {
         .map_err(|e| CryptoError::KeyError(format!("secp256k1 public key isn't valid: {e}")))?;
 
     // Convert to AffinePoint to validate the point is on the curve
-    let ap: AffinePoint = AffinePoint::from_encoded_point(&ep)
+    let ap: AffinePoint = AffinePoint::from_sec1_point(&ep)
         .into_option()
         .ok_or_else(|| {
             CryptoError::KeyError("Couldn't convert secp256k1 EncodedPoint to AffinePoint".into())
         })?;
 
     // Decompress to get x and y coordinates
-    let ep = ap.to_encoded_point(false);
+    let ep = ap.to_sec1_point(false);
 
     Ok(JWK {
         key_id: None,

--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Affinidi mdoc Changelog
 
+## 2nd August 2026 (0.2.5)
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## 31st July 2026 (0.2.4)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
-p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
-p384 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
+p256 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
+p384 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 sha2 = "0.10"
 hmac = "0.12"

--- a/crates/credentials/affinidi-mdoc/src/es256_cose.rs
+++ b/crates/credentials/affinidi-mdoc/src/es256_cose.rs
@@ -8,6 +8,7 @@
  */
 
 use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer, signature::Verifier};
+use p256::elliptic_curve::Generate;
 
 use crate::cose::{CoseSigner, CoseVerifier};
 use crate::error::{MdocError, Result};
@@ -36,7 +37,7 @@ impl Es256CoseSigner {
 
     /// Generate a new random P-256 key pair for signing.
     pub fn generate() -> Self {
-        let signing_key = SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        let signing_key = SigningKey::generate();
         Self {
             signing_key,
             x5chain: None,
@@ -59,7 +60,7 @@ impl Es256CoseSigner {
     /// Get the public key as uncompressed SEC1 bytes.
     pub fn public_key_bytes(&self) -> Vec<u8> {
         VerifyingKey::from(&self.signing_key)
-            .to_encoded_point(false)
+            .to_sec1_point(false)
             .to_bytes()
             .to_vec()
     }

--- a/crates/credentials/affinidi-mdoc/src/es384_cose.rs
+++ b/crates/credentials/affinidi-mdoc/src/es384_cose.rs
@@ -17,6 +17,7 @@
  */
 
 use p384::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer, signature::Verifier};
+use p384::elliptic_curve::Generate;
 
 use crate::cose::{CoseSigner, CoseVerifier};
 use crate::error::{MdocError, Result};
@@ -42,7 +43,7 @@ impl Es384CoseSigner {
 
     /// Generate a new random P-384 key pair for signing.
     pub fn generate() -> Self {
-        let signing_key = SigningKey::random(&mut p384::elliptic_curve::rand_core::OsRng);
+        let signing_key = SigningKey::generate();
         Self {
             signing_key,
             x5chain: None,
@@ -65,7 +66,7 @@ impl Es384CoseSigner {
     /// Get the public key as uncompressed SEC1 bytes (97 bytes).
     pub fn public_key_bytes(&self) -> Vec<u8> {
         VerifyingKey::from(&self.signing_key)
-            .to_encoded_point(false)
+            .to_sec1_point(false)
             .to_bytes()
             .to_vec()
     }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Affinidi DID Resolver Cache SDK
 
+## 2nd August 2026 (0.8.22)
+
+**BREAKING (behaviour): `did:ethr` and `did:pkh` are now behind features and
+OFF by default.**
+
+These were the only two DID methods in this crate with no feature gate —
+`did-jwk`, `did-webvh`, `did-cheqd`, `did-scid`, `did-ebsi` and `did_example`
+are all already optional. Because they were unconditional, every build of this
+crate pulled the entire `ssi-*` stack, and with it `p256`/`k256` **0.13** —
+which is what kept two generations of the RustCrypto stack in the graph.
+
+Enable `did-ethr` / `did-pkh` explicitly to restore the previous behaviour.
+Resolution of those methods returns "method not supported" when the feature is
+off, exactly as the other gated methods do.
+
+`ssi-dids-core` is likewise optional now, pulled in only by those features.
+With all three off, a default build of this crate resolves the elliptic-curve
+family entirely at **0.14** and links no `ssi-*` crate at all.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md)
+point 3: this crate is redirected through `[patch.crates-io]` by external
+consumers, so a minor bump would break the redirect. The behavioural break is
+called out here rather than encoded in the version — see R3.6 in CLAUDE.md.
+
 ## Changelog history
 
 ## 23rd July 2026

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.21"
+version = "0.8.22"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -40,7 +40,11 @@ network = [
 # `ring` backend and install a CryptoProvider in your binary's `main`.
 did-methods = ["did-webvh", "did-scid"]
 did_example = ["dep:did-example"]
-did-jwk = ["dep:did-jwk"]
+did-jwk = ["dep:did-jwk", "dep:ssi-dids-core"]
+# Legacy blockchain DID methods. Ungated until now, which meant every
+# build pulled the whole ssi-* stack (and with it p256/k256 0.13).
+did-ethr = ["dep:did-ethr", "dep:ssi-dids-core"]
+did-pkh = ["dep:did-pkh", "dep:ssi-dids-core"]
 did-cheqd = ["dep:did-resolver-cheqd"]
 did-webvh = ["dep:didwebvh-rs"]
 # Agent names: human-memorable "/@" shortcuts resolvable via `resolve_any()`.
@@ -85,10 +89,10 @@ serde_json = "1"
 serde-wasm-bindgen = "0.6"
 sha1 = { version = "0.10", optional = true }
 affinidi-did-web = { version = "0.1", path = "../did-methods/did-web" }
-did-ethr = "0.3"
+did-ethr = { version = "0.3", optional = true }
 did-jwk = { version = "0.2", optional = true }
-did-pkh = "0.3"
-ssi-dids-core = "0.1"
+did-pkh = { version = "0.3", optional = true }
+ssi-dids-core = { version = "0.1", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -24,8 +24,8 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | `did:key` | Yes | — |
 | `did:peer` | Yes | — |
 | `did:web` | Yes | — |
-| `did:ethr` | Yes | — |
-| `did:pkh` | Yes | — |
+| `did:ethr` | No | `did-ethr` (opt-in — pulls the `ssi-*` stack, see below) |
+| `did:pkh` | No | `did-pkh` (opt-in — pulls the `ssi-*` stack, see below) |
 | `did:webvh` | Yes | `did-methods` |
 | `did:scid` | Yes | `did-methods` |
 | `did:cheqd` | No | `did-cheqd` (opt-in — pulls a `ring` TLS backend, see below) |
@@ -38,6 +38,8 @@ affinidi-did-resolver-cache-sdk = "0.8"
 |---|---|---|
 | `local` | Yes | Reserved for future local-only features |
 | `did-methods` | Yes | Includes `did-webvh`, `did-scid` |
+| `did-ethr` | No | `did:ethr` resolution. Pulls the `ssi-*` stack, which pins `p256`/`k256` 0.13 — enabling it puts two generations of the elliptic-curve stack in your graph. |
+| `did-pkh` | No | `did:pkh` resolution. Same `ssi-*` cost as `did-ethr`. |
 | `did-ebsi` | No | EBSI DID method (requires network access to EU API) |
 | `network` | No | Enable network mode for remote cache server |
 | `did-webvh` | — | WebVH DID method support |
@@ -161,7 +163,7 @@ The cache uses **per-method TTL** to avoid unnecessary re-resolution:
 
 | Category | Methods | TTL | Rationale |
 |---|---|---|---|
-| **Immutable** | `did:key`, `did:peer`, `did:jwk`, `did:ethr`, `did:pkh` | None (capacity-evicted only) | Document is derived deterministically from the DID string |
+| **Immutable** | `did:key`, `did:peer`, `did:jwk`, `did:ethr`, `did:pkh` (last three feature-gated) | None (capacity-evicted only) | Document is derived deterministically from the DID string |
 | **Mutable** | `did:web`, `did:webvh`, `did:cheqd`, `did:scid` | Configurable (`cache_ttl`, default 300s) | Document is fetched from external infrastructure and can change |
 
 The `cache_ttl` configuration option only applies to mutable DID methods.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -815,10 +815,12 @@ impl DIDCacheClient {
             .or_default()
             .push_back(Box::new(affinidi_did_resolver_traits::PeerResolver));
         // Network resolvers
+        #[cfg(feature = "did-ethr")]
         resolvers
             .entry(MethodName::Ethr)
             .or_default()
             .push_back(Box::new(network_resolvers::EthrResolver));
+        #[cfg(feature = "did-pkh")]
         resolvers
             .entry(MethodName::Pkh)
             .or_default()

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
@@ -55,12 +55,14 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
 
+    #[cfg(feature = "did-ethr")]
     const DID_ETHR: &str = "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a";
     #[cfg(feature = "did-jwk")]
     const DID_JWK: &str = "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9";
     // ED25519
     const DID_KEY: &str = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
     const DID_PEER: &str = "did:peer:2.Vz6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv.EzQ3shQLqRUza6AMJFbPuMdvFRFWm1wKviQRnQSC1fScovJN4s.SeyJ0IjoiRElEQ29tbU1lc3NhZ2luZyIsInMiOnsidXJpIjoiaHR0cHM6Ly8xMjcuMC4wLjE6NzAzNyIsImEiOlsiZGlkY29tbS92MiJdLCJyIjpbXX19";
+    #[cfg(feature = "did-pkh")]
     const DID_PKH: &str = "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev";
     #[cfg(feature = "did-webvh")]
     const DID_WEBVH: &str = "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs";
@@ -69,6 +71,7 @@ mod tests {
     #[cfg(feature = "did-scid")]
     const DID_SCID: &str = "did:scid:vh:1:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai?src=identity.foundation/didwebvh-implementations/implementations/affinidi-didwebvh-rs";
 
+    #[cfg(feature = "did-ethr")]
     #[tokio::test]
     async fn local_resolve_ethr() {
         let config = config::DIDCacheConfigBuilder::default().build();
@@ -173,6 +176,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "did-pkh")]
     #[tokio::test]
     async fn local_resolve_pkh() {
         let config = config::DIDCacheConfigBuilder::default().build();

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
@@ -7,7 +7,15 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use affinidi_did_common::{DID, DIDMethod, Document};
+use affinidi_did_common::{DID, DIDMethod};
+// `Document` is only named by the ssi-backed helpers below, which are gated.
+#[cfg(any(
+    feature = "did-ethr",
+    feature = "did-pkh",
+    feature = "did-jwk",
+    feature = "did-cheqd"
+))]
+use affinidi_did_common::Document;
 use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
 use tracing::error;
 
@@ -16,6 +24,12 @@ use tracing::error;
 // ---------------------------------------------------------------------------
 
 /// Convert an ssi `DIDMethodResolver` result (raw bytes) into a `Document`.
+#[cfg(any(
+    feature = "did-ethr",
+    feature = "did-pkh",
+    feature = "did-jwk",
+    feature = "did-cheqd"
+))]
 fn document_from_bytes(bytes: Vec<u8>) -> Result<Document, ResolverError> {
     let json = String::from_utf8(bytes)
         .map_err(|e| ResolverError::InvalidDocument(format!("Invalid UTF-8: {e}")))?;
@@ -24,6 +38,12 @@ fn document_from_bytes(bytes: Vec<u8>) -> Result<Document, ResolverError> {
 }
 
 /// Convert an ssi `DIDResolver` result (typed output) into a `Document`.
+#[cfg(any(
+    feature = "did-ethr",
+    feature = "did-pkh",
+    feature = "did-jwk",
+    feature = "did-cheqd"
+))]
 fn document_from_ssi_output(output: impl serde::Serialize) -> Result<Document, ResolverError> {
     let value = serde_json::to_value(output)
         .map_err(|e| ResolverError::InvalidDocument(format!("Serialization failed: {e}")))?;
@@ -36,8 +56,10 @@ fn document_from_ssi_output(output: impl serde::Serialize) -> Result<Document, R
 // ---------------------------------------------------------------------------
 
 /// Resolver for `did:ethr` — Ethereum DID method.
+#[cfg(feature = "did-ethr")]
 pub struct EthrResolver;
 
+#[cfg(feature = "did-ethr")]
 impl AsyncResolver for EthrResolver {
     fn name(&self) -> &str {
         "EthrResolver"
@@ -80,8 +102,10 @@ impl AsyncResolver for EthrResolver {
 // ---------------------------------------------------------------------------
 
 /// Resolver for `did:pkh` — PKH (Public Key Hash) DID method.
+#[cfg(feature = "did-pkh")]
 pub struct PkhResolver;
 
+#[cfg(feature = "did-pkh")]
 impl AsyncResolver for PkhResolver {
     fn name(&self) -> &str {
         "PkhResolver"

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi DID Resolver Cache Server
 
+## 2nd August 2026 (0.9.10)
+
+Opts back in to `did:ethr` and `did:pkh`, which became optional in
+`affinidi-did-resolver-cache-sdk` 0.8.22.
+
+Those methods pull the `ssi-*` stack (and with it a second generation of the
+elliptic-curve crates), which most libraries embedding the SDK do not want — so
+the SDK now gates them off by default. This is a general-purpose resolver
+*service*, not an embedded library, so it keeps full method coverage and accepts
+that cost. **No change in what this server resolves.**
+
 ## Changelog history
 
 ## 20th July 2026

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.9"
+version = "0.9.10"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -23,7 +23,11 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 [dependencies]
 # Affinidi Crates
 # Requires 0.8.19 for WSRequest::agent_name / WSResponse::with_agent_name.
-affinidi-did-resolver-cache-sdk = { version = "0.8.19", default-features = true, path = "../affinidi-did-resolver-cache-sdk/" }
+# `did-ethr` / `did-pkh` are opt-in in the SDK as of 0.8.22 — they pull the
+# `ssi-*` stack, which most embedding libraries do not want. This is a
+# general-purpose resolver *service* though, so it keeps full method
+# coverage and accepts that cost.
+affinidi-did-resolver-cache-sdk = { version = "0.8.22", default-features = true, features = ["did-ethr", "did-pkh"], path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,29 @@
 # did:scid
 
+## 2nd August 2026 (0.1.13)
+
+`ssi-dids-core` becomes an optional dependency, enabled by `did-cheqd` —
+the only feature whose code actually uses it. No behavioural change; the
+dependency was previously unconditional but only ever referenced under
+that gate.
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## Changelog history
 
 ## 19th July 2026

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.12"
+version = "0.1.13"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -23,7 +23,7 @@ rust-version.workspace = true
 # CryptoProvider in your binary's `main`).
 default = ["did-webvh"]
 
-did-cheqd = ["dep:did-resolver-cheqd"]
+did-cheqd = ["dep:did-resolver-cheqd", "dep:ssi-dids-core"]
 did-webvh = ["dep:didwebvh-rs"]
 
 [lib]
@@ -36,7 +36,7 @@ didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"
-ssi-dids-core = "0.1"
+ssi-dids-core = { version = "0.1", optional = true }
 thiserror = "2"
 tracing = "0.1"
 

--- a/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2nd August 2026 (0.15.7)
+
+The unused `jwk` feature is dropped from the `p256`/`k256` deps — JWK
+handling goes through `affinidi-crypto`'s own `to_jwk`/`from_jwk`, and the
+feature does not exist in 0.14.
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## 31st July 2026 (0.15.6)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm"
 description = "DIDComm v2.1 messaging implementation for the Affinidi TDK"
-version = "0.15.6"
+version = "0.15.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -28,8 +28,8 @@ affinidi-crypto = { version = "0.2", features = ["jose"] }
 
 # Curve crates — still used directly by the adapter for SEC1 point
 # encoding (`ToEncodedPoint`) on resolved public keys.
-p256 = { version = "0.13", features = ["ecdh", "jwk"] }
-k256 = { version = "0.13", features = ["ecdh", "jwk"] }
+p256 = { version = "0.14", features = ["ecdh"] }
+k256 = { version = "0.14", features = ["ecdh"] }
 
 # Ed25519 — test helpers generate keys directly.
 ed25519-dalek = { version = "3", features = ["rand_core"] }
@@ -59,8 +59,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 # ECDSA signing for ES256 / ES256K JWS verification tests (the runtime deps
 # only need `ecdh`/`jwk`; tests additionally sign with P-256 / secp256k1).
 # Cargo unifies the feature set so this enables `ecdsa` for test builds only.
-p256 = { version = "0.13", features = ["ecdsa"] }
-k256 = { version = "0.13", features = ["ecdsa"] }
+p256 = { version = "0.14", features = ["ecdsa"] }
+k256 = { version = "0.14", features = ["ecdsa"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
+++ b/crates/messaging/affinidi-messaging-didcomm/src/jws/verify.rs
@@ -230,6 +230,7 @@ mod tests {
 
     // ─── ES256 / ECDSA P-256 ────────────────────────────────────────────────
     use p256::ecdsa::{SigningKey as P256SigningKey, signature::Signer as _};
+    use p256::elliptic_curve::Generate as _;
 
     /// Build an ES256 JWS (General JSON Serialization) over `payload`, placing
     /// `kid` in the protected header (or omitting it when `None`).
@@ -258,15 +259,12 @@ mod tests {
     }
 
     fn p256_pub_sec1(sk: &P256SigningKey) -> Vec<u8> {
-        sk.verifying_key()
-            .to_encoded_point(false)
-            .as_bytes()
-            .to_vec()
+        sk.verifying_key().to_sec1_point(false).as_bytes().to_vec()
     }
 
     #[test]
     fn es256_sign_verify_roundtrip() {
-        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let sk = P256SigningKey::generate();
         let payload = b"{\"type\":\"test\",\"body\":{}}";
         let jws_str = build_es256_jws(payload, Some("did:example:alice#p256-1"), &sk);
 
@@ -280,8 +278,8 @@ mod tests {
 
     #[test]
     fn es256_wrong_key_fails() {
-        let sk = P256SigningKey::random(&mut rand_core::OsRng);
-        let other = P256SigningKey::random(&mut rand_core::OsRng);
+        let sk = P256SigningKey::generate();
+        let other = P256SigningKey::generate();
         let jws_str = build_es256_jws(b"test", Some("did:example:alice#p256-1"), &sk);
 
         assert!(verify_p256(&jws_str, &p256_pub_sec1(&other)).is_err());
@@ -303,7 +301,7 @@ mod tests {
     /// Symmetric guard: the Ed25519 verifier must reject an ES256 JWS.
     #[test]
     fn ed25519_rejects_es256_alg() {
-        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let sk = P256SigningKey::generate();
         let jws_str = build_es256_jws(b"x", Some("did:example:alice#p256-1"), &sk);
 
         let dummy_pub = [0u8; 32];
@@ -316,7 +314,7 @@ mod tests {
     /// must still be attributed.
     #[test]
     fn es256_signer_kid_from_unprotected_header() {
-        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let sk = P256SigningKey::generate();
         let payload = b"{\"type\":\"test\"}";
 
         let protected = JwsProtectedHeader {
@@ -423,15 +421,12 @@ mod tests {
     }
 
     fn k256_pub_sec1(sk: &K256SigningKey) -> Vec<u8> {
-        sk.verifying_key()
-            .to_encoded_point(false)
-            .as_bytes()
-            .to_vec()
+        sk.verifying_key().to_sec1_point(false).as_bytes().to_vec()
     }
 
     #[test]
     fn es256k_sign_verify_roundtrip() {
-        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let sk = K256SigningKey::generate();
         let payload = b"{\"type\":\"test\",\"body\":{}}";
         let jws_str = build_es256k_jws(payload, Some("did:example:alice#k256-1"), &sk);
 
@@ -445,8 +440,8 @@ mod tests {
 
     #[test]
     fn es256k_wrong_key_fails() {
-        let sk = K256SigningKey::random(&mut rand_core::OsRng);
-        let other = K256SigningKey::random(&mut rand_core::OsRng);
+        let sk = K256SigningKey::generate();
+        let other = K256SigningKey::generate();
         let jws_str = build_es256k_jws(b"test", Some("did:example:alice#k256-1"), &sk);
 
         assert!(verify_secp256k1(&jws_str, &k256_pub_sec1(&other)).is_err());
@@ -457,7 +452,7 @@ mod tests {
     /// algorithm-confusion attempt across the two ECDSA curves.
     #[test]
     fn es256k_rejects_es256_alg() {
-        let sk = P256SigningKey::random(&mut rand_core::OsRng);
+        let sk = P256SigningKey::generate();
         let jws_str = build_es256_jws(b"x", Some("did:example:alice#p256-1"), &sk);
 
         let dummy_pub = [0x04u8; 65];
@@ -468,7 +463,7 @@ mod tests {
     /// Symmetric guard: the ES256 verifier must reject an ES256K JWS.
     #[test]
     fn es256_rejects_es256k_alg() {
-        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let sk = K256SigningKey::generate();
         let jws_str = build_es256k_jws(b"x", Some("did:example:alice#k256-1"), &sk);
 
         let dummy_pub = [0x04u8; 65];
@@ -481,7 +476,7 @@ mod tests {
     /// must still be attributed.
     #[test]
     fn es256k_signer_kid_from_unprotected_header() {
-        let sk = K256SigningKey::random(&mut rand_core::OsRng);
+        let sk = K256SigningKey::generate();
         let payload = b"{\"type\":\"test\"}";
 
         let protected = JwsProtectedHeader {

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Affinidi Messaging Mediator
 
+## 2nd August 2026 (0.18.4)
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## 2nd August 2026 (0.18.3)
 
 Adds **`MediatorBuilder::listener`**, which hands the server a listener the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.3"
+version = "0.18.4"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -254,7 +254,7 @@ affinidi-secrets-resolver = "0.5"
 tokio = { workspace = true, features = ["test-util"] }
 ## ES256K test signing for the `verify_inner_jws` secp256k1 path (the runtime
 ## is verify-only, via affinidi-crypto / affinidi-messaging-didcomm).
-k256 = { version = "0.13", features = ["ecdsa"] }
+k256 = { version = "0.14", features = ["ecdsa"] }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -1378,7 +1378,7 @@ mod tests {
         let signer = "did:example:k256jwk";
         let kid = format!("{signer}#key-1");
         let sk = k256::ecdsa::SigningKey::from_slice(&[0x43u8; 32]).unwrap();
-        let point = sk.verifying_key().to_encoded_point(false);
+        let point = sk.verifying_key().to_sec1_point(false);
         let doc = json!({
             "id": signer,
             "verificationMethod": [{

--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Affinidi OID4VC Core Changelog
 
+## 2nd August 2026 (0.1.7)
+
+**`Es256Signer::generate_with_rng` now bounds `R: rand::CryptoRng`** (rand
+0.10) instead of the rand_core 0.6 traits. Callers passing a rand 0.8-era
+RNG must update. This mirrors the same change made to `EddsaSigner` in the
+curve25519-dalek 5 move.
+
+The `es256` feature now also enables `rand_10`, which it needs directly.
+
+Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /
+`p384` / `p521` 0.13 -> 0.14), which brings rand_core 0.10, digest 0.11 and
+signature 3 with it.
+
+API changes handled: the sec1 traits were renamed (`ToEncodedPoint` ->
+`ToSec1Point`, `FromEncodedPoint` -> `FromSec1Point`), `EncodedPoint` became a
+generic alias for `Sec1Point<C>` so it needs a per-module binding, and the
+deprecated `SigningKey::random(rng)` is now `Generate::generate()` (system
+CSPRNG, panics on failure).
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` and `didwebvh-rs` redirect
+this crate through `[patch.crates-io]`, and a minor bump breaks the redirect.
+
+Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roundtrip`,
+`secp256k1_es256k_golden` RFC 6979, `ecdh_1pu_x25519_kek_golden`,
+`concat_kdf_es_golden`, `a256cbc_hs512_golden`) all still pass.
+
 ## 31st July 2026 (0.1.6)
 
 `EddsaSigner::generate_with_rng` now bounds `R: rand::CryptoRng` (rand 0.10)

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -15,13 +15,13 @@ rust-version.workspace = true
 [features]
 default = ["es256", "eddsa"]
 _test-utils = []
-es256 = ["dep:p256"]
+es256 = ["dep:p256", "dep:rand_10"]
 eddsa = ["dep:ed25519-dalek", "dep:rand_10"]
 
 [dependencies]
 base64 = "0.22"
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
-p256 = { version = "0.13", features = ["ecdsa", "arithmetic"], optional = true }
+p256 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
 rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/protocols/affinidi-oid4vc-core/src/es256.rs
+++ b/crates/protocols/affinidi-oid4vc-core/src/es256.rs
@@ -10,6 +10,7 @@
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer, signature::Verifier};
+use p256::elliptic_curve::Generate;
 
 use crate::jwt::{JwtError, JwtSigner, JwtVerifier};
 
@@ -32,7 +33,7 @@ impl Es256Signer {
 
     /// Generate a new random P-256 key pair using the OS RNG.
     pub fn generate() -> Self {
-        Self::generate_with_rng(&mut p256::elliptic_curve::rand_core::OsRng)
+        Self::generate_with_rng(&mut rand_10::rng())
     }
 
     /// Generate a new P-256 key pair using a caller-supplied RNG.
@@ -40,9 +41,9 @@ impl Es256Signer {
     /// Useful for tests that need deterministic keys via a seeded RNG.
     pub fn generate_with_rng<R>(rng: &mut R) -> Self
     where
-        R: p256::elliptic_curve::rand_core::CryptoRng + p256::elliptic_curve::rand_core::RngCore,
+        R: rand_10::CryptoRng,
     {
-        let signing_key = SigningKey::random(rng);
+        let signing_key = SigningKey::generate_from_rng(rng);
         Self {
             signing_key,
             kid: None,
@@ -58,7 +59,7 @@ impl Es256Signer {
     /// Get the public key as uncompressed SEC1 bytes.
     pub fn public_key_bytes(&self) -> Vec<u8> {
         VerifyingKey::from(&self.signing_key)
-            .to_encoded_point(false)
+            .to_sec1_point(false)
             .to_bytes()
             .to_vec()
     }
@@ -66,7 +67,7 @@ impl Es256Signer {
     /// Get the public key as a JWK Value.
     pub fn public_key_jwk(&self) -> serde_json::Value {
         let vk = VerifyingKey::from(&self.signing_key);
-        let point = vk.to_encoded_point(false);
+        let point = vk.to_sec1_point(false);
 
         serde_json::json!({
             "kty": "EC",


### PR DESCRIPTION
Takes `p256`/`k256`/`p384`/`p521` 0.13 → 0.14, and puts `did:ethr` and `did:pkh`
behind features that are **off by default**.

## Why these are one change

Every workspace crate *could* move to the 0.14 family — but the graph kept **both**
generations anyway, because the `ssi-*` stack pins `p256`/`k256` 0.13. And `ssi-*`
was reachable only through `did:ethr` and `did:pkh`.

Those two were the **only** DID methods in the resolver SDK with no feature gate.
`did-jwk`, `did-webvh`, `did-cheqd`, `did-scid`, `did-ebsi` and `did_example` are
all already optional. An inconsistency in the gating was what held the old stack in
place.

```
resolver SDK, default build
  before:  elliptic-curve 0.13   p256 0.13   k256 0.13   ssi-jwk 0.3.2
  after:   elliptic-curve 0.14   p256 0.14   k256 0.14   (no ssi-* at all)
```

## ⚠️ BREAKING

**`did:ethr` and `did:pkh` no longer resolve unless `did-ethr` / `did-pkh` are
enabled.** Enable them to restore previous behaviour — at the cost of pulling
`ssi-*`, and with it a second elliptic-curve generation, back into your graph.
Resolution returns "method not supported" when off, exactly as the other gated
methods do. Verified both ways: with the features on, those resolvers still pass
their tests.

`ssi-dids-core` is now optional in both the resolver SDK and `did-scid`, reached
only via those features and `did-cheqd`. (`did-scid`'s only use of it was already
inside `#[cfg(feature = "did-cheqd")]`, which is not in default — so no code
change was needed there.)

**`affinidi-oid4vc-core`**: `Es256Signer::generate_with_rng` now bounds
`R: rand::CryptoRng` instead of the rand_core 0.6 traits, mirroring the
`EddsaSigner` change from the curve25519-dalek 5 move.

## 0.14 migration notes

- sec1 traits renamed: `ToEncodedPoint` → `ToSec1Point`, `FromEncodedPoint` → `FromSec1Point`
- `EncodedPoint` is now a *deprecated* alias for the generic `Sec1Point<C>`; it needs a per-module binding
- `SigningKey::random(rng)` / `SecretKey::random(rng)` are deprecated in favour of the `Generate` trait (`generate()` uses the system CSPRNG and panics on failure; `generate_from_rng(rng)` takes one)
- didcomm's `jwk` feature on p256/k256 is dropped — it doesn't exist in 0.14, and JWK handling goes through `affinidi-crypto`'s own `to_jwk`/`from_jwk`. It was dead weight already.

## Deliberately NOT included

**`affinidi-bbs` stays on elliptic-curve 0.13.** `bls12_381_plus` links both
generations by design — its `groups` feature enables `group_013` **and** `group`
0.14, with no way to pick one — so 0.13 is in the graph either way. Migrating BBS
to `hash2curve` 0.14 + sha2 0.11 would mean touching signature-critical crypto for
zero graph benefit. BBS is byte-identical to main.

Residual 0.13 therefore comes only from `bls12_381_plus` and `aws-sigv4` — both
external, both already at their latest version.

## Versioning

Patch bumps throughout, per [ADR 0003](docs/adr/0003-public-api-semver-policy.md)
point 3: `vta-sdk` and `didwebvh-rs` redirect these crates through
`[patch.crates-io]`, and a minor bump breaks the redirect. The behavioural break is
recorded in the changelog rather than the version number, per R3.6 — which is
exactly the case that ADR anticipates.

Seven crates: affinidi-crypto 0.2.7, affinidi-mdoc 0.2.5,
affinidi-did-resolver-cache-sdk 0.8.22, did-scid 0.1.13,
affinidi-messaging-didcomm 0.15.7, affinidi-messaging-mediator 0.18.3,
affinidi-oid4vc-core 0.1.7.

## Verification

- `cargo check --workspace --all-features --all-targets` clean
- **2958 tests pass, 0 failures** — identical to main
- **all 25 golden/KAT vectors pass**: `p256_sign_verify_roundtrip`,
  `secp256k1_es256k_golden` (deterministic RFC 6979), `ecdh_1pu_x25519_kek_golden`,
  `concat_kdf_es_golden`, `a256cbc_hs512_golden`, `aes256_kw_rfc3394_section_4_6`.
  Crypto behaviour is unchanged.
- clippy clean in **both** feature states — default, and with `did-ethr,did-pkh,did-jwk`
  enabled (CI builds `-D warnings`)
- `cargo fmt --all --check` clean
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` green
- README support table updated — it listed `did:ethr`/`did:pkh` as unconditionally
  "Yes", which would have been wrong the moment this lands