### PR TITLE
fix: refuse an in-transit-rewritable JWS signer kid before resolving it

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Affinidi Messaging Mediator
 
+## 7th August 2026 (0.18.6)
+
+**Security — pre-authentication server-side SSRF via the JWS signer `kid`.**
+
+`extract_jws_signer_kid` fell back to the per-signature **unprotected** header,
+and `verify_inner_jws` resolved the resulting DID — an outbound HTTPS fetch for
+`did:web` — **before** verifying the signature. The unprotected header is
+outside the JWS signing input, so any intermediary can rewrite it in transit
+without invalidating the signature.
+
+This was reachable **before authentication**: `MetaEnvelope::new` is called from
+`handlers/authenticate/response.rs` and `handlers/authenticate/refresh.rs`, and
+anoncrypt needs no sender key, so any unauthenticated peer could POST an
+envelope whose signer `kid` named `did:web:<host>` and make the mediator issue a
+request to that host — including hosts reachable only from inside the mediator's
+network.
+
+An unprotected `kid` is now resolved only when it names the same DID as the
+signed payload's `from`, which *is* inside the signing input and so cannot be
+rewritten in transit. A rewritten `kid` is refused **before any outbound
+request** — the check runs ahead of resolution, so a refused `kid` costs zero
+fetches. A payload with no readable `from` offers nothing to bind against and is
+refused too. A `kid` in the protected header is unaffected: it is the original
+sender's own choice, and resolving a claimed sender's DID is inherent to DID
+messaging.
+
+Both call sites are covered — the top-level JWS in `unpack_jws` and the nested
+sign-then-encrypt JWS in `recurse_decrypted_plaintext`.
+
+This is the mediator-side counterpart of the SDK fix in
+`affinidi-messaging-sdk` 0.19.0. It is *not* a general SSRF fix: a sender naming
+its own `did:web` still causes one fetch, so resolver-side host allow-listing
+remains worthwhile as defence in depth.
+
 ## 4th August 2026 (0.18.5)
 
 Dependency bump to `affinidi-messaging-sdk` 0.19.0 (secure-by-default `unpack`).

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.5"
+version = "0.18.6"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_compat.rs
@@ -337,8 +337,16 @@ async fn recurse_decrypted_plaintext(
         let jws_str = std::str::from_utf8(plaintext)
             .map_err(|e| format!("Inner JWS is not valid UTF-8: {e}"))?;
 
-        let signer_kid = extract_jws_signer_kid(&value)
+        let (signer_kid, kid_from_protected) = extract_jws_signer_kid_with_provenance(&value)
             .ok_or("Inner JWS has no signer kid to resolve a verification key")?;
+        // Refuse an in-transit-rewritable kid before it can steer an outbound
+        // DID resolution (SSRF) — see `signer_kid_is_resolvable`.
+        if !signer_kid_is_resolvable(&value, &signer_kid, kid_from_protected) {
+            return Err(format!(
+                "Inner JWS carries its signer kid only in the unprotected header, and \
+                 '{signer_kid}' does not match the message `from`; refusing to resolve it"
+            ));
+        }
         let signer_did = did_part(&signer_kid);
         let alg = extract_jws_alg(&value).unwrap_or_default();
         let verified = verify_inner_jws(jws_str, &alg, &signer_did, &signer_kid, did_resolver)
@@ -395,7 +403,20 @@ async fn recurse_decrypted_plaintext(
 /// Extract the signer kid from a parsed JWS (General JSON Serialization).
 /// Prefers the integrity-protected header, falling back to the per-signature
 /// unprotected header (where credo-ts / didcomm-python place the kid).
-fn extract_jws_signer_kid(jws: &serde_json::Value) -> Option<String> {
+/// Extract the signer kid from a parsed JWS (General JSON Serialization),
+/// reporting whether it came from the **integrity-protected** header (`true`) or
+/// the per-signature *unprotected* one (`false`). The protected header takes
+/// precedence.
+///
+/// SECURITY: the unprotected header is outside the JWS signing input, so **any
+/// intermediary** — a relay, a peer mediator — can rewrite it in transit without
+/// invalidating the signature. Since resolving a signer DID is an outbound
+/// network fetch for `did:web`, and it happens *before* the signature is
+/// verified, an unprotected kid is an SSRF primitive: it lets a party who cannot
+/// forge a signature at all choose which host this mediator contacts. Callers
+/// must therefore gate resolution on the provenance — see
+/// [`signer_kid_is_resolvable`].
+fn extract_jws_signer_kid_with_provenance(jws: &serde_json::Value) -> Option<(String, bool)> {
     let sig = jws.get("signatures")?.as_array()?.first()?;
 
     // Protected header (base64url-encoded JSON) takes precedence.
@@ -404,14 +425,47 @@ fn extract_jws_signer_kid(jws: &serde_json::Value) -> Option<String> {
         && let Ok(header) = serde_json::from_slice::<serde_json::Value>(&bytes)
         && let Some(kid) = header.get("kid").and_then(|k| k.as_str())
     {
-        return Some(kid.to_string());
+        return Some((kid.to_string(), true));
     }
 
     // Fall back to the unprotected per-signature header.
     sig.get("header")
         .and_then(|h| h.get("kid"))
         .and_then(|k| k.as_str())
-        .map(|s| s.to_string())
+        .map(|s| (s.to_string(), false))
+}
+
+/// The `from` DID of a JWS payload, if the payload is a readable DIDComm
+/// plaintext. The payload *is* covered by the signature, so unlike the
+/// unprotected header it cannot be rewritten in transit.
+fn jws_payload_from(jws: &serde_json::Value) -> Option<String> {
+    let payload_b64 = jws.get("payload")?.as_str()?;
+    let bytes = BASE64_URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let msg: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    msg.get("from")?.as_str().map(|s| s.to_string())
+}
+
+/// Whether a signer kid may be turned into a (networked) DID resolution.
+///
+/// A **protected** kid always may: it is inside the signing input, so it is the
+/// original sender's own choice and cannot be altered in transit. That a claimed
+/// sender causes its own DID to be resolved is inherent to DID messaging.
+///
+/// An **unprotected** kid may only when it names the same DID as the signed
+/// payload's `from`. That binding is what removes the SSRF: an intermediary
+/// rewriting the kid no longer redirects the fetch, it merely makes the
+/// signature unattributable and the message is rejected — at zero outbound
+/// requests. A payload with no readable `from` offers nothing to bind against,
+/// so an unprotected kid is refused there too.
+fn signer_kid_is_resolvable(
+    jws: &serde_json::Value,
+    signer_kid: &str,
+    from_protected: bool,
+) -> bool {
+    if from_protected {
+        return true;
+    }
+    jws_payload_from(jws).is_some_and(|from| did_part(&from) == did_part(signer_kid))
 }
 
 /// Extract the JWS signature algorithm (`alg`) from the first signature's
@@ -536,8 +590,19 @@ async fn unpack_jws(
     let value: serde_json::Value =
         serde_json::from_str(msg_string).map_err(|e| format!("Cannot parse JWS: {e}"))?;
 
-    let signer_kid =
-        extract_jws_signer_kid(&value).ok_or("JWS has no signer kid to resolve a key")?;
+    let (signer_kid, kid_from_protected) = extract_jws_signer_kid_with_provenance(&value)
+        .ok_or("JWS has no signer kid to resolve a key")?;
+    // This path is reachable *pre-authentication* (the mediator's
+    // `/authenticate/*` handlers unpack before a session exists), so an
+    // unprotected kid here would let any unauthenticated peer aim the mediator's
+    // outbound DID resolution at a host of its choosing. Gate it on provenance
+    // before resolving anything — see `signer_kid_is_resolvable`.
+    if !signer_kid_is_resolvable(&value, &signer_kid, kid_from_protected) {
+        return Err(format!(
+            "JWS carries its signer kid only in the unprotected header, and \
+             '{signer_kid}' does not match the message `from`; refusing to resolve it"
+        ));
+    }
     let signer_did = did_part(&signer_kid);
     let alg = extract_jws_alg(&value).unwrap_or_default();
     let verified = verify_inner_jws(msg_string, &alg, &signer_did, &signer_kid, did_resolver)
@@ -901,9 +966,10 @@ mod tests {
             }]
         });
         assert_eq!(
-            extract_jws_signer_kid(&jws).as_deref(),
-            Some("did:example:alice#protected"),
-            "integrity-protected kid must win over the unprotected one"
+            extract_jws_signer_kid_with_provenance(&jws),
+            Some(("did:example:alice#protected".to_string(), true)),
+            "integrity-protected kid must win over the unprotected one, and be \
+             reported as protected"
         );
     }
 
@@ -920,9 +986,81 @@ mod tests {
             }]
         });
         assert_eq!(
-            extract_jws_signer_kid(&jws).as_deref(),
-            Some("did:example:alice#unprotected")
+            extract_jws_signer_kid_with_provenance(&jws),
+            Some(("did:example:alice#unprotected".to_string(), false)),
+            "the unprotected fallback must be reported as NOT integrity-protected, \
+             so callers can refuse to resolve it"
         );
+    }
+
+    /// SSRF guard. The per-signature unprotected header is outside the signing
+    /// input, so any intermediary can rewrite the signer kid in transit without
+    /// invalidating the signature. Resolving a signer DID is an outbound
+    /// `did:web` fetch and happens *before* verification — and this path is
+    /// reachable pre-authentication — so an unprotected kid may only be resolved
+    /// when it names the same DID as the signed payload's `from`.
+    #[test]
+    fn unprotected_signer_kid_is_only_resolvable_when_it_matches_from() {
+        // Payload is signed over, so `from` cannot be rewritten in transit.
+        let payload = BASE64_URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&json!({"from": "did:example:alice", "type": "x"})).unwrap(),
+        );
+        let jws = json!({
+            "payload": payload,
+            "signatures": [{
+                "protected": protected_b64(&json!({"alg": "EdDSA"})),
+                "header": {"kid": "did:web:attacker.example.com#key-1"},
+                "signature": "AA"
+            }]
+        });
+
+        assert!(
+            !signer_kid_is_resolvable(&jws, "did:web:attacker.example.com#key-1", false),
+            "a rewritten unprotected kid must not be resolvable — that is the SSRF"
+        );
+        assert!(
+            signer_kid_is_resolvable(&jws, "did:example:alice#key-1", false),
+            "an unprotected kid matching the signed `from` stays resolvable (interop)"
+        );
+        assert!(
+            signer_kid_is_resolvable(&jws, "did:web:attacker.example.com#key-1", true),
+            "a protected kid is inside the signing input and is always resolvable"
+        );
+    }
+
+    /// A payload with no readable `from` gives nothing to bind an unprotected
+    /// kid against, so it must be refused rather than resolved optimistically.
+    #[test]
+    fn unprotected_signer_kid_refused_when_payload_has_no_from() {
+        let payload =
+            BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json!({"type": "x"})).unwrap());
+        let jws = json!({
+            "payload": payload,
+            "signatures": [{
+                "protected": protected_b64(&json!({"alg": "EdDSA"})),
+                "header": {"kid": "did:web:attacker.example.com#key-1"},
+                "signature": "AA"
+            }]
+        });
+        assert!(!signer_kid_is_resolvable(
+            &jws,
+            "did:web:attacker.example.com#key-1",
+            false
+        ));
+        // A non-JSON / undecodable payload likewise yields no `from`.
+        let opaque = json!({
+            "payload": "!!not-base64!!",
+            "signatures": [{
+                "protected": protected_b64(&json!({"alg": "EdDSA"})),
+                "header": {"kid": "did:web:attacker.example.com#key-1"},
+                "signature": "AA"
+            }]
+        });
+        assert!(!signer_kid_is_resolvable(
+            &opaque,
+            "did:web:attacker.example.com#key-1",
+            false
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Pre-authentication server-side SSRF in the mediator's JWS signer-`kid` resolution

Found while scoping the AgenticSec finding *"Mediator's `didcomm_compat` unpack path does not enforce the hardened SDK `UnpackPolicy`"* (medium). That finding describes a policy-enforcement gap; the more serious issue underneath it is an unauthenticated SSRF, which is what this PR fixes.

### The bug

`extract_jws_signer_kid` (`didcomm_compat.rs`) falls back to the per-signature **unprotected** header for the signer `kid`, and `verify_inner_jws` then resolves that DID — an outbound HTTPS fetch for `did:web` — **before** verifying the signature.

The unprotected header is outside the JWS signing input, so **any intermediary can rewrite it in transit without invalidating the signature**. This is not a "malicious sender" problem: it is available to a party who cannot forge a signature at all.

### Why it matters more here than in the SDK

It is reachable **before authentication**. `MetaEnvelope::new` is called from:

- `handlers/authenticate/response.rs:49`
- `handlers/authenticate/refresh.rs:43`
- `messages/inbound.rs:569`, `:843`
- `messages/protocols/routing.rs:413`

The first two are the mediator's own `/authenticate/*` endpoints, which by definition run before a session exists. And because anoncrypt requires no sender key, an unauthenticated peer can wrap a JWS the mediator will decrypt and recurse into.

So any internet host could POST an envelope whose signer `kid` names `did:web:<host>` and make the mediator issue a request to that host — including hosts reachable only from inside the mediator's network. That is a server-side SSRF on a public endpoint, which is a strictly worse position than the client-side instance in the SDK that was rated **high** and fixed in `affinidi-messaging-sdk` 0.19.0.

### The fix

Mirrors the SDK fix. An unprotected `kid` is resolved **only** when it names the same DID as the signed payload's `from` — which *is* inside the signing input, so the binding cannot be forged in transit. An intermediary rewriting the `kid` no longer redirects the fetch; it merely makes the signature unattributable and the message is rejected.

Details that matter:

- The check runs **before** resolution, so a refused `kid` costs **zero** outbound requests. Ordering it the other way would leave the guard itself as the SSRF trigger.
- A payload with no readable `from` offers nothing to bind against, so an unprotected `kid` is refused there too.
- A `kid` in the **protected** header is unaffected. It is the original sender's own, integrity-protected choice, and resolving a claimed sender's DID is inherent to DID messaging — authcrypt resolves the `skid` identically.
- Both production call sites are covered: the top-level JWS in `unpack_jws`, and the nested sign-then-encrypt JWS in `recurse_decrypted_plaintext`.

### Scope — what this does *not* do

This is **not** a general SSRF fix. A sender naming its own `did:web` still causes one outbound fetch; that is inherent to DID-based messaging. Resolver-side host allow-listing remains worthwhile as defence in depth. The changelog says so rather than implying the problem is solved.

### Two corrections to the original finding

While scoping it I checked the other claims in that alert, and they overstate the gap:

- **"no crypto-layer depth limits"** — the mediator already has `MAX_NEST_DEPTH = 8` in `recurse_decrypted_plaintext`.
- **"no addressing-consistency checks"** — the mediator already binds sender identity to the authenticated session via `force_session_did_match` → `check_session_sender_match`, using `sign_from` or `encrypted_from_kid`.

What genuinely remains from that alert is the missing **wrapping-taxonomy classification** (and arguably aligning `MAX_NEST_DEPTH` with the SDK's 2-layer bound). That is deliberately left for a follow-up so this security fix stays small and reviewable.

### Verification

- 3 new unit tests: the rewrite attack is refused; a `from`-matching unprotected `kid` still resolves (credo-ts / didcomm-python interop preserved); a protected `kid` is always resolvable. Plus payload-has-no-`from` and undecodable-payload cases.
- Existing `didcomm_compat` suite: 19 passed.
- Full workspace: **2828 passed, 0 failed**.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and the version-bump / changelog / workspace-duplicate guards all clean.

`affinidi-messaging-mediator` 0.18.5 → **0.18.6**.
