### PR TITLE
fix: hand the test mediator's listener over instead of re-binding its port

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Affinidi Messaging Mediator
 
+## 2nd August 2026 (0.18.3)
+
+Adds **`MediatorBuilder::listener`**, which hands the server a listener the
+caller has already bound instead of making it bind for itself.
+
+A caller that needs the bound port *before* startup — to mint a DID whose
+service endpoint embeds the URL, say — previously had to bind, read the port,
+drop the listener, and pass the address for the server to re-bind. That leaves
+a window between the drop and the re-bind in which another process can take the
+port. Handing the listener across removes the window: the port is never
+released.
+
+Additive. `listen_addr` is unchanged and still the right choice when you do not
+need the port in advance; the TOML/binary path is untouched.
+
 ## 1st August 2026 (0.18.2)
 
 Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.2"
+version = "0.18.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/builder.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/builder.rs
@@ -68,6 +68,14 @@ pub enum TracingMode {
 #[derive(Debug)]
 pub struct StartOpts {
     pub tls: TlsMode,
+    /// A listener the caller already bound, handed over to the server.
+    ///
+    /// Without this the caller has to bind to learn the ephemeral port,
+    /// drop the listener, and let the server re-bind the same port —
+    /// which leaves a window where another process can claim it. Passing
+    /// the listener across closes that window: the port is never
+    /// unbound. See [`MediatorBuilder::listener`].
+    pub listener: Option<std::net::TcpListener>,
     pub tracing: TracingMode,
     /// Install SIGINT/SIGTERM handlers that cancel the shutdown token
     /// passed to [`MediatorBuilder::start`]. The mediator binary sets
@@ -82,6 +90,7 @@ impl Default for StartOpts {
             tls: TlsMode::Plain,
             tracing: TracingMode::External,
             install_signal_handlers: false,
+            listener: None,
         }
     }
 }
@@ -356,6 +365,26 @@ impl MediatorBuilder {
 
     /// Set the address to bind. Defaults to `127.0.0.1:0` (ephemeral
     /// port chosen by the OS) when not set.
+    /// Hand the server a listener you have already bound.
+    ///
+    /// Use this instead of [`listen_addr`](Self::listen_addr) when you need
+    /// the bound port *before* the server starts — minting a DID whose
+    /// service endpoint embeds the URL, say. Binding, reading the port,
+    /// dropping the listener and letting the server re-bind leaves a
+    /// window in which another process can take the port; handing the
+    /// listener over removes it, because the port is never released.
+    ///
+    /// The address is read back off the listener, so `listen_addr` does
+    /// not need to be set as well (and is ignored if it is).
+    pub fn listener(mut self, listener: std::net::TcpListener) -> Self {
+        if let Ok(addr) = listener.local_addr() {
+            self.listen_addr = Some(addr);
+            self.config.listen_address = addr.to_string();
+        }
+        self.opts.listener = Some(listener);
+        self
+    }
+
     pub fn listen_addr(mut self, addr: SocketAddr) -> Self {
         self.listen_addr = Some(addr);
         self.config.listen_address = addr.to_string();

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -151,6 +151,8 @@ pub async fn start(config_path: &str) -> Result<(), MediatorError> {
         // Tracing is already installed by `init` above.
         tracing: TracingMode::External,
         install_signal_handlers: true,
+        // The TOML/binary path binds its own listener from config.
+        listener: None,
     };
 
     // Honour the optional `[storage]` section. When the operator
@@ -736,14 +738,22 @@ pub async fn serve_internal(
             format!("Invalid listen_address '{}': {e}", config.listen_address),
         )
     })?;
-    let std_listener = std::net::TcpListener::bind(configured_addr).map_err(|e| {
-        error!("Failed to bind {}: {e}", configured_addr);
-        MediatorError::InternalError(
-            error_codes::INTERNAL_ERROR,
-            "NA".into(),
-            format!("Failed to bind {configured_addr}: {e}"),
-        )
-    })?;
+    // A caller that needed the port before startup (to mint a DID whose
+    // service endpoint embeds the URL, say) can bind it themselves and
+    // hand the listener over. Re-binding an address they had already
+    // bound and released leaves a window for another process to claim
+    // it — taking the listener means the port is never released.
+    let std_listener = match opts.listener {
+        Some(listener) => listener,
+        None => std::net::TcpListener::bind(configured_addr).map_err(|e| {
+            error!("Failed to bind {}: {e}", configured_addr);
+            MediatorError::InternalError(
+                error_codes::INTERNAL_ERROR,
+                "NA".into(),
+                format!("Failed to bind {configured_addr}: {e}"),
+            )
+        })?,
+    };
     std_listener.set_nonblocking(true).map_err(|e| {
         MediatorError::InternalError(
             error_codes::INTERNAL_ERROR,

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Affinidi Messaging Test Mediator
 
+## 2nd August 2026 (0.2.45)
+
+`TestMediator` now hands its listener to the mediator instead of dropping it
+and letting the server re-bind the same port.
+
+**This was a real flake, not a theoretical one.** The helper's own comment
+called out the TOCTOU window and said to fix it this way "if this proves flaky
+in CI" — it did, on affinidi/affinidi-tdk-rs#673:
+
+```
+env spawn: Mediator(InternalError(17, "NA",
+  "Failed to bind 127.0.0.1:38221: Address already in use (os error 98)"))
+```
+
+`add_admin_rejects_mismatched_identity` lost the race to another process. It
+surfaced under `cargo llvm-cov` (the Coverage job) rather than the plain test
+run because the slower, differently-timed execution widens the window.
+
+`bind_ephemeral_listener` now returns `(TcpListener, SocketAddr)` and the
+listener is passed to `MediatorBuilder::listener`, so the port stays bound from
+our bind through to the server's use of it. New test
+`ephemeral_listener_keeps_the_port_bound` asserts the port is *not* re-bindable
+while we hold the listener — if that ever passes a second bind, the race is
+back.
+
 ## Changelog history
 
 ## 29th July 2026

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.44"
+version = "0.2.45"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -714,7 +714,7 @@ impl TestMediatorBuilder {
         // idempotent and removes that boilerplate from consumers.
         install_default_crypto_provider();
 
-        let bound_addr = bind_ephemeral_listener(self.listen_addr)?;
+        let (listener, bound_addr) = bind_ephemeral_listener(self.listen_addr)?;
         let api_prefix = "/mediator/v1/".to_string();
         // When `advertise_host` is set, the mediator's DID service endpoint uses
         // that host (with the bound port) so clients in other network namespaces
@@ -819,7 +819,7 @@ impl TestMediatorBuilder {
             .secrets_backend(secrets_backend)
             .secrets_backend_url("memory://(test-mediator)")
             .store(store)
-            .listen_addr(bound_addr)
+            .listener(listener)
             .api_prefix(api_prefix)
             .security(security)
             .limits(limits)
@@ -1055,18 +1055,21 @@ pub fn install_default_crypto_provider() {
 
 // ─── Internals ───────────────────────────────────────────────────────────────
 
-/// Bind an ephemeral listener, capture the address, then drop it so
-/// the mediator can re-bind to the same port. There is a tiny TOCTOU
-/// window between drop and re-bind during which another process could
-/// claim the port; in practice it's microseconds and harmless for
-/// tests. If this proves flaky in CI, extend `MediatorBuilder` to
-/// accept a pre-bound `TcpListener` and remove the rebind step.
-fn bind_ephemeral_listener(requested: Option<SocketAddr>) -> Result<SocketAddr, TestMediatorError> {
+/// Bind a listener and return it *with* its address.
+///
+/// The listener is handed to `MediatorBuilder::listener` rather than
+/// dropped, so the port is never released between our bind and the
+/// server's. The previous version dropped it and let the mediator
+/// re-bind the same port, which left a window another process could
+/// win — and did win, intermittently, under `cargo llvm-cov` where the
+/// wider timing made it far more likely.
+fn bind_ephemeral_listener(
+    requested: Option<SocketAddr>,
+) -> Result<(TcpListener, SocketAddr), TestMediatorError> {
     let target: SocketAddr = requested.unwrap_or_else(|| "127.0.0.1:0".parse().unwrap());
     let listener = TcpListener::bind(target).map_err(TestMediatorError::Bind)?;
     let addr = listener.local_addr().map_err(TestMediatorError::Bind)?;
-    drop(listener);
-    Ok(addr)
+    Ok((listener, addr))
 }
 
 /// Generate the mediator's `did:peer:2` identity:
@@ -1224,9 +1227,25 @@ mod tests {
 
     #[test]
     fn ephemeral_listener_returns_real_port() {
-        let addr = bind_ephemeral_listener(None).expect("bind");
+        let (_listener, addr) = bind_ephemeral_listener(None).expect("bind");
         assert_eq!(addr.ip().to_string(), "127.0.0.1");
         assert!(addr.port() > 0, "OS-assigned port should be non-zero");
+    }
+
+    /// The returned listener must still hold the port.
+    ///
+    /// This is the whole point of returning it rather than dropping it:
+    /// while we hold it, nobody else can bind that port, so there is no
+    /// window between our bind and the mediator's. If this ever starts
+    /// passing a second bind, the TOCTOU race is back.
+    #[test]
+    fn ephemeral_listener_keeps_the_port_bound() {
+        let (listener, addr) = bind_ephemeral_listener(None).expect("bind");
+        assert!(
+            TcpListener::bind(addr).is_err(),
+            "port {addr} was re-bindable, so the listener is not holding it"
+        );
+        drop(listener);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The race

`TestMediator` bound `127.0.0.1:0` to learn the ephemeral port, **dropped** the
listener, then passed the address to `MediatorBuilder::listen_addr` so the server
could bind that same port again. Between the drop and the re-bind the port is
free, and another process can take it.

It did — on #673's Coverage job:

```
env spawn: Mediator(InternalError(17, "NA",
  "Failed to bind 127.0.0.1:38221: Address already in use (os error 98)"))
```

`add_admin_rejects_mismatched_identity` lost that race. It surfaced under
`cargo llvm-cov` rather than the plain test run because the slower,
differently-timed execution widens the window — which is why Coverage failed
while Test Suite passed on the same commit.

The helper's own comment had already called this out and prescribed the fix:

> *"There is a tiny TOCTOU window between drop and re-bind during which another
> process could claim the port… If this proves flaky in CI, extend
> `MediatorBuilder` to accept a pre-bound `TcpListener` and remove the rebind
> step."*

## Why the pre-bind can't just be deleted

The harness needs the bound port **before** the server starts — it mints the
mediator's `did:peer` whose service endpoint embeds the URL. So the listener is
handed over rather than the bind removed.

## The fix

- **`MediatorBuilder::listener(TcpListener)`** — additive. Takes a listener the
  caller already bound and reads the address back off it. `listen_addr` is
  unchanged and still the right choice when you don't need the port in advance.
- `StartOpts` carries the listener through; `serve_internal` uses it when present
  and otherwise binds exactly as before — **the TOML/binary path is untouched**.
- `bind_ephemeral_listener` now returns `(TcpListener, SocketAddr)`, and the
  harness passes the listener to the builder. **The port is never released**, so
  the window is gone.

## Regression guard

New test `ephemeral_listener_keeps_the_port_bound` asserts the port is *not*
re-bindable while we hold the listener:

```rust
let (listener, addr) = bind_ephemeral_listener(None).expect("bind");
assert!(TcpListener::bind(addr).is_err(), "…the listener is not holding it");
```

If that ever passes a second bind, the race is back.

## Verification

- `cargo check --workspace --all-features --all-targets` clean
- **2959 tests pass, 0 failures** (2958 as on main, plus the new guard)
- default-feature suite green as well, not just `--all-features`
- lifecycle suite — the one that flaked — run **5× consecutively, 22 passed each time**
- clippy clean on both feature sets (default redis-backend, and
  `--no-default-features --features didcomm,memory-backend`)
- `cargo fmt --all --check` clean; version-bump and changelog guards green

## Note for whoever merges second

This and #674 both bump `affinidi-messaging-mediator` 0.18.2 → 0.18.3, so they
will conflict on the version line and changelog. Whichever lands second needs a
rebase and a re-bump to 0.18.4 — a one-line fix.