### PR TITLE
feat(did-webs): derive service endpoints from signed KERI authorisations

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Affinidi DID Resolver Cache SDK
-## 0.8.29
+## 0.8.30
 
 ### Changed
 
+- `did-webs` feature now requires `affinidi-did-webs` 0.4, which derives service
+  endpoints from signed KERI endpoint authorisations.
 - `did-scid` feature now requires `did-scid` 0.2, which adds `did:scid:ke:1`
   (KERI AIDs via `did:webs`) and reports an unresolvable format by name.
 
@@ -122,7 +124,9 @@ called out here rather than encoded in the version — see R3.6 in CLAUDE.md.
 
 ## 23rd July 2026
 
-### 0.8.21 — `resolve_any` accepts a community name
+#
+
+## 0.8.21 — `resolve_any` accepts a community name
 
 `resolve_any("example.com/@")` now classifies as an agent name and resolves,
 where it previously failed as malformed. The agent name FAQ gives a name with

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.29"
+version = "0.8.30"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ did-scid = { version = "0.2", optional = true, default-features = false, feature
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.3", path = "../did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.4", path = "../did-methods/did-webs", optional = true }
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # did:scid
 
+## 0.2.1
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.4, which derives service
+  endpoints from signed KERI endpoint authorisations.
+
 ## 0.2.0
 
 ### Added
@@ -60,7 +67,9 @@ Crypto behaviour is unchanged — the golden/KAT vectors (`p256_sign_verify_roun
 
 ## 19th July 2026
 
-### 0.1.12 — didwebvh-rs 0.6
+#
+
+## 0.1.12 — didwebvh-rs 0.6
 
 - Bumped the `didwebvh-rs` requirement from `"0.5"` to `"0.6"`.
 

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.0"
+version = "0.2.1"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -35,7 +35,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
-affinidi-did-webs = { version = "0.3", optional = true }
+affinidi-did-webs = { version = "0.4", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"

--- a/crates/identity/did-methods/did-webs/CHANGELOG.md
+++ b/crates/identity/did-methods/did-webs/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this crate are documented here.
 
+## [0.4.0] - 2026-08-23
+
+### Added
+
+- **Service endpoints**, derived from signed KERI endpoint authorisations.
+  A `did:webs` document does not get to list whatever endpoints it likes, any
+  more than it gets to assert its own aliases. An endpoint is published only
+  when two signed `rpy` messages agree: `/end/role/add` from this AID
+  authorising an identifier in a role, and `/loc/scheme` from **that**
+  identifier saying where it is reachable.
+
+  Both halves are required. The first without the second is an authorisation
+  pointing nowhere; the second without the first is a stranger volunteering to
+  act on someone's behalf. `/end/role/cut` withdraws an authorisation, and
+  where the same subject is addressed more than once the latest `dt` wins — so
+  a stale `cut` replayed after an `add` does not take effect.
+
+  Signatures are checked both ways KERI identifiers come: a transferable
+  identifier signs with an indexed signature group verified against the key
+  state its own KEL establishes, while a non-transferable one — a witness,
+  typically — has its public key as its prefix, so a receipt couple is checked
+  directly.
+
+  Roles are not enumerated. KERI does not fix the set, and rejecting an unknown
+  role would drop endpoints we simply have not heard of.
+
+### Changed
+
+- **Breaking:** `document_from_keys` takes the derived services as a fourth
+  argument.
+
 ## [0.3.0] - 2026-08-23
 
 ### Security

--- a/crates/identity/did-methods/did-webs/Cargo.toml
+++ b/crates/identity/did-methods/did-webs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-webs"
-version = "0.3.0"
+version = "0.4.0"
 description = "Implementation of the did:webs DID method: did:web discovery with KERI-verified key state"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-webs/README.md
+++ b/crates/identity/did-methods/did-webs/README.md
@@ -64,6 +64,10 @@ let doc = resolve_from_artifacts(&did, keri_cesr, Some(did_json))?;
   whose own key state names backers and a threshold is only accepted once that
   many designated witnesses have receipted it — from the event's attachments or
   from separate `rct` messages. A KEL with `bt: 0` is unaffected.
+- **Service endpoints**, from signed KERI endpoint authorisations. An endpoint
+  appears only when two signed replies agree: `/end/role/add` from this AID
+  authorising an identifier in a role, and `/loc/scheme` from *that* identifier
+  saying where it is. `/end/role/cut` withdraws it, and the latest `dt` wins.
 - The published `did.json`, against the derived key state: it must name this
   identifier (or its `did:web` twin) and publish exactly the keys the KEL
   authorised — no more and no fewer.
@@ -73,8 +77,6 @@ let doc = resolve_from_artifacts(&did, keri_cesr, Some(did_json))?;
 - **Credential schema validation.** A designated-aliases attestation is matched
   by its schema SAID and its issuance chain is verified, but the credential body
   is not validated against the schema itself.
-- **Service endpoints**, which come from KERI endpoint role authorisations
-  rather than the KEL.
 
 ## Related crates
 

--- a/crates/identity/did-methods/did-webs/src/document.rs
+++ b/crates/identity/did-methods/did-webs/src/document.rs
@@ -7,7 +7,9 @@
 //! is not asserted here, because nothing in the KEL alone establishes it.
 
 use affinidi_cesr::Matter;
-use affinidi_did_common::{Document, DocumentBuilder, VerificationMethodBuilder};
+use affinidi_did_common::{
+    Document, DocumentBuilder, ServiceBuilder, VerificationMethodBuilder, service::Endpoint,
+};
 use serde_json::json;
 
 use crate::errors::DidWebsError;
@@ -26,6 +28,7 @@ pub fn document_from_keys(
     did: &DidWebs,
     keys: &[String],
     aliases: &[String],
+    services: &[crate::services::ServiceEndpoint],
 ) -> Result<Document, DidWebsError> {
     if keys.is_empty() {
         return Err(DidWebsError::Kel(
@@ -68,6 +71,18 @@ pub fn document_from_keys(
         builder = builder
             .assertion_method_reference(&vm_id)
             .map_err(|e| DidWebsError::Kel(format!("could not reference {vm_id}: {e}")))?;
+    }
+
+    // Services come from signed KERI endpoint authorisations, never from the
+    // published did.json — see `crate::services`.
+    for service in services {
+        let endpoint = Endpoint::Map(json!(service.urls));
+        let mut sb = ServiceBuilder::new(service.role.clone(), endpoint);
+        let id = format!("{controller}{}", service.id());
+        sb = sb
+            .id(&id)
+            .map_err(|e| DidWebsError::Kel(format!("could not build service {id}: {e}")))?;
+        builder = builder.service(sb.build());
     }
 
     Ok(builder.build())
@@ -126,7 +141,7 @@ mod tests {
 
     #[test]
     fn builds_a_document_for_an_ed25519_key() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[], &[]).expect("builds");
 
         assert_eq!(doc.id.as_str(), format!("did:webs:example.com:{AID}"));
         assert_eq!(doc.verification_method.len(), 1);
@@ -146,7 +161,7 @@ mod tests {
 
     #[test]
     fn records_the_did_web_twin() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[], &[]).expect("builds");
         let aka: Vec<&str> = doc.also_known_as.iter().map(String::as_str).collect();
         assert!(
             aka.contains(&format!("did:web:example.com:{AID}").as_str()),
@@ -156,25 +171,25 @@ mod tests {
 
     #[test]
     fn every_key_is_an_authentication_and_assertion_method() {
-        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[]).expect("builds");
+        let doc = document_from_keys(&did(), &[ED25519_KEY.to_string()], &[], &[]).expect("builds");
         assert_eq!(doc.authentication.len(), 1);
         assert_eq!(doc.assertion_method.len(), 1);
     }
 
     #[test]
     fn rejects_an_empty_key_state() {
-        assert!(document_from_keys(&did(), &[], &[]).is_err());
+        assert!(document_from_keys(&did(), &[], &[], &[]).is_err());
     }
 
     #[test]
     fn rejects_a_key_that_is_not_a_cesr_primitive() {
-        assert!(document_from_keys(&did(), &["not-a-key".to_string()], &[]).is_err());
+        assert!(document_from_keys(&did(), &["not-a-key".to_string()], &[], &[]).is_err());
     }
 
     #[test]
     fn rejects_a_non_key_cesr_primitive() {
         // A digest is a valid CESR primitive but not a public key: it must not
         // silently become a verification method.
-        assert!(document_from_keys(&did(), &[AID.to_string()], &[]).is_err());
+        assert!(document_from_keys(&did(), &[AID.to_string()], &[], &[]).is_err());
     }
 }

--- a/crates/identity/did-methods/did-webs/src/lib.rs
+++ b/crates/identity/did-methods/did-webs/src/lib.rs
@@ -22,6 +22,7 @@ pub mod fetch;
 pub mod identifier;
 pub mod kel;
 pub mod resolver;
+pub mod services;
 
 pub use aliases::{DesignatedAliases, designated_aliases};
 pub use errors::DidWebsError;
@@ -29,3 +30,4 @@ pub use fetch::{WebsResolver, resolve};
 pub use identifier::{DID_JSON, DidWebs, KERI_CESR};
 pub use kel::Kels;
 pub use resolver::resolve_from_artifacts;
+pub use services::{ServiceEndpoint, service_endpoints};

--- a/crates/identity/did-methods/did-webs/src/resolver.rs
+++ b/crates/identity/did-methods/did-webs/src/resolver.rs
@@ -15,6 +15,7 @@ use crate::document::document_from_keys;
 use crate::errors::DidWebsError;
 use crate::identifier::DidWebs;
 use crate::kel::Kels;
+use crate::services::service_endpoints;
 
 /// Resolve a `did:webs` identifier from artifacts already fetched.
 ///
@@ -54,7 +55,10 @@ pub fn resolve_from_artifacts(
         warn!("{}: designated aliases not used: {reason}", did.did());
     }
 
-    let document = document_from_keys(did, &state.keys, &designated.aliases)?;
+    // Endpoints, like aliases, are only what the AID itself signed for.
+    let services = service_endpoints(&kels, did.aid())?;
+
+    let document = document_from_keys(did, &state.keys, &designated.aliases, &services)?;
 
     if let Some(published) = did_json {
         let published: Value = serde_json::from_slice(published)?;

--- a/crates/identity/did-methods/did-webs/src/services.rs
+++ b/crates/identity/did-methods/did-webs/src/services.rs
@@ -1,0 +1,228 @@
+//! Service endpoints, derived from signed KERI endpoint authorisations.
+//!
+//! A `did:webs` document does not get to list whatever endpoints it likes, any
+//! more than it gets to assert its own aliases. An endpoint appears only when
+//! two signed `rpy` messages agree:
+//!
+//! ```text
+//! /end/role/add   signed by THIS AID    "I authorise <eid> in role <role>"
+//! /loc/scheme     signed by <eid>       "I am reachable at <url> over <scheme>"
+//! ```
+//!
+//! Both halves are required. The first without the second is an authorisation
+//! pointing nowhere; the second without the first is a stranger volunteering to
+//! act on someone's behalf. Neither is published.
+//!
+//! `/end/role/cut` withdraws an authorisation. Where the same subject is
+//! addressed more than once the latest `dt` wins, which is how KERI reply
+//! messages supersede one another.
+
+use std::collections::BTreeMap;
+
+use affinidi_keri_core::parser::{Attachment, ParsedMessage};
+use affinidi_keri_crypto::Verfer;
+use serde_json::Value;
+
+use crate::errors::DidWebsError;
+use crate::kel::Kels;
+
+/// A service endpoint authorised by an AID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceEndpoint {
+    /// The authorised identifier.
+    pub eid: String,
+    /// The role it was authorised in — `agent`, `controller`, `witness`,
+    /// `mailbox`, and so on. Not an enumeration: KERI does not fix the set,
+    /// and rejecting an unknown role would drop endpoints we simply have not
+    /// heard of.
+    pub role: String,
+    /// Scheme to URL, e.g. `http` -> `http://example.com:5642`.
+    pub urls: BTreeMap<String, String>,
+}
+
+impl ServiceEndpoint {
+    /// The document-relative id, matching the reference implementation's
+    /// `#<eid>/<role>` form.
+    pub fn id(&self) -> String {
+        format!("#{}/{}", self.eid, self.role)
+    }
+}
+
+/// One `/end/role/*` authorisation, kept with its timestamp so a later reply
+/// can supersede it.
+struct RoleRecord {
+    added: bool,
+    dt: String,
+}
+
+/// Collect the service endpoints `aid` has authorised.
+///
+/// # Errors
+/// Returns [`DidWebsError::Kel`] if `aid`'s own key event log does not verify.
+/// An authorisation that fails to verify is skipped, not fatal — one malformed
+/// reply must not cost an identifier its other endpoints.
+pub fn service_endpoints(kels: &Kels, aid: &str) -> Result<Vec<ServiceEndpoint>, DidWebsError> {
+    // Fails loudly: an authorisation signed by an unverified AID means nothing.
+    kels.key_state(aid)?;
+
+    let mut roles: BTreeMap<(String, String), RoleRecord> = BTreeMap::new();
+
+    for rpy in kels.messages_with_ilk("rpy") {
+        let sad = rpy.serder.sad();
+        let route = sad.get("r").and_then(Value::as_str).unwrap_or_default();
+        let added = match route {
+            "/end/role/add" => true,
+            "/end/role/cut" => false,
+            _ => continue,
+        };
+
+        let attrs = sad.get("a");
+        let (Some(cid), Some(role), Some(eid)) = (
+            attrs.and_then(|a| a.get("cid")).and_then(Value::as_str),
+            attrs.and_then(|a| a.get("role")).and_then(Value::as_str),
+            attrs.and_then(|a| a.get("eid")).and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+
+        // Only this AID's own authorisations. Without this check, anyone
+        // could authorise endpoints on anyone's behalf by putting a reply in
+        // the stream.
+        if cid != aid {
+            continue;
+        }
+        if !signed_by(kels, rpy, aid) {
+            continue;
+        }
+
+        let dt = sad
+            .get("dt")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let key = (role.to_string(), eid.to_string());
+
+        // Reply messages supersede by timestamp, so a `cut` older than the
+        // `add` it tries to withdraw does not take effect.
+        match roles.get(&key) {
+            Some(existing) if existing.dt >= dt => {}
+            _ => {
+                roles.insert(key, RoleRecord { added, dt });
+            }
+        }
+    }
+
+    let mut endpoints = Vec::new();
+    for ((role, eid), record) in roles {
+        if !record.added {
+            continue;
+        }
+        let urls = location_schemes(kels, &eid);
+        if urls.is_empty() {
+            // Authorised, but it never said where it is. Publishing a service
+            // with no endpoint would be worse than publishing none.
+            continue;
+        }
+        endpoints.push(ServiceEndpoint { eid, role, urls });
+    }
+
+    Ok(endpoints)
+}
+
+/// The verified location schemes `eid` has published for itself.
+fn location_schemes(kels: &Kels, eid: &str) -> BTreeMap<String, String> {
+    let mut latest: BTreeMap<String, (String, String)> = BTreeMap::new();
+
+    for rpy in kels.messages_with_ilk("rpy") {
+        let sad = rpy.serder.sad();
+        if sad.get("r").and_then(Value::as_str) != Some("/loc/scheme") {
+            continue;
+        }
+
+        let attrs = sad.get("a");
+        let (Some(subject), Some(scheme), Some(url)) = (
+            attrs.and_then(|a| a.get("eid")).and_then(Value::as_str),
+            attrs.and_then(|a| a.get("scheme")).and_then(Value::as_str),
+            attrs.and_then(|a| a.get("url")).and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+
+        if subject != eid {
+            continue;
+        }
+        // The endpoint has to say this about *itself*. A third party asserting
+        // where someone else can be reached is a redirection, not a location.
+        if !signed_by(kels, rpy, eid) {
+            continue;
+        }
+
+        let dt = sad
+            .get("dt")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        match latest.get(scheme) {
+            Some((existing_dt, _)) if *existing_dt >= dt => {}
+            _ => {
+                latest.insert(scheme.to_string(), (dt, url.to_string()));
+            }
+        }
+    }
+
+    latest
+        .into_iter()
+        .map(|(scheme, (_, url))| (scheme, url))
+        .collect()
+}
+
+/// Whether `msg` carries a signature from `signer` that verifies.
+///
+/// Two shapes, because KERI identifiers come in two kinds:
+///
+/// * a **transferable** identifier signs with indexed signatures in a
+///   transferable signature group, checked against the key state its own KEL
+///   establishes — so that KEL must be in the stream and must verify;
+/// * a **non-transferable** identifier — a witness, typically — has its public
+///   key *as* its prefix, so a receipt couple can be checked directly.
+fn signed_by(kels: &Kels, msg: &ParsedMessage, signer: &str) -> bool {
+    // Transferable: indexed signatures against verified key state.
+    if let Some(group) = msg
+        .trans_idx_sig_groups()
+        .iter()
+        .find(|g| g.prefix == signer)
+        && let Ok(state) = kels.key_state(signer)
+    {
+        for sig in &group.sigs {
+            let Some(key) = state.keys.get(sig.index()) else {
+                continue;
+            };
+            let Ok(verfer) = Verfer::from_qb64(key) else {
+                continue;
+            };
+            if verfer.verify(msg.serder.raw(), sig.raw()).unwrap_or(false) {
+                return true;
+            }
+        }
+    }
+
+    // Non-transferable: the prefix is the key.
+    for att in &msg.attachments {
+        let Attachment::ReceiptCouples(couples) = att else {
+            continue;
+        };
+        for (prefix, sig) in couples {
+            if prefix != signer {
+                continue;
+            }
+            let Ok(verfer) = Verfer::from_qb64(prefix) else {
+                continue;
+            };
+            if verfer.verify(msg.serder.raw(), sig).unwrap_or(false) {
+                return true;
+            }
+        }
+    }
+
+    false
+}

--- a/crates/identity/did-methods/did-webs/tests/services.rs
+++ b/crates/identity/did-methods/did-webs/tests/services.rs
@@ -1,0 +1,383 @@
+//! Service endpoints appear only when the AID signed for them.
+//!
+//! Two signed replies must agree: `/end/role/add` from the AID authorising an
+//! endpoint identifier in a role, and `/loc/scheme` from that identifier saying
+//! where it is. The published artifact carries neither, so these are built with
+//! real keys and real signatures.
+
+use affinidi_cesr::Counter;
+use affinidi_did_webs::{DidWebs, Kels, resolve_from_artifacts, service_endpoints};
+use affinidi_keri_core::said;
+use affinidi_keri_core::serder::Serder;
+use affinidi_keri_core::version::SerializationKind;
+use affinidi_keri_crypto::{Diger, Signer};
+use serde_json::json;
+
+fn signer(seed: u8) -> Signer {
+    Signer::new("A", [seed; 32].to_vec()).expect("signer")
+}
+
+fn fix_version(sad: &mut serde_json::Value) {
+    let placeholder = "#".repeat(44);
+    let (d, i) = (sad["d"].clone(), sad.get("i").cloned());
+    let self_addressing = i.as_ref() == Some(&d);
+    sad["d"] = json!(placeholder);
+    if self_addressing {
+        sad["i"] = json!(placeholder);
+    }
+    let len = serde_json::to_vec(sad).expect("serialize").len();
+    sad["v"] = json!(format!("KERI10JSON{len:06x}_"));
+    sad["d"] = d;
+    if let Some(i) = i {
+        sad["i"] = i;
+    }
+}
+
+fn inception(controller: &Signer, next: &Signer) -> Serder {
+    let next_digest = Diger::from_data("E", next.verfer().qb64().expect("qb64").as_bytes())
+        .expect("digest")
+        .qb64()
+        .expect("qb64");
+    let mut sad = json!({
+        "v": "KERI10JSON000000_", "t": "icp", "d": "", "i": "", "s": "0",
+        "kt": "1", "k": [controller.verfer().qb64().expect("qb64")],
+        "nt": "1", "n": [next_digest],
+        "bt": "0", "b": [], "c": [], "a": [],
+    });
+    fix_version(&mut sad);
+    said::compute_said(&mut sad, "d", "E", SerializationKind::Json).expect("said");
+    Serder::new(SerializationKind::Json, sad).expect("serder")
+}
+
+/// A `rpy` message. `dt` drives supersedence, so it is explicit.
+fn reply(route: &str, attrs: serde_json::Value, dt: &str) -> Serder {
+    let mut sad = json!({
+        "v": "KERI10JSON000000_", "t": "rpy", "d": "", "dt": dt,
+        "r": route, "a": attrs,
+    });
+    fix_version(&mut sad);
+    said::compute_said(&mut sad, "d", "E", SerializationKind::Json).expect("said");
+    Serder::new(SerializationKind::Json, sad).expect("serder")
+}
+
+/// Append an event with controller indexed signatures (`-A` in the 1.x table).
+fn push_signed(out: &mut Vec<u8>, serder: &Serder, s: &Signer) {
+    out.extend_from_slice(serder.raw());
+    out.extend_from_slice(
+        Counter::new("-A", 1)
+            .expect("counter")
+            .qb64()
+            .expect("qb64")
+            .as_bytes(),
+    );
+    out.extend_from_slice(
+        s.sign_indexed(serder.raw(), 0, true)
+            .expect("sign")
+            .qb64()
+            .expect("qb64")
+            .as_bytes(),
+    );
+}
+
+/// Append a reply with a transferable indexed signature group (`-F`), which is
+/// how a transferable identifier signs something outside its own KEL.
+fn push_reply(out: &mut Vec<u8>, serder: &Serder, signer_prefix: &str, said: &str, s: &Signer) {
+    out.extend_from_slice(serder.raw());
+
+    let sig = s
+        .sign_indexed(serder.raw(), 0, true)
+        .expect("sign")
+        .qb64()
+        .expect("qb64");
+    let inner = format!(
+        "{}{sig}",
+        Counter::new("-A", 1)
+            .expect("counter")
+            .qb64()
+            .expect("qb64")
+    );
+    // prefix + sequence number + establishment SAID, then the signatures.
+    let body = format!("{signer_prefix}0AAAAAAAAAAAAAAAAAAAAAAA{said}{inner}");
+    out.extend_from_slice(
+        Counter::new("-F", 1)
+            .expect("counter")
+            .qb64()
+            .expect("qb64")
+            .as_bytes(),
+    );
+    out.extend_from_slice(body.as_bytes());
+}
+
+struct Fixture {
+    aid: String,
+    agent: String,
+    stream: Vec<u8>,
+}
+
+/// An AID that authorises `agent` in the `agent` role, where the agent has
+/// published an http location for itself.
+fn authorised(role_dt: &str, loc_dt: &str, cut: Option<&str>) -> Fixture {
+    let (controller, next) = (signer(1), signer(2));
+    let (agent_key, agent_next) = (signer(5), signer(6));
+
+    let icp = inception(&controller, &next);
+    let aid = icp.prefix().expect("prefix");
+    let agent_icp = inception(&agent_key, &agent_next);
+    let agent = agent_icp.prefix().expect("prefix");
+
+    let mut stream = Vec::new();
+    push_signed(&mut stream, &icp, &controller);
+    push_signed(&mut stream, &agent_icp, &agent_key);
+
+    let add = reply(
+        "/end/role/add",
+        json!({"cid": aid, "role": "agent", "eid": agent}),
+        role_dt,
+    );
+    push_reply(
+        &mut stream,
+        &add,
+        &aid,
+        &icp.said().expect("said"),
+        &controller,
+    );
+
+    if let Some(cut_dt) = cut {
+        let cut_rpy = reply(
+            "/end/role/cut",
+            json!({"cid": aid, "role": "agent", "eid": agent}),
+            cut_dt,
+        );
+        push_reply(
+            &mut stream,
+            &cut_rpy,
+            &aid,
+            &icp.said().expect("said"),
+            &controller,
+        );
+    }
+
+    let loc = reply(
+        "/loc/scheme",
+        json!({"eid": agent, "scheme": "http", "url": "http://agent.example:5642"}),
+        loc_dt,
+    );
+    push_reply(
+        &mut stream,
+        &loc,
+        &agent,
+        &agent_icp.said().expect("said"),
+        &agent_key,
+    );
+
+    Fixture { aid, agent, stream }
+}
+
+#[test]
+fn an_authorised_endpoint_becomes_a_service() {
+    let f = authorised(
+        "2026-01-01T00:00:00.000000+00:00",
+        "2026-01-01T00:00:00.000000+00:00",
+        None,
+    );
+    let kels = Kels::parse(&f.stream).expect("parses");
+
+    let services = service_endpoints(&kels, &f.aid).expect("KEL verifies");
+    assert_eq!(services.len(), 1, "got {services:?}");
+    assert_eq!(services[0].role, "agent");
+    assert_eq!(services[0].eid, f.agent);
+    assert_eq!(
+        services[0].urls.get("http").map(String::as_str),
+        Some("http://agent.example:5642"),
+    );
+    assert_eq!(services[0].id(), format!("#{}/agent", f.agent));
+}
+
+#[test]
+fn the_resolved_document_carries_it() {
+    let f = authorised(
+        "2026-01-01T00:00:00.000000+00:00",
+        "2026-01-01T00:00:00.000000+00:00",
+        None,
+    );
+    let did = DidWebs::parse(&format!("did:webs:example.com:{}", f.aid)).expect("valid did");
+
+    let doc = resolve_from_artifacts(&did, &f.stream, None).expect("resolves");
+    assert_eq!(doc.service.len(), 1, "got {:?}", doc.service);
+    assert_eq!(doc.service[0].type_, vec!["agent".to_string()]);
+}
+
+#[test]
+fn a_later_cut_withdraws_the_authorisation() {
+    let f = authorised(
+        "2026-01-01T00:00:00.000000+00:00",
+        "2026-01-01T00:00:00.000000+00:00",
+        Some("2026-06-01T00:00:00.000000+00:00"),
+    );
+    let kels = Kels::parse(&f.stream).expect("parses");
+    assert!(
+        service_endpoints(&kels, &f.aid)
+            .expect("verifies")
+            .is_empty(),
+        "a cut must withdraw the endpoint",
+    );
+}
+
+#[test]
+fn an_earlier_cut_does_not_withdraw_a_later_add() {
+    // Reply messages supersede by timestamp, so a stale `cut` replayed after
+    // the `add` must not take effect.
+    let f = authorised(
+        "2026-06-01T00:00:00.000000+00:00",
+        "2026-01-01T00:00:00.000000+00:00",
+        Some("2026-01-01T00:00:00.000000+00:00"),
+    );
+    let kels = Kels::parse(&f.stream).expect("parses");
+    assert_eq!(
+        service_endpoints(&kels, &f.aid).expect("verifies").len(),
+        1,
+        "a stale cut must not withdraw a newer authorisation",
+    );
+}
+
+#[test]
+fn an_authorisation_for_another_aid_is_ignored() {
+    let f = authorised(
+        "2026-01-01T00:00:00.000000+00:00",
+        "2026-01-01T00:00:00.000000+00:00",
+        None,
+    );
+    let kels = Kels::parse(&f.stream).expect("parses");
+
+    // The agent has its own verified KEL in this stream, but it authorised
+    // nothing — the authorisation names our AID as `cid`, not the agent.
+    assert!(
+        service_endpoints(&kels, &f.agent)
+            .expect("verifies")
+            .is_empty(),
+    );
+}
+
+#[test]
+fn an_endpoint_that_never_said_where_it_is_publishes_nothing() {
+    // Authorised, but no /loc/scheme. A service entry with no endpoint is
+    // worse than no service entry.
+    let (controller, next) = (signer(1), signer(2));
+    let (agent_key, agent_next) = (signer(5), signer(6));
+    let icp = inception(&controller, &next);
+    let aid = icp.prefix().expect("prefix");
+    let agent_icp = inception(&agent_key, &agent_next);
+    let agent = agent_icp.prefix().expect("prefix");
+
+    let mut stream = Vec::new();
+    push_signed(&mut stream, &icp, &controller);
+    push_signed(&mut stream, &agent_icp, &agent_key);
+    let add = reply(
+        "/end/role/add",
+        json!({"cid": aid, "role": "agent", "eid": agent}),
+        "2026-01-01T00:00:00.000000+00:00",
+    );
+    push_reply(
+        &mut stream,
+        &add,
+        &aid,
+        &icp.said().expect("said"),
+        &controller,
+    );
+
+    let kels = Kels::parse(&stream).expect("parses");
+    assert!(
+        service_endpoints(&kels, &aid).expect("verifies").is_empty(),
+        "an authorisation with no location must publish nothing",
+    );
+}
+
+#[test]
+fn a_location_signed_by_someone_else_is_ignored() {
+    // The agent is authorised, but the /loc/scheme naming it is signed by the
+    // controller rather than the agent. A third party saying where someone
+    // else can be reached is a redirection, not a location.
+    let (controller, next) = (signer(1), signer(2));
+    let (agent_key, agent_next) = (signer(5), signer(6));
+    let icp = inception(&controller, &next);
+    let aid = icp.prefix().expect("prefix");
+    let agent_icp = inception(&agent_key, &agent_next);
+    let agent = agent_icp.prefix().expect("prefix");
+
+    let mut stream = Vec::new();
+    push_signed(&mut stream, &icp, &controller);
+    push_signed(&mut stream, &agent_icp, &agent_key);
+    let add = reply(
+        "/end/role/add",
+        json!({"cid": aid, "role": "agent", "eid": agent}),
+        "2026-01-01T00:00:00.000000+00:00",
+    );
+    push_reply(
+        &mut stream,
+        &add,
+        &aid,
+        &icp.said().expect("said"),
+        &controller,
+    );
+
+    let loc = reply(
+        "/loc/scheme",
+        json!({"eid": agent, "scheme": "http", "url": "http://attacker.example"}),
+        "2026-01-01T00:00:00.000000+00:00",
+    );
+    // Signed by the controller, claiming to be the agent's location.
+    push_reply(
+        &mut stream,
+        &loc,
+        &aid,
+        &icp.said().expect("said"),
+        &controller,
+    );
+
+    let kels = Kels::parse(&stream).expect("parses");
+    assert!(
+        service_endpoints(&kels, &aid).expect("verifies").is_empty(),
+        "a location must be signed by the endpoint it describes",
+    );
+}
+
+#[test]
+fn an_unsigned_authorisation_is_ignored() {
+    let (controller, next) = (signer(1), signer(2));
+    let (agent_key, agent_next) = (signer(5), signer(6));
+    let icp = inception(&controller, &next);
+    let aid = icp.prefix().expect("prefix");
+    let agent_icp = inception(&agent_key, &agent_next);
+    let agent = agent_icp.prefix().expect("prefix");
+
+    let mut stream = Vec::new();
+    push_signed(&mut stream, &icp, &controller);
+    push_signed(&mut stream, &agent_icp, &agent_key);
+
+    // Appended with no signature at all.
+    let add = reply(
+        "/end/role/add",
+        json!({"cid": aid, "role": "agent", "eid": agent}),
+        "2026-01-01T00:00:00.000000+00:00",
+    );
+    stream.extend_from_slice(add.raw());
+
+    let loc = reply(
+        "/loc/scheme",
+        json!({"eid": agent, "scheme": "http", "url": "http://agent.example:5642"}),
+        "2026-01-01T00:00:00.000000+00:00",
+    );
+    push_reply(
+        &mut stream,
+        &loc,
+        &agent,
+        &agent_icp.said().expect("said"),
+        &agent_key,
+    );
+
+    let kels = Kels::parse(&stream).expect("parses");
+    assert!(
+        service_endpoints(&kels, &aid).expect("verifies").is_empty(),
+        "an unsigned authorisation must not create a service",
+    );
+}

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this crate are documented here. The format follows
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
-## 0.8.9
+## 0.8.10
 
 ### Changed
 
+- `did-webs` feature now re-exports `affinidi-did-webs` 0.4.
 - `did-scid` feature now re-exports `did-scid` 0.2.
 
 ## 0.8.7

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.9"
+version = "0.8.10"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 # DID methods
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.3", path = "../../identity/did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.4", path = "../../identity/did-methods/did-webs", optional = true }
 did-scid = { version = "0.2", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP


### PR DESCRIPTION
The last of the four gaps `did:webs` shipped with. A document now carries
service endpoints — but only ones the AID actually signed for.

## Two signed replies, or nothing

```
/end/role/add   signed by THIS AID   "I authorise <eid> in role <role>"
/loc/scheme     signed by <eid>      "I am reachable at <url> over <scheme>"
```

Both halves are required:

- the first without the second is an **authorisation pointing nowhere**
- the second without the first is a **stranger volunteering** to act on
  someone's behalf

Neither is published. A `did:webs` document does not get to list whatever
endpoints it likes, any more than it gets to assert its own aliases.

`/end/role/cut` withdraws an authorisation. Where the same subject is addressed
more than once the latest `dt` wins — so a stale `cut` replayed after an `add`
does **not** take effect, which is pinned in both directions.

## Signatures, both ways identifiers come

- **Transferable** — indexed signatures in a transferable signature group,
  checked against the key state that identifier's own KEL establishes. That KEL
  must be in the stream and must verify.
- **Non-transferable** (a witness, typically) — the public key *is* the prefix,
  so a receipt couple is checked directly.

Roles are deliberately **not** enumerated. KERI does not fix the set, and
rejecting an unknown role would silently drop endpoints we have simply not heard
of.

## Shape

Matches the reference implementation
(`hyperledger-labs/did-webs-resolver`, `didding.py`):

```json
{"id": "#<eid>/<role>", "type": "<role>", "serviceEndpoint": {"http": "http://…"}}
```

## Tests

The published artifact carries no `rpy` messages, so these build them with real
keys and real signatures. The negative cases are the substance:

| test | asserts |
|---|---|
| `an_authorised_endpoint_becomes_a_service` | the happy path, end to end into the document |
| `a_later_cut_withdraws_the_authorisation` | `cut` supersedes |
| `an_earlier_cut_does_not_withdraw_a_later_add` | a stale `cut` replayed afterwards does not |
| `an_authorisation_for_another_aid_is_ignored` | `cid` must be this AID |
| `an_unsigned_authorisation_is_ignored` | no signature, no service |
| `an_endpoint_that_never_said_where_it_is_publishes_nothing` | a service with no endpoint is worse than none |
| `a_location_signed_by_someone_else_is_ignored` | a third party naming where another identifier lives is a redirection, not a location |

## Versions

`affinidi-did-webs` 0.3.0 → **0.4.0** (`document_from_keys` takes the derived
services), `affinidi-did-resolver-cache-sdk` 0.8.28 → 0.8.29, `affinidi-tdk`
0.8.8 → 0.8.9.

## Verification

`cargo test -p affinidi-did-webs` — **47 passed** (19 unit, 16 conformance, 8
service, 4 witness), up from 39. clippy, `cargo fmt --check`, and all three repo
guards clean.

Note this branches from `main` at #735, so it does not include #736
(`did:scid:ke`). The two touch different crates and can merge in either order —
whichever lands second will want its `affinidi-did-webs` requirement checked, as
#736 pins `0.3`.