### PR TITLE
chore: require the SDK version whose trust-tasks types match

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.3.24] - 2026-08-09
+
+### Fixed
+
+- **Require `affinidi-messaging-sdk` 0.19.3, not "0.19".** 0.3.23 shipped asking
+  for `^0.19` while itself requiring `trust-tasks-rs` `^0.4.0`. Those two are
+  mutually satisfiable by a resolver and mutually incompatible at compile time:
+  `trust-tasks-rs` is a public dependency of the SDK's `trust_tasks()` surface,
+  and 0.19.2 exposes it as 0.2.x. This crate hands
+  `trust_tasks_rs::specs::messaging::account` types to `atm.trust_tasks()`, so
+  the pair 0.19.2 + 0.4.0 fails with `E0308`.
+
+  A fresh resolve picks 0.19.3 and compiles — which is why publishing 0.3.23
+  succeeded — but a consumer with an existing lockfile pinning 0.19.2, or one
+  passing `--precise 0.19.2`, gets the mismatch. The packaged manifest now names
+  the minimum SDK carrying the matching `trust-tasks-rs`, so a stale one is
+  rejected at resolve time instead of at compile time.
+
+  Same failure mode as `affinidi-messaging-didcomm-v1` 0.1.0's
+  `affinidi-messaging-core` requirement (#688).
+
 ## [0.3.23] - 2026-08-09
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.23"
+version = "0.3.24"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ tsp = ["affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 affinidi-tdk-common = "0.6"
-affinidi-messaging-sdk = "0.19"
+affinidi-messaging-sdk = "0.19.3"
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
 trust-tasks-rs = "0.4.0"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.3" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
 trust-tasks-rs = "0.4.0"
 ## TDK for DID resolution and crypto utilities

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Affinidi Messaging Mediator
 
+## 9th August 2026 (0.18.11)
+
+**Requires `affinidi-messaging-sdk` 0.19.3, not "0.19".** Preventive, not a fix:
+unlike `affinidi-messaging-didcomm-service` 0.3.24, no `trust-tasks-rs` type
+crosses this crate's SDK boundary today — it uses the SDK for `compat`
+metadata, message wrapping and Discover-Features only, and serves Trust Tasks
+through its own handlers. 0.18.10 therefore built correctly against either SDK.
+
+The requirement is tightened anyway so the invariant holds without anyone having
+to remember it: **a crate that declares both `trust-tasks-rs` and
+`affinidi-messaging-sdk` names the SDK version whose public `trust_tasks()`
+types match its own `trust-tasks-rs`.** The moment a trust-tasks type does cross
+that boundary here, the correct requirement is already in place rather than
+discovered by a downstream `E0308`.
+
 ## 9th August 2026 (0.18.10)
 
 **Tracks `trust-tasks-rs` 0.4.0 (was 0.2.46).** Dependency bump; no mediator

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.10"
+version = "0.18.11"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.3" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Affinidi Messaging Test Mediator
 
+## 0.2.49 — 9th August 2026
+
+**Requires `affinidi-messaging-sdk` 0.19.3, not "0.19".** 0.2.48 shipped asking
+for `^0.19` while itself requiring `trust-tasks-rs` `^0.4.0` — a pair a resolver
+can satisfy with SDK 0.19.2 and a compiler cannot, because `trust-tasks-rs` is a
+public dependency of the SDK's `trust_tasks()` surface and 0.19.2 exposes it as
+0.2.x.
+
+This fixture's own library never touches `trust_tasks_rs`, so the published lib
+built either way. The break lands on a *consumer*: a downstream crate that
+writes Trust Task assertions against this fixture declares `trust-tasks-rs` 0.4
+itself, and if the graph resolves SDK 0.19.2 its `atm.trust_tasks()` returns
+0.2.x types. Naming the minimum SDK here makes that resolve fail cleanly rather
+than compile-fail in the consumer's test code.
+
+See the `affinidi-messaging-didcomm-service` 0.3.24 entry for the full shape.
+
 ## 0.2.48 — 9th August 2026
 
 Tracks `trust-tasks-rs` 0.4.0 (was 0.2.46), alongside mediator 0.18.10 and SDK

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.48"
+version = "0.2.49"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secre
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.19", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.19.3", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 [dependencies]
 # Affinidi Crates
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.3" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
 trust-tasks-rs = "0.4.0"


### PR DESCRIPTION
Follow-up to #692. That PR moved `trust-tasks-rs` to 0.4.0 but left every
sibling requiring `affinidi-messaging-sdk = "0.19"`, which is one version too
loose to be correct.

## The bug

`affinidi-messaging-didcomm-service` 0.3.23 is on crates.io asking for:

```
affinidi-messaging-sdk = ^0.19      # accepts 0.19.2
trust-tasks-rs         = ^0.4.0
```

A resolver can satisfy both. A compiler cannot. `trust-tasks-rs` is a **public**
dependency of the SDK's `trust_tasks()` surface, SDK 0.19.2 exposes it as 0.2.x,
and this crate hands `trust_tasks_rs::specs::messaging::account` types straight
into `atm.trust_tasks()`.

Reproduced against the published crate — a fresh consumer of 0.3.23 plus
`cargo update -p affinidi-messaging-sdk --precise 0.19.2`:

```
Downgrading affinidi-messaging-sdk v0.19.3 -> v0.19.2
     Adding trust-tasks-rs v0.2.60
```

…leaving `trust-tasks-rs` 0.2.60 **and** 0.4.1 in one graph. Compiling that pair
is the `E0308` that `verify-publish` reported on #692. That job was red for what
looked like the usual registry-isolation reason and went green after release
only because a *fresh* resolve picks 0.19.3 — which is precisely what hides the
problem from CI and leaves it for whoever has a lockfile, or passes `--precise`.

Same failure mode as `affinidi-messaging-didcomm-v1` 0.1.0's
`affinidi-messaging-core` requirement (#688, `2527960`): a packaged manifest has
to name the minimum version carrying the API it actually uses, so a stale one is
rejected at resolve time rather than at compile time.

## The fix

Requirements now name `0.19.3`. Verified it rejects the bad pair cleanly:

```
error: failed to select a version for the requirement `affinidi-messaging-sdk = "^0.19.3"`
candidate versions found which didn't match: 0.19.2
```

Applied as an invariant rather than a spot fix: **a crate that declares both
`trust-tasks-rs` and `affinidi-messaging-sdk` names the SDK version whose public
`trust_tasks()` types match its own `trust-tasks-rs`.**

| crate | why | version |
| --- | --- | --- |
| `affinidi-messaging-didcomm-service` | proven break — passes trust-tasks types into `atm.trust_tasks()` | 0.3.23 → **0.3.24** |
| `affinidi-messaging-test-mediator` | breaks a downstream that writes its own Trust Task assertions against the fixture | 0.2.48 → **0.2.49** |
| `affinidi-messaging-mediator` | preventive — see below | 0.18.10 → **0.18.11** |
| `affinidi-messaging-helpers` | `publish = false` — never reached a registry | requirement only |
| `affinidi-messaging-text-client` | `publish = false` — never reached a registry | requirement only |

The mediator is deliberately labelled preventive in its changelog: no
`trust-tasks-rs` type crosses its SDK boundary today (it uses the SDK for
`compat` metadata, message wrapping and Discover-Features, and serves Trust
Tasks through its own handlers), so 0.18.10 built correctly either way. It is
tightened so the invariant holds without anyone having to remember it.

`affinidi-messaging-mediator-monitor` is untouched — it declares no
`trust-tasks-rs`, so the rule does not apply.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p affinidi-messaging-test-mediator --features tsp,didcomm-v1,fjall-backend` — **119 passed, 0 failed**
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` — all pass

`verify-publish` should be green on this PR: 0.19.3 is published, so the
registry-isolated resolve now finds a satisfying SDK.

Unrelated note: `trust-tasks-rs` 0.4.1 published today (purely additive —
`trust_task_next_step::v0_1` bindings). Our `^0.4.0` requirement picks it up with
no manifest change.
