### PR TITLE
feat: add v1 coordinate-mediation and message-pickup to the mediator

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
@@ -1,5 +1,40 @@
 # affinidi-messaging-didcomm-v1 changelog
 
+## 0.2.0 — 8th August 2026
+
+Adds the two Aries protocols a wallet needs to use a mediator.
+
+### Added
+
+- **`protocols::coordinate_mediation`** (RFC 0211) — `mediate-request` /
+  `-grant` / `-deny`, `keylist-update` and its response, `keylist-query` /
+  `keylist`.
+- **`protocols::message_pickup`** (RFC 0685, 2.0) — `status-request` /
+  `status`, `delivery-request` / `delivery`, `messages-received`,
+  `live-delivery-change`, plus `~transport.return_route` helpers.
+- **`Verkey::parse` / `from_did_key` / `to_did_key`** — a key field written as
+  bare base58 or as `did:key` names the same key, and both spellings are on the
+  wire.
+
+### Wire-format notes
+
+- **A third dual-spelling trap.** `recipient_key` and `routing_keys` accept
+  base58 *or* `did:key`: RFC 0211 specifies the latter, base58 predates it and
+  is still widely sent, and Credo normalises on receipt while choosing its
+  outbound form from `useDidKeyInProtocols`. Comparing the strings drops half
+  the ecosystem — the same shape as the two message-type document URIs, one
+  field down. Parse, then compare `Verkey`s. This crate emits base58.
+- **Delivery is not deletion.** A `delivery` removes nothing; only
+  `messages-received` may. A mediator that deletes on delivery loses any
+  message whose delivery was lost in flight.
+- **`~transport: { return_route: "all" }`** is how these requests expect their
+  reply in the HTTP response body. Credo's `isValidJweStructure` requires only
+  `protected` / `iv` / `ciphertext` / `tag`, so a v1 envelope is accepted there
+  unchanged.
+
+Scoped to pickup 2.0: Credo's default strategy is PickUpV2 and 1.0
+(`batch-pickup`) is legacy.
+
 ## 0.1.1 — 8th August 2026
 
 Manifest fix. No code change.

--- a/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm-v1"
 description = "DIDComm v1 (Aries RFC 0019) messaging implementation for the Affinidi TDK"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-didcomm-v1/src/identity.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/src/identity.rs
@@ -146,6 +146,38 @@ impl Verkey {
         Ok(Self(bytes))
     }
 
+    /// Decode a verkey written **either** as bare base58btc **or** as a
+    /// `did:key:z6Mk…`.
+    ///
+    /// Both spellings appear on the wire for the same key, and which one a peer
+    /// sends is its configuration. Aries RFC 0211 specifies `did:key` for
+    /// `recipient_key` and `routing_keys`, but base58 predates it and is still
+    /// widely sent; Credo normalises with `didKeyToVerkey` on receipt and picks
+    /// its own outbound form from `useDidKeyInProtocols`.
+    ///
+    /// Comparing the two spellings with `==` silently drops half the ecosystem,
+    /// in the same way [`crate::message::message_type`] describes for message
+    /// type URIs. Parse with this, then compare [`Verkey`]s.
+    pub fn parse(encoded: &str) -> Result<Self, DIDCommV1Error> {
+        let encoded = encoded.trim();
+        if encoded.starts_with("did:key:") {
+            return Self::from_did_key(encoded);
+        }
+        Self::from_base58(encoded)
+    }
+
+    /// Decode a `did:key:z6Mk…` Ed25519 identifier.
+    pub fn from_did_key(did_key: &str) -> Result<Self, DIDCommV1Error> {
+        Ok(Self(affinidi_crypto::did_key::did_key_to_ed25519_pub(
+            did_key.trim(),
+        )?))
+    }
+
+    /// This verkey as a `did:key:z6Mk…` identifier — the RFC 0211 spelling.
+    pub fn to_did_key(&self) -> String {
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&self.0)
+    }
+
     /// The raw Ed25519 public key bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
@@ -352,6 +384,52 @@ mod tests {
         let verkey = Verkey::from_bytes([7u8; 32]);
         let encoded = verkey.to_base58();
         assert_eq!(Verkey::from_base58(&encoded).unwrap(), verkey);
+    }
+
+    /// The property that keeps `recipient_key` / `routing_keys` interoperable:
+    /// both spellings of one key must parse to the same [`Verkey`].
+    #[test]
+    fn verkey_parses_both_did_key_and_base58() {
+        let verkey = Verkey::from_bytes([9u8; 32]);
+        let base58 = verkey.to_base58();
+        let did_key = verkey.to_did_key();
+
+        assert!(did_key.starts_with("did:key:z6Mk"));
+        assert_ne!(
+            base58, did_key,
+            "the two spellings are different strings..."
+        );
+        assert_eq!(Verkey::parse(&base58).unwrap(), verkey);
+        assert_eq!(
+            Verkey::parse(&did_key).unwrap(),
+            verkey,
+            "...but must name the same key"
+        );
+        assert_eq!(Verkey::from_did_key(&did_key).unwrap(), verkey);
+    }
+
+    #[test]
+    fn verkey_parse_tolerates_surrounding_whitespace() {
+        let verkey = Verkey::from_bytes([3u8; 32]);
+        assert_eq!(
+            Verkey::parse(&format!("  {}\n", verkey.to_base58())).unwrap(),
+            verkey
+        );
+        assert_eq!(
+            Verkey::parse(&format!(" {} ", verkey.to_did_key())).unwrap(),
+            verkey
+        );
+    }
+
+    #[test]
+    fn verkey_parse_rejects_a_non_ed25519_did_key() {
+        // A `did:key` for some other curve must not be silently accepted as an
+        // Ed25519 verkey.
+        assert!(
+            Verkey::from_did_key("did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme")
+                .is_err()
+        );
+        assert!(Verkey::parse("did:key:not-a-key").is_err());
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/coordinate_mediation.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/coordinate_mediation.rs
@@ -1,0 +1,485 @@
+//! Coordinate Mediation 1.0 (Aries RFC 0211).
+//!
+//! How an edge agent asks a mediator to route for it, and tells the mediator
+//! which keys to route to:
+//!
+//! ```text
+//! recipient                                mediator
+//!    │  mediate-request  ───────────────────▶ │
+//!    │ ◀─────────────── mediate-grant        │  { endpoint, routing_keys }
+//!    │  keylist-update (add K) ─────────────▶ │
+//!    │ ◀─────────── keylist-update-response  │  per-key result
+//!    │  keylist-query  ─────────────────────▶ │
+//!    │ ◀───────────────────────── keylist    │
+//! ```
+//!
+//! The keys registered by `keylist-update` are exactly what a
+//! `routing/1.0/forward` later addresses, so this protocol is what populates a
+//! mediator's verkey → account index.
+//!
+//! # `recipient_key` has two spellings
+//!
+//! RFC 0211 specifies `did:key`, but bare base58 predates it and is still
+//! widely sent — Credo normalises on receipt and chooses its outbound form from
+//! `useDidKeyInProtocols`. Every key field here is therefore parsed with
+//! [`Verkey::parse`], which accepts both, and comparisons happen on the decoded
+//! [`Verkey`] rather than the string. Comparing the strings drops half the
+//! ecosystem; see [`crate::identity::Verkey::parse`].
+//!
+//! This crate emits **base58** by default ([`KeyFormat`]), the form every
+//! Aries-lineage agent understands including pre-`did:key` ones — the same
+//! asymmetry that makes `did:sov` the default message-type prefix.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::error::DIDCommV1Error;
+use crate::identity::Verkey;
+use crate::message::{MessageV1, TypeFormat, types_match};
+
+/// `mediate-request` — ask a mediator to route.
+pub const MEDIATE_REQUEST_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/mediate-request";
+/// `mediate-grant` — permission given, with the routing information to use.
+pub const MEDIATE_GRANT_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/mediate-grant";
+/// `mediate-deny` — permission refused.
+pub const MEDIATE_DENY_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/mediate-deny";
+/// `keylist-update` — register or drop routing keys.
+pub const KEYLIST_UPDATE_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/keylist-update";
+/// `keylist-update-response` — per-key outcome of a `keylist-update`.
+pub const KEYLIST_UPDATE_RESPONSE_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/keylist-update-response";
+/// `keylist-query` — ask which keys the mediator holds.
+pub const KEYLIST_QUERY_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/keylist-query";
+/// `keylist` — the answer to a `keylist-query`.
+pub const KEYLIST_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/coordinate-mediation/1.0/keylist";
+
+/// How to spell a key on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum KeyFormat {
+    /// Bare base58btc. The default: understood by every Aries-lineage agent,
+    /// including those predating RFC 0211's `did:key` guidance.
+    #[default]
+    Base58,
+    /// `did:key:z6Mk…`, as RFC 0211 specifies.
+    DidKey,
+}
+
+impl KeyFormat {
+    fn render(&self, verkey: &Verkey) -> String {
+        match self {
+            KeyFormat::Base58 => verkey.to_base58(),
+            KeyFormat::DidKey => verkey.to_did_key(),
+        }
+    }
+}
+
+/// Whether to add or remove a key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum KeylistAction {
+    Add,
+    Remove,
+}
+
+/// Per-key outcome of a `keylist-update`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum KeylistResult {
+    /// The update was applied.
+    Success,
+    /// The update was a no-op (adding a key already held, removing one not
+    /// held). Distinct from `Success` so a client can tell "I did that" from
+    /// "that was already true".
+    NoChange,
+    /// The request was malformed or not permitted — e.g. removing a key owned
+    /// by a different account.
+    ClientError,
+    /// The mediator failed to apply the update.
+    ServerError,
+}
+
+/// One requested key change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeylistUpdate {
+    /// The key, decoded from either spelling.
+    pub recipient_key: Verkey,
+    pub action: KeylistAction,
+}
+
+/// One applied key change, as reported back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeylistUpdated {
+    pub recipient_key: Verkey,
+    pub action: KeylistAction,
+    pub result: KeylistResult,
+}
+
+/// Build a `mediate-request`. It carries no fields of its own.
+pub fn mediate_request() -> Result<MessageV1, DIDCommV1Error> {
+    MessageV1::new(MEDIATE_REQUEST_TYPE, json!({}))
+}
+
+/// Build a `mediate-grant` in reply to `request_id`.
+///
+/// `endpoint` is the URL the recipient should publish for inbound traffic, and
+/// `routing_keys` are the keys senders must forward through to reach it.
+pub fn mediate_grant(
+    request_id: &str,
+    endpoint: &str,
+    routing_keys: &[Verkey],
+    format: KeyFormat,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let keys: Vec<Value> = routing_keys
+        .iter()
+        .map(|k| Value::String(format.render(k)))
+        .collect();
+    Ok(MessageV1::new(
+        MEDIATE_GRANT_TYPE,
+        json!({ "endpoint": endpoint, "routing_keys": keys }),
+    )?
+    .thid(request_id))
+}
+
+/// Build a `mediate-deny` in reply to `request_id`.
+pub fn mediate_deny(request_id: &str) -> Result<MessageV1, DIDCommV1Error> {
+    Ok(MessageV1::new(MEDIATE_DENY_TYPE, json!({}))?.thid(request_id))
+}
+
+/// Read the `updates` of a `keylist-update`.
+///
+/// An entry whose `recipient_key` cannot be decoded is an error rather than a
+/// silent skip: dropping it would leave the client believing a key was
+/// registered when it was not.
+pub fn parse_keylist_update(msg: &MessageV1) -> Result<Vec<KeylistUpdate>, DIDCommV1Error> {
+    let updates = msg
+        .body
+        .get("updates")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            DIDCommV1Error::InvalidMessage("keylist-update has no `updates` array".into())
+        })?;
+
+    updates
+        .iter()
+        .map(|entry| {
+            let key = entry
+                .get("recipient_key")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    DIDCommV1Error::InvalidMessage(
+                        "keylist-update entry has no `recipient_key`".into(),
+                    )
+                })?;
+            let action = entry.get("action").and_then(Value::as_str).ok_or_else(|| {
+                DIDCommV1Error::InvalidMessage("keylist-update entry has no `action`".into())
+            })?;
+            let action = match action {
+                "add" => KeylistAction::Add,
+                "remove" => KeylistAction::Remove,
+                other => {
+                    return Err(DIDCommV1Error::InvalidMessage(format!(
+                        "unknown keylist-update action `{other}`"
+                    )));
+                }
+            };
+            Ok(KeylistUpdate {
+                recipient_key: Verkey::parse(key)?,
+                action,
+            })
+        })
+        .collect()
+}
+
+/// Build a `keylist-update` requesting `updates`.
+pub fn keylist_update(
+    updates: &[KeylistUpdate],
+    format: KeyFormat,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let entries: Vec<Value> = updates
+        .iter()
+        .map(|u| {
+            json!({
+                "recipient_key": format.render(&u.recipient_key),
+                "action": u.action,
+            })
+        })
+        .collect();
+    MessageV1::new(KEYLIST_UPDATE_TYPE, json!({ "updates": entries }))
+}
+
+/// Build a `keylist-update-response` in reply to `request_id`.
+///
+/// The member is `updated`, not `updates` — a detail worth pinning, since the
+/// request and the response differ by one letter and a client that finds
+/// neither reports the whole update as failed.
+pub fn keylist_update_response(
+    request_id: &str,
+    updated: &[KeylistUpdated],
+    format: KeyFormat,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let entries: Vec<Value> = updated
+        .iter()
+        .map(|u| {
+            json!({
+                "recipient_key": format.render(&u.recipient_key),
+                "action": u.action,
+                "result": u.result,
+            })
+        })
+        .collect();
+    Ok(
+        MessageV1::new(KEYLIST_UPDATE_RESPONSE_TYPE, json!({ "updated": entries }))?
+            .thid(request_id),
+    )
+}
+
+/// Build a `keylist` in reply to `request_id`.
+pub fn keylist(
+    request_id: &str,
+    keys: &[Verkey],
+    format: KeyFormat,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let entries: Vec<Value> = keys
+        .iter()
+        .map(|k| json!({ "recipient_key": format.render(k) }))
+        .collect();
+    Ok(MessageV1::new(KEYLIST_TYPE, json!({ "keys": entries }))?.thid(request_id))
+}
+
+/// Which coordinate-mediation message this is, if any.
+///
+/// Matching goes through [`types_match`], so both document-URI spellings are
+/// recognised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CoordinateMediation {
+    MediateRequest,
+    MediateGrant,
+    MediateDeny,
+    KeylistUpdate,
+    KeylistUpdateResponse,
+    KeylistQuery,
+    Keylist,
+}
+
+impl CoordinateMediation {
+    /// Classify `msg`, or `None` if it is not a coordinate-mediation message.
+    pub fn classify(msg: &MessageV1) -> Option<Self> {
+        for (typ, kind) in [
+            (MEDIATE_REQUEST_TYPE, Self::MediateRequest),
+            (MEDIATE_GRANT_TYPE, Self::MediateGrant),
+            (MEDIATE_DENY_TYPE, Self::MediateDeny),
+            (KEYLIST_UPDATE_TYPE, Self::KeylistUpdate),
+            (KEYLIST_UPDATE_RESPONSE_TYPE, Self::KeylistUpdateResponse),
+            (KEYLIST_QUERY_TYPE, Self::KeylistQuery),
+            (KEYLIST_TYPE, Self::Keylist),
+        ] {
+            if types_match(&msg.typ, typ) {
+                return Some(kind);
+            }
+        }
+        None
+    }
+}
+
+/// Re-render every message type in this protocol into the given document-URI
+/// form. Convenience for a peer that prefers `https://didcomm.org`.
+pub fn with_type_format(msg: MessageV1, format: TypeFormat) -> MessageV1 {
+    msg.with_type_format(format)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn verkey(seed: u8) -> Verkey {
+        Verkey::from_bytes([seed; 32])
+    }
+
+    #[test]
+    fn mediate_grant_wire_shape() {
+        let msg = mediate_grant(
+            "req-1",
+            "https://mediator.example/inbound",
+            &[verkey(1)],
+            KeyFormat::Base58,
+        )
+        .unwrap();
+
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+        assert_eq!(wire["@type"], MEDIATE_GRANT_TYPE);
+        assert_eq!(wire["endpoint"], "https://mediator.example/inbound");
+        assert_eq!(wire["routing_keys"][0], verkey(1).to_base58());
+        assert_eq!(
+            wire["~thread"]["thid"], "req-1",
+            "the grant must thread to the request"
+        );
+    }
+
+    #[test]
+    fn mediate_grant_can_emit_did_key_routing_keys() {
+        let msg = mediate_grant(
+            "req-1",
+            "https://x/inbound",
+            &[verkey(1)],
+            KeyFormat::DidKey,
+        )
+        .unwrap();
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+        assert_eq!(wire["routing_keys"][0], verkey(1).to_did_key());
+    }
+
+    /// The interop property: a `keylist-update` written in either key spelling
+    /// must parse to the same keys.
+    #[test]
+    fn keylist_update_parses_both_key_spellings() {
+        let key = verkey(7);
+
+        for spelling in [key.to_base58(), key.to_did_key()] {
+            let msg = MessageV1::new(
+                KEYLIST_UPDATE_TYPE,
+                json!({ "updates": [{ "recipient_key": spelling, "action": "add" }] }),
+            )
+            .unwrap();
+
+            let parsed = parse_keylist_update(&msg).unwrap();
+            assert_eq!(parsed.len(), 1);
+            assert_eq!(parsed[0].recipient_key, key);
+            assert_eq!(parsed[0].action, KeylistAction::Add);
+        }
+    }
+
+    #[test]
+    fn keylist_update_round_trips() {
+        let updates = vec![
+            KeylistUpdate {
+                recipient_key: verkey(1),
+                action: KeylistAction::Add,
+            },
+            KeylistUpdate {
+                recipient_key: verkey(2),
+                action: KeylistAction::Remove,
+            },
+        ];
+        let msg = keylist_update(&updates, KeyFormat::Base58).unwrap();
+        assert_eq!(parse_keylist_update(&msg).unwrap(), updates);
+    }
+
+    /// A malformed entry must fail the parse, not be skipped — a silent skip
+    /// would leave the client believing a key was registered when it was not.
+    #[test]
+    fn malformed_keylist_entries_are_errors_not_skips() {
+        for body in [
+            json!({ "updates": [{ "action": "add" }] }),
+            json!({ "updates": [{ "recipient_key": "not-a-key", "action": "add" }] }),
+            json!({ "updates": [{ "recipient_key": "z", "action": "sideways" }] }),
+            json!({ "no_updates": [] }),
+        ] {
+            let msg = MessageV1::new(KEYLIST_UPDATE_TYPE, body).unwrap();
+            assert!(parse_keylist_update(&msg).is_err());
+        }
+    }
+
+    /// The response member is `updated`, not `updates`.
+    #[test]
+    fn keylist_update_response_uses_the_updated_member() {
+        let msg = keylist_update_response(
+            "req-1",
+            &[KeylistUpdated {
+                recipient_key: verkey(4),
+                action: KeylistAction::Add,
+                result: KeylistResult::Success,
+            }],
+            KeyFormat::Base58,
+        )
+        .unwrap();
+
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+        assert!(
+            wire.get("updates").is_none(),
+            "the request member is `updates`"
+        );
+        assert_eq!(wire["updated"][0]["recipient_key"], verkey(4).to_base58());
+        assert_eq!(wire["updated"][0]["action"], "add");
+        assert_eq!(wire["updated"][0]["result"], "success");
+        assert_eq!(wire["~thread"]["thid"], "req-1");
+    }
+
+    /// `result` is snake_case on the wire; `no_change` in particular must not
+    /// serialise as `NoChange`.
+    #[test]
+    fn keylist_results_serialise_in_snake_case() {
+        for (result, expected) in [
+            (KeylistResult::Success, "success"),
+            (KeylistResult::NoChange, "no_change"),
+            (KeylistResult::ClientError, "client_error"),
+            (KeylistResult::ServerError, "server_error"),
+        ] {
+            assert_eq!(serde_json::to_value(result).unwrap(), json!(expected));
+        }
+    }
+
+    #[test]
+    fn classifies_every_message_in_both_type_spellings() {
+        for (typ, expected) in [
+            (MEDIATE_REQUEST_TYPE, CoordinateMediation::MediateRequest),
+            (MEDIATE_GRANT_TYPE, CoordinateMediation::MediateGrant),
+            (MEDIATE_DENY_TYPE, CoordinateMediation::MediateDeny),
+            (KEYLIST_UPDATE_TYPE, CoordinateMediation::KeylistUpdate),
+            (
+                KEYLIST_UPDATE_RESPONSE_TYPE,
+                CoordinateMediation::KeylistUpdateResponse,
+            ),
+            (KEYLIST_QUERY_TYPE, CoordinateMediation::KeylistQuery),
+            (KEYLIST_TYPE, CoordinateMediation::Keylist),
+        ] {
+            let legacy = MessageV1::new(typ, json!({})).unwrap();
+            assert_eq!(CoordinateMediation::classify(&legacy), Some(expected));
+
+            // Credo emits the https://didcomm.org form by default.
+            let modern = legacy.with_type_format(TypeFormat::DidCommOrg);
+            assert!(modern.typ.starts_with("https://didcomm.org/"));
+            assert_eq!(
+                CoordinateMediation::classify(&modern),
+                Some(expected),
+                "both document-URI spellings must classify identically"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_messages() {
+        let basic = crate::protocols::basic_message::BasicMessage::new("hi")
+            .unwrap()
+            .finalize();
+        assert_eq!(CoordinateMediation::classify(&basic), None);
+    }
+
+    #[test]
+    fn keylist_lists_keys_and_threads_to_the_query() {
+        let msg = keylist("q-1", &[verkey(1), verkey(2)], KeyFormat::Base58).unwrap();
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+        assert_eq!(wire["keys"][0]["recipient_key"], verkey(1).to_base58());
+        assert_eq!(wire["keys"][1]["recipient_key"], verkey(2).to_base58());
+        assert_eq!(wire["~thread"]["thid"], "q-1");
+    }
+
+    #[test]
+    fn deny_threads_to_the_request() {
+        let msg = mediate_deny("req-9").unwrap();
+        assert_eq!(msg.explicit_thid(), Some("req-9"));
+        assert_eq!(
+            CoordinateMediation::classify(&msg),
+            Some(CoordinateMediation::MediateDeny)
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/message_pickup.rs
@@ -1,0 +1,461 @@
+//! Message Pickup 2.0 (Aries RFC 0685).
+//!
+//! How an edge agent collects messages a mediator is holding for it:
+//!
+//! ```text
+//! recipient                                mediator
+//!    │  status-request  ────────────────────▶ │
+//!    │ ◀───────────────────────── status     │  { message_count }
+//!    │  delivery-request (limit) ───────────▶ │
+//!    │ ◀─────────────────────── delivery     │  messages in ~attach
+//!    │  messages-received (ids) ────────────▶ │
+//!    │ ◀───────────────────────── status     │  remaining count
+//! ```
+//!
+//! # Delivery is not deletion
+//!
+//! A `delivery` does **not** remove anything. The recipient acknowledges with
+//! `messages-received`, and only then may the mediator drop them. That is what
+//! makes pickup safe over a lossy transport: a delivery lost in flight is
+//! re-delivered on the next request, because nothing was deleted on send.
+//! A mediator that deletes on delivery silently loses messages.
+//!
+//! # `~transport.return_route`
+//!
+//! Every request here is sent expecting its response in the **HTTP response
+//! body** — Aries' synchronous request/response over a one-way transport. The
+//! decorator that asks for it is `~transport: { return_route: "all" }`; see
+//! [`with_return_route`] and [`wants_return_route`].
+//!
+//! # Version
+//!
+//! 2.0 only. Credo's default pickup strategy is `PickUpV2`, and 1.0
+//! (`batch-pickup`) is legacy — worth adding only if a target wallet turns out
+//! to need it.
+
+use serde_json::{Value, json};
+
+use crate::error::DIDCommV1Error;
+use crate::identity::Verkey;
+use crate::message::{MessageV1, types_match};
+
+/// `status-request` — ask how many messages are queued.
+pub const STATUS_REQUEST_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/status-request";
+/// `status` — the queue state.
+pub const STATUS_TYPE: &str = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/status";
+/// `delivery-request` — ask for up to `limit` queued messages.
+pub const DELIVERY_REQUEST_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/delivery-request";
+/// `delivery` — queued messages, carried in the `~attach` decorator.
+pub const DELIVERY_TYPE: &str = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/delivery";
+/// `messages-received` — acknowledge delivered messages so they can be dropped.
+pub const MESSAGES_RECEIVED_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/messages-received";
+/// `live-delivery-change` — turn push delivery on or off.
+pub const LIVE_DELIVERY_CHANGE_TYPE: &str =
+    "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/messagepickup/2.0/live-delivery-change";
+
+/// The `~transport` decorator value asking for a response on the same
+/// connection.
+pub const RETURN_ROUTE_ALL: &str = "all";
+
+/// One queued message to deliver: its id and the packed envelope.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueuedMessage {
+    /// The mediator's id for this message, echoed back in `messages-received`.
+    pub id: String,
+    /// The packed envelope, verbatim. Carried as attachment `data.json`.
+    pub envelope: Value,
+}
+
+/// Which pickup message this is, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MessagePickup {
+    StatusRequest,
+    Status,
+    DeliveryRequest,
+    Delivery,
+    MessagesReceived,
+    LiveDeliveryChange,
+}
+
+impl MessagePickup {
+    /// Classify `msg`, or `None` if it is not a pickup message. Recognises both
+    /// document-URI spellings.
+    pub fn classify(msg: &MessageV1) -> Option<Self> {
+        for (typ, kind) in [
+            (STATUS_REQUEST_TYPE, Self::StatusRequest),
+            (STATUS_TYPE, Self::Status),
+            (DELIVERY_REQUEST_TYPE, Self::DeliveryRequest),
+            (DELIVERY_TYPE, Self::Delivery),
+            (MESSAGES_RECEIVED_TYPE, Self::MessagesReceived),
+            (LIVE_DELIVERY_CHANGE_TYPE, Self::LiveDeliveryChange),
+        ] {
+            if types_match(&msg.typ, typ) {
+                return Some(kind);
+            }
+        }
+        None
+    }
+}
+
+/// Attach `~transport: { return_route: "all" }`, asking the peer to answer on
+/// the same connection.
+pub fn with_return_route(msg: MessageV1) -> MessageV1 {
+    msg.field("~transport", json!({ "return_route": RETURN_ROUTE_ALL }))
+}
+
+/// Whether `msg` asks for its response on the same connection.
+///
+/// A mediator uses this to decide between replying in the HTTP response body
+/// and queueing the reply for later pickup.
+pub fn wants_return_route(msg: &MessageV1) -> bool {
+    msg.body
+        .get("~transport")
+        .and_then(|t| t.get("return_route"))
+        .and_then(Value::as_str)
+        .is_some_and(|route| route == RETURN_ROUTE_ALL)
+}
+
+/// The optional `recipient_key` scoping a request to one of the caller's keys.
+///
+/// Absent means "all of my keys". A key that cannot be decoded is an error, not
+/// a silent fallback to "all" — the difference decides whose messages get
+/// returned.
+pub fn recipient_key(msg: &MessageV1) -> Result<Option<Verkey>, DIDCommV1Error> {
+    match msg.body.get("recipient_key").and_then(Value::as_str) {
+        Some(key) => Ok(Some(Verkey::parse(key)?)),
+        None => Ok(None),
+    }
+}
+
+/// Build a `status-request`.
+pub fn status_request(recipient_key: Option<&Verkey>) -> Result<MessageV1, DIDCommV1Error> {
+    let mut body = json!({});
+    if let Some(key) = recipient_key {
+        body["recipient_key"] = json!(key.to_base58());
+    }
+    Ok(with_return_route(MessageV1::new(
+        STATUS_REQUEST_TYPE,
+        body,
+    )?))
+}
+
+/// Build a `status` reply carrying the queue depth.
+pub fn status(
+    request_id: &str,
+    message_count: u64,
+    recipient_key: Option<&Verkey>,
+    live_delivery: bool,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let mut body = json!({ "message_count": message_count, "live_delivery": live_delivery });
+    if let Some(key) = recipient_key {
+        body["recipient_key"] = json!(key.to_base58());
+    }
+    Ok(MessageV1::new(STATUS_TYPE, body)?.thid(request_id))
+}
+
+/// Build a `delivery-request` for up to `limit` messages.
+pub fn delivery_request(
+    limit: u32,
+    recipient_key: Option<&Verkey>,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let mut body = json!({ "limit": limit });
+    if let Some(key) = recipient_key {
+        body["recipient_key"] = json!(key.to_base58());
+    }
+    Ok(with_return_route(MessageV1::new(
+        DELIVERY_REQUEST_TYPE,
+        body,
+    )?))
+}
+
+/// The `limit` of a `delivery-request`.
+///
+/// Absent or unreadable yields `None`; the caller decides its own default,
+/// since a mediator's sensible cap is a policy question rather than a protocol
+/// one.
+pub fn delivery_limit(msg: &MessageV1) -> Option<u32> {
+    msg.body
+        .get("limit")
+        .and_then(Value::as_u64)
+        .and_then(|l| u32::try_from(l).ok())
+}
+
+/// Build a `delivery` carrying `messages` in the `~attach` decorator.
+///
+/// Each attachment is `{ "@id": <message id>, "data": { "json": <envelope> } }`
+/// — the envelope inline, not re-encoded, matching what Credo emits and expects.
+pub fn delivery(
+    request_id: &str,
+    messages: &[QueuedMessage],
+    recipient_key: Option<&Verkey>,
+) -> Result<MessageV1, DIDCommV1Error> {
+    let attachments: Vec<Value> = messages
+        .iter()
+        .map(|m| json!({ "@id": m.id, "data": { "json": m.envelope } }))
+        .collect();
+
+    let mut body = json!({ "~attach": attachments });
+    if let Some(key) = recipient_key {
+        body["recipient_key"] = json!(key.to_base58());
+    }
+    Ok(MessageV1::new(DELIVERY_TYPE, body)?.thid(request_id))
+}
+
+/// Read the messages out of a `delivery`.
+pub fn parse_delivery(msg: &MessageV1) -> Result<Vec<QueuedMessage>, DIDCommV1Error> {
+    let attachments = msg
+        .body
+        .get("~attach")
+        .and_then(Value::as_array)
+        .ok_or_else(|| DIDCommV1Error::InvalidMessage("delivery has no `~attach`".into()))?;
+
+    attachments
+        .iter()
+        .map(|attachment| {
+            let id = attachment
+                .get("@id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    DIDCommV1Error::InvalidMessage("delivery attachment has no `@id`".into())
+                })?
+                .to_string();
+            let envelope = attachment
+                .get("data")
+                .and_then(|d| d.get("json"))
+                .ok_or_else(|| {
+                    DIDCommV1Error::InvalidMessage(
+                        "delivery attachment has no `data.json` envelope".into(),
+                    )
+                })?
+                .clone();
+            Ok(QueuedMessage { id, envelope })
+        })
+        .collect()
+}
+
+/// Build a `messages-received` acknowledging `ids`.
+pub fn messages_received(ids: &[String]) -> Result<MessageV1, DIDCommV1Error> {
+    Ok(with_return_route(MessageV1::new(
+        MESSAGES_RECEIVED_TYPE,
+        json!({ "message_id_list": ids }),
+    )?))
+}
+
+/// Read the ids acknowledged by a `messages-received`.
+pub fn parse_messages_received(msg: &MessageV1) -> Result<Vec<String>, DIDCommV1Error> {
+    let ids = msg
+        .body
+        .get("message_id_list")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            DIDCommV1Error::InvalidMessage("messages-received has no `message_id_list`".into())
+        })?;
+
+    ids.iter()
+        .map(|id| {
+            id.as_str().map(str::to_string).ok_or_else(|| {
+                DIDCommV1Error::InvalidMessage(
+                    "messages-received `message_id_list` holds a non-string".into(),
+                )
+            })
+        })
+        .collect()
+}
+
+/// Build a `live-delivery-change`.
+pub fn live_delivery_change(live: bool) -> Result<MessageV1, DIDCommV1Error> {
+    Ok(with_return_route(MessageV1::new(
+        LIVE_DELIVERY_CHANGE_TYPE,
+        json!({ "live_delivery": live }),
+    )?))
+}
+
+/// The requested state of a `live-delivery-change`.
+pub fn live_delivery_requested(msg: &MessageV1) -> Option<bool> {
+    msg.body.get("live_delivery").and_then(Value::as_bool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::TypeFormat;
+
+    fn envelope(tag: &str) -> Value {
+        json!({ "protected": "eyJ0eXAiOiJKV00vMS4wIn0", "iv": "aXY", "ciphertext": tag, "tag": "dGFn" })
+    }
+
+    #[test]
+    fn status_reports_the_queue_depth_and_threads_to_the_request() {
+        let msg = status("req-1", 7, None, false).unwrap();
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+
+        assert_eq!(wire["@type"], STATUS_TYPE);
+        assert_eq!(wire["message_count"], 7);
+        assert_eq!(wire["live_delivery"], false);
+        assert_eq!(wire["~thread"]["thid"], "req-1");
+    }
+
+    #[test]
+    fn delivery_carries_envelopes_inline_in_attach() {
+        let messages = vec![
+            QueuedMessage {
+                id: "m-1".into(),
+                envelope: envelope("one"),
+            },
+            QueuedMessage {
+                id: "m-2".into(),
+                envelope: envelope("two"),
+            },
+        ];
+        let msg = delivery("req-1", &messages, None).unwrap();
+        let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+
+        assert_eq!(wire["@type"], DELIVERY_TYPE);
+        assert_eq!(wire["~attach"][0]["@id"], "m-1");
+        assert_eq!(
+            wire["~attach"][0]["data"]["json"],
+            envelope("one"),
+            "the envelope rides inline as data.json, not re-encoded"
+        );
+        assert_eq!(wire["~attach"][1]["@id"], "m-2");
+        assert_eq!(parse_delivery(&msg).unwrap(), messages);
+    }
+
+    #[test]
+    fn messages_received_round_trips() {
+        let ids = vec!["m-1".to_string(), "m-2".to_string()];
+        let msg = messages_received(&ids).unwrap();
+        assert_eq!(msg.body["message_id_list"], json!(ids));
+        assert_eq!(parse_messages_received(&msg).unwrap(), ids);
+    }
+
+    /// Requests ask for a same-connection reply; a mediator keys its
+    /// reply-vs-queue decision off this.
+    #[test]
+    fn requests_carry_return_route_all() {
+        for msg in [
+            status_request(None).unwrap(),
+            delivery_request(10, None).unwrap(),
+            messages_received(&["m-1".to_string()]).unwrap(),
+            live_delivery_change(true).unwrap(),
+        ] {
+            assert!(
+                wants_return_route(&msg),
+                "{} must ask for a return route",
+                msg.typ
+            );
+            let wire: Value = serde_json::from_slice(&msg.to_json().unwrap()).unwrap();
+            assert_eq!(wire["~transport"]["return_route"], "all");
+        }
+    }
+
+    #[test]
+    fn return_route_is_absent_unless_asked_for() {
+        let msg = status("req-1", 0, None, false).unwrap();
+        assert!(
+            !wants_return_route(&msg),
+            "a reply does not itself request a return route"
+        );
+        // ...and an unrelated ~transport value is not mistaken for one.
+        let other = MessageV1::new(STATUS_REQUEST_TYPE, json!({}))
+            .unwrap()
+            .field("~transport", json!({ "return_route": "none" }));
+        assert!(!wants_return_route(&other));
+    }
+
+    #[test]
+    fn recipient_key_accepts_both_spellings_and_absence() {
+        let key = Verkey::from_bytes([5u8; 32]);
+
+        for spelling in [key.to_base58(), key.to_did_key()] {
+            let msg =
+                MessageV1::new(STATUS_REQUEST_TYPE, json!({ "recipient_key": spelling })).unwrap();
+            assert_eq!(recipient_key(&msg).unwrap(), Some(key));
+        }
+
+        let none = MessageV1::new(STATUS_REQUEST_TYPE, json!({})).unwrap();
+        assert_eq!(
+            recipient_key(&none).unwrap(),
+            None,
+            "absent means all of the caller's keys"
+        );
+    }
+
+    /// An unreadable `recipient_key` must fail rather than fall back to "all" —
+    /// the difference decides whose messages are returned.
+    #[test]
+    fn unreadable_recipient_key_is_an_error_not_a_wildcard() {
+        let msg =
+            MessageV1::new(STATUS_REQUEST_TYPE, json!({ "recipient_key": "nonsense" })).unwrap();
+        assert!(recipient_key(&msg).is_err());
+    }
+
+    #[test]
+    fn delivery_limit_is_read_when_present() {
+        assert_eq!(
+            delivery_limit(&delivery_request(25, None).unwrap()),
+            Some(25)
+        );
+        let no_limit = MessageV1::new(DELIVERY_REQUEST_TYPE, json!({})).unwrap();
+        assert_eq!(
+            delivery_limit(&no_limit),
+            None,
+            "the caller supplies its own default"
+        );
+    }
+
+    #[test]
+    fn malformed_delivery_and_ack_are_errors() {
+        let no_attach = MessageV1::new(DELIVERY_TYPE, json!({})).unwrap();
+        assert!(parse_delivery(&no_attach).is_err());
+
+        let no_data =
+            MessageV1::new(DELIVERY_TYPE, json!({ "~attach": [{ "@id": "m-1" }] })).unwrap();
+        assert!(parse_delivery(&no_data).is_err());
+
+        let bad_ids =
+            MessageV1::new(MESSAGES_RECEIVED_TYPE, json!({ "message_id_list": [1, 2] })).unwrap();
+        assert!(parse_messages_received(&bad_ids).is_err());
+    }
+
+    #[test]
+    fn classifies_every_message_in_both_type_spellings() {
+        for (typ, expected) in [
+            (STATUS_REQUEST_TYPE, MessagePickup::StatusRequest),
+            (STATUS_TYPE, MessagePickup::Status),
+            (DELIVERY_REQUEST_TYPE, MessagePickup::DeliveryRequest),
+            (DELIVERY_TYPE, MessagePickup::Delivery),
+            (MESSAGES_RECEIVED_TYPE, MessagePickup::MessagesReceived),
+            (LIVE_DELIVERY_CHANGE_TYPE, MessagePickup::LiveDeliveryChange),
+        ] {
+            let legacy = MessageV1::new(typ, json!({})).unwrap();
+            assert_eq!(MessagePickup::classify(&legacy), Some(expected));
+
+            let modern = legacy.with_type_format(TypeFormat::DidCommOrg);
+            assert!(
+                modern
+                    .typ
+                    .starts_with("https://didcomm.org/messagepickup/2.0/")
+            );
+            assert_eq!(MessagePickup::classify(&modern), Some(expected));
+        }
+    }
+
+    #[test]
+    fn live_delivery_change_carries_its_flag() {
+        assert_eq!(
+            live_delivery_requested(&live_delivery_change(true).unwrap()),
+            Some(true)
+        );
+        assert_eq!(
+            live_delivery_requested(&live_delivery_change(false).unwrap()),
+            Some(false)
+        );
+        let missing = MessageV1::new(LIVE_DELIVERY_CHANGE_TYPE, json!({})).unwrap();
+        assert_eq!(live_delivery_requested(&missing), None);
+    }
+}

--- a/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/mod.rs
@@ -6,4 +6,5 @@
 //! top-level members.
 
 pub mod basic_message;
+pub mod coordinate_mediation;
 pub mod forward;

--- a/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/mod.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/src/protocols/mod.rs
@@ -8,3 +8,4 @@
 pub mod basic_message;
 pub mod coordinate_mediation;
 pub mod forward;
+pub mod message_pickup;

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Affinidi Messaging Mediator
 
+## 8th August 2026 (0.18.9)
+
+**DIDComm v1 mediation: coordinate-mediation 1.0 and message-pickup 2.0.**
+
+Completes what 0.18.8 started. A v1 wallet can now register its routing keys and
+collect what arrives, so the `didcomm-v1` feature is usable end to end rather
+than plumbing.
+
+Replies go back as the **raw HTTP body** rather than the mediator's JSON success
+envelope — Aries' return-route, which is how a one-way transport carries a
+synchronous response. They are **authcrypt**, so a client can tell a real
+`mediate-grant` from a forged one; a forgeable grant would let an attacker
+nominate its own routing keys.
+
+Unlike forwards, these messages are authenticated by construction: opening the
+envelope proves which verkey sent it, and that key is the identity every
+decision is made against. An anonymous mediation request is refused.
+
+### Account identity and admission
+
+A client's account is the `did:key` derived from its authenticated verkey.
+Provisioning mirrors first-authentication rather than adding a second policy:
+unknown accounts are created with `global_acl_default`, unless
+`mediator_acl_mode` is `explicit_allow`, in which case mediation is denied.
+
+**`mediate-request` is denied when the account cannot receive.** Granting
+mediation to an account without `RECEIVE_MESSAGES` would be a silent black
+hole — the client publishes routing keys, senders forward to them, and every
+message is refused after the fact. Operators serving v1 wallets need a
+`global_acl_default` that grants receive; otherwise clients get an immediate,
+truthful `mediate-deny`.
+
+### Handler behaviour
+
+- `keylist-update` reports a result per key rather than failing the batch.
+  Claiming or removing a key bound to another account is refused as
+  `client_error` — the same answer as any other rejected entry, so it cannot be
+  used to probe which keys other accounts hold.
+- `delivery-request` fetches with `DoNotDelete`; `messages-received` deletes
+  under `Owner` authority, so a client cannot delete another's messages by
+  guessing ids. An empty queue answers `status`, not an empty `delivery`.
+- Delivery limits are capped and acknowledgement lists bounded — authenticated,
+  but the numbers are still caller-chosen.
+- `live-delivery-change` answers truthfully with `live_delivery: false` rather
+  than accepting and never pushing.
+
 ## 8th August 2026 (0.18.8)
 
 **DIDComm v1 (Aries RFC 0019) forward ingress — new `didcomm-v1` feature.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.8"
+version = "0.18.9"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -89,7 +89,7 @@ affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" 
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
-affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.1", optional = true }
+affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
 trust-tasks-rs = { version = "0.2.46", optional = true }

--- a/crates/messaging/affinidi-messaging-mediator/src/builder.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/builder.rs
@@ -460,6 +460,20 @@ impl MediatorBuilder {
         self
     }
 
+    /// Enable DIDComm v1 (Aries RFC 0019) support.
+    ///
+    /// `allow_unauthenticated_forwards` opts into accepting an anon-packed
+    /// forward with no authenticated session — see the `[didcomm_v1]` config
+    /// docs for what that widens and what it deliberately does not.
+    #[cfg(feature = "didcomm-v1")]
+    pub fn didcomm_v1(mut self, enabled: bool, allow_unauthenticated_forwards: bool) -> Self {
+        self.config.didcomm_v1 = crate::common::config::DidCommV1Config {
+            enabled,
+            allow_unauthenticated_forwards,
+        };
+        self
+    }
+
     /// Replace the processors config (forwarding, message expiry).
     /// Defaults disable both — embedded tests that don't need these
     /// background tasks save the spawn cost.

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/message_inbound.rs
@@ -7,16 +7,26 @@ use crate::{
     messages::inbound::handle_inbound,
 };
 use affinidi_messaging_mediator_common::errors::{AppError, MediatorError, SuccessResponse};
-use affinidi_messaging_sdk::messages::{
-    problem_report::{ProblemReportScope, ProblemReportSorter},
-    sending::InboundMessageResponse,
+use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
+use axum::{
+    Json,
+    body::Bytes,
+    extract::State,
+    response::{IntoResponse, Response},
 };
-use axum::{Json, body::Bytes, extract::State};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level, span};
 
 use crate::common::metrics::names;
+
+/// Content type for a raw DIDComm v1 envelope returned via Aries return-route.
+///
+/// Credo sniffs the body structure rather than trusting this header, but a
+/// truthful content type keeps proxies and logs from treating the reply as
+/// generic JSON.
+#[cfg(feature = "didcomm-v1")]
+const DIDCOMM_V1_CONTENT_TYPE: &str = "application/ssi-agent-wire";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RecipientHeader {
@@ -55,7 +65,7 @@ pub async fn message_inbound_handler(
     MaybeSession(session): MaybeSession,
     State(state): State<SharedData>,
     body: Bytes,
-) -> Result<(StatusCode, Json<SuccessResponse<InboundMessageResponse>>), AppError> {
+) -> Result<Response, AppError> {
     let _span = span!(
         Level::DEBUG,
         "message_inbound_handler",
@@ -95,7 +105,8 @@ pub async fn message_inbound_handler(
                     message: "Success".to_string(),
                     data: Some(response),
                 }),
-            ));
+            )
+                .into_response());
         }
 
         // DIDComm v1 (Aries RFC 0019). Sniffed before the v2 parse because a v1
@@ -141,20 +152,35 @@ pub async fn message_inbound_handler(
                 metrics::counter!(names::MESSAGES_INBOUND_TOTAL).increment(1);
                 metrics::counter!(names::MESSAGE_BYTES_INBOUND_TOTAL).increment(raw.len() as u64);
 
-                let response =
+                let outcome =
                     crate::messages::inbound_v1::handle_inbound_didcomm_v1(&state, &session, raw)
                         .await?;
-                return Ok((
-                    StatusCode::OK,
-                    Json(SuccessResponse {
-                        session_id: session.session_id,
-                        http_code: StatusCode::OK.as_u16(),
-                        error_code: 0,
-                        error_code_str: "NA".to_string(),
-                        message: "Success".to_string(),
-                        data: Some(response),
-                    }),
-                ));
+
+                return Ok(match outcome {
+                    // A routed forward answers like any other stored message.
+                    crate::messages::inbound_v1::V1Outcome::Stored(response) => (
+                        StatusCode::OK,
+                        Json(SuccessResponse {
+                            session_id: session.session_id,
+                            http_code: StatusCode::OK.as_u16(),
+                            error_code: 0,
+                            error_code_str: "NA".to_string(),
+                            message: "Success".to_string(),
+                            data: Some(response),
+                        }),
+                    )
+                        .into_response(),
+
+                    // A protocol reply goes back as the raw packed envelope —
+                    // Aries' return-route, which the client parses as an
+                    // inbound message. See `V1Outcome::Reply`.
+                    crate::messages::inbound_v1::V1Outcome::Reply(packed) => (
+                        StatusCode::OK,
+                        [(http::header::CONTENT_TYPE, DIDCOMM_V1_CONTENT_TYPE)],
+                        packed,
+                    )
+                        .into_response(),
+                });
             }
         }
 
@@ -212,7 +238,8 @@ pub async fn message_inbound_handler(
                 message: "Success".to_string(),
                 data: Some(response),
             }),
-        ))
+        )
+            .into_response())
     }
     .instrument(_span)
     .await

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound_v1.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound_v1.rs
@@ -31,7 +31,10 @@
 //!
 //! [`MediatorStore::v1_routing_key_bind`]: affinidi_messaging_mediator_common::store::MediatorStore::v1_routing_key_bind
 
-use affinidi_messaging_didcomm_v1::envelope::{self, ProtectedHeader, RecipientKey};
+use affinidi_messaging_didcomm_v1::envelope::{
+    self, EnvelopeProtection, ProtectedHeader, RecipientKey,
+};
+use affinidi_messaging_didcomm_v1::identity::Verkey;
 use affinidi_messaging_didcomm_v1::protocols::forward;
 use affinidi_messaging_mediator_common::errors::MediatorError;
 use affinidi_messaging_sdk::messages::{
@@ -87,17 +90,34 @@ pub(crate) fn is_didcomm_v1(body: &[u8]) -> bool {
         .unwrap_or(false)
 }
 
-/// Handle an inbound DIDComm v1 forward.
+/// What an inbound v1 message resulted in.
+pub(crate) enum V1Outcome {
+    /// A forward was routed and stored for its recipient. Answered with the
+    /// mediator's usual JSON success envelope.
+    Stored(InboundMessageResponse),
+    /// A protocol request was answered. The packed v1 envelope must go back as
+    /// the **raw HTTP body**: that is how Aries does synchronous
+    /// request/response over a one-way transport, and Credo's
+    /// `isValidJweStructure` accepts exactly this shape (`protected` / `iv` /
+    /// `ciphertext` / `tag`) as an inbound message. Wrapping it in the JSON
+    /// success envelope would hand the client a reply it cannot parse.
+    Reply(String),
+}
+
+/// Handle an inbound DIDComm v1 message.
 ///
-/// Opens the outer anoncrypt layer with the mediator's routing key, resolves
-/// the forward's `to` verkey to a local account, applies that account's ACLs,
-/// and stores the **inner envelope verbatim** for pickup. The inner bytes are
-/// never parsed: they are sealed to the recipient, who unpacks them natively.
+/// A **forward** is routed: the outer anoncrypt layer is opened with the
+/// mediator's routing key, the `to` verkey resolved to a local account, that
+/// account's ACLs applied, and the inner envelope stored verbatim for pickup.
+/// The inner bytes are never parsed — they are sealed to the recipient.
+///
+/// A **coordinate-mediation or message-pickup request** is answered instead,
+/// and the packed reply comes back as [`V1Outcome::Reply`].
 pub(crate) async fn handle_inbound_didcomm_v1(
     state: &SharedData,
     session: &Session,
     raw: &str,
-) -> Result<InboundMessageResponse, MediatorError> {
+) -> Result<V1Outcome, MediatorError> {
     let _span = span!(Level::DEBUG, "handle_inbound_didcomm_v1");
     async move {
         if !state.config.didcomm_v1.enabled {
@@ -147,6 +167,36 @@ pub(crate) async fn handle_inbound_didcomm_v1(
                 )
             })?;
 
+        // A mediation or pickup request is answered here rather than routed.
+        // These are authcrypt'd, so opening the envelope proved which verkey
+        // sent it — and that authenticated key, not anything the message
+        // claims, is the identity the request is served for.
+        if let Some(request) = crate::messages::v1_mediation::V1Request::classify(&message) {
+            let EnvelopeProtection::Authcrypt { sender_verkey } = opened.protection else {
+                return Err(v1_problem(
+                    session,
+                    37,
+                    "message.didcomm_v1.anonymous_request",
+                    "coordinate-mediation and message-pickup requests must be authcrypt'd: an \
+                     anonymous request names no client to answer for"
+                        .to_string(),
+                    StatusCode::BAD_REQUEST,
+                ));
+            };
+
+            let reply = crate::messages::v1_mediation::handle(
+                state,
+                session,
+                request,
+                &message,
+                &sender_verkey,
+            )
+            .await?;
+
+            let packed = pack_v1_reply(state, session, &reply, &sender_verkey).await?;
+            return Ok(V1Outcome::Reply(packed));
+        }
+
         if !forward::is_forward(&message) {
             return Err(v1_problem(
                 session,
@@ -179,7 +229,9 @@ pub(crate) async fn handle_inbound_didcomm_v1(
             )
         })?;
 
-        deliver_v1_forward(state, session, &to_verkey.to_base58(), &inner).await
+        deliver_v1_forward(state, session, &to_verkey.to_base58(), &inner)
+            .await
+            .map(V1Outcome::Stored)
     }
     .instrument(_span)
     .await
@@ -259,6 +311,35 @@ async fn deliver_v1_forward(
 
     debug!(%to_verkey, %to_did, "DIDComm v1 forward stored for local recipient");
     store_message(state, session, &data, &UnpackMetadata::default()).await
+}
+
+/// Authcrypt a reply from the mediator's routing key back to the client.
+///
+/// Authcrypt rather than anoncrypt: the client has to know the answer really
+/// came from its mediator. A `mediate-grant` an attacker could forge would let
+/// them nominate their own routing keys and capture the client's inbound
+/// traffic.
+async fn pack_v1_reply(
+    state: &SharedData,
+    session: &Session,
+    reply: &affinidi_messaging_didcomm_v1::MessageV1,
+    recipient: &Verkey,
+) -> Result<String, MediatorError> {
+    let identity = state.didcomm_v1_identity().await?;
+    affinidi_messaging_didcomm_v1::message::pack::pack_encrypted_authcrypt(
+        reply,
+        &identity.identity,
+        &[*recipient],
+    )
+    .map_err(|e| {
+        v1_problem(
+            session,
+            37,
+            "message.didcomm_v1.pack",
+            format!("couldn't pack the DIDComm v1 reply: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })
 }
 
 /// A v1-scoped problem report, mirroring the TSP path's `tsp_problem`.

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/mod.rs
@@ -45,6 +45,8 @@ pub mod inbound_v1;
 #[cfg(feature = "didcomm")]
 pub mod protocols;
 pub(crate) mod store;
+#[cfg(feature = "didcomm-v1")]
+pub mod v1_mediation;
 
 #[cfg(feature = "didcomm")]
 struct MessageType(SDKMessageType);

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
@@ -1,0 +1,562 @@
+//! DIDComm v1 mediation protocols: coordinate-mediation 1.0 and
+//! message-pickup 2.0.
+//!
+//! Stage 1 taught the mediator to *receive* v1 forwards. This is what lets a
+//! wallet set that up for itself and collect what arrives: register routing
+//! keys, then poll for messages.
+//!
+//! # These messages are authenticated; forwards are not
+//!
+//! A `routing/1.0/forward` is anon-packed by design, so
+//! [`crate::messages::inbound_v1`] has no sender to authorise against and leans
+//! on the recipient's ACL. Everything here is the opposite: the client
+//! **authcrypts** to the mediator, so opening the envelope proves which verkey
+//! sent it, and that key is the identity every decision below is made against.
+//! There is nothing to spoof — a v1 plaintext has no `from` header to lie in.
+//!
+//! # Account identity
+//!
+//! v1 has no DIDs, so the client's account is keyed by the `did:key` derived
+//! from its authenticated verkey. Deterministic, needs no extra state, and it
+//! is the same identifier Aries uses for a connection's keys.
+//!
+//! Provisioning deliberately mirrors [`crate::handlers::authenticate::response`]
+//! rather than inventing a second policy: an unknown account is created with
+//! `global_acl_default`, unless `mediator_acl_mode` is `explicit_allow`, in
+//! which case mediation is denied. One admission gate, two entry points.
+
+use affinidi_messaging_didcomm_v1::identity::Verkey;
+use affinidi_messaging_didcomm_v1::message::MessageV1;
+use affinidi_messaging_didcomm_v1::protocols::coordinate_mediation as cm;
+use affinidi_messaging_didcomm_v1::protocols::message_pickup as mp;
+use affinidi_messaging_mediator_common::errors::MediatorError;
+use affinidi_messaging_mediator_common::store::types::DeletionAuthority;
+use affinidi_messaging_mediator_common::types::messages::{FetchDeletePolicy, FetchOptions};
+use affinidi_messaging_sdk::messages::problem_report::{ProblemReportScope, ProblemReportSorter};
+use affinidi_messaging_sdk::protocols::mediator::acls::AccessListModeType;
+use http::StatusCode;
+use sha256::digest;
+use tracing::{debug, warn};
+
+use crate::SharedData;
+use crate::common::session::Session;
+
+/// Most messages a `delivery-request` may return when it names no `limit`.
+///
+/// A client that asks for everything still gets a bounded page; it can keep
+/// requesting. Matches the store's own default fetch limit.
+const DEFAULT_DELIVERY_LIMIT: u32 = 10;
+
+/// Hard cap on a `delivery-request`, whatever `limit` it asks for.
+///
+/// The request is authenticated but the number is attacker-chosen, and each
+/// message is copied into a response the mediator has to build in memory.
+const MAX_DELIVERY_LIMIT: u32 = 100;
+
+/// Cap on `message_id_list` in one `messages-received`.
+const MAX_ACK_IDS: usize = 100;
+
+/// A v1 request the mediator answers directly, rather than routing.
+pub(crate) enum V1Request {
+    CoordinateMediation(cm::CoordinateMediation),
+    MessagePickup(mp::MessagePickup),
+}
+
+impl V1Request {
+    /// Classify `msg`, or `None` when it is not a protocol this module serves.
+    pub(crate) fn classify(msg: &MessageV1) -> Option<Self> {
+        if let Some(kind) = cm::CoordinateMediation::classify(msg) {
+            return Some(Self::CoordinateMediation(kind));
+        }
+        mp::MessagePickup::classify(msg).map(Self::MessagePickup)
+    }
+}
+
+/// Handle an authenticated v1 protocol message, returning the reply to send
+/// back.
+///
+/// `sender` is the verkey that authenticated the envelope — not anything the
+/// message claimed.
+pub(crate) async fn handle(
+    state: &SharedData,
+    session: &Session,
+    request: V1Request,
+    msg: &MessageV1,
+    sender: &Verkey,
+) -> Result<MessageV1, MediatorError> {
+    let account = client_account(state, session, sender).await?;
+
+    match request {
+        V1Request::CoordinateMediation(kind) => {
+            coordinate_mediation(state, session, kind, msg, &account).await
+        }
+        V1Request::MessagePickup(kind) => message_pickup(state, session, kind, msg, &account).await,
+    }
+}
+
+/// The client's account: the `did:key` for its authenticated verkey, created on
+/// first contact under the same policy as first authentication.
+struct ClientAccount {
+    did: String,
+    did_hash: String,
+}
+
+async fn client_account(
+    state: &SharedData,
+    session: &Session,
+    sender: &Verkey,
+) -> Result<ClientAccount, MediatorError> {
+    let did = sender.to_did_key();
+    let did_hash = digest(did.as_bytes());
+
+    if !state.database.account_exists(&did_hash).await? {
+        // Same gate as `handlers::authenticate::response`: in explicit-allow
+        // mode an unknown identity is refused rather than self-registered.
+        if state.config.security.mediator_acl_mode == AccessListModeType::ExplicitAllow {
+            warn!(
+                %did,
+                "v1 mediation refused: no account and mediator_acl_mode is explicit_allow"
+            );
+            return Err(v1_problem(
+                session,
+                25,
+                "authorization.blocked",
+                "This mediator does not accept mediation requests from unknown clients".to_string(),
+                StatusCode::FORBIDDEN,
+            ));
+        }
+
+        debug!(%did, "v1 mediation: registering a new account for the client verkey");
+        state
+            .database
+            .account_add(&did_hash, &state.config.security.global_acl_default, None)
+            .await?;
+    }
+
+    Ok(ClientAccount { did, did_hash })
+}
+
+async fn coordinate_mediation(
+    state: &SharedData,
+    session: &Session,
+    kind: cm::CoordinateMediation,
+    msg: &MessageV1,
+    account: &ClientAccount,
+) -> Result<MessageV1, MediatorError> {
+    match kind {
+        cm::CoordinateMediation::MediateRequest => {
+            let identity = state.didcomm_v1_identity().await?;
+            let endpoint = mediator_endpoint(state);
+
+            debug!(did = %account.did, "granting v1 mediation");
+            cm::mediate_grant(
+                &msg.id,
+                &endpoint,
+                &[identity.verkey()],
+                cm::KeyFormat::Base58,
+            )
+            .map_err(|e| v1_build_error(session, e))
+        }
+
+        cm::CoordinateMediation::KeylistUpdate => {
+            let updates = cm::parse_keylist_update(msg).map_err(|e| {
+                v1_problem(
+                    session,
+                    37,
+                    "message.didcomm_v1.keylist",
+                    format!("malformed keylist-update: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            let mut results = Vec::with_capacity(updates.len());
+            for update in updates {
+                let result = apply_keylist_update(state, account, &update).await;
+                results.push(cm::KeylistUpdated {
+                    recipient_key: update.recipient_key,
+                    action: update.action,
+                    result,
+                });
+            }
+
+            cm::keylist_update_response(&msg.id, &results, cm::KeyFormat::Base58)
+                .map_err(|e| v1_build_error(session, e))
+        }
+
+        cm::CoordinateMediation::KeylistQuery => {
+            let keys = state
+                .database
+                .v1_routing_keys_for(&account.did_hash)
+                .await?
+                .iter()
+                .filter_map(|k| Verkey::from_base58(k).ok())
+                .collect::<Vec<_>>();
+
+            cm::keylist(&msg.id, &keys, cm::KeyFormat::Base58)
+                .map_err(|e| v1_build_error(session, e))
+        }
+
+        // Responses, not requests: a client sending one to the mediator is
+        // confused, but it is not an error worth a problem report either.
+        cm::CoordinateMediation::MediateGrant
+        | cm::CoordinateMediation::MediateDeny
+        | cm::CoordinateMediation::KeylistUpdateResponse
+        | cm::CoordinateMediation::Keylist => Err(v1_problem(
+            session,
+            37,
+            "message.didcomm_v1.unexpected",
+            format!(
+                "`{}` is a mediator-to-client message; the mediator does not accept it",
+                msg.typ
+            ),
+            StatusCode::BAD_REQUEST,
+        )),
+
+        // `CoordinateMediation` is `#[non_exhaustive]`.
+        _ => Err(v1_problem(
+            session,
+            37,
+            "message.didcomm_v1.unsupported",
+            format!("unsupported coordinate-mediation message `{}`", msg.typ),
+            StatusCode::BAD_REQUEST,
+        )),
+    }
+}
+
+/// Apply one keylist change, reporting the per-key outcome rather than failing
+/// the whole batch — RFC 0211 expects a result for every entry.
+async fn apply_keylist_update(
+    state: &SharedData,
+    account: &ClientAccount,
+    update: &cm::KeylistUpdate,
+) -> cm::KeylistResult {
+    let verkey = update.recipient_key.to_base58();
+
+    match update.action {
+        cm::KeylistAction::Add => {
+            match state.database.v1_routing_key_lookup(&verkey).await {
+                // Already ours: nothing to do, and say so rather than claiming
+                // to have made a change.
+                Ok(Some(owner)) if owner == account.did => cm::KeylistResult::NoChange,
+                // Someone else's key. Refusing is the whole point of the
+                // exclusive binding — granting it would hand this client
+                // another account's inbound traffic.
+                Ok(Some(_)) => cm::KeylistResult::ClientError,
+                Ok(None) => match state
+                    .database
+                    .v1_routing_key_bind(&verkey, &account.did)
+                    .await
+                {
+                    Ok(()) => cm::KeylistResult::Success,
+                    Err(e) => {
+                        warn!(%verkey, error = %e, "v1 keylist add failed");
+                        cm::KeylistResult::ServerError
+                    }
+                },
+                Err(e) => {
+                    warn!(%verkey, error = %e, "v1 keylist lookup failed");
+                    cm::KeylistResult::ServerError
+                }
+            }
+        }
+
+        cm::KeylistAction::Remove => {
+            match state.database.v1_routing_key_lookup(&verkey).await {
+                Ok(Some(owner)) if owner == account.did => {
+                    match state.database.v1_routing_key_unbind(&verkey).await {
+                        Ok(true) => cm::KeylistResult::Success,
+                        Ok(false) => cm::KeylistResult::NoChange,
+                        Err(e) => {
+                            warn!(%verkey, error = %e, "v1 keylist remove failed");
+                            cm::KeylistResult::ServerError
+                        }
+                    }
+                }
+                // Not bound at all — a no-op, not an error.
+                Ok(None) => cm::KeylistResult::NoChange,
+                // Bound to someone else: refuse, and report it the same way as
+                // any other rejected request so this cannot be used to probe
+                // which keys other accounts hold.
+                Ok(Some(_)) => cm::KeylistResult::ClientError,
+                Err(e) => {
+                    warn!(%verkey, error = %e, "v1 keylist lookup failed");
+                    cm::KeylistResult::ServerError
+                }
+            }
+        }
+
+        // `KeylistAction` is `#[non_exhaustive]`.
+        _ => cm::KeylistResult::ClientError,
+    }
+}
+
+async fn message_pickup(
+    state: &SharedData,
+    session: &Session,
+    kind: mp::MessagePickup,
+    msg: &MessageV1,
+    account: &ClientAccount,
+) -> Result<MessageV1, MediatorError> {
+    match kind {
+        mp::MessagePickup::StatusRequest => {
+            let status = state.database.inbox_status(&account.did_hash).await?;
+            mp::status(&msg.id, status.message_count, None, false)
+                .map_err(|e| v1_build_error(session, e))
+        }
+
+        mp::MessagePickup::DeliveryRequest => {
+            let limit = mp::delivery_limit(msg)
+                .unwrap_or(DEFAULT_DELIVERY_LIMIT)
+                .min(MAX_DELIVERY_LIMIT);
+
+            let fetched = state
+                .database
+                .fetch_messages(
+                    &session.session_id,
+                    &account.did_hash,
+                    &FetchOptions {
+                        limit: limit as usize,
+                        start_id: None,
+                        // Pickup 2.0 acknowledges separately: deleting on
+                        // delivery would lose any message whose delivery was
+                        // lost in flight. See the protocol module docs.
+                        delete_policy: FetchDeletePolicy::DoNotDelete,
+                    },
+                )
+                .await?;
+
+            let messages: Vec<mp::QueuedMessage> = fetched
+                .success
+                .iter()
+                .filter_map(|element| {
+                    // `msg` is optional on the store element; a record without
+                    // a body cannot be delivered, and skipping it leaves it
+                    // queued rather than acknowledging something never sent.
+                    let body = element.msg.as_deref()?;
+                    let envelope = serde_json::from_str(body).ok()?;
+                    Some(mp::QueuedMessage {
+                        id: element.msg_id.clone(),
+                        envelope,
+                    })
+                })
+                .collect();
+
+            // Nothing queued → answer with a status, as RFC 0685 specifies;
+            // an empty `delivery` would look like a delivery that dropped
+            // everything.
+            if messages.is_empty() {
+                let status = state.database.inbox_status(&account.did_hash).await?;
+                return mp::status(&msg.id, status.message_count, None, false)
+                    .map_err(|e| v1_build_error(session, e));
+            }
+
+            mp::delivery(&msg.id, &messages, None).map_err(|e| v1_build_error(session, e))
+        }
+
+        mp::MessagePickup::MessagesReceived => {
+            let ids = mp::parse_messages_received(msg).map_err(|e| {
+                v1_problem(
+                    session,
+                    37,
+                    "message.didcomm_v1.messages_received",
+                    format!("malformed messages-received: {e}"),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            if ids.len() > MAX_ACK_IDS {
+                return Err(v1_problem(
+                    session,
+                    37,
+                    "message.didcomm_v1.messages_received",
+                    format!(
+                        "messages-received lists {} ids, exceeding the maximum of {MAX_ACK_IDS}",
+                        ids.len()
+                    ),
+                    StatusCode::BAD_REQUEST,
+                ));
+            }
+
+            for id in &ids {
+                // `Owner` authority makes the store reject an id the client
+                // neither sent nor received, so one client cannot delete
+                // another's messages by guessing ids.
+                if let Err(e) = state
+                    .database
+                    .delete_message(
+                        id,
+                        DeletionAuthority::Owner {
+                            did_hash: account.did_hash.clone(),
+                        },
+                    )
+                    .await
+                {
+                    debug!(%id, error = %e, "v1 messages-received: delete failed");
+                }
+            }
+
+            let status = state.database.inbox_status(&account.did_hash).await?;
+            mp::status(&msg.id, status.message_count, None, false)
+                .map_err(|e| v1_build_error(session, e))
+        }
+
+        mp::MessagePickup::LiveDeliveryChange => {
+            // Live delivery would need a persistent connection to this client.
+            // RFC 0685 has a problem-report for exactly this case; answering
+            // with a truthful `live_delivery: false` status is the honest
+            // alternative to silently accepting and never pushing.
+            let status = state.database.inbox_status(&account.did_hash).await?;
+            mp::status(&msg.id, status.message_count, None, false)
+                .map_err(|e| v1_build_error(session, e))
+        }
+
+        // Mediator-to-client messages.
+        mp::MessagePickup::Status | mp::MessagePickup::Delivery => Err(v1_problem(
+            session,
+            37,
+            "message.didcomm_v1.unexpected",
+            format!(
+                "`{}` is a mediator-to-client message; the mediator does not accept it",
+                msg.typ
+            ),
+            StatusCode::BAD_REQUEST,
+        )),
+
+        _ => Err(v1_problem(
+            session,
+            37,
+            "message.didcomm_v1.unsupported",
+            format!("unsupported message-pickup message `{}`", msg.typ),
+            StatusCode::BAD_REQUEST,
+        )),
+    }
+}
+
+/// The endpoint a `mediate-grant` publishes for inbound traffic.
+fn mediator_endpoint(state: &SharedData) -> String {
+    // The DID document's DIDComm service endpoint is the authoritative answer;
+    // fall back to the configured listen address so a development mediator
+    // still returns something usable.
+    state
+        .config
+        .mediator_did_document
+        .as_ref()
+        .and_then(|doc| {
+            doc.service
+                .iter()
+                .find(|s| s.type_.iter().any(|t| t == "DIDCommMessaging"))
+                .and_then(|s| s.service_endpoint.get_uri())
+        })
+        .map(|uri| uri.trim_matches('"').to_string())
+        .unwrap_or_else(|| state.config.listen_address.clone())
+}
+
+fn v1_build_error(session: &Session, error: impl std::fmt::Display) -> MediatorError {
+    v1_problem(
+        session,
+        37,
+        "message.didcomm_v1.build",
+        format!("couldn't build the DIDComm v1 reply: {error}"),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+}
+
+fn v1_problem(
+    session: &Session,
+    code: u16,
+    descriptor: &str,
+    detail: String,
+    status: StatusCode,
+) -> MediatorError {
+    MediatorError::problem(
+        code,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Message,
+        descriptor,
+        "{1}",
+        vec![detail],
+        status,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn verkey(seed: u8) -> Verkey {
+        Verkey::from_bytes([seed; 32])
+    }
+
+    #[test]
+    fn classifies_both_protocols_and_nothing_else() {
+        let request = cm::mediate_request().unwrap();
+        assert!(matches!(
+            V1Request::classify(&request),
+            Some(V1Request::CoordinateMediation(
+                cm::CoordinateMediation::MediateRequest
+            ))
+        ));
+
+        let status = mp::status_request(None).unwrap();
+        assert!(matches!(
+            V1Request::classify(&status),
+            Some(V1Request::MessagePickup(mp::MessagePickup::StatusRequest))
+        ));
+
+        let forward = MessageV1::new(
+            affinidi_messaging_didcomm_v1::protocols::forward::FORWARD_TYPE,
+            json!({}),
+        )
+        .unwrap();
+        assert!(
+            V1Request::classify(&forward).is_none(),
+            "a forward is routed, not answered"
+        );
+
+        let basic = affinidi_messaging_didcomm_v1::protocols::basic_message::BasicMessage::new("x")
+            .unwrap()
+            .finalize();
+        assert!(V1Request::classify(&basic).is_none());
+    }
+
+    /// The account identifier must be derived purely from the authenticated
+    /// verkey, so two requests from one key always reach the same account and a
+    /// different key never does.
+    #[test]
+    fn account_did_is_derived_from_the_verkey() {
+        let a = verkey(1).to_did_key();
+        let b = verkey(1).to_did_key();
+        let c = verkey(2).to_did_key();
+
+        assert_eq!(a, b, "the same verkey must always yield the same account");
+        assert_ne!(a, c);
+        assert!(a.starts_with("did:key:z6Mk"));
+        assert_eq!(
+            Verkey::from_did_key(&a).unwrap(),
+            verkey(1),
+            "the derivation must be reversible, so a bound key can be read back"
+        );
+    }
+
+    #[test]
+    fn delivery_limits_are_bounded() {
+        // Asks for more than the cap → capped.
+        let big = mp::delivery_request(10_000, None).unwrap();
+        assert_eq!(
+            mp::delivery_limit(&big).unwrap().min(MAX_DELIVERY_LIMIT),
+            MAX_DELIVERY_LIMIT
+        );
+
+        // Asks for nothing → the default, not unbounded.
+        let none = MessageV1::new(mp::DELIVERY_REQUEST_TYPE, json!({})).unwrap();
+        assert_eq!(
+            mp::delivery_limit(&none).unwrap_or(DEFAULT_DELIVERY_LIMIT),
+            DEFAULT_DELIVERY_LIMIT
+        );
+
+        const { assert!(DEFAULT_DELIVERY_LIMIT <= MAX_DELIVERY_LIMIT) };
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
@@ -39,6 +39,7 @@ use sha256::digest;
 use tracing::{debug, warn};
 
 use crate::SharedData;
+use crate::common::authz::{self, Capability};
 use crate::common::session::Session;
 
 /// Most messages a `delivery-request` may return when it names no `limit`.
@@ -145,6 +146,32 @@ async fn coordinate_mediation(
 ) -> Result<MessageV1, MediatorError> {
     match kind {
         cm::CoordinateMediation::MediateRequest => {
+            // Do not grant mediation the account cannot actually use. Without
+            // RECEIVE_MESSAGES every forward for this client would be refused
+            // *after* it had been told mediation was granted and had published
+            // the routing keys — a silent black hole the client has no way to
+            // detect. `mediate-deny` says so immediately instead.
+            //
+            // Reached when `global_acl_default` does not grant receive; the
+            // operator either intends that (and v1 clients are not welcome) or
+            // has misconfigured it, and both are better surfaced than hidden.
+            let can_receive = state
+                .database
+                .get_did_acl(&account.did_hash)
+                .await?
+                .is_some_and(|acls| {
+                    authz::require_capability(&acls, Capability::ReceiveMessages).is_ok()
+                });
+
+            if !can_receive {
+                warn!(
+                    did = %account.did,
+                    "denying v1 mediation: the account is not permitted to receive messages, so \
+                     granting it would promise routing the mediator would then refuse"
+                );
+                return cm::mediate_deny(&msg.id).map_err(|e| v1_build_error(session, e));
+            }
+
             let identity = state.didcomm_v1_identity().await?;
             let endpoint = mediator_endpoint(state);
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi Messaging Test Mediator
 
+## 0.2.47 — 8th August 2026
+
+Adds a `didcomm-v1` feature that spawns the mediator with DIDComm v1 support, a
+`didcomm_v1(enabled, allow_unauthenticated_forwards)` builder setter, and a
+`didcomm_v1_routing_verkey()` accessor on the handle so a test can address v1
+forwards to the mediator without scraping its startup logs.
+
+Off by default: an existing test build is unaffected.
+
+
 ## 4th August 2026 (0.2.46)
 
 Dependency bump for `affinidi-messaging-mediator` 0.18.5 and

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -22,8 +22,13 @@ fjall-backend = ["affinidi-messaging-mediator/fjall-backend", "dep:tempfile"]
 ## Spawn the mediator with TSP support and expose `atm.tsp()` so the e2e suite
 ## can exercise the dual-protocol (DIDComm + TSP) flows.
 tsp = ["affinidi-messaging-mediator/tsp", "affinidi-messaging-sdk/tsp"]
+## Spawn the mediator with DIDComm v1 (Aries RFC 0019) support so the e2e suite
+## can exercise forward ingress, coordinate-mediation and message pickup.
+didcomm-v1 = ["affinidi-messaging-mediator/didcomm-v1", "dep:affinidi-messaging-didcomm-v1"]
 
 [dependencies]
+## Optional: v1 message construction for the didcomm-v1 e2e tests.
+affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 # ── Mediator: the thing we're spawning ───────────────────────────────────
 ##
 ## Sister-crate path deps carry an explicit `version =` so the package

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.46"
+version = "0.2.47"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -311,6 +311,10 @@ pub struct TestMediatorBuilder {
     /// Override for `SecurityConfig.mediator_acl_mode`. `None` keeps the
     /// production default (`ExplicitDeny`).
     acl_mode: Option<AccessListModeType>,
+    /// DIDComm v1: `(enabled, allow_unauthenticated_forwards)`. `None` leaves
+    /// it off, matching a production mediator that has not opted in.
+    #[cfg(feature = "didcomm-v1")]
+    didcomm_v1: Option<(bool, bool)>,
     /// Override for `SecurityConfig.global_acl_default`. `None` keeps the
     /// production default (`MediatorACLSet::default()`).
     global_acl_default: Option<MediatorACLSet>,
@@ -362,6 +366,8 @@ impl Default for TestMediatorBuilder {
             local_endpoints: Vec::new(),
             advertise_host: None,
             acl_mode: None,
+            #[cfg(feature = "didcomm-v1")]
+            didcomm_v1: None,
             global_acl_default: None,
             local_direct_delivery_allowed: None,
             local_direct_delivery_allow_anon: None,
@@ -512,6 +518,13 @@ impl TestMediatorBuilder {
     /// `ExplicitDeny` (matching `SecurityConfig::default`). Set to
     /// `ExplicitAllow` to simulate an allowlist deployment, where DIDs
     /// without an explicit `LOCAL` ACL bit are rejected.
+    /// Enable DIDComm v1, optionally accepting unauthenticated forwards.
+    #[cfg(feature = "didcomm-v1")]
+    pub fn didcomm_v1(mut self, enabled: bool, allow_unauthenticated_forwards: bool) -> Self {
+        self.didcomm_v1 = Some((enabled, allow_unauthenticated_forwards));
+        self
+    }
+
     pub fn acl_mode(mut self, mode: AccessListModeType) -> Self {
         self.acl_mode = Some(mode);
         self
@@ -827,6 +840,10 @@ impl TestMediatorBuilder {
             .streaming_enabled(self.enable_streaming)
             .local_endpoints(local_endpoints)
             .tls(TlsMode::Plain);
+        #[cfg(feature = "didcomm-v1")]
+        if let Some((enabled, allow_anon)) = self.didcomm_v1 {
+            builder = builder.didcomm_v1(enabled, allow_anon);
+        }
         if let Some(clock) = self.clock.clone() {
             builder = builder.clock(clock);
         }
@@ -907,6 +924,33 @@ impl TestMediatorHandle {
     /// caller wants to merge them into a different resolver.
     pub fn mediator_secrets(&self) -> &[Secret] {
         &self.mediator_secrets
+    }
+
+    /// The mediator's DIDComm v1 routing verkey.
+    ///
+    /// A real client is told this out of band, or reads it from a
+    /// `mediate-grant`; the mediator logs it at startup because v1 predates
+    /// DID documents as a discovery mechanism. Derived here the same way the
+    /// mediator derives it — from its Ed25519 authentication key — so a test
+    /// can address forwards to it without scraping logs.
+    #[cfg(feature = "didcomm-v1")]
+    pub fn didcomm_v1_routing_verkey(
+        &self,
+    ) -> Option<affinidi_messaging_didcomm_v1::identity::Verkey> {
+        use affinidi_secrets_resolver::secrets::KeyType;
+
+        self.mediator_secrets
+            .iter()
+            .find(|secret| secret.get_key_type() == KeyType::Ed25519)
+            .and_then(|secret| <[u8; 32]>::try_from(secret.get_private_bytes()).ok())
+            .and_then(|seed| {
+                affinidi_messaging_didcomm_v1::PrivateIdentity::from_signing_key(
+                    &self.inner.mediator_did,
+                    &seed,
+                )
+                .ok()
+            })
+            .map(|identity| identity.verkey)
     }
 
     /// Shareable shutdown token. Cancel from anywhere to drain the

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -514,17 +514,21 @@ impl TestMediatorBuilder {
 
     // ─── ACL / security knobs ────────────────────────────────────────
 
-    /// Override the mediator's access-list mode. Defaults to
-    /// `ExplicitDeny` (matching `SecurityConfig::default`). Set to
-    /// `ExplicitAllow` to simulate an allowlist deployment, where DIDs
-    /// without an explicit `LOCAL` ACL bit are rejected.
     /// Enable DIDComm v1, optionally accepting unauthenticated forwards.
+    ///
+    /// A mediator serving v1 wallets also needs a `global_acl_default` that
+    /// grants `RECEIVE_MESSAGES`, or `mediate-request` is denied — see
+    /// [`Self::global_acl_default`].
     #[cfg(feature = "didcomm-v1")]
     pub fn didcomm_v1(mut self, enabled: bool, allow_unauthenticated_forwards: bool) -> Self {
         self.didcomm_v1 = Some((enabled, allow_unauthenticated_forwards));
         self
     }
 
+    /// Override the mediator's access-list mode. Defaults to
+    /// `ExplicitDeny` (matching `SecurityConfig::default`). Set to
+    /// `ExplicitAllow` to simulate an allowlist deployment, where DIDs
+    /// without an explicit `LOCAL` ACL bit are rejected.
     pub fn acl_mode(mut self, mode: AccessListModeType) -> Self {
         self.acl_mode = Some(mode);
         self

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/didcomm_v1_mediation.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/didcomm_v1_mediation.rs
@@ -1,0 +1,488 @@
+//! End-to-end DIDComm v1 mediation against a live mediator.
+//!
+//! Walks the exact sequence an Aries wallet performs, over HTTP, with nothing
+//! stubbed:
+//!
+//! 1. `mediate-request` → `mediate-grant`, learning the mediator's routing key
+//! 2. `keylist-update` (add) → the mediator will now route to that key
+//! 3. a third party anon-packs a `routing/1.0/forward` for it → stored
+//! 4. `status-request` → one message queued
+//! 5. `delivery-request` → the message, still queued
+//! 6. `messages-received` → acknowledged and dropped
+//!
+//! Each request is authcrypt'd to the mediator's routing verkey and each reply
+//! comes back as the **raw HTTP body**, which is Aries' return-route. Opening
+//! those replies is what proves the mediator packed them correctly, so this
+//! covers the response path as well as the request path.
+
+#![cfg(feature = "didcomm-v1")]
+
+use affinidi_messaging_didcomm_v1::envelope::{self, EnvelopeProtection, RecipientKey};
+use affinidi_messaging_didcomm_v1::identity::{PrivateIdentity, Verkey};
+use affinidi_messaging_didcomm_v1::message::{MessageV1, pack};
+use affinidi_messaging_didcomm_v1::protocols::{
+    basic_message::BasicMessage, coordinate_mediation as cm, forward, message_pickup as mp,
+};
+use affinidi_messaging_test_mediator::{MediatorACLSet, TestMediator};
+use serde_json::Value;
+
+/// A v1 client: one Ed25519 identity plus the mediator's routing key.
+struct Client {
+    identity: PrivateIdentity,
+    mediator_verkey: Verkey,
+    endpoint: String,
+    http: reqwest::Client,
+}
+
+impl Client {
+    /// Authcrypt `msg` to the mediator, POST it, and open the reply.
+    ///
+    /// Returns `None` when the mediator answered with something other than a
+    /// v1 envelope (a routed forward gets the JSON success envelope instead).
+    async fn request(&self, msg: &MessageV1) -> Option<MessageV1> {
+        let packed =
+            pack::pack_encrypted_authcrypt(msg, &self.identity, &[self.mediator_verkey]).unwrap();
+
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .body(packed)
+            .send()
+            .await
+            .expect("POST /inbound");
+        assert!(
+            response.status().is_success(),
+            "mediator rejected {}: {}",
+            msg.typ,
+            response.status()
+        );
+        let body = response.text().await.expect("response body");
+
+        // A protocol reply is a bare v1 envelope; anything else is not one.
+        let value: Value = serde_json::from_str(&body).ok()?;
+        if value.get("protected").is_none() {
+            return None;
+        }
+
+        let x25519 = self.identity.x25519_private();
+        let keys = [RecipientKey {
+            verkey: self.identity.verkey,
+            x25519_private: &x25519,
+        }];
+        let opened = envelope::open(&body, &keys).expect("client opens the mediator's reply");
+
+        // The mediator authcrypts its replies, and it must be *this* mediator.
+        assert_eq!(
+            opened.protection,
+            EnvelopeProtection::Authcrypt {
+                sender_verkey: self.mediator_verkey
+            },
+            "a reply must be authenticated as coming from the mediator"
+        );
+
+        Some(MessageV1::from_json(&opened.plaintext).expect("reply is a v1 message"))
+    }
+}
+
+/// Drive the whole flow: register, receive, collect, acknowledge.
+#[tokio::test]
+async fn v1_wallet_registers_receives_and_collects() {
+    let mediator = TestMediator::builder()
+        .didcomm_v1(true, true)
+        // A mediator that serves v1 wallets has to let the accounts it creates
+        // for them receive; without this, mediation is denied (see
+        // `mediation_is_denied_when_the_account_cannot_receive`).
+        .global_acl_default(MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap())
+        .spawn()
+        .await
+        .expect("spawn mediator");
+
+    let endpoint = format!("{}inbound", mediator.endpoint());
+    let http = reqwest::Client::new();
+
+    // The mediator's routing verkey is derived from its Ed25519 authentication
+    // key; a real client is told it out of band. Here we ask for it the way a
+    // client does — via mediate-grant — starting from the key the mediator
+    // logs at startup.
+    let mediator_verkey = mediator
+        .didcomm_v1_routing_verkey()
+        .expect("mediator exposes its v1 routing verkey");
+
+    let client = Client {
+        identity: PrivateIdentity::generate("did:example:wallet").unwrap(),
+        mediator_verkey,
+        endpoint: endpoint.clone(),
+        http: http.clone(),
+    };
+
+    // ── 1. mediate-request → mediate-grant ──────────────────────────────
+    let request = cm::mediate_request().unwrap();
+    let grant = client.request(&request).await.expect("a grant");
+
+    assert_eq!(
+        cm::CoordinateMediation::classify(&grant),
+        Some(cm::CoordinateMediation::MediateGrant)
+    );
+    assert_eq!(
+        grant.explicit_thid(),
+        Some(request.id.as_str()),
+        "the grant must thread to the request"
+    );
+    let routing_keys = grant.body["routing_keys"]
+        .as_array()
+        .expect("routing_keys")
+        .iter()
+        .map(|k| Verkey::parse(k.as_str().unwrap()).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        routing_keys,
+        vec![mediator_verkey],
+        "the grant advertises the key senders must forward through"
+    );
+    assert!(
+        grant.body["endpoint"]
+            .as_str()
+            .is_some_and(|e| !e.is_empty())
+    );
+
+    // ── 2. keylist-update: register the key senders will address ────────
+    let recipient = PrivateIdentity::generate("did:example:wallet-recipient").unwrap();
+    let update = cm::keylist_update(
+        &[cm::KeylistUpdate {
+            recipient_key: recipient.verkey,
+            action: cm::KeylistAction::Add,
+        }],
+        cm::KeyFormat::Base58,
+    )
+    .unwrap();
+
+    let response = client.request(&update).await.expect("an update response");
+    assert_eq!(
+        cm::CoordinateMediation::classify(&response),
+        Some(cm::CoordinateMediation::KeylistUpdateResponse)
+    );
+    assert_eq!(response.body["updated"][0]["result"], "success");
+    assert_eq!(
+        response.body["updated"][0]["recipient_key"],
+        recipient.verkey.to_base58()
+    );
+
+    // Re-registering the same key is a no-op, not a second success.
+    let again = client.request(&update).await.expect("an update response");
+    assert_eq!(
+        again.body["updated"][0]["result"], "no_change",
+        "re-adding an already-registered key must report no_change"
+    );
+
+    // ── 3. a third party forwards a message to that key ─────────────────
+    let sender = PrivateIdentity::generate("did:example:someone-else").unwrap();
+    let payload = BasicMessage::new("your hovercraft is full of eels")
+        .unwrap()
+        .id("delivered-1")
+        .finalize();
+    let inner = pack::pack_encrypted_authcrypt(&payload, &sender, &[recipient.verkey]).unwrap();
+    let wrapped = forward::wrap_in_forward(&recipient.verkey, &inner, &mediator_verkey).unwrap();
+
+    let forwarded = http
+        .post(&endpoint)
+        .body(wrapped)
+        .send()
+        .await
+        .expect("POST forward");
+    let status_code = forwarded.status();
+    let detail = forwarded.text().await.unwrap_or_default();
+    assert!(
+        status_code.is_success(),
+        "the mediator must accept a forward for a registered key: {status_code} {detail}"
+    );
+
+    // ── 4. status-request → one queued ──────────────────────────────────
+    let status = client
+        .request(&mp::status_request(None).unwrap())
+        .await
+        .expect("a status");
+    assert_eq!(
+        mp::MessagePickup::classify(&status),
+        Some(mp::MessagePickup::Status)
+    );
+    assert_eq!(
+        status.body["message_count"], 1,
+        "the forwarded message must be queued for the registered key's owner"
+    );
+
+    // ── 5. delivery-request → the message, undeleted ────────────────────
+    let delivery = client
+        .request(&mp::delivery_request(10, None).unwrap())
+        .await
+        .expect("a delivery");
+    assert_eq!(
+        mp::MessagePickup::classify(&delivery),
+        Some(mp::MessagePickup::Delivery)
+    );
+
+    let delivered = mp::parse_delivery(&delivery).expect("delivery parses");
+    assert_eq!(delivered.len(), 1);
+
+    // The delivered bytes are the sender's envelope, still sealed to the
+    // recipient — the mediator never opened it.
+    let recipient_x25519 = recipient.x25519_private();
+    let recipient_keys = [RecipientKey {
+        verkey: recipient.verkey,
+        x25519_private: &recipient_x25519,
+    }];
+    let opened = envelope::open(
+        &serde_json::to_string(&delivered[0].envelope).unwrap(),
+        &recipient_keys,
+    )
+    .expect("recipient opens the delivered envelope");
+    assert_eq!(
+        opened.protection,
+        EnvelopeProtection::Authcrypt {
+            sender_verkey: sender.verkey
+        },
+        "the end-to-end sender survives the round trip through the mediator"
+    );
+    let received = MessageV1::from_json(&opened.plaintext).unwrap();
+    assert_eq!(received.id, "delivered-1");
+    assert_eq!(received.body["content"], "your hovercraft is full of eels");
+
+    // Delivery is not deletion: it is still queued until acknowledged.
+    let status = client
+        .request(&mp::status_request(None).unwrap())
+        .await
+        .expect("a status");
+    assert_eq!(
+        status.body["message_count"], 1,
+        "a delivered-but-unacknowledged message must remain queued"
+    );
+
+    // ── 6. messages-received → dropped ──────────────────────────────────
+    let ack = mp::messages_received(&[delivered[0].id.clone()]).unwrap();
+    let status = client.request(&ack).await.expect("a status");
+    assert_eq!(
+        mp::MessagePickup::classify(&status),
+        Some(mp::MessagePickup::Status)
+    );
+    assert_eq!(
+        status.body["message_count"], 0,
+        "acknowledged messages must be dropped"
+    );
+}
+
+/// A forward for a key nobody registered must not be accepted — otherwise the
+/// mediator stores traffic for accounts that never asked for it.
+#[tokio::test]
+async fn forward_to_an_unregistered_key_is_refused() {
+    let mediator = TestMediator::builder()
+        .didcomm_v1(true, true)
+        // A mediator that serves v1 wallets has to let the accounts it creates
+        // for them receive; without this, mediation is denied (see
+        // `mediation_is_denied_when_the_account_cannot_receive`).
+        .global_acl_default(MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap())
+        .spawn()
+        .await
+        .expect("spawn mediator");
+
+    let mediator_verkey = mediator.didcomm_v1_routing_verkey().unwrap();
+    let stranger = PrivateIdentity::generate("did:example:stranger").unwrap();
+    let sender = PrivateIdentity::generate("did:example:sender").unwrap();
+
+    let payload = BasicMessage::new("nobody asked for this")
+        .unwrap()
+        .finalize();
+    let inner = pack::pack_encrypted_anoncrypt(&payload, &[stranger.verkey]).unwrap();
+    let wrapped = forward::wrap_in_forward(&stranger.verkey, &inner, &mediator_verkey).unwrap();
+    let _ = sender;
+
+    let http = reqwest::Client::new();
+    let endpoint = format!("{}inbound", mediator.endpoint());
+
+    // Guard against passing for the wrong reason: a mistyped URL would also
+    // 404, and this assertion is only meaningful if the route exists. A
+    // forward for a *registered* key must succeed at the same URL — proved by
+    // `v1_wallet_registers_receives_and_collects` — so check the route answers
+    // something other than 404 for a well-formed non-forward first.
+    let probe = http
+        .post(&endpoint)
+        .body("not a v1 envelope")
+        .send()
+        .await
+        .expect("probe /inbound");
+    assert_ne!(
+        probe.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "the /inbound route must exist, or the 404 below would be meaningless"
+    );
+
+    let response = http
+        .post(&endpoint)
+        .body(wrapped)
+        .send()
+        .await
+        .expect("POST forward");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an unregistered routing key must not resolve to a mailbox"
+    );
+}
+
+/// One client must not be able to unregister another's routing key — that would
+/// let it silently cut off the other's inbound traffic.
+#[tokio::test]
+async fn a_client_cannot_remove_another_clients_routing_key() {
+    let mediator = TestMediator::builder()
+        .didcomm_v1(true, true)
+        // A mediator that serves v1 wallets has to let the accounts it creates
+        // for them receive; without this, mediation is denied (see
+        // `mediation_is_denied_when_the_account_cannot_receive`).
+        .global_acl_default(MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap())
+        .spawn()
+        .await
+        .expect("spawn mediator");
+
+    let endpoint = format!("{}inbound", mediator.endpoint());
+    let mediator_verkey = mediator.didcomm_v1_routing_verkey().unwrap();
+    let http = reqwest::Client::new();
+
+    let alice = Client {
+        identity: PrivateIdentity::generate("did:example:alice").unwrap(),
+        mediator_verkey,
+        endpoint: endpoint.clone(),
+        http: http.clone(),
+    };
+    let mallory = Client {
+        identity: PrivateIdentity::generate("did:example:mallory").unwrap(),
+        mediator_verkey,
+        endpoint,
+        http,
+    };
+
+    // Alice registers a key.
+    let key = PrivateIdentity::generate("did:example:alice-recipient").unwrap();
+    let add = cm::keylist_update(
+        &[cm::KeylistUpdate {
+            recipient_key: key.verkey,
+            action: cm::KeylistAction::Add,
+        }],
+        cm::KeyFormat::Base58,
+    )
+    .unwrap();
+    let response = alice.request(&add).await.expect("update response");
+    assert_eq!(response.body["updated"][0]["result"], "success");
+
+    // Mallory tries to claim it, then to remove it.
+    for action in [cm::KeylistAction::Add, cm::KeylistAction::Remove] {
+        let attempt = cm::keylist_update(
+            &[cm::KeylistUpdate {
+                recipient_key: key.verkey,
+                action,
+            }],
+            cm::KeyFormat::Base58,
+        )
+        .unwrap();
+        let response = mallory.request(&attempt).await.expect("update response");
+        assert_eq!(
+            response.body["updated"][0]["result"], "client_error",
+            "{action:?} on another account's key must be refused"
+        );
+    }
+
+    // Alice's binding is intact: a forward for her key still lands.
+    let query = alice
+        .request(&MessageV1::new(cm::KEYLIST_QUERY_TYPE, serde_json::json!({})).unwrap())
+        .await
+        .expect("keylist");
+    assert_eq!(
+        query.body["keys"][0]["recipient_key"],
+        key.verkey.to_base58()
+    );
+}
+
+/// A `did:key`-spelled `recipient_key` must register the same key a base58 one
+/// does — Credo picks its spelling from configuration, and getting this wrong
+/// means half of the wallets out there silently fail to receive.
+#[tokio::test]
+async fn keylist_accepts_did_key_and_base58_interchangeably() {
+    let mediator = TestMediator::builder()
+        .didcomm_v1(true, true)
+        // A mediator that serves v1 wallets has to let the accounts it creates
+        // for them receive; without this, mediation is denied (see
+        // `mediation_is_denied_when_the_account_cannot_receive`).
+        .global_acl_default(MediatorACLSet::from_string_ruleset("ALLOW_ALL").unwrap())
+        .spawn()
+        .await
+        .expect("spawn mediator");
+
+    let client = Client {
+        identity: PrivateIdentity::generate("did:example:wallet").unwrap(),
+        mediator_verkey: mediator.didcomm_v1_routing_verkey().unwrap(),
+        endpoint: format!("{}inbound", mediator.endpoint()),
+        http: reqwest::Client::new(),
+    };
+
+    let key = PrivateIdentity::generate("did:example:recipient").unwrap();
+
+    // Register with the did:key spelling.
+    let add = cm::keylist_update(
+        &[cm::KeylistUpdate {
+            recipient_key: key.verkey,
+            action: cm::KeylistAction::Add,
+        }],
+        cm::KeyFormat::DidKey,
+    )
+    .unwrap();
+    assert_eq!(
+        add.body["updates"][0]["recipient_key"],
+        key.verkey.to_did_key(),
+        "the request really is in did:key form"
+    );
+    let response = client.request(&add).await.expect("update response");
+    assert_eq!(response.body["updated"][0]["result"], "success");
+
+    // Removing it in base58 form must find the same binding.
+    let remove = cm::keylist_update(
+        &[cm::KeylistUpdate {
+            recipient_key: key.verkey,
+            action: cm::KeylistAction::Remove,
+        }],
+        cm::KeyFormat::Base58,
+    )
+    .unwrap();
+    let response = client.request(&remove).await.expect("update response");
+    assert_eq!(
+        response.body["updated"][0]["result"], "success",
+        "a key registered as did:key must be removable as base58 — one key, two spellings"
+    );
+}
+
+/// Granting mediation an account cannot use would be a silent black hole: the
+/// client publishes routing keys, senders forward to them, and every message is
+/// refused after the fact. The mediator must say so up front instead.
+#[tokio::test]
+async fn mediation_is_denied_when_the_account_cannot_receive() {
+    // The shipped default `global_acl_default` does not grant RECEIVE_MESSAGES.
+    let mediator = TestMediator::builder()
+        .didcomm_v1(true, true)
+        .spawn()
+        .await
+        .expect("spawn mediator");
+
+    let client = Client {
+        identity: PrivateIdentity::generate("did:example:wallet").unwrap(),
+        mediator_verkey: mediator.didcomm_v1_routing_verkey().unwrap(),
+        endpoint: format!("{}inbound", mediator.endpoint()),
+        http: reqwest::Client::new(),
+    };
+
+    let request = cm::mediate_request().unwrap();
+    let reply = client.request(&request).await.expect("a reply");
+
+    assert_eq!(
+        cm::CoordinateMediation::classify(&reply),
+        Some(cm::CoordinateMediation::MediateDeny),
+        "mediation the account cannot use must be denied, not granted"
+    );
+    assert_eq!(reply.explicit_thid(), Some(request.id.as_str()));
+}

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/didcomm_v1_mediation.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/didcomm_v1_mediation.rs
@@ -60,9 +60,7 @@ impl Client {
 
         // A protocol reply is a bare v1 envelope; anything else is not one.
         let value: Value = serde_json::from_str(&body).ok()?;
-        if value.get("protected").is_none() {
-            return None;
-        }
+        value.get("protected")?;
 
         let x25519 = self.identity.x25519_private();
         let keys = [RecipientKey {


### PR DESCRIPTION
Stage 2 of the mediator's DIDComm v1 support, completing what #689 started: a v1
wallet can now register its routing keys and collect what arrives, so the
`didcomm-v1` feature is usable end to end rather than plumbing.

Adds **coordinate-mediation 1.0** (RFC 0211) and **message-pickup 2.0**
(RFC 0685) — message types in the v1 crate, handlers in the mediator.

## The whole flow, tested against a live mediator

`tests/didcomm_v1_mediation.rs` walks the exact sequence an Aries wallet
performs, over HTTP, nothing stubbed:

```
mediate-request   →  mediate-grant            learn the routing key
keylist-update    →  keylist-update-response  register a recipient key
                     (third party forwards)   a message arrives
status-request    →  status                   one queued
delivery-request  →  delivery                 the message, still queued
messages-received →  status                   acknowledged and dropped
```

Each reply is opened by the client, which is what proves the mediator packed it
correctly — the response path is covered as well as the request path. The
delivered envelope is opened by its real recipient, showing the end-to-end
sender survives the round trip untouched.

## Three things worth reviewing closely

### 1. Replies go back as the raw HTTP body

That is Aries' return-route: a one-way transport carrying a synchronous
response. Credo's `isValidJweStructure` requires only `protected` / `iv` /
`ciphertext` / `tag`, so a v1 envelope is accepted there unchanged — wrapping it
in the mediator's JSON success envelope would hand the client a reply it cannot
parse. `/inbound` now returns a `Response` so the v1 branch can answer directly.

Replies are **authcrypt**, not anoncrypt: a forgeable `mediate-grant` would let
an attacker nominate its own routing keys and capture the client's inbound
traffic.

### 2. A third dual-spelling trap

`recipient_key` and `routing_keys` accept bare base58 **or** `did:key` for the
same key. RFC 0211 specifies `did:key`, base58 predates it and is still widely
sent, and Credo normalises on receipt while picking its outbound form from
`useDidKeyInProtocols`. Same shape as the two message-type document URIs found in
stage 1, one field down. `Verkey::parse` handles it and comparisons happen on the
decoded key; there is a test that a key registered as `did:key` is removable as
base58.

### 3. `mediate-request` is denied when the account cannot receive

The e2e test caught this. An auto-created account inherits `global_acl_default`,
which by default does not grant `RECEIVE_MESSAGES` — so the client was told
mediation was granted, published its routing keys, and then every forward was
refused with 403. A silent black hole with no way for the client to detect it.

`mediate-request` now checks and answers `mediate-deny` instead, with a test for
each branch. **Operators serving v1 wallets need a `global_acl_default` that
grants receive**; the changelog says so.

## Identity and admission

A client's account is the `did:key` derived from its authenticated verkey —
deterministic, no extra state. Unlike forwards, these messages are authenticated
by construction: opening the envelope proves which verkey sent it, and a v1
plaintext has no `from` header to lie in. An anonymous mediation request is
refused.

Provisioning mirrors `handlers::authenticate::response` rather than adding a
second policy: unknown accounts are created with `global_acl_default` unless
`mediator_acl_mode` is `explicit_allow`. One admission gate, two entry points.

## Handler behaviour

- `keylist-update` reports a result per key rather than failing the batch, as
  RFC 0211 expects. Claiming or removing another account's key is refused as
  `client_error` — the same answer as any other rejected entry, so it cannot be
  used to probe which keys others hold.
- `delivery-request` fetches with `DoNotDelete`: pickup acknowledges separately,
  and deleting on delivery loses any message whose delivery was lost in flight.
  `messages-received` deletes under `Owner` authority, so a client cannot delete
  another's messages by guessing ids.
- An empty queue answers `status`, not an empty `delivery`, which would read as
  a delivery that dropped everything.
- Delivery limits capped, acknowledgement lists bounded — authenticated, but the
  numbers are still caller-chosen.
- `live-delivery-change` answers truthfully with `live_delivery: false` rather
  than accepting and never pushing.

## A test that passed for the wrong reason

`forward_to_an_unregistered_key_is_refused` asserted 404 and got it — from a
mistyped URL, not from the mediator refusing anything. It now probes the route
first, so the assertion cannot pass unless `/inbound` exists.

## Scope

Pickup **2.0** only: Credo's default strategy is `PickUpV2` and 1.0
(`batch-pickup`) is legacy, worth adding if a target wallet needs it. Live
delivery is answered truthfully rather than implemented — it needs a persistent
connection per client, which is a separate piece of work.

## Verification

- `cargo test -p affinidi-messaging-test-mediator --features didcomm-v1` — 82 pass
- `cargo test -p affinidi-messaging-didcomm-v1` — 122 pass
- `cargo test -p affinidi-messaging-mediator --features didcomm-v1` — 185 lib pass
- `cargo clippy --workspace --all-targets` clean; mediator clean on default,
  `didcomm-v1`, and `didcomm-v1,tsp`
- `check-version-bumps.sh`, `check-changelogs.sh`,
  `check-workspace-duplicates.sh` — all pass

`publish dry-run` / `verify-publish` will be red on the same unpublished-sibling
grounds as #689: `affinidi-messaging-mediator` requires
`affinidi-messaging-didcomm-v1 = "0.2"`, which this PR publishes. The release job
publishes in dependency order.
