### PR TITLE
chore: accept vta-sdk 0.22 so VTI's patch keeps applying

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Affinidi Messaging Mediator
 
+## 12th August 2026 (0.18.12)
+
+**Accepts `vta-sdk` 0.21 *or* 0.22** — `">=0.21.0, <0.23.0"`, was `"0.21.0"`.
+No mediator code changed.
+
+This crate is the reason the VTI workspace carries a `[patch.crates-io]` entry
+for its own `vta-sdk`. Their lockfile would otherwise hold two `vta-sdk` nodes,
+the workspace path copy and a registry copy reached through
+`vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator ->
+affinidi-messaging-mediator -> vta-sdk`, and `cargo publish --locked` verifies
+their dependents against the stale registry one.
+
+A patch only applies while the workspace copy satisfies every requirement on
+it. Under 0.x semver `^0.21` excludes 0.22, so when VTI bumped `vta-sdk` to
+0.22.0 the patch silently stopped applying and the registry node came back at
+0.21.21 — caught by their lockfile guard, which blocks the release PR that
+would publish 0.22.0. Nothing on their side can resolve it: the requirement
+lives here.
+
+Hard-bumping this to `"0.22"` deadlocks instead of fixing it. 0.22.0 is not on
+crates.io and cannot get there until that release PR merges, which it cannot do
+until this requirement admits 0.22. A range satisfies both ends at once: it
+resolves to 0.21.21 today, so this release builds and publishes against exactly
+what 0.18.11 did, and it re-admits the patch the moment 0.22.0 lands.
+
+Safe on the facts rather than on optimism. `integration` is
+`["client", "session"]`; vta-sdk 0.22.0's sole breaking change is
+`ProvisionIntegrationRequest.request` becoming `serde_json::Value`, gated behind
+`#[cfg(feature = "provision-integration")]`. That module is not compiled into
+this crate under either version, so the surface it links against is identical.
+
+`affinidi-messaging-mediator-setup` keeps `"0.21.0"` on purpose: it enables
+`provision-client`, which *does* pull in the changed module. It is
+`publish = false`, so it never reaches a downstream lockfile, and the workspace
+resolves both requirements to 0.21.21 regardless.
+
+Two follow-ups, neither blocking: tighten to `"0.22"` once 0.22.0 is published,
+and put this dependency behind a default-on `vta` feature. The latter is the
+real fix — `affinidi-messaging-test-mediator` already depends on this crate with
+`default-features = false, features = ["didcomm", "memory-backend"]`, so gating
+`vta-sdk` removes it from that build entirely and the cross-repo cycle stops
+existing. Usage is already quarantined in `tasks/vta_refresh.rs`,
+`common/config/vta_bootstrap.rs`, `common/config/vta_cache.rs` and
+`commands/rotate_admin.rs`, with two call sites leaking into
+`common/config/security.rs` and `common/config/mod.rs`.
+
 ## 9th August 2026 (0.18.11)
 
 **Requires `affinidi-messaging-sdk` 0.19.3, not "0.19".** Preventive, not a fix:

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.11"
+version = "0.18.12"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -118,8 +118,33 @@ affinidi-did-common = "0.4"
 affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
-## VTA SDK for centralized DID/key management via Verifiable Trust Agent
-vta-sdk = { version = "0.21.0", features = ["integration"] }
+## VTA SDK for centralized DID/key management via Verifiable Trust Agent.
+##
+## Range, not `"0.21.0"`, and deliberately so. The VTI workspace carries a
+## `[patch.crates-io] vta-sdk = { path = "vta-sdk" }` to keep its own crate out
+## of its lockfile twice — this crate is what pulls the registry copy back in,
+## through `vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator
+## -> affinidi-messaging-mediator -> vta-sdk`. A patch only applies while the
+## workspace copy satisfies every requirement on it, and under 0.x semver
+## `^0.21` excludes 0.22. So the moment VTI bumps vta-sdk to 0.22.0 the patch
+## silently stops applying, the registry node it exists to delete comes back,
+## and VTI's release PR cannot merge. No local change on their side fixes that;
+## the requirement here is the constraint.
+##
+## Hard-bumping to `"0.22"` instead would deadlock: 0.22.0 cannot be published
+## until that release PR merges, and it cannot merge until this requirement
+## admits 0.22. A range breaks the cycle without waiting on a publish.
+##
+## Widening is safe on the facts, not on optimism: `integration` resolves to
+## `["client", "session"]`, and vta-sdk 0.22.0's only breaking change is
+## `ProvisionIntegrationRequest.request` becoming `serde_json::Value`, behind
+## `#[cfg(feature = "provision-integration")]`. That module is not compiled
+## into this crate under either version.
+##
+## Tighten to `"0.22"` once 0.22.0 is published, and see the `vta` feature
+## follow-up — making this dependency optional removes the cycle outright,
+## since the test mediator already builds with `default-features = false`.
+vta-sdk = { version = ">=0.21.0, <0.23.0", features = ["integration"] }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
chore: accept vta-sdk 0.22 so VTI's patch keeps applying

`vta-sdk = ">=0.21.0, <0.23.0"`, was `"0.21.0"`. No mediator code changed.

This crate is the reason the VTI workspace carries a `[patch.crates-io]`
entry for its own `vta-sdk`. Their lockfile would otherwise hold two
`vta-sdk` nodes — the workspace path copy and a registry copy reached
through `vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator
-> affinidi-messaging-mediator -> vta-sdk` — and `cargo publish --locked`
verifies their dependents against the stale registry one.

A patch only applies while the workspace copy satisfies every requirement
on it. Under 0.x semver `^0.21` excludes 0.22, so when VTI bumped vta-sdk
to 0.22.0 the patch silently stopped applying and the registry node came
back at 0.21.21. Their lockfile guard catches it and blocks the release PR
that would publish 0.22.0. Nothing on their side resolves it — the
requirement lives here.

Hard-bumping to `"0.22"` deadlocks rather than fixes: 0.22.0 is not on
crates.io and cannot get there until that release PR merges, which it
cannot do until this requirement admits 0.22. A range satisfies both ends
at once. It resolves to 0.21.21 today, so this release builds and
publishes against exactly what 0.18.11 did, and it re-admits the patch the
moment 0.22.0 lands.

Safe on the facts, not on optimism. `integration` is `["client",
"session"]`; vta-sdk 0.22.0's sole breaking change is
`ProvisionIntegrationRequest.request` becoming `serde_json::Value`, behind
`#[cfg(feature = "provision-integration")]`. That module is not compiled
into this crate under either version, so the surface it links against is
identical. Verified: `cargo check -p affinidi-messaging-mediator` clean,
still resolving vta-sdk 0.21.21.

`affinidi-messaging-mediator-setup` keeps `"0.21.0"` deliberately — it
enables `provision-client`, which does pull in the changed module. It is
`publish = false`, so it never reaches a downstream lockfile, and the
workspace resolves both requirements to 0.21.21 regardless.

Two follow-ups, neither blocking. Tighten to `"0.22"` once it is
published, and put this dependency behind a default-on `vta` feature. The
latter is the real fix: `affinidi-messaging-test-mediator` already depends
on this crate with `default-features = false, features = ["didcomm",
"memory-backend"]`, so gating `vta-sdk` drops it from that build entirely
and the cross-repo cycle stops existing. Usage is already quarantined in
`tasks/vta_refresh.rs`, `common/config/vta_bootstrap.rs`,
`common/config/vta_cache.rs` and `commands/rotate_admin.rs`, with two call
sites leaking into `common/config/security.rs` and `common/config/mod.rs`.

