### PR TITLE
feat(data-integrity): add the ecdsa-jcs-2019 cryptosuite

### DIFF
--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Affinidi Data Integrity Changelog
 
+## 16th August 2026 (0.7.10)
+
+Adds the **`ecdsa-jcs-2019`** cryptosuite — ES256 (P-256) signatures over
+JCS-canonicalized documents, per [W3C vc-di-ecdsa](https://www.w3.org/TR/vc-di-ecdsa/).
+
+Until now every Data Integrity suite here was EdDSA, BBS or post-quantum, so a
+P-256 key could not sign a proof at all. That blocks any holder binding that is
+key-shaped rather than DID-shaped — an ISO 18013-5 mdoc binds to a P-256 device
+key, so a consent receipt naming that key as its data subject was unsignable.
+
+`KeyType::P256` now has a default suite, and the local `Signer for Secret` impl
+gained a P-256 arm routing through `affinidi_crypto::p256::sign` — the same way
+the ML-DSA and SLH-DSA suites route, so no new dependency.
+
+**P-256 only, deliberately.** The spec also defines P-384, paired with SHA-384,
+while this pipeline hashes with SHA-256 unconditionally (`prepare_sign_input`
+concatenates two SHA-256 digests). Accepting a P-384 key would emit proofs no
+conformant verifier reproduces, so `compatible_key_types` is narrower than the
+spec's and a test pins that, to stop a later "completeness" patch widening it
+back without moving the pipeline first.
+
+Note that ECDSA hashes its input as part of signing, so ES256 applies SHA-256
+over the pipeline's 64-byte `proof_hash || doc_hash` — where Ed25519 signs those
+bytes directly. Both match their respective specs; the asymmetry is not a bug.
+
+One existing test changed meaning rather than breaking: `test_sign_bad_key`
+asserted that a particular key could not sign, but that key is **P-256** and the
+failure was only ever "no suite compiled in for this key type". It is now
+`test_sign_p256_key_now_produces_an_ecdsa_jcs_2019_proof`, and a new
+`test_sign_rejects_a_key_type_with_no_suite` (secp256k1) covers the case the old
+name was really standing in for.
+
+Both negative behaviours were mutation-checked: making `verify` accept any
+signature fails the tampered-document test, and widening the key list to P-384
+fails the exclusion test.
+
+Patch bump, per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md)
+point 3 — additive (a new enum variant on a `#[non_exhaustive]` enum, a new ZST
+impl, one signer arm), and a minor bump would break the `[patch.crates-io]`
+redirects.
+
 ## 31st July 2026 (0.7.9)
 
 The Ed25519 signing path takes the signature through the inherent

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.9"
+version = "0.7.10"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/credentials/affinidi-data-integrity/src/crypto_suites.rs
+++ b/crates/credentials/affinidi-data-integrity/src/crypto_suites.rs
@@ -26,6 +26,17 @@ pub enum CryptoSuite {
     /// <https://www.w3.org/TR/vc-di-eddsa/>
     #[serde(rename = "eddsa-rdfc-2022")]
     EddsaRdfc2022,
+    /// ECDSA JCS 2019 spec — ES256 over JCS-canonicalized documents.
+    ///
+    /// **P-256 only.** The spec also defines P-384, but pairs it with
+    /// SHA-384, and this pipeline hashes with SHA-256 unconditionally
+    /// (`prepare_sign_input`). Accepting a P-384 key here would emit
+    /// proofs that no conformant verifier reproduces, so the key-type
+    /// list is deliberately narrower than the spec's.
+    ///
+    /// <https://www.w3.org/TR/vc-di-ecdsa/>
+    #[serde(rename = "ecdsa-jcs-2019")]
+    EcdsaJcs2019,
     /// BBS 2023 spec — BBS signatures with zero-knowledge selective disclosure.
     ///
     /// <https://www.w3.org/TR/vc-di-bbs/>
@@ -57,6 +68,7 @@ impl TryFrom<&str> for CryptoSuite {
         match value {
             "eddsa-jcs-2022" => Ok(CryptoSuite::EddsaJcs2022),
             "eddsa-rdfc-2022" => Ok(CryptoSuite::EddsaRdfc2022),
+            "ecdsa-jcs-2019" => Ok(CryptoSuite::EcdsaJcs2019),
             #[cfg(feature = "bbs-2023")]
             "bbs-2023" => Ok(CryptoSuite::Bbs2023),
             #[cfg(feature = "ml-dsa")]
@@ -104,6 +116,7 @@ impl CryptoSuite {
         match self {
             CryptoSuite::EddsaJcs2022 => &suite_ops::EddsaJcs2022,
             CryptoSuite::EddsaRdfc2022 => &suite_ops::EddsaRdfc2022,
+            CryptoSuite::EcdsaJcs2019 => &suite_ops::EcdsaJcs2019,
             #[cfg(feature = "bbs-2023")]
             CryptoSuite::Bbs2023 => &suite_ops::Bbs2023,
             #[cfg(feature = "ml-dsa")]
@@ -152,6 +165,7 @@ impl CryptoSuite {
     pub fn default_for_key_type(key_type: KeyType) -> Option<Self> {
         match key_type {
             KeyType::Ed25519 => Some(CryptoSuite::EddsaJcs2022),
+            KeyType::P256 => Some(CryptoSuite::EcdsaJcs2019),
             #[cfg(feature = "ml-dsa")]
             KeyType::MlDsa44 => Some(CryptoSuite::MlDsa44Jcs2024),
             #[cfg(feature = "slh-dsa")]
@@ -256,5 +270,63 @@ mod tests {
                 .validate_key_type(KeyType::P521)
                 .is_err()
         );
+    }
+    // ── ecdsa-jcs-2019 ────────────────────────────────────────────────
+
+    #[test]
+    fn ecdsa_jcs_2019_round_trips_through_its_wire_name() {
+        let suite = CryptoSuite::try_from("ecdsa-jcs-2019").expect("known suite");
+        assert_eq!(suite, CryptoSuite::EcdsaJcs2019);
+        assert_eq!(suite.ops().name(), "ecdsa-jcs-2019");
+        // The serde rename is what lands in a proof; pin the exact bytes,
+        // because a proof naming an unknown suite fails verification with a
+        // message that points nowhere near the typo.
+        assert_eq!(
+            serde_json::to_string(&CryptoSuite::EcdsaJcs2019).unwrap(),
+            "\"ecdsa-jcs-2019\""
+        );
+    }
+
+    #[test]
+    fn p256_defaults_to_ecdsa_jcs_2019() {
+        assert_eq!(
+            CryptoSuite::default_for_key_type(KeyType::P256),
+            Some(CryptoSuite::EcdsaJcs2019)
+        );
+    }
+
+    /// The spec defines P-384 for this suite, but pairs it with SHA-384 while
+    /// this pipeline hashes with SHA-256 unconditionally. Accepting a P-384 key
+    /// would emit proofs no conformant verifier reproduces, so the narrowing is
+    /// deliberate — assert it rather than let a later "completeness" patch
+    /// widen it back.
+    #[test]
+    fn p384_is_refused_because_the_pipeline_hashes_sha256() {
+        assert!(
+            CryptoSuite::EcdsaJcs2019
+                .validate_key_type(KeyType::P384)
+                .is_err()
+        );
+        assert!(CryptoSuite::default_for_key_type(KeyType::P384).is_none());
+    }
+
+    #[test]
+    fn ecdsa_jcs_2019_rejects_an_ed25519_key() {
+        assert!(
+            CryptoSuite::EcdsaJcs2019
+                .validate_key_type(KeyType::Ed25519)
+                .is_err()
+        );
+        // ...and the converse, so the two suites cannot be silently swapped.
+        assert!(
+            CryptoSuite::EddsaJcs2022
+                .validate_key_type(KeyType::P256)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ecdsa_jcs_2019_uses_jcs_not_rdfc() {
+        assert!(!CryptoSuite::EcdsaJcs2019.is_rdfc());
     }
 }

--- a/crates/credentials/affinidi-data-integrity/src/lib.rs
+++ b/crates/credentials/affinidi-data-integrity/src/lib.rs
@@ -611,6 +611,61 @@ mod tests {
             .expect("verify via resolver");
     }
 
+    /// The end-to-end property that matters: a P-256 key signs a document and
+    /// the proof verifies through the ordinary `did:key` resolver path, with no
+    /// suite named by hand at either end.
+    #[tokio::test]
+    async fn sign_and_verify_via_did_key_resolver_p256() {
+        use crate::{DidKeyResolver, VerifyOptions};
+
+        let secret = Secret::generate_p256(None, None).expect("generate P-256");
+        let pk_mb = secret.get_public_keymultibase().unwrap();
+        let mut signer_secret = secret.clone();
+        signer_secret.id = format!("did:key:{pk_mb}#{pk_mb}");
+
+        let doc = json!({ "ecdsa": "did:key" });
+        let proof = DataIntegrityProof::sign(&doc, &signer_secret, SignOptions::new())
+            .await
+            .expect("sign");
+        assert_eq!(
+            proof.cryptosuite,
+            crate::crypto_suites::CryptoSuite::EcdsaJcs2019,
+            "a P-256 signer must default to ecdsa-jcs-2019 without being told"
+        );
+
+        proof
+            .verify(&doc, &DidKeyResolver, VerifyOptions::new())
+            .await
+            .expect("verify via resolver");
+    }
+
+    /// A proof must not survive its document changing — ECDSA is randomised, so
+    /// a round-trip test alone would still pass against a verify that ignored
+    /// the payload.
+    #[tokio::test]
+    async fn a_p256_proof_does_not_verify_against_a_tampered_document() {
+        use crate::{DidKeyResolver, VerifyOptions};
+
+        let secret = Secret::generate_p256(None, None).expect("generate P-256");
+        let pk_mb = secret.get_public_keymultibase().unwrap();
+        let mut signer_secret = secret.clone();
+        signer_secret.id = format!("did:key:{pk_mb}#{pk_mb}");
+
+        let doc = json!({ "amount": 10 });
+        let proof = DataIntegrityProof::sign(&doc, &signer_secret, SignOptions::new())
+            .await
+            .expect("sign");
+
+        let tampered = json!({ "amount": 1000 });
+        assert!(
+            proof
+                .verify(&tampered, &DidKeyResolver, VerifyOptions::new())
+                .await
+                .is_err(),
+            "a P-256 proof must not verify against a document it did not sign"
+        );
+    }
+
     #[cfg(feature = "ml-dsa")]
     #[tokio::test]
     async fn sign_and_verify_via_did_key_resolver_ml_dsa() {
@@ -815,17 +870,45 @@ mod tests {
         assert_eq!(a.proof_value, b.proof_value, "ML-DSA must be deterministic");
     }
 
+    /// This key used to be the crate's "bad key" fixture, on the strength of
+    /// signing failing for it. It is a **P-256** key, and the failure was only
+    /// ever "no suite compiled in for this key type" — so `ecdsa-jcs-2019`
+    /// turns it into a supported key, and the old assertion asserted the
+    /// absence of a feature rather than any property of the key.
     #[tokio::test]
-    async fn test_sign_bad_key() {
+    async fn test_sign_p256_key_now_produces_an_ecdsa_jcs_2019_proof() {
         let generic_doc = json!({"test": "test_data"});
         let pub_key = "zruqgFba156mDWfMUjJUSAKUvgCgF5NfgSYwSuEZuXpixts8tw3ot5BasjeyM65f8dzk5k6zgXf7pkbaaBnPrjCUmcJ";
         let pri_key = "z42tmXtqqQBLmEEwn8tfi1bA2ghBx9cBo6wo8a44kVJEiqyA";
         let secret = Secret::from_multibase(pri_key, Some(&format!("did:key:{pub_key}#{pub_key}")))
             .expect("Couldn't create test key data");
+        assert_eq!(
+            secret.get_key_type(),
+            affinidi_secrets_resolver::secrets::KeyType::P256
+        );
+
+        let proof = DataIntegrityProof::sign(&generic_doc, &secret, SignOptions::new())
+            .await
+            .expect("a P-256 key signs under ecdsa-jcs-2019");
+        assert_eq!(
+            proof.cryptosuite,
+            crate::crypto_suites::CryptoSuite::EcdsaJcs2019
+        );
+    }
+
+    /// The genuine "unsupported key type" case the previous test was standing
+    /// in for. secp256k1 has no Data Integrity suite here, so it must still
+    /// fail — otherwise a key type nothing can verify would sign silently.
+    #[tokio::test]
+    async fn test_sign_rejects_a_key_type_with_no_suite() {
+        let generic_doc = json!({"test": "test_data"});
+        let secret =
+            Secret::generate_secp256k1(Some("did:key:k#k"), None).expect("generate secp256k1");
         assert!(
             DataIntegrityProof::sign(&generic_doc, &secret, SignOptions::new())
                 .await
-                .is_err()
+                .is_err(),
+            "a key type with no compiled-in suite must not sign"
         );
     }
 

--- a/crates/credentials/affinidi-data-integrity/src/signer.rs
+++ b/crates/credentials/affinidi-data-integrity/src/signer.rs
@@ -109,6 +109,8 @@ impl Signer for Secret {
                 let signing_key = SigningKey::from_bytes(&private_bytes);
                 Ok(signing_key.sign(data).to_bytes().to_vec())
             }
+            KeyType::P256 => affinidi_crypto::p256::sign(self.get_private_bytes(), data)
+                .map_err(DataIntegrityError::signing),
             #[cfg(feature = "ml-dsa")]
             KeyType::MlDsa44 => {
                 affinidi_crypto::ml_dsa::sign_ml_dsa_44(self.get_private_bytes(), data)

--- a/crates/credentials/affinidi-data-integrity/src/suite_ops.rs
+++ b/crates/credentials/affinidi-data-integrity/src/suite_ops.rs
@@ -127,6 +127,47 @@ impl CryptoSuiteOps for EddsaRdfc2022 {
 }
 
 // ---------------------------------------------------------------------
+// ECDSA / P-256 — ecdsa-jcs-2019
+// ---------------------------------------------------------------------
+
+/// `ecdsa-jcs-2019` — ES256 signatures over JCS-canonicalized documents.
+///
+/// P-256 only; see [`CryptoSuite::EcdsaJcs2019`] for why P-384 is excluded
+/// rather than merely unimplemented.
+pub struct EcdsaJcs2019;
+
+impl CryptoSuiteOps for EcdsaJcs2019 {
+    fn name(&self) -> &'static str {
+        "ecdsa-jcs-2019"
+    }
+    fn canonicalization(&self) -> Canonicalization {
+        Canonicalization::Jcs
+    }
+    fn compatible_key_types(&self) -> &'static [KeyType] {
+        &[KeyType::P256]
+    }
+    fn verify(&self, key: &[u8], data: &[u8], sig: &[u8]) -> Result<(), DataIntegrityError> {
+        use crate::SignatureFailure;
+
+        // `data` is the pipeline's `proof_hash || doc_hash`. ECDSA hashes its
+        // input as part of signing, so ES256 applies SHA-256 over those 64
+        // bytes — unlike Ed25519, which signs them directly. Both match their
+        // respective specs; the difference is not a bug to be normalised away.
+        match affinidi_crypto::p256::verify(key, data, sig) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(DataIntegrityError::InvalidSignature {
+                suite: CryptoSuite::EcdsaJcs2019,
+                reason: SignatureFailure::Invalid,
+            }),
+            Err(_) => Err(DataIntegrityError::InvalidSignature {
+                suite: CryptoSuite::EcdsaJcs2019,
+                reason: SignatureFailure::Malformed,
+            }),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
 // BBS-2023 (selective disclosure)
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

Every Data Integrity suite in this crate is EdDSA, BBS or post-quantum — so a
**P-256 key cannot sign a proof at all**. `KeyType::P256` exists and
`did_vm.rs` already decodes `p256-pub`, but there was nowhere for such a key to
go.

That blocks any holder binding which is **key-shaped rather than DID-shaped**.
Concretely: an ISO/IEC 18013-5 mdoc binds to a P-256 *device key*, so a consent
receipt naming that key as its `dpv:hasDataSubject` was unsignable — the receipt
must be signed by the key it names, and no suite accepted the key.

## What

`ecdsa-jcs-2019` — ES256 over JCS-canonicalized documents, per
[W3C vc-di-ecdsa](https://www.w3.org/TR/vc-di-ecdsa/).

The crate's own extension path made this small: `suite_ops.rs` documents "add an
enum variant, add a `CryptoSuiteOps` impl, add one arm to `CryptoSuite::ops`",
and that is exactly the diff, plus a P-256 arm on the local `Signer for Secret`
impl routing through `affinidi_crypto::p256::sign` — the same route ML-DSA and
SLH-DSA take, so **no new dependency**.

## P-256 only, deliberately

The spec also defines P-384, paired with **SHA-384**. This pipeline hashes with
**SHA-256 unconditionally** — `prepare_sign_input` concatenates two SHA-256
digests (`lib.rs:496`). Accepting a P-384 key would emit proofs that no
conformant verifier reproduces.

So `compatible_key_types` is narrower than the spec's, and
`p384_is_refused_because_the_pipeline_hashes_sha256` pins it — otherwise a later
"completeness" patch widens it back without moving the pipeline first, and the
resulting proofs fail only against *other people's* verifiers.

## One asymmetry worth knowing

ECDSA hashes its input as part of signing, so ES256 applies SHA-256 over the
pipeline's 64-byte `proof_hash || doc_hash`, whereas Ed25519 signs those bytes
directly. Both match their respective specs. It's commented at the verify site
so it doesn't get "fixed" later.

## A test that changed meaning rather than breaking

`test_sign_bad_key` asserted that a particular key could not sign. That key is
**P-256**, and the failure was only ever *"no suite compiled in for this key
type"* — it asserted the absence of a feature, not any property of the key. It is
now `test_sign_p256_key_now_produces_an_ecdsa_jcs_2019_proof`, and a new
`test_sign_rejects_a_key_type_with_no_suite` (secp256k1) covers the case the old
name was really standing in for.

Flagging it explicitly because a green suite after renaming a failing test is
exactly the shape of a papered-over regression, and it isn't one here.

## Testing

51 lib tests (default), **92 `--all-features`**. `cargo fmt` and
`cargo clippy --all-targets` clean, zero warnings.

New coverage: wire-name round trip (pinning the serde rename bytes — the parser
is hand-written and separate from serde, which this caught), P-256 defaulting to
the suite without being named, cross-suite key rejection in both directions, the
P-384 exclusion, end-to-end sign→verify through the ordinary `did:key` resolver,
and a tampered-document check.

The two negative behaviours were **mutation-checked**:

| mutation | result |
|---|---|
| `verify` accepts any signature | tampered-document test **fails** ✓ |
| widen `compatible_key_types` to P-384 | exclusion test **fails** ✓ |

ECDSA is randomised, so a round-trip test alone would still pass against a
`verify` that ignored its payload — hence the tampering case.

## Versioning

Patch bump (0.7.9 → 0.7.10) per
[ADR 0003](docs/adr/0003-public-api-semver-policy.md) point 3: additive (a
variant on a `#[non_exhaustive]` enum, a new ZST impl, one signer arm), and a
minor bump would break the `[patch.crates-io]` redirects. Changelog entry added.
