### PR TITLE
build(deps): refresh base64, tower-http and tokio-tungstenite workspace-wide

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,9 +33,17 @@ jobs:
       # fixed: the lockfile takes h2 0.4.16. What remains is h2 **0.3.27**,
       # which has no patched release — it is the newest 0.3 and the advisory
       # names >=0.4.16 as the only fix. It arrives through reqwest 0.11 <-
-      # ssi-dids-core <- did-ethr / did-pkh, as an HTTP *client*.
-      # Drop when those crates move to reqwest 0.12 (hyper 1.x), or if h2
-      # backports the fix to 0.3.
+      # ssi-dids-core, as an HTTP *client*.
+      #
+      # Since #719 the ONLY path to it is the optional `did-cheqd` feature
+      # (did-resolver-cheqd 1.0.1 pins ssi-dids-core ^0.1). No crate in this
+      # workspace enables that feature, so h2 0.3.27 is never compiled — it is
+      # in Cargo.lock only, and cargo-audit reads the lockfile rather than the
+      # build graph. did:ethr / did:pkh / did:jwk no longer touch ssi at all.
+      #
+      # Drop this entry when did-resolver-cheqd moves off ssi-dids-core 0.1
+      # (see cheqd/did-resolver-rs#3), NOT when "those crates move to reqwest
+      # 0.12" as this comment previously said — the crates it named are gone.
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,17 @@ jobs:
       # fixed: the lockfile takes h2 0.4.16. What remains is h2 **0.3.27**,
       # which has no patched release — it is the newest 0.3 and the advisory
       # names >=0.4.16 as the only fix. It arrives through reqwest 0.11 <-
-      # ssi-dids-core <- did-ethr / did-pkh, as an HTTP *client*.
-      # Drop when those crates move to reqwest 0.12 (hyper 1.x), or if h2
-      # backports the fix to 0.3.
+      # ssi-dids-core, as an HTTP *client*.
+      #
+      # Since #719 the ONLY path to it is the optional `did-cheqd` feature
+      # (did-resolver-cheqd 1.0.1 pins ssi-dids-core ^0.1). No crate in this
+      # workspace enables that feature, so h2 0.3.27 is never compiled — it is
+      # in Cargo.lock only, and cargo-audit reads the lockfile rather than the
+      # build graph. did:ethr / did:pkh / did:jwk no longer touch ssi at all.
+      #
+      # Drop this entry when did-resolver-cheqd moves off ssi-dids-core 0.1
+      # (see cheqd/did-resolver-rs#3), NOT when "those crates move to reqwest
+      # 0.12" as this comment previously said — the crates it named are gone.
       auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       release_debug: true

--- a/crates/applications/affinidi-meeting-place/CHANGELOG.md
+++ b/crates/applications/affinidi-meeting-place/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Meeting Place Changelog
 
+## Unreleased (0.4.5) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 19th July 2026 (0.4.4)
 
 - Bumped the `affinidi-did-common` requirement from `"0.3"` to `"0.4"`.

--- a/crates/applications/affinidi-meeting-place/Cargo.toml
+++ b/crates/applications/affinidi-meeting-place/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-meeting-place"
-version = "0.4.4"
+version = "0.4.5"
 description = "Affinidi Meeting Place SDK. Discover and connect with others in a secure and private way."
 edition.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcom
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.4"
 
-base64 = "0.22"
+base64 = "0.23"
 chrono = "0.4"
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Crypto Changelog
 
+## Unreleased (0.2.8) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 2nd August 2026 (0.2.7)
 
 Moves this crate to the **elliptic-curve 0.14** family (`p256` / `k256` /

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.7"
+version = "0.2.8"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -37,7 +37,7 @@ jose = ["dep:aes", "dep:cbc", "dep:hmac", "dep:subtle", "ed25519", "p256", "k256
 affinidi-encoding = "0.1.4"
 
 base58 = "0.2"
-base64 = "0.22"
+base64 = "0.23"
 multibase = "0.9"
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 k256 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional = true }

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Secrets Manager
 
+## Unreleased (0.5.10) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 31st July 2026 (0.5.9)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.9"
+version = "0.5.10"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -29,7 +29,7 @@ affinidi-crypto = "0.2"
 affinidi-encoding = "0.1"
 ahash = "0.8"
 base58 = "0.2"
-base64 = "0.22"
+base64 = "0.23"
 multibase = "0.9"
 rand = "0.10"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
+++ b/crates/credentials/affinidi-sd-jwt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi SD-JWT Changelog
 
+## Unreleased (0.1.5) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 13th June 2026 Release 0.1.4
 
 Semver wave (W7/W10 — release W11). `SdJwtError` and `SdJwt` are now

--- a/crates/credentials/affinidi-sd-jwt/Cargo.toml
+++ b/crates/credentials/affinidi-sd-jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-sd-jwt"
 description = "SD-JWT (Selective Disclosure JWT) implementation per IETF SD-JWT specification."
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -19,7 +19,7 @@ default = []
 _test-utils = ["dep:subtle"]
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.23"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/credentials/affinidi-status-list/CHANGELOG.md
+++ b/crates/credentials/affinidi-status-list/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Status List Changelog
 
+## Unreleased (0.1.5) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 14th June 2026 Release 0.1.4
 
 - `StatusListError` is now `#[non_exhaustive]` (ADR-0003) so new variants land

--- a/crates/credentials/affinidi-status-list/Cargo.toml
+++ b/crates/credentials/affinidi-status-list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-status-list"
 description = "Credential status and revocation lists (Bitstring Status List, eIDAS ASL/ARL)."
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,7 +13,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.23"
 flate2 = "1"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/crates/identity/affinidi-did-authentication/CHANGELOG.md
+++ b/crates/identity/affinidi-did-authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Authentication
 
+## Unreleased (0.3.12) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 0.3.11 — 2026-08-18
 
 ### Fixed

--- a/crates/identity/affinidi-did-authentication/Cargo.toml
+++ b/crates/identity/affinidi-did-authentication/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-did-authentication"
 description = "Using proof of DID ownership to authenticate to services"
-version = "0.3.11"
+version = "0.3.12"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -20,7 +20,7 @@ affinidi-did-common = { version = "0.4", features = ["key-agreement"] }
 affinidi-secrets-resolver = "0.5"
 affinidi-encoding = "0.1"
 
-base64 = "0.22"
+base64 = "0.23"
 chrono = "0.4"
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/identity/affinidi-did-common/CHANGELOG.md
+++ b/crates/identity/affinidi-did-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.4.2) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 31st July 2026 (0.4.1)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/identity/affinidi-did-common/Cargo.toml
+++ b/crates/identity/affinidi-did-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-common"
-version = "0.4.1"
+version = "0.4.2"
 description = "Affinidi DID Library"
 edition.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ affinidi-crypto = "0.2"
 affinidi-encoding = "0.1"
 
 # External Crates
-base64 = "0.22"
+base64 = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Resolver Cache SDK
 
+## Unreleased (0.8.25) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## Unreleased (0.8.24) — drop the unmaintained `number_prefix`
 
 - The `benchmark` example formats binary sizes with a small inlined helper

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.24"
+version = "0.8.25"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -69,7 +69,7 @@ did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true 
 
 # External Crates
 ahash = "0.8"
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
 # Community-name support (`example.com/@`) needs agent-names >= 0.1.3. The
 # requirement stays at `0.1` rather than pinning that floor: both crates

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Resolver Cache Server
 
+## Unreleased (0.9.12) — dependency refresh
+
+- Bumps `tower-http` 0.6 → 0.7.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## Unreleased (0.9.11) — `did:jwk` is actually served
 
 - **Enables the SDK's `did-jwk` feature.** The README has listed `did:jwk`

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.11"
+version = "0.9.12"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 toml = "1"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.7", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/identity/did-methods/did-ethr/CHANGELOG.md
+++ b/crates/identity/did-methods/did-ethr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.1.1) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 0.1.0 — initial release
 
 In-tree replacement for the spruceid `did-ethr` crate, written to drop the

--- a/crates/identity/did-methods/did-ethr/Cargo.toml
+++ b/crates/identity/did-methods/did-ethr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-ethr"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minimal did:ethr DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 affinidi-did-common = "0.4"
-base64 = "0.22"
+base64 = "0.23"
 hex = "0.4"
 k256 = { version = "0.14", default-features = false, features = ["arithmetic"] }
 serde_json = "1"

--- a/crates/identity/did-methods/did-jwk/CHANGELOG.md
+++ b/crates/identity/did-methods/did-jwk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.1.1) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 0.1.0 — initial release
 
 In-tree replacement for the spruceid `did-jwk` crate, written to drop the

--- a/crates/identity/did-methods/did-jwk/Cargo.toml
+++ b/crates/identity/did-methods/did-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-jwk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minimal did:jwk DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 affinidi-did-common = "0.4"
-base64 = "0.22"
+base64 = "0.23"
 serde_json = "1"
 thiserror = "2"
 

--- a/crates/identity/did-methods/did-pkh/CHANGELOG.md
+++ b/crates/identity/did-methods/did-pkh/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.1.1) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 0.1.0 — initial release
 
 In-tree replacement for the spruceid `did-pkh` crate, written to drop the

--- a/crates/identity/did-methods/did-pkh/Cargo.toml
+++ b/crates/identity/did-methods/did-pkh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-pkh"
-version = "0.1.0"
+version = "0.1.1"
 description = "Minimal did:pkh DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 affinidi-did-common = "0.4"
-base64 = "0.22"
+base64 = "0.23"
 bech32 = "0.11"
 bs58 = "0.5"
 serde_json = "1"

--- a/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # affinidi-messaging-didcomm-v1 changelog
 
+## Unreleased (0.2.1) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 0.2.0 — 8th August 2026
 
 Adds the two Aries protocols a wallet needs to use a mediator.

--- a/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-v1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-messaging-didcomm-v1"
 description = "DIDComm v1 (Aries RFC 0019) messaging implementation for the Affinidi TDK"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -49,7 +49,7 @@ blake2 = "0.10"
 # Encoding / serialization. Note `bs58`, not base64: v1 key identifiers are
 # base58btc-encoded Ed25519 verkeys.
 bs58 = "0.5"
-base64 = "0.22"
+base64 = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 ahash = { version = "0.8", features = ["serde"] }
 ## Base64 encoding/decoding — used by example binaries
-base64 = "0.22"
+base64 = "0.23"
 
 # ── Utilities ────────────────────────────────────────────────────────────
 regex = "1"

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased (0.18.22) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- Bumps `tokio-tungstenite` 0.29 → 0.30.
+- Bumps `tower-http` 0.6 → 0.7.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## [0.18.21] - 2026-08-22
 
 ### Fixed

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.21"
+version = "0.18.22"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -168,7 +168,7 @@ axum-extra = { version = "0.12", features = ["typed-header"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 http = "1"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
+tower-http = { version = "0.7", features = ["cors", "trace", "limit"] }
 
 # ── Database (Redis) ─────────────────────────────────────────────────────
 ## Redis 7.1+ required. Uses multiplexed connection (not pool).
@@ -231,7 +231,7 @@ subtle = "2"
 # ── Serialization & Encoding ────────────────────────────────────────────
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-base64 = "0.22"
+base64 = "0.23"
 toml = "1"
 sha256 = "1"
 url = "2"
@@ -258,7 +258,7 @@ governor = "0.10"
 
 # ── HTTP Client (for forwarding to remote mediators) ─────────────────────
 reqwest = { version = "0.13", features = ["rustls", "json"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-native-roots"] }
 
 # ── Utilities ────────────────────────────────────────────────────────────
 ahash = { version = "0.8", features = ["serde"] }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.35) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- Bumps `tokio-tungstenite` 0.29 → 0.30.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 8th August 2026 (0.15.34)
 
 **`MediatorStore` gains a DIDComm v1 routing-key index.**

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 - Bumps `base64` 0.22 → 0.23.
 - Bumps `tokio-tungstenite` 0.29 → 0.30.
-- No source or API change; the bumps are declaration-only and the crate
-  compiles unmodified against them. Bumped workspace-wide in the same
-  change so no two versions of these crates are compiled side by side.
+- **Adds the `connect` feature to `tokio-tungstenite`.** This crate is the only
+  one in the workspace declaring it with `default-features = false`. In 0.29
+  `rustls-tls-native-roots` reached `connect_async` transitively; in 0.30 it
+  maps to `__rustls-tls`, which brings `stream` and `handshake` but not
+  `connect`. Without it the forwarding processor's tests do not compile — and
+  only when this crate is built alone, since a workspace build unifies the
+  feature in from the mediator.
+- No API change. Bumped workspace-wide in the same change so no two versions of
+  these crates are compiled side by side.
 
 ## 8th August 2026 (0.15.34)
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -178,7 +178,14 @@ reqwest = { version = "0.13", default-features = false, features = [
   "rustls",
   "json",
 ], optional = true }
+# `connect` is explicit because this is the one declaration in the workspace
+# with `default-features = false`. In 0.29 `rustls-tls-native-roots` reached
+# `connect_async` transitively; in 0.30 it maps to `__rustls-tls`, which brings
+# `stream` and `handshake` but NOT `connect`. Without it the forwarding
+# processor's tests fail to compile — and only when this crate is built alone,
+# because a workspace build has the feature unified in from the mediator.
 tokio-tungstenite = { version = "0.30", default-features = false, features = [
+  "connect",
   "rustls-tls-native-roots",
 ], optional = true }
 futures-util = { version = "0.3", default-features = false, features = [

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.34"
+version = "0.15.35"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -105,7 +105,7 @@ regex = "1"
 
 # ── Secrets module: core (gated on `server`) ────────────────────────
 async-trait = { version = "0.1", optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 
@@ -178,7 +178,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "rustls",
   "json",
 ], optional = true }
-tokio-tungstenite = { version = "0.29", default-features = false, features = [
+tokio-tungstenite = { version = "0.30", default-features = false, features = [
   "rustls-tls-native-roots",
 ], optional = true }
 futures-util = { version = "0.3", default-features = false, features = [

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -59,7 +59,7 @@ toml = "1"
 toml_edit = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-base64 = "0.22"
+base64 = "0.23"
 url = "2"
 
 # ── Affinidi TDK (DID generation, secrets, crypto) ──────────────────────

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased (0.19.12) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- Bumps `tokio-tungstenite` 0.29 → 0.30.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## Unreleased (0.19.11) — drop the unmaintained `rustls-pemfile`
 
 - SSL certificate loading in `config.rs` now parses PEM with

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.11"
+version = "0.19.12"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -59,7 +59,7 @@ affinidi-task-utils = "0.1"
 
 # External Crates
 ahash = { version = "0.8", features = ["serde"] }
-base64 = "0.22"
+base64 = "0.23"
 futures-util = "0.3"
 # Non-cryptographic jitter for WebSocket reconnect backoff (anti-thundering-herd)
 rand = "0.10"
@@ -77,7 +77,7 @@ serde_json = "1"
 sha256 = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-native-roots"] }
 tracing = { version = "0.1", features = ["valuable"] }
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased (0.2.53) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- Bumps `tokio-tungstenite` 0.29 → 0.30.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## [0.2.52] - 2026-08-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.52"
+version = "0.2.53"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -93,13 +93,13 @@ reqwest = { version = "0.13", features = ["rustls", "json"] }
 affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## Re-encode raw qb2 bytes from a flushed TSP websocket Binary frame back to
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
-base64 = "0.22"
+base64 = "0.23"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
 trust-tasks-rs = "0.11"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-native-roots"] }
 ## `StreamExt::next` to read frames from a `tokio-tungstenite` WebSocket
 ## stream (per-DID connection-cap test reads the server's Close frame).
 futures-util = "0.3"

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -24,7 +24,7 @@ affinidi-did-resolver-cache-sdk = "0.8"
 # External Crates
 ahash = { version = "0.8", features = ["serde"] }
 anyhow = '1.0'
-base64 = "0.22"
+base64 = "0.23"
 chrono = "0.4"
 circular-queue = { version = "0.2", features = ["serde_support"] }
 # Crossterm must match the version used in ratatui

--- a/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
+++ b/crates/protocols/affinidi-oid4vc-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi OID4VC Core Changelog
 
+## Unreleased (0.1.8) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 2nd August 2026 (0.1.7)
 
 **`Es256Signer::generate_with_rng` now bounds `R: rand::CryptoRng`** (rand

--- a/crates/protocols/affinidi-oid4vc-core/Cargo.toml
+++ b/crates/protocols/affinidi-oid4vc-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-oid4vc-core"
 description = "Shared types for the OpenID for Verifiable Credentials (OID4VC) protocol family."
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -19,7 +19,7 @@ es256 = ["dep:p256", "dep:rand_10"]
 eddsa = ["dep:ed25519-dalek", "dep:rand_10"]
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.23"
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 p256 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
 rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }

--- a/crates/protocols/affinidi-siopv2/CHANGELOG.md
+++ b/crates/protocols/affinidi-siopv2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi SIOPv2 Changelog
 
+## Unreleased (0.1.3) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 14th June 2026 Release 0.1.2
 
 - `SiopError` is now `#[non_exhaustive]` (ADR-0003) so new variants land

--- a/crates/protocols/affinidi-siopv2/Cargo.toml
+++ b/crates/protocols/affinidi-siopv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-siopv2"
 description = "Self-Issued OpenID Provider v2 (SIOPv2) for decentralized authentication."
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -23,7 +23,7 @@ path = "examples/did_authentication.rs"
 [dependencies]
 affinidi-oid4vc-core = { version = "0.1", path = "../affinidi-oid4vc-core" }
 
-base64 = "0.22"
+base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — `affinidi-tdk-common`
 
+## Unreleased (0.6.10) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## Unreleased (0.6.9) — drop the unmaintained `rustls-pemfile`
 
 - `TDKProfile::load_ssl_certificates` now parses PEM with

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.9"
+version = "0.6.10"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -25,7 +25,7 @@ affinidi-secrets-resolver = "0.5"
 affinidi-data-integrity = "0.7"
 
 ahash = "0.8"
-base64 = "0.22"
+base64 = "0.23"
 keyring-core = "1"
 moka = { version = "0.12", features = ["future"] }
 reqwest = { version = "0.13", features = ["rustls", "json"] }

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi TDK Test Support
 
+## Unreleased (0.8.3) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 31st July 2026 (0.8.2)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.8.2"
+version = "0.8.3"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true
@@ -57,7 +57,7 @@ affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secre
 ## EdDSA signer/verifier backing the scenario's JWS signing (the workspace
 ## sd-jwt crate ships only an HMAC test signer).
 ed25519-dalek = { version = "3" }
-base64 = "0.22"
+base64 = "0.23"
 
 # ── TI5b: mdoc (COSE sign_mso/verify_issuer_auth) + OID4VP present/verify ──
 ## mdoc issue/present/verify on the EdDSA COSE path; default-features off drops

--- a/crates/trust/affinidi-trust-lists/CHANGELOG.md
+++ b/crates/trust/affinidi-trust-lists/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi Trust Lists Changelog
 
+## Unreleased (0.1.4) — dependency refresh
+
+- Bumps `base64` 0.22 → 0.23.
+- No source or API change; the bumps are declaration-only and the crate
+  compiles unmodified against them. Bumped workspace-wide in the same
+  change so no two versions of these crates are compiled side by side.
+
 ## 14th June 2026
 
 ### 0.1.2 — non_exhaustive TrustListError (W7 sweep)

--- a/crates/trust/affinidi-trust-lists/Cargo.toml
+++ b/crates/trust/affinidi-trust-lists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-trust-lists"
 description = "EU Trusted Lists (ETSI TS 119 612) for eIDAS 2.0 trust infrastructure."
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -21,7 +21,7 @@ name = "browse_trust_list"
 path = "examples/browse_trust_list.rs"
 
 [dependencies]
-base64 = "0.22"
+base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 quick-xml = { version = "0.41", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Follow-up to #719 / #720: the remaining stale dependencies in the crates those PRs touch.

None of these could be moved crate-by-crate. `base64` is declared by more than twenty crates here, `tokio-tungstenite` by the four that make up the WebSocket stack, and `tower-http` by both HTTP servers. Bumping only the crates that happened to need a version bump for other reasons would have compiled two versions of each side by side — worse than either state — so all three move workspace-wide here.

| dependency | from → to | declared by |
| --- | --- | --- |
| `base64` | 0.22 → 0.23 | 22 crates |
| `tokio-tungstenite` | 0.29 → 0.30 | messaging-sdk, mediator, mediator-common, test-mediator |
| `tower-http` | 0.6 → 0.7 | cache-server, mediator |

**Declaration-only for 21 of the 22 crates** — no source change beyond `Cargo.toml` and `CHANGELOG.md`. One crate needed a feature added; see below.

### `affinidi-messaging-mediator-common` needs `tokio-tungstenite/connect`

```
error[E0425]: cannot find function `connect_async` in crate `tokio_tungstenite`
  --> .../tasks/forwarding/processor.rs:769
```

This is the only declaration in the workspace using `default-features = false`. In 0.29 `rustls-tls-native-roots` reached `connect_async` transitively; in 0.30 it maps to `__rustls-tls`, which brings `stream` and `handshake` but **not** `connect`. Fixed by naming `connect` explicitly, with a comment at the declaration.

**Worth knowing how this was nearly missed.** It reproduces only when the crate is built *alone*: `cargo test --workspace` unifies the mediator's `tokio-tungstenite` features into it and `connect` is present. CI's coverage job builds `-p affinidi-messaging-mediator-common` on its own, which is where it surfaced. The failing call is also in a test, so `cargo build --workspace` was never going to see it either.

That is the same feature-unification trap this repo hit before with `--all-features`: a whole-workspace green is not evidence for a per-package build. So rather than fix the one crate and re-push, I built the tests of **every** crate this PR touches in isolation under CI's exact `RUSTFLAGS`, on the assumption that if unification hid one instance it could hide others.

## `ssi-dids-core` is deliberately not bumped

0.3.1 exists, but our `0.1` declaration has to match the pin inside `did-resolver-cheqd 1.0.1`. Moving ours to 0.3 would put **two** copies of `ssi-dids-core` in the graph rather than fewer. It moves when that crate does — see cheqd/did-resolver-rs#3.

## The WebSocket bump

`tokio-tungstenite` 0.29 → 0.30 touches `crates/messaging/`, which CLAUDE.md flags as the widest blast radius in the repo. Worth reviewing on its own terms:

- All four declarers move together, so client and server stay on one version.
- No source change was required in any of them.
- `cargo test --workspace` is green, including the messaging and mediator suites.

If you would rather this one landed separately from the `base64` / `tower-http` bumps so it can be rolled back independently, say so and I will split it out.

## Version bumps

22 publishable crates changed, so 22 patch bumps with changelog entries. `check-version-bumps.sh`, `check-changelogs.sh` and `check-workspace-duplicates.sh` all pass.

## Rebased onto #720

#720 has merged. This branch was rebased onto it and the three colliding versions renumbered:

| crate | #720 took | here |
| --- | --- | --- |
| `affinidi-did-resolver-cache-sdk` | 0.8.24 | **0.8.25** |
| `affinidi-messaging-sdk` | 0.19.11 | **0.19.12** |
| `affinidi-tdk-common` | 0.6.9 | **0.6.10** |

## Also: corrects a stale `auditIgnore` comment

`release.yaml` and `checks.yaml` justified suppressing RUSTSEC-2026-0258 (the `h2` vulnerability) with "it arrives through `reqwest 0.11` ← `ssi-dids-core` ← **did-ethr / did-pkh**", and said to drop the suppression "when those crates move to reqwest 0.12".

Both halves are now wrong. Since #719, `did:ethr` / `did:pkh` / `did:jwk` do not touch ssi at all, so that exit condition can never fire. The only remaining path to `h2 0.3.27` is the optional `did-cheqd` feature — which **no crate in this workspace enables**, so it is never compiled and exists in `Cargo.lock` alone (cargo-audit reads the lockfile, not the build graph).

The replacement comment records that, and points at cheqd/did-resolver-rs#3 as the actual trigger for removing the entry. A suppression list is exactly where an advisory goes to be forgotten, so a comment that sends the next reader chasing crates that no longer exist is worth fixing.

## Resolved: the release cascade from #719

For the record, since it blocked this branch's CI too. #719's release run failed with `403 Forbidden: Trusted Publishing tokens do not support creating new crates` — Trusted Publishing cannot create the three new crates, and that cascaded into `cache-sdk@0.8.23` and `cache-server@0.9.11`.

Cleared: the three were published manually, Trusted Publishing was configured for them, and the release re-run succeeded. crates.io now has `affinidi-did-ethr/-jwk/-pkh@0.1.0`, `cache-sdk@0.8.23` and `cache-server@0.9.11`.

Every publish-check failure on this PR and #720 traced to that lag — a registry-isolated resolve looking for something `main` had merged but crates.io did not yet have.

## Checks

`cargo fmt --check`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` all clean.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no client constructed or reconfigured
- [x] No lock held across a network await (R1.3) — no source change
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — no source change
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — no source change
- [x] Accept/poll/listen loops survive transient errors (R1.5) — unchanged; tokio-tungstenite 0.30 needed no call-site changes in any of the four declarers
- [x] Acks/deletes happen only after durable handoff (R1.6) — no source change
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no wire types touched; the WebSocket framing layer moves version but not behaviour
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — no config surface touched
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — no source change
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none. R3.6 noted: tokio-tungstenite is a transport dependency, so the messaging crates take patch bumps and the change is called out above for consuming repos.
```
