### PR TITLE
fix: require affinidi-messaging-core 0.1.6 for the messaging-core feature

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
@@ -1,5 +1,20 @@
 # affinidi-messaging-didcomm-v1 changelog
 
+## 0.1.1 — 8th August 2026
+
+Manifest fix. No code change.
+
+- **Require `affinidi-messaging-core` 0.1.6, not 0.1.** The optional
+  `messaging-core` feature compiles `adapter.rs`, which names
+  `Protocol::DIDCommV1` — a variant that only exists from 0.1.6. The published
+  0.1.0 asked for `"0.1"`, which resolves to 0.1.6 on a fresh build (so publish
+  verification was green) but lets a consumer with an existing lockfile, or one
+  pinning `--precise 0.1.5`, fail with `no variant named DIDCommV1`.
+
+  The general shape is worth noting: when an optional feature depends on an API
+  added in the *same release train*, a loose minor requirement only looks
+  correct because no stale lockfile exists yet.
+
 ## 0.1.0 — 8th August 2026
 
 Initial release: DIDComm v1 (Aries RFC 0019) transport primitives, alongside the

--- a/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm-v1"
 description = "DIDComm v1 (Aries RFC 0019) messaging implementation for the Affinidi TDK"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -59,7 +59,13 @@ subtle = "2"
 rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 
 # Optional — messaging-core trait integration (see the `messaging-core` feature).
-affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1", optional = true }
+#
+# The patch is load-bearing, not decoration: `adapter.rs` names
+# `Protocol::DIDCommV1`, which was added in 0.1.6. A loose "0.1" resolves to
+# 0.1.6 on a *fresh* build — which is why publish verification passed — but a
+# consumer with an existing lockfile, or one pinning `--precise 0.1.5`, gets
+# `no variant named DIDCommV1` instead.
+affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Follow-up to #687. Manifest only — no code change.

`affinidi-messaging-didcomm-v1` 0.1.0 shipped asking for
`affinidi-messaging-core = "0.1"`, but the optional `messaging-core` feature
compiles `adapter.rs`, which names `Protocol::DIDCommV1` — a variant that only
exists from **0.1.6**.

## Why nothing caught it

A *fresh* resolve picks 0.1.6 and compiles, so `publish dry-run` /
`verify-publish` were both green and the workspace build never noticed
(`[patch.crates-io]` redirects to the local 0.1.6 anyway). The requirement is
only wrong for a consumer whose resolution is already constrained — an existing
lockfile, or an explicit `--precise`.

## Reproduced before fixing

Scratch crate against the **published** 0.1.0, forcing the stale core a lockfile
could plausibly hold:

```toml
affinidi-messaging-didcomm-v1 = { version = "=0.1.0", features = ["messaging-core"] }
affinidi-messaging-core = "=0.1.5"
```

```
   Compiling affinidi-messaging-core v0.1.5
error[E0599]: no variant or associated item named `DIDCommV1` found for enum
              `affinidi_messaging_core::Protocol` in the current scope
   86 |         Protocol::DIDCommV1
  145 |             protocol: Protocol::DIDCommV1,
error: could not compile `affinidi-messaging-didcomm-v1` (lib) due to 2 previous errors
```

## Verified fixed

A path dependency ignores the `version` field locally, so a workspace build
proves nothing here. The artifact that decides this is the **packaged**
manifest, where `path` is stripped and `version` is what consumers resolve
against:

```console
$ cargo package --no-verify -p affinidi-messaging-didcomm-v1
$ tar -xOzf target/package/affinidi-messaging-didcomm-v1-0.1.1.crate \
      affinidi-messaging-didcomm-v1-0.1.1/Cargo.toml | grep -A3 messaging-core
[dependencies.affinidi-messaging-core]
version = "0.1.6"
optional = true
```

0.1.5 no longer satisfies it, so the failure moves from a confusing `E0599` deep
inside a dependency to a resolution error that names the real constraint.

## The general shape

Worth remembering beyond this instance: **when an optional feature depends on an
API added in the same release train, a loose minor requirement only looks
correct because no stale lockfile exists yet.** Every green signal available at
publish time — dry-run, verify-publish, workspace build — resolves fresh and
therefore cannot see it. Pin the exact patch that introduced the API.

## Verification

- `cargo build -p affinidi-messaging-didcomm-v1 --features messaging-core` — pass
- `check-version-bumps.sh`, `check-changelogs.sh`,
  `check-workspace-duplicates.sh` — all pass

Unlike 0.1.0, CI can publish this one — the crate now exists on crates.io, so
Trusted Publishing no longer 403s.
