### PR TITLE
feat(did-webs): derive alsoKnownAs from verified designated aliases

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Affinidi DID Resolver Cache SDK
+## 0.8.27
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.2, which derives
+  `alsoKnownAs` from a verified designated-aliases attestation.
 
 ## 0.8.26
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.26"
+version = "0.8.27"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ did-scid = { version = "0.1", optional = true, default-features = false, feature
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.1", path = "../did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.2", path = "../did-methods/did-webs", optional = true }
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-webs/CHANGELOG.md
+++ b/crates/identity/did-methods/did-webs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this crate are documented here.
 
+## [0.2.0] - 2026-08-23
+
+### Added
+
+- **Designated aliases** — `alsoKnownAs` is now derived from a verified
+  attestation rather than omitted. A DID document does not get to assert its own
+  aliases: the AID must have issued a credential saying so, in a registry it
+  incepted, with both the registry inception and the issuance anchored in its own
+  key event log, the attestation signed by its key state, and no revocation. A
+  break anywhere in that chain yields no aliases rather than a partially-trusted
+  list.
+- `designated_aliases` and `DesignatedAliases`, which reports *why* an
+  attestation was not used. An attestation that fails to verify does not fail the
+  resolution — the key material is still sound, and refusing to resolve would
+  make a broken attestation a denial of service on the identifier.
+- `Kels::anchors_seal`, `Kels::message_by_said` and the ilk iterators.
+
+### Changed
+
+- **Breaking:** `document_from_keys` takes the verified aliases as a third
+  argument.
+- Requires `affinidi-keri-core` 0.3.2, which fixes a parser defect this work
+  uncovered: a message could take its declared length from a *different*
+  message in the stream, so an ACDC followed by any later key event mis-parsed.
+  A revocation event after a credential is exactly that shape.
+
 ## [0.1.0] - 2026-08-23
 
 Initial release.

--- a/crates/identity/did-methods/did-webs/Cargo.toml
+++ b/crates/identity/did-methods/did-webs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-webs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implementation of the did:webs DID method: did:web discovery with KERI-verified key state"
 repository.workspace = true
 edition.workspace = true
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-cesr = "0.1.3"
 affinidi-crypto = "0.2"
-affinidi-keri-core = "0.3"
-affinidi-keri-crypto = "0.3"
+affinidi-keri-core = "0.3.2"
+affinidi-keri-crypto = "0.3.2"
 affinidi-did-common = "0.4"
 reqwest = { version = "0.13", default-features = false, features = [
   "rustls",

--- a/crates/identity/did-methods/did-webs/README.md
+++ b/crates/identity/did-methods/did-webs/README.md
@@ -53,19 +53,24 @@ let doc = resolve_from_artifacts(&did, keri_cesr, Some(did_json))?;
 - **Delegation**: a delegated event is accepted only if the delegator's own
   verified KEL, present in the same stream, anchors a seal naming that exact
   event. Delegation chains are followed, bounded, and cycle-checked.
+- **Designated aliases**, which is where `alsoKnownAs` comes from. A DID
+  document does not get to assert its own aliases: an alias counts only if the
+  AID issued a credential saying so, and that credential is anchored in the
+  AID's own key event log. The whole chain is checked — registry inception
+  anchored, issuance anchored, attestation signed by the AID's key state, and
+  not revoked. A break anywhere yields no aliases rather than a
+  partially-trusted list.
 - The published `did.json`, against the derived key state: it must name this
   identifier (or its `did:web` twin) and publish exactly the keys the KEL
   authorised — no more and no fewer.
 
 ## What is not verified yet
 
-- **TEL and ACDC state.** The designated-aliases attestation parses and its
-  signing group is exposed, but nothing checks the registry behind it, so
-  `alsoKnownAs` beyond the `did:web` twin is not asserted. A document from this
-  crate therefore carries fewer `alsoKnownAs` entries than the published
-  `did.json` may.
 - **Witness receipts** are parsed but not required; a KEL is accepted on
   controller signatures alone.
+- **Credential schema validation.** A designated-aliases attestation is matched
+  by its schema SAID and its issuance chain is verified, but the credential body
+  is not validated against the schema itself.
 - **Service endpoints**, which come from KERI endpoint role authorisations
   rather than the KEL.
 

--- a/crates/identity/did-methods/did-webs/src/aliases.rs
+++ b/crates/identity/did-methods/did-webs/src/aliases.rs
@@ -1,0 +1,257 @@
+//! Designated aliases: the verified source of `alsoKnownAs`.
+//!
+//! `did:webs` does not let a DID document simply assert its own aliases. An
+//! alias is only real if the AID **issued a credential saying so**, and that
+//! credential is anchored in the AID's own key event log. The chain is:
+//!
+//! ```text
+//! KEL ixn ──anchors──▶ vcp   the credential registry, incepted by this AID
+//! KEL ixn ──anchors──▶ iss   an issuance in that registry
+//!                       │
+//!                       └──▶ ACDC   whose `a.ids` are the designated aliases,
+//!                                   signed by the AID's key state
+//! ```
+//!
+//! Every link is checked. A break anywhere yields no aliases rather than a
+//! partially-trusted list: an alias nobody authorised is exactly the claim an
+//! attacker wants a resolver to repeat.
+//!
+//! *Placement note:* transaction event logs are a KERI concept, not a
+//! `did:webs` one, so the `vcp`/`iss`/`rev` handling here belongs in
+//! `affinidi-keri-core` once something other than designated aliases needs it.
+//! It lives here while `did:webs` is the only consumer.
+
+use crate::errors::DidWebsError;
+use crate::kel::Kels;
+
+/// The aliases an AID has designated, and how far verification got.
+#[derive(Debug, Clone, Default)]
+pub struct DesignatedAliases {
+    /// Aliases whose full chain verified.
+    pub aliases: Vec<String>,
+    /// Why no aliases were produced, when a stream carried an attestation that
+    /// did not verify.
+    ///
+    /// A stream with no attestation at all is not a failure — most `did:webs`
+    /// identifiers designate nothing — so this stays `None` in that case.
+    pub rejected: Option<String>,
+}
+
+/// The ACDC schema SAID for the designated-aliases attestation.
+///
+/// Fixed by the `did:webs` specification. Checking it is what stops an
+/// unrelated credential the AID happens to have issued from being read as an
+/// alias designation.
+pub const DESIGNATED_ALIASES_SCHEMA: &str = "EN6Oh5XSD5_q2Hgu-aqpdfbVepdpYpFlgz6zvJL5b_r5";
+
+/// Collect the aliases `aid` has designated, verifying the whole chain.
+///
+/// Returns an empty list when the stream carries no designated-aliases
+/// attestation, which is the common case.
+///
+/// # Errors
+/// Returns [`DidWebsError::Kel`] only if `aid`'s own key event log does not
+/// verify. An attestation that fails to verify is reported through
+/// [`DesignatedAliases::rejected`], not as an error, so a broken attestation
+/// does not make an otherwise valid DID unresolvable.
+pub fn designated_aliases(kels: &Kels, aid: &str) -> Result<DesignatedAliases, DidWebsError> {
+    // Fails loudly: everything below is meaningless without a verified KEL.
+    kels.key_state(aid)?;
+
+    let mut rejected = None;
+
+    for acdc in kels.messages_with_ilk_none() {
+        let sad = acdc.serder.sad();
+
+        if sad.get("s").and_then(|v| v.as_str()) != Some(DESIGNATED_ALIASES_SCHEMA) {
+            continue;
+        }
+        if sad.get("i").and_then(|v| v.as_str()) != Some(aid) {
+            continue;
+        }
+
+        match verify_attestation(kels, aid, acdc) {
+            Ok(aliases) => {
+                return Ok(DesignatedAliases {
+                    aliases,
+                    rejected: None,
+                });
+            }
+            Err(e) => rejected = Some(e),
+        }
+    }
+
+    Ok(DesignatedAliases {
+        aliases: Vec::new(),
+        rejected,
+    })
+}
+
+/// Verify one designated-aliases attestation end to end.
+fn verify_attestation(
+    kels: &Kels,
+    aid: &str,
+    acdc: &affinidi_keri_core::parser::ParsedMessage,
+) -> Result<Vec<String>, String> {
+    let sad = acdc.serder.sad();
+    let acdc_said = acdc
+        .serder
+        .said()
+        .map_err(|e| format!("attestation has no SAID: {e}"))?;
+
+    // 1. The attestation is signed by the AID, under a key state from its KEL.
+    verify_signed_by(kels, aid, acdc)?;
+
+    // 2. It names a registry.
+    let registry = sad
+        .get("ri")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "attestation names no registry (`ri`)".to_string())?;
+
+    // 3. That registry was incepted by this AID, and the inception is anchored
+    //    in the AID's key event log.
+    verify_registry(kels, aid, registry)?;
+
+    // 4. The attestation was issued in that registry, and the issuance is
+    //    anchored in the key event log.
+    verify_issued(kels, aid, registry, &acdc_said)?;
+
+    // 5. It has not been revoked.
+    verify_not_revoked(kels, &acdc_said)?;
+
+    // 6. Only then are its aliases worth reading.
+    let ids = sad
+        .get("a")
+        .and_then(|a| a.get("ids"))
+        .and_then(|ids| ids.as_array())
+        .ok_or_else(|| "attestation carries no `a.ids` list".to_string())?;
+
+    Ok(ids
+        .iter()
+        .filter_map(|v| v.as_str())
+        .map(str::to_string)
+        .collect())
+}
+
+/// The attestation must carry a transferable indexed signature group from the
+/// AID, and those signatures must verify against the AID's key state.
+fn verify_signed_by(
+    kels: &Kels,
+    aid: &str,
+    acdc: &affinidi_keri_core::parser::ParsedMessage,
+) -> Result<(), String> {
+    let group = acdc
+        .trans_idx_sig_groups()
+        .iter()
+        .find(|g| g.prefix == aid)
+        .ok_or_else(|| format!("attestation carries no signature group from {aid}"))?;
+
+    let state = kels
+        .key_state(aid)
+        .map_err(|e| format!("cannot check the attestation signature: {e}"))?;
+
+    let verfers: Vec<affinidi_keri_crypto::Verfer> = state
+        .keys
+        .iter()
+        .map(|k| affinidi_keri_crypto::Verfer::from_qb64(k))
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("key state has an unusable key: {e}"))?;
+
+    let mut valid = 0usize;
+    for sig in &group.sigs {
+        let Some(verfer) = verfers.get(sig.index()) else {
+            continue;
+        };
+        if verfer
+            .verify(acdc.serder.raw(), sig.raw())
+            .map_err(|e| format!("signature check failed: {e}"))?
+        {
+            valid += 1;
+        }
+    }
+
+    if valid == 0 {
+        return Err(format!(
+            "no signature on the attestation verifies against {aid}'s key state"
+        ));
+    }
+
+    Ok(())
+}
+
+/// The registry inception must exist, name this AID as issuer, and be anchored
+/// in the AID's key event log.
+fn verify_registry(kels: &Kels, aid: &str, registry: &str) -> Result<(), String> {
+    let vcp = kels
+        .message_by_said(registry)
+        .ok_or_else(|| format!("registry {registry} has no inception event in the stream"))?;
+
+    if vcp.serder.ilk().ok().as_deref() != Some("vcp") {
+        return Err(format!("{registry} is not a registry inception event"));
+    }
+
+    // `ii` is the registry's issuer. Without this check, an AID could point at
+    // somebody else's registry and inherit its credentials.
+    if vcp.serder.sad().get("ii").and_then(|v| v.as_str()) != Some(aid) {
+        return Err(format!("registry {registry} was not incepted by {aid}"));
+    }
+
+    let anchored = kels
+        .anchors_seal(aid, registry, 0, registry)
+        .map_err(|e| format!("cannot check the registry anchor: {e}"))?;
+    if !anchored {
+        return Err(format!(
+            "{aid}'s key event log does not anchor the inception of registry {registry}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// The issuance event must exist, belong to the registry, and be anchored.
+fn verify_issued(kels: &Kels, aid: &str, registry: &str, acdc_said: &str) -> Result<(), String> {
+    let iss = kels
+        .messages_with_ilk("iss")
+        .find(|m| m.serder.sad().get("i").and_then(|v| v.as_str()) == Some(acdc_said))
+        .ok_or_else(|| format!("no issuance event for attestation {acdc_said}"))?;
+
+    if iss.serder.sad().get("ri").and_then(|v| v.as_str()) != Some(registry) {
+        return Err(format!(
+            "attestation {acdc_said} was issued in a different registry than it names"
+        ));
+    }
+
+    let iss_said = iss
+        .serder
+        .said()
+        .map_err(|e| format!("issuance event has no SAID: {e}"))?;
+
+    let anchored = kels
+        .anchors_seal(aid, acdc_said, 0, &iss_said)
+        .map_err(|e| format!("cannot check the issuance anchor: {e}"))?;
+    if !anchored {
+        return Err(format!(
+            "{aid}'s key event log does not anchor the issuance of {acdc_said}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// A revocation anywhere in the stream withdraws the attestation.
+///
+/// Revocations are not required to be anchored for this check: a *claimed*
+/// revocation is reason enough to stop repeating the aliases, and treating an
+/// unanchored revocation as invalid would let a stream suppress one by
+/// malforming it.
+fn verify_not_revoked(kels: &Kels, acdc_said: &str) -> Result<(), String> {
+    for ilk in ["rev", "brv"] {
+        let revoked = kels
+            .messages_with_ilk(ilk)
+            .any(|m| m.serder.sad().get("i").and_then(|v| v.as_str()) == Some(acdc_said));
+        if revoked {
+            return Err(format!("attestation {acdc_said} has been revoked"));
+        }
+    }
+    Ok(())
+}

--- a/crates/identity/did-methods/did-webs/src/document.rs
+++ b/crates/identity/did-methods/did-webs/src/document.rs
@@ -22,7 +22,11 @@ use crate::identifier::DidWebs;
 /// # Errors
 /// Returns [`DidWebsError::Kel`] if a key is not a CESR primitive this
 /// implementation can express as a JWK.
-pub fn document_from_keys(did: &DidWebs, keys: &[String]) -> Result<Document, DidWebsError> {
+pub fn document_from_keys(
+    did: &DidWebs,
+    keys: &[String],
+    aliases: &[String],
+) -> Result<Document, DidWebsError> {
     if keys.is_empty() {
         return Err(DidWebsError::Kel(
             "verified key state has no signing keys".into(),
@@ -35,9 +39,19 @@ pub fn document_from_keys(did: &DidWebs, keys: &[String]) -> Result<Document, Di
         .context_did_v1();
 
     // The did:web twin shares this document at the same location. Recording it
-    // as `equivalentId` is what lets a consumer that only speaks did:web be
-    // pointed at the same identifier.
-    builder = builder.also_known_as(did.did_web_twin());
+    // is what lets a consumer that only speaks did:web be pointed at the same
+    // identifier, and it holds without anything having to attest it.
+    let twin = did.did_web_twin();
+    builder = builder.also_known_as(twin.clone());
+
+    // Everything else comes from a designated-aliases attestation whose whole
+    // chain verified — never from the published did.json, which asserts its
+    // own aliases and so proves nothing.
+    for alias in aliases {
+        if *alias != twin && alias != did.did() {
+            builder = builder.also_known_as(alias.clone());
+        }
+    }
 
     for key in keys {
         let jwk = jwk_from_cesr_key(key)?;
@@ -112,7 +126,7 @@ mod tests {
 
     #[test]
     fn builds_a_document_for_an_ed25519_key() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
 
         assert_eq!(doc.id.as_str(), format!("did:webs:example.com:{AID}"));
         assert_eq!(doc.verification_method.len(), 1);
@@ -132,7 +146,7 @@ mod tests {
 
     #[test]
     fn records_the_did_web_twin() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
         let aka: Vec<&str> = doc.also_known_as.iter().map(String::as_str).collect();
         assert!(
             aka.contains(&format!("did:web:example.com:{AID}").as_str()),
@@ -142,25 +156,25 @@ mod tests {
 
     #[test]
     fn every_key_is_an_authentication_and_assertion_method() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
         assert_eq!(doc.authentication.len(), 1);
         assert_eq!(doc.assertion_method.len(), 1);
     }
 
     #[test]
     fn rejects_an_empty_key_state() {
-        assert!(document_from_keys(&did(), &[]).is_err());
+        assert!(document_from_keys(&did(), &[], &[]).is_err());
     }
 
     #[test]
     fn rejects_a_key_that_is_not_a_cesr_primitive() {
-        assert!(document_from_keys(&did(), &["not-a-key".to_string()]).is_err());
+        assert!(document_from_keys(&did(), &["not-a-key".to_string()], &[]).is_err());
     }
 
     #[test]
     fn rejects_a_non_key_cesr_primitive() {
         // A digest is a valid CESR primitive but not a public key: it must not
         // silently become a verification method.
-        assert!(document_from_keys(&did(), &[AID.to_string()]).is_err());
+        assert!(document_from_keys(&did(), &[AID.to_string()], &[]).is_err());
     }
 }

--- a/crates/identity/did-methods/did-webs/src/kel.rs
+++ b/crates/identity/did-methods/did-webs/src/kel.rs
@@ -122,6 +122,81 @@ impl Kels {
         Ok(state)
     }
 
+    /// Whether `aid`'s verified key event log anchors a seal naming
+    /// (`prefix`, `sn`, `said`).
+    ///
+    /// Anchoring is how a KEL authorises something outside itself — a
+    /// delegation, or an entry in a transaction event log. Unlike
+    /// [`DelegatorAnchors::anchors_at`] the caller does not know *which* event
+    /// carries the seal, so the whole verified log is searched.
+    ///
+    /// # Errors
+    /// Returns [`DidWebsError::Kel`] if `aid`'s key event log does not verify.
+    pub fn anchors_seal(
+        &self,
+        aid: &str,
+        prefix: &str,
+        sn: u64,
+        said: &str,
+    ) -> Result<bool, DidWebsError> {
+        // Verify first: a seal in an unverified event authorises nothing.
+        self.key_state(aid)?;
+
+        let Some(indices) = self.by_prefix.get(aid) else {
+            return Ok(false);
+        };
+
+        let expected_sn = format!("{sn:x}");
+        for i in indices {
+            let anchors = self.messages[*i]
+                .serder
+                .sad()
+                .get("a")
+                .and_then(|a| a.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            for anchor in anchors {
+                let matches = anchor.get("i").and_then(|v| v.as_str()) == Some(prefix)
+                    && anchor.get("d").and_then(|v| v.as_str()) == Some(said)
+                    && anchor.get("s").and_then(|v| v.as_str()) == Some(expected_sn.as_str());
+                if matches {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// The first message in the stream whose `d` field is `said`.
+    ///
+    /// Transaction events and credentials are addressed by SAID rather than by
+    /// position, and are not part of any KEL.
+    pub fn message_by_said(&self, said: &str) -> Option<&ParsedMessage> {
+        self.messages
+            .iter()
+            .find(|m| m.serder.said().ok().as_deref() == Some(said))
+    }
+
+    /// Every message in the stream with no `t` field at all.
+    ///
+    /// ACDCs are not events and carry no ilk, which is what distinguishes a
+    /// credential from a key or transaction event in the same stream.
+    pub fn messages_with_ilk_none(&self) -> impl Iterator<Item = &ParsedMessage> {
+        self.messages.iter().filter(|m| m.serder.ilk().is_err())
+    }
+
+    /// Every message in the stream whose `t` field is `ilk`.
+    pub fn messages_with_ilk<'a>(
+        &'a self,
+        ilk: &'a str,
+    ) -> impl Iterator<Item = &'a ParsedMessage> + 'a {
+        self.messages
+            .iter()
+            .filter(move |m| m.serder.ilk().ok().as_deref() == Some(ilk))
+    }
+
     /// Replay one identifier's KEL from its inception.
     fn verify_kel(&self, prefix: &str) -> Result<KeyState, DidWebsError> {
         let indices = self.by_prefix.get(prefix).ok_or_else(|| {

--- a/crates/identity/did-methods/did-webs/src/lib.rs
+++ b/crates/identity/did-methods/did-webs/src/lib.rs
@@ -15,6 +15,7 @@
  * error rather than a preference for one or the other.
  */
 
+pub mod aliases;
 pub mod document;
 pub mod errors;
 pub mod fetch;
@@ -22,6 +23,7 @@ pub mod identifier;
 pub mod kel;
 pub mod resolver;
 
+pub use aliases::{DesignatedAliases, designated_aliases};
 pub use errors::DidWebsError;
 pub use fetch::{WebsResolver, resolve};
 pub use identifier::{DID_JSON, DidWebs, KERI_CESR};

--- a/crates/identity/did-methods/did-webs/src/resolver.rs
+++ b/crates/identity/did-methods/did-webs/src/resolver.rs
@@ -8,6 +8,9 @@
 use affinidi_did_common::Document;
 use serde_json::Value;
 
+use tracing::warn;
+
+use crate::aliases::designated_aliases;
 use crate::document::document_from_keys;
 use crate::errors::DidWebsError;
 use crate::identifier::DidWebs;
@@ -41,7 +44,17 @@ pub fn resolve_from_artifacts(
         )));
     }
 
-    let document = document_from_keys(did, &state.keys)?;
+    // Aliases are only ever taken from a verified designated-aliases
+    // attestation. A stream carrying one that does not verify yields no
+    // aliases and a logged reason, rather than failing the whole resolution:
+    // the key material is still sound, and refusing to resolve would make a
+    // broken attestation a denial of service on the identifier.
+    let designated = designated_aliases(&kels, did.aid())?;
+    if let Some(reason) = &designated.rejected {
+        warn!("{}: designated aliases not used: {reason}", did.did());
+    }
+
+    let document = document_from_keys(did, &state.keys, &designated.aliases)?;
 
     if let Some(published) = did_json {
         let published: Value = serde_json::from_slice(published)?;

--- a/crates/identity/did-methods/did-webs/tests/conformance.rs
+++ b/crates/identity/did-methods/did-webs/tests/conformance.rs
@@ -192,3 +192,176 @@ fn a_did_json_cannot_be_reused_at_another_host() {
 fn did_from_host(host: &str) -> DidWebs {
     DidWebs::parse(&format!("did:webs:{host}:{AID}")).expect("valid did")
 }
+
+// -- designated aliases --------------------------------------------------
+
+use affinidi_did_webs::{Kels, designated_aliases};
+
+const REGISTRY: &str = "EHfE7gojVcX5Ldu8zzBr9WZhVz2ZP7XoYDaVEtqcyDRP";
+const ATTESTATION: &str = "EIEXitNCXQ_Y7HC6I7oiY7fPrRJyJzwvn_YIjvSHPzav";
+
+#[test]
+fn verifies_the_designated_aliases_chain() {
+    let kels = Kels::parse(KERI_CESR).expect("stream parses");
+    let found = designated_aliases(&kels, AID).expect("KEL verifies");
+
+    assert!(found.rejected.is_none(), "{:?}", found.rejected);
+    // The published attestation designates five aliases.
+    assert_eq!(found.aliases.len(), 5, "got {:?}", found.aliases);
+    assert!(
+        found
+            .aliases
+            .contains(&format!("did:webs:did-webs-service%3a7676:{AID}")),
+        "got {:?}",
+        found.aliases,
+    );
+}
+
+#[test]
+fn resolved_document_carries_the_verified_aliases() {
+    let doc = resolve_from_artifacts(&did(), KERI_CESR, None).expect("resolves");
+
+    // The did:web twin holds without attestation; the rest are designated.
+    assert!(
+        doc.also_known_as.len() > 1,
+        "expected designated aliases beyond the twin, got {:?}",
+        doc.also_known_as,
+    );
+    assert!(
+        doc.also_known_as
+            .iter()
+            .any(|a| a == &format!("did:webs:foo.com:{AID}")),
+        "got {:?}",
+        doc.also_known_as,
+    );
+}
+
+/// Cut one message (and its attachments) out of the stream, by its own SAID.
+///
+/// Matching on the first `"d":"<said>"` anywhere in the stream is wrong: a
+/// SAID appears in the seals that anchor it as well as in the message itself,
+/// and the first hit for a registry id is the KEL event anchoring it. Removing
+/// that instead breaks the key event log. So each message range is examined,
+/// and only its *own* `d` — the first one inside that range, since `d` comes
+/// third in a KERI event and second in an ACDC — is compared.
+fn without_message(stream: &[u8], said: &str) -> Vec<u8> {
+    let text = std::str::from_utf8(stream).expect("ascii stream");
+
+    let mut starts: Vec<usize> = text.match_indices("{\"v\":\"").map(|(i, _)| i).collect();
+    starts.push(text.len());
+
+    for window in starts.windows(2) {
+        let (start, end) = (window[0], window[1]);
+        let range = &text[start..end];
+        let Some(d_at) = range.find("\"d\":\"") else {
+            continue;
+        };
+        let value_at = d_at + 5;
+        if range[value_at..].starts_with(said) {
+            let mut out = text.as_bytes()[..start].to_vec();
+            out.extend_from_slice(&text.as_bytes()[end..]);
+            return out;
+        }
+    }
+
+    panic!("no message in the stream has SAID {said}");
+}
+
+/// Build a KERI event with the byte-accurate size in its version string.
+///
+/// The version string declares the message length and the parser slices the
+/// stream by it, so an event with a stale size derails everything after it.
+/// The size is measured from the serialized form rather than assumed.
+fn keri_event(mut sad: serde_json::Value) -> Vec<u8> {
+    let len = serde_json::to_vec(&sad).expect("serializes").len();
+    sad["v"] = serde_json::json!(format!("KERI10JSON{len:06x}_"));
+    serde_json::to_vec(&sad).expect("serializes")
+}
+
+#[test]
+fn an_attestation_without_its_registry_designates_nothing() {
+    // Remove the registry inception. The attestation is untouched and still
+    // signed by the AID — but nothing establishes the registry it claims to
+    // have been issued in, so its aliases must not be repeated.
+    //
+    // This cannot be tested by *tampering*: every KERI event is bound to its
+    // own SAID, so altering an anchor breaks the event carrying it and the
+    // whole key event log fails first. Removing a message is the only way to
+    // isolate this one link in the chain.
+    let stream = without_message(KERI_CESR, REGISTRY);
+
+    let kels = Kels::parse(&stream).expect("still parses");
+    let found = designated_aliases(&kels, AID).expect("KEL still verifies");
+    assert!(
+        found.aliases.is_empty(),
+        "a registry with no inception must yield no aliases, got {:?}",
+        found.aliases,
+    );
+    assert!(
+        found
+            .rejected
+            .as_deref()
+            .is_some_and(|r| r.contains("no inception event")),
+        "{:?}",
+        found.rejected,
+    );
+}
+
+#[test]
+fn an_attestation_without_its_issuance_designates_nothing() {
+    // The registry is real and anchored, but nothing says this credential was
+    // ever issued in it.
+    let stream = without_message(KERI_CESR, "EBK4vxXrJS0V42rbuX4Sgx2pYXV_WRKuH5dkqGepKPQ4");
+
+    let kels = Kels::parse(&stream).expect("still parses");
+    let found = designated_aliases(&kels, AID).expect("KEL still verifies");
+    assert!(found.aliases.is_empty(), "got {:?}", found.aliases);
+    assert!(
+        found
+            .rejected
+            .as_deref()
+            .is_some_and(|r| r.contains("no issuance event")),
+        "{:?}",
+        found.rejected,
+    );
+}
+
+#[test]
+fn a_revoked_attestation_designates_nothing() {
+    // A claimed revocation is enough to stop repeating the aliases.
+    let mut stream = KERI_CESR.to_vec();
+    stream.extend_from_slice(&keri_event(serde_json::json!({
+        "v": "KERI10JSON000000_",
+        "t": "rev",
+        "d": "ERevocation000000000000000000000000000000000",
+        "i": ATTESTATION,
+        "s": "1",
+        "ri": REGISTRY,
+        "dt": "2024-01-01T00:00:00.000000+00:00",
+    })));
+
+    let kels = Kels::parse(&stream).expect("parses");
+    let found = designated_aliases(&kels, AID).expect("KEL verifies");
+    assert!(
+        found.aliases.is_empty(),
+        "a revoked attestation must designate nothing, got {:?}",
+        found.aliases,
+    );
+    assert!(
+        found
+            .rejected
+            .as_deref()
+            .is_some_and(|r| r.contains("revoked")),
+        "{:?}",
+        found.rejected,
+    );
+}
+
+#[test]
+fn another_aid_cannot_claim_this_attestation() {
+    // The attestation is issued by ENro7uf0…; asking for a different AID's
+    // aliases must not return it. That AID has no KEL here, so this also
+    // pins that a missing KEL is an error rather than an empty answer.
+    let kels = Kels::parse(KERI_CESR).expect("parses");
+    assert!(designated_aliases(&kels, REGISTRY).is_err());
+}

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
+For the full code history see `git log` on `crates/tdk/affinidi-tdk`.## 0.8.7
+
+### Changed
+
+- `did-webs` feature now re-exports `affinidi-did-webs` 0.2.
+
 ## 0.8.6
 
 ### Added

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.6"
+version = "0.8.7"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 # DID methods
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.1", path = "../../identity/did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.2", path = "../../identity/did-methods/did-webs", optional = true }
 did-scid = { version = "0.1", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP


### PR DESCRIPTION
Closes the largest gap left by #723: `alsoKnownAs` was omitted entirely beyond
the `did:web` twin, because nothing verified the attestation the published
`did.json` builds it from.

## A DID document does not get to assert its own aliases

An alias counts only if the AID **issued a credential saying so**, and that
credential is anchored in the AID's own key event log:

```
KEL ixn ──anchors──▶ vcp   the credential registry, incepted by this AID
KEL ixn ──anchors──▶ iss   an issuance in that registry
                      │
                      └──▶ ACDC   signed by the AID's key state,
                                  whose `a.ids` are the designated aliases
```

Every link is checked. Refused specifically:

- an attestation issued by someone else
- one naming a registry this AID did not incept (`ii` mismatch) — otherwise an
  AID could point at another party's registry and inherit its credentials
- a registry inception the key event log does not anchor
- an issuance the key event log does not anchor
- a signature that does not verify against the AID's key state
- a revoked attestation

A break anywhere yields **no aliases**, not a partially-trusted list. An alias
nobody authorised is exactly the claim an attacker wants a resolver to repeat.

## A broken attestation does not break the DID

An attestation that fails to verify is reported through
`DesignatedAliases::rejected` and logged — it does not fail the resolution. The
key material is still sound, and refusing to resolve would turn a malformed
attestation into a denial of service on the identifier.

## Two tests that could not be written by tampering

Every KERI event is bound to its own SAID, so altering an anchor breaks the
event carrying it and the whole key event log fails **first** — you never reach
the condition you meant to test. Isolating one link means *removing* a message,
which is what the test helper does.

That helper also can't match on the first `"d":"<said>"` in the stream: a SAID
appears in the seals that anchor it as well as in the message itself, and for a
registry id the first hit is the KEL event doing the anchoring. Removing that
instead breaks the KEL. So each message range is examined and only its own `d`
is compared.

## This uncovered a parser defect

Building the revocation test is what surfaced
affinidi/affinidi-keri-rs#6: a message could take its declared length from a
**different** message in the stream, so an ACDC followed by any later key event
mis-parsed. A revocation event after a credential is exactly that shape.

Fixed and released as `affinidi-keri-core` 0.3.2, which this requires.

## Still not verified, and documented as such

- **Witness receipts** are parsed but not required.
- **Credential schema validation** — the attestation is matched by its schema
  SAID and its issuance chain verified, but the body is not validated against
  the schema.
- **Service endpoints**, which come from KERI endpoint role authorisations.

## Versions

`affinidi-did-webs` 0.1.0 → **0.2.0** — breaking: `document_from_keys` takes the
verified aliases as a third argument. `affinidi-did-resolver-cache-sdk` 0.8.26 →
0.8.27 and `affinidi-tdk` 0.8.6 → 0.8.7, both for the requirement bump only.

## Verification

`cargo test -p affinidi-did-webs` — **35 passed** (19 unit, 16 conformance), up
from 29. clippy, `cargo fmt --check`, per-package builds,
`check-workspace-duplicates.sh`, `check-changelogs.sh` and
`check-version-bumps.sh` all clean.

Both publish-resolution checks will be red again, for the same reason as #723:
`affinidi-did-webs` **0.2.0** is not on crates.io yet, so its dependents cannot
resolve it. Its own dry-run passes. Unlike #723 this needs no manual publish —
the crate name exists now, so the release job can publish it.