### PR TITLE
fix(delivery): never ack a message no consumer received

### DIFF
--- a/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-delivery/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.1.14] - 2026-08-16
+
+**A message no consumer received is no longer acked.** An ack is a delete at the
+mediator, so acking an undelivered message destroys it — and the dispatcher was
+acking unconditionally, including when `subscribers.send` had just reported that
+nobody was listening. This is the contract `Inbound` documents ("only **after**
+the message is durably handed off … never ack-before-handoff") and the one the
+SDK's transport adapter sets `auto_delete = false` to honour; the layer was the
+piece not keeping it.
+
+The window is small and its consequences are not: no subscriber is installed for
+a moment at startup and again on the way down, and what arrives in that window is
+whatever the peer happened to send — a membership credential, a join verdict.
+Downstream this surfaced as OpenVTC joins stuck `Pending` forever with clean logs
+on both sides (OpenVTC/openvtc#221), because the only record was that nothing
+happened.
+
+- **Ack is now conditional on handoff.** `broadcast::send` returns `Err` when
+  there are no subscribers; that is the signal. An unacked message stays at the
+  mediator and is offered again on the next pickup, which is exactly what the
+  contract is for.
+- **A reply whose waiter died falls through to subscribers.** A caller that timed
+  out leaves a dead `oneshot`; the reply used to be swallowed by it and acked
+  anyway. It is still application traffic, so it now goes to `subscribe()` and is
+  acked only if someone takes it.
+- **A lagging subscriber is reported at `error!` instead of skipped in silence.**
+  Overwritten messages are unrecoverable — the dispatcher acked them on the way
+  in — so this is the one lossy step left in the inbound path, and it was also
+  the only one with no trace. The count of lost messages is now named.
+- `SUBSCRIBE_BUFFER`'s note claimed "at-least-once, dedup on the key". That holds
+  for redelivery *before* an ack; this buffer sits after one. Corrected.
+
+3 new tests (61 total).
+
 ## [0.1.13] - 2026-08-08
 
 Dependency-pin bump only; no API or behaviour change.

--- a/crates/messaging/affinidi-messaging-delivery/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-delivery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-delivery"
 description = "Reliable messaging delivery layer (durable outbox + drain) over the MessageTransport trait"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-messaging-delivery/src/service.rs
+++ b/crates/messaging/affinidi-messaging-delivery/src/service.rs
@@ -82,7 +82,17 @@ pub type TransportId = String;
 type WaiterMap = Arc<Mutex<HashMap<String, oneshot::Sender<ReceivedMessage>>>>;
 
 /// Buffered unsolicited inbound messages per subscriber before a slow consumer
-/// starts lagging (and losing the oldest — at-least-once, dedup on the key).
+/// starts lagging.
+///
+/// A lagging consumer loses the **oldest** buffered messages, and loses them for
+/// good: the dispatcher acks each message once it has been handed to this
+/// buffer, and an ack is a delete at the mediator, so an overwritten entry
+/// exists nowhere else. The old note here claimed "at-least-once, dedup on the
+/// key" — that is true of redelivery *before* an ack, and this is after one.
+///
+/// So this is the one lossy step left in the inbound path, and the only defence
+/// is a consumer that drains promptly. `subscribe()` logs at `error!` when it
+/// happens rather than skipping the gap in silence.
 const SUBSCRIBE_BUFFER: usize = 256;
 
 static KEY_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -582,8 +592,28 @@ impl MessagingService {
             loop {
                 match rx.recv().await {
                     Ok(item) => return Some((item, rx)),
-                    // A slow subscriber that fell behind: skip the gap, keep going.
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    // A slow subscriber that fell behind. The gap is skipped —
+                    // `broadcast` has already overwritten those messages and
+                    // there is no way to get them back from here.
+                    //
+                    // Reported, not swallowed. This used to `continue` in
+                    // silence, which made the one unrecoverable loss in the
+                    // inbound path also the only one with no trace: the
+                    // dispatcher had already acked (deleted) each of those
+                    // messages at the mediator, so `skipped` is a count of
+                    // application messages that no longer exist anywhere. An
+                    // operator seeing this should make the consumer drain
+                    // faster or raise `SUBSCRIBE_BUFFER`.
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::error!(
+                            skipped,
+                            buffer = SUBSCRIBE_BUFFER,
+                            "subscriber fell behind: {skipped} inbound message(s) were \
+                             overwritten and are unrecoverable — this consumer is not \
+                             draining fast enough"
+                        );
+                        continue;
+                    }
                     Err(broadcast::error::RecvError::Closed) => return None,
                 }
             }
@@ -726,6 +756,10 @@ async fn run_dispatcher(
 ) {
     while let Some((src_id, item)) = rx.recv().await {
         let ack = item.ack.clone();
+        // Kept for the no-consumer diagnostic below: `item` is moved into the
+        // routing arms, and a warning that cannot name the message is one an
+        // operator cannot act on.
+        let item_thread_id = item.thread_id.clone();
 
         // 1. A layer receipt is consumed by the layer, not the application: it
         //    confirms the matching outbox entry Sent → Delivered. A receipt for
@@ -772,36 +806,71 @@ async fn run_dispatcher(
             .clone()
             .and_then(|thid| inner.waiters.lock().expect("waiters mutex").remove(&thid));
 
-        match waiter {
+        let handed_off = match waiter {
             // A reply for an in-flight request → its waiter. A reply is its own
             // evidence (the protocol-reply source); we do NOT also receipt it.
-            Some(tx) => {
-                let _ = tx.send(item.message);
-            }
-            // Unsolicited → subscribers (dropped if none are listening). If we
-            // run the layer (a packer is configured) AND this is a fresh inbound
-            // rather than a reply to our own Guaranteed send, emit a fire-and-
-            // forget receipt echoing the correlation so *that* sender's outbox
-            // entry settles Delivered. A message that just confirmed one of our
-            // sends is a reply, not a fresh Guaranteed push, so it needs no
-            // receipt from us (its thread id is the original thread, not the
-            // reply's own key — a receipt would be a no-op on the peer anyway).
-            None => {
-                if !confirmed_our_send
-                    && let Some(packer) = inner.receipt_packer.as_ref()
-                    && let (Some(to), Some(confirms)) =
-                        (item.message.sender.clone(), item.thread_id.clone())
-                {
-                    spawn_receipt(&inner, packer.clone(), to, confirms);
-                }
-                let _ = inner.subscribers.send(item);
-            }
-        }
+            //
+            // The send is on a clone so a *dead* waiter — the caller timed out
+            // and dropped its receiver between our `remove` above and here — does
+            // not consume the message. It is still application traffic, and a
+            // reply that arrived a moment after its caller gave up is worth
+            // delivering to whoever else is listening rather than discarding.
+            Some(tx) => match tx.send(item.message.clone()) {
+                Ok(()) => true,
+                Err(_) => deliver_unsolicited(&inner, confirmed_our_send, item),
+            },
+            None => deliver_unsolicited(&inner, confirmed_our_send, item),
+        };
 
         // Ack once, HERE, after handoff — over the transport the message arrived
         // on, never in a per-caller loop and never before handoff.
-        ack_via_source(&inner, &src_id, ack).await;
+        //
+        // **Only when the handoff actually happened.** This used to ack
+        // unconditionally, which broke the contract `Inbound` states and the
+        // transport adapter sets `auto_delete = false` to honour: an ack is a
+        // delete at the mediator, so acking a message nobody received destroys
+        // it. The `send` above returns `Err` precisely when there was no
+        // consumer — no subscriber installed yet at startup, or the host on its
+        // way down — and those are the moments a client is most likely to be
+        // handed a membership credential it will never see again.
+        //
+        // Leaving it unacked is the whole point of the contract: the mediator
+        // keeps its copy and offers it again on the next pickup, where a
+        // subscriber that has since appeared collects it.
+        if handed_off {
+            ack_via_source(&inner, &src_id, ack).await;
+        } else {
+            tracing::warn!(
+                transport = %src_id,
+                thread_id = ?item_thread_id,
+                "inbound message had no consumer — leaving it unacked so the mediator \
+                 redelivers it, rather than acking (deleting) a message nobody received"
+            );
+        }
     }
+}
+
+/// Offer an unsolicited inbound to `subscribe()` consumers, emitting a delivery
+/// receipt first when this layer runs one.
+///
+/// Returns whether anyone actually received it — `broadcast::send` reports `Err`
+/// when there are no subscribers, and that is the signal
+/// [`run_dispatcher`] needs to decide whether acking would be honest.
+///
+/// If we run the layer (a packer is configured) AND this is a fresh inbound
+/// rather than a reply to our own Guaranteed send, emit a fire-and-forget receipt
+/// echoing the correlation so *that* sender's outbox entry settles Delivered. A
+/// message that just confirmed one of our sends is a reply, not a fresh
+/// Guaranteed push, so it needs no receipt from us (its thread id is the original
+/// thread, not the reply's own key — a receipt would be a no-op on the peer).
+fn deliver_unsolicited(inner: &Arc<ServiceInner>, confirmed_our_send: bool, item: Inbound) -> bool {
+    if !confirmed_our_send
+        && let Some(packer) = inner.receipt_packer.as_ref()
+        && let (Some(to), Some(confirms)) = (item.message.sender.clone(), item.thread_id.clone())
+    {
+        spawn_receipt(inner, packer.clone(), to, confirms);
+    }
+    inner.subscribers.send(item).is_ok()
 }
 
 /// Ack `ack` over the transport it arrived on (`src_id`). If that transport was
@@ -1075,6 +1144,98 @@ mod tests {
         assert_eq!(got.message.id, "push-1");
         tokio::time::sleep(Duration::from_millis(20)).await;
         assert_eq!(h.transport.acked.lock().unwrap().as_slice(), &["q-push"]);
+    }
+
+    /// The bug this pair of tests exists for: an ack is a delete at the
+    /// mediator, so acking a message no consumer received destroys it. The
+    /// transport sets `auto_delete = false` and `Inbound` documents
+    /// "never ack-before-handoff" precisely so the layer can decline to ack —
+    /// and the layer was acking unconditionally.
+    ///
+    /// With no subscriber installed, the message must be left **unacked** so the
+    /// mediator keeps it and offers it again.
+    #[tokio::test]
+    async fn a_message_with_no_consumer_is_not_acked() {
+        let h = mock();
+        let svc = MessagingService::new(h.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+
+        // Deliberately no `subscribe()` — the startup window, and the shape of
+        // every "the client never got its credential" report.
+        h.inbound_tx
+            .send(inbound("orphan-1", None, "q-orphan"))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            h.transport.acked.lock().unwrap().is_empty(),
+            "acking here deletes a message nobody received; it must stay at the \
+             mediator for redelivery"
+        );
+        // Keep the service alive to the end of the test so the assertion is
+        // about routing, not about a dropped dispatcher.
+        drop(svc);
+    }
+
+    /// The complement: once a consumer exists the message is delivered *and*
+    /// acked, so declining to ack above cannot become a mediator that never
+    /// drains.
+    #[tokio::test]
+    async fn a_message_with_a_consumer_is_still_acked() {
+        let h = mock();
+        let svc = MessagingService::new(h.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let mut sub = svc.subscribe();
+
+        h.inbound_tx
+            .send(inbound("push-2", None, "q-push-2"))
+            .unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .expect("subscribe yields the push")
+            .expect("stream item");
+        assert_eq!(got.message.id, "push-2");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            h.transport.acked.lock().unwrap().as_slice(),
+            &["q-push-2"],
+            "a delivered message must still be acked, or the mailbox never drains"
+        );
+    }
+
+    /// A reply whose caller timed out used to be swallowed by the dead oneshot
+    /// and acked anyway — deleted, unseen, with the caller's own timeout as the
+    /// only clue. It is still application traffic: offer it to subscribers.
+    #[tokio::test]
+    async fn a_reply_whose_waiter_died_falls_through_to_subscribers() {
+        let h = mock();
+        let svc = MessagingService::new(h.transport.clone(), Arc::new(InMemoryOutboxStore::new()));
+        let mut sub = svc.subscribe();
+
+        // Register a waiter for the thread, then drop its receiver — exactly what
+        // a timed-out `request` leaves behind.
+        let (tx, rx) = oneshot::channel();
+        svc.inner
+            .waiters
+            .lock()
+            .expect("waiters mutex")
+            .insert("thread-late".to_string(), tx);
+        drop(rx);
+
+        h.inbound_tx
+            .send(inbound("late-reply", Some("thread-late"), "q-late"))
+            .unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .expect("a late reply must reach subscribers, not vanish")
+            .expect("stream item");
+        assert_eq!(got.message.id, "late-reply");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            h.transport.acked.lock().unwrap().as_slice(),
+            &["q-late"],
+            "it was delivered, so it is acked"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
An ack is a delete at the mediator. `run_dispatcher` acked every inbound message unconditionally — including when `subscribers.send` had just reported that nobody was listening. Those messages were destroyed.

## The contract this breaks

`Inbound` states it in its own doc comment:

> The delivery layer above decides when to `MessageTransport::ack` — only **after** the message is durably handed off — so a host teardown between receipt and persistence cannot lose it (never ack-before-handoff).

And the SDK's transport adapter sets `auto_delete = false` specifically to make that possible:

> `auto_delete = false` so the mediator keeps its copy until the caller acks after a durable handoff (never ack-before-handoff).

The transport held up its end. This layer did not — the routing arm's own comment said *"dropped if none are listening"*, and then acked:

```rust
None => {
    …
    let _ = inner.subscribers.send(item);   // Err = nobody received it
}
…
ack_via_source(&inner, &src_id, ack).await; // …acked regardless
```

The `Err` that says "nobody received this" was being discarded with `let _ =`.

## Why it matters

The window is small and its contents are not. No subscriber is installed for a moment at startup and again on the way down, and what arrives in that window is whatever the peer happened to send — a membership credential, a join verdict.

Downstream this surfaced as OpenVTC joins stuck `Pending` forever with clean logs on **every** service ([OpenVTC/openvtc#221](https://github.com/OpenVTC/openvtc/pull/221)). The only record that anything had gone wrong was that nothing happened. It took four services' logs and several passes to find, because every component correctly reported success.

## Changes

**Ack is conditional on handoff.** `broadcast::send` reports `Err` when there are no subscribers; that's the signal. An unacked message stays at the mediator and is offered again on the next pickup — the entire purpose of the contract.

**A reply whose waiter died falls through to subscribers.** A caller that timed out leaves a dead `oneshot`; the reply was swallowed by it and acked anyway. It's still application traffic, so it now goes to `subscribe()` and is acked only if something takes it. Sent on a clone so a dead waiter can't consume it on the way past.

**A lagging subscriber is reported at `error!` instead of skipped in silence.** Overwritten entries are unrecoverable — the dispatcher acked them on the way in — so this is the one lossy step left in the inbound path, and it was also the only one leaving no trace:

```rust
Err(broadcast::error::RecvError::Lagged(_)) => continue,   // before
```

**`SUBSCRIBE_BUFFER`'s doc corrected.** It claimed "at-least-once, dedup on the key". That holds for redelivery *before* an ack; this buffer sits after one. Left as-was it would tell the next reader the loss above was recoverable.

## Testing

3 new tests (61 total, all passing), plus the full workspace suite green:

- `a_message_with_no_consumer_is_not_acked` — the regression itself.
- `a_message_with_a_consumer_is_still_acked` — the complement, so declining to ack cannot silently become a mailbox that never drains.
- `a_reply_whose_waiter_died_falls_through_to_subscribers` — the late-reply path.

`cargo fmt` and `clippy -D warnings` clean.

## Note on the remaining lossy step

The `Lagged` case is now *reported* but still loses messages, and I did not try to fix it here. Making it lossless means replacing the subscriber `broadcast` with something that applies backpressure or fans out losslessly — a real API change for `subscribe()`, and one worth designing rather than bolting on. Until then a consumer that drains promptly is the only defence, and it now says so loudly when that fails.

Version bumped to 0.1.14 with a CHANGELOG entry.
