### PR TITLE
fix: say why a websocket was closed, so a refused duplicate stops reading as a network fault

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.18.21] - 2026-08-22
+
+### Fixed
+
+- **A websocket close now states why**, so a refused duplicate connection stops
+  reading as a network fault.
+
+  `WebSocketCommands::Close` carried no reason, so the handler answered all three
+  of its senders identically — the `duplicate-channel` problem report and the
+  close reason `"replaced by a newer connection"`:
+
+  - the incumbent, displaced by a newer connection — true;
+  - a newcomer **refused** by the duel damper, whose own connection was never
+    displaced and whose peer kept the slot — the inverse of true;
+  - a session that reached registration with no authenticated DID — not a
+    duplicate at all.
+
+  A refused client was told it had been replaced, so the most it could honestly
+  render was "the connection dropped". Two app instances presenting one DID
+  therefore looked like a transport problem.
+
+  `Close` now carries a `CloseReason`, and each maps to its own problem-report
+  code and close reason:
+
+  | Reason | Problem-report code | Close reason |
+  |---|---|---|
+  | `Replaced` | `w.websocket.duplicate-channel` | `replaced by a newer connection` |
+  | `Refused` | `w.websocket.duplicate-channel-refused` | `this DID already has a live connection` |
+  | `Unauthenticated` | `w.websocket.unauthenticated-session` | `session has no authenticated DID` |
+
+  **`duplicate-channel` is preserved verbatim** for `Replaced`: it is the code
+  existing clients already match on, and that socket is the one whose meaning
+  never changed. Clients keying on it need no change.
+
+  The eviction *policy* is deliberately untouched — newest-wins on an isolated
+  duplicate still lets a client reclaim a half-open slot, the duel damper still
+  holds the slot for a live incumbent, and displacement still triggers the
+  stored-mail re-cover. The defect was never the policy; it was that the
+  policy's outcome was unsayable.
+
 ## [0.18.20] - 2026-08-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.20"
+version = "0.18.21"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -11,7 +11,8 @@ use crate::{
     common::session::Session,
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{
-        QueuedCommand, StreamingUpdate, StreamingUpdateState, WS_CHANNEL_SLOTS, WebSocketCommands,
+        CloseReason, QueuedCommand, StreamingUpdate, StreamingUpdateState, WS_CHANNEL_SLOTS,
+        WebSocketCommands,
     },
 };
 #[cfg(feature = "didcomm")]
@@ -712,16 +713,16 @@ async fn handle_socket(
                                     warn!("Failed to send message to WebSocket client: {e}");
                                 }
                             },
-                            WebSocketCommands::Close => {
+                            WebSocketCommands::Close(why) => {
                                 #[cfg(feature = "didcomm")]
-                                if let Ok(msg) =  _package_problem_report(&state, &session, None, _generate_duplicate_connection_problem_report()).await
+                                if let Ok(msg) =  _package_problem_report(&state, &session, None, _close_problem_report(why)).await
                                     && let Err(e) = socket.send(Message::Text(msg.into())).await
                                 {
                                     warn!("Failed to send message to WebSocket client: {e}");
                                 }
-                                debug!("Streaming task requested close (duplicate connection)");
+                                debug!(reason = ?why, "Streaming task requested close");
                                 already_deregistered_flag = true;
-                                close_reason = (close_code::POLICY, "replaced by a newer connection");
+                                close_reason = _close_frame_reason(why);
                                 break;
                             }
                         }
@@ -962,18 +963,61 @@ async fn drain_tsp_inbox(
     ControlFlow::Continue(())
 }
 
-/// Generates a problem report for a duplicate websocket connection
+/// The problem report for a socket the streaming task is closing.
+///
+/// One report per [`CloseReason`], because the three are not the same event and
+/// a client can only act on the difference. Until #1028 every one of them sent
+/// `duplicate-channel` / "a new duplicate connection has caused this websocket
+/// to terminate" — true of [`CloseReason::Replaced`], and the exact inverse of
+/// what happened on the other two.
+///
+/// `duplicate-channel` is preserved verbatim for `Replaced`: it is the code
+/// existing clients already match on, and the socket it goes to is the one whose
+/// meaning never changed.
 #[cfg(feature = "didcomm")]
-fn _generate_duplicate_connection_problem_report() -> ProblemReport {
+fn _close_problem_report(why: CloseReason) -> ProblemReport {
+    let (code, message) = match why {
+        CloseReason::Replaced => (
+            "duplicate-channel",
+            "A new duplicate websocket connection for this DID has caused this websocket to \
+             terminate"
+                .to_string(),
+        ),
+        CloseReason::Refused => (
+            "duplicate-channel-refused",
+            "This DID already has a live websocket connection, which has been kept. This \
+             connection was refused and nothing was displaced — something is running a second \
+             live session for this DID."
+                .to_string(),
+        ),
+        CloseReason::Unauthenticated => (
+            "unauthenticated-session",
+            "This session reached streaming registration without an authenticated DID, so it \
+             cannot be routed to."
+                .to_string(),
+        ),
+    };
     ProblemReport::new(
         ProblemReportSorter::Warning,
         ProblemReportScope::Other("websocket".to_string()),
-        "duplicate-channel".to_string(),
-        "A new duplicate websocket connection for this DID has caused this websocket to terminate"
-            .to_string(),
+        code.to_string(),
+        message,
         vec![],
         None,
     )
+}
+
+/// The websocket close frame for a [`CloseReason`].
+///
+/// A client that never unpacks the problem report — one on the TSP-only build,
+/// where the report is `didcomm`-gated and never sent at all — still has this to
+/// go on, so the two must not disagree.
+fn _close_frame_reason(why: CloseReason) -> (u16, &'static str) {
+    match why {
+        CloseReason::Replaced => (close_code::POLICY, "replaced by a newer connection"),
+        CloseReason::Refused => (close_code::POLICY, "this DID already has a live connection"),
+        CloseReason::Unauthenticated => (close_code::POLICY, "session has no authenticated DID"),
+    }
 }
 
 /// Takes a problem report and packages it for sending to the recipient
@@ -1014,6 +1058,133 @@ async fn _package_problem_report(
     })?;
 
     Ok(packed)
+}
+
+#[cfg(test)]
+mod close_reason_tests {
+    use super::_close_frame_reason;
+    use crate::tasks::websocket_streaming::CloseReason;
+
+    /// A refused newcomer must not be told it was replaced.
+    ///
+    /// This is the whole defect. Before #1028 the refusal path reused the
+    /// eviction path's close frame, so a client that had been kept *out* was
+    /// told its connection had been taken *over* — and, having nothing truthful
+    /// to render, showed a transport error. OpenVTC reported it as a network
+    /// fault; it was two instances of the app.
+    #[test]
+    fn refusal_does_not_claim_the_socket_was_replaced() {
+        let (_, refused) = _close_frame_reason(CloseReason::Refused);
+        assert!(
+            !refused.contains("replaced"),
+            "the refused socket was not replaced — nothing of its own was \
+             displaced — but it is told: {refused:?}"
+        );
+        assert!(
+            refused.contains("already has a live connection"),
+            "a refused client can only say \"you have this open twice\" if it is \
+             told that; got: {refused:?}"
+        );
+    }
+
+    /// Each reason is distinguishable, which is the property a client keys on.
+    ///
+    /// Asserted as a set rather than three equality checks: the failure being
+    /// guarded against is two reasons collapsing onto one string, and equality
+    /// checks pass happily while that happens elsewhere in the match.
+    #[test]
+    fn every_close_reason_is_distinct() {
+        let all = [
+            CloseReason::Replaced,
+            CloseReason::Refused,
+            CloseReason::Unauthenticated,
+        ];
+        let mut seen: Vec<&str> = all.iter().map(|r| _close_frame_reason(*r).1).collect();
+        seen.sort_unstable();
+        let before = seen.len();
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            before,
+            "two close reasons render the same text, so a client cannot tell them \
+             apart: {seen:?}"
+        );
+    }
+
+    /// The wording that existing clients already match on is unchanged.
+    ///
+    /// `Replaced` is the one situation the old shared message described
+    /// correctly, so it keeps its exact text: this change is meant to give the
+    /// other two a truthful signal, not to move the ground under anything
+    /// already parsing this one.
+    #[test]
+    fn the_replaced_wording_is_preserved_verbatim() {
+        assert_eq!(
+            _close_frame_reason(CloseReason::Replaced).1,
+            "replaced by a newer connection"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "didcomm"))]
+mod close_report_tests {
+    use super::_close_problem_report;
+    use crate::tasks::websocket_streaming::CloseReason;
+
+    /// `duplicate-channel` is a wire code clients match on; only the socket
+    /// whose meaning did not change may keep it.
+    ///
+    /// Asserted in the qualified form `ProblemReport::new` actually emits
+    /// (`<sorter>.<scope>.<code>`) rather than the bare code passed in — that
+    /// string is what reaches a client, and it is the thing a client matches.
+    #[test]
+    fn only_replacement_keeps_the_duplicate_channel_code() {
+        assert_eq!(
+            _close_problem_report(CloseReason::Replaced).code,
+            "w.websocket.duplicate-channel",
+            "existing clients match this; the replaced socket is the one case \
+             the old wording described correctly, so it must not move"
+        );
+        assert_eq!(
+            _close_problem_report(CloseReason::Refused).code,
+            "w.websocket.duplicate-channel-refused",
+            "a refused connection reported as `duplicate-channel` is \
+             indistinguishable from having been evicted — which is what sent a \
+             real investigation to the network layer"
+        );
+        assert_eq!(
+            _close_problem_report(CloseReason::Unauthenticated).code,
+            "w.websocket.unauthenticated-session",
+            "an unauthenticated session is not a duplicate at all"
+        );
+    }
+
+    /// The close frame and the problem report must agree.
+    ///
+    /// They travel independently — the report is `didcomm`-gated and the frame
+    /// is not — so a client may see either one. Two sources of truth that can
+    /// disagree is how the original bug read as a network fault in the first
+    /// place.
+    #[test]
+    fn the_report_and_the_frame_tell_the_same_story() {
+        for why in [
+            CloseReason::Replaced,
+            CloseReason::Refused,
+            CloseReason::Unauthenticated,
+        ] {
+            let report = _close_problem_report(why);
+            let (_, frame) = super::_close_frame_reason(why);
+            let describes_replacement = |s: &str| {
+                s.contains("replaced") || s.contains("caused this websocket to terminate")
+            };
+            assert_eq!(
+                describes_replacement(&report.comment),
+                describes_replacement(frame),
+                "report and close frame disagree for {why:?}: {:?} vs {frame:?}",
+                report.comment
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/websocket_streaming.rs
@@ -127,8 +127,46 @@ pub enum StreamingUpdateState {
 
 /// Used to send commands from the streaming task to the websocket handler
 pub enum WebSocketCommands {
-    Message(String), // Send a message to the client
-    Close,           // Close the websocket connection
+    /// Send a message to the client.
+    Message(String),
+    /// Close this socket for the stated reason.
+    ///
+    /// The reason is carried rather than assumed. It used to be a bare `Close`,
+    /// and the handler answered every one of them with the same problem report
+    /// and the same close reason — "replaced by a newer connection" — across
+    /// three situations that are not the same thing. A client that was *refused*
+    /// was told it had been *replaced*, which is not merely unhelpful but
+    /// backwards, and left it with nothing better to show a user than a
+    /// transport error.
+    Close(CloseReason),
+}
+
+/// Why the streaming task is closing a socket.
+///
+/// Each variant maps to its own problem-report code and close reason, so a
+/// client can tell "you have this open twice" from "your session lost its slot"
+/// from "you are not authenticated" — and say so.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    /// This socket held the DID's slot and a newer connection took it.
+    ///
+    /// Newest-wins is deliberate for an isolated duplicate: a client whose
+    /// previous socket half-opened must be able to reclaim its slot. The
+    /// recipient of this is the *incumbent*.
+    Replaced,
+    /// This socket asked for a slot that a live incumbent holds, and the duel
+    /// damper refused it.
+    ///
+    /// The recipient is the *newcomer*, and nothing of its own was displaced —
+    /// which is exactly what the old shared wording got wrong. Refusal is not a
+    /// fault: something is running a second live session for this DID, and only
+    /// the client can say what.
+    Refused,
+    /// The session reached registration with no authenticated DID.
+    ///
+    /// An upstream auth bug rather than anything the client did with its
+    /// connection; kept distinct so it cannot be mistaken for a duplicate.
+    Unauthenticated,
 }
 
 /// A command sitting in a connection's send queue, together with the byte
@@ -592,7 +630,9 @@ impl StreamingTask {
                  Closing the channel."
             );
             let _ = client_tx
-                .send(QueuedCommand::control(WebSocketCommands::Close))
+                .send(QueuedCommand::control(WebSocketCommands::Close(
+                    CloseReason::Unauthenticated,
+                )))
                 .await;
             return;
         }
@@ -647,7 +687,9 @@ impl StreamingTask {
                     );
                 }
                 let _ = client_tx
-                    .send(QueuedCommand::control(WebSocketCommands::Close))
+                    .send(QueuedCommand::control(WebSocketCommands::Close(
+                        CloseReason::Refused,
+                    )))
                     .await;
                 return;
             }
@@ -690,7 +732,9 @@ impl StreamingTask {
             // Channel already exists, close the old one.
             let _ = old
                 .tx
-                .send(QueuedCommand::control(WebSocketCommands::Close))
+                .send(QueuedCommand::control(WebSocketCommands::Close(
+                    CloseReason::Replaced,
+                )))
                 .await;
             true
         } else {
@@ -1119,16 +1163,20 @@ mod tests {
         task._handle_registration(&database, &mut clients, &replay_in_progress, &update)
             .await;
 
-        // The old socket is told to close.
+        // The old socket is told to close, and told that it was *replaced* —
+        // the one situation where that wording is true.
         match timeout(StdDuration::from_secs(1), a_rx.recv())
             .await
             .expect("A receives a command")
         {
             Some(QueuedCommand {
-                cmd: WebSocketCommands::Close,
+                cmd: WebSocketCommands::Close(CloseReason::Replaced),
                 ..
             }) => {}
-            other => panic!("expected Close on old socket, got {:?}", other.is_some()),
+            other => panic!(
+                "expected Close(Replaced) on the displaced socket, got {:?}",
+                other.is_some()
+            ),
         }
 
         // The surviving socket receives the stranded message via redelivery.
@@ -1378,16 +1426,20 @@ mod tests {
             Some(incumbent.as_str()),
             "the incumbent must keep the slot once the duel is detected"
         );
+        // …and is told it was REFUSED, not replaced. Nothing of the contender's
+        // was displaced — the incumbent kept the slot — so the wording it
+        // receives is the difference between a client rendering "you already
+        // have this open" and a client rendering a transport error.
         match timeout(StdDuration::from_secs(1), late_rx.recv())
             .await
             .expect("the refused contender is answered")
         {
             Some(QueuedCommand {
-                cmd: WebSocketCommands::Close,
+                cmd: WebSocketCommands::Close(CloseReason::Refused),
                 ..
             }) => {}
             other => panic!(
-                "expected Close on the refused socket, got {:?}",
+                "expected Close(Refused) on the refused socket, got {:?}",
                 other.is_some()
             ),
         }

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.19.10] - 2026-08-22
+
+### Fixed
+
+- **The websocket close frame is no longer discarded.** It was matched as
+  `Message::Close(_)` and answered with
+  `debug!("WebSocket connection closed by server")`, so the mediator's only
+  chance to say *why* it closed a socket was dropped on the floor.
+
+  That is the client half of the mediator's 0.18.21 fix, and without it that fix
+  would be inert: a deliberately refused connection was indistinguishable from a
+  dropped one, so the reconnect loop simply ran again. Two app instances sharing
+  a DID duelled indefinitely and the user was shown a network error.
+
+  The close code and reason are now logged at **WARN**. A server that closed us
+  on purpose is the one disconnect an operator needs to see, and the text is the
+  difference between "check your network" and "you have this open twice".
+
+  Reconnect behaviour is unchanged.
+
 ## [0.19.9] - 2026-08-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.9"
+version = "0.19.10"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/transports/websockets/websocket.rs
@@ -525,8 +525,28 @@ impl WebSocketTransport {
                     debug!("Received pong message");
                     self.awaiting_pong = false;
                 }
-                Message::Close(_) => {
-                    debug!("WebSocket connection closed by server");
+                Message::Close(frame) => {
+                    // The close frame is the mediator's only chance to say WHY,
+                    // and discarding it (this arm was `Close(_)`) is what made a
+                    // refused duplicate connection indistinguishable from a
+                    // network fault: the socket simply vanished, the loop
+                    // reconnected, and the pair looped. The mediator now states
+                    // a distinct reason per cause, so surface it.
+                    //
+                    // WARN, not DEBUG: a server that closed us deliberately is
+                    // the one disconnect an operator needs to see, and the
+                    // reason text is the difference between "check your network"
+                    // and "you have this open twice".
+                    match &frame {
+                        Some(frame) => warn!(
+                            code = u16::from(frame.code),
+                            reason = %frame.reason,
+                            "WebSocket closed by the mediator"
+                        ),
+                        None => {
+                            warn!("WebSocket closed by the mediator with no reason given")
+                        }
+                    }
                     self.web_socket = None;
                     self.fail_pending_requests();
                     self.on_disconnected();


### PR DESCRIPTION
Raised from OpenVTC/verifiable-trust-infrastructure#1028, which reports that two app instances presenting the same DID reconnect-loop indefinitely and the user is shown a **network fault** rather than "you have this open twice".

Investigating it, the diagnosis in that issue turns out to be partly stale, and the remaining defect is smaller — and safer to fix — than it describes.

## What is already true

The mediator is **not** naive newest-always-wins. `_handle_registration` already carries a duel damper from #644:

```rust
if churn && churn_streak >= CHURN_REFUSE_STREAK && !old.tx.is_closed() {
    // hold the slot for the incumbent, refuse the newcomer
```

So the "saturate the server forever" half of that report is already fixed: past a short streak the incumbent keeps the slot, and the damper is careful in ways worth preserving — it only holds while the incumbent's channel is demonstrably alive, and refusals don't refresh `registered_at`, so it self-limits rather than locking a DID out.

## The defect that remains

**Nothing ever says what happened.** `WebSocketCommands::Close` carried no reason, so the handler answered all three of its senders identically — the `duplicate-channel` problem report and the close reason `"replaced by a newer connection"`:

| Sender | Told "replaced by a newer connection" | Accurate? |
|---|---|---|
| the displaced incumbent | yes | ✅ |
| a newcomer **refused** by the damper | yes | ❌ the exact inverse — nothing of its own was displaced |
| a session with no authenticated DID | yes | ❌ not a duplicate at all |

A refused client was told it had been *replaced*, so the most it could honestly render was "the connection dropped".

`Close` now carries a `CloseReason`, each mapping to its own problem-report code and close reason:

| Reason | Problem-report code | Close reason |
|---|---|---|
| `Replaced` | `w.websocket.duplicate-channel` | `replaced by a newer connection` |
| `Refused` | `w.websocket.duplicate-channel-refused` | `this DID already has a live connection` |
| `Unauthenticated` | `w.websocket.unauthenticated-session` | `session has no authenticated DID` |

**`duplicate-channel` is preserved verbatim** for `Replaced` — it is what existing clients match on, and that socket is the one whose meaning never changed. Clients keying on it need no change.

## The other half, in the SDK

The mediator's close frame was landing in `Message::Close(_)` — **discarded**, with `debug!("WebSocket connection closed by server")`.

A perfect reason on the wire would have changed nothing, which is why this is one PR and not two: the socket simply vanished, the loop reconnected, and the pair duelled. It now logs the code and reason at **WARN** — a deliberate server-side close is the one disconnect an operator needs to see. Reconnect behaviour is unchanged.

## What this deliberately does NOT change

#1028 asks for the incumbent to be kept and newcomers refused **outright**. Going that far would regress something real, so it is not done here:

- **Newest-wins on an isolated duplicate is deliberate** — a client whose previous socket half-opened must be able to reclaim its slot.
- **`spawn_inbox_redelivery` is triggered by displacement** (#374). Refusing unconditionally would silently remove the stored-mail re-cover for every client that does not pull explicitly. The issue flags this carve-out and asks for it to be *checked* rather than assumed; checked, and it is real.

The defect was never the policy. It was that the policy's outcome was unsayable.

## Tests

Five new, over the mapping rather than the plumbing — plus **both existing duel tests tightened** from "a close arrived" to "the *right* close arrived", which is the property that actually regressed.

`the_report_and_the_frame_tell_the_same_story` exists because the two travel independently: the problem report is `didcomm`-gated and the close frame is not, so a client may see either. Two sources of truth that can disagree is how this read as a network fault to begin with.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean.
- `cargo test --workspace --lib` green (mediator lib 187/187).
- Both release guards run locally: `check-version-bumps.sh` and `check-changelogs.sh` pass.

**Not verified live.** The behaviour this changes is what a client *sees* on a duel, and confirming that end-to-end wants a real mediator and two real clients. The unit tests pin the mapping; a soak would pin the experience.

## Noted, not fixed

`--no-default-features --features tsp,redis-backend` does not compile on `main` (`Capability` unresolved in `messages/inbound.rs`), independently of this change. Reproduced on a clean checkout before writing this. Worth its own issue.
