### PR TITLE
chore: track trust-tasks-rs 0.4.0

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.23] - 2026-08-09
+
+### Changed
+
+- Track `trust-tasks-rs` 0.4.0 (was 0.2.46) and `affinidi-messaging-sdk` 0.19.3.
+  This crate uses `trust_tasks_rs::specs::messaging::account` to register with a
+  mediator; those types are unchanged across the bump, so no code changed.
+
+  `trust-tasks-rs` is a public dependency of the SDK's `trust_tasks()` surface
+  and therefore of this crate's, so a consumer still on `trust-tasks-rs` 0.2.x
+  must move to `0.4` in the same change that takes this version. See the
+  `affinidi-messaging-sdk` 0.19.3 entry for why this is a patch rather than a
+  minor.
+
 ## [0.3.22] - 2026-07-30
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.22"
+version = "0.3.23"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -24,7 +24,7 @@ affinidi-tdk-common = "0.6"
 affinidi-messaging-sdk = "0.19"
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.2.46"
+trust-tasks-rs = "0.4.0"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-helpers"
-version = "0.13.2"
+version = "0.13.3"
 description = "CLI tools for Affinidi Messaging (mediator administration)"
 edition.workspace = true
 authors.workspace = true
@@ -23,7 +23,7 @@ path = "src/mediator_administration/main.rs"
 ## SDK for connecting to and communicating with a running mediator
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.2.46"
+trust-tasks-rs = "0.4.0"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Affinidi Messaging Mediator
 
+## 9th August 2026 (0.18.10)
+
+**Tracks `trust-tasks-rs` 0.4.0 (was 0.2.46).** Dependency bump; no mediator
+code changed.
+
+The one observable difference: a Trust Task request that carries the new
+optional `parentThreadId` envelope member now has it echoed onto the response,
+because `respond_with` propagates it. Nothing sends it yet, and the member is
+omitted from the wire when unset, so a response to a request from an older
+client is byte-identical to 0.18.9's.
+
+The framework's other 0.3/0.4 changes do not reach this crate. Error responses
+moved to `trust-task-error/0.3` with an `inResponseTo` member — the mediator
+emits no Trust Task error documents (its failures travel as
+`affinidi-messaging-mediator-common`'s HTTP `ErrorResponse`), so that is inert
+here. Digest-carrying payload members became the `DigestMultibase` newtype; the
+only one this crate touches is `audit::list::v0_1::AuditEnvelope`'s
+`entryHash`/`prevHash`, which the messaging audit log leaves `None` — the log is
+not hash-chained.
+
+Requires `affinidi-messaging-sdk` 0.19.3. That crate's `trust_tasks()` surface
+is typed in `trust-tasks-rs`, so the two have to cross the version boundary
+together.
+
 ## 8th August 2026 (0.18.9)
 
 **DIDComm v1 mediation: coordinate-mediation 1.0 and message-pickup 2.0.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.9"
+version = "0.18.10"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -92,7 +92,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.2.46", optional = true }
+trust-tasks-rs = { version = "0.4.0", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.19.3] - 2026-08-09
+
+### Changed
+
+- **Tracks `trust-tasks-rs` 0.4.0 (was 0.2.46). Source-breaking for a consumer
+  that also depends on `trust-tasks-rs` 0.2.x, despite the patch version.**
+  `atm.trust_tasks()` returns `trust_tasks_rs` types — `TrustTask<R>`,
+  `account::update::v0_1::MediatorAcl`, `audit::list::v0_1::Response` and the
+  rest — so `trust-tasks-rs` is a *public* dependency of this crate's API.
+  Crossing its leading version component changes those types' identity: a caller
+  still on 0.2.x gets `E0308` at the call site, not a deprecation warning.
+
+  It ships as a patch because it cannot ship as a minor. `vta-sdk` requires
+  `affinidi-messaging-sdk = "0.19"` and resolves it from the registry (it
+  deliberately keeps no `[patch.crates-io]`), and this workspace's own mediator
+  depends on `vta-sdk`. A 0.20 would therefore pull a *second*, registry copy of
+  this crate into the mediator's graph alongside the workspace one — the ADR
+  0003 trap. Update in lockstep instead: a consumer moves its own
+  `trust-tasks-rs` requirement to `0.4` in the same change that takes this
+  version.
+
+- Nothing in this crate is affected by the framework's own breaking changes.
+  `TrustTask` gained `parentThreadId` and `ErrorPayload` gained `inResponseTo`,
+  both of which only break struct-literal construction — this crate builds
+  documents through `TrustTask::for_payload` / `respond_with`. The digest-carrying
+  members that became the `DigestMultibase` newtype (`audit`, `chat`, `consent`,
+  `policy`, `task-consent`) are not constructed here. `decode_body` deserialises
+  whatever the mediator returns without asserting a Type URI, so an older peer's
+  documents still parse.
+
+- No wire-format change from this crate. `parentThreadId` is optional and
+  omitted when unset, so a request this SDK sends is byte-identical to 0.19.2's
+  unless the caller populates it.
+
 ## [0.19.2] - 2026-08-08
 
 Dependency-pin bump only; no API or behaviour change.

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.2"
+version = "0.19.3"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.2.46"
+trust-tasks-rs = "0.4.0"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Affinidi Messaging Test Mediator
 
+## 0.2.48 — 9th August 2026
+
+Tracks `trust-tasks-rs` 0.4.0 (was 0.2.46), alongside mediator 0.18.10 and SDK
+0.19.3. The `trust_tasks` e2e suite builds its request payloads from
+`trust_tasks_rs::specs::messaging::account` types, which are unchanged across
+the bump; no test changed.
+
+A downstream test crate that writes its own Trust Task assertions against this
+fixture has to move its own `trust-tasks-rs` requirement to `0.4` at the same
+time — the types are public across the SDK boundary.
+
 ## 0.2.47 — 8th August 2026
 
 Adds a `didcomm-v1` feature that spawns the mediator with DIDComm v1 support, a

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.47"
+version = "0.2.48"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.22"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.2.46"
+trust-tasks-rs = "0.4.0"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.12.5] - 2026-08-09
+
+### Changed
+
+- Track `trust-tasks-rs` 0.4.0 (was 0.2.46) and `affinidi-messaging-sdk` 0.19.3.
+  The `MediatorAclAccessListMode` and `account` types this client reads are
+  unchanged across the bump; no code changed.
+
 ## [0.12.4] - 2026-06-01
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.4"
+version = "0.12.5"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.2.46"
+trust-tasks-rs = "0.4.0"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates


### PR DESCRIPTION
Moves `trust-tasks-rs` from 0.2.46 to **0.4.0** across the six crates that depend
on it. No source changed beyond the version requirements.

## What changed upstream

Two breaking releases sit between the pins:

**0.3.0** — `TrustTask` gained `parentThreadId` and `ErrorPayload` gained
`inResponseTo` (both break struct-literal construction only); error responses
moved to `trust-task-error/0.3`.

**0.4.0** — digest-carrying payload members became the `DigestMultibase`
newtype, in `audit`, `chat`, `consent`, `policy` and `task-consent`.

## Why none of it reaches our code

- Documents are built through `TrustTask::for_payload` / `respond_with`, never
  by struct literal, so the two new envelope members are additive here.
- The mediator emits no Trust Task error documents — its failures travel as
  `affinidi-messaging-mediator-common`'s HTTP `ErrorResponse` — so
  `trust-task-error/0.3` is inert.
- The only `DigestMultibase` field this workspace touches is
  `audit::list::v0_1::AuditEnvelope`'s `entryHash`/`prevHash`, which the
  messaging audit log leaves `None`: the log is not hash-chained.
- The SDK's `decode_body` deserialises whatever the mediator returns without
  asserting a Type URI, so an older peer's documents still parse.

The one observable difference on the wire: a request carrying the new optional
`parentThreadId` now has it echoed onto the response, because `respond_with`
propagates it. Nothing sends it yet, and it is omitted when unset, so responses
to existing clients are byte-identical.

## Why these are patches and not minors

`trust-tasks-rs` is a **public** dependency of `affinidi-messaging-sdk`'s API —
`atm.trust_tasks()` returns `TrustTask<R>`, `account::update::v0_1::MediatorAcl`
and friends — so crossing its leading version component is source-breaking for a
consumer that also depends on `trust-tasks-rs` 0.2.x. That would ordinarily
argue for a minor.

It cannot be a minor. `vta-sdk` requires `affinidi-messaging-sdk = "0.19"` and
resolves it from the registry (it deliberately keeps no `[patch.crates-io]`),
and this workspace's own mediator depends on `vta-sdk`. A 0.20 would pull a
second, registry copy of the SDK into the mediator's graph — the ADR 0003 trap.

So: patch versions, with the break spelled out in each CHANGELOG per **R3.6**.

## Downstream coordination (R3.6)

`vta-sdk` 0.21.7 pins `trust-tasks-rs = "0.2.55"` and calls
`atm.trust_tasks().account_update(..., Some(MediatorAcl), ...)` at
`vta-sdk/src/acl_setup.rs:142`. It gets an `E0308` the moment it takes these
versions, so `verifiable-trust-infrastructure` needs one PR that moves its
workspace `trust-tasks-rs` requirement to `0.4` and updates the SDK together.

Two things make this safe to land and publish first:

- VTI commits its `Cargo.lock` (pinning `affinidi-messaging-sdk` 0.19.2 and
  `trust-tasks-rs` 0.2.60), so publishing does not break their build until they
  deliberately `cargo update`.
- `deny.toml` sets `multiple-versions = "allow"`, so the transient duplicate
  (0.2.60 via `vta-sdk`, 0.4.0 direct) does not fail CI. It clears when VTI
  moves.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p affinidi-messaging-test-mediator --features tsp,didcomm-v1,fjall-backend --no-fail-fast` — **119 passed, 0 failed**
- `scripts/check-version-bumps.sh` and `scripts/check-changelogs.sh` — both pass
- `scripts/check-workspace-duplicates.sh` — no workspace member shadowed

## Versions

| crate | from | to |
| --- | --- | --- |
| `affinidi-messaging-sdk` | 0.19.2 | 0.19.3 |
| `affinidi-messaging-mediator` | 0.18.9 | 0.18.10 |
| `affinidi-messaging-didcomm-service` | 0.3.22 | 0.3.23 |
| `affinidi-messaging-test-mediator` | 0.2.47 | 0.2.48 |
| `affinidi-messaging-helpers` | 0.13.2 | 0.13.3 |
| `affinidi-messaging-text-client` | 0.12.4 | 0.12.5 |
