### PR TITLE
ci: scan main on a schedule and on demand, not only on pull requests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,18 @@ on:
     types:
       - opened
       - synchronize
+  # Nothing else in this repo runs against `main`. Without these triggers every
+  # security job — `audit`, `cargo-deny`, `rust-scan` — only ever sees a PR's
+  # merge preview, so an advisory published *after* a PR merges is never
+  # noticed by anything: the code stops being checked the moment it lands.
+  # A daily run re-checks `main` against the current advisory database.
+  schedule:
+    # 06:17 UTC. Deliberately off the hour — GitHub delays cron runs that land
+    # on popular slots, and a scheduled scan that silently drifts by an hour is
+    # exactly the kind of thing nobody notices.
+    - cron: "17 6 * * *"
+  # On demand, e.g. to confirm a security fix on `main` without waiting a day.
+  workflow_dispatch:
 
 jobs:
   rust-pipeline:
@@ -21,5 +33,11 @@ jobs:
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true
-      verifyPublish: true
+      # PR-only. `verify-publish` resolves each crate from the registry in
+      # isolation, which is a useful pre-merge gate but is *expected* to fail on
+      # `main`: the release job publishes after merge, so between a merge and
+      # its release every bumped crate is unpublished and cannot resolve. Left
+      # on, every scheduled run would report a permanent false failure and the
+      # whole scan would be ignored within a week.
+      verifyPublish: ${{ github.event_name == 'pull_request' }}
       deprecationCheck: true


### PR DESCRIPTION
## The gap

`checks.yaml` was `on: pull_request` only. Nothing in this repo has ever run against `main`.

That means every security job — `audit`, `cargo-deny`, `rust-scan` — only ever saw a PR's *merge preview*. Code stopped being checked the moment it landed, and an advisory published **after** a PR merges was never noticed by anything. It also meant there was no way to confirm a security fix on `main` at all; the recent SSRF work had to be hand-verified locally because no automation would look at the merged result.

## The change

- **`schedule: "17 6 * * *"`** — daily re-check of `main` against the current advisory database. Deliberately off the hour: GitHub delays cron runs that land on popular slots, and a scheduled scan that silently drifts is exactly the sort of thing nobody notices.
- **`workflow_dispatch`** — on-demand runs, e.g. confirming a fix on `main` without waiting a day.
- **`verifyPublish` becomes PR-only** via `${{ github.event_name == 'pull_request' }}`.

## Why `verifyPublish` had to be gated

`verify-publish` resolves each crate from the registry in isolation. That is a useful pre-merge gate, but it is **expected to fail on `main`**: the release job publishes *after* merge, so in the window between a merge and its release every bumped crate is unpublished and cannot resolve.

Left enabled, every scheduled run would report a permanent false failure — and a scan that is always red is a scan everyone ignores within a week. The reusable pipeline already gates that job on `if: ${{ inputs.verifyPublish }}`, so passing the expression cleanly skips it outside PRs.

## What this does *not* do

**It does not make the AgenticSec app scan `main`.** That is a separate external GitHub App with no workflow in this repository — its one and only analysis to date was a manual/one-off run when code scanning was first enabled. Re-running it still needs whoever owns that app.

What this covers is the pipeline's own jobs: `audit`, `cargo-deny`, `rust-scan`, `check`, `test`, `fmt`, `clippy`, `deprecation-check`.

## Verification

- YAML parses; triggers resolve to `["pull_request", "schedule", "workflow_dispatch"]`, cron `17 6 * * *`, and the `verifyPublish` expression is preserved.
- No publishable crate source changed, so the version-bump and changelog guards correctly report nothing to check.
- Current `main` was scanned by hand first, so the first scheduled run has a known-good baseline: `cargo audit` 0 vulnerabilities across 1048 deps, `cargo deny` bans/licenses/sources ok, clippy clean and 2833 tests passing under CI's exact `RUSTFLAGS`.

One thing to expect on the first scheduled run: `cargo deny check advisories` currently flags four *unmaintained* crates (`number_prefix`, `rustls-pemfile` ×2, `smallstr`). These are not vulnerabilities and do not fail the pipeline's deny job today, which is scoped to licences — noting it so the first green run isn't mistaken for "nothing outstanding".