### PR TITLE
chore(deps): track trust-tasks-rs 0.9.0 across the messaging stack

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.26] - 2026-08-17
+
+### Changed
+
+- **Track `trust-tasks-rs` 0.9.0** and `affinidi-messaging-sdk` 0.19.8, up from
+  0.6.1 / 0.19.7. Version requirements only — the single use here is
+  `specs::messaging::account`, whose `v0_1` types are shape-identical across the
+  move. See the SDK's 0.19.8 entry for what the three intervening breaking
+  releases changed and why this ships as a patch.
+
 ## [0.3.25] - 2026-08-14
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.25"
+version = "0.3.26"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -21,10 +21,10 @@ tsp = ["affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 affinidi-tdk-common = "0.6"
-affinidi-messaging-sdk = "0.19.7"
+affinidi-messaging-sdk = "0.19.8"
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.6.1"
+trust-tasks-rs = "0.9"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-helpers"
-version = "0.13.3"
+version = "0.13.4"
 description = "CLI tools for Affinidi Messaging (mediator administration)"
 edition.workspace = true
 authors.workspace = true
@@ -21,9 +21,9 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.8" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.6.1"
+trust-tasks-rs = "0.9"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Affinidi Messaging Mediator
 
+## 17th August 2026 (0.18.18)
+
+**Tracks `trust-tasks-rs` 0.9.0**, up from 0.6.1, with the
+`affinidi-messaging-sdk` requirement moved to 0.19.8 alongside it — the same
+pairing 0.18.15 adopted preventively, since `trust-tasks-rs` is a public
+dependency of the SDK's `trust_tasks()` surface and a manifest naming both must
+name an SDK whose types match.
+
+Unlike the last three bumps, this one **does** reach the source. 0.9.0 gives
+`consume_inbound` a required `PayloadPolicy` argument (SPEC.md §7.2 item 2), and
+the `ping` consume path now passes
+`PayloadPolicy::<NoValidator>::AcceptUnvalidated` — the behaviour the call has
+always had, now stated rather than implied. `ping::v0_1::Payload` is a generated
+struct with `deny_unknown_fields` and validating newtypes, so deserializing into
+it already enforced the required members, their types, and the pattern/length
+constraints. What `Validate` would add is the residue a Rust type cannot express
+(`minProperties`, `minItems` on an optional array, conditional subschemas), and
+the `ping` spec declares none of it.
+
+**No document is accepted or refused differently as a result of this release.**
+Moving to `Validate` would be a behaviour change — it can begin refusing
+documents a peer sends today — and belongs in its own release with its own
+rollout, not folded into a dependency bump.
+
+The other two breaking releases in between do not reach this code: 0.7.0 made
+`StandardCode` `#[non_exhaustive]` and nothing here matches on it, and 0.8.0's
+new `cancelled` code and `trust-task-control/0.1` payloads are additive. No
+`trust-tasks` type crosses the mediator's `vta-sdk` boundary, so the second
+`trust-tasks-rs` that boundary still carries stays inert.
+
 ## 14th August 2026 (0.18.17)
 
 **Tracks `trust-tasks-rs` 0.6.1**, up from 0.4.0, with the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.17"
+version = "0.18.18"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,14 +113,14 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.8" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.6.1", optional = true }
+trust-tasks-rs = { version = "0.9", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -39,8 +39,8 @@ use subtle::ConstantTimeEq;
 use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
 use trust_tasks_rs::specs::{audit, config};
 use trust_tasks_rs::{
-    ConsumeOutcome, Payload, ProofPolicy, ProofVerifier, TransportContext, TransportHandler,
-    TrustTask, TypeUri, VerificationError, consume_inbound,
+    ConsumeOutcome, NoValidator, Payload, PayloadPolicy, ProofPolicy, ProofVerifier,
+    TransportContext, TransportHandler, TrustTask, TypeUri, VerificationError, consume_inbound,
 };
 use uuid::Uuid;
 
@@ -1624,6 +1624,19 @@ async fn consume_ping(
     let outcome = consume_inbound(
         &transport,
         ProofPolicy::<NoProof>::AcceptUnverified,
+        // SPEC §7.2 item 2. `AcceptUnvalidated` keeps the behaviour this call
+        // has always had, now stated rather than implied: `ping::v0_1::Payload`
+        // is a codegen struct with `deny_unknown_fields` and validating
+        // newtypes, so deserializing into it already enforced the required
+        // members, their types, and the pattern/length constraints. What
+        // `Validate` would add is the residue a Rust type cannot express
+        // (`minProperties`, `minItems` on an optional array, conditional
+        // subschemas), and `ping` declares none of it.
+        //
+        // Turning this to `Validate` is a behaviour change, not a tidy-up: it
+        // can start refusing documents a peer sends today. Do it as its own
+        // change, with its own rollout, never folded into a version bump.
+        PayloadPolicy::<NoValidator>::AcceptUnvalidated,
         doc,
         mediator_did,
         now,

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.19.8] - 2026-08-17
+
+### Changed
+
+- **Track `trust-tasks-rs` 0.9.0**, up from 0.6.1. Three breaking releases sit
+  in between, none of which reaches this crate's source:
+
+  - **0.7.0** made `StandardCode` `#[non_exhaustive]`. Nothing here matches on
+    it, so no arm had to be added — and this is the last time a new framework
+    error code will break a downstream `match`.
+  - **0.8.0** added `StandardCode::Cancelled` and the `trust-task-control/0.1`
+    payloads, and moved emitted error documents to `trust-task-error/0.5`.
+    Additive on the Rust side because of the attribute above.
+  - **0.9.0** gave `consume_inbound` a required `PayloadPolicy` argument
+    (SPEC.md §7.2 item 2) and replaced `ValidatedPayload::SCHEMA_JSON` with
+    `Payload::PAYLOAD_SCHEMA`. This crate calls neither: it builds documents
+    through `TrustTask::for_payload` / `respond_with` and decodes replies
+    directly, so only the version requirement moved.
+
+  The `v0_1` payload types the `trust_tasks()` surface returns — `ping`,
+  `account`, `acl`, `access_list`, `audit`, `config` — are shape-identical
+  across the move. What changes is which crate version provides them.
+
+  It ships as a patch rather than a minor, for the reason 0.19.2 and 0.19.7
+  both give: consumers require `affinidi-messaging-sdk` `^0.19` and resolve it
+  from the registry, so a 0.20 would pull a second registry copy of this crate
+  into their graphs — the exact defect this bump exists to remove, relocated one
+  crate over. The cost is unchanged and still worth stating: `trust-tasks-rs` is
+  a public dependency of the `trust_tasks()` surface, so this is
+  **source-breaking for a consumer still on `trust-tasks-rs` 0.6.x** despite the
+  patch version. Move that pin in the same change.
+
 ## [0.19.7] - 2026-08-14
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.7"
+version = "0.19.8"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.6.1"
+trust-tasks-rs = "0.9"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Affinidi Messaging Test Mediator
 
+## 0.2.51 — 17th August 2026
+
+**Tracks `trust-tasks-rs` 0.9.0**, up from 0.6.1, with the
+`affinidi-messaging-sdk` requirement moved to 0.19.8 and
+`affinidi-messaging-mediator` to 0.18.18 alongside it — the same pairing 0.2.49
+introduced, applied to the new versions.
+
+The breaking changes in between are `StandardCode` becoming `#[non_exhaustive]`
+(0.7.0), the additive `cancelled` code and `trust-task-control/0.1` payloads
+(0.8.0), and a required `PayloadPolicy` argument on `consume_inbound` (0.9.0).
+None reaches this crate — it calls `consume_inbound` nowhere and matches on no
+standard code. No source changed.
+
 ## 0.2.50 — 14th August 2026
 
 **Tracks `trust-tasks-rs` 0.6.1**, up from 0.4.0, with the

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.50"
+version = "0.2.51"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secre
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.19.7", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.19.8", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
@@ -95,7 +95,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.22"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.6.1"
+trust-tasks-rs = "0.9"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.12.6] - 2026-08-17
+
+### Changed
+
+- Track `trust-tasks-rs` 0.9.0 (was 0.6.1) and `affinidi-messaging-sdk` 0.19.8.
+  The `account` and ACL types this client reads are unchanged across the bump;
+  no code changed.
+
 ## [0.12.5] - 2026-08-09
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.5"
+version = "0.12.6"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -15,10 +15,10 @@ repository.workspace = true
 [dependencies]
 # Affinidi Crates
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.7" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.8" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.6.1"
+trust-tasks-rs = "0.9"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates


### PR DESCRIPTION
## What

Moves the six messaging crates from `trust-tasks-rs` 0.6.1 to **0.9.0**.

| crate | version |
|---|---|
| `affinidi-messaging-sdk` | 0.19.7 → 0.19.8 |
| `affinidi-messaging-mediator` | 0.18.17 → 0.18.18 |
| `affinidi-messaging-didcomm-service` | 0.3.25 → 0.3.26 |
| `affinidi-messaging-test-mediator` | 0.2.50 → 0.2.51 |
| `affinidi-messaging-text-client` | 0.12.5 → 0.12.6 |
| `affinidi-messaging-helpers` | 0.13.3 → 0.13.4 |

## What changed upstream, and what reaches us

Three breaking releases sit between 0.6.1 and 0.9.0. **One** reaches the source.

- **0.7.0** — `StandardCode` became `#[non_exhaustive]`. Nothing in this repo matches on it, so no arm had to be added. It is also the last time a new framework error code will break a downstream `match`.
- **0.8.0** — added `StandardCode::Cancelled` and `trust-task-control/0.1`; emitted error documents moved to `trust-task-error/0.5`. Additive in Rust because of the attribute above.
- **0.9.0** — `consume_inbound` gained a required `PayloadPolicy` argument (SPEC.md §7.2 item 2), and `ValidatedPayload::SCHEMA_JSON` was replaced by `Payload::PAYLOAD_SCHEMA`. **One** call site in the repo (the mediator's `ping` consume path); `SCHEMA_JSON` had no users.

## The one behavioural decision, and it is a deliberate no-op

The `ping` path passes `PayloadPolicy::<NoValidator>::AcceptUnvalidated` — the behaviour the call has always had, now stated rather than implied. `ping::v0_1::Payload` is a generated struct with `deny_unknown_fields` and validating newtypes, so deserializing into it already enforced the required members, their types, and the pattern/length constraints. What `Validate` would add is the residue a Rust type cannot express (`minProperties`, `minItems` on an optional array, conditional subschemas) — and the `ping` spec declares none of it.

**No document is accepted or refused differently as a result of this PR.** Moving to `Validate` can begin refusing documents a peer sends today, so it belongs in its own release with its own rollout, never folded into a dependency bump.

## Why patches, not minors

`trust-tasks-rs` is a public dependency of the SDK's `trust_tasks()` surface, so on the face of it this is breaking. It ships as a patch anyway, following the convention 0.19.2 and 0.19.7 set and for the same reason: every consumer requires `affinidi-messaging-sdk` `^0.19` and resolves it from the registry, so a `0.20` would pull a **second registry copy of the SDK** into their graphs — the exact defect this bump exists to remove, relocated one crate over.

The cost is unchanged and is stated in each changelog: this is **source-breaking for a consumer still on `trust-tasks-rs` 0.6.x** despite the patch version. Those consumers move their own pin in the same change.

## The other `trust-tasks-rs` in the lockfile is untouched

The lock still carries `trust-tasks-rs` 0.2.57, reached through `vta-sdk` 0.21.6 behind the mediator's `vta-sdk = ">=0.21.0, <0.23.0"` ceiling. It stays **inert**: no file in the mediator uses both `vta_sdk` and `trust_tasks_rs`, so no trust-tasks type crosses that boundary and the two copies never have to unify.

Collapsing it needs a `vta-sdk` release built on 0.9, which does not exist yet — that is a later, separate PR, deliberately not bundled here.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo check --workspace --all-features --all-targets` — clean
- `cargo test --workspace` — all suites pass, 0 failures
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` — clean
- All four release guards run locally and pass: version-bump, changelog, workspace-duplicates, toolchain-sync (plus test-clock isolation)