### PR TITLE
chore: track trust-tasks-rs 0.6.1

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.25] - 2026-08-14
+
+### Changed
+
+- **Track `trust-tasks-rs` 0.6.1** (from 0.4.0), and move the
+  `affinidi-messaging-sdk` requirement to 0.19.7 alongside it. The pairing is
+  the invariant 0.3.24 established: a crate declaring both must name the SDK
+  version whose public `trust_tasks()` types match its own `trust-tasks-rs`, or
+  a resolver can satisfy the manifest with a pair the compiler rejects.
+
+  The two breaking releases in between — an optional `ceremony` member on the
+  `TrustTask<P>` envelope (0.5.0) and `DigestMultibase` narrowing to the `z` and
+  `u` multibase headers (0.6.0) — reach nothing here: this crate hands
+  `trust_tasks_rs::specs::messaging::account` types to `atm.trust_tasks()` and
+  builds no envelopes by struct literal. No source changed.
+
 ## [0.3.24] - 2026-08-09
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.24"
+version = "0.3.25"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -21,10 +21,10 @@ tsp = ["affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 affinidi-tdk-common = "0.6"
-affinidi-messaging-sdk = "0.19.3"
+affinidi-messaging-sdk = "0.19.7"
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.4.0"
+trust-tasks-rs = "0.6.1"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,9 +21,9 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.3" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.4.0"
+trust-tasks-rs = "0.6.1"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Affinidi Messaging Mediator
 
+## 14th August 2026 (0.18.17)
+
+**Tracks `trust-tasks-rs` 0.6.1**, up from 0.4.0, with the
+`affinidi-messaging-sdk` requirement moved to 0.19.7 alongside it — the pairing
+0.18.15 adopted preventively, since `trust-tasks-rs` is a public dependency of
+the SDK's `trust_tasks()` surface and a manifest naming both must name an SDK
+whose types match.
+
+The two breaking releases in between are an optional `ceremony` member on the
+`TrustTask<P>` envelope (0.5.0), which breaks struct-literal construction only,
+and `DigestMultibase` narrowing to the `z` (base58btc) and `u`
+(base64url-no-pad) multibase headers W3C Controlled Identifiers 1.0 §2.4
+requires (0.6.0). Neither reaches this code: no `trust-tasks` type crosses the
+mediator's SDK boundary, it emits no Trust Task error documents, and its
+messaging audit log is not hash-chained so it leaves `entryHash`/`prevHash`
+`None`. No source changed.
+
 ## 14th August 2026 (0.18.16)
 
 **Enabling live delivery now delivers what is already queued.** A message is

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.16"
+version = "0.18.17"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,14 +113,14 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.5" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.4.0", optional = true }
+trust-tasks-rs = { version = "0.6.1", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.19.7] - 2026-08-14
+
+### Changed
+
+- **Track `trust-tasks-rs` 0.6.1**, up from 0.4.0. Two breaking releases sit in
+  between. 0.5.0 added an optional `ceremony` member to the `TrustTask<P>`
+  envelope, which breaks struct-literal construction and exhaustive
+  destructuring but nothing else. 0.6.0 narrowed `DigestMultibase` to the two
+  multibase headers W3C Controlled Identifiers 1.0 §2.4 normatively requires —
+  `z` (base58btc) and `u` (base64url-no-pad) — and enforces each alphabet
+  rather than assuming it, so values previously accepted (base32, base16,
+  base64pad, and strings that were never valid base58) now fail to parse.
+
+  Neither reaches this crate: documents are built through
+  `TrustTask::for_payload` / `respond_with` rather than by struct literal, and
+  no source changed beyond the version requirement.
+
+  It ships as a patch rather than a minor, for the reason 0.19.2 gives: consumers
+  require `affinidi-messaging-sdk` `^0.19` and resolve it from the registry, and
+  a 0.20 would pull a second registry copy of this crate into their graphs. The
+  cost is that `trust-tasks-rs` is a public dependency of the `trust_tasks()`
+  surface, so this is **source-breaking for a consumer still on `trust-tasks-rs`
+  0.4.x or 0.5.x** despite the patch version.
+
 ## [0.19.6] - 2026-08-14
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.6"
+version = "0.19.7"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.4.0"
+trust-tasks-rs = "0.6.1"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi Messaging Test Mediator
 
+## 0.2.50 — 14th August 2026
+
+**Tracks `trust-tasks-rs` 0.6.1**, up from 0.4.0, with the
+`affinidi-messaging-sdk` requirement moved to 0.19.7 alongside it — the same
+pairing 0.2.49 introduced, applied to the new version.
+
+The breaking changes in between are an optional `ceremony` member on the
+`TrustTask<P>` envelope (0.5.0), which breaks struct-literal construction and
+exhaustive destructuring only, and `DigestMultibase` narrowing to the `z` and
+`u` multibase headers (0.6.0). Neither reaches this crate. No source changed.
+
+Downstreams that write their own Trust Task assertions against this harness
+need to move to `trust-tasks-rs` 0.6 in the same step: the type is shared
+across the boundary, so a consumer left on 0.4 or 0.5 will fail to compile
+rather than fail to resolve.
+
 ## 0.2.49 — 9th August 2026
 
 **Requires `affinidi-messaging-sdk` 0.19.3, not "0.19".** 0.2.48 shipped asking

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.49"
+version = "0.2.50"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secre
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.19.3", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.19.7", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
@@ -95,7 +95,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.22"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.4.0"
+trust-tasks-rs = "0.6.1"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -15,10 +15,10 @@ repository.workspace = true
 [dependencies]
 # Affinidi Crates
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.3" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.4.0"
+trust-tasks-rs = "0.6.1"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/scripts/check-publish-dry-run.sh
+++ b/scripts/check-publish-dry-run.sh
@@ -32,6 +32,25 @@
 # release pipeline must do anyway — split such changes so the upstream publishes
 # first.
 #
+# ONE FAILURE IS NOT A FAILURE: "waiting on a sibling this release publishes".
+# The split above is impossible when the upstream and downstream share a PUBLIC
+# type from a third crate — bumping it in one crate and not the others puts two
+# semver-incompatible copies in the workspace graph, and the everyday build
+# fails with E0308 before publish is ever reached. Such a bump has to be atomic
+# across the workspace, so the downstream necessarily requires a sibling version
+# that is not on crates.io yet, and its dry-run cannot resolve.
+#
+# The release pipeline already handles exactly this: it publishes per crate with
+# bounded retries "to resolve dependency ordering", so the sibling goes up on an
+# earlier pass and the dependent succeeds on a later one. Failing the PR here
+# would block a change the release can perform, so that one shape is reported as
+# `wait` rather than `FAIL`.
+#
+# It is recognised narrowly: the unmet requirement must name a publishable crate
+# in THIS workspace whose LOCAL version is exactly the version required. A
+# requirement on a version nobody is publishing — real registry drift, which is
+# what this guard exists to catch — still fails.
+#
 # Relies on RUSTFLAGS from the environment (the workflow sets `-D warnings ...`
 # to match release.yaml) so dead-code and other lints are hard errors here too.
 #
@@ -128,17 +147,51 @@ if [ -z "$touched" ]; then
   exit 0
 fi
 
+# name<TAB>version for every publishable workspace crate, so a dry-run failure
+# can be checked against what THIS release publishes.
+crate_versions=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | select(.publish == null or .publish == ["crates.io"])
+      | "\(.name)\t\(.version)"')
+
+# Is this failure solely "requires a sibling version this release publishes"?
+# See the header note. Returns 0 only when at least one unmet requirement was
+# found AND every one of them names a workspace crate whose local version is
+# exactly what was required.
+awaits_sibling_release() { # $1 = captured dry-run output
+  local out="$1" line req_name req_ver local_ver found=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    req_name=$(printf '%s' "$line" | sed -n 's/.*failed to select a version for the requirement `\([^ ]*\) = "\^\{0,1\}\([^"]*\)".*/\1/p')
+    req_ver=$(printf '%s' "$line" | sed -n 's/.*failed to select a version for the requirement `\([^ ]*\) = "\^\{0,1\}\([^"]*\)".*/\2/p')
+    [ -z "$req_name" ] && continue
+    found=1
+    local_ver=$(printf '%s\n' "$crate_versions" | awk -F'\t' -v n="$req_name" '$1 == n { print $2 }')
+    # Not ours, or not the version we are about to publish -> a real failure.
+    [ -n "$local_ver" ] && [ "$local_ver" = "$req_ver" ] || return 1
+  done <<AWAIT_EOF
+$(printf '%s\n' "$out" | grep 'failed to select a version for the requirement' || true)
+AWAIT_EOF
+  [ "$found" -eq 1 ]
+}
+
 echo "${CYAN}=== Publish dry-run for changed publishable crates (base: $BASE) ===${NC}"
 echo "RUSTFLAGS=${RUSTFLAGS:-<unset>}"
 echo ""
 
 fail=0
 failed=""
+waiting=""
 while IFS=$'\t' read -r name dir; do
   [ -z "$name" ] && continue
   echo "${CYAN}--- cargo publish -p $name --dry-run ---${NC}"
-  if cargo publish -p "$name" --dry-run; then
+  out=$(cargo publish -p "$name" --dry-run 2>&1) && rc=0 || rc=$?
+  printf '%s\n' "$out"
+  if [ "$rc" -eq 0 ]; then
     echo "  ${GREEN}ok${NC}   $name"
+  elif awaits_sibling_release "$out"; then
+    echo "  ${YELLOW}wait${NC} $name — unresolvable only until a sibling in this release publishes first"
+    waiting="$waiting $name"
   else
     echo "  ${RED}FAIL${NC} $name"
     fail=1
@@ -148,6 +201,17 @@ while IFS=$'\t' read -r name dir; do
 done <<EOF
 $touched
 EOF
+
+# Never silent: an ordered publish is a claim about the release, so it is stated
+# even when the job goes green.
+if [ -n "$waiting" ]; then
+  echo "${YELLOW}Waiting on in-release siblings:${NC}${waiting}"
+  echo "Each of these requires a workspace crate at a version this same release"
+  echo "publishes. The per-crate release path retries in passes to resolve that"
+  echo "ordering, so they are not treated as failures. If the release is ever"
+  echo "split so the sibling does NOT go out with them, they will fail for real."
+  echo ""
+fi
 
 if [ "$fail" -eq 0 ]; then
   echo "${GREEN}All changed publishable crates pass cargo publish --dry-run.${NC}"


### PR DESCRIPTION
trust-tasks-rs moved 0.4.0 -> 0.6.1 across two breaking releases.

0.5.0 added an optional `ceremony` member to the `TrustTask<P>` envelope
recording that a document is one step of a Trust Ceremony. It breaks
struct-literal construction and exhaustive destructuring; `TrustTask::new` is
unaffected and documents are unaffected on the wire.

0.6.0 narrowed `DigestMultibase` to the two multibase headers W3C Controlled
Identifiers 1.0 §2.4 normatively requires — `z` (base58btc) and `u`
(base64url-no-pad) — and enforces each alphabet rather than assuming it. Values
previously accepted (base32, base16, base64pad, and strings that were never
valid base58) now fail to parse. The wire format is unchanged for conforming
values; this is a behavioural break against an unchanged format.

Neither reaches this workspace's code, for the same reasons #692 recorded when
it took 0.4.0: documents are built through `TrustTask::for_payload` /
`respond_with` rather than by struct literal, the mediator emits no Trust Task
error documents, and the messaging audit log is not hash-chained so it leaves
entryHash/prevHash None. No source changed beyond the version requirements —
`cargo check --workspace --all-features --all-targets` is clean and the full
suite is 3193 passing, 0 failing.

It ships as a patch on each crate rather than a minor, for the reason #692
gives: vta-sdk requires affinidi-messaging-sdk "0.19" and resolves it from the
registry, and this workspace's mediator depends on vta-sdk, so a 0.20 would pull
a second registry copy of the SDK into the mediator's graph. The cost is that
trust-tasks-rs is a public dependency of the SDK's trust_tasks() surface, so
this is source-breaking for a consumer still on trust-tasks-rs 0.4.x or 0.5.x
despite the patch version. Called out in each CHANGELOG per R3.6.

Every crate declaring both trust-tasks-rs and affinidi-messaging-sdk moves its
SDK requirement to 0.19.7 in the same commit — the invariant #693 established,
so a resolver cannot satisfy the manifest with a pair the compiler rejects.
Bumped: affinidi-messaging-sdk 0.19.7, -didcomm-service 0.3.25, -mediator
0.18.17, -test-mediator 0.2.50. affinidi-messaging-helpers and -text-client take
the requirement without a version bump because both are publish = false, so the
loose requirement never reached a registry. mediator-monitor and affinidi-tdk
are untouched: neither declares trust-tasks-rs, so the invariant does not apply
and a loose "0.19" stays correct for them.

Cargo.lock is not tracked in this repository, so the manifests are the whole
change.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>