### PR TITLE
chore(deps): tighten the mediator's vta-sdk pin to 0.25

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Affinidi Messaging Mediator
 
+## 17th August 2026 (0.18.19)
+
+**Tightens `vta-sdk` from `>=0.21.0, <0.23.0` back to a plain `"0.25"`,** and
+moves `mediator-setup`'s two `"0.21.0"` pins with it.
+
+The range was a stopgap, and its own comment said so: *"Range rather than
+`"0.22"` only because 0.22.0 is not on crates.io yet ... Tighten once it is."*
+It was never tightened, and it outlived its reason. VTI went on to publish 0.23,
+0.24 and 0.25 while the `<0.23.0` ceiling held this workspace on `vta-sdk`
+0.21.6 — and *that* is what kept a second `trust-tasks-rs` (0.2.57, reached
+through 0.21.6) in the lockfile after 0.18.18 moved everything else to 0.9. The
+`mediator-setup` pins were doing the same thing one crate over, holding a third
+`vta-sdk` (0.21.21) and a `trust-tasks-rs` 0.4.1 behind it.
+
+With both moved, `cargo tree -d -e normal,build` and `-e normal,build,dev` are
+each clean: one `vta-sdk`, one `trust-tasks-rs`, one `vti-common`, one
+`affinidi-tdk`. No source changed — four `vta-sdk` minors, and nothing this
+crate uses moved with them.
+
+The lesson is worth keeping: **a bounded upper range is a tax that comes due
+silently.** Nothing fails when the ceiling goes stale; the graph just quietly
+carries an extra copy of everything behind it, and the cost surfaces somewhere
+else entirely. Prefer a caret and move it deliberately.
+
+Note that the `vta` feature — not the version range — is what actually breaks
+the cross-repository dependency cycle described in this crate's `Cargo.toml`.
+That reasoning is unchanged.
+
 ## 17th August 2026 (0.18.18)
 
 **Tracks `trust-tasks-rs` 0.9.0**, up from 0.6.1, with the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.18"
+version = "0.18.19"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -150,9 +150,14 @@ affinidi-task-utils = "0.1"
 ## Optional, behind the default-on `vta` feature — see that feature's comment
 ## for why the optionality matters more than the version range does.
 ##
-## Range rather than `"0.22"` only because 0.22.0 is not on crates.io yet; it
-## is published by the very VTI release that needed this. Tighten once it is.
-vta-sdk = { version = ">=0.21.0, <0.23.0", features = [
+## Tightened back to a plain caret now that the release it was waiting on has
+## shipped. The `>=0.21.0, <0.23.0` range was a stopgap for a version that was
+## not yet on crates.io, and it outlived its reason: VTI went on to 0.23, 0.24
+## and 0.25 while the ceiling held this crate on 0.21.6, and *that* is what kept
+## a second `trust-tasks-rs` (0.2.57, from vta-sdk 0.21.6) in this workspace's
+## lockfile long after everything else had moved to 0.9. A bounded range is a
+## tax that comes due silently; prefer a caret and move it deliberately.
+vta-sdk = { version = "0.25", features = [
   "integration",
 ], optional = true }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.27"
+version = "0.1.28"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.21.0", features = ["provision-client"] }
+vta-sdk = { version = "0.25", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -186,7 +186,7 @@ aws-sdk-s3 = { version = "1", optional = true, default-features = false, feature
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.21.0", features = ["test-support"] }
+vta-sdk = { version = "0.25", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via


### PR DESCRIPTION
## What

`affinidi-messaging-mediator`: `vta-sdk = ">=0.21.0, <0.23.0"` → `"0.25"`.
`mediator-setup`: two `vta-sdk = "0.21.0"` pins → `"0.25"`.

No source changed, across four `vta-sdk` minors.

## Why now

The range was a stopgap, and its own comment said so:

> *Range rather than `"0.22"` only because 0.22.0 is not on crates.io yet; it is published by the very VTI release that needed this. **Tighten once it is.***

It never was tightened, and it outlived its reason. VTI went on to publish 0.23, 0.24 and 0.25 while the `<0.23.0` ceiling held this workspace on `vta-sdk` 0.21.6.

**That ceiling is what kept a second `trust-tasks-rs` in the lockfile.** After #714 moved all six messaging crates to `trust-tasks-rs` 0.9, the graph still carried 0.2.57 — reached only through `vta-sdk` 0.21.6, held only by this range. `mediator-setup` was doing the same thing one crate over: its two `0.21.0` pins held a third `vta-sdk` (0.21.21) and a `trust-tasks-rs` 0.4.1 behind it.

## Result

Both duplicate views are now clean:

```
$ cargo tree -d -e normal,build          # shipped
$ cargo tree -d -e normal,build,dev      # dev
# neither lists trust-tasks-rs, vta-sdk, vti-common or affinidi-tdk
```

This workspace no longer carries a duplicate of anything in the family.

## The bit worth keeping

This is the second bounded upper bound to cost something in as many weeks. **A bounded range is a tax that comes due silently.** Nothing fails when the ceiling goes stale — the graph just quietly carries an extra copy of everything behind it, and the cost surfaces somewhere else entirely, usually as a confusing `E0308` in an unrelated crate. Prefer a caret and move it deliberately.

To be clear about what this does *not* change: the **`vta` feature**, not the version range, is what breaks the cross-repository dependency cycle documented in this crate's `Cargo.toml` (`vtc-service [dev] → test-mediator → mediator → vta-sdk`). That reasoning is untouched.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo check --workspace --all-features --all-targets` — clean
- `cargo test --workspace` — green
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` — clean
- All release guards pass locally: version-bump, changelog, workspace-duplicates, toolchain-sync, test-clock

Unlike #714, `verify-publish` should pass here: `mediator-setup` is `publish = false`, and the mediator's own dependencies are all already on the registry.