### PR TITLE
test(did-webs): exercise the fetch path, and allow plain HTTP for loopback

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Affinidi DID Resolver Cache SDK
+
+## 0.8.31
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.5, which fetches over
+  plain HTTP for loopback hosts and adds `WebsResolver::allow_http`.
+
 ## 0.8.30
 
 ### Changed

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.30"
+version = "0.8.31"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ did-scid = { version = "0.2", optional = true, default-features = false, feature
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.4", path = "../did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.5", path = "../did-methods/did-webs", optional = true }
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # did:scid
 
+## 0.2.2
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.5.
+
 ## 0.2.1
 
 ### Changed

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.1"
+version = "0.2.2"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -35,7 +35,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
-affinidi-did-webs = { version = "0.4", optional = true }
+affinidi-did-webs = { version = "0.5", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"

--- a/crates/identity/did-methods/did-webs/CHANGELOG.md
+++ b/crates/identity/did-methods/did-webs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this crate are documented here.
 
+## [0.5.0] - 2026-08-23
+
+### Added
+
+- **Plain HTTP for loopback hosts**, and `WebsResolver::allow_http` to permit it
+  anywhere. Artifacts are still fetched over HTTPS by default.
+
+  The reference implementation fetches over plain HTTP — `resolving.py` builds
+  `http://{domain}{port}{path}/{aid}` with no HTTPS path at all — so a
+  strict-HTTPS resolver cannot read the artifacts the ecosystem's own tooling
+  serves. Loopback is safe by construction; anything else is opt-in and
+  documented as such, because a plain-HTTP fetch lets an attacker serve a
+  *stale* key event log and hide a rotation that has already happened.
+
+- `DidWebs::is_loopback` and `DidWebs::artifact_url_with_scheme`.
+
+- **Network tests.** `WebsResolver::resolve` was previously never executed: the
+  conformance tests verify artifacts already in hand, and the one HTTP test
+  fetched with `reqwest` directly and verified offline. `fetch.rs` had no tests
+  at all. Seven tests now drive the real entry point against a live server —
+  the URLs requested, a missing `did.json` (not fatal), a missing `keri.cesr`
+  (fatal), a 5xx, the size cap, a `did.json` that disagrees, and that the
+  loopback accommodation does not leak into ordinary hosts.
+
 ## [0.4.0] - 2026-08-23
 
 ### Added

--- a/crates/identity/did-methods/did-webs/Cargo.toml
+++ b/crates/identity/did-methods/did-webs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-webs"
-version = "0.4.0"
+version = "0.5.0"
 description = "Implementation of the did:webs DID method: did:web discovery with KERI-verified key state"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-webs/README.md
+++ b/crates/identity/did-methods/did-webs/README.md
@@ -72,6 +72,22 @@ let doc = resolve_from_artifacts(&did, keri_cesr, Some(did_json))?;
   identifier (or its `did:web` twin) and publish exactly the keys the KEL
   authorised — no more and no fewer.
 
+## HTTPS, and the loopback exception
+
+Artifacts are fetched over **HTTPS**. Two exceptions use plain HTTP:
+
+- a **loopback** host (`localhost`, `127.0.0.1`, `::1`), which cannot be
+  intercepted from elsewhere and rarely has a certificate;
+- any host, if you opt in with `WebsResolver::allow_http(true)`.
+
+The opt-in exists because the reference implementation
+(`hyperledger-labs/did-webs-resolver`) fetches over plain HTTP, so
+interoperating with it — or with KERI tooling on a private network without TLS
+— is otherwise impossible. Leave it off in production: a `did:webs` document is
+derived from a self-verifying key event log, so an attacker cannot *forge* one,
+but they can serve a **stale** log and hide a key rotation that has already
+happened, which is the attack pre-rotation exists to defeat.
+
 ## What is not verified yet
 
 - **Credential schema validation.** A designated-aliases attestation is matched

--- a/crates/identity/did-methods/did-webs/src/fetch.rs
+++ b/crates/identity/did-methods/did-webs/src/fetch.rs
@@ -32,6 +32,7 @@ pub const MAX_ARTIFACT_BYTES: usize = 4 * 1024 * 1024;
 #[derive(Debug, Clone)]
 pub struct WebsResolver {
     client: reqwest::Client,
+    allow_http: bool,
 }
 
 impl WebsResolver {
@@ -46,13 +47,45 @@ impl WebsResolver {
             .timeout(DEFAULT_TIMEOUT)
             .build()
             .unwrap_or_default();
-        Self { client }
+        Self {
+            client,
+            allow_http: false,
+        }
     }
 
     /// A resolver over a caller-supplied client, for custom timeouts, proxies,
     /// or a client shared with the rest of an application.
     pub fn with_client(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            allow_http: false,
+        }
+    }
+
+    /// Permit plain HTTP for **any** host, not just loopback.
+    ///
+    /// Off by default, and it should stay off in production. A `did:webs`
+    /// document is derived from a self-verifying key event log, so an attacker
+    /// on the network cannot forge one — but they can serve a *stale* log,
+    /// hiding a key rotation that has already happened, which is exactly the
+    /// attack pre-rotation exists to defeat.
+    ///
+    /// It exists because the reference implementation
+    /// (`hyperledger-labs/did-webs-resolver`) fetches over plain HTTP, so
+    /// interoperating with it — or with any KERI tooling on a private network
+    /// without TLS — otherwise cannot work at all.
+    pub fn allow_http(mut self, allow: bool) -> Self {
+        self.allow_http = allow;
+        self
+    }
+
+    /// The scheme to fetch this DID's artifacts over.
+    fn scheme(&self, did: &DidWebs) -> &'static str {
+        if self.allow_http || did.is_loopback() {
+            "http"
+        } else {
+            "https"
+        }
     }
 
     /// Resolve a `did:webs` identifier.
@@ -64,14 +97,15 @@ impl WebsResolver {
     pub async fn resolve(&self, did: &str) -> Result<Document, DidWebsError> {
         let parsed = DidWebs::parse(did)?;
 
-        let cesr_url = parsed.artifact_url(KERI_CESR);
+        let scheme = self.scheme(&parsed);
+        let cesr_url = parsed.artifact_url_with_scheme(scheme, KERI_CESR);
         let keri_cesr = self.fetch(&cesr_url).await?;
 
         // A missing or unreadable did.json does not change the answer, because
         // the answer comes from the KEL. It is only ever a cross-check, so a
         // fetch failure is logged rather than propagated — while a document
         // that *disagrees* is refused inside `resolve_from_artifacts`.
-        let did_json_url = parsed.artifact_url(DID_JSON);
+        let did_json_url = parsed.artifact_url_with_scheme(scheme, DID_JSON);
         let did_json = match self.fetch(&did_json_url).await {
             Ok(bytes) => Some(bytes),
             Err(e) => {

--- a/crates/identity/did-methods/did-webs/src/identifier.rs
+++ b/crates/identity/did-methods/did-webs/src/identifier.rs
@@ -111,7 +111,27 @@ impl DidWebs {
     /// The AID is always the final path element, so `did.json` for
     /// `did:webs:example.com:EAid` is at `https://example.com/EAid/did.json`.
     pub fn artifact_url(&self, artifact: &str) -> String {
-        let mut url = format!("https://{}", self.host);
+        self.artifact_url_with_scheme("https", artifact)
+    }
+
+    /// Whether this DID's host is a loopback address.
+    ///
+    /// `did:webs` artifacts are fetched over HTTPS, but a host that can only
+    /// be reached from this machine cannot be intercepted, and local tooling
+    /// rarely has a certificate for it — the reference implementation serves
+    /// its own examples over plain HTTP. Resolvers therefore permit `http` for
+    /// loopback, the same accommodation `did:web` implementations make.
+    pub fn is_loopback(&self) -> bool {
+        let host = self.host.split(':').next().unwrap_or(&self.host);
+        host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
+    }
+
+    /// The URL an artifact is published at, over an explicit scheme.
+    ///
+    /// Prefer [`artifact_url`](Self::artifact_url). This exists for resolvers
+    /// that permit plain HTTP for loopback or in a controlled environment.
+    pub fn artifact_url_with_scheme(&self, scheme: &str, artifact: &str) -> String {
+        let mut url = format!("{scheme}://{}", self.host);
         for segment in &self.path {
             url.push('/');
             url.push_str(segment);
@@ -267,6 +287,38 @@ mod tests {
         assert_eq!(d.aid(), AID);
         let d = DidWebs::parse(&format!("did:webs:example.com:{AID}?versionId=1")).expect("valid");
         assert_eq!(d.aid(), AID);
+    }
+
+    #[test]
+    fn loopback_hosts_are_recognised() {
+        for host in [
+            "localhost",
+            "127.0.0.1",
+            "localhost%3A7676",
+            "127.0.0.1%3A8080",
+        ] {
+            let d = DidWebs::parse(&format!("did:webs:{host}:{AID}")).expect("valid");
+            assert!(d.is_loopback(), "{host} should be loopback");
+        }
+        for host in [
+            "example.com",
+            "did-webs-service%3a7676",
+            "127.0.0.1.example.com",
+        ] {
+            let d = DidWebs::parse(&format!("did:webs:{host}:{AID}")).expect("valid");
+            assert!(!d.is_loopback(), "{host} should not be loopback");
+        }
+    }
+
+    #[test]
+    fn a_scheme_can_be_supplied_explicitly() {
+        let d = DidWebs::parse(&format!("did:webs:localhost%3A7676:{AID}")).expect("valid");
+        assert_eq!(
+            d.artifact_url_with_scheme("http", DID_JSON),
+            format!("http://localhost:7676/{AID}/did.json"),
+        );
+        // The default stays HTTPS.
+        assert!(d.artifact_url(DID_JSON).starts_with("https://"));
     }
 
     #[test]

--- a/crates/identity/did-methods/did-webs/tests/network.rs
+++ b/crates/identity/did-methods/did-webs/tests/network.rs
@@ -1,0 +1,198 @@
+//! The fetch path, exercised end to end against a live HTTP server.
+//!
+//! Every other test here verifies artifacts already in hand. These drive
+//! `WebsResolver::resolve` itself — the URLs it actually requests, the order it
+//! requests them in, what it does when one is missing, and the size caps — by
+//! serving the real conformance artifacts from a local server and resolving a
+//! DID that points at it.
+
+use affinidi_did_webs::WebsResolver;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const KERI_CESR: &[u8] = include_bytes!("fixtures/ENro7uf0.keri.cesr");
+const DID_JSON: &[u8] = include_bytes!("fixtures/ENro7uf0.did.json");
+const AID: &str = "ENro7uf0ePmiK3jdTo2YCdXLqW7z7xoP6qhhBou6gBLe";
+const SIGNING_KEY: &str = "DHr0-I-mMN7h6cLMOTRJkkfPuMd0vgQPrOk4Y3edaHjr";
+
+/// A DID pointing at the mock server.
+///
+/// The mock listens on 127.0.0.1, which the resolver recognises as loopback
+/// and therefore fetches over plain HTTP — the same accommodation that lets it
+/// talk to the reference implementation.
+fn did_for(server: &MockServer) -> String {
+    let host = server.address().to_string().replace(':', "%3A");
+    format!("did:webs:{host}:{AID}")
+}
+
+/// The fixture's `did.json` names the host it was published on, and the
+/// host-binding check refuses it anywhere else — deliberately, so a document
+/// cannot be lifted from one host and replayed at another. Retarget it at the
+/// mock so the *rest* of the resolution is what these tests exercise.
+fn did_json_for(server: &MockServer) -> serde_json::Value {
+    let host = server.address().to_string().replace(':', "%3A");
+    let mut doc: serde_json::Value = serde_json::from_slice(DID_JSON).expect("json");
+    doc["id"] = serde_json::json!(format!("did:web:{host}:{AID}"));
+    doc
+}
+
+async fn serve(server: &MockServer, artifact: &str, body: &[u8]) {
+    Mock::given(method("GET"))
+        .and(path(format!("/{AID}/{artifact}")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn resolves_a_did_over_the_network() {
+    let server = MockServer::start().await;
+    serve(&server, "keri.cesr", KERI_CESR).await;
+    let published = serde_json::to_vec(&did_json_for(&server)).expect("serializes");
+    serve(&server, "did.json", &published).await;
+
+    let did = did_for(&server);
+    let doc = WebsResolver::new()
+        .resolve(&did)
+        .await
+        .expect("a served did:webs must resolve");
+
+    assert_eq!(doc.id.as_str(), did);
+    assert_eq!(doc.verification_method.len(), 1);
+    assert!(
+        doc.verification_method[0]
+            .id
+            .as_str()
+            .ends_with(&format!("#{SIGNING_KEY}")),
+    );
+
+    // Both artifacts were actually requested, at the paths we derive.
+    let requests = server.received_requests().await.expect("recorded");
+    let paths: Vec<String> = requests.iter().map(|r| r.url.path().to_string()).collect();
+    assert!(paths.contains(&format!("/{AID}/keri.cesr")), "{paths:?}");
+    assert!(paths.contains(&format!("/{AID}/did.json")), "{paths:?}");
+}
+
+#[tokio::test]
+async fn resolves_when_did_json_is_missing() {
+    // did.json carries no authority — it is only ever cross-checked. A 404 for
+    // it must not stop resolution, because the key event log alone determines
+    // the answer.
+    let server = MockServer::start().await;
+    serve(&server, "keri.cesr", KERI_CESR).await;
+
+    let doc = WebsResolver::new()
+        .resolve(&did_for(&server))
+        .await
+        .expect("a missing did.json must not fail resolution");
+    assert_eq!(doc.verification_method.len(), 1);
+}
+
+#[tokio::test]
+async fn a_missing_keri_cesr_fails_resolution() {
+    // The key event log is the only thing that carries authority, so its
+    // absence is fatal — the opposite of did.json.
+    let server = MockServer::start().await;
+    serve(&server, "did.json", DID_JSON).await;
+
+    let err = WebsResolver::new()
+        .resolve(&did_for(&server))
+        .await
+        .expect_err("no key event log means no resolution");
+    assert!(err.to_string().contains("keri.cesr"), "{err}");
+}
+
+#[tokio::test]
+async fn a_server_error_is_surfaced_not_swallowed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{AID}/keri.cesr")))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let err = WebsResolver::new()
+        .resolve(&did_for(&server))
+        .await
+        .expect_err("a 500 must fail resolution");
+    assert!(err.to_string().contains("500"), "{err}");
+}
+
+#[tokio::test]
+async fn an_oversized_artifact_is_refused() {
+    // A key event log grows with every rotation and has no natural bound, and
+    // the server is not trusted, so an artifact past the cap is refused rather
+    // than read into memory.
+    //
+    // The body is genuinely oversized rather than merely claiming to be: hyper
+    // will not serve a response whose Content-Length contradicts its body, so
+    // a lying header cannot be tested this way.
+    let oversized = vec![b'{'; 5 * 1024 * 1024];
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{AID}/keri.cesr")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized))
+        .mount(&server)
+        .await;
+
+    let err = WebsResolver::new()
+        .resolve(&did_for(&server))
+        .await
+        .expect_err("an oversized artifact must be refused");
+    assert!(err.to_string().contains("cap"), "{err}");
+}
+
+#[tokio::test]
+async fn a_did_json_that_disagrees_fails_resolution() {
+    // Served alongside a valid key event log, but publishing a key the log
+    // never authorised. Resolution must fail rather than pick a winner.
+    let server = MockServer::start().await;
+    // Retargeted at this host, so the only thing wrong with it is the key.
+    let mut published = did_json_for(&server);
+    let mut extra = published["verificationMethod"][0].clone();
+    extra["id"] = serde_json::json!("#DNotAuthorised000000000000000000000000000");
+    extra["publicKeyJwk"]["kid"] = serde_json::json!("DNotAuthorised000000000000000000000000000");
+    published["verificationMethod"]
+        .as_array_mut()
+        .expect("array")
+        .push(extra);
+
+    serve(&server, "keri.cesr", KERI_CESR).await;
+    serve(
+        &server,
+        "did.json",
+        &serde_json::to_vec(&published).expect("serializes"),
+    )
+    .await;
+
+    let err = WebsResolver::new()
+        .resolve(&did_for(&server))
+        .await
+        .expect_err("a did.json publishing an unauthorised key must fail resolution");
+    assert!(
+        err.to_string().contains("never authorised"),
+        "should fail on the unauthorised key, got: {err}",
+    );
+}
+
+#[tokio::test]
+async fn a_non_loopback_host_is_fetched_over_https() {
+    // The loopback accommodation must not leak into ordinary hosts: a DID on
+    // a public host is fetched over HTTPS, so pointing one at a plain HTTP
+    // server fails to connect rather than silently downgrading.
+    let server = MockServer::start().await;
+    serve(&server, "keri.cesr", KERI_CESR).await;
+
+    // Same server, addressed through a non-loopback name.
+    let port = server.address().port();
+    let did = format!("did:webs:localtest.me%3A{port}:{AID}");
+
+    let err = WebsResolver::new()
+        .resolve(&did)
+        .await
+        .expect_err("a non-loopback host must not be fetched over plain HTTP");
+    assert!(
+        !err.to_string().contains("key event log verification"),
+        "should have failed to fetch, not to verify: {err}",
+    );
+}

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this crate are documented here. The format follows
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
+
+## 0.8.11
+
+### Changed
+
+- `did-webs` feature now re-exports `affinidi-did-webs` 0.5.
+
 ## 0.8.10
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.10"
+version = "0.8.11"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 # DID methods
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.4", path = "../../identity/did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.5", path = "../../identity/did-methods/did-webs", optional = true }
 did-scid = { version = "0.2", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP


### PR DESCRIPTION
`WebsResolver::resolve` — the public entry point — had **never been executed**.

Every conformance test verifies artifacts already in hand; the one HTTP test
fetched with `reqwest` directly and then verified offline; and `fetch.rs` had no
tests at all. So the URLs actually requested, the two-artifact sequencing, the
`did.json` fallback and both size-cap paths were unverified.

## Testing it found a real interop gap

The reference implementation fetches over **plain HTTP**. From
`hyperledger-labs/did-webs-resolver`, `src/dkr/core/resolving.py`:

```python
base_url = f"http://{domain}{opt_port}{opt_path}/{aid}"
```

No HTTPS path at all. We hardcoded `https`, so we could not read the artifacts
the ecosystem's own tooling serves — including its published examples, which run
on `did-webs-service:7676`.

## What changed

HTTPS remains the default. Plain HTTP is used in two cases:

- **loopback hosts** (`localhost`, `127.0.0.1`, `::1`) — cannot be intercepted
  from elsewhere, and rarely have a certificate;
- **any host**, if you opt in with `WebsResolver::allow_http(true)`.

The opt-in is documented as production-unsafe, and the reason is worth being
precise about: a `did:webs` document is derived from a self-verifying key event
log, so an attacker on the network cannot **forge** one. What they *can* do over
plain HTTP is serve a **stale** log — hiding a key rotation that has already
happened, which is exactly the attack pre-rotation exists to defeat.

## The tests

Seven, all driving the real entry point against a live server:

| test | asserts |
|---|---|
| `resolves_a_did_over_the_network` | full resolution, and that both artifact URLs were actually requested |
| `resolves_when_did_json_is_missing` | not fatal — `did.json` carries no authority |
| `a_missing_keri_cesr_fails_resolution` | fatal — it carries all of it |
| `a_server_error_is_surfaced_not_swallowed` | a 5xx fails, with the status in the error |
| `an_oversized_artifact_is_refused` | the size cap holds |
| `a_did_json_that_disagrees_fails_resolution` | an unauthorised published key fails resolution |
| `a_non_loopback_host_is_fetched_over_https` | the loopback accommodation does not leak into ordinary hosts |

Two details worth knowing, both cases where the obvious test would have been
wrong:

- The fixture `did.json` is **host-bound** — it names the host it was published
  on, and the resolver refuses it anywhere else so a document cannot be lifted
  from one host and replayed at another. The tests **retarget it at the mock**
  rather than weakening that check.
- The oversized body is **genuinely** oversized. Hyper will not serve a response
  whose `Content-Length` contradicts its body, so a lying header cannot be
  tested this way — an earlier attempt panicked inside hyper.

## Not covered

No public `did:webs` identifier appears to be resolvable on the open internet —
`didwebs.info` is a docs shell with no live example, and the reference
implementation's own examples are Docker-local. So this is a real server over a
real socket with real artifacts, but not a third-party deployment. If you know
of a live one, pointing a test at it would be the last unexercised path.

## Versions

`affinidi-did-webs` 0.4.0 → **0.5.0**, `did-scid` 0.2.1 → 0.2.2,
`affinidi-did-resolver-cache-sdk` 0.8.30 → 0.8.31, `affinidi-tdk` 0.8.10 →
0.8.11.

## Verification

`cargo test -p affinidi-did-webs` — **56 passed** (21 unit, 16 conformance, 8
service, 7 network, 4 witness), up from 47. clippy, `cargo fmt --check` and all
three repo guards clean.