### PR TITLE
feat(identity): resolve did:ethr, did:pkh and did:jwk in-tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ members = [
   "crates/identity/did-methods/did-scid",
   "crates/identity/did-methods/did-ebsi",
   "crates/identity/did-methods/did-web",
+  "crates/identity/did-methods/did-ethr",
+  "crates/identity/did-methods/did-jwk",
+  "crates/identity/did-methods/did-pkh",
   "crates/identity/affinidi-did-resolver-traits",
   "crates/identity/affinidi-did-authentication",
   "crates/identity/shortcuts/agent-names",
@@ -110,6 +113,9 @@ affinidi-tdk = { path = "crates/tdk/affinidi-tdk" }
 affinidi-meeting-place = { path = "crates/applications/affinidi-meeting-place" }
 affinidi-tsp = { path = "crates/messaging/affinidi-tsp" }
 affinidi-did-web = { path = "crates/identity/did-methods/did-web" }
+affinidi-did-ethr = { path = "crates/identity/did-methods/did-ethr" }
+affinidi-did-jwk = { path = "crates/identity/did-methods/did-jwk" }
+affinidi-did-pkh = { path = "crates/identity/did-methods/did-pkh" }
 did-scid = { path = "crates/identity/did-methods/did-scid" }
 did-example = { path = "crates/identity/did-methods/did-example" }
 affinidi-messaging-core = { path = "crates/messaging/affinidi-messaging-core" }

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,1 +1,17 @@
 This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the this notice when  they are further distributing this code.
+
+---
+
+## Third-party material reproduced in this repository
+
+`crates/identity/did-methods/did-pkh/tests/did-*.jsonld` — 19 DID Document
+fixtures reproduced verbatim from the `did-pkh` crate (v0.3.2) of the
+spruceid/ssi project, licensed Apache-2.0. They are used unmodified as
+conformance vectors for the in-tree `affinidi-did-pkh` resolver. See
+`crates/identity/did-methods/did-pkh/tests/ATTRIBUTION.md`.
+
+The `affinidi-did-ethr`, `affinidi-did-jwk` and `affinidi-did-pkh` crates are
+independent implementations, written against the published DID method
+specifications. They reproduce no upstream source code; the test vectors
+embedded in `affinidi-did-ethr` are derived from the same Apache-2.0 spruceid
+test suite and from the did:ethr method specification.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Affinidi DID Resolver Cache SDK
 
+## Unreleased (0.8.23) — did:ethr, did:pkh and did:jwk resolve in-tree
+
+- **`did:ethr`, `did:pkh` and `did:jwk` are now resolved by in-tree crates**
+  (`affinidi-did-ethr`, `affinidi-did-pkh`, `affinidi-did-jwk`) instead of the
+  spruceid `did-ethr` / `did-pkh` / `did-jwk` crates. Those reached the whole
+  `ssi-*` stack, which pulls `im`, `sized-chunks`, `bitmaps`, `smallstr`,
+  `proc-macro-error` and `derivative` — all unmaintained and archived upstream
+  with no fixed release — plus `reqwest 0.11` and the vulnerable `h2 0.3.x`.
+
+  With this change **none of those crates are compiled by anything in the
+  workspace**. `did-cheqd` still resolves them into `Cargo.lock` as an optional
+  dependency, but it is not enabled by any crate here.
+
+- **`did:ethr` and `did:pkh` documents are unchanged.** Every resolution vector
+  from the replaced crates' own test suites — 2 for `did:ethr`, all 19
+  `did-*.jsonld` fixtures for `did:pkh` — is asserted byte-for-byte.
+
+- **`did:jwk` documents changed shape.** The replaced crate emitted `Multikey` /
+  `publicKeyMultibase` and ignored the key's `use`; both diverge from the
+  specification, which mandates `JsonWebKey2020` / `publicKeyJwk` and honours
+  `use`. The in-tree crate follows the specification. No production caller is
+  affected — the `did-jwk` feature was not enabled by any crate in the
+  workspace — but this crate's own `local_resolve_jwk` test asserted the old
+  shape and has been updated.
+
+- **Malformed identifiers are now rejected rather than resolved.** Previously a
+  `did:ethr` or `did:pkh` `eip155` identifier only had to *look* right (correct
+  length, or a `0x` prefix) to produce a document naming an account that cannot
+  exist; Tezos addresses were checked only by their three-character prefix.
+  These are now validated — hex, base58check, and the CAIP-2/CAIP-10 grammar —
+  and a bad identifier resolves to an error.
+
+- `did:pkh` refuses an unknown chain namespace instead of resolving it
+  generically.
+
 ## 2nd August 2026 (0.8.22)
 
 **BREAKING (behaviour): `did:ethr` and `did:pkh` are now behind features and

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.22"
+version = "0.8.23"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -40,12 +40,12 @@ network = [
 # `ring` backend and install a CryptoProvider in your binary's `main`.
 did-methods = ["did-webvh", "did-scid"]
 did_example = ["dep:did-example"]
-did-jwk = ["dep:did-jwk", "dep:ssi-dids-core"]
-# Legacy blockchain DID methods. Ungated until now, which meant every
-# build pulled the whole ssi-* stack (and with it p256/k256 0.13).
-did-ethr = ["dep:did-ethr", "dep:ssi-dids-core"]
-did-pkh = ["dep:did-pkh", "dep:ssi-dids-core"]
-did-cheqd = ["dep:did-resolver-cheqd"]
+did-jwk = ["dep:affinidi-did-jwk"]
+# Legacy blockchain DID methods, resolved by in-tree crates. These were the
+# last consumers of the ssi-* stack outside `did-cheqd`.
+did-ethr = ["dep:affinidi-did-ethr"]
+did-pkh = ["dep:affinidi-did-pkh"]
+did-cheqd = ["dep:did-resolver-cheqd", "dep:ssi-dids-core"]
 did-webvh = ["dep:didwebvh-rs"]
 # Agent names: human-memorable "/@" shortcuts resolvable via `resolve_any()`.
 agent-names = ["dep:agent-names"]
@@ -89,11 +89,25 @@ serde_json = "1"
 serde-wasm-bindgen = "0.6"
 sha1 = { version = "0.10", optional = true }
 affinidi-did-web = { version = "0.1", path = "../did-methods/did-web" }
-did-ethr = { version = "0.3", optional = true }
-did-jwk = { version = "0.2", optional = true }
-did-pkh = { version = "0.3", optional = true }
-ssi-dids-core = { version = "0.1", optional = true }
+affinidi-did-ethr = { version = "0.1", optional = true, path = "../did-methods/did-ethr" }
+affinidi-did-jwk = { version = "0.1", optional = true, path = "../did-methods/did-jwk" }
+affinidi-did-pkh = { version = "0.1", optional = true, path = "../did-methods/did-pkh" }
 did-resolver-cheqd = { version = "1", optional = true }
+# `did-cheqd` is the ONLY remaining consumer of the ssi stack — did:ethr,
+# did:pkh and did:jwk moved to in-tree crates that do not depend on it. Because
+# `did-resolver-cheqd 1.0.1` pins `ssi-dids-core ^0.1`, this optional dep is
+# what still resolves `reqwest 0.11` (and with it the vulnerable `h2 0.3.x`),
+# `rustls-pemfile 1.0.4`, `im`, `sized-chunks`, `bitmaps`, `smallstr` and
+# `proc-macro-error` into Cargo.lock — even though none of them compile,
+# because `did-cheqd` is not enabled by any crate in this workspace.
+#
+# A patched fork of `did-resolver-cheqd` is in progress. Note that moving it to
+# `ssi-dids-core 0.3` clears `h2` and `rustls-pemfile 1.0.4` (that line uses
+# reqwest 0.13) but NOT the archived `im`/`sized-chunks`/`bitmaps`/`smallstr`/
+# `proc-macro-error` cluster: ssi 0.3 still reaches `json-ld 0.21` and
+# `linked-data 0.1.2`, which are themselves unmaintained. Clearing those needs
+# the fork to drop `ssi-dids-core` outright, as the in-tree method crates did.
+ssi-dids-core = { version = "0.1", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 tokio-rustls = { version = "0.26", optional = true }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -47,6 +47,13 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | `did-scid` | — | Self-Certifying Identifier DID method |
 | `did_example` | — | Example DID method for testing |
 
+### `did:ethr`, `did:pkh` and `did:jwk` are resolved in-tree
+
+These three methods are implemented by `affinidi-did-ethr`, `affinidi-did-pkh`
+and `affinidi-did-jwk` in this workspace, not by the spruceid crates of the
+same names. Enabling them costs three small dependencies rather than the whole
+`ssi-*` stack. See each crate's README for scope and conformance.
+
 ### `did-cheqd` and the rustls `ring` backend
 
 `did-cheqd` is **not** enabled by default. It pulls `did-resolver-cheqd`, whose

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/mod.rs
@@ -106,13 +106,20 @@ mod tests {
         assert_eq!(did_document.capability_delegation.len(), 1);
 
         assert_eq!(did_document.verification_method.len(), 1);
+        // The in-tree `did:jwk` resolver follows the method specification:
+        // `JsonWebKey2020` carrying the key verbatim as `publicKeyJwk`. The
+        // spruceid crate this replaced emitted `Multikey` /
+        // `publicKeyMultibase`, which the specification does not define.
+        let vm = did_document.verification_method.first().unwrap();
+        assert_eq!(vm.type_, "JsonWebKey2020");
         assert_eq!(
-            did_document
-                .verification_method
-                .first()
-                .unwrap()
-                .property_set["publicKeyMultibase"],
-            "zDnaepnC2eBkx4oZkNLGDnVK8ofKzoGk1Yui8fzC6FLoV1F1e"
+            vm.property_set["publicKeyJwk"],
+            serde_json::json!({
+                "crv": "P-256",
+                "kty": "EC",
+                "x": "acbIQiuMs3i8_uszEjJ2tpTtRM4EU3yz91PH6CdH2V0",
+                "y": "_KcyLj9vWMptnmKtm46GqDz8wf74I5LKgrl2GzH3nSE"
+            })
         );
     }
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
@@ -8,13 +8,8 @@ use std::future::Future;
 use std::pin::Pin;
 
 use affinidi_did_common::{DID, DIDMethod};
-// `Document` is only named by the ssi-backed helpers below, which are gated.
-#[cfg(any(
-    feature = "did-ethr",
-    feature = "did-pkh",
-    feature = "did-jwk",
-    feature = "did-cheqd"
-))]
+// `Document` is only named by the ssi-backed helper below, which is gated.
+#[cfg(feature = "did-cheqd")]
 use affinidi_did_common::Document;
 use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
 use tracing::error;
@@ -23,27 +18,8 @@ use tracing::error;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Convert an ssi `DIDMethodResolver` result (raw bytes) into a `Document`.
-#[cfg(any(
-    feature = "did-ethr",
-    feature = "did-pkh",
-    feature = "did-jwk",
-    feature = "did-cheqd"
-))]
-fn document_from_bytes(bytes: Vec<u8>) -> Result<Document, ResolverError> {
-    let json = String::from_utf8(bytes)
-        .map_err(|e| ResolverError::InvalidDocument(format!("Invalid UTF-8: {e}")))?;
-    serde_json::from_str(&json)
-        .map_err(|e| ResolverError::InvalidDocument(format!("Invalid JSON document: {e}")))
-}
-
 /// Convert an ssi `DIDResolver` result (typed output) into a `Document`.
-#[cfg(any(
-    feature = "did-ethr",
-    feature = "did-pkh",
-    feature = "did-jwk",
-    feature = "did-cheqd"
-))]
+#[cfg(feature = "did-cheqd")]
 fn document_from_ssi_output(output: impl serde::Serialize) -> Result<Document, ResolverError> {
     let value = serde_json::to_value(output)
         .map_err(|e| ResolverError::InvalidDocument(format!("Serialization failed: {e}")))?;
@@ -56,6 +32,9 @@ fn document_from_ssi_output(output: impl serde::Serialize) -> Result<Document, R
 // ---------------------------------------------------------------------------
 
 /// Resolver for `did:ethr` — Ethereum DID method.
+///
+/// Resolution is an offline derivation from the identifier: this does not
+/// replay ERC-1056 registry events, so the document is the DID's genesis state.
 #[cfg(feature = "did-ethr")]
 pub struct EthrResolver;
 
@@ -75,23 +54,11 @@ impl AsyncResolver for EthrResolver {
                 _ => return None,
             };
 
-            let method = did_ethr::DIDEthr;
-            use ssi_dids_core::DIDMethodResolver;
-
             Some(
-                match method
-                    .resolve_method_representation(
-                        &identifier,
-                        ssi_dids_core::resolution::Options::default(),
-                    )
-                    .await
-                {
-                    Ok(res) => document_from_bytes(res.document),
-                    Err(e) => {
-                        error!("did:ethr resolution error: {e:?}");
-                        Err(ResolverError::ResolutionFailed(e.to_string()))
-                    }
-                },
+                affinidi_did_ethr::resolve_identifier(&identifier).map_err(|e| {
+                    error!("did:ethr resolution error: {e:?}");
+                    ResolverError::ResolutionFailed(e.to_string())
+                }),
             )
         })
     }
@@ -116,29 +83,17 @@ impl AsyncResolver for PkhResolver {
         did: &'a DID,
     ) -> Pin<Box<dyn Future<Output = Resolution> + Send + 'a>> {
         Box::pin(async move {
-            if !matches!(did.method(), DIDMethod::Pkh { .. }) {
-                return None;
-            }
-
-            let method = did_pkh::DIDPKH;
-            let did_str = did.to_string();
-            use ssi_dids_core::DIDResolver;
-            let ssi_did = match ssi_dids_core::DID::new(&did_str) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Some(Err(ResolverError::InvalidDocument(format!(
-                        "Invalid DID: {e}"
-                    ))));
-                }
+            let identifier = match did.method() {
+                DIDMethod::Pkh { identifier, .. } => identifier,
+                _ => return None,
             };
 
-            Some(match method.resolve(ssi_did).await {
-                Ok(res) => document_from_ssi_output(res.document.into_document()),
-                Err(e) => {
+            Some(
+                affinidi_did_pkh::resolve_identifier(&identifier).map_err(|e| {
                     error!("did:pkh resolution error: {e:?}");
-                    Err(ResolverError::ResolutionFailed(e.to_string()))
-                }
-            })
+                    ResolverError::ResolutionFailed(e.to_string())
+                }),
+            )
         })
     }
 }
@@ -217,27 +172,16 @@ impl AsyncResolver for JwkResolver {
         did: &'a DID,
     ) -> Pin<Box<dyn Future<Output = Resolution> + Send + 'a>> {
         Box::pin(async move {
-            if !matches!(did.method(), DIDMethod::Jwk { .. }) {
-                return None;
-            }
-
-            let method = did_jwk::DIDJWK;
-            use ssi_dids_core::DIDMethodResolver;
+            let identifier = match did.method() {
+                DIDMethod::Jwk { identifier, .. } => identifier,
+                _ => return None,
+            };
 
             Some(
-                match method
-                    .resolve_method_representation(
-                        &did.method_specific_id(),
-                        ssi_dids_core::resolution::Options::default(),
-                    )
-                    .await
-                {
-                    Ok(res) => document_from_bytes(res.document),
-                    Err(e) => {
-                        error!("did:jwk resolution error: {e:?}");
-                        Err(ResolverError::ResolutionFailed(e.to_string()))
-                    }
-                },
+                affinidi_did_jwk::resolve_identifier(&identifier).map_err(|e| {
+                    error!("did:jwk resolution error: {e:?}");
+                    ResolverError::ResolutionFailed(e.to_string())
+                }),
             )
         })
     }

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi DID Resolver Cache Server
 
+## Unreleased (0.9.11) — `did:jwk` is actually served
+
+- **Enables the SDK's `did-jwk` feature.** The README has listed `did:jwk`
+  among the methods this server resolves, and the dependency comment claimed
+  full method coverage, but SDK 0.8.22 moved the method behind a feature and
+  only `did-ethr` and `did-pkh` were opted back in — so `did:jwk` has not been
+  compiled into the server since. It now is.
+
+- Picks up SDK 0.8.23, in which `did:ethr`, `did:pkh` and `did:jwk` resolve via
+  in-tree crates rather than the `ssi-*` stack. `did:ethr` and `did:pkh`
+  documents are byte-for-byte unchanged; `did:jwk` now follows the method
+  specification (`JsonWebKey2020` / `publicKeyJwk`) instead of the `Multikey` /
+  `publicKeyMultibase` shape the replaced crate emitted. Malformed `did:ethr`
+  and `did:pkh` identifiers are now rejected rather than resolved into a
+  document naming an account that cannot exist.
+
 ## 2nd August 2026 (0.9.10)
 
 Opts back in to `did:ethr` and `did:pkh`, which became optional in

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.10"
+version = "0.9.11"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -23,11 +23,12 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 [dependencies]
 # Affinidi Crates
 # Requires 0.8.19 for WSRequest::agent_name / WSResponse::with_agent_name.
-# `did-ethr` / `did-pkh` are opt-in in the SDK as of 0.8.22 — they pull the
-# `ssi-*` stack, which most embedding libraries do not want. This is a
-# general-purpose resolver *service* though, so it keeps full method
-# coverage and accepts that cost.
-affinidi-did-resolver-cache-sdk = { version = "0.8.22", default-features = true, features = ["did-ethr", "did-pkh"], path = "../affinidi-did-resolver-cache-sdk/" }
+# `did-ethr` / `did-pkh` / `did-jwk` are opt-in in the SDK: most embedding
+# libraries do not want them. This is a general-purpose resolver *service*, so
+# it keeps full method coverage. `did-jwk` was advertised in the README but not
+# actually enabled here between 0.8.22 and now — the SDK gating in #674 moved
+# it behind a feature and only `did-ethr` / `did-pkh` were opted back in.
+affinidi-did-resolver-cache-sdk = { version = "0.8.23", default-features = true, features = ["did-ethr", "did-pkh", "did-jwk"], path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"

--- a/crates/identity/did-methods/did-ethr/CHANGELOG.md
+++ b/crates/identity/did-methods/did-ethr/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+In-tree replacement for the spruceid `did-ethr` crate, written to drop the
+`ssi-*` dependency stack (`im`, `sized-chunks`, `bitmaps`, `smallstr`,
+`proc-macro-error`, `derivative` — all unmaintained and archived with no fixed
+release — plus `reqwest 0.11` and the vulnerable `h2 0.3.x`).
+
+See `README.md` for scope, conformance and behavioural differences.

--- a/crates/identity/did-methods/did-ethr/Cargo.toml
+++ b/crates/identity/did-methods/did-ethr/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "affinidi-did-ethr"
+version = "0.1.0"
+description = "Minimal did:ethr DID method resolver for the Affinidi TDK"
+repository.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+affinidi-did-common = "0.4"
+base64 = "0.22"
+hex = "0.4"
+k256 = { version = "0.14", default-features = false, features = ["arithmetic"] }
+serde_json = "1"
+sha3 = "0.11"
+thiserror = "2"
+tracing = "0.1"
+
+[lints]
+workspace = true

--- a/crates/identity/did-methods/did-ethr/README.md
+++ b/crates/identity/did-methods/did-ethr/README.md
@@ -1,0 +1,58 @@
+# affinidi-did-ethr
+
+Minimal `did:ethr` DID method resolver for the Affinidi TDK.
+
+Resolves `did:ethr:[{network}:]{address-or-public-key}` into a DID Document,
+with no network access and no dependencies beyond `affinidi-did-common`,
+`k256` and `sha3`.
+
+## Scope: genesis documents only
+
+Resolution is a pure derivation from the identifier — what the DID resolves to
+before any on-chain change. This crate does **not** replay ERC-1056
+`DIDRegistry` events, so delegates, attributes and owner changes recorded
+on-chain are not reflected.
+
+This matches the behaviour of the `did-ethr` crate it replaced. It is a
+deliberate limit: **a `did:ethr` document from this crate is not proof of
+current on-chain control**, because a controller may have rotated keys in the
+registry since the DID was minted.
+
+## Identifier forms
+
+| Form | Length | Verification methods |
+| --- | --- | --- |
+| Account address | `0x` + 40 hex | `#controller` (`EcdsaSecp256k1RecoveryMethod2020`), `#Eip712Method2021` |
+| Compressed public key | `0x` + 66 hex | `#controller` (`EcdsaSecp256k1RecoveryMethod2020`), `#controllerKey` (`EcdsaSecp256k1VerificationKey2019`) |
+
+The address form carries the address through exactly as written in the DID.
+The public-key form *derives* the address, and emits it EIP-55 checksummed.
+
+Named networks (`mainnet`, `morden`, `ropsten`, `rinkeby`, `goerli`, `kovan`)
+map to their chain ids; anything else must be an explicit `0x`-prefixed hex
+chain id.
+
+## Stricter than the crate it replaced
+
+The upstream implementation switched on identifier *length* alone and copied
+the result into `blockchainAccountId` unchecked, so `did:ethr:0xZZ…` (42
+characters, not hex) resolved to a document naming an impossible account. This
+crate validates the hex and rejects it.
+
+## Conformance
+
+Both resolution vectors from the `did-ethr` 0.3.2 test suite — the method
+specification's "Create (Register)" example and the `tests/did-pk.jsonld`
+fixture — are asserted byte-for-byte in `src/lib.rs`.
+
+## Why this crate exists
+
+Upstream `did-ethr` reaches the rest of the `ssi-*` stack, which pulls `im`,
+`sized-chunks`, `bitmaps`, `smallstr` and `proc-macro-error` — all unmaintained
+and archived upstream with no fixed release (RUSTSEC-2026-0248 / -0251 / -0247 /
+-0215, RUSTSEC-2024-0370) — plus `reqwest 0.11` and with it the vulnerable
+`h2 0.3.x` (RUSTSEC-2026-0258).
+
+Almost all of that weight is JSON-LD `@context` machinery. Our `Document`
+carries `@context` as plain JSON, so re-implementing the derivation here drops
+the entire chain. Same reasoning as the sibling `affinidi-did-web` crate.

--- a/crates/identity/did-methods/did-ethr/src/lib.rs
+++ b/crates/identity/did-methods/did-ethr/src/lib.rs
@@ -1,0 +1,532 @@
+/*!
+ * did:ethr — Ethereum DID method resolver.
+ *
+ * Implements resolution of `did:ethr` identifiers per the
+ * [did:ethr method specification](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md).
+ *
+ * # DID Format
+ *
+ * ```text
+ * did:ethr:[{network}:]{address-or-public-key}
+ * ```
+ *
+ * - `network` is a named Ethereum network (`mainnet`, `ropsten`, …) or a
+ *   `0x`-prefixed hex chain id. It defaults to `mainnet` (chain id 1).
+ * - The identifier is either a 20-byte account address (`0x` + 40 hex) or a
+ *   33-byte compressed secp256k1 public key (`0x` + 66 hex).
+ *
+ * # Scope: genesis documents only
+ *
+ * Resolution here is a pure, offline derivation from the identifier — exactly
+ * what the DID resolves to before any on-chain change. This crate does **not**
+ * replay ERC-1056 `DIDRegistry` events, so delegates, attributes and owner
+ * changes recorded on-chain are not reflected. That matches the behaviour of
+ * the spruceid `did-ethr` crate this replaced; it is a deliberate limit, not an
+ * oversight. A DID whose registry state has been updated will resolve to its
+ * genesis document, which may name a key the controller has since rotated away
+ * from — do not treat a `did:ethr` document from this crate as proof of current
+ * on-chain control.
+ *
+ * # Why this crate exists
+ *
+ * The spruceid `did-ethr` crate reaches the rest of the `ssi-*` stack, which
+ * pulls `im`, `sized-chunks`, `bitmaps`, `smallstr` and `proc-macro-error` —
+ * all unmaintained and archived upstream (RUSTSEC-2026-0248 / -0251 / -0247 /
+ * -0215, RUSTSEC-2024-0370) with no fixed release — plus `reqwest 0.11` and
+ * with it the vulnerable `h2 0.3.x` (RUSTSEC-2026-0258). Almost all of that
+ * weight is JSON-LD `@context` machinery; our `Document` carries `@context` as
+ * plain JSON, so re-implementing the derivation here drops the entire chain.
+ * Same reasoning as the sibling `affinidi-did-web` crate.
+ *
+ * # Usage
+ *
+ * ```
+ * # fn main() -> Result<(), affinidi_did_ethr::DidEthrError> {
+ * let doc = affinidi_did_ethr::resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")?;
+ * assert_eq!(doc.verification_method.len(), 2);
+ * # Ok(()) }
+ * ```
+ */
+
+use affinidi_did_common::verification_method::VerificationMethod;
+use affinidi_did_common::{DocumentBuilder, VerificationMethodBuilder};
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use k256::{
+    AffinePoint,
+    elliptic_curve::sec1::{FromSec1Point, ToSec1Point},
+};
+use serde_json::{Value, json};
+use sha3::{Digest, Keccak256};
+use thiserror::Error;
+
+pub use affinidi_did_common::Document;
+
+/// `elliptic-curve` 0.14 made `EncodedPoint` a generic alias for `Sec1Point<C>`.
+type EncodedPoint = k256::elliptic_curve::sec1::Sec1Point<k256::Secp256k1>;
+
+/// did:ethr resolver errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DidEthrError {
+    /// The supplied string was not a `did:ethr` DID.
+    #[error("not a did:ethr DID: {0}")]
+    NotEthr(String),
+
+    /// The network segment named neither a known network nor a hex chain id.
+    #[error("invalid did:ethr network: {0}")]
+    InvalidNetwork(String),
+
+    /// The identifier was neither a 20-byte address nor a 33-byte compressed
+    /// secp256k1 public key.
+    #[error("invalid did:ethr method-specific id: {0}")]
+    InvalidIdentifier(String),
+
+    /// The public key parsed as hex but is not a point on secp256k1.
+    #[error("did:ethr public key is not a valid secp256k1 point: {0}")]
+    InvalidPublicKey(String),
+}
+
+/// IRI for `EcdsaSecp256k1RecoveryMethod2020`.
+const IRI_RECOVERY_2020: &str = "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020";
+/// IRI for `EcdsaSecp256k1VerificationKey2019`.
+const IRI_VERIFICATION_KEY_2019: &str =
+    "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019";
+/// IRI for `Eip712Method2021`.
+const IRI_EIP712_2021: &str = "https://w3id.org/security#Eip712Method2021";
+/// IRI for the `blockchainAccountId` property.
+const IRI_BLOCKCHAIN_ACCOUNT_ID: &str = "https://w3id.org/security#blockchainAccountId";
+/// IRI for the `publicKeyJwk` property.
+const IRI_PUBLIC_KEY_JWK: &str = "https://w3id.org/security#publicKeyJwk";
+
+/// Resolve a `did:ethr` DID into its genesis DID Document.
+///
+/// Returns [`DidEthrError::NotEthr`] when `did` does not start with `did:ethr:`.
+pub fn resolve(did: &str) -> Result<Document, DidEthrError> {
+    let identifier = did
+        .strip_prefix("did:ethr:")
+        .ok_or_else(|| DidEthrError::NotEthr(did.to_string()))?;
+    resolve_identifier(identifier)
+}
+
+/// Resolve the method-specific identifier of a `did:ethr` DID — everything
+/// after `did:ethr:` — into its genesis DID Document.
+pub fn resolve_identifier(identifier: &str) -> Result<Document, DidEthrError> {
+    // The network segment is optional; without it the DID is on mainnet.
+    let (chain_id, key_or_address) = match identifier.split_once(':') {
+        None => (1u64, identifier),
+        Some((network, rest)) => (chain_id_for(network)?, rest),
+    };
+
+    let did = format!("did:ethr:{identifier}");
+
+    // Length alone distinguishes the two forms: 20-byte address vs 33-byte
+    // compressed public key, both `0x`-prefixed hex.
+    match key_or_address.len() {
+        42 => document_for_address(&did, chain_id, key_or_address),
+        68 => document_for_public_key(&did, chain_id, key_or_address),
+        _ => Err(DidEthrError::InvalidIdentifier(identifier.to_string())),
+    }
+}
+
+/// Map a `did:ethr` network segment to its EIP-155 chain id.
+///
+/// The named networks are the set the method specification froze; anything else
+/// must be given as an explicit `0x`-prefixed hex chain id.
+fn chain_id_for(network: &str) -> Result<u64, DidEthrError> {
+    match network {
+        "mainnet" => Ok(1),
+        "morden" => Ok(2),
+        "ropsten" => Ok(3),
+        "rinkeby" => Ok(4),
+        "goerli" => Ok(5),
+        "kovan" => Ok(42),
+        hex_id if hex_id.starts_with("0x") => u64::from_str_radix(&hex_id[2..], 16)
+            .map_err(|_| DidEthrError::InvalidNetwork(network.to_string())),
+        _ => Err(DidEthrError::InvalidNetwork(network.to_string())),
+    }
+}
+
+/// Reject anything that is not `0x` followed by exactly `hex_digits` hex chars.
+///
+/// The upstream implementation switched on string *length* alone and copied the
+/// identifier into `blockchainAccountId` unchecked, so `did:ethr:0xZZ…` (42
+/// characters, not hex) resolved to a document naming an impossible account.
+/// We validate instead — a DID that cannot denote an account is not resolvable.
+fn require_hex(identifier: &str, hex_digits: usize) -> Result<Vec<u8>, DidEthrError> {
+    let body = identifier
+        .strip_prefix("0x")
+        .ok_or_else(|| DidEthrError::InvalidIdentifier(identifier.to_string()))?;
+    if body.len() != hex_digits {
+        return Err(DidEthrError::InvalidIdentifier(identifier.to_string()));
+    }
+    hex::decode(body).map_err(|_| DidEthrError::InvalidIdentifier(identifier.to_string()))
+}
+
+/// Genesis document for the account-address form.
+///
+/// The address is carried through exactly as written in the DID — re-checksumming
+/// it would change the DID's own `blockchainAccountId` and break signatures made
+/// against the document.
+fn document_for_address(did: &str, chain_id: u64, address: &str) -> Result<Document, DidEthrError> {
+    require_hex(address, 40)?;
+    let account = format!("eip155:{chain_id}:{address}");
+
+    let controller = verification_method(
+        &format!("{did}#controller"),
+        "EcdsaSecp256k1RecoveryMethod2020",
+        did,
+        "blockchainAccountId",
+        json!(account),
+    )?;
+    let eip712 = verification_method(
+        &format!("{did}#Eip712Method2021"),
+        "Eip712Method2021",
+        did,
+        "blockchainAccountId",
+        json!(account),
+    )?;
+
+    build(
+        did,
+        json!([
+            "https://www.w3.org/ns/did/v1",
+            {
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                "EcdsaSecp256k1RecoveryMethod2020": IRI_RECOVERY_2020,
+                "Eip712Method2021": IRI_EIP712_2021,
+            }
+        ]),
+        vec![controller, eip712],
+    )
+}
+
+/// Genesis document for the compressed-public-key form.
+///
+/// The account address is *derived* here rather than read from the DID, so it is
+/// emitted EIP-55 checksummed — matching the reference resolver.
+fn document_for_public_key(
+    did: &str,
+    chain_id: u64,
+    public_key_hex: &str,
+) -> Result<Document, DidEthrError> {
+    let pk_bytes = require_hex(public_key_hex, 66)?;
+    let (x, y) = decompress(&pk_bytes, public_key_hex)?;
+
+    let account = format!("eip155:{chain_id}:{}", eip55_address(&x, &y));
+
+    let controller = verification_method(
+        &format!("{did}#controller"),
+        "EcdsaSecp256k1RecoveryMethod2020",
+        did,
+        "blockchainAccountId",
+        json!(account),
+    )?;
+    let controller_key = verification_method(
+        &format!("{did}#controllerKey"),
+        "EcdsaSecp256k1VerificationKey2019",
+        did,
+        "publicKeyJwk",
+        json!({
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": BASE64_URL_SAFE_NO_PAD.encode(&x),
+            "y": BASE64_URL_SAFE_NO_PAD.encode(&y),
+        }),
+    )?;
+
+    build(
+        did,
+        json!([
+            "https://www.w3.org/ns/did/v1",
+            {
+                "EcdsaSecp256k1RecoveryMethod2020": IRI_RECOVERY_2020,
+                "EcdsaSecp256k1VerificationKey2019": IRI_VERIFICATION_KEY_2019,
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                "publicKeyJwk": {
+                    "@id": IRI_PUBLIC_KEY_JWK,
+                    "@type": "@json",
+                },
+            }
+        ]),
+        vec![controller, controller_key],
+    )
+}
+
+/// Decompress a SEC1 secp256k1 public key into its affine `(x, y)` coordinates,
+/// rejecting anything that is not actually on the curve.
+fn decompress(pk_bytes: &[u8], original: &str) -> Result<(Vec<u8>, Vec<u8>), DidEthrError> {
+    let encoded = EncodedPoint::from_bytes(pk_bytes)
+        .map_err(|e| DidEthrError::InvalidPublicKey(format!("{original}: {e}")))?;
+
+    let affine: AffinePoint = AffinePoint::from_sec1_point(&encoded)
+        .into_option()
+        .ok_or_else(|| DidEthrError::InvalidPublicKey(format!("{original}: not on curve")))?;
+
+    let point = affine.to_sec1_point(false);
+    let x = point
+        .x()
+        .ok_or_else(|| DidEthrError::InvalidPublicKey(format!("{original}: no X coordinate")))?
+        .to_vec();
+    let y = point
+        .y()
+        .ok_or_else(|| DidEthrError::InvalidPublicKey(format!("{original}: no Y coordinate")))?
+        .to_vec();
+    Ok((x, y))
+}
+
+/// Derive the EIP-55 checksummed Ethereum address for a public key.
+///
+/// The address is the low 20 bytes of `keccak256(x || y)`; EIP-55 then re-cases
+/// each hex letter according to the corresponding nibble of the keccak hash of
+/// the lowercase address.
+fn eip55_address(x: &[u8], y: &[u8]) -> String {
+    let mut hasher = Keccak256::new();
+    hasher.update(x);
+    hasher.update(y);
+    let address = hex::encode(&hasher.finalize()[12..]);
+
+    let checksum = hex::encode(Keccak256::digest(address.as_bytes()));
+
+    let mut out = String::with_capacity(42);
+    out.push_str("0x");
+    for (c, nibble) in address.chars().zip(checksum.chars()) {
+        // Digits have no case to carry the checksum bit; only letters do.
+        if c.is_ascii_digit() || nibble < '8' {
+            out.push(c);
+        } else {
+            out.push(c.to_ascii_uppercase());
+        }
+    }
+    out
+}
+
+/// Build one verification method carrying a single extra property.
+fn verification_method(
+    id: &str,
+    type_: &str,
+    controller: &str,
+    property: &str,
+    value: Value,
+) -> Result<VerificationMethod, DidEthrError> {
+    Ok(VerificationMethodBuilder::new(id, type_, controller)
+        .map_err(|e| DidEthrError::InvalidIdentifier(format!("{id}: {e}")))?
+        .property(property, value)
+        .build())
+}
+
+/// Assemble the document: every verification method is referenced from both
+/// `authentication` and `assertionMethod`, in declaration order.
+fn build(
+    did: &str,
+    context: Value,
+    methods: Vec<VerificationMethod>,
+) -> Result<Document, DidEthrError> {
+    let mut builder = DocumentBuilder::new(did)
+        .map_err(|e| DidEthrError::InvalidIdentifier(format!("{did}: {e}")))?
+        .context(context);
+
+    for vm in &methods {
+        let id = vm.id.as_str();
+        builder = builder
+            .authentication_reference(id)
+            .and_then(|b| b.assertion_method_reference(id))
+            .map_err(|e| DidEthrError::InvalidIdentifier(format!("{id}: {e}")))?;
+    }
+
+    Ok(builder.verification_methods(methods).build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip the document through JSON so the assertions below compare the
+    /// wire form — which is what consumers actually see.
+    fn resolved(did: &str) -> Value {
+        serde_json::to_value(resolve(did).unwrap()).unwrap()
+    }
+
+    /// Vector from the did:ethr method specification ("Create (Register)"),
+    /// carried over verbatim from the spruceid `did-ethr` test suite so the
+    /// replacement is checked against the implementation it replaced.
+    #[test]
+    fn resolves_account_address_form() {
+        let did = "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a";
+        assert_eq!(
+            resolved(did),
+            json!({
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+                  "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+                  "Eip712Method2021": "https://w3id.org/security#Eip712Method2021"
+                }
+              ],
+              "id": did,
+              "verificationMethod": [{
+                "id": format!("{did}#controller"),
+                "type": "EcdsaSecp256k1RecoveryMethod2020",
+                "controller": did,
+                "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
+              }, {
+                "id": format!("{did}#Eip712Method2021"),
+                "type": "Eip712Method2021",
+                "controller": did,
+                "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
+              }],
+              "authentication": [
+                format!("{did}#controller"),
+                format!("{did}#Eip712Method2021")
+              ],
+              "assertionMethod": [
+                format!("{did}#controller"),
+                format!("{did}#Eip712Method2021")
+              ]
+            })
+        );
+    }
+
+    /// Vector carried over from the spruceid `did-ethr` `tests/did-pk.jsonld`
+    /// fixture. Pins the two things this form derives rather than copies: the
+    /// EIP-55 checksummed address and the decompressed public key JWK.
+    #[test]
+    fn resolves_public_key_form() {
+        let did = "did:ethr:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479";
+        assert_eq!(
+            resolved(did),
+            json!({
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+                  "EcdsaSecp256k1VerificationKey2019": "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019",
+                  "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+                  "publicKeyJwk": {
+                    "@id": "https://w3id.org/security#publicKeyJwk",
+                    "@type": "@json"
+                  }
+                }
+              ],
+              "id": did,
+              "verificationMethod": [{
+                "id": format!("{did}#controller"),
+                "type": "EcdsaSecp256k1RecoveryMethod2020",
+                "controller": did,
+                "blockchainAccountId": "eip155:1:0xF3beAC30C498D9E26865F34fCAa57dBB935b0D74"
+              }, {
+                "id": format!("{did}#controllerKey"),
+                "type": "EcdsaSecp256k1VerificationKey2019",
+                "controller": did,
+                "publicKeyJwk": {
+                  "kty": "EC",
+                  "crv": "secp256k1",
+                  "x": "_dV63sPUOOojf-RrM-4eAW7aa1hcPifqZmhsLqU1hHk",
+                  "y": "Rjk_gUUlLupor-Z-KHs-2bMWhbpsOwAGCnO5sSQtaPc"
+                }
+              }],
+              "authentication": [
+                format!("{did}#controller"),
+                format!("{did}#controllerKey")
+              ],
+              "assertionMethod": [
+                format!("{did}#controller"),
+                format!("{did}#controllerKey")
+              ]
+            })
+        );
+    }
+
+    #[test]
+    fn named_networks_map_to_their_chain_ids() {
+        for (network, chain_id) in [
+            ("mainnet", 1),
+            ("morden", 2),
+            ("ropsten", 3),
+            ("rinkeby", 4),
+            ("goerli", 5),
+            ("kovan", 42),
+        ] {
+            assert_eq!(chain_id_for(network).unwrap(), chain_id, "{network}");
+        }
+    }
+
+    #[test]
+    fn hex_network_is_read_as_a_chain_id() {
+        assert_eq!(chain_id_for("0x3").unwrap(), 3);
+        assert_eq!(chain_id_for("0x2a").unwrap(), 42);
+    }
+
+    #[test]
+    fn network_segment_reaches_the_blockchain_account_id() {
+        let doc = resolved("did:ethr:0x3:0xb9c5714089478a327f09197987f16f9e5d936e8a");
+        assert_eq!(
+            doc["verificationMethod"][0]["blockchainAccountId"],
+            json!("eip155:3:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        );
+    }
+
+    #[test]
+    fn unknown_network_is_rejected() {
+        assert!(matches!(
+            resolve("did:ethr:sepolia:0xb9c5714089478a327f09197987f16f9e5d936e8a"),
+            Err(DidEthrError::InvalidNetwork(_))
+        ));
+    }
+
+    #[test]
+    fn non_ethr_did_is_rejected() {
+        assert!(matches!(
+            resolve("did:key:z6Mk"),
+            Err(DidEthrError::NotEthr(_))
+        ));
+    }
+
+    /// The upstream implementation switched on length alone, so a 42-character
+    /// non-hex identifier produced a document naming an impossible account.
+    #[test]
+    fn non_hex_identifier_of_the_right_length_is_rejected() {
+        assert!(matches!(
+            resolve("did:ethr:0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"),
+            Err(DidEthrError::InvalidIdentifier(_))
+        ));
+    }
+
+    #[test]
+    fn wrong_length_identifier_is_rejected() {
+        assert!(matches!(
+            resolve("did:ethr:0xb9c57140"),
+            Err(DidEthrError::InvalidIdentifier(_))
+        ));
+    }
+
+    #[test]
+    fn public_key_off_the_curve_is_rejected() {
+        // Valid length and hex, but not a point on secp256k1.
+        let did = format!("did:ethr:0x03{}", "ff".repeat(32));
+        assert!(matches!(
+            resolve(&did),
+            Err(DidEthrError::InvalidPublicKey(_))
+        ));
+    }
+
+    /// EIP-55 vectors from the specification itself.
+    #[test]
+    fn eip55_matches_the_specification_vectors() {
+        // Derived addresses are checksummed; check the casing rule directly by
+        // resolving a key whose address contains both cases.
+        let doc = resolved(
+            "did:ethr:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+        );
+        let account = doc["verificationMethod"][0]["blockchainAccountId"]
+            .as_str()
+            .unwrap();
+        let address = account.rsplit(':').next().unwrap();
+        assert_eq!(address, "0xF3beAC30C498D9E26865F34fCAa57dBB935b0D74");
+        // Checksumming must be case-flipping only, never a different address.
+        assert_eq!(
+            address.to_ascii_lowercase(),
+            "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+        );
+    }
+}

--- a/crates/identity/did-methods/did-jwk/CHANGELOG.md
+++ b/crates/identity/did-methods/did-jwk/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+In-tree replacement for the spruceid `did-jwk` crate, written to drop the
+`ssi-*` dependency stack (`im`, `sized-chunks`, `bitmaps`, `smallstr`,
+`proc-macro-error`, `derivative` — all unmaintained and archived with no fixed
+release — plus `reqwest 0.11` and the vulnerable `h2 0.3.x`).
+
+See `README.md` for scope, conformance and behavioural differences.

--- a/crates/identity/did-methods/did-jwk/Cargo.toml
+++ b/crates/identity/did-methods/did-jwk/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "affinidi-did-jwk"
+version = "0.1.0"
+description = "Minimal did:jwk DID method resolver for the Affinidi TDK"
+repository.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+affinidi-did-common = "0.4"
+base64 = "0.22"
+serde_json = "1"
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/identity/did-methods/did-jwk/README.md
+++ b/crates/identity/did-methods/did-jwk/README.md
@@ -1,0 +1,44 @@
+# affinidi-did-jwk
+
+Minimal `did:jwk` DID method resolver for the Affinidi TDK.
+
+Resolves `did:jwk:{base64url-nopad(utf8(jwk))}` into a DID Document. There is
+no network step and no state — the whole document is derived from the
+identifier.
+
+## The `use` member
+
+Per the specification, a key restricts which verification relationships it
+appears in:
+
+| `use` | Relationships |
+| --- | --- |
+| `"sig"` | all except `keyAgreement` |
+| `"enc"` | `keyAgreement` only |
+| absent | all five |
+
+## Private key material is refused
+
+A DID is a public identifier. An identifier encoding a JWK with `d`, `p`, `q`,
+`dp`, `dq`, `qi` or `k` is rejected rather than stripped — silently discarding
+the private half would publish a document while leaving the holder believing
+the secret was never there.
+
+## Deviation from the crate it replaced
+
+The `did-jwk` crate this replaced emitted `Multikey` verification methods with
+`publicKeyMultibase`, and applied every verification relationship regardless of
+the key's `use`. Both diverge from the specification, which mandates
+`JsonWebKey2020` with `publicKeyJwk` and honours `use`. This crate follows the
+specification.
+
+No production caller consumed the old shape — the `did-jwk` feature was not
+enabled by any crate in the workspace — though the resolver SDK's own
+`local_resolve_jwk` test asserted it, and was updated alongside this change.
+
+## Why this crate exists
+
+Upstream `did-jwk` reaches the rest of the `ssi-*` stack, which pulls
+`derivative` (RUSTSEC-2024-0388, unmaintained) along with the `im` /
+`sized-chunks` / `bitmaps` / `smallstr` cluster shared with `did:ethr` and
+`did:pkh`. See `affinidi-did-ethr` for the full rationale.

--- a/crates/identity/did-methods/did-jwk/src/lib.rs
+++ b/crates/identity/did-methods/did-jwk/src/lib.rs
@@ -1,0 +1,292 @@
+/*!
+ * did:jwk — JSON Web Key DID method resolver.
+ *
+ * Implements resolution of `did:jwk` identifiers per the
+ * [did:jwk method specification](https://github.com/quartzjer/did-jwk/blob/main/spec.md).
+ *
+ * # DID Format
+ *
+ * ```text
+ * did:jwk:{base64url-nopad(utf8(jwk))}
+ * ```
+ *
+ * The whole document is derived from the identifier — there is no network step
+ * and no state, so resolution cannot fail for any reason other than the DID
+ * being malformed.
+ *
+ * # Relationship to the `use` member
+ *
+ * Per the specification, a key restricts which verification relationships it
+ * appears in:
+ *
+ * - `"use": "sig"` — every relationship except `keyAgreement`
+ * - `"use": "enc"` — `keyAgreement` only
+ * - no `use` — all five relationships
+ *
+ * # Why this crate exists
+ *
+ * The spruceid `did-jwk` crate reaches the rest of the `ssi-*` stack, which
+ * pulls `derivative` (RUSTSEC-2024-0388, unmaintained) along with the `im` /
+ * `sized-chunks` / `bitmaps` / `smallstr` cluster shared with `did:ethr` and
+ * `did:pkh`. See the sibling `affinidi-did-ethr` crate for the full rationale.
+ *
+ * # Deviation from the crate this replaced
+ *
+ * The spruceid implementation emitted `Multikey` verification methods with
+ * `publicKeyMultibase`, and applied every verification relationship regardless
+ * of the key's `use`. Both diverge from the specification, which mandates
+ * `JsonWebKey2020` with `publicKeyJwk` and honours `use`. This crate follows
+ * the specification. No production caller consumed the old shape — the
+ * `did-jwk` feature was not enabled by any crate in the workspace.
+ *
+ * # Usage
+ *
+ * ```
+ * # fn main() -> Result<(), affinidi_did_jwk::DidJwkError> {
+ * let did = "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9";
+ * let doc = affinidi_did_jwk::resolve(did)?;
+ * assert_eq!(doc.verification_method.len(), 1);
+ * # Ok(()) }
+ * ```
+ */
+
+use affinidi_did_common::{DocumentBuilder, VerificationMethodBuilder};
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use serde_json::{Value, json};
+use thiserror::Error;
+
+pub use affinidi_did_common::Document;
+
+/// did:jwk resolver errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DidJwkError {
+    /// The supplied string was not a `did:jwk` DID.
+    #[error("not a did:jwk DID: {0}")]
+    NotJwk(String),
+
+    /// The identifier was not base64url (no padding).
+    #[error("did:jwk identifier is not base64url: {0}")]
+    InvalidBase64(String),
+
+    /// The decoded identifier was not a JSON object.
+    #[error("did:jwk identifier does not decode to a JSON object")]
+    InvalidJwk,
+
+    /// The encoded key carries private material.
+    ///
+    /// A DID is a public identifier. Resolving a private key into a DID
+    /// Document would publish the secret to every party that resolves the DID,
+    /// so this is refused rather than stripped — silently discarding the
+    /// private half would leave the holder believing the secret was never
+    /// there.
+    #[error("did:jwk identifier contains private key material ({0})")]
+    PrivateKeyMaterial(&'static str),
+
+    /// The DID could not be expressed as a document (unparseable as a URL).
+    #[error("did:jwk document could not be built: {0}")]
+    InvalidDocument(String),
+}
+
+/// JWK members that only ever appear on a private (or symmetric) key.
+///
+/// `d` covers both EC/OKP private scalars and the RSA private exponent; the
+/// rest are RSA CRT parameters; `k` is a symmetric key.
+const PRIVATE_MEMBERS: [&str; 7] = ["d", "p", "q", "dp", "dq", "qi", "k"];
+
+/// Resolve a `did:jwk` DID into its DID Document.
+pub fn resolve(did: &str) -> Result<Document, DidJwkError> {
+    let identifier = did
+        .strip_prefix("did:jwk:")
+        .ok_or_else(|| DidJwkError::NotJwk(did.to_string()))?;
+    resolve_identifier(identifier)
+}
+
+/// Resolve the method-specific identifier of a `did:jwk` DID — everything after
+/// `did:jwk:` — into its DID Document.
+pub fn resolve_identifier(identifier: &str) -> Result<Document, DidJwkError> {
+    let decoded = BASE64_URL_SAFE_NO_PAD
+        .decode(identifier)
+        .map_err(|_| DidJwkError::InvalidBase64(identifier.to_string()))?;
+
+    let jwk: Value = serde_json::from_slice(&decoded).map_err(|_| DidJwkError::InvalidJwk)?;
+    let members = jwk.as_object().ok_or(DidJwkError::InvalidJwk)?;
+
+    if let Some(member) = PRIVATE_MEMBERS
+        .iter()
+        .find(|member| members.contains_key(**member))
+    {
+        return Err(DidJwkError::PrivateKeyMaterial(member));
+    }
+
+    // `use` selects which relationships the key may appear in. An unrecognised
+    // value is treated as unrestricted, matching the specification's silence.
+    let key_use = members.get("use").and_then(Value::as_str);
+    let signing = key_use != Some("enc");
+    let key_agreement = key_use != Some("sig");
+
+    let did = format!("did:jwk:{identifier}");
+    let vm_id = format!("{did}#0");
+
+    let vm = VerificationMethodBuilder::new(&vm_id, "JsonWebKey2020", &did)
+        .map_err(|e| DidJwkError::InvalidDocument(format!("{vm_id}: {e}")))?
+        .public_key_jwk(jwk)
+        .build();
+
+    let mut builder = DocumentBuilder::new(&did)
+        .map_err(|e| DidJwkError::InvalidDocument(format!("{did}: {e}")))?
+        .context(json!([
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/jws-2020/v1"
+        ]))
+        .verification_method(vm);
+
+    let to_document_error = |e: affinidi_did_common::DocumentError| {
+        DidJwkError::InvalidDocument(format!("{vm_id}: {e}"))
+    };
+
+    if signing {
+        builder = builder
+            .assertion_method_reference(&vm_id)
+            .and_then(|b| b.authentication_reference(&vm_id))
+            .and_then(|b| b.capability_invocation_reference(&vm_id))
+            .and_then(|b| b.capability_delegation_reference(&vm_id))
+            .map_err(to_document_error)?;
+    }
+    if key_agreement {
+        builder = builder
+            .key_agreement_reference(&vm_id)
+            .map_err(to_document_error)?;
+    }
+
+    Ok(builder.build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// P-256 key from the did:jwk specification's own example.
+    const P256_DID: &str = "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9";
+
+    fn resolved(did: &str) -> Value {
+        serde_json::to_value(resolve(did).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn resolves_the_specification_example() {
+        assert_eq!(
+            resolved(P256_DID),
+            json!({
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                "https://w3id.org/security/suites/jws-2020/v1"
+              ],
+              "id": P256_DID,
+              "verificationMethod": [{
+                "id": format!("{P256_DID}#0"),
+                "type": "JsonWebKey2020",
+                "controller": P256_DID,
+                "publicKeyJwk": {
+                  "crv": "P-256",
+                  "kty": "EC",
+                  "x": "acbIQiuMs3i8_uszEjJ2tpTtRM4EU3yz91PH6CdH2V0",
+                  "y": "_KcyLj9vWMptnmKtm46GqDz8wf74I5LKgrl2GzH3nSE"
+                }
+              }],
+              "assertionMethod": [format!("{P256_DID}#0")],
+              "authentication": [format!("{P256_DID}#0")],
+              "capabilityInvocation": [format!("{P256_DID}#0")],
+              "capabilityDelegation": [format!("{P256_DID}#0")],
+              "keyAgreement": [format!("{P256_DID}#0")]
+            })
+        );
+    }
+
+    fn did_for(jwk: Value) -> String {
+        format!(
+            "did:jwk:{}",
+            BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(&jwk).unwrap())
+        )
+    }
+
+    #[test]
+    fn use_sig_drops_key_agreement() {
+        let doc = resolved(&did_for(json!({
+            "kty": "OKP", "crv": "Ed25519", "use": "sig",
+            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+        })));
+        assert!(doc.get("keyAgreement").is_none());
+        assert!(doc.get("authentication").is_some());
+        assert!(doc.get("assertionMethod").is_some());
+    }
+
+    #[test]
+    fn use_enc_keeps_only_key_agreement() {
+        let doc = resolved(&did_for(json!({
+            "kty": "OKP", "crv": "X25519", "use": "enc",
+            "x": "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08"
+        })));
+        assert!(doc.get("keyAgreement").is_some());
+        for omitted in [
+            "authentication",
+            "assertionMethod",
+            "capabilityInvocation",
+            "capabilityDelegation",
+        ] {
+            assert!(doc.get(omitted).is_none(), "{omitted} should be absent");
+        }
+    }
+
+    #[test]
+    fn private_key_material_is_refused() {
+        for member in PRIVATE_MEMBERS {
+            let did = did_for(json!({
+                "kty": "OKP", "crv": "Ed25519",
+                "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+                member: "c2VjcmV0"
+            }));
+            assert!(
+                matches!(resolve(&did), Err(DidJwkError::PrivateKeyMaterial(_))),
+                "{member} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn non_jwk_did_is_rejected() {
+        assert!(matches!(
+            resolve("did:key:z6Mk"),
+            Err(DidJwkError::NotJwk(_))
+        ));
+    }
+
+    #[test]
+    fn non_base64_identifier_is_rejected() {
+        assert!(matches!(
+            resolve("did:jwk:not!base64"),
+            Err(DidJwkError::InvalidBase64(_))
+        ));
+    }
+
+    #[test]
+    fn non_object_payload_is_rejected() {
+        let did = format!("did:jwk:{}", BASE64_URL_SAFE_NO_PAD.encode("[1,2,3]"));
+        assert!(matches!(resolve(&did), Err(DidJwkError::InvalidJwk)));
+    }
+
+    /// The JWK is embedded verbatim, so member order and unknown members
+    /// survive resolution — a resolver must not silently rewrite the key.
+    #[test]
+    fn unknown_members_are_preserved() {
+        let did = did_for(json!({
+            "kty": "OKP", "crv": "Ed25519",
+            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+            "kid": "key-1", "alg": "EdDSA"
+        }));
+        let doc = resolved(&did);
+        let jwk = &doc["verificationMethod"][0]["publicKeyJwk"];
+        assert_eq!(jwk["kid"], json!("key-1"));
+        assert_eq!(jwk["alg"], json!("EdDSA"));
+    }
+}

--- a/crates/identity/did-methods/did-pkh/CHANGELOG.md
+++ b/crates/identity/did-methods/did-pkh/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+In-tree replacement for the spruceid `did-pkh` crate, written to drop the
+`ssi-*` dependency stack (`im`, `sized-chunks`, `bitmaps`, `smallstr`,
+`proc-macro-error`, `derivative` — all unmaintained and archived with no fixed
+release — plus `reqwest 0.11` and the vulnerable `h2 0.3.x`).
+
+See `README.md` for scope, conformance and behavioural differences.

--- a/crates/identity/did-methods/did-pkh/Cargo.toml
+++ b/crates/identity/did-methods/did-pkh/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "affinidi-did-pkh"
+version = "0.1.0"
+description = "Minimal did:pkh DID method resolver for the Affinidi TDK"
+repository.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+affinidi-did-common = "0.4"
+base64 = "0.22"
+bech32 = "0.11"
+bs58 = "0.5"
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/identity/did-methods/did-pkh/README.md
+++ b/crates/identity/did-methods/did-pkh/README.md
@@ -1,0 +1,60 @@
+# affinidi-did-pkh
+
+Minimal `did:pkh` DID method resolver for the Affinidi TDK.
+
+Resolves a [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
+account id into a DID Document:
+
+```text
+did:pkh:{chain-namespace}:{chain-reference}:{account-address}
+```
+
+Resolution is a pure derivation from the identifier: no network access, no
+chain state. The document describes the account the DID names, and nothing
+about what that account currently holds.
+
+## Supported chains
+
+| Namespace | Verification methods |
+| --- | --- |
+| `tezos` | `#blockchainAccountId` (per `tz1`/`tz2`/`tz3` prefix), `#TezosMethod2021` |
+| `eip155` | `#blockchainAccountId` (`EcdsaSecp256k1RecoveryMethod2020`) |
+| `bip122` | `#blockchainAccountId` (`EcdsaSecp256k1RecoveryMethod2020`) |
+| `solana` | `#controller` (`Ed25519VerificationKey2018`), `#SolanaMethod2021` |
+| `aleo` | `#blockchainAccountId` (`BlockchainVerificationMethod2021`) |
+
+The deprecated single-token prefixes `tz`, `eth`, `celo`, `poly`, `sol`, `btc`
+and `doge` are still resolved, each pinned to its mainnet. The `eth` / `celo` /
+`poly` forms keep their distinct `#Recovery2020` fragment (see
+[spruceid/ssi#297](https://github.com/spruceid/ssi/issues/297)).
+
+An unknown namespace is **refused**, not resolved generically: a document
+naming a chain we cannot pick verification-method types for would assert key
+material semantics that have not been established.
+
+## Stricter than the crate it replaced
+
+Upstream validated the Solana and Aleo addresses properly but accepted any
+`eip155` address starting with `0x`, and checked only the three-character
+prefix of a Tezos address. This crate additionally:
+
+- validates `eip155` addresses as `0x` + exactly 40 hex digits;
+- verifies the Tezos base58check checksum;
+- enforces the CAIP-2 / CAIP-10 grammar on namespace, reference and address.
+
+A malformed account id is refused here rather than copied into
+`blockchainAccountId`, where it would read as a real account to every consumer
+of the document.
+
+## Conformance
+
+All 19 `did-*.jsonld` fixtures from the `did-pkh` 0.3.2 test suite are checked
+byte-for-byte in `tests/conformance.rs` — every namespace, in both the CAIP-10
+and legacy forms.
+
+## Why this crate exists
+
+Upstream `did-pkh` reaches the rest of the `ssi-*` stack, which pulls `im`,
+`sized-chunks`, `bitmaps`, `smallstr` and `proc-macro-error` — all unmaintained
+and archived upstream with no fixed release — plus `reqwest 0.11` and the
+vulnerable `h2 0.3.x`. See `affinidi-did-ethr` for the full rationale.

--- a/crates/identity/did-methods/did-pkh/src/lib.rs
+++ b/crates/identity/did-methods/did-pkh/src/lib.rs
@@ -1,0 +1,608 @@
+/*!
+ * did:pkh — Public Key Hash DID method resolver.
+ *
+ * Implements resolution of `did:pkh` identifiers per the
+ * [did:pkh method draft](https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md).
+ *
+ * # DID Format
+ *
+ * The current form names a [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
+ * account:
+ *
+ * ```text
+ * did:pkh:{chain-namespace}:{chain-reference}:{account-address}
+ * ```
+ *
+ * Supported namespaces are `tezos`, `eip155`, `bip122`, `solana` and `aleo`.
+ * A set of deprecated single-token prefixes (`tz`, `eth`, `celo`, `poly`,
+ * `sol`, `btc`, `doge`) is still resolved, each pinned to its mainnet.
+ *
+ * Resolution is a pure derivation from the identifier: no network access, no
+ * chain state. The document describes the account the DID names, and nothing
+ * about what that account currently holds.
+ *
+ * # Why this crate exists
+ *
+ * The spruceid `did-pkh` crate reaches the rest of the `ssi-*` stack, which
+ * pulls `im`, `sized-chunks`, `bitmaps`, `smallstr` and `proc-macro-error` —
+ * all unmaintained and archived upstream with no fixed release — plus
+ * `reqwest 0.11` and the vulnerable `h2 0.3.x`. Most of that weight is JSON-LD
+ * `@context` machinery, which our `Document` carries as plain JSON. See the
+ * sibling `affinidi-did-ethr` crate for the full rationale.
+ *
+ * Every document this crate emits is checked byte-for-byte against the
+ * fixtures from the crate it replaced — see `tests/`.
+ *
+ * # Usage
+ *
+ * ```
+ * # fn main() -> Result<(), affinidi_did_pkh::DidPkhError> {
+ * let doc = affinidi_did_pkh::resolve("did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a")?;
+ * assert_eq!(doc.verification_method.len(), 1);
+ * # Ok(()) }
+ * ```
+ */
+
+use affinidi_did_common::verification_method::VerificationMethod;
+use affinidi_did_common::{DocumentBuilder, VerificationMethodBuilder};
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub use affinidi_did_common::Document;
+
+/// did:pkh resolver errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DidPkhError {
+    /// The supplied string was not a `did:pkh` DID.
+    #[error("not a did:pkh DID: {0}")]
+    NotPkh(String),
+
+    /// The identifier was not a CAIP-10 account id or a known legacy prefix.
+    #[error("invalid did:pkh method-specific id: {0}")]
+    InvalidIdentifier(String),
+
+    /// The chain namespace is not one this resolver knows how to describe.
+    ///
+    /// Refused rather than resolved generically: a document naming a chain we
+    /// cannot pick verification-method types for would assert key material
+    /// semantics we have not established.
+    #[error("unsupported did:pkh chain namespace: {0}")]
+    UnsupportedNamespace(String),
+
+    /// The account address is not valid for its chain namespace.
+    #[error("invalid {namespace} account address: {address}")]
+    InvalidAddress {
+        /// CAIP-2 chain namespace the address was checked against.
+        namespace: &'static str,
+        /// The offending address.
+        address: String,
+    },
+
+    /// The DID could not be expressed as a document (unparseable as a URL).
+    #[error("did:pkh document could not be built: {0}")]
+    InvalidDocument(String),
+}
+
+// Mainnet references for the deprecated single-token prefixes.
+// CAIP-3 / CAIP-4 / CAIP-26 / CAIP-30 respectively.
+const REFERENCE_EIP155_ETHEREUM_MAINNET: &str = "1";
+const REFERENCE_EIP155_CELO_MAINNET: &str = "42220";
+const REFERENCE_EIP155_POLYGON_MAINNET: &str = "137";
+const REFERENCE_BIP122_BITCOIN_MAINNET: &str = "000000000019d6689c085ae165831e93";
+const REFERENCE_BIP122_DOGECOIN_MAINNET: &str = "1a91e3dace36e2be3bf030a65679fe82";
+const REFERENCE_TEZOS_MAINNET: &str = "NetXdQprcVkpaWU";
+const REFERENCE_SOLANA_MAINNET: &str = "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ";
+
+const IRI_BLOCKCHAIN_ACCOUNT_ID: &str = "https://w3id.org/security#blockchainAccountId";
+const IRI_PUBLIC_KEY_JWK: &str = "https://w3id.org/security#publicKeyJwk";
+const IRI_PUBLIC_KEY_BASE58: &str = "https://w3id.org/security#publicKeyBase58";
+const IRI_RECOVERY_2020: &str = "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020";
+const CONTEXT_BLOCKCHAIN_2021_V1: &str = "https://w3id.org/security/suites/blockchain-2021/v1";
+const CONTEXT_DID_V1: &str = "https://www.w3.org/ns/did/v1";
+
+/// A `w3id.org/security#` term IRI for a verification-method type name.
+fn security_iri(name: &str) -> String {
+    format!("https://w3id.org/security#{name}")
+}
+
+/// Resolve a `did:pkh` DID into its DID Document.
+pub fn resolve(did: &str) -> Result<Document, DidPkhError> {
+    let identifier = did
+        .strip_prefix("did:pkh:")
+        .ok_or_else(|| DidPkhError::NotPkh(did.to_string()))?;
+    resolve_identifier(identifier)
+}
+
+/// Resolve the method-specific identifier of a `did:pkh` DID — everything after
+/// `did:pkh:` — into its DID Document.
+pub fn resolve_identifier(identifier: &str) -> Result<Document, DidPkhError> {
+    let (prefix, rest) = identifier
+        .split_once(':')
+        .ok_or_else(|| DidPkhError::InvalidIdentifier(identifier.to_string()))?;
+
+    let did = format!("did:pkh:{identifier}");
+
+    // The deprecated prefixes name a chain outright; everything else is read as
+    // a CAIP-10 account id.
+    match prefix {
+        "tz" => tezos(&did, rest, REFERENCE_TEZOS_MAINNET),
+        "eth" => eip155(&did, rest, REFERENCE_EIP155_ETHEREUM_MAINNET, true),
+        "celo" => eip155(&did, rest, REFERENCE_EIP155_CELO_MAINNET, true),
+        "poly" => eip155(&did, rest, REFERENCE_EIP155_POLYGON_MAINNET, true),
+        "sol" => solana(&did, rest, REFERENCE_SOLANA_MAINNET),
+        "btc" => bip122(&did, rest, REFERENCE_BIP122_BITCOIN_MAINNET),
+        "doge" => bip122(&did, rest, REFERENCE_BIP122_DOGECOIN_MAINNET),
+        _ => caip10(&did, identifier),
+    }
+}
+
+/// Resolve a CAIP-10 `namespace:reference:address` account id.
+fn caip10(did: &str, account_id: &str) -> Result<Document, DidPkhError> {
+    let mut parts = account_id.splitn(3, ':');
+    let namespace = parts.next().unwrap_or_default();
+    let reference = parts
+        .next()
+        .ok_or_else(|| DidPkhError::InvalidIdentifier(account_id.to_string()))?;
+    let address = parts
+        .next()
+        .ok_or_else(|| DidPkhError::InvalidIdentifier(account_id.to_string()))?;
+
+    // CAIP-2 / CAIP-10 grammar. Enforced so a malformed account id is refused
+    // here rather than copied into `blockchainAccountId`, where it would read
+    // as a real account to every consumer of the document.
+    let valid_namespace = (3..=8).contains(&namespace.len())
+        && namespace
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    let valid_reference = (1..=32).contains(&reference.len())
+        && reference
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    let valid_address = (1..=128).contains(&address.len())
+        && address
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '%'));
+    if !valid_namespace || !valid_reference || !valid_address {
+        return Err(DidPkhError::InvalidIdentifier(account_id.to_string()));
+    }
+
+    match namespace {
+        "tezos" => tezos(did, address, reference),
+        "eip155" => eip155(did, address, reference, false),
+        "bip122" => bip122(did, address, reference),
+        "solana" => solana(did, address, reference),
+        "aleo" => aleo(did, address, reference),
+        other => Err(DidPkhError::UnsupportedNamespace(other.to_string())),
+    }
+}
+
+/// Tezos accounts: the `tz1`/`tz2`/`tz3` prefix selects the key algorithm, and
+/// so the verification-method type.
+fn tezos(did: &str, address: &str, reference: &str) -> Result<Document, DidPkhError> {
+    let invalid = || DidPkhError::InvalidAddress {
+        namespace: "tezos",
+        address: address.to_string(),
+    };
+
+    let key_type = match address.get(0..3) {
+        Some("tz1") => "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+        Some("tz2") => "EcdsaSecp256k1RecoveryMethod2020",
+        Some("tz3") => "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+        _ => return Err(invalid()),
+    };
+    require_base58check(address, 27).ok_or_else(invalid)?;
+
+    let account = format!("tezos:{reference}:{address}");
+    let type_iri = if key_type == "EcdsaSecp256k1RecoveryMethod2020" {
+        IRI_RECOVERY_2020.to_string()
+    } else {
+        security_iri(key_type)
+    };
+
+    build(
+        did,
+        json!([
+            CONTEXT_DID_V1,
+            {
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                key_type: type_iri,
+                "TezosMethod2021": security_iri("TezosMethod2021"),
+            }
+        ]),
+        vec![
+            account_method(did, "blockchainAccountId", key_type, &account, None)?,
+            account_method(did, "TezosMethod2021", "TezosMethod2021", &account, None)?,
+        ],
+    )
+}
+
+/// EIP-155 (Ethereum and friends) accounts.
+///
+/// `legacy` selects the verification-method fragment: the deprecated `eth` /
+/// `celo` / `poly` prefixes use `#Recovery2020`, CAIP-10 uses
+/// `#blockchainAccountId` (see spruceid/ssi#297).
+fn eip155(
+    did: &str,
+    address: &str,
+    reference: &str,
+    legacy: bool,
+) -> Result<Document, DidPkhError> {
+    // Upstream checked only for a `0x` prefix, so a non-hex "address" resolved
+    // to a document naming an account that cannot exist. Validate it properly.
+    let hex_body = address
+        .strip_prefix("0x")
+        .filter(|body| body.len() == 40 && body.chars().all(|c| c.is_ascii_hexdigit()));
+    if hex_body.is_none() {
+        return Err(DidPkhError::InvalidAddress {
+            namespace: "eip155",
+            address: address.to_string(),
+        });
+    }
+
+    let account = format!("eip155:{reference}:{address}");
+    let fragment = if legacy {
+        "Recovery2020"
+    } else {
+        "blockchainAccountId"
+    };
+
+    build(
+        did,
+        json!([
+            CONTEXT_DID_V1,
+            {
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                "EcdsaSecp256k1RecoveryMethod2020": IRI_RECOVERY_2020,
+            }
+        ]),
+        vec![account_method(
+            did,
+            fragment,
+            "EcdsaSecp256k1RecoveryMethod2020",
+            &account,
+            None,
+        )?],
+    )
+}
+
+/// BIP-122 (Bitcoin-family) accounts.
+fn bip122(did: &str, address: &str, reference: &str) -> Result<Document, DidPkhError> {
+    // Only the two chains whose address prefix we know are checked; an
+    // unrecognised chain reference carries no prefix expectation.
+    let expected_prefix = match reference {
+        REFERENCE_BIP122_BITCOIN_MAINNET => Some('1'),
+        REFERENCE_BIP122_DOGECOIN_MAINNET => Some('D'),
+        _ => None,
+    };
+    if let Some(prefix) = expected_prefix
+        && !address.starts_with(prefix)
+    {
+        return Err(DidPkhError::InvalidAddress {
+            namespace: "bip122",
+            address: address.to_string(),
+        });
+    }
+
+    let account = format!("bip122:{reference}:{address}");
+
+    build(
+        did,
+        json!([
+            CONTEXT_DID_V1,
+            {
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                "EcdsaSecp256k1RecoveryMethod2020": IRI_RECOVERY_2020,
+            }
+        ]),
+        vec![account_method(
+            did,
+            "blockchainAccountId",
+            "EcdsaSecp256k1RecoveryMethod2020",
+            &account,
+            None,
+        )?],
+    )
+}
+
+/// Solana accounts. The address *is* the Ed25519 public key, so unlike the
+/// other namespaces the document can carry real key material.
+fn solana(did: &str, address: &str, reference: &str) -> Result<Document, DidPkhError> {
+    let key_bytes = bs58::decode(address)
+        .into_vec()
+        .ok()
+        .filter(|bytes| bytes.len() == 32)
+        .ok_or_else(|| DidPkhError::InvalidAddress {
+            namespace: "solana",
+            address: address.to_string(),
+        })?;
+
+    let account = format!("solana:{reference}:{address}");
+
+    build(
+        did,
+        json!([
+            CONTEXT_DID_V1,
+            {
+                "blockchainAccountId": IRI_BLOCKCHAIN_ACCOUNT_ID,
+                "publicKeyBase58": IRI_PUBLIC_KEY_BASE58,
+                "publicKeyJwk": {
+                    "@id": IRI_PUBLIC_KEY_JWK,
+                    "@type": "@json",
+                },
+                "Ed25519VerificationKey2018": security_iri("Ed25519VerificationKey2018"),
+                "SolanaMethod2021": security_iri("SolanaMethod2021"),
+            }
+        ]),
+        vec![
+            account_method(
+                did,
+                "controller",
+                "Ed25519VerificationKey2018",
+                &account,
+                Some(("publicKeyBase58", json!(address))),
+            )?,
+            account_method(
+                did,
+                "SolanaMethod2021",
+                "SolanaMethod2021",
+                &account,
+                Some((
+                    "publicKeyJwk",
+                    json!({
+                        "kty": "OKP",
+                        "crv": "Ed25519",
+                        "x": BASE64_URL_SAFE_NO_PAD.encode(&key_bytes),
+                    }),
+                )),
+            )?,
+        ],
+    )
+}
+
+/// Aleo accounts. Validated as bech32 with the `aleo` human-readable part; the
+/// decoded payload is used for validation only, never published.
+fn aleo(did: &str, address: &str, reference: &str) -> Result<Document, DidPkhError> {
+    let invalid = || DidPkhError::InvalidAddress {
+        namespace: "aleo",
+        address: address.to_string(),
+    };
+
+    let (hrp, data) = bech32::decode(address).map_err(|_| invalid())?;
+    if hrp.as_str() != "aleo" || data.len() != 32 {
+        return Err(invalid());
+    }
+
+    let account = format!("aleo:{reference}:{address}");
+
+    // The blockchain-2021 context already defines `BlockchainVerificationMethod2021`
+    // and `blockchainAccountId`, so no inline term definitions are emitted.
+    build(
+        did,
+        json!([CONTEXT_DID_V1, CONTEXT_BLOCKCHAIN_2021_V1]),
+        vec![account_method(
+            did,
+            "blockchainAccountId",
+            "BlockchainVerificationMethod2021",
+            &account,
+            None,
+        )?],
+    )
+}
+
+/// Verify a Tezos-style base58check string and return its payload length.
+///
+/// Base58check is `payload || sha256(sha256(payload))[..4]`; upstream checked
+/// only the three-character prefix, so a mistyped address resolved happily.
+fn require_base58check(address: &str, expected_len: usize) -> Option<()> {
+    let decoded = bs58::decode(address).into_vec().ok()?;
+    if decoded.len() != expected_len {
+        return None;
+    }
+    let (payload, checksum) = decoded.split_at(expected_len - 4);
+    let digest = Sha256::digest(Sha256::digest(payload));
+    (digest[..4] == *checksum).then_some(())
+}
+
+/// Build one verification method for an account, optionally carrying key material.
+fn account_method(
+    did: &str,
+    fragment: &str,
+    type_: &str,
+    account: &str,
+    public_key: Option<(&str, Value)>,
+) -> Result<VerificationMethod, DidPkhError> {
+    let id = format!("{did}#{fragment}");
+    let mut builder = VerificationMethodBuilder::new(&id, type_, did)
+        .map_err(|e| DidPkhError::InvalidDocument(format!("{id}: {e}")))?
+        .property("blockchainAccountId", json!(account));
+    if let Some((property, value)) = public_key {
+        builder = builder.property(property, value);
+    }
+    Ok(builder.build())
+}
+
+/// Assemble the document: every verification method is referenced from both
+/// `authentication` and `assertionMethod`, in declaration order.
+fn build(
+    did: &str,
+    context: Value,
+    methods: Vec<VerificationMethod>,
+) -> Result<Document, DidPkhError> {
+    let mut builder = DocumentBuilder::new(did)
+        .map_err(|e| DidPkhError::InvalidDocument(format!("{did}: {e}")))?
+        .context(context);
+
+    for vm in &methods {
+        let id = vm.id.as_str();
+        builder = builder
+            .authentication_reference(id)
+            .and_then(|b| b.assertion_method_reference(id))
+            .map_err(|e| DidPkhError::InvalidDocument(format!("{id}: {e}")))?;
+    }
+
+    Ok(builder.verification_methods(methods).build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real mainnet address, used as the base for the mutation tests below.
+    const TZ1: &str = "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8";
+    const ETH: &str = "0xb9c5714089478a327f09197987f16f9e5d936e8a";
+
+    #[test]
+    fn non_pkh_did_is_rejected() {
+        assert!(matches!(
+            resolve("did:key:z6Mk"),
+            Err(DidPkhError::NotPkh(_))
+        ));
+    }
+
+    #[test]
+    fn identifier_without_a_colon_is_rejected() {
+        assert!(matches!(
+            resolve("did:pkh:solo"),
+            Err(DidPkhError::InvalidIdentifier(_))
+        ));
+    }
+
+    #[test]
+    fn caip10_needs_all_three_segments() {
+        assert!(matches!(
+            resolve("did:pkh:eip155:1"),
+            Err(DidPkhError::InvalidIdentifier(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_namespace_is_refused_not_guessed() {
+        let err =
+            resolve("did:pkh:cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0");
+        assert!(matches!(err, Err(DidPkhError::UnsupportedNamespace(ns)) if ns == "cosmos"));
+    }
+
+    #[test]
+    fn malformed_caip2_is_rejected() {
+        // Namespace too short, and outside the CAIP-2 character set.
+        for bad in ["did:pkh:ab:1:0xabc", "did:pkh:EIP155:1:0xabc"] {
+            assert!(
+                matches!(resolve(bad), Err(DidPkhError::InvalidIdentifier(_))),
+                "{bad}"
+            );
+        }
+    }
+
+    /// Upstream accepted any string starting with `0x`, so a mistyped address
+    /// resolved to a document naming an account that cannot exist.
+    #[test]
+    fn eip155_address_must_be_hex_of_the_right_length() {
+        for bad in [
+            "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+            "0xb9c5714089",
+            "b9c5714089478a327f09197987f16f9e5d936e8a",
+        ] {
+            assert!(
+                matches!(
+                    resolve(&format!("did:pkh:eip155:1:{bad}")),
+                    Err(DidPkhError::InvalidAddress { .. })
+                ),
+                "{bad}"
+            );
+        }
+    }
+
+    /// Upstream checked only the three-character prefix.
+    #[test]
+    fn tezos_address_checksum_is_verified() {
+        // Flip the final character to break the base58check checksum.
+        let mut corrupted = TZ1.to_string();
+        corrupted.pop();
+        corrupted.push(if TZ1.ends_with('9') { '8' } else { '9' });
+        assert_ne!(corrupted, TZ1);
+        assert!(matches!(
+            resolve(&format!("did:pkh:tezos:NetXdQprcVkpaWU:{corrupted}")),
+            Err(DidPkhError::InvalidAddress { .. })
+        ));
+    }
+
+    #[test]
+    fn tezos_prefix_must_be_tz1_tz2_or_tz3() {
+        assert!(matches!(
+            resolve("did:pkh:tezos:NetXdQprcVkpaWU:tz9TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"),
+            Err(DidPkhError::InvalidAddress { .. })
+        ));
+    }
+
+    #[test]
+    fn solana_address_must_be_32_bytes_of_base58() {
+        for bad in ["CKg5d12", "not-base58-0OIl"] {
+            assert!(
+                matches!(
+                    resolve(&format!(
+                        "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:{bad}"
+                    )),
+                    Err(DidPkhError::InvalidAddress { .. })
+                ),
+                "{bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn aleo_address_must_be_bech32_with_the_aleo_hrp() {
+        // Valid bech32, wrong human-readable part.
+        assert!(matches!(
+            resolve("did:pkh:aleo:1:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"),
+            Err(DidPkhError::InvalidAddress { .. })
+        ));
+    }
+
+    #[test]
+    fn bip122_mainnet_address_prefixes_are_checked() {
+        // A Bitcoin-mainnet address must start with `1`, Dogecoin with `D`.
+        assert!(matches!(
+            resolve(
+                "did:pkh:bip122:000000000019d6689c085ae165831e93:Dnn4Fp9dHnMBFFYUJnsLhHhWbXBHUcHnb1"
+            ),
+            Err(DidPkhError::InvalidAddress { .. })
+        ));
+        assert!(matches!(
+            resolve(
+                "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6"
+            ),
+            Err(DidPkhError::InvalidAddress { .. })
+        ));
+    }
+
+    /// An unrecognised bip122 chain carries no prefix expectation, so the
+    /// address is accepted as given rather than checked against the wrong rule.
+    #[test]
+    fn bip122_unknown_chain_skips_the_prefix_check() {
+        assert!(
+            resolve(
+                "did:pkh:bip122:000000000933ea01ad0ee984209779ba:Xnn4Fp9dHnMBFFYUJnsLhHhWbXBHUcHnb1"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn legacy_prefixes_pin_their_mainnet() {
+        let doc = serde_json::to_value(resolve(&format!("did:pkh:eth:{ETH}")).unwrap()).unwrap();
+        assert_eq!(
+            doc["verificationMethod"][0]["blockchainAccountId"],
+            json!(format!("eip155:1:{ETH}"))
+        );
+        // The legacy form keeps its distinct fragment (spruceid/ssi#297).
+        assert!(
+            doc["verificationMethod"][0]["id"]
+                .as_str()
+                .unwrap()
+                .ends_with("#Recovery2020")
+        );
+    }
+}

--- a/crates/identity/did-methods/did-pkh/tests/ATTRIBUTION.md
+++ b/crates/identity/did-methods/did-pkh/tests/ATTRIBUTION.md
@@ -1,0 +1,17 @@
+# Attribution for the `did-*.jsonld` fixtures
+
+The 19 `did-*.jsonld` files in this directory are copied **verbatim** from the
+`did-pkh` crate, version 0.3.2, part of the [spruceid/ssi](https://github.com/spruceid/ssi)
+project (`did-pkh/tests/`).
+
+- Upstream: <https://github.com/spruceid/ssi/tree/main/crates/dids/methods/pkh>
+- Upstream licence: Apache-2.0 — the same licence this workspace uses.
+
+They are reproduced unmodified, as conformance vectors: `conformance.rs`
+resolves each fixture's own `id` with `affinidi-did-pkh` and asserts the result
+matches the file byte-for-byte. Keeping them unmodified is the point — they are
+the evidence that replacing `did-pkh` did not change any document this
+workspace emits.
+
+Do not edit these files. If a fixture needs to change, the change belongs
+upstream, and the divergence should be recorded here.

--- a/crates/identity/did-methods/did-pkh/tests/conformance.rs
+++ b/crates/identity/did-methods/did-pkh/tests/conformance.rs
@@ -1,0 +1,111 @@
+//! Conformance against the crate this one replaced.
+//!
+//! Every `did-*.jsonld` file in this directory is a fixture copied verbatim
+//! from the spruceid `did-pkh` 0.3.2 test suite. Each one is resolved by DID —
+//! taken from the fixture's own `id` — and compared in full, so any divergence
+//! in document shape, `@context`, verification-method type or relationship
+//! ordering fails the build.
+
+use serde_json::Value;
+
+/// Fixtures and the DID each one describes, keyed by file so a failure names
+/// the case. Loaded at compile time so a missing fixture is a build error
+/// rather than a silently skipped test.
+const FIXTURES: &[(&str, &str)] = &[
+    ("did-tz1.jsonld", include_str!("did-tz1.jsonld")),
+    ("did-tz2.jsonld", include_str!("did-tz2.jsonld")),
+    ("did-tz3.jsonld", include_str!("did-tz3.jsonld")),
+    (
+        "did-tz1-legacy.jsonld",
+        include_str!("did-tz1-legacy.jsonld"),
+    ),
+    (
+        "did-tz2-legacy.jsonld",
+        include_str!("did-tz2-legacy.jsonld"),
+    ),
+    (
+        "did-tz3-legacy.jsonld",
+        include_str!("did-tz3-legacy.jsonld"),
+    ),
+    ("did-eth.jsonld", include_str!("did-eth.jsonld")),
+    (
+        "did-eth-legacy.jsonld",
+        include_str!("did-eth-legacy.jsonld"),
+    ),
+    ("did-celo.jsonld", include_str!("did-celo.jsonld")),
+    (
+        "did-celo-legacy.jsonld",
+        include_str!("did-celo-legacy.jsonld"),
+    ),
+    ("did-poly.jsonld", include_str!("did-poly.jsonld")),
+    (
+        "did-poly-legacy.jsonld",
+        include_str!("did-poly-legacy.jsonld"),
+    ),
+    ("did-btc.jsonld", include_str!("did-btc.jsonld")),
+    (
+        "did-btc-legacy.jsonld",
+        include_str!("did-btc-legacy.jsonld"),
+    ),
+    ("did-doge.jsonld", include_str!("did-doge.jsonld")),
+    (
+        "did-doge-legacy.jsonld",
+        include_str!("did-doge-legacy.jsonld"),
+    ),
+    ("did-sol.jsonld", include_str!("did-sol.jsonld")),
+    (
+        "did-sol-legacy.jsonld",
+        include_str!("did-sol-legacy.jsonld"),
+    ),
+    ("did-aleo.jsonld", include_str!("did-aleo.jsonld")),
+];
+
+#[test]
+fn every_fixture_resolves_identically() {
+    for (name, contents) in FIXTURES {
+        let expected: Value = serde_json::from_str(contents)
+            .unwrap_or_else(|e| panic!("{name} is not valid JSON: {e}"));
+        let did = expected["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name} has no string `id`"));
+
+        let resolved = affinidi_did_pkh::resolve(did)
+            .unwrap_or_else(|e| panic!("{name}: resolving {did} failed: {e}"));
+        let actual = serde_json::to_value(resolved).unwrap();
+
+        assert_eq!(actual, expected, "{name} ({did})");
+    }
+}
+
+/// The suite is only meaningful if it actually covers every namespace and both
+/// identifier forms; guard against a fixture being dropped from the list above.
+#[test]
+fn fixture_coverage_is_complete() {
+    assert_eq!(FIXTURES.len(), 19);
+
+    let dids: Vec<&str> = FIXTURES
+        .iter()
+        .map(|(_, c)| {
+            serde_json::from_str::<Value>(c).unwrap()["id"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .map(|s| Box::leak(s.into_boxed_str()) as &str)
+        .collect();
+
+    for namespace in ["tezos", "eip155", "bip122", "solana", "aleo"] {
+        assert!(
+            dids.iter()
+                .any(|d| d.starts_with(&format!("did:pkh:{namespace}:"))),
+            "no CAIP-10 fixture for {namespace}"
+        );
+    }
+    for legacy in ["tz", "eth", "celo", "poly", "btc", "doge", "sol"] {
+        assert!(
+            dids.iter()
+                .any(|d| d.starts_with(&format!("did:pkh:{legacy}:"))),
+            "no legacy fixture for {legacy}"
+        );
+    }
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-aleo.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-aleo.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/blockchain-2021/v1"
+  ],
+  "id": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId",
+      "type": "BlockchainVerificationMethod2021",
+      "controller": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348",
+      "blockchainAccountId": "aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348"
+    }
+  ],
+  "authentication": [
+    "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-btc-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-btc-legacy.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+      "blockchainAccountId": "bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6"
+    }
+  ],
+  "authentication": [
+    "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-btc.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-btc.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+      "blockchainAccountId": "bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6"
+    }
+  ],
+  "authentication": [
+    "did:pkh:bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-celo-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-celo-legacy.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#Recovery2020",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+      "blockchainAccountId": "eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011"
+    }
+  ],
+  "authentication": [
+    "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#Recovery2020"
+  ],
+  "assertionMethod": [
+    "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#Recovery2020"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-celo.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-celo.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+      "blockchainAccountId": "eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011"
+    }
+  ],
+  "authentication": [
+    "did:pkh:eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-doge-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-doge-legacy.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+      "blockchainAccountId": "bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"
+    }
+  ],
+  "authentication": [
+    "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-doge.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-doge.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+      "blockchainAccountId": "bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"
+    }
+  ],
+  "authentication": [
+    "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-eth-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-eth-legacy.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a#Recovery2020",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+      "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
+    }
+  ],
+  "authentication": [
+    "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a#Recovery2020"
+  ],
+  "assertionMethod": [
+    "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a#Recovery2020"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-eth.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-eth.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+      "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
+    }
+  ],
+  "authentication": [
+    "did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-poly-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-poly-legacy.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:poly:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:poly:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#Recovery2020",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:poly:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5",
+      "blockchainAccountId": "eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5"
+    }
+  ],
+  "authentication": [
+    "did:pkh:poly:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#Recovery2020"
+  ],
+  "assertionMethod": [
+    "did:pkh:poly:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#Recovery2020"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-poly.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-poly.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
+  "id": "did:pkh:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5",
+      "blockchainAccountId": "eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5"
+    }
+  ],
+  "authentication": [
+    "did:pkh:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5#blockchainAccountId"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-sol-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-sol-legacy.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "publicKeyBase58": "https://w3id.org/security#publicKeyBase58",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      },
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "SolanaMethod2021": "https://w3id.org/security#SolanaMethod2021"
+    }
+  ],
+  "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "publicKeyBase58": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev"
+    },
+    {
+      "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
+      "type": "SolanaMethod2021",
+      "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+      }
+    }
+  ],
+  "authentication": [
+    "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-sol.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-sol.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "publicKeyBase58": "https://w3id.org/security#publicKeyBase58",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      },
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "SolanaMethod2021": "https://w3id.org/security#SolanaMethod2021"
+    }
+  ],
+  "id": "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "publicKeyBase58": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev"
+    },
+    {
+      "id": "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
+      "type": "SolanaMethod2021",
+      "controller": "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+      }
+    }
+  ],
+  "authentication": [
+    "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:pkh:solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz1-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz1-legacy.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+      "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+    },
+    {
+      "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz1.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz1.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+      "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+    },
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz2-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz2-legacy.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+    },
+    {
+      "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz2.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz2.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+    },
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz3-legacy.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz3-legacy.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+      "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+    },
+    {
+      "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
+  ]
+}

--- a/crates/identity/did-methods/did-pkh/tests/did-tz3.jsonld
+++ b/crates/identity/did-methods/did-pkh/tests/did-tz3.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
+  "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+      "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+    },
+    {
+      "id": "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+    }
+  ],
+  "authentication": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
+  ],
+  "assertionMethod": [
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
+  ]
+}


### PR DESCRIPTION
Closes #695, #696, #697, #698, #706, #686, #683, #680 — once `did-cheqd` stops resolving the same crates into `Cargo.lock` (see **What this does not do**).

`did:ethr`, `did:pkh` and `did:jwk` were resolved by the spruceid crates of the same names. Those reach the whole `ssi-*` stack, which pulls **`im`, `sized-chunks`, `bitmaps`, `smallstr`, `proc-macro-error` and `derivative`** — every one unmaintained and archived upstream with no fixed release — plus `reqwest 0.11` and with it the vulnerable **`h2 0.3.x`** (RUSTSEC-2026-0258, currently suppressed in `auditIgnore`).

Upgrading does not fix this. I resolved `did-ethr 0.5` / `did-pkh 0.5` / `did-jwk 0.4` in a scratch crate: it clears `h2` and `rustls-pemfile 1.0.4`, but every one of the archived crates survives, because `ssi-dids-core 0.3` still reaches `json-ld 0.21.4` and `linked-data 0.1.2` — themselves the newest published versions, and themselves unmaintained.

So this replaces them. Three new crates in `crates/identity/did-methods/`, following the `affinidi-did-web` precedent — that crate exists for the same reason, and says so in its own doc comment.

## Why this is cheap

The adapter in `network_resolvers.rs` already round-tripped the ssi document through JSON (`document_from_bytes` / `document_from_ssi_output`), so **no ssi type ever escaped it**. The new crates build `affinidi_did_common::Document` directly and those helpers go away.

And most of what is *not* ported is the win: `json_ld_context.rs` in the two replaced crates (113 + 195 lines) exists only to build JSON-LD `@context` through the `linked-data`/`json-ld` types — which is precisely what drags in `im`/`sized-chunks`/`bitmaps`/`smallstr`. Our `Document` carries `@context` as plain JSON, so that becomes a `serde_json` value.

## Conformance

| crate | tests | vectors |
| --- | --- | --- |
| `affinidi-did-ethr` | 11 | both resolution vectors from the spruceid suite, byte-for-byte |
| `affinidi-did-jwk` | 8 | the did:jwk specification's own P-256 example |
| `affinidi-did-pkh` | 15 | **all 19** `did-*.jsonld` fixtures from the spruceid suite, byte-for-byte |

The `did:pkh` fixtures are copied verbatim and resolved by their own `id`, so any divergence in document shape, `@context`, verification-method type or relationship ordering fails the build. Every namespace, in both CAIP-10 and legacy forms. Apache-2.0 attribution in `tests/ATTRIBUTION.md` and `NOTICE.txt`.

## Behaviour changes

**`did:ethr` and `did:pkh` documents are unchanged.** That is what the fixtures assert.

**`did:jwk` documents change shape.** The replaced crate emitted `Multikey` / `publicKeyMultibase` and applied every verification relationship regardless of the key's `use`. Both diverge from the specification, which mandates `JsonWebKey2020` / `publicKeyJwk` and honours `use`. The in-tree crate follows the specification. No production caller is affected — the `did-jwk` feature was enabled by no crate — but the SDK's own `local_resolve_jwk` test asserted the old shape and is updated here.

**Malformed identifiers are now rejected rather than resolved.** Both replaced crates were loose here:

- `did:ethr` switched on identifier **length alone**, so `did:ethr:0xZZ…` (42 chars, not hex) resolved to a document naming an account that cannot exist.
- `did:pkh` accepted any `eip155` address starting with `0x`, and checked only the three-character prefix of a Tezos address.

Now validated — hex, base58check, and the CAIP-2/CAIP-10 grammar — and an unknown `did:pkh` namespace is refused rather than resolved generically. A malformed account id is refused rather than copied into `blockchainAccountId`, where it reads as a real account to every consumer of the document.

**`did:ethr` scope is unchanged and still partial.** Resolution is an offline derivation; ERC-1056 registry events are not replayed. That matches the crate it replaces, and is now stated plainly in the README: a `did:ethr` document from this crate is **not** proof of current on-chain control.

## Also: `did:jwk` was advertised but not compiled in

The cache-server README lists `did:jwk` among the methods it resolves, and its dependency comment claims full method coverage — but #674 moved the method behind a feature and only `did-ethr` / `did-pkh` were opted back in. `did:jwk` has not been in the server since 0.8.22. Enabled here.

## What this does not do

`cargo audit` reads `Cargo.lock`, not the build graph. `did-cheqd` is an optional feature that no crate in this workspace enables, but its `did-resolver-cheqd 1.0.1` hard-pins `ssi-dids-core ^0.1`, so all of these crates stay in the lockfile and the bot keeps filing.

Measured, on this branch:

- **build graph: clean.** None of `im`, `sized-chunks`, `bitmaps`, `smallstr`, `proc-macro-error`, `derivative`, `h2 0.3.27`, `reqwest 0.11`, `rustls-pemfile 1.0.4` is compiled by anything.
- **`cargo audit`: unchanged**, because of the above.
- with `did-cheqd` removed as an experiment: **13 warnings + 1 vulnerability → 4 warnings + 0 vulnerabilities.**

cheqd/did-resolver-rs#3 refreshes that crate to `ssi-dids-core 0.3` + `tonic 0.14`, which clears the `h2` vulnerability and `rustls-pemfile`, and makes the rustls provider selectable (`tls-ring` / `tls-aws-lc`) — that last part is why `did-cheqd` is opt-out here at all. It will not clear the archived cluster; that needs `ssi-dids-core` dropped from it outright, which is a two-file change there. Left in place with a comment recording all of this, so the swap is a one-line change.

## Note for merge

Both this PR and the `rustls-pemfile` / `number_prefix` PR bump `affinidi-did-resolver-cache-sdk` to **0.8.23**. Whichever merges second needs renumbering.

## Checks

`cargo fmt`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` all clean. `check-version-bumps.sh`, `check-changelogs.sh` and `check-workspace-duplicates.sh` all pass.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no HTTP client added; all three methods resolve offline
- [x] No lock held across a network await (R1.3) — n/a, no locks and no network
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a, pure functions
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — DID Document output is unchanged for did:ethr/did:pkh (fixture-asserted); the did:jwk shape change is called out above and in the CHANGELOG
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — a malformed or unsupported identifier now errors instead of resolving to a document; this is the fail-closed direction
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — README and rustdoc state plainly that did:ethr documents are genesis-only and not proof of current on-chain control
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — n/a, no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
