### PR TITLE
fix(did-scid): did:scid:ke was unreachable through resolve

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Resolver Cache SDK
 
+## 0.8.32
+
+### Changed
+
+- `did-scid` feature now requires `did-scid` 0.2.3, which fixes `did:scid:ke`
+  being unreachable through `resolve`.
+
 ## 0.8.31
 
 ### Changed

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.31"
+version = "0.8.32"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -64,7 +64,7 @@ did-example = { version = "0.5", optional = true }
 # `default-features = false` keeps did-scid's own optional `did-cheqd` backend
 # (and its `tonic`/`ring` TLS stack) out of this SDK's default build; pulling
 # `did-cheqd` here re-enables it deliberately.
-did-scid = { version = "0.2", optional = true, default-features = false, features = [
+did-scid = { version = "0.2.3", optional = true, default-features = false, features = [
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,21 @@
 # did:scid
 
+## 0.2.3
+
+### Fixed
+
+- **`did:scid:ke` was unreachable through `resolve`.** The public entry point
+  still opened with `if did.starts_with("did:scid:vh:1")`, so a `ke` DID
+  returned `UnsupportedFormat` and never reached the conversion added in 0.2.0.
+  The format dispatch was correct; nothing could get to it.
+
+  Every test for `ke` called the private `convert_scid_to_method` directly, so
+  the whole suite passed while the feature did not work. `resolve` is now tested
+  at the public boundary — including that a `ke` DID gets *past* format dispatch
+  — and those tests fail if the gate is put back.
+
+  `did:scid:ke` did not work in 0.2.0, 0.2.1 or 0.2.2.
+
 ## 0.2.2
 
 ### Changed

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.2"
+version = "0.2.3"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-scid/src/lib.rs
+++ b/crates/identity/did-methods/did-scid/src/lib.rs
@@ -78,57 +78,55 @@ pub async fn resolve(
     peer_src: Option<ScidMethod>,
     timeout: Option<Duration>,
 ) -> Result<Document, DIDSCIDError> {
-    if did.starts_with("did:scid:vh:1") {
-        // Implement the resolution logic here
-        match convert_scid_to_method(did, peer_src)? {
-            ScidMethod::WebVH(webvh_did) => {
-                debug!("Resolving WebVH DID: {}", webvh_did);
-                let mut method = DIDWebVHState::default();
-                match method
-                    .resolve(
-                        &webvh_did,
-                        didwebvh_rs::resolve::ResolveOptions {
-                            timeout,
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                {
-                    Ok((log_entry, _)) => {
-                        Ok(serde_json::from_value(log_entry.get_did_document()?)?)
-                    }
-                    Err(e) => {
-                        error!("Error: {:?}", e);
-                        Err(DIDSCIDError::WebVHError(e))
-                    }
-                }
-            }
-            ScidMethod::Webs(webs_did) => resolve_webs(&webs_did).await,
-            #[cfg(feature = "did-cheqd")]
-            ScidMethod::Cheqd(cheqd_did) => {
-                use did_resolver_cheqd::DIDCheqd;
-                use ssi_dids_core::{DID, DIDResolver};
-
-                debug!("Resolving Cheqd DID: {}", cheqd_did);
-                let parsed = DID::new::<str>(&cheqd_did).map_err(|e| {
-                    DIDSCIDError::DidUrlError(format!(
-                        "derived cheqd DID is not a valid DID ({cheqd_did}): {e}"
-                    ))
-                })?;
-                match DIDCheqd::default().resolve(parsed).await {
-                    Ok(res) => {
-                        let doc_value = serde_json::to_value(res.document.into_document())?;
-                        Ok(serde_json::from_value(doc_value)?)
-                    }
-                    Err(e) => {
-                        error!("Error: {:?}", e);
-                        Err(DIDSCIDError::CheqdError(e.to_string()))
-                    }
+    // No prefix test here: `convert_scid_to_method` matches the whole
+    // `did:scid:<format>:<version>:<scid>` shape and reports an unknown format
+    // or version by name. A `starts_with("did:scid:vh:1")` gate used to sit in
+    // front of it, which made every format other than `vh` unreachable through
+    // this function no matter what the conversion supported.
+    match convert_scid_to_method(did, peer_src)? {
+        ScidMethod::WebVH(webvh_did) => {
+            debug!("Resolving WebVH DID: {webvh_did}");
+            let mut method = DIDWebVHState::default();
+            match method
+                .resolve(
+                    &webvh_did,
+                    didwebvh_rs::resolve::ResolveOptions {
+                        timeout,
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                Ok((log_entry, _)) => Ok(serde_json::from_value(log_entry.get_did_document()?)?),
+                Err(e) => {
+                    error!("Error: {e:?}");
+                    Err(DIDSCIDError::WebVHError(e))
                 }
             }
         }
-    } else {
-        Err(DIDSCIDError::UnsupportedFormat)
+        ScidMethod::Webs(webs_did) => resolve_webs(&webs_did).await,
+        #[cfg(feature = "did-cheqd")]
+        ScidMethod::Cheqd(cheqd_did) => {
+            use did_resolver_cheqd::DIDCheqd;
+            use ssi_dids_core::{DID, DIDResolver};
+
+            debug!("Resolving Cheqd DID: {cheqd_did}");
+            let parsed = DID::new::<str>(&cheqd_did).map_err(|e| {
+                DIDSCIDError::DidUrlError(format!(
+                    "derived cheqd DID is not a valid DID ({cheqd_did}): {e}"
+                ))
+            })?;
+            match DIDCheqd::default().resolve(parsed).await {
+                Ok(res) => {
+                    let doc_value = serde_json::to_value(res.document.into_document())?;
+                    Ok(serde_json::from_value(doc_value)?)
+                }
+                Err(e) => {
+                    error!("Error: {e:?}");
+                    Err(DIDSCIDError::CheqdError(e.to_string()))
+                }
+            }
+        }
     }
 }
 
@@ -575,6 +573,55 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    // -- the PUBLIC entry point --------------------------------------------
+    //
+    // Everything above tests `convert_scid_to_method`, which is private. These
+    // go through `resolve` itself, because a gate in front of the conversion
+    // once made every format except `vh` unreachable while all the conversion
+    // tests still passed.
+
+    #[tokio::test]
+    async fn resolve_reaches_the_webs_path() {
+        // Without the `did-webs` feature this stops at "the feature is
+        // missing", and with it, it would try to fetch. Either way it must get
+        // *past* the format dispatch — an `UnsupportedFormat` here means `ke`
+        // is unreachable through the public API.
+        let err = resolve(&format!("did:scid:ke:1:{AID}?src=example.com"), None, None)
+            .await
+            .expect_err("no network in tests");
+        assert!(
+            !matches!(err, DIDSCIDError::UnsupportedFormat),
+            "did:scid:ke must reach the did:webs path, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_reports_an_unknown_format_by_name() {
+        let err = resolve(&format!("did:scid:jl:1:{AID}?src=example.com"), None, None)
+            .await
+            .expect_err("jl is not implemented");
+        match err {
+            DIDSCIDError::UnknownFormat(f) => assert_eq!(f, "jl"),
+            other => panic!("expected UnknownFormat, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_a_non_scid_did() {
+        assert!(matches!(
+            resolve("did:web:example.com", None, None).await,
+            Err(DIDSCIDError::UnsupportedFormat),
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_an_unsupported_version() {
+        assert!(matches!(
+            resolve(&format!("did:scid:vh:2:{AID}?src=example.com"), None, None).await,
+            Err(DIDSCIDError::UnsupportedVersion(_)),
+        ));
     }
 
     // -- format and version handling ---------------------------------------

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## 0.8.12
+
+### Changed
+
+- `did-scid` feature now re-exports `did-scid` 0.2.3.
+
 ## 0.8.11
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.11"
+version = "0.8.12"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -86,7 +86,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
 affinidi-did-webs = { version = "0.5", path = "../../identity/did-methods/did-webs", optional = true }
-did-scid = { version = "0.2", path = "../../identity/did-methods/did-scid", optional = true }
+did-scid = { version = "0.2.3", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP
 affinidi-trust-lists = { version = "0.1", path = "../../trust/affinidi-trust-lists", optional = true }


### PR DESCRIPTION
**`did:scid:ke` has never worked through the public API.** Not in 0.2.0, 0.2.1
or 0.2.2.

## What happened

`resolve` still opened with a prefix test left over from when `vh` was the only
format:

```rust
pub async fn resolve(did: &str, ...) -> Result<Document, DIDSCIDError> {
    if did.starts_with("did:scid:vh:1") {
        match convert_scid_to_method(did, peer_src)? { ... }
    } else {
        Err(DIDSCIDError::UnsupportedFormat)
    }
}
```

A `ke` DID took the `else` branch and returned `UnsupportedFormat`. The format
dispatch added in #736 was correct — nothing could reach it.

## Why the tests passed

Every `ke` test called the **private** `convert_scid_to_method` directly. The
conversion was right, so they all passed, while the feature did not exist as far
as any caller was concerned. The only tests touching `resolve` were two
`#[ignore]`d network tests for `vh`.

This is the same shape as the bug fixed in #738 — a public entry point nobody
executed, with the layer below it thoroughly tested. Finding that one is what
prompted re-reading this.

## The fix

The prefix test is **removed**, not extended. `convert_scid_to_method` already
matches the whole `did:scid:<format>:<version>:<scid>` shape and reports an
unknown format or version by name, so a second, narrower gate in front of it
could only ever disagree with it — which is precisely what happened.

`resolve` is now tested at the public boundary:

| test | asserts |
|---|---|
| `resolve_reaches_the_webs_path` | a `ke` DID gets **past** format dispatch |
| `resolve_reports_an_unknown_format_by_name` | `jl` yields `UnknownFormat("jl")` |
| `resolve_rejects_a_non_scid_did` | `did:web:…` is still `UnsupportedFormat` |
| `resolve_rejects_an_unsupported_version` | `vh:2` is refused |

Checked in both directions: reinstating the gate makes
`resolve_reaches_the_webs_path` fail with exactly the original symptom
(`did:scid:ke must reach the did:webs path, got UnsupportedFormat`), and
removing it makes it pass. A regression test that cannot catch the regression
is worse than none.

## Versions

`did-scid` 0.2.2 → **0.2.3**, `affinidi-did-resolver-cache-sdk` 0.8.31 → 0.8.32,
`affinidi-tdk` 0.8.11 → 0.8.12.

The three published `did-scid` versions with the broken path are worth a yank
decision — `did:scid:ke` silently reports "unsupported format" in all of them.

## Verification

`cargo test -p did-scid` — **33 passed**. clippy, `cargo fmt --check`,
`affinidi-tdk --features did-methods`, and all three repo guards clean.