### PR TITLE
feat(did-webs): require witness receipts when a KEL declares witnesses

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Affinidi DID Resolver Cache SDK## 0.8.28
+# Affinidi DID Resolver Cache SDK
+
+## 0.8.28
 
 ### Changed
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Affinidi DID Resolver Cache SDK
+# Affinidi DID Resolver Cache SDK## 0.8.28
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.3, which enforces
+  witness receipts when a key event log declares witnesses.
+
 ## 0.8.27
 
 ### Changed

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.27"
+version = "0.8.28"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ did-scid = { version = "0.1", optional = true, default-features = false, feature
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.2", path = "../did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.3", path = "../did-methods/did-webs", optional = true }
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-webs/CHANGELOG.md
+++ b/crates/identity/did-methods/did-webs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this crate are documented here.
 
+## [0.3.0] - 2026-08-23
+
+### Security
+
+- **Witness receipts are now required when a key event log declares them.** An
+  event naming backers and a threshold was accepted on controller signatures
+  alone, which discards exactly what witnessing exists to provide: a controller
+  that later equivocates cannot be caught if nobody had to witness the original.
+  `affinidi-keri-core` has verified receipts all along and direct mode used it —
+  this resolver simply never called it.
+
+  Receipts are collected both from the event's own attachments and from separate
+  `rct` messages naming it, since witnesses commonly receipt out of band. A KEL
+  with `bt: 0`, which is the common `did:webs` case, is unaffected.
+
 ## [0.2.0] - 2026-08-23
 
 ### Added

--- a/crates/identity/did-methods/did-webs/Cargo.toml
+++ b/crates/identity/did-methods/did-webs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-webs"
-version = "0.2.0"
+version = "0.3.0"
 description = "Implementation of the did:webs DID method: did:web discovery with KERI-verified key state"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-webs/README.md
+++ b/crates/identity/did-methods/did-webs/README.md
@@ -60,14 +60,16 @@ let doc = resolve_from_artifacts(&did, keri_cesr, Some(did_json))?;
   anchored, issuance anchored, attestation signed by the AID's key state, and
   not revoked. A break anywhere yields no aliases rather than a
   partially-trusted list.
+- **Witness receipts**, when the key event log declares witnesses. An event
+  whose own key state names backers and a threshold is only accepted once that
+  many designated witnesses have receipted it — from the event's attachments or
+  from separate `rct` messages. A KEL with `bt: 0` is unaffected.
 - The published `did.json`, against the derived key state: it must name this
   identifier (or its `did:web` twin) and publish exactly the keys the KEL
   authorised — no more and no fewer.
 
 ## What is not verified yet
 
-- **Witness receipts** are parsed but not required; a KEL is accepted on
-  controller signatures alone.
 - **Credential schema validation.** A designated-aliases attestation is matched
   by its schema SAID and its issuance chain is verified, but the credential body
   is not validated against the schema itself.

--- a/crates/identity/did-methods/did-webs/src/kel.rs
+++ b/crates/identity/did-methods/did-webs/src/kel.rs
@@ -18,7 +18,7 @@ use affinidi_keri_core::delegation::{DelegationProof, DelegatorAnchors};
 use affinidi_keri_core::error::CoreError;
 use affinidi_keri_core::kever::Kever;
 use affinidi_keri_core::key_state::KeyState;
-use affinidi_keri_core::parser::{self, ParsedMessage};
+use affinidi_keri_core::parser::{self, Attachment, ParsedMessage};
 use affinidi_keri_crypto::Verfer;
 
 use crate::errors::DidWebsError;
@@ -209,6 +209,7 @@ impl Kels {
         })?;
 
         let mut kever = self.incept(prefix, first)?;
+        self.require_witness_receipts(prefix, first, kever.state())?;
 
         for (n, msg) in events.enumerate() {
             let ilk = msg
@@ -229,10 +230,90 @@ impl Kels {
                     .verify_update(&msg.serder, sigs)
                     .map_err(|e| DidWebsError::Kel(format!("{prefix} event {}: {e}", n + 1)))?
             };
+            self.require_witness_receipts(prefix, msg, &state)?;
             kever.apply_verified_update(state);
         }
 
         Ok(kever.state().clone())
+    }
+
+    /// Enforce the witness threshold an event's own key state declares.
+    ///
+    /// A KEL that names witnesses and a threshold is saying it is only valid
+    /// when that many of them have receipted it. Accepting it on controller
+    /// signatures alone discards exactly the protection witnessing exists to
+    /// provide — a controller that later rotates cannot be caught equivocating
+    /// if nobody had to witness the original.
+    ///
+    /// Events with `bt: 0` (no witnesses) are unaffected, which is the common
+    /// case for `did:webs`.
+    fn require_witness_receipts(
+        &self,
+        prefix: &str,
+        msg: &ParsedMessage,
+        state: &KeyState,
+    ) -> Result<(), DidWebsError> {
+        if state.backer_threshold == 0 {
+            return Ok(());
+        }
+
+        let couples = self.receipt_couples_for(msg);
+
+        Kever::verify_witness_receipts_static(
+            msg.serder.raw(),
+            &couples,
+            &state.backers,
+            state.backer_threshold,
+        )
+        .map_err(|e| {
+            DidWebsError::Kel(format!(
+                "{prefix} event at sn {} declares {} of {} witnesses but {e}",
+                state.sn,
+                state.backer_threshold,
+                state.backers.len(),
+            ))
+        })
+    }
+
+    /// Every witness receipt couple that applies to `msg`.
+    ///
+    /// Receipts reach a stream two ways: attached to the event itself, or as
+    /// separate `rct` messages naming it. Both count, so both are collected —
+    /// looking only at the attachments would reject a KEL whose witnesses
+    /// receipted it out of band, which is the usual arrangement.
+    fn receipt_couples_for(&self, msg: &ParsedMessage) -> Vec<(String, Vec<u8>)> {
+        let mut couples: Vec<(String, Vec<u8>)> = msg
+            .attachments
+            .iter()
+            .filter_map(|a| match a {
+                Attachment::ReceiptCouples(c) => Some(c.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        let (Ok(said), Ok(prefix), Ok(sn)) =
+            (msg.serder.said(), msg.serder.prefix(), msg.serder.sn())
+        else {
+            return couples;
+        };
+
+        for rct in self.messages_with_ilk("rct") {
+            let sad = rct.serder.sad();
+            let names_event = sad.get("d").and_then(|v| v.as_str()) == Some(said.as_str())
+                && sad.get("i").and_then(|v| v.as_str()) == Some(prefix.as_str())
+                && sad.get("s").and_then(|v| v.as_str()) == Some(format!("{sn:x}").as_str());
+            if !names_event {
+                continue;
+            }
+            for att in &rct.attachments {
+                if let Attachment::ReceiptCouples(c) = att {
+                    couples.extend(c.iter().cloned());
+                }
+            }
+        }
+
+        couples
     }
 
     /// Build the initial key state from an inception or delegated inception.

--- a/crates/identity/did-methods/did-webs/tests/witnesses.rs
+++ b/crates/identity/did-methods/did-webs/tests/witnesses.rs
@@ -1,0 +1,180 @@
+//! A key event log that declares witnesses is only valid once enough of them
+//! have receipted it.
+//!
+//! The published conformance artifact has `bt: 0` and no witnesses, so this is
+//! built here with real keys and real signatures rather than taken from a
+//! fixture. Everything is genuine except the transport.
+
+use affinidi_cesr::Counter;
+use affinidi_did_webs::{DidWebs, Kels, resolve_from_artifacts};
+use affinidi_keri_core::said;
+use affinidi_keri_core::serder::Serder;
+use affinidi_keri_core::version::SerializationKind;
+use affinidi_keri_crypto::Signer;
+use serde_json::json;
+
+fn signer(seed: u8, transferable: bool) -> Signer {
+    let code = "A";
+    let s = Signer::new(code, [seed; 32].to_vec()).expect("signer");
+    assert!(
+        transferable || s.verfer().qb64().is_ok(),
+        "signer construction"
+    );
+    s
+}
+
+/// Fix the `v` size before computing the SAID, so the SAID covers the bytes
+/// the event is actually serialized as.
+fn fix_version(sad: &mut serde_json::Value) {
+    let placeholder = "#".repeat(44);
+    let (d, i) = (sad["d"].clone(), sad["i"].clone());
+    let self_addressing = d == i;
+    sad["d"] = json!(placeholder);
+    if self_addressing {
+        sad["i"] = json!(placeholder);
+    }
+    let len = serde_json::to_vec(sad).expect("serialize").len();
+    sad["v"] = json!(format!("KERI10JSON{len:06x}_"));
+    sad["d"] = d;
+    sad["i"] = i;
+}
+
+/// An inception naming `witness` as a backer with threshold 1.
+fn witnessed_inception(controller: &Signer, next: &Signer, witness_prefix: &str) -> Serder {
+    let next_digest =
+        affinidi_keri_crypto::Diger::from_data("E", next.verfer().qb64().expect("qb64").as_bytes())
+            .expect("digest")
+            .qb64()
+            .expect("qb64");
+
+    let mut sad = json!({
+        "v": "KERI10JSON000000_",
+        "t": "icp",
+        "d": "",
+        "i": "",
+        "s": "0",
+        "kt": "1",
+        "k": [controller.verfer().qb64().expect("qb64")],
+        "nt": "1",
+        "n": [next_digest],
+        "bt": "1",
+        "b": [witness_prefix],
+        "c": [],
+        "a": [],
+    });
+    fix_version(&mut sad);
+    said::compute_said(&mut sad, "d", "E", SerializationKind::Json).expect("said");
+    Serder::new(SerializationKind::Json, sad).expect("serder")
+}
+
+/// Serialize the event with controller signatures, and optionally a witness
+/// receipt couple, using the KERI 1.x counter codes.
+fn stream(serder: &Serder, controller: &Signer, witness: Option<&Signer>) -> Vec<u8> {
+    let mut out = serder.raw().to_vec();
+
+    let sig = controller
+        .sign_indexed(serder.raw(), 0, true)
+        .expect("sign")
+        .qb64()
+        .expect("qb64");
+    // `-A` is controller indexed signatures in the 1.x table.
+    out.extend_from_slice(
+        Counter::new("-A", 1)
+            .expect("counter")
+            .qb64()
+            .expect("qb64")
+            .as_bytes(),
+    );
+    out.extend_from_slice(sig.as_bytes());
+
+    if let Some(w) = witness {
+        // `-C` is non-transferable receipt couples in the 1.x table.
+        out.extend_from_slice(
+            Counter::new("-C", 1)
+                .expect("counter")
+                .qb64()
+                .expect("qb64")
+                .as_bytes(),
+        );
+        out.extend_from_slice(w.verfer().qb64().expect("qb64").as_bytes());
+        out.extend_from_slice(
+            w.sign(serder.raw())
+                .expect("sign")
+                .qb64()
+                .expect("qb64")
+                .as_bytes(),
+        );
+    }
+
+    out
+}
+
+fn parts() -> (Signer, Signer, Signer) {
+    // The witness is non-transferable: its prefix *is* its public key, which is
+    // what lets a receipt be checked without resolving the witness first.
+    (signer(1, true), signer(2, true), signer(3, false))
+}
+
+#[test]
+fn a_witnessed_kel_verifies_when_the_receipt_is_present() {
+    let (controller, next, witness) = parts();
+    let witness_prefix = witness.verfer().qb64().expect("qb64");
+    let icp = witnessed_inception(&controller, &next, &witness_prefix);
+
+    let bytes = stream(&icp, &controller, Some(&witness));
+    let kels = Kels::parse(&bytes).expect("parses");
+    let state = kels
+        .key_state(&icp.prefix().expect("prefix"))
+        .expect("a receipted witnessed KEL must verify");
+
+    assert_eq!(state.backer_threshold, 1);
+    assert_eq!(state.backers, vec![witness_prefix]);
+}
+
+#[test]
+fn a_witnessed_kel_without_its_receipt_is_refused() {
+    let (controller, next, witness) = parts();
+    let icp = witnessed_inception(&controller, &next, &witness.verfer().qb64().expect("qb64"));
+
+    // Correctly signed by the controller, and complete in every other way —
+    // the only thing missing is the witnessing the KEL itself demands.
+    let bytes = stream(&icp, &controller, None);
+    let kels = Kels::parse(&bytes).expect("parses");
+
+    let err = kels
+        .key_state(&icp.prefix().expect("prefix"))
+        .expect_err("an unwitnessed event must not establish key state");
+    assert!(err.to_string().contains("witness"), "{err}");
+}
+
+#[test]
+fn a_receipt_from_an_undesignated_witness_does_not_count() {
+    let (controller, next, witness) = parts();
+    let icp = witnessed_inception(&controller, &next, &witness.verfer().qb64().expect("qb64"));
+
+    // Someone else receipts it. They are not in the backer list, so the
+    // threshold is still unmet.
+    let impostor = signer(9, false);
+    let bytes = stream(&icp, &controller, Some(&impostor));
+    let kels = Kels::parse(&bytes).expect("parses");
+
+    assert!(
+        kels.key_state(&icp.prefix().expect("prefix")).is_err(),
+        "a receipt from an undesignated witness must not satisfy the threshold",
+    );
+}
+
+#[test]
+fn resolution_refuses_an_unwitnessed_did() {
+    let (controller, next, witness) = parts();
+    let icp = witnessed_inception(&controller, &next, &witness.verfer().qb64().expect("qb64"));
+    let aid = icp.prefix().expect("prefix");
+
+    let did = DidWebs::parse(&format!("did:webs:example.com:{aid}")).expect("valid did");
+    let bytes = stream(&icp, &controller, None);
+
+    assert!(
+        resolve_from_artifacts(&did, &bytes, None).is_err(),
+        "resolution must not return a document for a KEL missing its witnessing",
+    );
+}

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -9,6 +9,11 @@ For the full code history see `git log` on `crates/tdk/affinidi-tdk`.## 0.8.7
 ### Changed
 
 - `did-webs` feature now re-exports `affinidi-did-webs` 0.2.
+## 0.8.8
+
+### Changed
+
+- `did-webs` feature now re-exports `affinidi-did-webs` 0.3.
 
 ## 0.8.6
 

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-For the full code history see `git log` on `crates/tdk/affinidi-tdk`.## 0.8.7
+For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
+
+## 0.8.7
 
 ### Changed
 

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.7"
+version = "0.8.8"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 # DID methods
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.2", path = "../../identity/did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.3", path = "../../identity/did-methods/did-webs", optional = true }
 did-scid = { version = "0.1", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP


### PR DESCRIPTION
An event whose own key state names backers and a threshold was accepted on
controller signatures alone.

That discards exactly what witnessing exists to provide: a controller who later
equivocates cannot be caught if nobody had to witness the original. A KEL that
declares witnesses is *saying* it is only valid once enough of them have
receipted it, and we were ignoring that.

`affinidi-keri-core` has verified receipts all along, and direct mode calls it.
This resolver simply never did.

## What is enforced

For every event, if the key state that event establishes has `bt > 0`, enough
receipts from **designated** backers must verify against the event bytes. The
threshold is checked against the state the event itself establishes, matching
direct mode — a rotation that changes the witness set is judged by its new set,
not the old one.

Receipts are gathered from **both** the event's own attachments and any separate
`rct` messages naming it. Witnesses commonly receipt out of band, so looking
only at attachments would reject a correctly witnessed KEL.

A KEL with `bt: 0` — the common `did:webs` case, including the published
conformance artifact — is unaffected.

## Tests

The published artifact has no witnesses, so these build a witnessed KEL with
real keys and real signatures. Everything is genuine except the transport.

| test | asserts |
|---|---|
| `a_witnessed_kel_verifies_when_the_receipt_is_present` | the happy path establishes key state |
| `a_witnessed_kel_without_its_receipt_is_refused` | correctly controller-signed, but unwitnessed, is refused |
| `a_receipt_from_an_undesignated_witness_does_not_count` | a receipt from someone outside the backer list does not satisfy the threshold |
| `resolution_refuses_an_unwitnessed_did` | no document is returned for any of the above |

The witness is deliberately non-transferable: its prefix *is* its public key,
which is what lets a receipt be checked without resolving the witness first.

## Versions

`affinidi-did-webs` 0.2.0 → **0.3.0** (behavioural: KELs that were accepted are
now refused), `affinidi-did-resolver-cache-sdk` 0.8.27 → 0.8.28, `affinidi-tdk`
0.8.7 → 0.8.8.

## Verification

`cargo test -p affinidi-did-webs` — **39 passed** (19 unit, 16 conformance, 4
witness), up from 35. clippy, `cargo fmt --check`,
`check-workspace-duplicates.sh`, `check-changelogs.sh` and
`check-version-bumps.sh` all clean.

Expect the two publish-resolution checks to be red until `affinidi-did-webs`
0.3.0 is on crates.io, as with #723 and #734. No manual publish needed — the
crate name exists.