### PR TITLE
fix: let a TSP frame name itself in a build without the tsp feature

### DIFF
--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## [0.19.5] - 2026-08-11
+
+### Fixed
+
+- **A TSP frame now names itself in a build without the `tsp` feature, instead
+  of surfacing as a JSON parse error.** Recognising a TSP frame and processing
+  one are different jobs, but classification lived behind the `tsp` feature
+  alongside the machinery. A build without it therefore did not merely fail to
+  *handle* a TSP frame — it failed to *recognise* one, handed the CESR bytes to
+  the DIDComm unpacker, and reported
+
+  ```text
+  Error unpacking message: DidcommError("Cannot parse message as JSON",
+  "invalid number at line 1 column 2")
+  ```
+
+  CESR qb64 opens with `-`, which `serde_json` reads as the start of a number,
+  hence the column-2 failure. Nothing in that message names TSP, names the
+  missing feature, or suggests the frame was well-formed and simply unreadable
+  by this build.
+
+  This was found downstream: a VTC advertising `#tsp` in its DID document, built
+  without the feature, accepted every community join and recorded none. Senders
+  saw success — the frames were delivered, just never decoded.
+
+  Two `#[cfg(not(feature = "tsp"))]` warnings written for exactly this case could
+  never fire, because both sit *downstream* of classification —
+  `transport_adapter::tsp_to_inbound`'s fallback is reached only after a frame
+  has been tagged TSP, which was the gated step. Its doc comment read "a
+  DIDComm-only build never advertises TSP, so this is unreachable in practice";
+  a build does not control what its operator's DID document advertises.
+
+  Classification now lives in the new `tsp_wire` module and is compiled into
+  **every** build — it inspects one leading byte and needs no TSP machinery.
+  Unpacking still requires the feature; the difference is that a build lacking
+  it now says so by name. Three paths improve:
+
+  - the live websocket transport tags the frame as packed rather than feeding it
+    to the DIDComm unpacker;
+  - `transport_adapter::tsp_to_inbound`'s non-`tsp` arm is now reachable and
+    logs at ERROR, naming the transport, why this build cannot read it, and both
+    remedies (rebuild with `--features tsp`, or stop advertising `TSPTransport`);
+  - the DIDComm-only pickup path (`_handle_delivery`) identifies a TSP
+    attachment and purges it as undeliverable-by-name, rather than as a failed
+    DIDComm unpack.
+
+  No behaviour change for a build **with** `tsp`: classification is byte-for-byte
+  the same test, and `TspOps::is_tsp` now delegates to the shared implementation
+  so the gated and ungated answers cannot disagree. `tsp_wire::TSP_MAGIC_BYTE`
+  is pinned to `affinidi_tsp::TSP_MAGIC_BYTE` by a test that compiles under the
+  feature, and a second test asserts the two classifiers agree on real frames, so
+  the copy cannot drift.
+
+  The regression guard is
+  `transports::websockets::websocket::tests::a_tsp_frame_is_delivered_packed_in_every_build`,
+  which compiles in **every** feature configuration. Re-introducing a
+  `#[cfg(feature = "tsp")]` around the classification fails the default build —
+  verified by mutation. Notably, that same mutation still *passes* with `tsp`
+  enabled, which is exactly how the original defect survived: every TSP-focused
+  test run has the feature on, so no existing test could have caught it.
+
+### Added
+
+- `tsp_wire::{looks_like_tsp, TSP_MAGIC_BYTE}`, re-exported at the crate root.
+  Lets any consumer — including one built without `tsp` — tell a TSP frame from
+  a DIDComm one without pulling in the TSP stack.
+
 ## [0.19.4] - 2026-08-10
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.4"
+version = "0.19.5"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/lib.rs
@@ -226,8 +226,10 @@ pub mod protocols;
 pub mod public;
 pub mod transport_adapter;
 pub mod transports;
+pub mod tsp_wire;
 
 pub use transport_adapter::DidCommTransport;
+pub use tsp_wire::{TSP_MAGIC_BYTE, looks_like_tsp};
 
 #[derive(Clone)]
 pub struct ATM {

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -949,6 +949,35 @@ impl MessagePickup {
                         }
                     };
 
+                    // Name a TSP frame before it reaches the DIDComm unpacker.
+                    // This is the DIDComm-only pickup path, so a TSP frame here
+                    // cannot be delivered either way — but "this is TSP and this
+                    // stream doesn't carry TSP" is a diagnosis, where the unpack
+                    // failure below is `Cannot parse message as JSON ... invalid
+                    // number at line 1 column 2` (CESR qb64 opens with `-`),
+                    // which names nothing an operator can act on. Purged like
+                    // any other undeliverable attachment so the mediator stops
+                    // redelivering it every pickup cycle.
+                    if crate::tsp_wire::looks_like_tsp(&decoded) {
+                        warn!(
+                            "Undeliverable attachment: a TSP frame arrived on a DIDComm-only \
+                             pickup stream; purging. id({:?}). The frame is not corrupt — either \
+                             this build lacks the `tsp` feature, or this consumer is using the \
+                             DIDComm-only pickup path (use `live_stream_next_frame` to \
+                             multiplex TSP + DIDComm).",
+                            attachment.id
+                        );
+                        report_and_delete(
+                            atm,
+                            profile,
+                            &attachment.id,
+                            decoded.clone(),
+                            "TSP frame received on a DIDComm-only pickup stream".to_string(),
+                        )
+                        .await;
+                        continue;
+                    }
+
                     match atm
                         .inner
                         .unpack_with(&decoded, atm.inner.config.unpack_policy())

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -438,11 +438,14 @@ impl TspOps<'_> {
     /// Whether a fetched/stored message is a TSP message (base64url-decode +
     /// magic-byte check). DIDComm JSON / compact JWS is not valid base64url of a
     /// TSP message, so it returns `false`.
+    ///
+    /// Delegates to [`crate::tsp_wire::looks_like_tsp`], which is available in
+    /// every build. Classification deliberately does not live behind the `tsp`
+    /// feature — see that module for why — and having one implementation is
+    /// what keeps the gated and ungated answers from disagreeing about the same
+    /// frame.
     pub fn is_tsp(&self, stored: &str) -> bool {
-        BASE64_URL_SAFE_NO_PAD
-            .decode(stored.as_bytes())
-            .map(|bytes| affinidi_tsp::is_tsp(&bytes))
-            .unwrap_or(false)
+        crate::tsp_wire::looks_like_tsp(stored)
     }
 
     /// Decode a stored TSP message (`base64url(qb2)`) back to its raw qb2 bytes.

--- a/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transport_adapter.rs
@@ -244,11 +244,30 @@ async fn tsp_to_inbound(atm: &ATM, profile: &Arc<ATMProfile>, packed: &str) -> O
 
 /// Fallback when the `tsp` feature is off: an inbound TSP frame can't be
 /// unpacked (no `atm.tsp()`), so it is skipped rather than dropping the whole
-/// stream. A DIDComm-only build never advertises TSP, so this is unreachable in
-/// practice.
+/// stream.
+///
+/// **Reachable, and reached in production.** This used to carry the note "a
+/// DIDComm-only build never advertises TSP, so this is unreachable in
+/// practice" — but a build does not control what its operator's DID document
+/// advertises. One advertised `#tsp` against a binary compiled without the
+/// feature, and because frame *classification* was gated on that same feature,
+/// the frame never got here: it went to the DIDComm unpacker and surfaced as a
+/// JSON parse error naming nothing relevant. Classification is unconditional
+/// now (see [`crate::tsp_wire`]), so this arm runs and can say what happened.
+///
+/// The message names the transport, why this build cannot read it, and both
+/// remedies — a rejection an operator can act on, rather than one that reads
+/// like a corrupt message.
 #[cfg(not(feature = "tsp"))]
-async fn tsp_to_inbound(_atm: &ATM, _profile: &Arc<ATMProfile>, _packed: &str) -> Option<Inbound> {
-    tracing::warn!("received an inbound TSP frame but the `tsp` feature is disabled — skipping it");
+async fn tsp_to_inbound(_atm: &ATM, _profile: &Arc<ATMProfile>, packed: &str) -> Option<Inbound> {
+    tracing::error!(
+        bytes = packed.len(),
+        "received a well-formed inbound TSP frame, but this build of \
+         affinidi-messaging-sdk was compiled without the `tsp` feature and cannot unpack it — \
+         dropping. The frame is not corrupt; this binary simply has no TSP support. Either \
+         rebuild with `--features tsp`, or stop advertising a `TSPTransport` service in this \
+         DID's document so senders fall back to a transport this build serves."
+    );
     None
 }
 

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -596,13 +596,24 @@ impl WebSocketTransport {
         // self-describing (CESR qb64), so sniff it and deliver TSP frames packed
         // — the consumer unpacks them via `atm.tsp()`. Without this a TSP frame
         // would fail the DIDComm `unpack` below and be silently dropped.
-        #[cfg(feature = "tsp")]
-        let force_packed = atm.tsp().is_tsp(&message);
-        #[cfg(not(feature = "tsp"))]
-        let force_packed = false;
-
+        //
+        // Classification is **not** gated on the `tsp` feature, and that is
+        // load-bearing. It used to be, which meant a build without the feature
+        // did not merely fail to handle a TSP frame — it failed to *recognise*
+        // one, sent it to the DIDComm unpacker, and surfaced the whole thing as
+        // `Cannot parse message as JSON ... invalid number at line 1 column 2`
+        // (CESR qb64 opens with `-`). That named neither TSP nor the missing
+        // feature, and it short-circuited the two `cfg(not(feature = "tsp"))`
+        // warnings written for this exact case: both sit *downstream* of
+        // classification, so gating classification made them unreachable.
+        //
+        // Recognising a frame needs one byte; only unpacking needs the TSP
+        // stack. Every consumer path already handles a packed frame it did not
+        // ask for — the DIDComm-only streams warn by name and delete it (no
+        // redelivery loop), and `transport_adapter::tsp_to_inbound`'s non-`tsp`
+        // arm now actually runs and says what arrived and why it can't be read.
         // If skip_unpack_messages is true, send the packed message directly
-        if self.skip_unpack_messages || force_packed {
+        if deliver_packed(self.skip_unpack_messages, &message) {
             // A packed frame has exactly three possible homes, tried in order:
             // an outstanding `Next` request, the direct channel, or the packed
             // cache. It must reach one of them — every arm that gives up on the
@@ -993,9 +1004,53 @@ fn refresh_after_secs(ttl_secs: u64) -> u64 {
     (ttl_secs * 4) / 5
 }
 
+/// Should this inbound frame be delivered **packed** rather than DIDComm-
+/// unpacked?
+///
+/// Two reasons to skip the unpacker: the consumer asked for packed frames
+/// (`skip_unpack`), or the frame is TSP and the unpacker would only mangle it.
+///
+/// A free function purely so the decision is testable in *both* feature
+/// configurations — see [`tests::a_tsp_frame_is_delivered_packed_in_every_build`].
+/// The TSP half must never be gated on the `tsp` feature: gating it is precisely
+/// the defect this replaced, where an unrecognised TSP frame reached
+/// `atm.unpack` and surfaced as `Cannot parse message as JSON`.
+fn deliver_packed(skip_unpack: bool, message: &str) -> bool {
+    skip_unpack || crate::tsp_wire::looks_like_tsp(message)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The regression guard for the gating defect. This test compiles and runs
+    /// in **every** feature configuration, so re-introducing a
+    /// `#[cfg(feature = "tsp")]` around the TSP classification fails the default
+    /// build rather than silently restoring the silent-drop behaviour.
+    #[test]
+    fn a_tsp_frame_is_delivered_packed_in_every_build() {
+        use base64::prelude::*;
+        let tsp = BASE64_URL_SAFE_NO_PAD.encode([crate::tsp_wire::TSP_MAGIC_BYTE, 0x41, 0x42]);
+
+        assert!(
+            deliver_packed(false, &tsp),
+            "a TSP frame must bypass the DIDComm unpacker even when the consumer did not ask \
+             for packed frames, and even in a build without the `tsp` feature — otherwise it \
+             dies in serde_json as `invalid number at line 1 column 2`"
+        );
+    }
+
+    /// The other direction: DIDComm still goes to the unpacker unless the
+    /// consumer opted out. A classifier that over-claimed would divert real
+    /// DIDComm traffic into the packed path — a worse failure than the one fixed.
+    #[test]
+    fn didcomm_still_goes_to_the_unpacker() {
+        let didcomm =
+            r#"{"protected":"eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIn0"}"#;
+        assert!(!deliver_packed(false, didcomm));
+        // ...unless the consumer explicitly wants packed frames.
+        assert!(deliver_packed(true, didcomm));
+    }
 
     #[test]
     fn a_long_lived_connection_earns_an_immediate_retry() {

--- a/crates/messaging/affinidi-messaging-sdk/src/tsp_wire.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/tsp_wire.rs
@@ -1,0 +1,143 @@
+//! Classifying a TSP frame **without** the `tsp` feature.
+//!
+//! Recognising a TSP frame and *processing* one are different jobs with very
+//! different requirements. Processing needs the whole TSP stack. Recognising
+//! needs one byte.
+//!
+//! Conflating them cost a downstream deployment a working service. A VTC
+//! advertised `#tsp` in its DID document while its binary was built without
+//! this crate's `tsp` feature. Classification lived behind that feature, so an
+//! inbound CESR frame was never recognised as TSP at all — it fell through to
+//! [`crate::ATM::unpack`], and the operator's only clue was
+//!
+//! ```text
+//! Error unpacking message: DidcommError("Cannot parse message as JSON",
+//! "invalid number at line 1 column 2")
+//! ```
+//!
+//! CESR qb64 begins with `-`, which `serde_json` reads as the start of a
+//! number, hence the column-2 failure. Nothing in that message names TSP, names
+//! the missing feature, or hints that the frame was a perfectly well-formed
+//! message this build simply could not read.
+//!
+//! Worse, the two warnings written for exactly this case could never fire.
+//! [`crate::transport_adapter`]'s `tsp_to_inbound` has a
+//! `#[cfg(not(feature = "tsp"))]` arm that says the right thing — but it is
+//! reached only *after* a frame has been classified as TSP, which is the step
+//! that was gated. Its comment read "a DIDComm-only build never advertises TSP,
+//! so this is unreachable in practice". A build does not control what its
+//! operator's DID document advertises, and this one advertised it.
+//!
+//! So classification moves here, where it is unconditional. A build without
+//! `tsp` still cannot *unpack* a TSP frame — that genuinely needs the feature —
+//! but it can now say so by name instead of emitting a JSON parse error.
+
+use base64::prelude::*;
+
+/// The leading byte of every TSP message: the first byte of the binary-CESR
+/// `-E` count code. DIDComm is JSON or compact JWS, so it starts with `{`
+/// (`0x7B`) or `ey…` — making this byte an unambiguous discriminator.
+///
+/// Deliberately duplicated from `affinidi_tsp::TSP_MAGIC_BYTE` rather than
+/// imported: importing it would put this classifier back behind the `tsp`
+/// feature, which is the whole defect. The copy is pinned to the original by
+/// [`tests::magic_byte_matches_affinidi_tsp`], which compiles only when the
+/// feature is on — so the two cannot drift without a test failing.
+pub const TSP_MAGIC_BYTE: u8 = 0xF8;
+
+/// Does `stored` look like a TSP frame?
+///
+/// `stored` is the transit/storage form the mediator streams: `base64url(qb2)`,
+/// no padding. Decodes and inspects the leading byte only.
+///
+/// A *pre-classifier for routing*, not a validator — exactly the contract of
+/// `affinidi_tsp::is_tsp`, which it mirrors. `true` means "hand this to the TSP
+/// path, which will validate it"; `false` is conclusive, since no TSP message
+/// can start with any other byte. DIDComm JSON and compact JWS are not valid
+/// base64url of a TSP frame, so they return `false`.
+///
+/// Available in every build. That is the point: see the module docs.
+#[must_use]
+pub fn looks_like_tsp(stored: &str) -> bool {
+    BASE64_URL_SAFE_NO_PAD
+        .decode(stored.as_bytes())
+        .is_ok_and(|bytes| bytes.first() == Some(&TSP_MAGIC_BYTE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A frame whose decoded bytes lead with the magic byte, in the qb64 form
+    /// the mediator actually streams.
+    fn qb64(leading: u8) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode([leading, 0x41, 0x42, 0x43])
+    }
+
+    #[test]
+    fn recognises_a_tsp_frame() {
+        let frame = qb64(TSP_MAGIC_BYTE);
+        // The property that made this bug so confusing: qb64 of a TSP frame
+        // renders as text starting `-`, which serde_json reads as the start of
+        // a number and reports as "invalid number at line 1 column 2".
+        assert!(frame.starts_with('-'), "expected CESR qb64 text: {frame}");
+        assert!(looks_like_tsp(&frame));
+    }
+
+    /// DIDComm in both its wire shapes. A false positive here would divert real
+    /// DIDComm traffic into the TSP path, which is a worse failure than the one
+    /// being fixed — so both are pinned.
+    #[test]
+    fn does_not_claim_didcomm() {
+        assert!(!looks_like_tsp(
+            r#"{"typ":"application/didcomm-plain+json"}"#
+        ));
+        assert!(!looks_like_tsp("eyJhbGciOiJFZERTQSJ9.e30.c2ln"));
+    }
+
+    #[test]
+    fn does_not_claim_a_non_tsp_binary_frame() {
+        assert!(!looks_like_tsp(&qb64(0x7B)));
+    }
+
+    #[test]
+    fn empty_and_undecodable_input_is_not_tsp() {
+        assert!(!looks_like_tsp(""));
+        // Not valid base64url — must be `false`, never a panic: this runs on
+        // every inbound frame, so untrusted input must not be able to crash a
+        // consumer's receive loop.
+        assert!(!looks_like_tsp("!!! not base64 !!!"));
+        assert!(!looks_like_tsp(&BASE64_URL_SAFE_NO_PAD.encode([])));
+    }
+
+    /// The anti-drift pin. `affinidi_tsp` owns the wire definition; this crate
+    /// keeps a copy so classification can happen without the feature. If the
+    /// upstream constant ever changes, this fails rather than the copy silently
+    /// misclassifying every frame.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn magic_byte_matches_affinidi_tsp() {
+        assert_eq!(
+            TSP_MAGIC_BYTE,
+            affinidi_tsp::TSP_MAGIC_BYTE,
+            "the local copy of the TSP magic byte has drifted from affinidi_tsp"
+        );
+    }
+
+    /// Stronger than the constant check: the two classifiers must agree on
+    /// actual frames, so a change to *how* upstream classifies (not just which
+    /// byte) is caught too.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn agrees_with_affinidi_tsp_on_real_frames() {
+        for leading in [TSP_MAGIC_BYTE, 0x7B, 0x00, 0xFF] {
+            let frame = qb64(leading);
+            let decoded = BASE64_URL_SAFE_NO_PAD.decode(frame.as_bytes()).unwrap();
+            assert_eq!(
+                looks_like_tsp(&frame),
+                affinidi_tsp::is_tsp(&decoded),
+                "classifiers disagree on a frame leading with {leading:#04x}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Recognising a TSP frame and processing one are different jobs with very
different requirements — processing needs the whole TSP stack, recognising needs
one byte — but classification lived behind the `tsp` feature alongside the
machinery.

So a build without the feature did not merely fail to *handle* a TSP frame; it
failed to **recognise** one, handed the CESR bytes to the DIDComm unpacker, and
reported:

```
ERROR affinidi_messaging_sdk::…::websocket: Error unpacking message:
DidcommError("Cannot parse message as JSON", "invalid number at line 1 column 2")
```

CESR qb64 opens with `-`, which `serde_json` reads as the start of a number,
hence the column-2 failure. Nothing there names TSP, names the missing feature,
or suggests the frame was well-formed and simply unreadable by this build.

## How it was found

Downstream, the expensive way. A VTC advertising `#tsp` in its DID document,
built without the feature, accepted every community join and recorded none.
Senders saw success — the frames arrived, they were just never decoded. The
stack prefers TSP over DIDComm, so *every conforming client* chose the one
transport that could not work.

## Why no warning fired

Two `#[cfg(not(feature = "tsp"))]` arms were written for exactly this case, and
neither could ever run — both sit **downstream of classification**.
`transport_adapter::tsp_to_inbound`'s fallback is reached only after a frame has
been tagged `InboundFrame::Tsp`, which was the gated step.

Its doc comment read:

> A DIDComm-only build never advertises TSP, so this is unreachable in practice.

A build does not control what its operator's DID document advertises. This one
advertised it.

## The change

Classification moves to a new `tsp_wire` module compiled into **every** build —
it inspects one leading byte (`0xF8`) and needs no TSP machinery. Unpacking still
requires the feature; the difference is that a build lacking it now says so by
name. Three paths improve:

- **live websocket transport** — tags the frame as packed instead of feeding it
  to the DIDComm unpacker;
- **`transport_adapter::tsp_to_inbound`** — the non-`tsp` arm is now reachable
  and logs at ERROR, naming the transport, why this build cannot read it, and
  both remedies (rebuild with `--features tsp`, or stop advertising
  `TSPTransport`);
- **DIDComm-only pickup path** (`_handle_delivery`) — identifies a TSP
  attachment and purges it as undeliverable-by-name rather than as a failed
  DIDComm unpack, so it still can't poison the redelivery loop.

## No behaviour change with `tsp` enabled

The classification test is byte-for-byte the same one, and `TspOps::is_tsp` now
delegates to the shared implementation so the gated and ungated answers cannot
disagree about the same frame. `tsp_wire::TSP_MAGIC_BYTE` is pinned to
`affinidi_tsp::TSP_MAGIC_BYTE` by a test that compiles under the feature, and a
second test asserts both classifiers agree on real frames — so the copy cannot
drift.

Also considered and checked: making classification unconditional means a
non-`tsp` consumer can now receive a packed frame it did not ask for. Every
consumer path already handles that — the DIDComm-only streams in `message_pickup`
warn by name and delete the frame (added earlier to avoid exactly this poison
loop), and `InboundFrame` / `WebSocketResponses::PackedMessageReceived` are both
unconditional types. So this is strictly better than the previous outcome, which
was an unpack error.

## The regression guard, and why nothing caught this before

`transports::websockets::websocket::tests::a_tsp_frame_is_delivered_packed_in_every_build`
compiles in **every** feature configuration. The decision was extracted into a
free `deliver_packed(skip_unpack, message)` purely so it is testable without a
live socket.

Verified by mutation — re-introducing the `#[cfg(feature = "tsp")]` gate:

| build | result |
|---|---|
| default (no `tsp`) | **FAILS** — catches the regression |
| `--features tsp` | passes |

That second row is the whole story of how this defect survived: every
TSP-focused test in the repo runs with the feature on, so no existing test
*could* have caught it. The new guard is the one that runs where the bug lives.

## Verification

- `affinidi-messaging-sdk` lib tests: 121 pass (default), 148 pass (`--features tsp`)
- `affinidi-messaging-test-mediator` TSP integration suites unaffected —
  `tsp_delivery` 6/6 (direct, nested, routed, control, cross-mediator forward,
  DIDComm bridge) and `tsp_pickup_socket` 2/2 (the between-polls and
  slow-consumer packed-frame paths this change touches)
- `cargo clippy -p affinidi-messaging-sdk --all-targets` clean in both configs;
  `cargo fmt` clean
- `cargo check --workspace` clean
- version-bump guard: `affinidi-messaging-sdk 0.19.4 -> 0.19.5`, CHANGELOG updated
