### PR TITLE
feat!: make vta-sdk optional behind a default-on `vta` feature

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Affinidi Messaging Mediator
 
+## 12th August 2026 (0.18.13)
+
+**`vta-sdk` is now optional, behind a default-on `vta` feature.** Nothing
+changes for the mediator binary or for anyone building this crate with default
+features.
+
+A patch bump, following the precedent this repo set in
+affinidi/affinidi-tdk-rs#674 (`feat!: … gate the legacy ssi-backed DID
+methods`), which put `did:ethr` / `did:pkh` behind off-by-default features and
+released `affinidi-did-resolver-cache-sdk` 0.8.21 → 0.8.22. Same shape here:
+the only consumers who lose anything are those already building with
+`default-features = false`, who now add `vta` to get `tasks::vta_refresh` and
+`commands::rotate_admin` back. The `!` on the commit marks that; the version
+follows the repo's convention rather than contradicting it.
+
+Keeping it a patch also means `affinidi-messaging-test-mediator` needs no
+release at all: its existing `affinidi-messaging-mediator = "0.18"` requirement
+resolves straight to this version, so the already-published 0.2.49 drops
+`vta-sdk` the moment a consumer updates.
+
+0.18.12, released hours earlier, widened the `vta-sdk` requirement so VTI's
+`[patch.crates-io]` would keep applying across their 0.22 bump. That fixed the
+instance. This fixes the cause.
+
+The cause is a dependency cycle spanning two repositories:
+
+```
+vta-sdk (VTI) ──published──▶ affinidi-messaging-mediator (this crate)
+    ▲                                       │
+    └───────── vtc-service [dev-deps] ──────┘
+               via affinidi-messaging-test-mediator
+```
+
+VTI papers over it with `[patch.crates-io] vta-sdk = { path = "vta-sdk" }`,
+which holds only while their workspace copy satisfies the requirement declared
+here. Under 0.x semver a minor bump does not, so the patch silently stops
+applying, the registry node it exists to delete returns, and their release is
+blocked until this crate is re-released. That has now happened at 0.20, 0.21
+and 0.22 — three times, each fixed by widening a requirement, which buys one
+version of headroom and leaves the cycle in place.
+
+`affinidi-messaging-test-mediator` — the crate VTI actually depends on —
+already builds this one with `default-features = false, features = ["didcomm",
+"memory-backend"]`. Gating `vta-sdk` therefore drops it from that build with no
+change on their side and no change in this repo either: `cargo tree -p
+affinidi-messaging-test-mediator -i vta-sdk` now reports no such package. The
+cycle stops existing and VTI can delete the patch entry rather than keep
+re-releasing this crate to keep it applying.
+
+Shape of the change: four already-VTA-specific modules are `cfg`-gated whole
+(`tasks/vta_refresh`, `common/config/vta_bootstrap`, `common/config/vta_cache`,
+`commands/rotate_admin`), as are the `rotate-admin` subcommand and the
+`Config::vta_refresher` field. The two places where SDK types had leaked into
+otherwise-generic code are handled by a seam rather than by more `cfg`:
+
+- `common/config/security.rs` took `Option<&DidSecretsBundle>` purely to read
+  `key_id` + `private_key_multibase` off each entry. It now takes
+  `Option<&[OperatingSecret]>`, a mediator-local type, so the conversion to
+  `Secret`, the resolver population and the self-hosted fallback all compile
+  identically either way and need no `cfg` at all.
+- `common/config/mod.rs` projects the SDK's `StartupResult` into two local
+  values (`authority_did`, `operating_secrets`) immediately after the gated
+  startup block. Every consumer downstream reads those, so the DID resolution,
+  the `operating_keys_loaded` flag and the security conversion are unchanged
+  source in both builds.
+
+Self-hosted deployments — operating secrets from the backend's well-known
+`mediator/operating/secrets` entry — never touched `vta-sdk` and are unaffected
+by any of this.
+
+Verified: `cargo clippy --all-targets` clean under both default features and
+`--no-default-features --features didcomm,memory-backend`; the 200-test suite
+passes; the test mediator builds with no `vta-sdk` in its graph.
+
+Follow-up: tighten `vta-sdk` from `">=0.21.0, <0.23.0"` to `"0.22"` once 0.22.0
+is on crates.io. With the dependency optional that requirement no longer gates
+anyone else's release, so it can happen whenever.
+
 ## 12th August 2026 (0.18.12)
 
 **Accepts `vta-sdk` 0.21 *or* 0.22** — `">=0.21.0, <0.23.0"`, was `"0.21.0"`.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.12"
+version = "0.18.13"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -17,9 +17,37 @@ name = "mediator"
 path = "src/main.rs"
 
 [features]
-## Default: DIDComm v2 protocol support + Redis storage backend + jemalloc.
+## Default: DIDComm v2 protocol support + Redis storage backend + jemalloc,
+## plus VTA-backed key management.
 ## AWS integration is opt-in: use --features aws when deploying to AWS.
-default = ["didcomm", "redis-backend", "jemalloc"]
+default = ["didcomm", "redis-backend", "jemalloc", "vta"]
+
+## VTA-backed key management — the mediator fetches its operating secrets from
+## a Verifiable Trust Agent at boot, refreshes them periodically, and offers
+## `mediator rotate-admin`. ON by default: this is how the VTA-linked
+## deployment works, and turning it off changes what the binary can do.
+##
+## It exists to be turned OFF by *library* consumers, and that is the point.
+## `vta-sdk` lives in the VTI workspace, which depends on this crate back
+## through `vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator
+## -> affinidi-messaging-mediator -> vta-sdk` — a dependency cycle across two
+## repositories. VTI papers over it with `[patch.crates-io] vta-sdk = { path =
+## "vta-sdk" }`, which holds only while the workspace copy satisfies the
+## requirement below; under 0.x semver a minor bump breaks it, the registry
+## node the patch exists to delete comes back, and their release is blocked
+## until this crate is re-released. That has now happened at 0.20, 0.21 and
+## 0.22.
+##
+## `affinidi-messaging-test-mediator` already depends on this crate with
+## `default-features = false, features = ["didcomm", "memory-backend"]`, so
+## gating `vta-sdk` here drops it from that build entirely. The cycle stops
+## existing, and VTI can delete the patch rather than keep re-releasing this
+## crate to keep it applying.
+##
+## Self-hosted mediators (operating secrets from the unified secret backend's
+## well-known entry) are unaffected either way — that path never touches
+## `vta-sdk`.
+vta = ["dep:vta-sdk"]
 
 ## Use jemalloc as the binary's global allocator (see the dependency comment).
 ## On by default: with the system allocator the process holds its RSS high-water
@@ -119,32 +147,14 @@ affinidi-secrets-resolver = "0.5"
 ## Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 ## VTA SDK for centralized DID/key management via Verifiable Trust Agent.
+## Optional, behind the default-on `vta` feature — see that feature's comment
+## for why the optionality matters more than the version range does.
 ##
-## Range, not `"0.21.0"`, and deliberately so. The VTI workspace carries a
-## `[patch.crates-io] vta-sdk = { path = "vta-sdk" }` to keep its own crate out
-## of its lockfile twice — this crate is what pulls the registry copy back in,
-## through `vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator
-## -> affinidi-messaging-mediator -> vta-sdk`. A patch only applies while the
-## workspace copy satisfies every requirement on it, and under 0.x semver
-## `^0.21` excludes 0.22. So the moment VTI bumps vta-sdk to 0.22.0 the patch
-## silently stops applying, the registry node it exists to delete comes back,
-## and VTI's release PR cannot merge. No local change on their side fixes that;
-## the requirement here is the constraint.
-##
-## Hard-bumping to `"0.22"` instead would deadlock: 0.22.0 cannot be published
-## until that release PR merges, and it cannot merge until this requirement
-## admits 0.22. A range breaks the cycle without waiting on a publish.
-##
-## Widening is safe on the facts, not on optimism: `integration` resolves to
-## `["client", "session"]`, and vta-sdk 0.22.0's only breaking change is
-## `ProvisionIntegrationRequest.request` becoming `serde_json::Value`, behind
-## `#[cfg(feature = "provision-integration")]`. That module is not compiled
-## into this crate under either version.
-##
-## Tighten to `"0.22"` once 0.22.0 is published, and see the `vta` feature
-## follow-up — making this dependency optional removes the cycle outright,
-## since the test mediator already builds with `default-features = false`.
-vta-sdk = { version = ">=0.21.0, <0.23.0", features = ["integration"] }
+## Range rather than `"0.22"` only because 0.22.0 is not on crates.io yet; it
+## is published by the very VTI release that needed this. Tighten once it is.
+vta-sdk = { version = ">=0.21.0, <0.23.0", features = [
+  "integration",
+], optional = true }
 
 # ── Web Framework ────────────────────────────────────────────────────────
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/messaging/affinidi-messaging-mediator/src/commands/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/commands/mod.rs
@@ -10,4 +10,7 @@
 //! and returns. The CLI dispatcher in `main.rs` matches on a clap
 //! subcommand enum and calls the right `run`.
 
+/// Admin-credential rotation against a VTA. Requires `vta` — the whole
+/// operation is a conversation with one.
+#[cfg(feature = "vta")]
 pub mod rotate_admin;

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -3,7 +3,9 @@ pub mod limits;
 pub mod processors;
 pub mod security;
 pub mod validate;
+#[cfg(feature = "vta")]
 pub(crate) mod vta_bootstrap;
+#[cfg(feature = "vta")]
 pub mod vta_cache;
 
 pub use limits::*;
@@ -37,6 +39,7 @@ use async_convert::{TryFrom, async_trait};
 #[cfg(feature = "aws")]
 use aws_config::{self, BehaviorVersion, Region};
 use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+#[cfg(feature = "vta")]
 use vta_sdk::credentials::CredentialBundle;
 
 /// AWS SDK configuration type — conditionally compiled.
@@ -51,6 +54,7 @@ use sha256::digest;
 use std::{collections::HashMap, env, fmt, sync::Arc};
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
+#[cfg(feature = "vta")]
 use vta_sdk::integration::{
     self, SecretSource, TransportPreference, VtaIntegrationError, VtaServiceConfig,
 };
@@ -98,6 +102,7 @@ fn database_config_from_raw(
 }
 
 /// Default VTA cache TTL when `[secrets].cache_ttl` is not set.
+#[cfg(feature = "vta")]
 const DEFAULT_CACHE_TTL_SECS: u64 = 30 * 86_400; // 30 days
 
 /// Typed `[didcomm_v1]` settings. See
@@ -203,6 +208,7 @@ pub struct Config {
     /// VTA-linked deployments. The task itself is spawned by
     /// [`crate::server::serve_internal`] alongside the other
     /// background workers, gated on this field being `Some`.
+    #[cfg(feature = "vta")]
     #[serde(skip)]
     pub vta_refresher: Option<crate::tasks::vta_refresh::VtaRefresher>,
 }
@@ -279,6 +285,7 @@ impl Config {
             operating_keys_loaded: false,
             storage: None,
             didcomm_v1: DidCommV1Config::default(),
+            #[cfg(feature = "vta")]
             vta_refresher: None,
             security: SecurityConfig::default(secrets_resolver),
             processors: ProcessorsConfig {
@@ -304,6 +311,7 @@ impl Config {
 /// seed the cache (or the cache was wiped). Spell out both remediation
 /// paths so the operator doesn't have to read the SDK source to figure
 /// out which one applies.
+#[cfg(feature = "vta")]
 fn vta_startup_error(context: &str, err: VtaIntegrationError) -> MediatorError {
     let detail = match &err {
         VtaIntegrationError::NoCachedSecrets => format!(
@@ -355,6 +363,7 @@ fn vta_startup_error(context: &str, err: VtaIntegrationError) -> MediatorError {
 /// write to stderr (not via `tracing`) so the message survives any
 /// `RUST_LOG` filter — the operator needs this regardless of log
 /// configuration when the process is about to exit.
+#[cfg(feature = "vta")]
 fn print_vta_recovery_playbook(context: &str) {
     eprintln!(
         "
@@ -512,6 +521,12 @@ impl TryFrom<ConfigRaw> for Config {
         // If the backend has an admin credential, we're in VTA mode:
         // authenticate, fetch fresh operating keys, cache them, fall back
         // to the cached copy if the VTA is unreachable.
+        //
+        // Not read at all without the `vta` feature — and not loaded either,
+        // rather than loaded and discarded: the credential is the input to
+        // the branch below, so a build that cannot take that branch has no
+        // reason to touch the backend for it.
+        #[cfg(feature = "vta")]
         let admin_cred = mediator_secrets
             .load_admin_credential()
             .await
@@ -527,6 +542,7 @@ impl TryFrom<ConfigRaw> for Config {
         // Self-hosted admin credentials (stored so subsequent wizard
         // runs can recover the private key) have `vta_did` / `vta_url`
         // unset; the mediator skips VTA integration for those.
+        #[cfg(feature = "vta")]
         let vta_startup = if let Some(admin) = admin_cred.as_ref().filter(|a| a.is_vta_linked()) {
             let credential = CredentialBundle {
                 did: admin.did.clone(),
@@ -666,10 +682,36 @@ impl TryFrom<ConfigRaw> for Config {
             None
         };
 
+        // ── Project the startup result into mediator-local values ────────
+        //
+        // Everything below this point reads these two rather than the SDK's
+        // `StartupResult`, so it compiles identically with or without the
+        // `vta` feature and needs no `cfg` of its own. Without the feature
+        // there is no key authority, and every consumer takes the
+        // self-hosted branch it already had.
+        #[cfg(feature = "vta")]
+        let authority_did: Option<String> = vta_startup.as_ref().map(|(r, _)| r.did.clone());
+        #[cfg(not(feature = "vta"))]
+        let authority_did: Option<String> = None;
+
+        #[cfg(feature = "vta")]
+        let operating_secrets: Option<Vec<OperatingSecret>> = vta_startup.as_ref().map(|(r, _)| {
+            r.bundle
+                .secrets
+                .iter()
+                .map(|entry| OperatingSecret {
+                    key_id: entry.key_id.clone(),
+                    private_key_multibase: entry.private_key_multibase.clone(),
+                })
+                .collect()
+        });
+        #[cfg(not(feature = "vta"))]
+        let operating_secrets: Option<Vec<OperatingSecret>> = None;
+
         // Resolve mediator DID — from VTA startup result (if VTA mode)
         // or the mediator.toml `mediator_did` field (self-hosted mode).
-        let mediator_did = if let Some((ref result, _)) = vta_startup {
-            result.did.clone()
+        let mediator_did = if let Some(did) = &authority_did {
+            did.clone()
         } else {
             read_did_config(&raw.mediator_did, &aws_config, "mediator_did").await?
         };
@@ -719,7 +761,7 @@ impl TryFrom<ConfigRaw> for Config {
                 .convert(
                     secrets_resolver.clone(),
                     &mediator_secrets,
-                    vta_startup.as_ref().map(|(r, _)| &r.bundle),
+                    operating_secrets.as_deref(),
                 )
                 .await?,
             processors: ProcessorsConfig {
@@ -749,7 +791,7 @@ impl TryFrom<ConfigRaw> for Config {
             // we get here, so we can ask the backend directly: if the
             // entry is present we loaded it; otherwise the VTA bundle
             // (when present) supplied them.
-            operating_keys_loaded: vta_startup.is_some()
+            operating_keys_loaded: authority_did.is_some()
                 || mediator_secrets
                     .load_entry::<Vec<affinidi_secrets_resolver::secrets::Secret>>(
                         affinidi_messaging_mediator_common::OPERATING_SECRETS,
@@ -762,6 +804,7 @@ impl TryFrom<ConfigRaw> for Config {
             // VTA-linked deployments get a periodic refresh task; built
             // alongside the StartupResult above so the service config
             // and TTL parsing aren't re-derived here.
+            #[cfg(feature = "vta")]
             vta_refresher: vta_startup.as_ref().map(|(_, refresher)| refresher.clone()),
             ..Config::default(secrets_resolver)
         };

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -19,7 +19,22 @@ use std::{
     sync::Arc,
 };
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use vta_sdk::did_secrets::DidSecretsBundle;
+
+/// One operating key handed to the mediator by an external key authority.
+///
+/// Deliberately mediator-local rather than `vta_sdk::did_secrets::SecretEntry`,
+/// even though today's only producer is a VTA `DidSecretsBundle`. This type is
+/// the seam that lets `vta-sdk` be an optional dependency: everything below it
+/// — the conversion to `Secret`, the resolver population, the self-hosted
+/// fallback — compiles identically with or without the `vta` feature, so none
+/// of it needs `cfg`. The mapping from the SDK's bundle lives at the single
+/// call site in `config/mod.rs`, which is already `vta`-gated.
+pub(crate) struct OperatingSecret {
+    /// Key id the secret is filed under (becomes the `Secret`'s id).
+    pub key_id: String,
+    /// Multibase-encoded private key material.
+    pub private_key_multibase: String,
+}
 
 /// Resolved cross-origin policy for browser clients.
 ///
@@ -326,7 +341,7 @@ pub(crate) trait SecurityConfigRawExt {
         &self,
         secrets_resolver: Arc<ThreadedSecretsResolver>,
         secrets: &MediatorSecrets,
-        vta_bundle: Option<&DidSecretsBundle>,
+        vta_bundle: Option<&[OperatingSecret]>,
     ) -> Result<SecurityConfig, MediatorError>;
 }
 
@@ -461,7 +476,7 @@ impl SecurityConfigRawExt for SecurityConfigRaw {
         &self,
         secrets_resolver: Arc<ThreadedSecretsResolver>,
         secrets: &MediatorSecrets,
-        vta_bundle: Option<&DidSecretsBundle>,
+        vta_bundle: Option<&[OperatingSecret]>,
     ) -> Result<SecurityConfig, MediatorError> {
         let warn_default = |field: &str, value: &str, default: &str| {
             tracing::warn!(
@@ -592,10 +607,9 @@ impl SecurityConfigRawExt for SecurityConfigRaw {
             // VTA mode: operating keys arrived via integration::startup.
             tracing::info!(
                 "Loading {} operating secret(s) from VTA DidSecretsBundle",
-                bundle.secrets.len()
+                bundle.len()
             );
             let converted = bundle
-                .secrets
                 .iter()
                 .map(|entry| {
                     Secret::from_multibase(&entry.private_key_multibase, Some(&entry.key_id))

--- a/crates/messaging/affinidi-messaging-mediator/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/main.rs
@@ -1,5 +1,9 @@
-use affinidi_messaging_mediator::{commands, server::start};
-use clap::{Parser, Subcommand};
+#[cfg(feature = "vta")]
+use affinidi_messaging_mediator::commands;
+use affinidi_messaging_mediator::server::start;
+use clap::Parser;
+#[cfg(feature = "vta")]
+use clap::Subcommand;
 
 // ─── Allocator ──────────────────────────────────────────────────────────────
 //
@@ -50,10 +54,16 @@ struct Cli {
     #[arg(short = 'c', long, default_value = "conf/mediator.toml", global = true)]
     config: String,
 
+    /// `rotate-admin` is the only subcommand, and it is a conversation
+    /// with a VTA. A build without `vta` has none, so the field goes too:
+    /// clap's `Subcommand` derive has nothing to generate from an empty
+    /// enum.
+    #[cfg(feature = "vta")]
     #[command(subcommand)]
     command: Option<Command>,
 }
 
+#[cfg(feature = "vta")]
 #[derive(Subcommand)]
 enum Command {
     /// Rotate the mediator's admin credential.
@@ -75,24 +85,27 @@ enum Command {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    match cli.command {
-        None => {
-            if let Err(e) = start(&cli.config).await {
-                eprintln!("\x1b[31mMediator failed:\x1b[0m {e}");
-                std::process::exit(1);
-            }
+
+    // Subcommand first, server second: no subcommand means "run the
+    // mediator", which is the historical behaviour and the only one a
+    // build without `vta` has.
+    #[cfg(feature = "vta")]
+    if let Some(Command::RotateAdmin { dry_run }) = cli.command {
+        // Subcommands handle their own tracing init lazily
+        // (rotate_admin uses the global subscriber if one is
+        // already in place; otherwise it falls back to a minimal
+        // env-filter setup so info!/warn! land somewhere visible).
+        init_subcommand_tracing();
+        if let Err(e) = commands::rotate_admin::run(&cli.config, dry_run).await {
+            eprintln!("\x1b[31mError:\x1b[0m {e}");
+            std::process::exit(1);
         }
-        Some(Command::RotateAdmin { dry_run }) => {
-            // Subcommands handle their own tracing init lazily
-            // (rotate_admin uses the global subscriber if one is
-            // already in place; otherwise it falls back to a minimal
-            // env-filter setup so info!/warn! land somewhere visible).
-            init_subcommand_tracing();
-            if let Err(e) = commands::rotate_admin::run(&cli.config, dry_run).await {
-                eprintln!("\x1b[31mError:\x1b[0m {e}");
-                std::process::exit(1);
-            }
-        }
+        return;
+    }
+
+    if let Err(e) = start(&cli.config).await {
+        eprintln!("\x1b[31mMediator failed:\x1b[0m {e}");
+        std::process::exit(1);
     }
 }
 
@@ -101,6 +114,7 @@ async fn main() {
 /// minimal one here so `tracing::info!` calls inside the rotation
 /// flow actually surface to stderr — without this the rotation runs
 /// "silent" except for `println!`s.
+#[cfg(feature = "vta")]
 fn init_subcommand_tracing() {
     use tracing_subscriber::EnvFilter;
     let _ = tracing_subscriber::fmt()

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -503,6 +503,7 @@ pub async fn serve_internal(
     // secret means the mediator silently fails to decrypt its own inbound
     // DIDComm). Only spawned for VTA-linked deployments. `run` honours the
     // shutdown token itself; the supervisor's abort is a backstop.
+    #[cfg(feature = "vta")]
     if let Some(refresher) = config.vta_refresher.clone() {
         let refresh_token = shutdown_token.clone();
         supervisor.spawn("vta_refresh", true, move || {

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
@@ -7,5 +7,7 @@
 pub use affinidi_messaging_mediator_common::tasks::forwarding as forwarding_processor;
 pub mod statistics;
 pub mod supervisor;
+/// Periodic refresh of VTA-supplied operating secrets. Requires `vta`.
+#[cfg(feature = "vta")]
 pub mod vta_refresh;
 pub mod websocket_streaming;


### PR DESCRIPTION
feat!: make vta-sdk optional behind a default-on `vta` feature

Mediator 0.19.0, test-mediator 0.2.50. Nothing changes for the mediator
binary or for any consumer building with default features.

0.18.12, released hours ago, widened the `vta-sdk` requirement so VTI's
`[patch.crates-io]` would keep applying across their 0.22 bump. That fixed
the instance. This fixes the cause.

The cause is a dependency cycle spanning two repositories:

  vta-sdk (VTI) --published--> affinidi-messaging-mediator (this crate)
      ^                                     |
      +------- vtc-service [dev-deps] ------+
               via affinidi-messaging-test-mediator

VTI papers over it with `[patch.crates-io] vta-sdk = { path = "vta-sdk" }`,
which holds only while their workspace copy satisfies the requirement
declared here. Under 0.x semver a minor bump does not, so the patch
silently stops applying, the registry node it exists to delete returns,
and their release is blocked until this crate is re-released. That has now
happened at 0.20, 0.21 and 0.22 — three times, each fixed by widening a
requirement, which buys one version of headroom and leaves the cycle
intact.

`affinidi-messaging-test-mediator` — the crate VTI actually depends on —
already builds this one with `default-features = false, features =
["didcomm", "memory-backend"]`. Gating `vta-sdk` therefore drops it from
that build with no change on their side. `cargo tree -p
affinidi-messaging-test-mediator -i vta-sdk` now reports no such package:
the cycle stops existing, and VTI can delete the patch entry rather than
keep re-releasing this crate to keep it applying.

Four already-VTA-specific modules are cfg-gated whole (`tasks/vta_refresh`,
`common/config/vta_bootstrap`, `common/config/vta_cache`,
`commands/rotate_admin`), as are the `rotate-admin` subcommand and the
`Config::vta_refresher` field. The two places where SDK types had leaked
into otherwise-generic code are handled by a seam rather than by more cfg:

- `common/config/security.rs` took `Option<&DidSecretsBundle>` purely to
  read `key_id` + `private_key_multibase` off each entry. It now takes
  `Option<&[OperatingSecret]>`, a mediator-local type, so the conversion to
  `Secret`, the resolver population and the self-hosted fallback compile
  identically either way and need no cfg at all.
- `common/config/mod.rs` projects the SDK's `StartupResult` into two local
  values (`authority_did`, `operating_secrets`) right after the gated
  startup block, so the DID resolution, the `operating_keys_loaded` flag
  and the security conversion are unchanged source in both builds.

Breaking, hence the minor bump: a `default-features = false` consumer that
previously got `tasks::vta_refresh` and `commands::rotate_admin` no longer
does unless it asks for `vta`. Self-hosted deployments, which take their
operating secrets from the backend's well-known
`mediator/operating/secrets` entry, never touched `vta-sdk` and are
unaffected either way.

Verified: `cargo clippy --all-targets` clean under both default features
and `--no-default-features --features didcomm,memory-backend`; the
200-test mediator suite and the test-mediator suite pass; the test mediator
builds with no `vta-sdk` in its graph.

Follow-up: tighten `vta-sdk` from `">=0.21.0, <0.23.0"` to `"0.22"` once
0.22.0 is on crates.io. With the dependency optional, that requirement no
longer gates anyone else's release, so it can happen whenever.

