### PR TITLE
feat(did-scid): add did:scid:ke:1 — KERI AIDs via did:webs

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Affinidi DID Resolver Cache SDK
+## 0.8.29
+
+### Changed
+
+- `did-scid` feature now requires `did-scid` 0.2, which adds `did:scid:ke:1`
+  (KERI AIDs via `did:webs`) and reports an unresolvable format by name.
 
 ## 0.8.28
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.28"
+version = "0.8.29"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -64,7 +64,7 @@ did-example = { version = "0.5", optional = true }
 # `default-features = false` keeps did-scid's own optional `did-cheqd` backend
 # (and its `tonic`/`ring` TLS stack) out of this SDK's default build; pulling
 # `did-cheqd` here re-enables it deliberately.
-did-scid = { version = "0.1", optional = true, default-features = false, features = [
+did-scid = { version = "0.2", optional = true, default-features = false, features = [
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,37 @@
 # did:scid
 
+## 0.2.0
+
+### Added
+
+- **`did:scid:ke:1` — KERI AIDs via `did:webs`**, behind a new `did-webs`
+  feature so the KERI stack stays out of builds that never resolve it.
+
+  ⚠️ The method type registry (Appendix A of the specification) is still marked
+  TODO and lists `ke` as a **proposed** entry, not a registered one. It is
+  implemented because did:webs is named explicitly as a supported verification
+  metadata format, but the code could change before the registry settles.
+
+  Note the SCID's position differs by format: `did:webvh` puts it first,
+  `did:webs` puts the AID **last**, because the AID is the final path element of
+  the URL its artifacts are served from. Reusing the webvh formatting would
+  produce a well-formed DID pointing at the wrong location, so the two are
+  derived separately and a test pins both.
+
+- `DIDSCIDError::UnknownFormat` and `DIDSCIDError::UnsupportedVersion`.
+
+### Changed
+
+- **Breaking:** the DID pattern now captures the format and version instead of
+  hard-coding `vh:1`, so a well-formed `did:scid` naming an unresolvable format
+  reports `UnknownFormat("...")` by name. It previously returned
+  `UnsupportedFormat`, indistinguishable from a string that is not a `did:scid`
+  at all.
+- **Breaking:** `ScidMethod` gains a `Webs` variant and is now
+  `#[non_exhaustive]`, since the registry is still open.
+- A peer source for one format is no longer accepted for another. They place the
+  SCID differently, so crossing them resolved to the wrong location.
+
 ## 2nd August 2026 (0.1.13)
 
 `ssi-dids-core` becomes an optional dependency, enabled by `did-cheqd` —

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.1.13"
+version = "0.2.0"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -25,6 +25,9 @@ default = ["did-webvh"]
 
 did-cheqd = ["dep:did-resolver-cheqd", "dep:ssi-dids-core"]
 did-webvh = ["dep:didwebvh-rs"]
+# did:scid:ke — a KERI AID via did:webs. Optional so did-scid does not pull the
+# KERI stack into builds that never resolve it.
+did-webs = ["dep:affinidi-did-webs"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -32,6 +35,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
+affinidi-did-webs = { version = "0.3", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"

--- a/crates/identity/did-methods/did-scid/README.md
+++ b/crates/identity/did-methods/did-scid/README.md
@@ -23,14 +23,32 @@ did-scid = "0.1"
 | Feature | Default | Description |
 |---|---|---|
 | `did-webvh` | Yes | Verifiable History via WebVH |
+| `did-webs` | No | KERI AIDs via did:webs (`did:scid:ke:1`) |
 | `did-cheqd` | Yes | Verifiable History via Cheqd |
 
 ## Capabilities
 
-- `did:scid:vh` — Verifiable History support
+- `did:scid:vh:1` — Verifiable History
   - WebVH backend
   - Cheqd backend
+- `did:scid:ke:1` — a KERI AID via did:webs (requires the `did-webs` feature)
 - Peer-level `did:scid` implementations
+
+> ⚠️ The did:scid method type registry (Appendix A of the specification) is
+> still marked TODO, and `ke` is listed there as a **proposed** entry rather
+> than a registered one. It is implemented because did:webs is named explicitly
+> as a supported verification metadata format, but the code could change before
+> the registry is settled.
+
+### The SCID sits in a different place per format
+
+`did:webvh` puts the SCID **first**; `did:webs` puts the AID **last**, because
+the AID is the final path element of the URL its artifacts are served from:
+
+```text
+did:scid:vh:1:<scid>?src=example.com/dids  ->  did:webvh:<scid>:example.com:dids
+did:scid:ke:1:<aid>?src=example.com/dids   ->  did:webs:example.com:dids:<aid>
+```
 
 ## Specification
 

--- a/crates/identity/did-methods/did-scid/src/errors.rs
+++ b/crates/identity/did-methods/did-scid/src/errors.rs
@@ -4,6 +4,20 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum DIDSCIDError {
+    /// A `did:webs` resolution failed.
+    #[error("did:webs error: {0}")]
+    WebsError(String),
+
+    /// The DID names a `did:scid` format this implementation does not
+    /// resolve. Distinct from [`Self::UnsupportedFormat`], which means the
+    /// string is not a `did:scid` at all.
+    #[error("unknown did:scid format: {0}")]
+    UnknownFormat(String),
+
+    /// The DID names a format version this implementation does not resolve.
+    #[error("unsupported did:scid version: {0}")]
+    UnsupportedVersion(String),
+
     #[error("Unsupported format")]
     UnsupportedFormat,
     #[error("DID URL Error: {0}")]

--- a/crates/identity/did-methods/did-scid/src/lib.rs
+++ b/crates/identity/did-methods/did-scid/src/lib.rs
@@ -1,7 +1,15 @@
 /*! Implementation of the `did:scid` (Self-Certifying Identifier) DID method.
  *
- * Supported sub-methods:
+ * Supported formats:
  *   - `did:scid:vh:1` — Verifiable History via did:webvh or did:cheqd
+ *   - `did:scid:ke:1` — a KERI AID via did:webs (requires the `did-webs`
+ *     feature)
+ *
+ * ⚠️ The did:scid method type registry (Appendix A of the specification) is
+ * still marked TODO, and `ke` is listed there as a *proposed* entry rather
+ * than a registered one. It is implemented here because did:webs is named
+ * explicitly as a supported verification metadata format, but the code could
+ * still change before the registry is settled.
  *
  * Two invocation modes are supported:
  *   - **URL mode**: `did:scid:vh:1:<scid>?src=<source>` — the `src` parameter
@@ -31,12 +39,26 @@ use tracing::{debug, error};
 
 pub mod errors;
 
-static SCID_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^did:scid:vh:1:([^\?]*)(?:\?src=(.*))?$").unwrap());
+/// `did:scid:<format>:<version>:<scid>[?src=<source>]`
+///
+/// The format name is two characters by convention and the version is one or
+/// more digits; both are captured rather than hard-coded so an unknown format
+/// produces a clear error instead of failing to match at all.
+static SCID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^did:scid:([a-z0-9]+):([0-9]+):([^\?]*)(?:\?src=(.*))?$").unwrap()
+});
 
+/// The verification metadata format a `did:scid` resolves through.
+///
+/// `#[non_exhaustive]`: the did:scid method type registry is still open — see
+/// the note on [`resolve`] — so more formats are expected.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum ScidMethod {
     WebVH(String),
+
+    /// `did:webs` — a KERI AID with its key event log published on the web.
+    Webs(String),
 
     #[cfg(feature = "did-cheqd")]
     Cheqd(String),
@@ -81,6 +103,7 @@ pub async fn resolve(
                     }
                 }
             }
+            ScidMethod::Webs(webs_did) => resolve_webs(&webs_did).await,
             #[cfg(feature = "did-cheqd")]
             ScidMethod::Cheqd(cheqd_did) => {
                 use did_resolver_cheqd::DIDCheqd;
@@ -121,12 +144,40 @@ fn derive_cheqd_url(src: &str, scid: &str) -> Result<ScidMethod, DIDSCIDError> {
     Ok(ScidMethod::Cheqd(cheqd))
 }
 
+/// Resolve a derived `did:webs` DID.
+#[cfg(feature = "did-webs")]
+async fn resolve_webs(webs_did: &str) -> Result<Document, DIDSCIDError> {
+    debug!("Resolving Webs DID: {webs_did}");
+    affinidi_did_webs::resolve(webs_did).await.map_err(|e| {
+        error!("did:webs resolution error: {e:?}");
+        DIDSCIDError::WebsError(e.to_string())
+    })
+}
+
+/// `did-webs` is optional so that `did-scid` does not pull the KERI stack into
+/// builds that never resolve `did:scid:ke`. Without the feature the format is
+/// still parsed — so the error says what is missing rather than looking like a
+/// malformed DID.
+#[cfg(not(feature = "did-webs"))]
+async fn resolve_webs(_webs_did: &str) -> Result<Document, DIDSCIDError> {
+    Err(DIDSCIDError::WebsError(
+        "did:scid:ke resolution requires the `did-webs` feature".to_string(),
+    ))
+}
+
 #[cfg(not(feature = "did-cheqd"))]
 fn derive_cheqd_url(_src: &str, _scid: &str) -> Result<ScidMethod, DIDSCIDError> {
     Err(DIDSCIDError::CheqdError(
         "did:cheqd source requires the `did-cheqd` feature".to_string(),
     ))
 }
+
+/// The did:scid format names this implementation understands.
+///
+/// Two characters by convention, per the specification. `vh` is did:webvh; `ke`
+/// is did:webs.
+const FORMAT_WEBVH: &str = "vh";
+const FORMAT_WEBS: &str = "ke";
 
 /// Converts a SCID DID to a valid Method DID Identifier
 /// peer_src: Optional meta_data if operating in peer mode
@@ -138,9 +189,30 @@ fn convert_scid_to_method(
         return Err(DIDSCIDError::UnsupportedFormat);
     };
 
-    let scid = &caps[1];
+    let format = &caps[1];
+    let version = &caps[2];
+    let scid = &caps[3];
 
-    if let Some(src) = caps.get(2).map(|m| m.as_str()) {
+    if version != "1" {
+        return Err(DIDSCIDError::UnsupportedVersion(format!(
+            "format {format:?} version {version:?}"
+        )));
+    }
+
+    match format {
+        FORMAT_WEBVH => convert_webvh(scid, caps.get(4).map(|m| m.as_str()), peer_src),
+        FORMAT_WEBS => convert_webs(scid, caps.get(4).map(|m| m.as_str()), peer_src),
+        other => Err(DIDSCIDError::UnknownFormat(other.to_string())),
+    }
+}
+
+/// `did:scid:vh:1:<scid>` — did:webvh, or did:cheqd via a DID-valued source.
+fn convert_webvh(
+    scid: &str,
+    src: Option<&str>,
+    peer_src: Option<ScidMethod>,
+) -> Result<ScidMethod, DIDSCIDError> {
+    if let Some(src) = src {
         if src.starts_with("did:cheqd:") {
             derive_cheqd_url(src, scid)
         } else if src.starts_with("did:") {
@@ -166,9 +238,52 @@ fn convert_scid_to_method(
                 debug!("derived peer cheqd DID: {cheqd}");
                 Ok(ScidMethod::Cheqd(cheqd))
             }
+            Some(other) => Err(DIDSCIDError::InvalidSrc(format!(
+                "did:scid:vh cannot resolve through {other:?}"
+            ))),
             None => Err(DIDSCIDError::MissingPeerSource),
         }
     }
+}
+
+/// `did:scid:ke:1:<AID>` — did:webs.
+///
+/// ⚠️ The SCID lands in a **different position** than it does for did:webvh.
+/// `did:webvh` puts it first (`did:webvh:<scid>:<host>:<path>`), while
+/// `did:webs` puts the AID **last** (`did:webs:<host>:<path>:<AID>`), because
+/// the AID is the final path element of the URL the artifacts are served from.
+/// Reusing the webvh formatting here would silently produce a DID that
+/// resolves to the wrong location.
+fn convert_webs(
+    scid: &str,
+    src: Option<&str>,
+    peer_src: Option<ScidMethod>,
+) -> Result<ScidMethod, DIDSCIDError> {
+    let source = match (src, peer_src) {
+        (Some(src), _) => {
+            if src.starts_with("did:") {
+                // A DID-valued source names a method that stores the
+                // verification metadata. did:webs stores it on the web, so a
+                // DID source is not meaningful for this format.
+                return Err(DIDSCIDError::UnsupportedFormat);
+            }
+            src.to_string()
+        }
+        (None, Some(ScidMethod::Webs(src))) => src,
+        (None, Some(other)) => {
+            return Err(DIDSCIDError::InvalidSrc(format!(
+                "did:scid:ke cannot resolve through {other:?}"
+            )));
+        }
+        (None, None) => return Err(DIDSCIDError::MissingPeerSource),
+    };
+
+    // The tail encoding is the same as did:webvh's — host with `%3A`-encoded
+    // port, path segments joined by `:` — only the SCID's position differs.
+    let tail = normalize_webvh_src(&source)?;
+    let webs = format!("did:webs:{tail}:{scid}");
+    debug!("derived webs DID: {webs}");
+    Ok(ScidMethod::Webs(webs))
 }
 
 /// Normalises a WebVH `src` (URL-style or partial) into a did:webvh method tail.
@@ -234,7 +349,9 @@ fn normalize_webvh_src(src: &str) -> Result<String, DIDSCIDError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{convert_scid_to_method, errors::DIDSCIDError, normalize_webvh_src, resolve};
+    use crate::{
+        ScidMethod, convert_scid_to_method, errors::DIDSCIDError, normalize_webvh_src, resolve,
+    };
 
     // -- normalize_webvh_src ------------------------------------------------
 
@@ -374,6 +491,120 @@ mod tests {
         }
     }
 
+    // -- did:scid:ke (did:webs) --------------------------------------------
+
+    const AID: &str = "ENro7uf0ePmiK3jdTo2YCdXLqW7z7xoP6qhhBou6gBLe";
+
+    #[test]
+    fn webs_puts_the_scid_last_not_first() {
+        // The trap this test exists for: did:webvh puts the SCID FIRST, while
+        // did:webs puts the AID LAST, because the AID is the final path
+        // element of the URL the artifacts are served from. Reusing the webvh
+        // formatting would produce a DID that resolves to the wrong location
+        // while looking perfectly well-formed.
+        match convert_scid_to_method(&format!("did:scid:ke:1:{AID}?src=example.com/dids"), None) {
+            Ok(ScidMethod::Webs(did)) => {
+                assert_eq!(did, format!("did:webs:example.com:dids:{AID}"));
+            }
+            other => panic!("Incorrect conversion: {other:?}"),
+        }
+
+        // Same inputs through the vh format, for contrast.
+        match convert_scid_to_method(&format!("did:scid:vh:1:{AID}?src=example.com/dids"), None) {
+            Ok(ScidMethod::WebVH(did)) => {
+                assert_eq!(did, format!("did:webvh:{AID}:example.com:dids"));
+            }
+            other => panic!("Incorrect conversion: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn webs_encodes_the_port_in_the_host() {
+        match convert_scid_to_method(&format!("did:scid:ke:1:{AID}?src=localhost:3000/x"), None) {
+            Ok(ScidMethod::Webs(did)) => {
+                assert_eq!(did, format!("did:webs:localhost%3A3000:x:{AID}"));
+            }
+            other => panic!("Incorrect conversion: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn webs_peer_mode_uses_the_supplied_source() {
+        match convert_scid_to_method(
+            &format!("did:scid:ke:1:{AID}"),
+            Some(ScidMethod::Webs("example.com".to_string())),
+        ) {
+            Ok(ScidMethod::Webs(did)) => assert_eq!(did, format!("did:webs:example.com:{AID}")),
+            other => panic!("Incorrect conversion: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn webs_rejects_a_did_valued_source() {
+        // A DID source names a method that stores the verification metadata.
+        // did:webs stores it on the web, so a DID source means nothing here.
+        assert!(matches!(
+            convert_scid_to_method(&format!("did:scid:ke:1:{AID}?src=did:cheqd:mainnet"), None),
+            Err(DIDSCIDError::UnsupportedFormat),
+        ));
+    }
+
+    #[test]
+    fn webs_without_a_source_needs_peer_mode() {
+        assert!(matches!(
+            convert_scid_to_method(&format!("did:scid:ke:1:{AID}"), None),
+            Err(DIDSCIDError::MissingPeerSource),
+        ));
+    }
+
+    #[test]
+    fn formats_do_not_borrow_each_others_peer_sources() {
+        // A webvh peer source must not satisfy a ke DID, or vice versa: they
+        // place the SCID differently, so crossing them yields a wrong location.
+        assert!(
+            convert_scid_to_method(
+                &format!("did:scid:ke:1:{AID}"),
+                Some(ScidMethod::WebVH("example.com".to_string())),
+            )
+            .is_err()
+        );
+        assert!(
+            convert_scid_to_method(
+                &format!("did:scid:vh:1:{AID}"),
+                Some(ScidMethod::Webs("example.com".to_string())),
+            )
+            .is_err()
+        );
+    }
+
+    // -- format and version handling ---------------------------------------
+
+    #[test]
+    fn unknown_formats_say_so() {
+        // `jl` (did:jlinc) is in the registry as a proposed entry but is not
+        // implemented. The error should name the format rather than claim the
+        // DID is malformed.
+        let err = convert_scid_to_method(&format!("did:scid:jl:1:{AID}?src=example.com"), None)
+            .expect_err("jl is not implemented");
+        assert!(err.to_string().contains("jl"), "{err}");
+    }
+
+    #[test]
+    fn unsupported_versions_say_so() {
+        assert!(matches!(
+            convert_scid_to_method(&format!("did:scid:vh:2:{AID}?src=example.com"), None),
+            Err(DIDSCIDError::UnsupportedVersion(_)),
+        ));
+    }
+
+    #[test]
+    fn a_missing_version_is_not_a_did_scid() {
+        assert!(matches!(
+            convert_scid_to_method(&format!("did:scid:vh:{AID}?src=example.com"), None),
+            Err(DIDSCIDError::UnsupportedFormat),
+        ));
+    }
+
     // -- prefix tightening / robustness ------------------------------------
 
     #[test]
@@ -452,9 +683,12 @@ mod tests {
 
     #[test]
     fn test_bad_id() {
+        // A well-formed did:scid naming a format we do not resolve now reports
+        // the format by name. It used to be indistinguishable from a string
+        // that is not a did:scid at all.
         match convert_scid_to_method("did:scid:invalid:1:abcde?src=did:example:abcd", None) {
-            Err(DIDSCIDError::UnsupportedFormat) => {}
-            _ => panic!("Incorrect conversion"),
+            Err(DIDSCIDError::UnknownFormat(f)) => assert_eq!(f, "invalid"),
+            other => panic!("Incorrect conversion: {other:?}"),
         }
     }
 

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate are documented here. The format follows
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
+## 0.8.9
+
+### Changed
+
+- `did-scid` feature now re-exports `did-scid` 0.2.
 
 ## 0.8.7
 

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.8"
+version = "0.8.9"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -86,7 +86,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
 affinidi-did-webs = { version = "0.3", path = "../../identity/did-methods/did-webs", optional = true }
-did-scid = { version = "0.1", path = "../../identity/did-methods/did-scid", optional = true }
+did-scid = { version = "0.2", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP
 affinidi-trust-lists = { version = "0.1", path = "../../trust/affinidi-trust-lists", optional = true }


### PR DESCRIPTION
The `did:scid` specification names `did:webs` as a supported verification
metadata format, under the format code `ke`. This resolves it.

## ⚠️ `ke` is proposed, not registered

Appendix A of the specification — the "did:scid Method Type Registry" — is
still marked **TODO**, and lists its entries as *proposed*:

> **TODO: Add did:scid method types (which of course need their own specs).**
> Proposed entries:
> - `did:scid:ke` — uses the did:webs verification metadata format.
> - `did:scid:vh` — uses the did:webvh verification metadata format.
> - `did:scid:jl` — uses did:jlinc verification metadata format.

No `ke` specification exists. It is implemented here because did:webs is named
explicitly as a supported format and the shape is unambiguous, but the code
could change before the registry settles. That caveat is in the crate docs, the
README and the CHANGELOG so nobody reads it as ratified.

Our existing `vh` support matches the proposed webvh entry, so this stays
consistent with the same source.

## The trap: the SCID sits in a different place per format

`did:webvh` puts the SCID **first**. `did:webs` puts the AID **last**, because
the AID is the final path element of the URL its artifacts are served from:

```text
did:scid:vh:1:<scid>?src=example.com/dids  ->  did:webvh:<scid>:example.com:dids
did:scid:ke:1:<aid>?src=example.com/dids   ->  did:webs:example.com:dids:<aid>
```

Reusing the webvh formatting would produce a **well-formed DID pointing at the
wrong location** — which resolves to nothing, or to somebody else. The two are
derived separately and `webs_puts_the_scid_last_not_first` pins both side by
side so the distinction cannot quietly collapse.

For the same reason, a peer source for one format is no longer accepted for the
other.

## Format and version handling

The DID pattern now captures the format and version rather than hard-coding
`vh:1`. A well-formed `did:scid` naming a format we do not resolve reports
`UnknownFormat("jl")` by name; previously it returned `UnsupportedFormat`,
indistinguishable from a string that is not a `did:scid` at all. Unsupported
versions likewise get `UnsupportedVersion`.

## Feature gating

`did:webs` resolution sits behind an optional `did-webs` feature, so `did-scid`
does not pull the KERI stack into builds that never resolve `did:scid:ke`. This
mirrors how `did-cheqd` is handled. Without the feature the format still
*parses*, and the error says what is missing rather than looking like a
malformed DID.

## Versions

`did-scid` 0.1.13 → **0.2.0** — `ScidMethod` gains a `Webs` variant and is now
`#[non_exhaustive]` (the registry is still open, so more formats are expected),
and the unknown-format error changes. `affinidi-did-resolver-cache-sdk` 0.8.28 →
0.8.29 and `affinidi-tdk` 0.8.8 → 0.8.9 for the requirement bump.

## Verification

`cargo test -p did-scid` — **29 passed**. clippy with `--features did-webs`,
`cargo fmt --check`, per-package builds, `affinidi-tdk --features did-methods`,
and all three repo guards clean.

The publish-resolution checks will be red until `did-scid` 0.2.0 is on
crates.io, as with the previous three. No manual publish needed.