### PR TITLE
fix: a poll in flight must not block stop_websocket

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.19.4] - 2026-08-10
+
+### Fixed
+
+- **A poll in flight no longer blocks `stop_websocket`, so shutdown is prompt.**
+  The four `live_stream_next*` entry points in `message_pickup` took a **read**
+  guard on `Mediator::ws_channel_tx` to get the command sender and then held it
+  across the wait for a frame. `stop_websocket` takes the **write** guard on that
+  same lock, so any teardown with a poll parked had to wait the poll out.
+
+  For the delivery layer that is `INBOUND_POLL_WAIT`, 10 seconds — its inbound
+  pump issues a read-ahead after every frame, so a consumer whose work finished
+  mid-window paid the remainder on exit. A CLI felt this as a fixed pause after
+  every command: the result printed, then up to 10s of nothing before the process
+  left. For a `wait: None` caller it was worse — that sleep is `Duration::MAX`,
+  so the read guard was held until a frame arrived, and a shutdown could block
+  indefinitely.
+
+  The sender is now cloned out and the guard dropped before the wait. `mpsc::Sender`
+  is `Clone`, so this costs nothing and the poll behaves identically; only the
+  lock is released earlier. No API change.
+
+  Covered by `profiles::tests::a_poll_in_flight_does_not_block_stop_websocket`,
+  which parks a 120s poll and asserts `stop_websocket` still returns within 2s.
+
 ## [0.19.3] - 2026-08-09
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.3"
+version = "0.19.4"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/profiles.rs
@@ -717,6 +717,83 @@ mod tests {
         atm.graceful_shutdown().await;
     }
 
+    /// A poll in flight must not block `stop_websocket`.
+    ///
+    /// `live_stream_next*` takes a **read** guard on `ws_channel_tx` to get the
+    /// command sender, then waits for a frame. `stop_websocket` takes the
+    /// **write** guard on the same lock. If the read guard is held across the
+    /// wait, every shutdown blocks until the poll window elapses — 10s for the
+    /// delivery layer's `INBOUND_POLL_WAIT`, and *forever* for a `wait: None`
+    /// caller, whose sleep is `Duration::MAX`.
+    ///
+    /// This is what made every `pnm` command sit for ~10s after printing its
+    /// result: the command finished mid-window, the inbound pump had just
+    /// issued its next read-ahead, and teardown waited the poll out.
+    ///
+    /// The fix clones the sender and drops the guard before waiting, so this
+    /// test's `stop_websocket` returns promptly while the poll is still parked.
+    #[tokio::test]
+    async fn a_poll_in_flight_does_not_block_stop_websocket() {
+        let tdk_cfg = TDKConfig::headless().expect("headless tdk config");
+        let tdk = Arc::new(
+            TDKSharedState::new(tdk_cfg)
+                .await
+                .expect("tdk shared state"),
+        );
+        let atm_cfg = ATMConfig::builder().build().expect("atm config");
+        let atm = ATM::new(atm_cfg, tdk).await.expect("atm");
+
+        let profile = fake_profile();
+        let mediator = mediator_of(&profile);
+
+        // A stand-in for the websocket task: we keep the receiver so the
+        // channel stays open and the poll parks on its `rx` exactly as it
+        // would against a real socket that has nothing to deliver.
+        let (tx, mut rx) = mpsc::channel::<WebSocketCommands>(8);
+        mediator.ws_channel_tx.write().await.replace(tx);
+
+        // Park a poll with a wait far longer than this test's patience. Without
+        // the fix it holds the read guard for all of it.
+        let poll_profile = profile.clone();
+        let poll_atm = atm.clone();
+        let poll = tokio::spawn(async move {
+            poll_atm
+                .message_pickup()
+                .live_stream_next_frame(&poll_profile, Some(Duration::from_secs(120)), false)
+                .await
+        });
+
+        // Wait until the poll has actually sent its `Next` — only then is it
+        // parked on the wait, which is the state under test. Asserting on the
+        // command also proves we are exercising the real path, not a poll that
+        // bailed out early on a missing channel.
+        let cmd = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("the poll should send its Next command promptly")
+            .expect("channel open");
+        assert!(
+            matches!(cmd, WebSocketCommands::Next(..)),
+            "expected the poll to request the next frame"
+        );
+
+        // The property: shutdown is not held hostage by that parked poll.
+        timeout(Duration::from_secs(2), profile.stop_websocket())
+            .await
+            .expect(
+                "stop_websocket blocked behind an in-flight poll — the read guard \
+                 is being held across the wait again",
+            )
+            .expect("stop_websocket should succeed");
+
+        assert!(
+            mediator.ws_channel_tx.read().await.is_none(),
+            "the sender slot must be cleared by stop_websocket",
+        );
+
+        poll.abort();
+        atm.graceful_shutdown().await;
+    }
+
     /// The connection-state signal is `None` until a transport runs, then is
     /// exposed via `ATMProfile::connection_state()` starting at `Connecting`.
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -304,14 +304,24 @@ impl MessagePickup {
 
             let (tx, rx) = tokio::sync::oneshot::channel();
             // Send the next request to the profile websocket
-            let Some(ws_channel) = &*mediator.ws_channel_tx.read().await else {
-                warn!(
-                    "WebSocket channel not set for profile {}",
-                    profile.inner.alias
-                );
-                return Err(ATMError::ProfileError(
-                    "No WebSocket channel set for profile".into(),
-                ));
+            // Clone the sender, then drop the read guard *before* the wait
+            // below. `stop_websocket` takes the WRITE lock on this same
+            // `ws_channel_tx`, so a guard held across the wait blocks every
+            // shutdown until the poll window elapses — and with `wait: None`
+            // that window is `Duration::MAX`, i.e. forever. The sender is an
+            // `mpsc::Sender`, so a clone is cheap and carries no borrow.
+            let ws_channel = {
+                let guard = mediator.ws_channel_tx.read().await;
+                let Some(ws_channel) = guard.as_ref() else {
+                    warn!(
+                        "WebSocket channel not set for profile {}",
+                        profile.inner.alias
+                    );
+                    return Err(ATMError::ProfileError(
+                        "No WebSocket channel set for profile".into(),
+                    ));
+                };
+                ws_channel.clone()
             };
 
             let tx_uuid = mediator.get_tx_uuid();
@@ -413,14 +423,24 @@ impl MessagePickup {
             };
 
             let (tx, rx) = tokio::sync::oneshot::channel();
-            let Some(ws_channel) = &*mediator.ws_channel_tx.read().await else {
-                warn!(
-                    "WebSocket channel not set for profile {}",
-                    profile.inner.alias
-                );
-                return Err(ATMError::ProfileError(
-                    "No WebSocket channel set for profile".into(),
-                ));
+            // Clone the sender, then drop the read guard *before* the wait
+            // below. `stop_websocket` takes the WRITE lock on this same
+            // `ws_channel_tx`, so a guard held across the wait blocks every
+            // shutdown until the poll window elapses — and with `wait: None`
+            // that window is `Duration::MAX`, i.e. forever. The sender is an
+            // `mpsc::Sender`, so a clone is cheap and carries no borrow.
+            let ws_channel = {
+                let guard = mediator.ws_channel_tx.read().await;
+                let Some(ws_channel) = guard.as_ref() else {
+                    warn!(
+                        "WebSocket channel not set for profile {}",
+                        profile.inner.alias
+                    );
+                    return Err(ATMError::ProfileError(
+                        "No WebSocket channel set for profile".into(),
+                    ));
+                };
+                ws_channel.clone()
             };
 
             let tx_uuid = mediator.get_tx_uuid();
@@ -514,14 +534,24 @@ impl MessagePickup {
 
             let (tx, rx) = tokio::sync::oneshot::channel();
             // Send the next request to the profile websocket
-            let Some(ws_channel) = &*mediator.ws_channel_tx.read().await else {
-                warn!(
-                    "WebSocket channel not set for profile {}",
-                    profile.inner.alias
-                );
-                return Err(ATMError::ProfileError(
-                    "No WebSocket channel set for profile".into(),
-                ));
+            // Clone the sender, then drop the read guard *before* the wait
+            // below. `stop_websocket` takes the WRITE lock on this same
+            // `ws_channel_tx`, so a guard held across the wait blocks every
+            // shutdown until the poll window elapses — and with `wait: None`
+            // that window is `Duration::MAX`, i.e. forever. The sender is an
+            // `mpsc::Sender`, so a clone is cheap and carries no borrow.
+            let ws_channel = {
+                let guard = mediator.ws_channel_tx.read().await;
+                let Some(ws_channel) = guard.as_ref() else {
+                    warn!(
+                        "WebSocket channel not set for profile {}",
+                        profile.inner.alias
+                    );
+                    return Err(ATMError::ProfileError(
+                        "No WebSocket channel set for profile".into(),
+                    ));
+                };
+                ws_channel.clone()
             };
 
             // Send the get request to the ws_handler
@@ -1122,14 +1152,24 @@ impl MessagePickup {
 
             let (tx, rx) = tokio::sync::oneshot::channel();
             // Send the next request to the profile websocket
-            let Some(ws_channel) = &*mediator.ws_channel_tx.read().await else {
-                warn!(
-                    "WebSocket channel not set for profile {}",
-                    profile.inner.alias
-                );
-                return Err(ATMError::ProfileError(
-                    "No WebSocket channel set for profile".into(),
-                ));
+            // Clone the sender, then drop the read guard *before* the wait
+            // below. `stop_websocket` takes the WRITE lock on this same
+            // `ws_channel_tx`, so a guard held across the wait blocks every
+            // shutdown until the poll window elapses — and with `wait: None`
+            // that window is `Duration::MAX`, i.e. forever. The sender is an
+            // `mpsc::Sender`, so a clone is cheap and carries no borrow.
+            let ws_channel = {
+                let guard = mediator.ws_channel_tx.read().await;
+                let Some(ws_channel) = guard.as_ref() else {
+                    warn!(
+                        "WebSocket channel not set for profile {}",
+                        profile.inner.alias
+                    );
+                    return Err(ATMError::ProfileError(
+                        "No WebSocket channel set for profile".into(),
+                    ));
+                };
+                ws_channel.clone()
             };
 
             let tx_uuid = mediator.get_tx_uuid();


### PR DESCRIPTION
A poll in flight holds a read lock that `stop_websocket` needs, so shutdown
waits the poll out. Found while diagnosing a CLI that paused ~10s after every
command.

## The bug

All four `live_stream_next*` entry points in `message_pickup` do:

```rust
let Some(ws_channel) = &*mediator.ws_channel_tx.read().await else { … };
//  ^ `ws_channel` borrows the guard, so the guard lives to end of scope
…
select! { _ = sleep, … }   // ← guard still held, for up to `wait`
```

`ws_channel` borrows from the temporary `RwLockReadGuard`, which extends its
lifetime to the end of the enclosing scope — across the wait.

`ATMProfile::stop_websocket` takes the **write** guard on that same
`ws_channel_tx`. So while any poll is parked, every shutdown blocks.

## What it costs

- **Delivery layer: 10s per teardown.** `DidCommTransport::inbound()` polls with
  `INBOUND_POLL_WAIT` (10s) in a loop, issuing a fresh read-ahead after every
  frame. A consumer that finishes mid-window pays the remainder on exit. A CLI
  shows this as a fixed pause *after* its output: work done, result printed, then
  up to 10s of nothing.
- **`wait: None`: unbounded.** That sleep is `Duration::MAX`, so the read guard
  is held until a frame arrives and a shutdown can block indefinitely.

Real trace from the CLI that surfaced it — command completes at 3.03s, exit at
13.03s, the whole gap ending in the poll's own timeout:

```
 3.033  live_stream_next_frame: sent next request to websocket for inbound frame
 3.035  ┌ Contexts (10) ─────┐        ← command done, output printed
13.034  live_stream_next_frame: Timeout reached, no message received
13.034  Profile: Removed from profiles / Stopping WebSocket connection
```

Exactly 10.001s, and every step of teardown lands in the millisecond after the
poll expires.

## The fix

Clone the sender and drop the guard before waiting. `mpsc::Sender` is `Clone`, so
this costs nothing; the poll is otherwise unchanged and only the lock is released
earlier. Applied to all four sites, which were byte-identical.

**No API change**, and the poll windows are untouched — 10s is a fine long-poll
cadence. What was wrong is that a process exiting had to wait for one.

## Test

`profiles::tests::a_poll_in_flight_does_not_block_stop_websocket` parks a 120s
poll, confirms it has actually sent its `Next` command (so it is genuinely parked
rather than bailing out early on a missing channel), then asserts
`stop_websocket` returns within 2s.

Verified to fail without the fix, timing out with exactly its diagnostic:

```
stop_websocket blocked behind an in-flight poll — the read guard is being
held across the wait again: Elapsed(())
```

Full `affinidi-messaging-sdk` lib suite: 115 passed, 0 failed. Clippy and
`cargo fmt --check` clean.

## Version

`affinidi-messaging-sdk` 0.19.3 → **0.19.4**. A patch: pure bug fix, no API
change — and per the 0.19.3 changelog note, a minor here would pull a second
registry copy of this crate into the mediator's graph via `vta-sdk` (the ADR 0003
trap).

## Note for the downstream bump

I could not verify this end-to-end against the real CLI: `[patch.crates-io]`-ing
just this crate from a local checkout drags its workspace siblings
(`affinidi-tsp`, `mediator-common`) into the consumer's graph, and `affinidi-tsp`
then fails to compile there — the same double-copy trap. So the proof here is the
unit test plus the trace above, and end-to-end confirmation wants a released
0.19.4.
