### PR TITLE
fix(deps): drop the unmaintained rustls-pemfile and number_prefix

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi DID Resolver Cache SDK
 
+## Unreleased (0.8.24) — drop the unmaintained `number_prefix`
+
+- The `benchmark` example formats binary sizes with a small inlined helper
+  instead of `number_prefix`, which is unmaintained (RUSTSEC-2025-0119). One
+  helper in one example did not justify a dependency, so no replacement crate
+  was added.
+- No library change.
+
 ## Unreleased (0.8.23) — did:ethr, did:pkh and did:jwk resolve in-tree
 
 - **`did:ethr`, `did:pkh` and `did:jwk` are now resolved by in-tree crates**

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -6,6 +6,9 @@
   instead of `number_prefix`, which is unmaintained (RUSTSEC-2025-0119). One
   helper in one example did not justify a dependency, so no replacement crate
   was added.
+- Bumps `sha1` 0.10 → 0.11 (the WebSocket handshake accept-key, `network`
+  feature only). This crate is its sole declarer in the workspace, so the bump
+  does not split the dependency.
 - No library change.
 
 ## Unreleased (0.8.23) — did:ethr, did:pkh and did:jwk resolve in-tree

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.23"
+version = "0.8.24"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -126,7 +126,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 clap = { version = "4", features = ["derive"] }
 num-format = "0.4"
-number_prefix = "0.4"
 rayon = "1"
 
 # Exercises `resolve_any` and `with_resolve_shortcuts`, so it only builds with

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -87,7 +87,7 @@ rustls-platform-verifier = { version = "0.7", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
-sha1 = { version = "0.10", optional = true }
+sha1 = { version = "0.11", optional = true }
 affinidi-did-web = { version = "0.1", path = "../did-methods/did-web" }
 affinidi-did-ethr = { version = "0.1", optional = true, path = "../did-methods/did-ethr" }
 affinidi-did-jwk = { version = "0.1", optional = true, path = "../did-methods/did-jwk" }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/examples/benchmark.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/examples/benchmark.rs
@@ -9,7 +9,6 @@ use affinidi_did_resolver_cache_sdk::{
 use clap::Parser;
 use futures_util::future::join_all;
 use num_format::{Locale, ToFormattedString};
-use number_prefix::NumberPrefix;
 use rand::RngExt;
 use rayon::prelude::*;
 use std::sync::Arc;
@@ -121,15 +120,27 @@ fn pretty_print_float(f: f64) -> String {
 }
 
 /// Pretty print a binary size (1.2 KiB)
+///
+/// Inlined rather than pulled from `number_prefix`, which is unmaintained
+/// (RUSTSEC-2025-0119). One helper in one example does not justify a
+/// dependency.
 fn pretty_print_binary_size(n: f64) -> String {
-    match NumberPrefix::binary(n) {
-        NumberPrefix::Standalone(bytes) => {
-            format!("{bytes} bytes",)
-        }
-        NumberPrefix::Prefixed(prefix, n) => {
-            format!("{n:.1} {prefix}B",)
+    const PREFIXES: [&str; 8] = ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"];
+
+    if n.abs() < 1024.0 {
+        return format!("{n} bytes");
+    }
+
+    let mut value = n;
+    for prefix in PREFIXES {
+        value /= 1024.0;
+        // Stop at the first prefix that brings the value under the next step,
+        // or at the largest prefix we have.
+        if value.abs() < 1024.0 || prefix == "Yi" {
+            return format!("{value:.1} {prefix}B");
         }
     }
+    unreachable!("the loop returns on its final iteration")
 }
 
 /// Generates a set of keys for testing purposes, can do in parallel

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased (0.19.11) — drop the unmaintained `rustls-pemfile`
+
+- SSL certificate loading in `config.rs` now parses PEM with
+  `CertificateDer::pem_reader_iter` from `rustls-pki-types`, which `rustls`
+  already re-exports as `rustls::pki_types`. The `rustls-pemfile` dependency is
+  removed; it is archived and unmaintained (RUSTSEC-2025-0134), and its final
+  release is a thin wrapper over exactly this code.
+- No new dependency and no behaviour change: the same certificates parse into
+  the same `CertificateDer` values.
+
 ## [0.19.10] - 2026-08-22
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.10"
+version = "0.19.11"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,10 @@ rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
   "tls12",
 ] }
-rustls-pemfile = "2"
+# PEM parsing comes from rustls-pki-types (already re-exported by rustls as
+# `rustls::pki_types`) rather than rustls-pemfile: that crate is archived and
+# unmaintained (RUSTSEC-2025-0134), and its final release is a thin wrapper
+# over exactly this code. No replacement dependency is needed.
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 sha256 = "1"

--- a/crates/messaging/affinidi-messaging-sdk/src/config.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/config.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use affinidi_crypto::jose::key_agreement::Curve;
 use affinidi_messaging_mediator_common::types::clock::{Clock, SystemClock};
-use rustls::pki_types::CertificateDer;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
 use std::{fs::File, io::BufReader, sync::Arc, time::Duration};
 use tokio::sync::{RwLock, broadcast::Sender};
 use tracing::error;
@@ -548,9 +548,9 @@ impl ATMConfigBuilder {
             })?;
             let mut reader = BufReader::new(file);
 
-            for cert in rustls_pemfile::certs(&mut reader) {
+            for cert in CertificateDer::pem_reader_iter(&mut reader) {
                 match cert {
-                    Ok(cert) => certs.push(cert.into_owned()),
+                    Ok(cert) => certs.push(cert),
                     Err(e) => {
                         failed_certs = true;
                         error!("Couldn't parse SSL certificate! Reason: {}", e)

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `affinidi-tdk-common`
 
+## Unreleased (0.6.9) — drop the unmaintained `rustls-pemfile`
+
+- `TDKProfile::load_ssl_certificates` now parses PEM with
+  `CertificateDer::pem_reader_iter` from `rustls-pki-types`, which `rustls`
+  already re-exports as `rustls::pki_types`. The `rustls-pemfile` dependency is
+  removed; it is archived and unmaintained (RUSTSEC-2025-0134), and its final
+  release is a thin wrapper over exactly this code.
+- No new dependency and no behaviour change: the same certificates parse into
+  the same `CertificateDer` values.
+
 ## 0.6.8 — 2026-08-18
 
 ### Fixed

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.8"
+version = "0.6.9"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -33,7 +33,10 @@ rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",
   "tls12",
 ] }
-rustls-pemfile = "2"
+# PEM parsing comes from rustls-pki-types (already re-exported by rustls as
+# `rustls::pki_types`) rather than rustls-pemfile: that crate is archived and
+# unmaintained (RUSTSEC-2025-0134), and its final release is a thin wrapper
+# over exactly this code. No replacement dependency is needed.
 rustls-platform-verifier = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/crates/tdk/affinidi-tdk-common/src/environments.rs
+++ b/crates/tdk/affinidi-tdk-common/src/environments.rs
@@ -20,7 +20,7 @@ use crate::{
     errors::{Result, TDKError},
     profiles::TDKProfile,
 };
-use rustls::pki_types::CertificateDer;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -158,7 +158,7 @@ impl TDKEnvironment {
                 TDKError::Config(format!("Couldn't open SSL certificate file ({path}): {e}"))
             })?;
             let mut reader = BufReader::new(file);
-            for cert in rustls_pemfile::certs(&mut reader) {
+            for cert in CertificateDer::pem_reader_iter(&mut reader) {
                 let cert = cert.map_err(|e| {
                     TDKError::Config(format!("Couldn't parse SSL certificate from ({path}): {e}"))
                 })?;


### PR DESCRIPTION
Closes #2.

Refreshes the two direct dependencies that between them account for every `cargo audit` finding in this crate's graph.

**Before → after** (project whose only dependency is `did-resolver-cheqd`):

|  | `main` | this PR |
|---|---|---|
| vulnerabilities | **1** | **0** |
| warnings | 9 | 7 |
| crates in graph | 335 | 318 |

## What changed

### `ssi-dids-core` 0.1.3 → 0.3.1 — clears the vulnerability

0.1.3 depends on `reqwest 0.11` → `hyper 0.14` → **`h2 0.3.27`**, which is affected by [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258). That one is not resolvable downstream: the advisory names `>=0.4.16` as the only fix and `0.3.27` is already the newest `0.3.x`, so no consumer can `cargo update` out of it. 0.3 drops the `reqwest 0.11` path entirely, taking `rustls-pemfile 1.0.4` ([RUSTSEC-2025-0134](https://rustsec.org/advisories/RUSTSEC-2025-0134)) with it.

It also puts this crate back in step with the rest of the ssi ecosystem — `did-ethr 0.5`, `did-pkh 0.5` and `did-jwk 0.4` are all on `ssi-dids-core ^0.3` already.

**No source changes were required for this bump.**

### `tonic` 0.12.3 → 0.14.6, `prost` 0.13 → 0.14

Removes `rustls-pemfile 2.2.0` (RUSTSEC-2025-0134).

The checked-in generated code needed exactly two mechanical renames:

```
tonic::body::BoxBody     -> tonic::body::Body
tonic::codec::ProstCodec -> tonic_prost::ProstCodec
```

I applied these by hand rather than regenerating, because the crate documents that these files are checked in specifically so changes stay reviewable, and a full regeneration would have produced an unreviewable diff. I diffed the rest of the emitted client against the `tonic-build 0.14.6` client template and it is byte-identical to what is already in the repo — but **it would still be worth regenerating from the Buf registry before you release**, to confirm. I did not have `protoc`/`buf` set up against your proto source.

### New: selectable TLS backend (`tls-ring` / `tls-aws-lc`)

`tonic 0.12` hard-wires the rustls `ring` provider. A consumer whose process selects `aws-lc-rs` anywhere else (`reqwest`, `kube`, `jsonwebtoken`, …) links both providers, and rustls then cannot auto-select one — it panics with `no process-level CryptoProvider available` at the first TLS call. `tonic 0.14` makes this a feature choice, so this PR exposes it:

```toml
default    = ["tls-ring"]                  # unchanged behaviour
tls-ring   = ["tonic/tls-ring"]
tls-aws-lc = ["tonic/tls-aws-lc"]
```

### `thiserror` 1 → 2

No source changes; the derive attributes used here are unchanged in 2.x.

### MSRV 1.87 → 1.88 — please read this one

`tonic 0.14` and `tonic-prost 0.14` both declare `rust-version = 1.88`, so this upgrade cannot land on a declared MSRV of 1.87 — the build fails outright rather than degrading quietly, and since CI installs the toolchain from that field it would have gone red.

**Separately, and worth knowing regardless of this PR: 1.87 does not hold on `main` today either.** `Cargo.lock` is gitignored, so CI resolves fresh on every run, and the current graph picks up `base45 3.2.0` (via `multibase` ← `ssi-jwk`), which uses `slice_as_chunks` — stabilised in 1.88. A clean 1.87 build of `main` already fails inside that dependency:

```
error[E0658]: use of unstable library feature `slice_as_chunks`
  --> base45-3.2.0/src/decode.rs:67:45
```

So this change is largely making an existing requirement explicit. If you would rather keep the floor at 1.87, that is possible — but it means staying on `tonic 0.12` and pinning `base45`, and it does not address the `h2` advisory.

Two lint fixes ride along with the bump, both *caused* by it rather than independent cleanups:

- `clippy::uninlined_format_args` is warn-by-default under clippy 1.88 (two sites).
- `clippy::collapsible_if` is MSRV-gated — let-chains need 1.88, so raising the floor lets clippy suggest collapsing two nested `if let`s. The collapsed form compiles at 1.88 under edition 2024.

## Two pre-existing fixes, split into their own commits

Both are independent of the dependency work and can be dropped or taken on their own:

- **`fix: bind the DID version with if-let instead of is_some/unwrap`** — `clippy::unnecessary_unwrap`.
- **`fix(docs): import the config types used by the crate-level doctest`** — `cargo test --doc` fails on `main` with two `E0422`s: the example uses `DidCheqdResolverConfiguration` and `NetworkConfiguration` without importing them. CI misses this because `cargo nextest run` does not execute doctests. README regenerated so `cargo rdme --check` stays satisfied.

## The other dependencies — deliberately left alone

`chrono`, `url`, `serde`, `serde_json` and `tokio` are all caret requirements that already resolve to the newest release, so there is nothing to gain by touching them:

| declared | resolves to |
|---|---|
| `chrono 0.4.39` | 0.4.45 |
| `url 2.5.4` | 2.5.8 |
| `serde 1.0` | 1.0.229 |
| `serde_json 1.0` | 1.0.151 |
| `tokio 1.42.0` | 1.53.1 |

None carry advisories, and raising the declared floors would not change a single resolved version — it would only narrow what consumers can build against. Mentioning it so it is clear this was checked rather than skipped.

## What this does *not* fix

7 `cargo audit` warnings remain — `im`, `bitmaps`, `sized-chunks`, `smallstr`, `proc-macro-error`, reached through `ssi-json-ld` → `json-ld` → `linked-data`. These are upstream of `ssi` and not actionable here; `ssi-dids-core 0.3.1` on its own carries exactly the same 7.

## Breaking change

The `ssi-dids-core` and `tonic` types are both part of this crate's public API, so this needs a major:

- `DIDCheqd` implements `ssi_dids_core` **0.3** traits. Callers passing `ssi_dids_core::DID` into `resolve()` must move to 0.3 in the same step.
- `DidCheqdError::TransportError` / `NonSuccessResponse` wrap **tonic 0.14** types.
- MSRV is now 1.88.

Commits are marked so `semantic-release` picks up the major. I deliberately did not touch the version in `Cargo.toml`, since `cargo set-version` handles that in your release flow.

## Verification

Your CI's own commands, run across three toolchains — **1.88 (the new MSRV), 1.95 and 1.97**:

```
cargo fmt --check                                                  PASS
cargo clippy --all-targets --all-features --workspace -Dwarnings   PASS
cargo test                                        18 passed + 1 doctest
cargo test --no-default-features --features tls-aws-lc
                                                  18 passed + 1 doctest
cargo doc --no-deps --all-features                                 PASS
cargo audit                                 0 vulnerabilities (was 1)
```

`cargo rdme --check` needs a nightly toolchain for intralink resolution that I did not have, so I verified the README differently: regenerated it with `cargo rdme --intralinks-strip-links` and confirmed the only delta against the committed README is the intralink stripping itself, which `main` also does not apply.

I could not get CI to run on the fork (the build/lint workflows trigger `on: push`, and Actions are disabled on forks by default), so all of the above is local. Worth a maintainer run.

---

Filed from the [Affinidi TDK](https://github.com/affinidi/affinidi-tdk-rs), which uses this crate for `did:cheqd` resolution. Happy to split this into separate PRs per dependency if you would rather take them one at a time.
