### PR TITLE
fix(ci): stop verify-publish checking crates marked publish = false

### DIFF
--- a/verify-publish.sh
+++ b/verify-publish.sh
@@ -12,8 +12,20 @@ NC='\033[0m' # No Color
 # Cache metadata once
 METADATA=$(cargo metadata --format-version 1 --no-deps 2>/dev/null)
 
-# Get all publishable crates in workspace order
-CRATES=$(echo "$METADATA" | jq -r '.packages[] | select(.publish == null or .publish == [] or .publish == ["crates.io"]) | .name')
+# Get all publishable crates in workspace order.
+#
+# `cargo metadata` reports the `publish` field as:
+#   null              -> publishable anywhere (no `publish` key, or `publish = true`)
+#   []                -> `publish = false`, i.e. MUST NEVER be published
+#   ["crates.io", ..] -> restricted to those registries
+#
+# The `[]` case previously matched here, so crates marked `publish = false`
+# were checked as if they were publishable. That is not a harmless extra check:
+# such a crate is allowed to depend on a workspace sibling by path with no
+# version requirement, which `cargo package` rejects — so it fails this script
+# for a reason that is correct behaviour. `affinidi-messaging-helpers` fails
+# exactly that way on a clean tree.
+CRATES=$(echo "$METADATA" | jq -r '.packages[] | select(.publish == null or ((.publish | length) > 0 and (.publish | index("crates.io")))) | .name')
 
 get_local_version() {
   echo "$METADATA" | jq -r ".packages[] | select(.name == \"$1\") | .version"


### PR DESCRIPTION
Found while working through the RUSTSEC backlog (#719 / #720 / #721). Small, self-contained, no crate versions involved.

## The bug

`cargo metadata` reports a package's `publish` field three ways:

| value | meaning |
| --- | --- |
| `null` | publishable anywhere (no `publish` key, or `publish = true`) |
| `[]` | **`publish = false`** — must never be published |
| `["crates.io", …]` | restricted to those registries |

The filter accepted the `[]` case:

```jq
select(.publish == null or .publish == [] or .publish == ["crates.io"])
```

so the four crates marked `publish = false` were checked as if they were publishable.

## Why it is not a harmless extra check

A crate that never publishes is *allowed* to depend on a workspace sibling by path with no version requirement. `cargo package` rejects exactly that — so such a crate fails this script for doing something correct. `affinidi-messaging-helpers` fails that way on a clean tree today:

```
$ cargo package -p affinidi-messaging-helpers --no-verify
error: failed to verify manifest at .../affinidi-messaging-helpers/Cargo.toml
Caused by:
  all dependencies must have a version requirement specified when packaging.
  dependency `affinidi-messaging-core` does not specify a version
```

Nothing to fix in that crate — the manifest is right, the check is wrong.

## The fix

```diff
-select(.publish == null or .publish == [] or .publish == ["crates.io"])
+select(.publish == null or ((.publish | length) > 0 and (.publish | index("crates.io"))))
```

Also accepts multi-registry `publish` lists, which the old exact-match on `["crates.io"]` would have missed.

## Verified

Checked against real `cargo metadata` before and after — the fix drops **exactly** the `publish = false` set and nothing else:

```
before: 53 crates checked   →  affinidi-messaging-helpers FAILED
after:  49 crates checked   →  Passed: 49, Failed: 0
```

Rebased onto latest `main` (`fbd8826`) and re-verified. The counts are one higher
than first measured because `main` has since gained the publishable
`affinidi-did-webs` crate; the fix still drops **exactly** the `publish = false`
set and nothing else.

Dropped: `affinidi-messaging-helpers`, `affinidi-messaging-mediator-setup`, `affinidi-messaging-mediator-monitor`, `affinidi-messaging-text-client` — all four marked `publish = false`.

## Noted but not fixed here

`get_remote_version` uses `cargo search "$1" | head -1`, which is a prefix search — so it can report a *different* crate's version. That is why `affinidi-messaging-mediator-setup` displayed as `0.18.21 → 0.1.28`: `0.18.21` is the **mediator's** version, not the setup tool's.

This change happens to remove the observed victim from the list (it is `publish = false`), but the fragility remains for any published crate whose name is a prefix of another. Worth a follow-up; left out to keep this diff to the one bug.

## Checks

No crate source touched, so no version bumps or changelog entries. `check-version-bumps.sh`, `check-changelogs.sh` and `check-workspace-duplicates.sh` all pass, and the full `verify-publish.sh` run is green.

