### PR TITLE
feat: add DIDComm v1 forward ingress to the mediator

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Affinidi Messaging Mediator
 
+## 8th August 2026 (0.18.8)
+
+**DIDComm v1 (Aries RFC 0019) forward ingress — new `didcomm-v1` feature.**
+
+Off by default; a mediator built or configured without it behaves exactly as
+before. Enabling it lets the mediator act as an Aries mediator for inbound
+forwards: it opens the outer anoncrypt layer with its own routing key, resolves
+the forward's `to` **verkey** through the new routing-key index, applies the
+recipient's ACLs, and stores the inner envelope verbatim for pickup. The inner
+bytes are never parsed — they are sealed end-to-end to the recipient.
+
+Requires the `didcomm` feature (v1 is additive over v2.1, not a replacement) and
+a storage backend implementing the v1 routing-key index. Startup **refuses to
+run** with `[didcomm_v1] enabled = true` on a backend that does not, rather than
+accepting traffic it could not route.
+
+### New `[didcomm_v1]` configuration
+
+```toml
+[didcomm_v1]
+enabled = true
+# Aries mediators accept anon-packed forwards from anyone; this mediator
+# normally requires an authenticated session. Off by default.
+allow_unauthenticated_forwards = false
+```
+
+`allow_unauthenticated_forwards` is a **deliberate, per-deployment loosening**
+of this mediator's posture, and is required for stock Credo wallets, which
+cannot complete the v2 authentication challenge. An RFC 0019 forward is
+anon-packed by design, so there is no authenticated sender to apply a
+sender-side ACL to and the recipient's access list carries the weight.
+
+Turning it on does **not** open anonymous DIDComm v2 inbound. A session admitted
+only by this flag is v1-scoped: the handler refuses any non-v1 body on it, and
+the session carries `SEND_MESSAGES` without `SEND_FORWARDED`, so it cannot drive
+a v2 relay forward even if that check were bypassed. Inter-mediator relay
+admission keeps precedence and its existing capabilities, and a *presented but
+invalid* credential is still never downgraded to anonymous.
+
+### Routing key
+
+The mediator's v1 routing verkey is derived from the Ed25519 authentication key
+it already holds — no new key material, the same trick `tsp_identity` uses. It
+is logged at startup because v1 predates DID documents as a discovery
+mechanism, so operators must hand it to clients out of band.
+
+### Not yet included
+
+The Aries `coordinate-mediation/1.0` and `messagepickup` protocols. Until those
+land there is no client-facing way to register a routing key, so a stock Credo
+wallet cannot yet use this mediator end-to-end — bindings can only be created
+through the store API.
+
 ## 8th August 2026 (0.18.7)
 
 **Envelope-wrapping observability — warn on non-conformant layering.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.7"
+version = "0.18.8"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -102,10 +102,10 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.32", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.34", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
-affinidi-messaging-mediator-config = { version = "0.2", path = "affinidi-messaging-mediator-config" }
+affinidi-messaging-mediator-config = { version = "0.2.1", path = "affinidi-messaging-mediator-config" }
 ## Humantime for the VTA cache TTL (`[secrets].cache_ttl = "30d"`).
 humantime = "2"
 ## CLI parsing for the mediator binary's subcommands (`mediator`,

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -48,6 +48,16 @@ memory-backend = []
 ## together (`--features didcomm,tsp`), which is the dual-protocol deployment.
 didcomm = ["dep:affinidi-messaging-didcomm", "dep:affinidi-encoding", "dep:affinidi-crypto", "dep:trust-tasks-rs"]
 
+## DIDComm v1 (Aries RFC 0019) — additive alongside DIDComm v2.1, and requires
+## it: a v1 sender still reaches the mediator over the v2-authenticated session
+## unless `allow_unauthenticated_forwards` is turned on, and the mediator's v1
+## routing verkey is derived from the same Ed25519 authentication key its v2
+## identity uses. Accepts inbound v1 forwards and stores them for the local
+## recipient; the Aries coordinate-mediation and message-pickup protocols a
+## wallet needs to register keys and collect messages land separately, so this
+## feature alone does not yet make the mediator usable by a stock Credo wallet.
+didcomm-v1 = ["didcomm", "dep:affinidi-messaging-didcomm-v1"]
+
 ## TSP (Trust Spanning Protocol) — supported, additive alongside DIDComm. Carries TSP
 ## Direct / Routed / Nested / Control messages, the TSP↔DIDComm bridge, Trust Tasks over
 ## TSP, and advertises a TSPTransport service for discovery. Run together with `didcomm`:
@@ -78,6 +88,8 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
+## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
+affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.1", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
 trust-tasks-rs = { version = "0.2.46", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Affinidi Messaging Mediator Common
 
+## 8th August 2026 (0.15.34)
+
+**`MediatorStore` gains a DIDComm v1 routing-key index.**
+
+DIDComm v1 addresses a forward's destination by base58 Ed25519 **verkey**, while
+every routing, ACL and storage decision in the mediator is keyed by DID. The new
+methods bridge the two: `v1_routing_key_bind` / `_lookup` / `_unbind` /
+`v1_routing_keys_for`, plus a `supports_v1_routing_keys()` capability probe.
+
+All carry default implementations, so a third-party backend written against an
+earlier version of the trait keeps compiling; the probe defaults to `false` and
+the mediator refuses to start with DIDComm v1 enabled on such a backend.
+
+**Security contract:** a verkey binds to at most one DID. An implementation MUST
+reject a bind whose verkey is already bound to a different DID — otherwise any
+account could claim another's routing key and capture its inbound v1 traffic.
+Redis enforces this with `SETNX`; the in-process backends do it under their
+write lock. Account removal purges an account's bindings, or a removed account's
+verkeys keep resolving to a mailbox that no longer exists.
+
+The index stores the **DID**, not its hash: forward ingress hands the looked-up
+value to the message-store path, which addresses a recipient by DID and hashes
+it itself. The reverse index stays hash-keyed, because that is what account
+removal works from.
+
 ## 1st August 2026 (0.15.33)
 
 Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.33"
+version = "0.15.34"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/mod.rs
@@ -338,6 +338,64 @@ pub trait MediatorStore: Send + Sync + std::fmt::Debug {
         receive_queue_limit: Option<i32>,
     ) -> Result<(), MediatorError>;
 
+    // ─── DIDComm v1 routing keys ─────────────────────────────────────────────
+
+    /// Whether this backend implements the DIDComm v1 routing-key index below.
+    ///
+    /// Defaults to `false` so a third-party backend written against an earlier
+    /// version of this trait keeps compiling. The mediator checks this at
+    /// startup and **refuses to start** with the `didcomm-v1` feature enabled
+    /// on a backend that returns `false`, rather than accepting v1 traffic it
+    /// would then silently fail to route.
+    fn supports_v1_routing_keys(&self) -> bool {
+        false
+    }
+
+    /// Bind a base58 Ed25519 routing verkey to a local account's DID.
+    ///
+    /// DIDComm v1 addresses a forward's destination by **verkey**, not DID,
+    /// while every routing, ACL, and storage decision in this mediator is
+    /// keyed by DID (or its hash). This index is the bridge.
+    ///
+    /// Takes and returns the **DID**, not its hash: forward ingress hands the
+    /// looked-up value straight to the message-store path, which addresses a
+    /// recipient by DID and hashes it itself — and a hash cannot be turned back
+    /// into a DID. The *reverse* index ([`Self::v1_routing_keys_for`]) is still
+    /// keyed by hash, because that is what account removal works from.
+    ///
+    /// # Security
+    ///
+    /// A verkey binds to **at most one** DID. An implementation MUST reject a
+    /// bind whose verkey is already bound to a *different* DID, because
+    /// otherwise any account could claim another account's routing key and
+    /// capture its inbound v1 traffic. Re-binding a verkey to the DID that
+    /// already holds it is idempotent and succeeds.
+    async fn v1_routing_key_bind(&self, _verkey: &str, _did: &str) -> Result<(), MediatorError> {
+        Err(MediatorError::ConfigError(
+            12,
+            "NA".into(),
+            "this storage backend does not implement DIDComm v1 routing keys".into(),
+        ))
+    }
+
+    /// The **DID** bound to `verkey`, or `None` when the verkey is unknown.
+    async fn v1_routing_key_lookup(&self, _verkey: &str) -> Result<Option<String>, MediatorError> {
+        Ok(None)
+    }
+
+    /// Drop a binding. Returns whether one was removed.
+    async fn v1_routing_key_unbind(&self, _verkey: &str) -> Result<bool, MediatorError> {
+        Ok(false)
+    }
+
+    /// Every routing verkey bound to the account with this DID **hash**.
+    ///
+    /// Used by account removal (so a deleted account's keys stop resolving)
+    /// and, once the coordinate-mediation protocol lands, by `keylist-query`.
+    async fn v1_routing_keys_for(&self, _did_hash: &str) -> Result<Vec<String>, MediatorError> {
+        Ok(Vec::new())
+    }
+
     // ─── ACLs ────────────────────────────────────────────────────────────────
 
     /// Replace the ACL bitmask for a DID. Caller is responsible for

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/accounts.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/accounts.rs
@@ -214,6 +214,11 @@ impl Database {
                     .await?;
             }
 
+            // Drop any DIDComm v1 routing keys the account owns. Left behind,
+            // its verkeys keep resolving and inbound v1 traffic keeps being
+            // accepted for a mailbox that no longer exists.
+            self.v1_routing_keys_purge(did_hash).await?;
+
             // Remove from Known DIDs
             // Remove DID Record
             // Remove ACCESS_LIST Set

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/mod.rs
@@ -23,6 +23,7 @@ pub mod session;
 pub mod stats;
 pub mod store;
 pub mod streaming;
+pub(crate) mod v1_routing_keys;
 
 /// Compatibility alias preserved during the Database → RedisStore fold.
 /// External callers that still hold `&Database` references see

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/v1_routing_keys.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/database/v1_routing_keys.rs
@@ -1,0 +1,215 @@
+//! DIDComm v1 routing-key index.
+//!
+//! DIDComm v1 addresses a forward's destination by **base58 Ed25519 verkey**,
+//! while every routing, ACL, and storage decision in this mediator is keyed by
+//! DID hash. This index is the bridge. See
+//! [`MediatorStore::v1_routing_key_bind`](crate::store::MediatorStore::v1_routing_key_bind)
+//! for the security contract it has to uphold.
+//!
+//! Two keys per binding, mirroring how `ACCESS_LIST:` pairs with `KNOWN_DIDS`:
+//!
+//! | Key | Type | Purpose |
+//! |---|---|---|
+//! | `V1_KEY:<verkey>` | string → DID | forward ingress: verkey → account |
+//! | `V1_KEYS:<did_hash>` | set of verkeys | keylist-query and account removal |
+
+use redis::Pipeline;
+use tracing::{Instrument, Level, span};
+
+use crate::{errors::MediatorError, store::redis::RedisStore};
+
+/// The verkey → DID-hash key.
+pub(crate) fn key_owner(verkey: &str) -> String {
+    ["V1_KEY:", verkey].concat()
+}
+
+/// The DID-hash → verkey-set key.
+pub(crate) fn key_owned(did_hash: &str) -> String {
+    ["V1_KEYS:", did_hash].concat()
+}
+
+impl RedisStore {
+    /// Bind a routing verkey to an account, refusing to steal one already
+    /// bound elsewhere.
+    ///
+    /// `SETNX` is what makes this safe under concurrency: the claim either
+    /// wins atomically or loses, and a loser only succeeds if the existing
+    /// owner is already this same account. A read-then-write would let two
+    /// simultaneous binds both observe "unbound" and the second silently take
+    /// over the first account's inbound v1 traffic.
+    pub(crate) async fn v1_routing_key_bind(
+        &self,
+        verkey: &str,
+        did: &str,
+    ) -> Result<(), MediatorError> {
+        let did_hash = sha256::digest(did.as_bytes());
+        let _span = span!(Level::DEBUG, "v1_routing_key_bind", verkey, did_hash);
+        async move {
+            let mut con = self.get_connection().await?;
+
+            let claimed: bool = redis::cmd("SETNX")
+                .arg(key_owner(verkey))
+                .arg(did)
+                .query_async(&mut con)
+                .await
+                .map_err(|err| {
+                    MediatorError::DatabaseError(
+                        14,
+                        "NA".to_string(),
+                        format!("Failed to claim v1 routing key. Reason: {err}"),
+                    )
+                })?;
+
+            if !claimed {
+                let owner: Option<String> = redis::cmd("GET")
+                    .arg(key_owner(verkey))
+                    .query_async(&mut con)
+                    .await
+                    .map_err(|err| {
+                        MediatorError::DatabaseError(
+                            14,
+                            "NA".to_string(),
+                            format!("Failed to read v1 routing key owner. Reason: {err}"),
+                        )
+                    })?;
+
+                // A binding that vanished between SETNX and GET (expired or
+                // concurrently unbound) is not ours to assume; report it as a
+                // conflict rather than silently taking it.
+                if owner.as_deref() != Some(did) {
+                    return Err(MediatorError::ConfigError(
+                        12,
+                        "NA".to_string(),
+                        "routing verkey is already bound to a different account".to_string(),
+                    ));
+                }
+            }
+
+            // Idempotent either way: the reverse index is a set.
+            redis::cmd("SADD")
+                .arg(key_owned(&did_hash))
+                .arg(verkey)
+                .exec_async(&mut con)
+                .await
+                .map_err(|err| {
+                    MediatorError::DatabaseError(
+                        14,
+                        "NA".to_string(),
+                        format!("Failed to index v1 routing key. Reason: {err}"),
+                    )
+                })?;
+
+            Ok(())
+        }
+        .instrument(_span)
+        .await
+    }
+
+    /// The DID bound to `verkey`, if any.
+    pub(crate) async fn v1_routing_key_lookup(
+        &self,
+        verkey: &str,
+    ) -> Result<Option<String>, MediatorError> {
+        let mut con = self.get_connection().await?;
+        redis::cmd("GET")
+            .arg(key_owner(verkey))
+            .query_async(&mut con)
+            .await
+            .map_err(|err| {
+                MediatorError::DatabaseError(
+                    14,
+                    "NA".to_string(),
+                    format!("Failed to look up v1 routing key. Reason: {err}"),
+                )
+            })
+    }
+
+    /// Drop a binding, returning whether one existed.
+    pub(crate) async fn v1_routing_key_unbind(&self, verkey: &str) -> Result<bool, MediatorError> {
+        let mut con = self.get_connection().await?;
+
+        let owner: Option<String> = redis::cmd("GET")
+            .arg(key_owner(verkey))
+            .query_async(&mut con)
+            .await
+            .map_err(|err| {
+                MediatorError::DatabaseError(
+                    14,
+                    "NA".to_string(),
+                    format!("Failed to read v1 routing key owner. Reason: {err}"),
+                )
+            })?;
+
+        let Some(owner) = owner else {
+            return Ok(false);
+        };
+
+        let mut pipe = Pipeline::new();
+        pipe.atomic()
+            .cmd("DEL")
+            .arg(key_owner(verkey))
+            .cmd("SREM")
+            .arg(key_owned(&sha256::digest(owner.as_bytes())))
+            .arg(verkey);
+        pipe.exec_async(&mut con).await.map_err(|err| {
+            MediatorError::DatabaseError(
+                14,
+                "NA".to_string(),
+                format!("Failed to unbind v1 routing key. Reason: {err}"),
+            )
+        })?;
+
+        Ok(true)
+    }
+
+    /// Every routing verkey bound to `did_hash`.
+    pub(crate) async fn v1_routing_keys_for(
+        &self,
+        did_hash: &str,
+    ) -> Result<Vec<String>, MediatorError> {
+        let mut con = self.get_connection().await?;
+        let mut keys: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(key_owned(did_hash))
+            .query_async(&mut con)
+            .await
+            .map_err(|err| {
+                MediatorError::DatabaseError(
+                    14,
+                    "NA".to_string(),
+                    format!("Failed to list v1 routing keys. Reason: {err}"),
+                )
+            })?;
+        // Redis set order is unspecified; sort so callers see a stable list.
+        keys.sort();
+        Ok(keys)
+    }
+
+    /// Remove every v1 routing key owned by `did_hash`.
+    ///
+    /// Called from `account_remove`: without it a removed account's verkeys
+    /// keep resolving, and inbound v1 traffic keeps being accepted for a
+    /// mailbox that no longer exists.
+    pub(crate) async fn v1_routing_keys_purge(&self, did_hash: &str) -> Result<(), MediatorError> {
+        let verkeys = self.v1_routing_keys_for(did_hash).await?;
+        if verkeys.is_empty() {
+            return Ok(());
+        }
+
+        let mut con = self.get_connection().await?;
+        let mut pipe = Pipeline::new();
+        pipe.atomic();
+        for verkey in &verkeys {
+            pipe.cmd("DEL").arg(key_owner(verkey));
+        }
+        pipe.cmd("DEL").arg(key_owned(did_hash));
+        pipe.exec_async(&mut con).await.map_err(|err| {
+            MediatorError::DatabaseError(
+                14,
+                "NA".to_string(),
+                format!("Failed to purge v1 routing keys for ({did_hash}). Reason: {err}"),
+            )
+        })?;
+
+        Ok(())
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/store/redis/store.rs
@@ -604,6 +604,28 @@ impl MediatorStore for RedisStore {
         self.account_exists(did_hash).await
     }
 
+    // ─── DIDComm v1 routing keys ─────────────────────────────────────────────
+
+    fn supports_v1_routing_keys(&self) -> bool {
+        true
+    }
+
+    async fn v1_routing_key_bind(&self, verkey: &str, did_hash: &str) -> Result<(), MediatorError> {
+        self.v1_routing_key_bind(verkey, did_hash).await
+    }
+
+    async fn v1_routing_key_lookup(&self, verkey: &str) -> Result<Option<String>, MediatorError> {
+        self.v1_routing_key_lookup(verkey).await
+    }
+
+    async fn v1_routing_key_unbind(&self, verkey: &str) -> Result<bool, MediatorError> {
+        self.v1_routing_key_unbind(verkey).await
+    }
+
+    async fn v1_routing_keys_for(&self, did_hash: &str) -> Result<Vec<String>, MediatorError> {
+        self.v1_routing_keys_for(did_hash).await
+    }
+
     async fn account_get(&self, did_hash: &str) -> Result<Option<Account>, MediatorError> {
         self.account_get(did_hash).await
     }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Messaging Mediator Config
 
+## 8th August 2026 (0.2.1)
+
+Adds the optional `[didcomm_v1]` section (`DidCommV1ConfigRaw`): `enabled` and
+`allow_unauthenticated_forwards`, both defaulting to `false`. Additive and
+`#[serde(default)]`, so an existing `mediator.toml` parses unchanged. See the
+mediator's changelog for what the knobs do and why the second one exists.
+
 ## Changelog history
 
 ## 14th June 2026

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-config"
-version = "0.2.0"
+version = "0.2.1"
 description = "Raw TOML configuration schema for the Affinidi Messaging Mediator (shared by the mediator and its setup tool)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-config/src/schema.rs
@@ -98,6 +98,37 @@ pub struct ConfigRaw {
     /// → embedded Fjall at `data_dir`, `[database]` is ignored.
     #[serde(default)]
     pub storage: Option<StorageConfig>,
+    /// Optional `[didcomm_v1]` section. Absent → DIDComm v1 is off, which is
+    /// also what a mediator built without the `didcomm-v1` feature does.
+    #[serde(default)]
+    pub didcomm_v1: Option<DidCommV1ConfigRaw>,
+}
+
+/// `[didcomm_v1]` section — Aries RFC 0019 support.
+///
+/// Requires the mediator to be built with the `didcomm-v1` feature; the binary
+/// warns and ignores the section otherwise, rather than pretending v1 traffic
+/// will be handled.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DidCommV1ConfigRaw {
+    /// Accept inbound DIDComm v1 forwards. Default `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Accept a v1 forward that arrives **without** an authenticated session.
+    ///
+    /// Default `false`, which keeps this mediator's existing posture: every
+    /// inbound message rides an authenticated session.
+    ///
+    /// Aries mediators do the opposite — a `routing/1.0/forward` is anoncrypt'd
+    /// to the mediator's routing key by design, so the sender is anonymous and
+    /// the mediator applies the *recipient's* access list instead. A stock
+    /// Credo wallet has no way to complete this mediator's v2 challenge, so
+    /// `true` is required for real Aries interop and is a deliberate,
+    /// per-deployment loosening: it lets an unauthenticated party cause a store
+    /// write, bounded by the recipient's ACL, the message-size limit, and the
+    /// per-IP rate limiter.
+    #[serde(default)]
+    pub allow_unauthenticated_forwards: bool,
 }
 
 /// `[storage]` section — selects the mediator's storage backend.
@@ -125,7 +156,7 @@ pub struct StorageConfig {
 ///
 /// Fjall ships with defaults sized for a general-purpose embedded database
 /// (32 MiB block cache, 64 MiB of memtable *per keyspace*, 512 MiB of journal).
-/// The mediator opens 14 keyspaces, so the stock per-keyspace memtable default
+/// The mediator opens 15 keyspaces, so the stock per-keyspace memtable default
 /// alone allows ~896 MiB of write buffer. These knobs bring that down to a
 /// budget the operator chooses.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/messaging/affinidi-messaging-mediator/docs/memory-tuning.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/memory-tuning.md
@@ -49,7 +49,7 @@ you need to size.
 
 Fjall's own defaults are sized for a general-purpose embedded database, and are a
 poor fit here: it allows **64 MiB of write buffer per keyspace**, and the
-mediator opens 14 keyspaces. Left alone, that permits roughly **900 MiB** of
+mediator opens 15 keyspaces. Left alone, that permits roughly **900 MiB** of
 memtable. The shipped `[storage.fjall]` defaults exist to bring that down.
 
 Two Fjall behaviours are worth knowing, because they are not obvious:

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -100,6 +100,24 @@ fn database_config_from_raw(
 /// Default VTA cache TTL when `[secrets].cache_ttl` is not set.
 const DEFAULT_CACHE_TTL_SECS: u64 = 30 * 86_400; // 30 days
 
+/// Typed `[didcomm_v1]` settings. See
+/// [`DidCommV1ConfigRaw`](affinidi_messaging_mediator_config::DidCommV1ConfigRaw)
+/// for what each knob means and why `allow_unauthenticated_forwards` exists.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct DidCommV1Config {
+    pub enabled: bool,
+    pub allow_unauthenticated_forwards: bool,
+}
+
+impl From<affinidi_messaging_mediator_config::DidCommV1ConfigRaw> for DidCommV1Config {
+    fn from(raw: affinidi_messaging_mediator_config::DidCommV1ConfigRaw) -> Self {
+        Self {
+            enabled: raw.enabled,
+            allow_unauthenticated_forwards: raw.allow_unauthenticated_forwards,
+        }
+    }
+}
+
 #[derive(Clone, Serialize)]
 pub struct Config {
     #[serde(skip_serializing)]
@@ -173,6 +191,14 @@ pub struct Config {
     /// `[storage]` section the wizard wrote.
     #[serde(default)]
     pub storage: Option<StorageConfig>,
+    /// DIDComm v1 (Aries RFC 0019) settings, from `[didcomm_v1]`.
+    ///
+    /// Defaults to disabled. A mediator built without the `didcomm-v1` feature
+    /// carries the parsed value but never acts on it — [`validate`] warns so an
+    /// operator who enabled it in TOML is told the binary cannot honour it,
+    /// rather than silently dropping every v1 message.
+    #[serde(default)]
+    pub didcomm_v1: DidCommV1Config,
     /// Inputs for the periodic VTA refresh task. `Some` only in
     /// VTA-linked deployments. The task itself is spawned by
     /// [`crate::server::serve_internal`] alongside the other
@@ -252,6 +278,7 @@ impl Config {
             )),
             operating_keys_loaded: false,
             storage: None,
+            didcomm_v1: DidCommV1Config::default(),
             vta_refresher: None,
             security: SecurityConfig::default(secrets_resolver),
             processors: ProcessorsConfig {
@@ -710,6 +737,11 @@ impl TryFrom<ConfigRaw> for Config {
             // server::serve_internal inspects it to decide between the
             // legacy Redis path and the embedded Fjall path.
             storage: raw.storage.clone(),
+            didcomm_v1: raw
+                .didcomm_v1
+                .clone()
+                .map(DidCommV1Config::from)
+                .unwrap_or_default(),
             // Operating keys come either from the VTA (when integration
             // is active) or from the unified backend's well-known
             // `mediator/operating/secrets` entry (self-hosted). The

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -283,6 +283,29 @@ fn relay_anonymous_acls() -> MediatorACLSet {
     MediatorACLSet::from_string_ruleset("DENY_ALL,SEND_MESSAGES,SEND_FORWARDED").unwrap_or_default()
 }
 
+/// Session id marking an anonymous session admitted **only** because
+/// `[didcomm_v1] allow_unauthenticated_forwards` is on.
+///
+/// The distinction matters, and `message_inbound_handler` enforces it. An Aries
+/// wallet is not an inter-mediator relay: it anoncrypts a
+/// `routing/1.0/forward` to the mediator's routing key and presents no
+/// credential, which is normal for v1 and abnormal for everything else here.
+/// Admitting it must therefore not also open anonymous *v2* inbound — so a
+/// session carrying this id is refused unless the body really is a v1 envelope.
+#[cfg(feature = "didcomm-v1")]
+pub(crate) const ANON_V1_SESSION_ID: &str = "ANON-INBOUND-V1";
+
+/// ACLs for a v1-only anonymous session.
+///
+/// Deliberately **without** `SEND_FORWARDED`, which the v2 anonymous-forward
+/// branch in `routing.rs` consumes: even if the body check were somehow
+/// bypassed, this session could not drive a v2 relay forward. `SEND_MESSAGES`
+/// alone satisfies the handler-level gate.
+#[cfg(feature = "didcomm-v1")]
+fn v1_anonymous_acls() -> MediatorACLSet {
+    MediatorACLSet::from_string_ruleset("DENY_ALL,SEND_MESSAGES").unwrap_or_default()
+}
+
 /// Decide whether an authentication failure should be downgraded to an anonymous
 /// relay session, and if so build that session.
 ///
@@ -302,17 +325,34 @@ fn anonymous_session_for(
     err: &AuthError,
     enable_relay_flag: bool,
     global_acl_default: &MediatorACLSet,
+    #[cfg_attr(not(feature = "didcomm-v1"), allow(unused_variables))] allow_v1_anon: bool,
 ) -> Option<Session> {
-    let relay_enabled = enable_relay_flag || anonymous_inbound_allowed(global_acl_default);
-    if matches!(err, AuthError::MissingCredentials) && relay_enabled {
-        Some(Session {
+    if !matches!(err, AuthError::MissingCredentials) {
+        return None;
+    }
+
+    // Relay admission is unchanged and takes precedence: such a session keeps
+    // its SEND_FORWARDED capability and is not restricted to v1 bodies.
+    if enable_relay_flag || anonymous_inbound_allowed(global_acl_default) {
+        return Some(Session {
             session_id: "ANON-INBOUND".to_string(),
             acls: relay_anonymous_acls(),
             ..Default::default()
-        })
-    } else {
-        None
+        });
     }
+
+    // Otherwise a v1 forward may still be admitted, but only as a v1-scoped
+    // session — see [`ANON_V1_SESSION_ID`].
+    #[cfg(feature = "didcomm-v1")]
+    if allow_v1_anon {
+        return Some(Session {
+            session_id: ANON_V1_SESSION_ID.to_string(),
+            acls: v1_anonymous_acls(),
+            ..Default::default()
+        });
+    }
+
+    None
 }
 
 /// Extractor that wraps `Session`, optionally allowing anonymous relay requests.
@@ -344,6 +384,8 @@ where
                     &e,
                     security.enable_inter_mediator_relay,
                     &security.global_acl_default,
+                    shared.config.didcomm_v1.enabled
+                        && shared.config.didcomm_v1.allow_unauthenticated_forwards,
                 ) {
                     Some(session) => Ok(MaybeSession(session)),
                     None => Err(e),
@@ -429,7 +471,7 @@ mod tests {
     fn missing_credentials_downgrades_to_relay_session_only_when_relay_enabled() {
         let relay = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
         // Legacy implicit relay: ACL grants SEND_FORWARDED, flag off.
-        let session = anonymous_session_for(&AuthError::MissingCredentials, false, &relay)
+        let session = anonymous_session_for(&AuthError::MissingCredentials, false, &relay, false)
             .expect("relay-enabled mediator accepts anonymous inbound");
         // Not authenticated, no DID, and scoped to the minimal relay ACL — never
         // the full global default.
@@ -442,7 +484,9 @@ mod tests {
         let secure =
             MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
                 .unwrap();
-        assert!(anonymous_session_for(&AuthError::MissingCredentials, false, &secure).is_none());
+        assert!(
+            anonymous_session_for(&AuthError::MissingCredentials, false, &secure, false).is_none()
+        );
     }
 
     #[test]
@@ -453,11 +497,13 @@ mod tests {
             MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
                 .unwrap();
         assert!(
-            anonymous_session_for(&AuthError::MissingCredentials, true, &secure).is_some(),
+            anonymous_session_for(&AuthError::MissingCredentials, true, &secure, false).is_some(),
             "explicit enable_inter_mediator_relay must accept anonymous inbound"
         );
         // ...and with neither the flag nor the ACL bit, it stays rejected.
-        assert!(anonymous_session_for(&AuthError::MissingCredentials, false, &secure).is_none());
+        assert!(
+            anonymous_session_for(&AuthError::MissingCredentials, false, &secure, false).is_none()
+        );
     }
 
     #[test]
@@ -474,8 +520,75 @@ mod tests {
             AuthError::InternalServerError("backend down".into()),
         ] {
             assert!(
-                anonymous_session_for(&err, false, &relay).is_none(),
+                anonymous_session_for(&err, false, &relay, false).is_none(),
                 "{err:?} must not be downgraded to an anonymous session"
+            );
+        }
+    }
+
+    /// `allow_unauthenticated_forwards` admits an anonymous session, but a
+    /// **v1-scoped** one: it must not become a general anonymous-inbound
+    /// licence. The handler refuses a non-v1 body on this session; the ACL is
+    /// the second line of defence.
+    #[cfg(feature = "didcomm-v1")]
+    #[test]
+    fn v1_anonymous_session_is_scoped_and_cannot_relay() {
+        let secure =
+            MediatorACLSet::from_string_ruleset("DENY_ALL,LOCAL,SEND_MESSAGES,RECEIVE_MESSAGES")
+                .unwrap();
+
+        // Off by default: still rejected.
+        assert!(
+            anonymous_session_for(&AuthError::MissingCredentials, false, &secure, false).is_none(),
+            "v1 anonymous inbound must be opt-in"
+        );
+
+        let session = anonymous_session_for(&AuthError::MissingCredentials, false, &secure, true)
+            .expect("allow_unauthenticated_forwards admits an anonymous v1 session");
+
+        assert_eq!(
+            session.session_id, ANON_V1_SESSION_ID,
+            "the session must be identifiable as v1-scoped so the handler can refuse other bodies"
+        );
+        assert!(!session.authenticated);
+        assert!(session.did.is_empty());
+        // Enough to pass the handler gate...
+        assert!(session.acls.get_send_messages().0);
+        // ...but never enough to drive a v2 relay forward.
+        assert!(
+            !session.acls.get_send_forwarded().0,
+            "a v1-scoped anonymous session must not carry SEND_FORWARDED"
+        );
+        assert!(!session.acls.get_local());
+    }
+
+    /// A relay-enabled mediator keeps its existing behaviour: the anonymous
+    /// session is the relay one, not the narrower v1 session, so turning on v1
+    /// does not silently downgrade inter-mediator relay.
+    #[cfg(feature = "didcomm-v1")]
+    #[test]
+    fn relay_admission_takes_precedence_over_v1() {
+        let relay = MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap();
+        let session = anonymous_session_for(&AuthError::MissingCredentials, true, &relay, true)
+            .expect("relay session");
+        assert_eq!(session.session_id, "ANON-INBOUND");
+        assert!(session.acls.get_send_forwarded().0);
+    }
+
+    /// The v1 flag must not rescue a *presented* bad credential either.
+    #[cfg(feature = "didcomm-v1")]
+    #[test]
+    fn v1_flag_does_not_downgrade_invalid_credentials() {
+        let secure = MediatorACLSet::from_string_ruleset("DENY_ALL,SEND_MESSAGES").unwrap();
+        for err in [
+            AuthError::InvalidToken,
+            AuthError::ExpiredToken,
+            AuthError::Blocked,
+            AuthError::WrongCredentials,
+        ] {
+            assert!(
+                anonymous_session_for(&err, false, &secure, true).is_none(),
+                "{err:?} must not be downgraded even with v1 anonymous forwards enabled"
             );
         }
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/didcomm_v1_identity.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/didcomm_v1_identity.rs
@@ -1,0 +1,134 @@
+//! The mediator's own DIDComm v1 identity.
+//!
+//! A v1 client anoncrypts a `routing/1.0/forward` **to the mediator's routing
+//! verkey** — a bare base58 Ed25519 key, because v1 envelopes carry no DID
+//! (see [`affinidi_messaging_didcomm_v1::identity`]). To open that forward the
+//! mediator needs the private half.
+//!
+//! It does not need a *new* key. The mediator already holds an Ed25519
+//! authentication key for its DID, and v1 does key agreement on that key's
+//! Montgomery form, so its v1 routing verkey is simply that key seen through a
+//! v1 lens. This mirrors [`crate::tsp_identity`], which derives the mediator's
+//! TSP identity from the same material for the same reason: one set of
+//! operating secrets, three protocols.
+//!
+//! # What clients need
+//!
+//! The base58 form of [`MediatorDidCommV1Identity::verkey`] is what a v1 client
+//! puts in its `routingKeys`. It is logged at startup and reported by
+//! `mediator-setup`, because there is nowhere in a DID document that a v1
+//! client would look for it — v1 predates DID documents as a discovery
+//! mechanism, and Aries clients are configured with routing keys out of band.
+
+use affinidi_did_common::document::DocumentExt;
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_messaging_didcomm_v1::{PrivateIdentity, Verkey};
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_secrets_resolver::{SecretsResolver, secrets::KeyType};
+
+/// The mediator's v1 identity, derived from its DID document + operating secrets.
+pub struct MediatorDidCommV1Identity {
+    /// The v1 identity used to open forwards addressed to this mediator.
+    pub identity: PrivateIdentity,
+}
+
+impl MediatorDidCommV1Identity {
+    /// The routing verkey clients address forwards to.
+    pub fn verkey(&self) -> Verkey {
+        self.identity.verkey
+    }
+
+    /// Derive from the mediator's DID document and operating secrets.
+    ///
+    /// Fails with a config error when the DID cannot be resolved or its
+    /// document has no Ed25519 authentication key whose private half the
+    /// mediator holds — the same precondition [`crate::tsp_identity`] has.
+    pub(crate) async fn derive(
+        did: &str,
+        did_resolver: &DIDCacheClient,
+        secrets: &impl SecretsResolver,
+    ) -> Result<Self, MediatorError> {
+        let doc = did_resolver
+            .resolve(did)
+            .await
+            .map_err(|e| {
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!(
+                        "couldn't resolve mediator DID {did} to derive its DIDComm v1 identity: {e}"
+                    ),
+                )
+            })?
+            .doc;
+
+        let signing_key = first_ed25519_private(doc.find_authentication(None), secrets)
+            .await
+            .ok_or_else(|| {
+                MediatorError::ConfigError(
+                    12,
+                    "NA".into(),
+                    format!(
+                        "mediator DID {did} has no Ed25519 authentication key, so it cannot \
+                         derive a DIDComm v1 routing key"
+                    ),
+                )
+            })?;
+
+        let identity = PrivateIdentity::from_signing_key(did, &signing_key).map_err(|e| {
+            MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                format!("couldn't build the mediator's DIDComm v1 identity: {e}"),
+            )
+        })?;
+
+        Ok(Self { identity })
+    }
+}
+
+/// First authentication `kid` whose secret is an Ed25519 key, as raw bytes.
+async fn first_ed25519_private(
+    kids: Vec<&str>,
+    secrets: &impl SecretsResolver,
+) -> Option<[u8; 32]> {
+    for kid in kids {
+        if let Some(secret) = secrets.get_secret(kid).await
+            && secret.get_key_type() == KeyType::Ed25519
+            && let Ok(bytes) = <[u8; 32]>::try_from(secret.get_private_bytes())
+        {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The routing verkey must be the plain Ed25519 verkey, in the base58 form
+    /// an Aries client puts in its `routingKeys`.
+    ///
+    /// Pinned against a value produced by a real Credo agent for this seed (the
+    /// `alice` party in `affinidi-messaging-didcomm-v1`'s Credo fixtures), so
+    /// this asserts interop-visible output rather than restating the derivation.
+    #[test]
+    fn routing_verkey_is_the_base58_ed25519_verkey() {
+        const SEED_HEX: &str = "3da13d1f57cf58ddeebae88c92679c2c88dc792423e971b3c17f5ab83b79ad89";
+        const CREDO_VERKEY: &str = "3hLMcPh9X6vtEJfuJmCinWRHAYFMjea1cfLA2eCvWA5A";
+
+        let seed: [u8; 32] = <[u8; 32]>::try_from(hex_to_bytes(SEED_HEX).as_slice()).unwrap();
+        let identity = PrivateIdentity::from_signing_key("did:example:mediator", &seed).unwrap();
+        let derived = MediatorDidCommV1Identity { identity };
+
+        assert_eq!(derived.verkey().to_base58(), CREDO_VERKEY);
+    }
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -98,6 +98,66 @@ pub async fn message_inbound_handler(
             ));
         }
 
+        // DIDComm v1 (Aries RFC 0019). Sniffed before the v2 parse because a v1
+        // envelope has no top-level `recipients` and would otherwise fail the v2
+        // deserialise with a misleading error. See `is_didcomm_v1`.
+        #[cfg(feature = "didcomm-v1")]
+        {
+            let is_v1 = crate::messages::inbound_v1::is_didcomm_v1(&body);
+
+            // A session admitted *only* by `allow_unauthenticated_forwards` is
+            // scoped to v1: anything else on it is refused here, so opening the
+            // door for Aries wallets does not also open anonymous v2 inbound.
+            if session.session_id == crate::common::jwt_auth::ANON_V1_SESSION_ID && !is_v1 {
+                return Err(MediatorError::problem(
+                    44,
+                    session.session_id,
+                    None,
+                    ProblemReportSorter::Error,
+                    ProblemReportScope::Protocol,
+                    "authorization.authentication_required",
+                    "Anonymous inbound is accepted only for DIDComm v1 forwards on this mediator",
+                    vec![],
+                    StatusCode::UNAUTHORIZED,
+                )
+                .into());
+            }
+
+            if is_v1 {
+                let raw = std::str::from_utf8(&body).map_err(|e| {
+                    MediatorError::problem(
+                        19,
+                        session.session_id.clone(),
+                        None,
+                        ProblemReportSorter::Warning,
+                        ProblemReportScope::Message,
+                        "message.deserialize",
+                        "DIDComm v1 envelope is not valid UTF-8. Reason: {1}",
+                        vec![e.to_string()],
+                        StatusCode::BAD_REQUEST,
+                    )
+                })?;
+
+                metrics::counter!(names::MESSAGES_INBOUND_TOTAL).increment(1);
+                metrics::counter!(names::MESSAGE_BYTES_INBOUND_TOTAL).increment(raw.len() as u64);
+
+                let response =
+                    crate::messages::inbound_v1::handle_inbound_didcomm_v1(&state, &session, raw)
+                        .await?;
+                return Ok((
+                    StatusCode::OK,
+                    Json(SuccessResponse {
+                        session_id: session.session_id,
+                        http_code: StatusCode::OK.as_u16(),
+                        error_code: 0,
+                        error_code_str: "NA".to_string(),
+                        message: "Success".to_string(),
+                        data: Some(response),
+                    }),
+                ));
+            }
+        }
+
         // DIDComm: parse the JWE envelope, then re-serialise it to the exact
         // canonical string used historically (the `Json<InboundMessage>`
         // extractor parsed then the handler `to_string`'d it). Re-creating that

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -26,6 +26,8 @@ pub mod commands;
 pub mod common;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_compat;
+#[cfg(feature = "didcomm-v1")]
+pub mod didcomm_v1_identity;
 pub mod handlers;
 pub mod messages;
 pub mod server;
@@ -86,6 +88,13 @@ pub struct SharedData {
     /// delivery is a blind store-and-forward and never touches it.
     #[cfg(feature = "tsp")]
     pub tsp_identity: Arc<tokio::sync::OnceCell<tsp_identity::MediatorTspIdentity>>,
+    /// The mediator's own DIDComm v1 identity, derived lazily on first use from
+    /// the same Ed25519 authentication key its v2 identity uses. Needed to open
+    /// the anoncrypt `routing/1.0/forward` a v1 client addresses to the
+    /// mediator's routing verkey.
+    #[cfg(feature = "didcomm-v1")]
+    pub didcomm_v1_identity:
+        Arc<tokio::sync::OnceCell<didcomm_v1_identity::MediatorDidCommV1Identity>>,
 }
 
 impl SharedData {
@@ -108,6 +117,26 @@ impl SharedData {
             })
             .await
     }
+    /// The mediator's DIDComm v1 identity, derived (and cached) on first use
+    /// from its configured DID document and operating secrets.
+    #[cfg(feature = "didcomm-v1")]
+    pub async fn didcomm_v1_identity(
+        &self,
+    ) -> Result<
+        &didcomm_v1_identity::MediatorDidCommV1Identity,
+        affinidi_messaging_mediator_common::errors::MediatorError,
+    > {
+        self.didcomm_v1_identity
+            .get_or_try_init(|| {
+                didcomm_v1_identity::MediatorDidCommV1Identity::derive(
+                    &self.config.mediator_did,
+                    &self.did_resolver,
+                    &*self.config.security.mediator_secrets,
+                )
+            })
+            .await
+    }
+
     /// Bound for request-path storage calls made during admission/validation
     /// (see [`common::storage_timeout`]). Sourced from the existing
     /// `[database] database_timeout` (the same knob that caps Redis

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound_v1.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound_v1.rs
@@ -1,0 +1,388 @@
+//! DIDComm v1 (Aries RFC 0019) forward ingress.
+//!
+//! An Aries client that routes through a mediator anoncrypts a
+//! `routing/1.0/forward` **to the mediator's routing verkey**, wrapping an inner
+//! envelope already sealed end-to-end to the final recipient. The mediator
+//! opens only the outer layer: it learns where to deliver, never what was said.
+//!
+//! ```text
+//! anoncrypt(to = mediator routing verkey)
+//!   └── { "@type": ".../routing/1.0/forward",
+//!         "to":  "<recipient base58 verkey>",
+//!         "msg": { …inner envelope, opaque to us… } }
+//! ```
+//!
+//! # Why the sender is anonymous
+//!
+//! By construction. RFC 0019 anon-packs a forward so the mediator cannot see
+//! who sent it, so there is no authenticated sender to apply a sender-side ACL
+//! to — the mediator applies the **recipient's** access list instead, exactly as
+//! the TSP path does for a relayed message. That is a real difference from this
+//! mediator's v2 posture, which is why accepting an unauthenticated v1 forward
+//! is opt-in per deployment (`[didcomm_v1] allow_unauthenticated_forwards`).
+//!
+//! # Why the recipient is a verkey
+//!
+//! v1 has no DID anywhere in the envelope. The `to` is a bare Ed25519 verkey,
+//! resolved to a local account through the store's routing-key index (see
+//! [`MediatorStore::v1_routing_key_bind`]). Until the coordinate-mediation
+//! protocol lands there is no client-facing way to create those bindings, so a
+//! forward for an unbound verkey is refused as "not local".
+//!
+//! [`MediatorStore::v1_routing_key_bind`]: affinidi_messaging_mediator_common::store::MediatorStore::v1_routing_key_bind
+
+use affinidi_messaging_didcomm_v1::envelope::{self, ProtectedHeader, RecipientKey};
+use affinidi_messaging_didcomm_v1::protocols::forward;
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_sdk::messages::{
+    compat::UnpackMetadata,
+    problem_report::{ProblemReportScope, ProblemReportSorter},
+    sending::InboundMessageResponse,
+};
+use base64::Engine;
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+use http::StatusCode;
+use sha256::digest;
+use tracing::{Instrument, Level, debug, span, warn};
+
+use crate::SharedData;
+use crate::common::authz::{self, Capability};
+use crate::common::session::Session;
+use crate::messages::store::store_message;
+use crate::messages::{ProcessMessageResponse, WrapperType};
+
+/// Whether `body` is a DIDComm **v1** envelope.
+///
+/// A v2 JWE and a v1 envelope share `protected` / `iv` / `ciphertext` / `tag`,
+/// so shape alone cannot separate them. Two independent discriminators are used
+/// together:
+///
+/// * a v2 JWE carries `recipients` at the **top level**, whereas v1 nests them
+///   *inside* the protected header;
+/// * v1's protected header declares `"typ": "JWM/1.0"`.
+///
+/// Requiring both means a malformed or unknown envelope falls through to the v2
+/// path and gets v2's error, rather than being misreported as a broken v1
+/// message.
+pub(crate) fn is_didcomm_v1(body: &[u8]) -> bool {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return false;
+    };
+    if !envelope::is_envelope(&value) || value.get("recipients").is_some() {
+        return false;
+    }
+
+    let Some(protected) = value.get("protected").and_then(|p| p.as_str()) else {
+        return false;
+    };
+    // RFC 0019 requires decoders to accept padded and unpadded base64url.
+    let Ok(decoded) = URL_SAFE_NO_PAD
+        .decode(protected)
+        .or_else(|_| URL_SAFE.decode(protected))
+    else {
+        return false;
+    };
+    serde_json::from_slice::<ProtectedHeader>(&decoded)
+        .map(|header| header.typ == envelope::ENVELOPE_TYP)
+        .unwrap_or(false)
+}
+
+/// Handle an inbound DIDComm v1 forward.
+///
+/// Opens the outer anoncrypt layer with the mediator's routing key, resolves
+/// the forward's `to` verkey to a local account, applies that account's ACLs,
+/// and stores the **inner envelope verbatim** for pickup. The inner bytes are
+/// never parsed: they are sealed to the recipient, who unpacks them natively.
+pub(crate) async fn handle_inbound_didcomm_v1(
+    state: &SharedData,
+    session: &Session,
+    raw: &str,
+) -> Result<InboundMessageResponse, MediatorError> {
+    let _span = span!(Level::DEBUG, "handle_inbound_didcomm_v1");
+    async move {
+        if !state.config.didcomm_v1.enabled {
+            return Err(v1_problem(
+                session,
+                37,
+                "protocol.unsupported",
+                "DIDComm v1 is not enabled on this mediator".to_string(),
+                StatusCode::BAD_REQUEST,
+            ));
+        }
+
+        let identity = state.didcomm_v1_identity().await?;
+        let x25519_private = identity.identity.x25519_private();
+        let keys = [RecipientKey {
+            verkey: identity.verkey(),
+            x25519_private: &x25519_private,
+        }];
+
+        // The outer layer is addressed to this mediator. A failure here is a
+        // message we are not the recipient of, or one that is malformed —
+        // either way we cannot route it.
+        let opened = envelope::open(raw, &keys).map_err(|e| {
+            v1_problem(
+                session,
+                37,
+                "message.didcomm_v1.unpack",
+                format!("couldn't open the DIDComm v1 envelope addressed to this mediator: {e}"),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        // The mediator is the outer recipient, so it is *its own* unpack: no
+        // sender bindings are consulted and none are needed. An authcrypt outer
+        // layer is accepted (some agents authcrypt forwards) but its sender is
+        // deliberately not used for routing — RFC 0019 anon-packs forwards, so
+        // treating a sometimes-present sender as authoritative would make
+        // delivery depend on the sender's choice of packing.
+        let message = affinidi_messaging_didcomm_v1::MessageV1::from_json(&opened.plaintext)
+            .map_err(|e| {
+                v1_problem(
+                    session,
+                    37,
+                    "message.didcomm_v1.malformed",
+                    format!("DIDComm v1 payload is not a valid message: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+        if !forward::is_forward(&message) {
+            return Err(v1_problem(
+                session,
+                37,
+                "message.didcomm_v1.not_forward",
+                format!(
+                    "the mediator only accepts DIDComm v1 `routing/1.0/forward` messages, got `{}`",
+                    message.typ
+                ),
+                StatusCode::BAD_REQUEST,
+            ));
+        }
+
+        let to_verkey = forward::destination(&message).map_err(|e| {
+            v1_problem(
+                session,
+                37,
+                "message.didcomm_v1.destination",
+                format!("forward has no usable `to` verkey: {e}"),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+        let inner = forward::extract_payload(&message).map_err(|e| {
+            v1_problem(
+                session,
+                37,
+                "message.didcomm_v1.payload",
+                format!("forward has no usable `msg` payload: {e}"),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        deliver_v1_forward(state, session, &to_verkey.to_base58(), &inner).await
+    }
+    .instrument(_span)
+    .await
+}
+
+/// Resolve `to_verkey` to a local account, apply its ACLs, and store `inner`.
+async fn deliver_v1_forward(
+    state: &SharedData,
+    session: &Session,
+    to_verkey: &str,
+    inner: &str,
+) -> Result<InboundMessageResponse, MediatorError> {
+    let Some(to_did) = state.database.v1_routing_key_lookup(to_verkey).await? else {
+        // Deliberately the same shape of answer as "no such account": a prober
+        // learns only that this mediator will not route for that verkey.
+        return Err(v1_problem(
+            session,
+            58,
+            "direct_delivery.recipient.unknown",
+            "no local account is bound to that DIDComm v1 routing key".to_string(),
+            StatusCode::NOT_FOUND,
+        ));
+    };
+
+    let to_hash = digest(to_did.as_bytes());
+
+    // The forward is anonymous by construction, so there is no sender to apply
+    // an access list against — `None` makes the recipient's access-list check
+    // evaluate on its mode alone, exactly as the TSP relay path does.
+    let Some(recipient) = state.database.delivery_decision(&to_hash, None).await? else {
+        warn!(
+            %to_verkey,
+            "v1 routing key resolves to a DID with no account record; treating as unknown"
+        );
+        return Err(v1_problem(
+            session,
+            58,
+            "direct_delivery.recipient.unknown",
+            "no local account is bound to that DIDComm v1 routing key".to_string(),
+            StatusCode::NOT_FOUND,
+        ));
+    };
+
+    if authz::require_capability(&recipient.acls, Capability::ReceiveMessages).is_err() {
+        return Err(v1_problem(
+            session,
+            74,
+            "authorization.receive",
+            "Recipient DID is not authorized to receive messages through this mediator".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    if !recipient.access_list_allows {
+        return Err(v1_problem(
+            session,
+            73,
+            "authorization.access_list.denied",
+            "Delivery blocked due to ACLs (access_list denied)".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
+    // Stored verbatim as the JSON text the recipient's v1 agent expects. A
+    // pickup client tells it apart from a v2 envelope the same way this handler
+    // did — see `is_didcomm_v1`.
+    let data = ProcessMessageResponse {
+        store_message: true,
+        force_live_delivery: false,
+        forward_message: false,
+        data: WrapperType::Envelope(
+            to_did.clone(),
+            inner.to_string(),
+            state.clock.unix_secs() + state.config.limits.message_expiry_seconds,
+        ),
+    };
+
+    debug!(%to_verkey, %to_did, "DIDComm v1 forward stored for local recipient");
+    store_message(state, session, &data, &UnpackMetadata::default()).await
+}
+
+/// A v1-scoped problem report, mirroring the TSP path's `tsp_problem`.
+fn v1_problem(
+    session: &Session,
+    code: u16,
+    descriptor: &str,
+    detail: String,
+    status: StatusCode,
+) -> MediatorError {
+    MediatorError::problem(
+        code,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Message,
+        descriptor,
+        "{1}",
+        vec![detail],
+        status,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_messaging_didcomm_v1::message::unpack::{NoBindings, UnpackResult, unpack};
+    use affinidi_messaging_didcomm_v1::{
+        PrivateIdentity, message::pack, protocols::basic_message::BasicMessage,
+    };
+
+    fn v1_forward_envelope() -> (String, PrivateIdentity, PrivateIdentity) {
+        let mediator = PrivateIdentity::generate("did:example:mediator").unwrap();
+        let bob = PrivateIdentity::generate("did:example:bob").unwrap();
+        let msg = BasicMessage::new("hello").unwrap().finalize();
+        let inner = pack::pack_encrypted_anoncrypt(&msg, &[bob.verkey]).unwrap();
+        let outer = forward::wrap_in_forward(&bob.verkey, &inner, &mediator.verkey).unwrap();
+        (outer, mediator, bob)
+    }
+
+    #[test]
+    fn recognises_a_v1_envelope() {
+        let (outer, _, _) = v1_forward_envelope();
+        assert!(is_didcomm_v1(outer.as_bytes()));
+    }
+
+    /// A v2 JWE must not be mistaken for v1 — it has top-level `recipients` and
+    /// a different `typ`, and misrouting it would give the caller a nonsense
+    /// error from the wrong protocol handler.
+    #[test]
+    fn does_not_claim_a_v2_jwe() {
+        let v2 = serde_json::json!({
+            "protected": URL_SAFE_NO_PAD.encode(
+                br#"{"typ":"application/didcomm-encrypted+json","alg":"ECDH-1PU+A256KW","enc":"A256CBC-HS512"}"#
+            ),
+            "recipients": [{ "header": { "kid": "did:example:bob#key-1" }, "encrypted_key": "x" }],
+            "iv": "aXY",
+            "ciphertext": "Y3Q",
+            "tag": "dGFn",
+        });
+        assert!(!is_didcomm_v1(
+            serde_json::to_string(&v2).unwrap().as_bytes()
+        ));
+    }
+
+    #[test]
+    fn does_not_claim_non_envelopes() {
+        assert!(!is_didcomm_v1(b"not json"));
+        assert!(!is_didcomm_v1(br#"{"@id":"1","@type":"t"}"#));
+        // Envelope shape but an unknown `typ` — falls through to the v2 path.
+        let odd = serde_json::json!({
+            "protected": URL_SAFE_NO_PAD.encode(br#"{"typ":"JWM/9.9","alg":"Anoncrypt","enc":"x","recipients":[]}"#),
+            "iv": "aXY",
+            "ciphertext": "Y3Q",
+            "tag": "dGFn",
+        });
+        assert!(!is_didcomm_v1(
+            serde_json::to_string(&odd).unwrap().as_bytes()
+        ));
+    }
+
+    /// The mediator must be able to open the outer layer and read the routing
+    /// information, while the inner envelope stays sealed to the recipient.
+    #[test]
+    fn mediator_reads_routing_without_reading_the_payload() {
+        let (outer, mediator, bob) = v1_forward_envelope();
+
+        let x25519 = mediator.x25519_private();
+        let keys = [RecipientKey {
+            verkey: mediator.verkey,
+            x25519_private: &x25519,
+        }];
+        let opened = envelope::open(&outer, &keys).expect("mediator opens the outer layer");
+
+        let message =
+            affinidi_messaging_didcomm_v1::MessageV1::from_json(&opened.plaintext).unwrap();
+        assert!(forward::is_forward(&message));
+        assert_eq!(forward::destination(&message).unwrap(), bob.verkey);
+
+        // The inner is an envelope the mediator cannot open with its own key.
+        let inner = forward::extract_payload(&message).unwrap();
+        assert!(envelope::open(&inner, &keys).is_err());
+
+        // ...but Bob can.
+        let bob_x25519 = bob.x25519_private();
+        let bob_keys = [RecipientKey {
+            verkey: bob.verkey,
+            x25519_private: &bob_x25519,
+        }];
+        let delivered = unpack(&inner, &[&bob], &NoBindings).expect("bob unpacks");
+        assert!(matches!(delivered, UnpackResult::Anoncrypt { .. }));
+        let _ = bob_keys;
+    }
+
+    /// The outer forward really is anonymous, so the mediator has no sender to
+    /// route or authorise on — the reason recipient-side ACLs carry the weight.
+    #[test]
+    fn outer_forward_is_anonymous_to_the_mediator() {
+        let (outer, mediator, _) = v1_forward_envelope();
+        let result = unpack(&outer, &[&mediator], &NoBindings).expect("mediator unpacks");
+        assert!(
+            matches!(result, UnpackResult::Anoncrypt { .. }),
+            "a v1 forward must not expose a sender to the mediator"
+        );
+        assert!(!result.is_authcrypt());
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
@@ -40,6 +40,8 @@ use serde_json::Value;
 #[cfg(feature = "didcomm")]
 pub mod error_response;
 pub mod inbound;
+#[cfg(feature = "didcomm-v1")]
+pub mod inbound_v1;
 #[cfg(feature = "didcomm")]
 pub mod protocols;
 pub(crate) mod store;

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -663,6 +663,48 @@ pub async fn serve_internal(
         didcomm_v1_identity: Arc::new(tokio::sync::OnceCell::new()),
     };
 
+    // DIDComm v1 startup checks. Both run before the listener binds, so a
+    // misconfiguration is a refusal to start rather than traffic the mediator
+    // accepts and then silently drops.
+    #[cfg(feature = "didcomm-v1")]
+    if shared_state.config.didcomm_v1.enabled {
+        // The routing-key index is what turns a forward's `to` verkey into an
+        // account. A backend without it would accept v1 forwards and fail every
+        // lookup, so refuse rather than serve a protocol we cannot route.
+        if !shared_state.database.supports_v1_routing_keys() {
+            return Err(MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                "[didcomm_v1] is enabled but the configured storage backend does not implement \
+                 the v1 routing-key index; DIDComm v1 forwards could not be routed"
+                    .into(),
+            ));
+        }
+
+        // Derive eagerly so a missing Ed25519 authentication key fails at
+        // startup rather than on the first inbound forward, and so the routing
+        // verkey can be logged: v1 predates DID documents as a discovery
+        // mechanism, so an operator has to hand this to clients out of band and
+        // has nowhere else to read it from.
+        let identity = shared_state.didcomm_v1_identity().await?;
+        info!(
+            "DIDComm v1 enabled. Routing verkey (give this to v1 clients as their routingKey): {}",
+            identity.verkey().to_base58()
+        );
+        if shared_state
+            .config
+            .didcomm_v1
+            .allow_unauthenticated_forwards
+        {
+            warn!(
+                "DIDComm v1: allow_unauthenticated_forwards is ON. Anonymous callers may submit \
+                 v1 forwards to this mediator (recipient ACLs, message-size limits and per-IP \
+                 rate limiting still apply). This matches Aries mediator behaviour and is \
+                 required for stock Credo wallets; it does NOT open anonymous DIDComm v2 inbound."
+            );
+        }
+    }
+
     let app: Router = application_routes(&api_prefix, &shared_state);
 
     // The `RATE_LIMITED_TOTAL` metric used to be emitted inside the limiter

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -659,6 +659,8 @@ pub async fn serve_internal(
         clock,
         #[cfg(feature = "tsp")]
         tsp_identity: Arc::new(tokio::sync::OnceCell::new()),
+        #[cfg(feature = "didcomm-v1")]
+        didcomm_v1_identity: Arc::new(tokio::sync::OnceCell::new()),
     };
 
     let app: Router = application_routes(&api_prefix, &shared_state);

--- a/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/fjall_store.rs
@@ -100,7 +100,7 @@ const PUBSUB_BROADCAST_CAPACITY: usize = 32;
 /// Memory tuning for the embedded Fjall database.
 ///
 /// Fjall's stock defaults are sized for a general-purpose embedded store, not
-/// for a service that opens 14 keyspaces: 64 MiB of memtable *per keyspace*
+/// for a service that opens 15 keyspaces: 64 MiB of memtable *per keyspace*
 /// would permit ~896 MiB of write buffer on its own. These values come from
 /// `[storage.fjall]`.
 #[derive(Clone, Copy, Debug)]
@@ -152,6 +152,7 @@ const KEYSPACE_WRITE_WEIGHTS: &[(&str, u32)] = &[
     // Cold: written on admin action only.
     (PARTITION_ACCESS_LISTS, 1),
     (PARTITION_ADMINS, 1),
+    (PARTITION_V1_ROUTING_KEYS, 1),
     (PARTITION_OOB_INVITES, 1),
     (PARTITION_GLOBALS, 1),
 ];
@@ -180,6 +181,7 @@ const PARTITION_SESSIONS: &str = "sessions";
 const PARTITION_ACCOUNTS: &str = "accounts";
 const PARTITION_ACCESS_LISTS: &str = "access_lists";
 const PARTITION_ADMINS: &str = "admins";
+const PARTITION_V1_ROUTING_KEYS: &str = "v1_routing_keys";
 const PARTITION_OOB_INVITES: &str = "oob_invites";
 const PARTITION_FORWARD_QUEUE: &str = "forward_queue";
 const PARTITION_FORWARD_PENDING: &str = "forward_pending";
@@ -208,6 +210,9 @@ pub struct FjallStore {
     accounts: Keyspace,
     access_lists: Keyspace,
     admins: Keyspace,
+    /// base58 routing verkey -> owning account's DID hash. See
+    /// `MediatorStore::v1_routing_key_bind`.
+    v1_routing_keys: Keyspace,
     oob_invites: Keyspace,
     forward_queue: Keyspace,
     forward_pending: Keyspace,
@@ -556,6 +561,7 @@ impl FjallStore {
             accounts: open_partition(PARTITION_ACCOUNTS)?,
             access_lists: open_partition(PARTITION_ACCESS_LISTS)?,
             admins: open_partition(PARTITION_ADMINS)?,
+            v1_routing_keys: open_partition(PARTITION_V1_ROUTING_KEYS)?,
             oob_invites: open_partition(PARTITION_OOB_INVITES)?,
             forward_queue,
             forward_pending: open_partition(PARTITION_FORWARD_PENDING)?,
@@ -1699,10 +1705,98 @@ impl MediatorStore for FjallStore {
                 .map_err(|e| Self::db_err("account_remove:al.iter", e))?;
             batch.remove(&self.access_lists, key.as_ref());
         }
+        // Drop the account's v1 routing keys, or its verkeys keep resolving
+        // and inbound v1 traffic keeps being accepted for a mailbox that no
+        // longer exists. The index is keyed by verkey, so this is a scan —
+        // acceptable on a cold keyspace touched only by account removal and
+        // keylist updates.
+        for guard in self.v1_routing_keys.iter() {
+            let (key, value) = guard
+                .into_inner()
+                .map_err(|e| Self::db_err("account_remove:v1keys.iter", e))?;
+            if sha256::digest(value.as_ref()) == did_hash {
+                batch.remove(&self.v1_routing_keys, key.as_ref());
+            }
+        }
         batch
             .commit()
             .map_err(|e| Self::db_err("account_remove:commit", e))?;
         Ok(true)
+    }
+
+    // ─── DIDComm v1 routing keys ─────────────────────────────────────────────
+
+    fn supports_v1_routing_keys(&self) -> bool {
+        true
+    }
+
+    async fn v1_routing_key_bind(&self, verkey: &str, did: &str) -> Result<(), MediatorError> {
+        // Read-modify-write under the write lock: without it two concurrent
+        // binds for the same verkey could both observe "unbound" and the
+        // second would silently steal the first account's routing key.
+        let _guard = self.write_lock.lock().await;
+        if let Some(existing) = self
+            .v1_routing_keys
+            .get(verkey.as_bytes())
+            .map_err(|e| Self::db_err("v1_routing_key_bind:get", e))?
+        {
+            return if existing.as_ref() == did.as_bytes() {
+                Ok(()) // idempotent re-bind by the same owner
+            } else {
+                Err(MediatorError::ConfigError(
+                    12,
+                    "fjall".into(),
+                    "routing verkey is already bound to a different account".into(),
+                ))
+            };
+        }
+        self.v1_routing_keys
+            .insert(verkey.as_bytes(), did.as_bytes())
+            .map_err(|e| Self::db_err("v1_routing_key_bind:insert", e))?;
+        Ok(())
+    }
+
+    async fn v1_routing_key_lookup(&self, verkey: &str) -> Result<Option<String>, MediatorError> {
+        let Some(raw) = self
+            .v1_routing_keys
+            .get(verkey.as_bytes())
+            .map_err(|e| Self::db_err("v1_routing_key_lookup:get", e))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(String::from_utf8_lossy(raw.as_ref()).into_owned()))
+    }
+
+    async fn v1_routing_key_unbind(&self, verkey: &str) -> Result<bool, MediatorError> {
+        let _guard = self.write_lock.lock().await;
+        let existed = self
+            .v1_routing_keys
+            .get(verkey.as_bytes())
+            .map_err(|e| Self::db_err("v1_routing_key_unbind:get", e))?
+            .is_some();
+        if existed {
+            self.v1_routing_keys
+                .remove(verkey.as_bytes())
+                .map_err(|e| Self::db_err("v1_routing_key_unbind:remove", e))?;
+        }
+        Ok(existed)
+    }
+
+    async fn v1_routing_keys_for(&self, did_hash: &str) -> Result<Vec<String>, MediatorError> {
+        // The index is keyed by verkey and stores the DID, so matching by hash
+        // means hashing each stored DID. Acceptable on a cold keyspace touched
+        // only by keylist updates and account removal.
+        let mut keys = Vec::new();
+        for guard in self.v1_routing_keys.iter() {
+            let (key, value) = guard
+                .into_inner()
+                .map_err(|e| Self::db_err("v1_routing_keys_for:iter", e))?;
+            if sha256::digest(value.as_ref()) == did_hash {
+                keys.push(String::from_utf8_lossy(key.as_ref()).into_owned());
+            }
+        }
+        keys.sort();
+        Ok(keys)
     }
 
     async fn account_list(

--- a/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/store/memory_store.rs
@@ -206,6 +206,13 @@ struct MemoryState {
     access_lists: HashMap<String, Vec<String>>, // ordered for cursor pagination
     admins: HashSet<String>,
 
+    // ─── DIDComm v1 routing keys ────────────────────────────────────
+    /// base58 routing verkey → `(owning DID, its hash)`. A verkey binds to at
+    /// most one DID; see `MediatorStore::v1_routing_key_bind`. Both forms are
+    /// kept because forward ingress needs the DID while account removal works
+    /// from the hash.
+    v1_routing_keys: HashMap<String, (String, String)>,
+
     // ─── Audit log ──────────────────────────────────────────────────
     /// Privileged-change records, newest-first. Bounded ring capped at
     /// `AUDIT_LOG_MAX_ENTRIES` — the oldest (back) entry is dropped once
@@ -941,7 +948,75 @@ impl MediatorStore for MemoryStore {
         state.access_lists.remove(did_hash);
         state.admins.remove(did_hash);
         state.known_dids.retain(|d| d != did_hash);
+        // Drop the account's v1 routing keys too, or a removed account's
+        // verkeys keep resolving and its inbound v1 traffic keeps being
+        // accepted for a mailbox that no longer exists.
+        state
+            .v1_routing_keys
+            .retain(|_, (_, owner_hash)| owner_hash != did_hash);
         Ok(true)
+    }
+
+    // ─── DIDComm v1 routing keys ─────────────────────────────────────────────
+
+    fn supports_v1_routing_keys(&self) -> bool {
+        true
+    }
+
+    async fn v1_routing_key_bind(&self, verkey: &str, did: &str) -> Result<(), MediatorError> {
+        let mut state = self.state.lock().await;
+        match state.v1_routing_keys.get(verkey) {
+            // Idempotent re-bind by the same owner.
+            Some((owner, _)) if owner == did => Ok(()),
+            // Claiming another account's routing key would capture its inbound
+            // v1 traffic; see the trait's security note.
+            Some(_) => Err(MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                "routing verkey is already bound to a different account".into(),
+            )),
+            None => {
+                state.v1_routing_keys.insert(
+                    verkey.to_string(),
+                    (did.to_string(), sha256::digest(did.as_bytes())),
+                );
+                Ok(())
+            }
+        }
+    }
+
+    async fn v1_routing_key_lookup(&self, verkey: &str) -> Result<Option<String>, MediatorError> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .v1_routing_keys
+            .get(verkey)
+            .map(|(did, _)| did.clone()))
+    }
+
+    async fn v1_routing_key_unbind(&self, verkey: &str) -> Result<bool, MediatorError> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .v1_routing_keys
+            .remove(verkey)
+            .is_some())
+    }
+
+    async fn v1_routing_keys_for(&self, did_hash: &str) -> Result<Vec<String>, MediatorError> {
+        let state = self.state.lock().await;
+        let mut keys: Vec<String> = state
+            .v1_routing_keys
+            .iter()
+            .filter(|(_, (_, owner_hash))| owner_hash == did_hash)
+            .map(|(verkey, _)| verkey.clone())
+            .collect();
+        // HashMap order is not stable; sort so callers (and tests) see a
+        // deterministic list.
+        keys.sort();
+        Ok(keys)
     }
 
     async fn account_list(

--- a/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/store_conformance.rs
@@ -842,6 +842,134 @@ async fn check_oob_discovery_roundtrip(store: Arc<dyn MediatorStore>) {
     );
 }
 
+/// DIDComm v1 routing-key index: the bridge from a v1 forward's base58 verkey
+/// to the DID everything else in the mediator is keyed by.
+///
+/// The exclusivity assertion is the load-bearing one. If a verkey could be
+/// bound by two accounts, any account could claim another's routing key and
+/// capture its inbound v1 traffic — so a backend that lets the second bind
+/// through is not merely lax, it is a delivery-hijack primitive.
+async fn check_v1_routing_keys(store: Arc<dyn MediatorStore>) {
+    assert!(
+        store.supports_v1_routing_keys(),
+        "an in-tree backend must implement the v1 routing-key index"
+    );
+
+    // Bindings carry the DID; the reverse index is keyed by its hash. Both
+    // forms appear here because forward ingress needs the DID while account
+    // removal works from the hash.
+    let alice = "did:example:v1_alice";
+    let bob = "did:example:v1_bob";
+    let alice_hash = sha256::digest(alice.as_bytes());
+    let bob_hash = sha256::digest(bob.as_bytes());
+    let verkey = "3hLMcPh9X6vtEJfuJmCinWRHAYFMjea1cfLA2eCvWA5A";
+    let other = "9tovpLUbsf4mzkP1YVaZK31W7iWvcetc24QrnfhiFkkN";
+
+    store
+        .account_add(&alice_hash, &allow_all(), None)
+        .await
+        .expect("add alice");
+    store
+        .account_add(&bob_hash, &allow_all(), None)
+        .await
+        .expect("add bob");
+
+    assert_eq!(
+        store.v1_routing_key_lookup(verkey).await.expect("lookup"),
+        None,
+        "an unbound verkey must not resolve"
+    );
+
+    store
+        .v1_routing_key_bind(verkey, alice)
+        .await
+        .expect("bind");
+    assert_eq!(
+        store.v1_routing_key_lookup(verkey).await.expect("lookup"),
+        Some(alice.to_string())
+    );
+
+    // Re-binding to the same owner is idempotent.
+    store
+        .v1_routing_key_bind(verkey, alice)
+        .await
+        .expect("re-bind by the same owner is idempotent");
+
+    // ...but another account may not take it.
+    assert!(
+        store.v1_routing_key_bind(verkey, bob).await.is_err(),
+        "a verkey bound to one account must not be claimable by another"
+    );
+    assert_eq!(
+        store.v1_routing_key_lookup(verkey).await.expect("lookup"),
+        Some(alice.to_string()),
+        "the failed claim must not have changed the owner"
+    );
+
+    // Reverse index.
+    store
+        .v1_routing_key_bind(other, alice)
+        .await
+        .expect("bind second");
+    let mut expected = vec![other.to_string(), verkey.to_string()];
+    expected.sort();
+    assert_eq!(
+        store
+            .v1_routing_keys_for(&alice_hash)
+            .await
+            .expect("keys_for"),
+        expected,
+        "both of alice's verkeys must be listed, in a stable order"
+    );
+    assert!(
+        store
+            .v1_routing_keys_for(&bob_hash)
+            .await
+            .expect("keys_for")
+            .is_empty(),
+        "bob owns no routing keys"
+    );
+
+    // Unbind is reported truthfully and frees the verkey for another account.
+    assert!(store.v1_routing_key_unbind(other).await.expect("unbind"));
+    assert!(
+        !store
+            .v1_routing_key_unbind(other)
+            .await
+            .expect("unbind twice"),
+        "unbinding an already-unbound verkey reports false"
+    );
+    store
+        .v1_routing_key_bind(other, bob)
+        .await
+        .expect("a released verkey may be claimed by another account");
+
+    // Removing an account drops its bindings, or its verkeys keep resolving to
+    // a mailbox that no longer exists.
+    store
+        .account_remove(&admin_session("admin_hash"), &alice_hash)
+        .await
+        .expect("account_remove");
+    assert_eq!(
+        store.v1_routing_key_lookup(verkey).await.expect("lookup"),
+        None,
+        "a removed account's routing keys must stop resolving"
+    );
+    assert!(
+        store
+            .v1_routing_keys_for(&alice_hash)
+            .await
+            .expect("keys_for")
+            .is_empty(),
+        "a removed account owns no routing keys"
+    );
+    assert_eq!(
+        store.v1_routing_key_lookup(other).await.expect("lookup"),
+        Some(bob.to_string()),
+        "removing one account must not disturb another's bindings"
+    );
+}
+
 /// Generate one `#[tokio::test]` per check for a backend `$ctor`.
 /// Gated to the in-process backends that use it — a Redis-only build drives the
 /// async `conformance_for_redis!` instead, so an ungated def would warn (unused)
@@ -904,6 +1032,10 @@ macro_rules! conformance_for {
             async fn delivery_decision_matches_access_list() {
                 check_delivery_decision_matches_access_list(ready($ctor).await).await;
             }
+            #[tokio::test]
+            async fn v1_routing_keys() {
+                check_v1_routing_keys(ready($ctor).await).await;
+            }
         }
     };
 }
@@ -950,4 +1082,5 @@ conformance_for_redis!(redis,
     audit_log_lifecycle      => check_audit_log_lifecycle      @ 11,
     oob_discovery_roundtrip  => check_oob_discovery_roundtrip  @ 12,
     delivery_decision_matches_access_list => check_delivery_decision_matches_access_list @ 13,
+    v1_routing_keys          => check_v1_routing_keys          @ 14,
 );

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/app.rs
@@ -373,6 +373,13 @@ pub struct WizardConfig {
     pub didcomm_enabled: bool,
     /// TSP protocol enabled (experimental, default: false)
     pub tsp_enabled: bool,
+    /// DIDComm v1 (Aries RFC 0019) enabled (default: false). Additive
+    /// alongside DIDComm v2.1, and dependent on it.
+    pub didcomm_v1_enabled: bool,
+    /// Accept DIDComm v1 forwards without an authenticated session
+    /// (default: false). Required for stock Credo wallets, which cannot
+    /// complete this mediator's v2 challenge; see the `[didcomm_v1]` docs.
+    pub didcomm_v1_allow_unauthenticated_forwards: bool,
     pub did_method: String,
     pub public_url: String,
     /// When `did_method` produces a did:webvh, also export a did:web copy
@@ -533,6 +540,12 @@ impl WizardConfig {
         if self.tsp_enabled {
             features.push("tsp");
         }
+        // `didcomm-v1` implies `didcomm` in the mediator's Cargo features, but
+        // list it explicitly so the rendered build command reads as what the
+        // operator chose rather than relying on the implication.
+        if self.didcomm_v1_enabled {
+            features.push("didcomm-v1");
+        }
 
         features.push(match self.storage_backend.as_str() {
             crate::consts::STORAGE_BACKEND_FJALL => "fjall-backend",
@@ -579,6 +592,8 @@ impl Default for WizardConfig {
             vta_context: DEFAULT_VTA_CONTEXT.into(),
             didcomm_enabled: true,
             tsp_enabled: false,
+            didcomm_v1_enabled: false,
+            didcomm_v1_allow_unauthenticated_forwards: false,
             did_method: String::new(),
             public_url: String::new(),
             save_did_web: false,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/config_writer.rs
@@ -187,6 +187,24 @@ fn generate_toml(config: &WizardConfig, generated: &GeneratedValues) -> anyhow::
         }
     }
 
+    // ── [didcomm_v1] ───────────────────────────────────────────────────
+    // Aries RFC 0019 support. Written only when the operator enabled it, so a
+    // v2-only mediator.toml stays exactly as it was — and a re-run that turns
+    // v1 off strips the section rather than leaving a stale `enabled = true`.
+    {
+        if config.didcomm_v1_enabled {
+            if doc.get("didcomm_v1").is_none() {
+                doc["didcomm_v1"] = toml_edit::Item::Table(toml_edit::Table::new());
+            }
+            let v1 = doc.get_mut("didcomm_v1").expect("just inserted");
+            v1["enabled"] = toml_edit::value(true);
+            v1["allow_unauthenticated_forwards"] =
+                toml_edit::value(config.didcomm_v1_allow_unauthenticated_forwards);
+        } else {
+            doc.remove("didcomm_v1");
+        }
+    }
+
     // ── [security] ─────────────────────────────────────────────────────
     if let Some(sec) = doc.get_mut("security") {
         // SSL
@@ -878,6 +896,48 @@ mod tests {
                 "cors_allow_origin = \"https://app.affinidi.com,https://*.affinidi.com\""
             )
         );
+    }
+
+    /// The `[didcomm_v1]` section is written only when enabled, and a re-run
+    /// that turns it off strips it — leaving a stale `enabled = true` behind
+    /// would keep the mediator accepting v1 traffic the operator just disabled.
+    #[test]
+    fn didcomm_v1_section_is_written_only_when_enabled() {
+        let base = WizardConfig {
+            config_path: "conf/mediator.toml".into(),
+            deployment_type: "Local development".into(),
+            didcomm_enabled: true,
+            did_method: DID_PEER.into(),
+            secret_storage: STORAGE_STRING.into(),
+            ssl_mode: SSL_NONE.into(),
+            database_url: DEFAULT_REDIS_URL.into(),
+            admin_did_mode: ADMIN_GENERATE.into(),
+            listen_address: DEFAULT_LISTEN_ADDR.into(),
+            ..WizardConfig::default()
+        };
+
+        // Off (the default): no section at all, so a v2-only config is untouched.
+        let toml = generate_toml(&base, &test_generated()).unwrap();
+        assert!(!toml.contains("[didcomm_v1]"));
+
+        // On, forwards still authenticated.
+        let enabled = WizardConfig {
+            didcomm_v1_enabled: true,
+            ..base.clone()
+        };
+        let toml = generate_toml(&enabled, &test_generated()).unwrap();
+        assert!(toml.contains("[didcomm_v1]"));
+        assert!(toml.contains("enabled = true"));
+        assert!(toml.contains("allow_unauthenticated_forwards = false"));
+
+        // On, with the Aries-compatible posture explicitly chosen.
+        let anon = WizardConfig {
+            didcomm_v1_enabled: true,
+            didcomm_v1_allow_unauthenticated_forwards: true,
+            ..base.clone()
+        };
+        let toml = generate_toml(&anon, &test_generated()).unwrap();
+        assert!(toml.contains("allow_unauthenticated_forwards = true"));
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/recipe.rs
@@ -514,11 +514,21 @@ pub fn to_wizard_config(recipe: &BuildRecipe) -> anyhow::Result<WizardConfig> {
     // Protocols
     config.didcomm_enabled = false;
     config.tsp_enabled = false;
+    config.didcomm_v1_enabled = false;
     for proto in &recipe.deployment.protocols {
         match proto.as_str() {
             "didcomm" => config.didcomm_enabled = true,
             "tsp" => config.tsp_enabled = true,
-            other => anyhow::bail!("Invalid protocol '{other}': expected 'didcomm' or 'tsp'"),
+            // Additive over v2.1 and dependent on it: the mediator's
+            // `didcomm-v1` Cargo feature implies `didcomm`, and the v1 routing
+            // identity is derived from the same Ed25519 authentication key.
+            "didcomm-v1" => {
+                config.didcomm_v1_enabled = true;
+                config.didcomm_enabled = true;
+            }
+            other => anyhow::bail!(
+                "Invalid protocol '{other}': expected 'didcomm', 'didcomm-v1' or 'tsp'"
+            ),
         }
     }
     if !config.didcomm_enabled && !config.tsp_enabled {
@@ -716,6 +726,9 @@ pub fn from_wizard_config(config: &WizardConfig) -> String {
     }
     if config.tsp_enabled {
         protocols.push("\"tsp\"");
+    }
+    if config.didcomm_v1_enabled {
+        protocols.push("\"didcomm-v1\"");
     }
     out.push_str(&format!("protocols = [{}]\n", protocols.join(", ")));
     out.push_str(&format!("use_vta = {}\n", config.use_vta));
@@ -1402,6 +1415,47 @@ ssl = "none"
         let config = to_wizard_config(&recipe).unwrap();
         assert_eq!(config.ssl_cert_path, "/path/cert.pem");
         assert_eq!(config.ssl_key_path, "/path/key.pem");
+    }
+
+    /// `didcomm-v1` is additive over v2.1 and depends on it, so selecting it
+    /// alone must still turn v2.1 on — a recipe listing only `didcomm-v1`
+    /// otherwise produces a build whose Cargo features imply `didcomm` while
+    /// the wizard believes it is off.
+    #[test]
+    fn didcomm_v1_protocol_implies_didcomm() {
+        let mut recipe = minimal_recipe();
+        recipe.deployment.protocols = vec!["didcomm-v1".into()];
+
+        let config = to_wizard_config(&recipe).unwrap();
+        assert!(config.didcomm_v1_enabled);
+        assert!(
+            config.didcomm_enabled,
+            "didcomm-v1 must imply didcomm, matching the mediator's Cargo feature"
+        );
+        assert!(config.cargo_features().contains(&"didcomm-v1"));
+        assert!(config.cargo_features().contains(&"didcomm"));
+    }
+
+    #[test]
+    fn didcomm_v1_is_off_unless_requested() {
+        let mut recipe = minimal_recipe();
+        recipe.deployment.protocols = vec!["didcomm".into()];
+
+        let config = to_wizard_config(&recipe).unwrap();
+        assert!(!config.didcomm_v1_enabled);
+        assert!(!config.cargo_features().contains(&"didcomm-v1"));
+    }
+
+    #[test]
+    fn unknown_protocol_names_didcomm_v1_in_its_error() {
+        let mut recipe = minimal_recipe();
+        recipe.deployment.protocols = vec!["didcommv1".into()];
+
+        let err = to_wizard_config(&recipe).unwrap_err().to_string();
+        assert!(
+            err.contains("didcomm-v1"),
+            "the error should list the accepted spellings, got: {err}"
+        );
     }
 
     // ── from_wizard_config round-trip ──────────────────────────────────


### PR DESCRIPTION
Adds DIDComm v1 (Aries RFC 0019) **forward ingress** to the mediator, behind a
new `didcomm-v1` feature. Follows the `tsp` precedent: additive, compile-time,
off by default. A mediator built or configured without it behaves exactly as
before.

This is stage 1 of the two agreed. Stage 2 brings the Aries
`coordinate-mediation/1.0` and `messagepickup` protocols — see *Not yet usable
by a wallet* below.

## What it does

```text
anoncrypt(to = mediator routing verkey)
  └── { "@type": ".../routing/1.0/forward",
        "to":  "<recipient base58 verkey>",
        "msg": { …inner envelope, opaque to the mediator… } }
```

The mediator opens only the outer layer, resolves the `to` verkey to a local
account, applies that account's ACLs, and stores the inner envelope verbatim for
pickup. The inner bytes are never parsed — they are sealed end-to-end to the
recipient, exactly as the TSP relay path treats an opaque inner.

## Three things worth reviewing closely

### 1. The sniff needs two discriminators

A v2 JWE and a v1 envelope share `protected` / `iv` / `ciphertext` / `tag`, so
shape alone cannot separate them. v1 is identified by having **no top-level
`recipients`** (it nests them inside the protected header) **and** declaring
`"typ": "JWM/1.0"`. Requiring both means an unknown envelope falls through to the
v2 path and gets v2's error, rather than being misreported as broken v1.

### 2. Anonymous admission is v1-scoped, deliberately

An RFC 0019 forward is anon-packed *by design*, so there is no authenticated
sender to apply a sender-side ACL to — the recipient's access list carries the
weight. That is a real departure from this mediator's posture, so it is opt-in
per deployment via `[didcomm_v1] allow_unauthenticated_forwards` (default
`false`), and it is what stock Credo wallets need, since they cannot complete
the v2 challenge.

Turning it on must not become a general anonymous-inbound licence. So
`anonymous_session_for` yields a **v1-scoped** session when admitted only by that
flag:

- the handler refuses any non-v1 body on it (`ANON_V1_SESSION_ID`);
- as defence in depth the session carries `SEND_MESSAGES` **without**
  `SEND_FORWARDED`, so it could not drive a v2 relay forward even if the body
  check were bypassed;
- inter-mediator relay admission keeps precedence and its existing capabilities;
- a *presented but invalid* credential is still never downgraded to anonymous.

Four tests cover exactly these.

### 3. A verkey binds to at most one DID

Otherwise any account could claim another's routing key and capture its inbound
v1 traffic — a delivery-hijack primitive, not a tidiness issue. Redis enforces it
with `SETNX`; the in-process backends do it under their write lock. The
conformance suite asserts the second claim is refused **and** that the failed
claim leaves the original owner intact.

## The store layer

`MediatorStore` gains `v1_routing_key_bind` / `_lookup` / `_unbind` /
`v1_routing_keys_for`, plus a `supports_v1_routing_keys()` probe. All have
defaults so third-party backends keep compiling, and the probe defaults to
`false` — **startup refuses to run** with v1 enabled on a backend that returns
it, rather than accepting traffic it could not route.

The index stores the **DID**, not its hash. I wrote it hash-keyed first, then
found `WrapperType::Envelope` takes a DID and hashes it internally: a hash cannot
be reversed, so ingress would have had nothing to hand the store path. The
*reverse* index stays hash-keyed because that is what `account_remove` works
from — and it does purge, or a removed account's verkeys keep resolving to a
mailbox that no longer exists.

Implemented for all three backends (memory, fjall, redis) with conformance
coverage.

## No new key material

The mediator's v1 routing verkey is derived from the Ed25519 authentication key
it already holds — v1 does key agreement on that key's Montgomery form. Same
trick `tsp_identity` uses: one set of operating secrets, three protocols. Pinned
in a test against the verkey a real Credo agent produced for the same seed.

It is logged at startup, and the identity is derived eagerly so a missing key
fails at boot rather than on the first inbound forward. v1 predates DID
documents as a discovery mechanism, so operators have to hand this to clients out
of band and have nowhere else to read it from.

## mediator-setup

`didcomm-v1` becomes a recipe protocol and writes a `[didcomm_v1]` section.
Selecting it turns `didcomm` on too, matching the Cargo feature — otherwise a
recipe listing only `didcomm-v1` produces a build whose features imply v2.1 while
the wizard believes it is off. The section is written only when enabled, and a
re-run that disables v1 strips it rather than leaving a stale `enabled = true`.

## Not yet usable by a wallet

Deliberately, per the staged plan. There is no client-facing way to register a
routing key until `coordinate-mediation/1.0` lands, so bindings can only be
created through the store API and a stock Credo wallet cannot yet use this
mediator end-to-end. Stage 2 adds registration and pickup.

## Incidental

Corrects the fjall keyspace count in three places (14 → 15) now that the routing
index adds one.

## Verification

- `cargo test -p affinidi-messaging-mediator` — 254 pass on
  `didcomm-v1,memory-backend,fjall-backend`; 182 lib tests on the default build
- `cargo test -p affinidi-messaging-mediator-setup` — 406 pass
- Store conformance green on memory + fjall (Redis paths are `REDIS_URL`-gated
  as usual)
- `cargo clippy --workspace --all-targets` clean; mediator clean on default,
  `didcomm-v1`, and `didcomm-v1,tsp`
- `check-version-bumps.sh`, `check-changelogs.sh`,
  `check-workspace-duplicates.sh` — all pass
