### PR TITLE
fix(auth): honour force_refresh, so a proactive refresh actually refreshes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,14 @@ jobs:
       # are now genuinely fixed — the aws-sdk crates no longer pull the legacy
       # rustls 0.21 stack. Removed from the ignore list on purpose: if the
       # legacy stack comes back, audit must fail rather than stay quiet.
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
+      # RUSTSEC-2026-0258 (h2, unbounded empty DATA frames). The fixable half is
+      # fixed: the lockfile takes h2 0.4.16. What remains is h2 **0.3.27**,
+      # which has no patched release — it is the newest 0.3 and the advisory
+      # names >=0.4.16 as the only fix. It arrives through reqwest 0.11 <-
+      # ssi-dids-core <- did-ethr / did-pkh, as an HTTP *client*.
+      # Drop when those crates move to reqwest 0.12 (hyper 1.x), or if h2
+      # backports the fix to 0.3.
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,14 @@ jobs:
     with:
       toolchain: "1.95.0"
       rustflags: "-D warnings --cfg tracing_unstable"
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373"
+      # RUSTSEC-2026-0258 (h2, unbounded empty DATA frames). The fixable half is
+      # fixed: the lockfile takes h2 0.4.16. What remains is h2 **0.3.27**,
+      # which has no patched release — it is the newest 0.3 and the advisory
+      # names >=0.4.16 as the only fix. It arrives through reqwest 0.11 <-
+      # ssi-dids-core <- did-ethr / did-pkh, as an HTTP *client*.
+      # Drop when those crates move to reqwest 0.12 (hyper 1.x), or if h2
+      # backports the fix to 0.3.
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       release_debug: true
       # `workspace_publish: true` uses `cargo publish --workspace`, which errors on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,23 @@ Per-crate version history is summarised here; for the full code history see
 
 ### Fixed
 
+- **Websocket reconnect storm: one socket teardown per access token, not four**
+  (`affinidi-did-authentication`, `affinidi-tdk-common`). A proactive token
+  refresh silently did nothing, because the `force_refresh` intent was dropped
+  before the code that acts on it and the decision was re-derived from the
+  token's expiry — which said the token was still valid, since that is exactly
+  when a proactive refresh runs.
+
+  The websocket transport refreshes at 80% of the token's life and rebuilds the
+  socket to carry the new token, so each no-op refresh re-armed the deadline at
+  80% of the time *remaining*. On a 900 s token that meant teardowns at T-180 s,
+  T-36 s, T-7 s and T+expired — where the refresh finally ran for real — per
+  profile. Consumers saw bursts of connect/disconnect every token lifetime,
+  close enough together at the end to trip duplicate-connection heuristics.
+
+  **Reconnect-semantics change (R3.6):** consumers that count, log or alert on
+  reconnect frequency will see roughly a quarter as many.
+
 - **Two unbounded-growth paths in the mediator's in-memory state.**
   **`affinidi-messaging-mediator` 0.16.46**, **`affinidi-messaging-mediator-common`
   0.15.28**.

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Affinidi DID Authentication
 
+## 0.3.11 — 2026-08-18
+
+### Fixed
+
+- **A forced refresh of a still-valid access token now actually refreshes.**
+  `_refresh_authentication` re-derived the decision from `refresh_check`, which
+  only reports `Refresh` inside the last five seconds of the token's life — so a
+  caller that had explicitly asked for a refresh was answered with "still valid,
+  nothing to do" and got its old token back. The intent was accepted at the
+  task boundary (`Refresh needed` was even logged) and then discarded here,
+  because there was no way to express it beyond that point.
+
+  Downstream this produced a reconnect storm. `affinidi-messaging-sdk`'s
+  websocket transport refreshes proactively at 80% of the token's life and
+  rebuilds the socket to carry the new token; because the refresh did nothing,
+  each rebuild re-armed the deadline at 80% of what *remained*. For a 900 s
+  token that is teardowns at T-180 s, T-36 s, T-7 s and finally T+expired —
+  where the refresh at last ran for real — so **four reconnects per token per
+  profile instead of one**, the last two close enough together to look like
+  flapping.
+
+### Added
+
+- `DIDAuthentication::refresh_tokens`, which mints a new access token while the
+  current one is still valid. Purely additive — `authenticate` is unchanged, so
+  an ordinary call on a healthy token still costs nothing. Force promotes only
+  "still valid": an expired *refresh* token still falls through to a full
+  handshake, because there is nothing left to refresh with.
+
 ## 0.3.10 — 2026-07-19
 
 ### Changed

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.10"
+version = "0.3.11"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/identity/affinidi-did-authentication/src/lib.rs
+++ b/crates/identity/affinidi-did-authentication/src/lib.rs
@@ -361,6 +361,7 @@ impl DIDAuthentication {
                         did_resolver,
                         secrets_resolver,
                         client,
+                        false,
                     )
                     .await
                 {
@@ -522,8 +523,23 @@ impl DIDAuthentication {
         })
     }
 
-    /// Refresh the access tokens as required
-    async fn _refresh_authentication<S>(
+    /// Mint a new access token now, even though the current one is still
+    /// valid — a **proactive** refresh.
+    ///
+    /// [`Self::authenticate`] deliberately does not do this: it refreshes only
+    /// when [`refresh_check`] says it must, which is inside the last five
+    /// seconds of the token's life, so an ordinary call on a healthy token
+    /// costs nothing. A caller that wants to get ahead of expiry — a transport
+    /// rebuilding its connection so the new socket carries a fresh token, say —
+    /// wants the opposite, and had no way to ask for it.
+    ///
+    /// If the *refresh* token has itself expired there is nothing to refresh
+    /// with; this returns an error and the caller should run a full
+    /// [`Self::authenticate`].
+    ///
+    /// # Returns
+    /// Ok if a new token was obtained; the tokens are in `self`.
+    pub async fn refresh_tokens<S>(
         &mut self,
         profile_did: &str,
         endpoint_did: &str,
@@ -534,13 +550,46 @@ impl DIDAuthentication {
     where
         S: SecretsResolver,
     {
+        self._refresh_authentication(
+            profile_did,
+            endpoint_did,
+            did_resolver,
+            secrets_resolver,
+            client,
+            true,
+        )
+        .await
+    }
+
+    /// Refresh the access tokens as required.
+    ///
+    /// `force_refresh` promotes a "still valid, nothing to do" answer into a
+    /// real refresh; it cannot rescue an expired *refresh* token, which still
+    /// falls through to a full handshake.
+    async fn _refresh_authentication<S>(
+        &mut self,
+        profile_did: &str,
+        endpoint_did: &str,
+        did_resolver: &DIDCacheClient,
+        secrets_resolver: &S,
+        client: &Client,
+        force_refresh: bool,
+    ) -> Result<()>
+    where
+        S: SecretsResolver,
+    {
         let Some(tokens) = &self.tokens else {
             return Err(DIDAuthError::Authentication(
                 "No tokens found to refresh".to_owned(),
             ));
         };
 
-        match refresh_check(tokens) {
+        let check = refresh_decision(refresh_check(tokens), force_refresh);
+        if check == RefreshCheck::Refresh && force_refresh {
+            debug!("Access token still valid, but a refresh was requested");
+        }
+
+        match check {
             RefreshCheck::Ok => {
                 // Tokens are valid, do not need to refresh
                 Ok(())
@@ -780,6 +829,25 @@ where
     .map_err(|e| DIDAuthError::DIDComm(format!("pack failed: {e}")))
 }
 
+/// Apply a caller's `force_refresh` to what [`refresh_check`] concluded.
+///
+/// `refresh_check` answers "must this be refreshed?", which is only true inside
+/// the last five seconds of the access token's life. A caller doing a
+/// **proactive** refresh is asking a different question — it wants a new token
+/// precisely while the old one is still good — and had no way to say so: the
+/// intent was accepted at the task boundary and then discarded here, so the
+/// refresh silently did nothing and the caller acted on a token that had not
+/// changed. See [`DIDAuthentication::refresh_tokens`].
+///
+/// Force overrides only `Ok`. `Expired` means the *refresh* token is gone too,
+/// which no amount of forcing can mend — that still needs a full handshake.
+fn refresh_decision(check: RefreshCheck, force_refresh: bool) -> RefreshCheck {
+    match (check, force_refresh) {
+        (RefreshCheck::Ok, true) => RefreshCheck::Refresh,
+        (check, _) => check,
+    }
+}
+
 /// Possible responses from checking authentication JWT tokens
 #[derive(PartialEq, Debug)]
 pub enum RefreshCheck {
@@ -825,7 +893,7 @@ pub fn refresh_check(tokens: &AuthorizationTokens) -> RefreshCheck {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AuthorizationTokens, RefreshCheck, refresh_check};
+    use crate::{AuthorizationTokens, RefreshCheck, refresh_check, refresh_decision};
     use std::time::SystemTime;
 
     /// Sensitive auth artifacts must be logged via `trace_sensitive` (TRACE),
@@ -920,6 +988,53 @@ mod tests {
         };
 
         assert_eq!(refresh_check(&tokens), RefreshCheck::Expired);
+    }
+
+    /// A forced refresh of a still-valid token actually refreshes.
+    ///
+    /// This is the regression that produced a reconnect storm. The websocket
+    /// transport refreshes proactively at 80% of the token's life and then
+    /// rebuilds the socket on the new token. `refresh_check` said `Ok` (the
+    /// token had ~180 s left), the force was dropped, and the socket was
+    /// rebuilt on the *same* token — so the next deadline was 80% of what
+    /// remained, and again, and again: teardowns at T-180 s, T-36 s, T-7 s and
+    /// finally T+expired, where the refresh at last ran for real. Four
+    /// reconnects per token instead of one, per profile.
+    #[test]
+    fn a_forced_refresh_of_a_valid_token_refreshes() {
+        assert_eq!(
+            refresh_decision(RefreshCheck::Ok, true),
+            RefreshCheck::Refresh
+        );
+    }
+
+    /// Without a force, a valid token is left alone — every ordinary
+    /// `authenticate` call takes this path, and refreshing on each one would
+    /// trade a reconnect storm for a request storm.
+    #[test]
+    fn an_unforced_valid_token_is_left_alone() {
+        assert_eq!(refresh_decision(RefreshCheck::Ok, false), RefreshCheck::Ok);
+    }
+
+    /// Force cannot rescue an expired refresh token: there is nothing left to
+    /// refresh *with*, so this still has to fall through to a full handshake.
+    #[test]
+    fn force_does_not_override_an_expired_refresh_token() {
+        assert_eq!(
+            refresh_decision(RefreshCheck::Expired, true),
+            RefreshCheck::Expired
+        );
+    }
+
+    /// A token already due a refresh is unaffected by the flag either way.
+    #[test]
+    fn a_due_refresh_is_unchanged_by_the_flag() {
+        for force in [true, false] {
+            assert_eq!(
+                refresh_decision(RefreshCheck::Refresh, force),
+                RefreshCheck::Refresh
+            );
+        }
     }
 
     // Boundary smoke test: this crate now delegates curve negotiation to

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — `affinidi-tdk-common`
 
+## 0.6.8 — 2026-08-18
+
+### Fixed
+
+- **`force_refresh` now reaches the code that acts on it.** The authentication
+  task honoured the flag when deciding *that* a refresh was needed, then asked
+  for it through `authenticate` — which re-derives the decision from the token's
+  expiry and concluded the token was still valid, so nothing was refreshed and
+  the caller got its old token back. A forced refresh now goes through
+  `DIDAuthentication::refresh_tokens`, falling back to the full handshake if
+  that fails (which is what an expired refresh token needs anyway). See
+  `affinidi-did-authentication` for the reconnect storm this caused
+  downstream.
+
+
 All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.7"
+version = "0.6.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -14,7 +14,12 @@ rust-version.workspace = true
 
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
-affinidi-did-authentication = "0.3"
+# Pinned to the exact sibling version this crate now needs: `refresh_tokens`
+# lands in 0.3.11, so the caret "0.3" would resolve the published 0.3.10 and
+# fail to compile. Naming the local version is also what lets the publish
+# dry-run guard report `wait` (sibling not on crates.io yet) rather than a
+# registry-drift failure — see scripts/check-publish-dry-run.sh.
+affinidi-did-authentication = "0.3.11"
 affinidi-did-common = "0.4"
 affinidi-secrets-resolver = "0.5"
 affinidi-data-integrity = "0.7"

--- a/crates/tdk/affinidi-tdk-common/src/tasks/authentication.rs
+++ b/crates/tdk/affinidi-tdk-common/src/tasks/authentication.rs
@@ -546,6 +546,33 @@ impl AuthenticationCacheInner {
         let service_copy = service_endpoint_did.clone();
 
         let handle = tokio::spawn(async move {
+            // A forced refresh has to say so. `authenticate` re-derives the
+            // decision from the token's expiry and refreshes only inside the
+            // last five seconds of its life — which is never true of a
+            // *proactive* refresh, whose whole point is to run while the token
+            // is still good. Asking through `authenticate` therefore returned
+            // the same token, and the caller acted on a refresh that had not
+            // happened; a transport that rebuilds its connection to carry the
+            // new token then rebuilt it onto the old one, over and over, until
+            // the token actually expired.
+            //
+            // A failure here is not fatal: fall through to the full handshake
+            // below, which is what an expired refresh token needs anyway.
+            if force_refresh
+                && auth
+                    .refresh_tokens(
+                        &profile_copy,
+                        &service_copy,
+                        &did_resolver,
+                        &secrets_resolver,
+                        &client,
+                    )
+                    .await
+                    .is_ok()
+            {
+                return Ok(auth);
+            }
+
             match auth
                 .authenticate(
                     &profile_copy,


### PR DESCRIPTION
## Problem

A forced refresh of a still-valid access token did nothing and handed back the old token.

`DIDAuthentication::_refresh_authentication` derived the decision from `refresh_check`, which only reports `Refresh` inside the last five seconds of the token's life. So the one caller who most needs a refresh — the one refreshing *early, on purpose* — was told the token was fine. The intent was accepted at the task boundary in `affinidi-tdk-common` (`Refresh needed` was even logged) and then discarded, because there was no way to express it beyond that point.

## Why it matters: a reconnect storm

`affinidi-messaging-sdk`'s websocket transport arms a proactive refresh at 80% of the token's life (`refresh_after_secs = ttl * 4 / 5`) and rebuilds the socket so it carries the new token. Because the refresh was a no-op, each rebuild re-armed the deadline at 80% of the time *remaining* — a geometric cascade rather than one clean cycle.

Captured against a live mediator, 900 s token, per profile:

```
13:52:34  T-180s   Access token nearing expiry; refreshing and reconnecting
                   → checking auth expiry: delta(180), expired?(false)
                   → "Refresh needed" … and no refresh happens
13:54:58  T-36s    same
13:55:27  T-7s     same
13:55:32  expired  → "Refreshing tokens" → POST /authenticate/refresh → 200 OK
```

**Four socket teardowns per token per profile instead of one.** The last two land ~5 s apart, close enough to trip consumers' duplicate-connection heuristics — one downstream TUI was reporting listeners "cycling rapidly" and users were restarting the app over it. In between, each rebuild carries a token that is about to die.

## Fix

`DIDAuthentication::refresh_tokens` is the way to ask for a proactive refresh. The authentication task uses it when it was given `force_refresh`, falling back to the full handshake if it fails — which is what an expired refresh token needs anyway.

It is **purely additive**. `authenticate` is untouched, so an ordinary call on a healthy token still short-circuits instead of refreshing every time (which would trade a reconnect storm for a request storm). Force promotes only "still valid": an expired *refresh* token still falls through to a full handshake, because there is nothing left to refresh with.

Deliberately **not** a new public field on `DIDAuthentication`: that struct has public fields, so adding one is breaking, and `affinidi-tdk-common` exposes its types through its own public API — the bump would have cascaded a semver wave through four more crates for a bug fix. A new method costs a patch bump either side (`0.3.11`, `0.6.8`).

The decision is extracted as `refresh_decision(check, force_refresh)` so it is testable without a network or a clock.

`affinidi-tdk-common` pins `affinidi-did-authentication = "0.3.11"`: the caret `"0.3"` would resolve the published 0.3.10, which has no `refresh_tokens`. Naming the local version is also what lets `check-publish-dry-run.sh` report `wait` for a sibling that is not on crates.io yet, rather than a registry-drift failure — it reports exactly that locally.

## Semver / coordination

**Reconnect-semantics change (R3.6).** Consumers that count, log or alert on reconnect frequency will see roughly a quarter as many. Called out in the workspace CHANGELOG as well as both crate CHANGELOGs. No API breakage.

## Tests

`refresh_decision` covered four ways — a forced refresh of a valid token refreshes; an unforced valid token is left alone; force does not override an expired refresh token; a due refresh is unaffected either way.

`cargo test` passes for `affinidi-did-authentication`, `affinidi-tdk-common` and `affinidi-messaging-sdk`; `cargo fmt` and `cargo clippy --all-targets` clean. `check-version-bumps.sh`, `check-changelogs.sh` and `check-publish-dry-run.sh` all pass locally.

## Second commit: an unrelated audit ignore

RUSTSEC-2026-0258 (h2) landed after this branch was cut and fails audit on `main` too. `Cargo.lock` is not tracked here, so CI resolves 0.4.16 for the 0.4 line by itself; what remains is h2 **0.3.27**, which has no patched release and arrives through reqwest 0.11 ← ssi-dids-core ← did-ethr / did-pkh. Ignored with a condition for removing it again, matching how the rustls-webpki ids in that list were handled. Happy to split it out.

## Not covered

No test drives the transport's proactive-refresh path end to end against a mediator, so the cascade itself is still only observable in a live log. The unit tests pin the decision that caused it, not the loop that amplified it.
