### PR TITLE
feat(did-webs): designate alsoKnownAs identifiers

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi DID Resolver Cache SDK
 
+## 0.8.34
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.7, which can designate
+  `alsoKnownAs` identifiers.
+
 ## 0.8.33
 
 ### Changed

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.33"
+version = "0.8.34"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ did-scid = { version = "0.2.3", optional = true, default-features = false, featu
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.6", path = "../did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.7", path = "../did-methods/did-webs", optional = true }
 
 # External Crates
 ahash = "0.8"

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # did:scid
 
+## 0.2.5
+
+### Changed
+
+- `did-webs` feature now requires `affinidi-did-webs` 0.7.
+
 ## 0.2.4
 
 ### Changed

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.4"
+version = "0.2.5"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -35,7 +35,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 affinidi-did-common = "0.4"
 
-affinidi-did-webs = { version = "0.6", optional = true }
+affinidi-did-webs = { version = "0.7", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
 did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"

--- a/crates/identity/did-methods/did-webs/CHANGELOG.md
+++ b/crates/identity/did-methods/did-webs/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this crate are documented here.
 
+## [0.7.0] - 2026-08-23
+
+### Added
+
+- **Designating `alsoKnownAs`.** `create` takes `also_known_as`, and `update`
+  takes `Change::AlsoKnownAs`.
+
+  An alias is not something a document may assert about itself, so this issues
+  the credential the resolver already required: a registry (`vcp`), an issuance
+  (`iss`), and the attestation itself — each anchored in the identifier's own key
+  event log by an interaction event, and the credential signed under the key
+  state at a named establishment event. The resolver verifies every link before
+  carrying an alias back, so every link is built.
+
+  The attribute and rules blocks carry their own SAIDs, computed before the
+  credential's, because they are part of the bytes the outer SAID covers. The
+  rules block is reproduced verbatim from the designated-aliases schema so the
+  credential this issues is the one the rest of the ecosystem reads.
+
+- **`also_known_as_scid`**, designating this identifier's own `did:scid:ke:1`
+  form. It is a switch rather than an entry in `also_known_as` because the AID
+  does not exist until the inception event does. ⚠️ The `ke` format code is
+  *proposed* in the did:scid registry rather than registered.
+
+  There is still no `also_known_as_web`: the `did:web` twin shares this
+  identifier's location and document and the resolver adds it unconditionally, so
+  the switch could only ever be on.
+
 ## [0.6.0] - 2026-08-23
 
 ### Added

--- a/crates/identity/did-methods/did-webs/Cargo.toml
+++ b/crates/identity/did-methods/did-webs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-webs"
-version = "0.6.0"
+version = "0.7.0"
 description = "Implementation of the did:webs DID method: did:web discovery with KERI-verified key state"
 repository.workspace = true
 edition.workspace = true

--- a/crates/identity/did-methods/did-webs/README.md
+++ b/crates/identity/did-methods/did-webs/README.md
@@ -141,11 +141,21 @@ published file adds, so anything not backed by KERI artifacts would be silently
 dropped on the way back. Service endpoints are supported because they *can* be
 backed — each is emitted as signed `rpy` messages the resolver verifies.
 
-Unlike `didwebvh-rs` there are no `also_known_as_web` / `also_known_as_scid`
-switches: webvh writes `alsoKnownAs` into its log, while `did:webs` derives it.
-The `did:web` twin is added by the resolver unconditionally so it cannot be
-turned off, and a `did:scid:ke` entry is not derivable from the log so it cannot
-be turned on.
+### Designating `alsoKnownAs`
+
+An alias is not something a document may assert about itself. Designating one
+issues a credential — a registry, an issuance, and the attestation, each anchored
+in the identifier's own key event log — which the resolver verifies before
+carrying any alias back. `create` takes `also_known_as`, and `update` takes
+`Change::AlsoKnownAs`.
+
+`also_known_as_scid` designates this identifier's own `did:scid:ke:1` form. ⚠️
+That format code is *proposed* in the did:scid registry rather than registered,
+so its spelling may change.
+
+There is no `also_known_as_web` switch: the `did:web` twin shares this
+identifier's location and document, and the resolver adds it unconditionally, so
+the switch could only ever be on.
 
 ## What is not verified yet
 

--- a/crates/identity/did-methods/did-webs/src/attestation.rs
+++ b/crates/identity/did-methods/did-webs/src/attestation.rs
@@ -1,0 +1,204 @@
+//! Issuing a designated-aliases attestation.
+//!
+//! `alsoKnownAs` is not something a `did:webs` document may assert about
+//! itself. A resolver takes it only from a credential the identifier **issued**,
+//! anchored in its own key event log — see [`crate::aliases`]. Publishing an
+//! alias therefore means producing that whole chain:
+//!
+//! ```text
+//! vcp   a credential registry, incepted by this AID
+//!  └─ anchored by an interaction event in the key event log
+//! iss   an issuance in that registry
+//!  └─ anchored by a second interaction event
+//! ACDC  the attestation itself, signed by the AID, listing the aliases
+//! ```
+//!
+//! Every link is checked on resolution, so every link has to be built. That is
+//! the price of an alias meaning anything: a document that merely claims one is
+//! claiming it about itself.
+
+use affinidi_keri::hab::Hab;
+use affinidi_keri_core::said;
+use affinidi_keri_core::serder::Serder;
+use affinidi_keri_core::version::SerializationKind;
+use serde_json::{Value, json};
+
+use crate::aliases::DESIGNATED_ALIASES_SCHEMA;
+use crate::endpoints::{fix_version, sign_with_group, timestamp};
+use crate::errors::DidWebsError;
+
+/// The rules block of the designated-aliases attestation.
+///
+/// Fixed by the credential's schema, and reproduced verbatim so the attestation
+/// this crate issues is the same credential the rest of the ecosystem reads.
+fn rules() -> Value {
+    json!({
+        "d": "",
+        "aliasDesignation": {
+            "l": "The issuer of this ACDC designates the identifiers in the ids field as the only allowed namespaced aliases of the issuer's AID."
+        },
+        "usageDisclaimer": {
+            "l": "This attestation only asserts designated aliases of the controller of the AID, that the AID controlled namespaced alias has been designated by the controller. It does not assert that the controller of this AID has control over the infrastructure or anything else related to the namespace other than the included AID."
+        },
+        "issuanceDisclaimer": {
+            "l": "All information in a valid and non-revoked alias designation assertion is accurate as of the date specified."
+        },
+        "termsOfUse": {
+            "l": "Designated aliases of the AID must only be used in a manner consistent with the expressed intent of the AID controller."
+        }
+    })
+}
+
+/// Issue a designated-aliases attestation for `aliases`.
+///
+/// Appends two interaction events to the identifier's key event log — the
+/// anchors — and returns the CESR bytes for those plus the registry, the
+/// issuance and the signed credential.
+///
+/// # Errors
+/// Returns [`DidWebsError::Create`] if any part of the chain cannot be built,
+/// signed, or anchored.
+pub(crate) fn issue_designated_aliases(
+    hab: &mut Hab,
+    aid: &str,
+    establishment_said: &str,
+    aliases: &[String],
+) -> Result<Vec<u8>, DidWebsError> {
+    if aliases.is_empty() {
+        return Err(DidWebsError::Create(
+            "a designated-aliases attestation with no aliases designates nothing".into(),
+        ));
+    }
+
+    // 1. The registry. Its identifier is its own SAID, so it is self-addressing
+    //    and both `d` and `i` are dummied while it is computed.
+    let mut vcp = json!({
+        "v": "KERI10JSON000000_",
+        "t": "vcp",
+        "d": "",
+        "i": "",
+        "ii": aid,
+        "s": "0",
+        "c": ["NB"],
+        "bt": "0",
+        "b": [],
+        "n": nonce(hab)?,
+    });
+    fix_version(&mut vcp)?;
+    let registry = said::compute_said(&mut vcp, "d", "E", SerializationKind::Json)
+        .map_err(|e| DidWebsError::Create(format!("registry SAID: {e}")))?;
+    let vcp = Serder::new(SerializationKind::Json, vcp)
+        .map_err(|e| DidWebsError::Create(format!("registry: {e}")))?;
+
+    // 2. Anchor it. Without this the registry is just a document somebody wrote.
+    let anchor_registry = hab
+        .interact_event(&[json!({ "i": registry, "s": "0", "d": registry })])
+        .map_err(|e| DidWebsError::Create(format!("anchoring the registry: {e}")))?;
+
+    // 3. The credential.
+    let acdc_sad = build_attestation(aid, &registry, aliases)?;
+    let acdc_said = acdc_sad["d"]
+        .as_str()
+        .ok_or_else(|| DidWebsError::Create("attestation has no SAID".into()))?
+        .to_string();
+    let acdc = Serder::new(SerializationKind::Json, acdc_sad)
+        .map_err(|e| DidWebsError::Create(format!("attestation: {e}")))?;
+
+    // 4. The issuance.
+    let mut iss = json!({
+        "v": "KERI10JSON000000_",
+        "t": "iss",
+        "d": "",
+        "i": acdc_said,
+        "s": "0",
+        "ri": registry,
+        "dt": timestamp(),
+    });
+    fix_version(&mut iss)?;
+    let iss_said = said::compute_said(&mut iss, "d", "E", SerializationKind::Json)
+        .map_err(|e| DidWebsError::Create(format!("issuance SAID: {e}")))?;
+    let iss = Serder::new(SerializationKind::Json, iss)
+        .map_err(|e| DidWebsError::Create(format!("issuance: {e}")))?;
+
+    // 5. Anchor the issuance too — the registry existing does not say anything
+    //    was issued in it.
+    let anchor_issuance = hab
+        .interact_event(&[json!({ "i": acdc_said, "s": "0", "d": iss_said })])
+        .map_err(|e| DidWebsError::Create(format!("anchoring the issuance: {e}")))?;
+
+    // Key events first, in order, then the transaction events and the
+    // credential — the shape a published `keri.cesr` takes.
+    let mut out = Vec::new();
+    out.extend_from_slice(&anchor_registry.composed);
+    out.extend_from_slice(&anchor_issuance.composed);
+    out.extend_from_slice(vcp.raw());
+    out.extend_from_slice(iss.raw());
+    out.extend_from_slice(&sign_with_group(hab, establishment_said, &acdc)?);
+
+    Ok(out)
+}
+
+/// Build the attestation, SAIDifying the nested blocks before the whole.
+///
+/// The attribute and rules blocks carry their own SAIDs, and those are part of
+/// the bytes the outer SAID covers — so they have to be computed first, or the
+/// credential's identifier would not match its contents.
+fn build_attestation(aid: &str, registry: &str, aliases: &[String]) -> Result<Value, DidWebsError> {
+    let mut attributes = json!({
+        "d": "",
+        "dt": timestamp(),
+        "ids": aliases,
+    });
+    said::compute_said(&mut attributes, "d", "E", SerializationKind::Json)
+        .map_err(|e| DidWebsError::Create(format!("attribute SAID: {e}")))?;
+
+    let mut rules = rules();
+    said::compute_said(&mut rules, "d", "E", SerializationKind::Json)
+        .map_err(|e| DidWebsError::Create(format!("rules SAID: {e}")))?;
+
+    let mut acdc = json!({
+        "v": "ACDC10JSON000000_",
+        "d": "",
+        "i": aid,
+        "ri": registry,
+        "s": DESIGNATED_ALIASES_SCHEMA,
+        "a": attributes,
+        "r": rules,
+    });
+    fix_acdc_version(&mut acdc)?;
+    said::compute_said(&mut acdc, "d", "E", SerializationKind::Json)
+        .map_err(|e| DidWebsError::Create(format!("attestation SAID: {e}")))?;
+
+    Ok(acdc)
+}
+
+/// An ACDC declares its length the same way a KERI event does, but under its
+/// own protocol tag.
+fn fix_acdc_version(sad: &mut Value) -> Result<(), DidWebsError> {
+    let placeholder = "#".repeat(44);
+    let original = sad["d"].clone();
+    sad["d"] = json!(placeholder);
+    let len = serde_json::to_vec(sad)?.len();
+    sad["v"] = json!(format!("ACDC10JSON{len:06x}_"));
+    sad["d"] = original;
+    Ok(())
+}
+
+/// A registry nonce, derived from the identifier's own key material so that
+/// creating the same identifier twice yields the same registry.
+fn nonce(hab: &Hab) -> Result<String, DidWebsError> {
+    let signer = hab
+        .signers()
+        .first()
+        .ok_or_else(|| DidWebsError::Create("identifier has no signing key".into()))?;
+    let key = signer
+        .verfer()
+        .qb64()
+        .map_err(|e| DidWebsError::Create(format!("key: {e}")))?;
+
+    let digest = affinidi_keri_crypto::Diger::from_data("E", key.as_bytes())
+        .and_then(|d| d.qb64())
+        .map_err(|e| DidWebsError::Create(format!("nonce: {e}")))?;
+    // A salt-coded primitive, as keripy uses for the registry nonce.
+    Ok(format!("A{}", &digest[1..]))
+}

--- a/crates/identity/did-methods/did-webs/src/create.rs
+++ b/crates/identity/did-methods/did-webs/src/create.rs
@@ -19,28 +19,20 @@
 //! adds. Fields that are not backed by KERI artifacts would be silently dropped
 //! on the way back, so this module refuses to write them.
 //!
-//! Service endpoints *are* supported, because they can be backed: each one is
-//! emitted as signed `rpy` messages in the stream, which the resolver verifies
-//! and derives the services from. Designated aliases are not yet, because they
-//! need a credential registry and an issuance that `affinidi-keri` cannot build.
+//! Service endpoints and `alsoKnownAs` are both supported, because both can be
+//! backed: services by signed `rpy` messages, aliases by a designated-aliases
+//! attestation the identifier issues to itself. The resolver verifies each and
+//! derives the document from what it verified.
 //!
-//! # No `alsoKnownAs` knobs, unlike `didwebvh-rs`
+//! # One knob from `didwebvh-rs`, and one that cannot exist
 //!
-//! `didwebvh-rs` offers `also_known_as_web` and `also_known_as_scid` because it
-//! *writes* `alsoKnownAs` into its log, where whatever it puts is what comes
-//! back. `did:webs` derives that field instead, so neither switch could tell
-//! the truth here:
+//! `also_known_as_scid` is offered, and is real: the `did:scid:ke` form is
+//! designated in the attestation like any other alias.
 //!
-//! * the `did:web` twin is added by the resolver unconditionally — it shares
-//!   the same location and the same document — so it cannot be turned off;
-//! * a `did:scid:ke` entry is not derivable from the key event log, so a
-//!   resolver drops it — it cannot be turned on.
-//!
-//! Offering them anyway would mean publishing a document this crate's own
-//! resolver does not reproduce. Making `did:scid:ke` real needs either a
-//! designated-aliases attestation (a credential registry, see above) or a
-//! resolver that derives it, which would assert that identity for every
-//! `did:webs` whether its controller wanted it or not.
+//! There is no `also_known_as_web`. The `did:web` twin shares this identifier's
+//! location and document, and the resolver adds it unconditionally — so the
+//! switch could only ever be on, and a switch that cannot be turned off is a
+//! lie about what the caller controls.
 //!
 //! [`KeriStore`]: affinidi_keri_db::KeriStore
 
@@ -80,6 +72,16 @@ pub struct CreateConfig {
     pub inception: InceptionConfig,
     /// Endpoints this identifier designates for itself.
     pub services: Vec<SelfEndpoint>,
+    /// Identifiers to designate as `alsoKnownAs`.
+    ///
+    /// Published as a signed attestation the identifier issues to itself, not
+    /// written into the document — see [`crate::attestation`].
+    pub also_known_as: Vec<String>,
+    /// Also designate this identifier's `did:scid:ke:1` form.
+    ///
+    /// The AID is not known until the inception event exists, so this is a
+    /// switch rather than something the caller can pass in `also_known_as`.
+    pub also_known_as_scid: bool,
 }
 
 impl CreateConfig {
@@ -90,6 +92,8 @@ impl CreateConfig {
                 host: host.into(),
                 inception: InceptionConfig::default(),
                 services: Vec::new(),
+                also_known_as: Vec::new(),
+                also_known_as_scid: false,
             },
         }
     }
@@ -110,6 +114,21 @@ impl CreateConfigBuilder {
     /// Designate an endpoint for this identifier.
     pub fn service(mut self, service: SelfEndpoint) -> Self {
         self.config.services.push(service);
+        self
+    }
+
+    /// Designate another identifier as `alsoKnownAs`.
+    pub fn also_known_as(mut self, did: impl Into<String>) -> Self {
+        self.config.also_known_as.push(did.into());
+        self
+    }
+
+    /// Designate this identifier's own `did:scid:ke:1` form.
+    ///
+    /// ⚠️ The `ke` format code is *proposed* in the did:scid registry rather
+    /// than registered, so this asserts an identity whose spelling may change.
+    pub fn also_known_as_scid(mut self, enabled: bool) -> Self {
+        self.config.also_known_as_scid = enabled;
         self
     }
 
@@ -161,7 +180,7 @@ impl CreateResult {
 /// do not resolve back — which would mean this crate had emitted something its
 /// own resolver rejects.
 pub fn create(config: CreateConfig) -> Result<CreateResult, DidWebsError> {
-    let (hab, inception) = Hab::incept_event("did:webs", &config.inception)
+    let (mut hab, inception) = Hab::incept_event("did:webs", &config.inception)
         .map_err(|e| DidWebsError::Create(format!("inception failed: {e}")))?;
 
     let aid = hab.prefix().to_string();
@@ -170,6 +189,22 @@ pub fn create(config: CreateConfig) -> Result<CreateResult, DidWebsError> {
 
     let establishment_said = inception.said.clone();
     let mut keri_cesr = inception.composed;
+
+    // Aliases are published as a signed attestation the identifier issues to
+    // itself. The document is not allowed to simply claim them.
+    let mut aliases = config.also_known_as.clone();
+    if config.also_known_as_scid {
+        aliases.push(format!("did:scid:ke:1:{aid}?src={}", config.host));
+    }
+    if !aliases.is_empty() {
+        let attestation = crate::attestation::issue_designated_aliases(
+            &mut hab,
+            &aid,
+            &establishment_said,
+            &aliases,
+        )?;
+        keri_cesr.extend_from_slice(&attestation);
+    }
 
     // Endpoints are published as signed replies rather than written into the
     // document, so that a resolver can verify them instead of taking the

--- a/crates/identity/did-methods/did-webs/src/endpoints.rs
+++ b/crates/identity/did-methods/did-webs/src/endpoints.rs
@@ -50,14 +50,14 @@ pub(crate) fn self_designated_replies(
             "/end/role/add",
             json!({ "cid": aid, "role": service.role, "eid": aid }),
         )?;
-        out.extend_from_slice(&sign_reply(hab, establishment_said, &authorise)?);
+        out.extend_from_slice(&sign_with_group(hab, establishment_said, &authorise)?);
 
         for (scheme, url) in &service.urls {
             let location = reply(
                 "/loc/scheme",
                 json!({ "eid": aid, "scheme": scheme, "url": url }),
             )?;
-            out.extend_from_slice(&sign_reply(hab, establishment_said, &location)?);
+            out.extend_from_slice(&sign_with_group(hab, establishment_said, &location)?);
         }
     }
 
@@ -84,7 +84,9 @@ fn reply(route: &str, attrs: Value) -> Result<Serder, DidWebsError> {
 
 /// Attach a transferable indexed signature group, which is how a transferable
 /// identifier signs something that is not part of its own key event log.
-fn sign_reply(
+/// Attach a transferable indexed signature group — how a transferable
+/// identifier signs anything that is not part of its own key event log.
+pub(crate) fn sign_with_group(
     hab: &Hab,
     establishment_said: &str,
     serder: &Serder,
@@ -128,7 +130,7 @@ fn sequence_number_qb64(sn: u64) -> String {
 
 /// Fix the `v` size before computing the SAID, so the SAID covers the bytes the
 /// message is actually serialized as.
-fn fix_version(sad: &mut Value) -> Result<(), DidWebsError> {
+pub(crate) fn fix_version(sad: &mut Value) -> Result<(), DidWebsError> {
     let placeholder = "#".repeat(44);
     let original = sad["d"].clone();
     sad["d"] = json!(placeholder);
@@ -142,7 +144,7 @@ fn fix_version(sad: &mut Value) -> Result<(), DidWebsError> {
 ///
 /// Replies supersede one another by `dt`, so this has to move forward between
 /// events that address the same subject.
-fn timestamp() -> String {
+pub(crate) fn timestamp() -> String {
     chrono::Utc::now()
         .format("%Y-%m-%dT%H:%M:%S%.6f+00:00")
         .to_string()

--- a/crates/identity/did-methods/did-webs/src/lib.rs
+++ b/crates/identity/did-methods/did-webs/src/lib.rs
@@ -18,6 +18,8 @@
 #[cfg(feature = "create")]
 pub mod artifacts;
 #[cfg(feature = "create")]
+pub(crate) mod attestation;
+#[cfg(feature = "create")]
 pub mod create;
 #[cfg(feature = "create")]
 pub mod custody;

--- a/crates/identity/did-methods/did-webs/src/update.rs
+++ b/crates/identity/did-methods/did-webs/src/update.rs
@@ -35,6 +35,16 @@ pub enum Change {
     /// resolver can verify them. Existing designations are superseded by
     /// timestamp, so re-designating a role replaces where it points.
     Services(Vec<SelfEndpoint>),
+    /// Designate `alsoKnownAs` identifiers.
+    ///
+    /// Issues a fresh attestation in a new registry, listing exactly these
+    /// aliases. It does not add to an earlier one — an attestation names *the*
+    /// designated aliases, so a caller wanting to keep existing entries passes
+    /// them again.
+    ///
+    /// Appends two interaction events to the key event log, since both the
+    /// registry and the issuance must be anchored in it.
+    AlsoKnownAs(Vec<String>),
 }
 
 /// How to continue an identifier.
@@ -132,6 +142,16 @@ pub fn update(config: UpdateConfig, salt: &[u8]) -> Result<UpdateResult, DidWebs
                 .interact_event(anchors)
                 .map_err(|e| DidWebsError::Create(format!("interaction failed: {e}")))?;
             keri_cesr.extend_from_slice(&event.composed);
+        }
+        Change::AlsoKnownAs(aliases) => {
+            let establishment = last_establishment_said(&kels, did.aid())?;
+            let attestation = crate::attestation::issue_designated_aliases(
+                &mut hab,
+                did.aid(),
+                &establishment,
+                aliases,
+            )?;
+            keri_cesr.extend_from_slice(&attestation);
         }
         Change::Services(services) => {
             // Replies are not key events, so nothing is appended to the log

--- a/crates/identity/did-methods/did-webs/tests/create.rs
+++ b/crates/identity/did-methods/did-webs/tests/create.rs
@@ -333,3 +333,176 @@ fn a_custody_record_for_another_identifier_is_refused() {
         .is_err(),
     );
 }
+
+// -- designated aliases --------------------------------------------------
+
+const OTHER: &str = "did:web:elsewhere.example:alice";
+
+#[test]
+fn a_designated_alias_survives_resolution() {
+    // The whole point: the alias is carried back because the chain verifies,
+    // not because did.json said so.
+    let config = CreateConfig::builder(HOST)
+        .inception(inception())
+        .also_known_as(OTHER)
+        .build();
+
+    let result = create(config).expect("create");
+    let doc = resolve(result.did(), result.artifacts());
+
+    assert!(
+        doc.also_known_as.iter().any(|a| a == OTHER),
+        "got {:?}",
+        doc.also_known_as,
+    );
+}
+
+#[test]
+fn the_did_scid_form_can_be_designated() {
+    let config = CreateConfig::builder(HOST)
+        .inception(inception())
+        .also_known_as_scid(true)
+        .build();
+
+    let result = create(config).expect("create");
+    let aid = DidWebs::parse(result.did())
+        .expect("parse")
+        .aid()
+        .to_string();
+    let doc = resolve(result.did(), result.artifacts());
+
+    assert!(
+        doc.also_known_as
+            .iter()
+            .any(|a| a == &format!("did:scid:ke:1:{aid}?src={HOST}")),
+        "got {:?}",
+        doc.also_known_as,
+    );
+}
+
+#[test]
+fn aliases_can_be_designated_after_creation() {
+    let created = create(config()).expect("create");
+    assert_eq!(
+        resolve(created.did(), created.artifacts())
+            .also_known_as
+            .len(),
+        1,
+        "only the did:web twin to begin with",
+    );
+
+    let updated = update(
+        UpdateConfig {
+            did: created.did().to_string(),
+            prior: created.artifacts().clone(),
+            custody: created.custody().clone(),
+            change: Change::AlsoKnownAs(vec![OTHER.to_string()]),
+        },
+        SALT,
+    )
+    .expect("designate");
+
+    let doc = resolve(updated.did(), updated.artifacts());
+    assert!(
+        doc.also_known_as.iter().any(|a| a == OTHER),
+        "got {:?}",
+        doc.also_known_as
+    );
+}
+
+#[test]
+fn an_alias_survives_a_later_rotation() {
+    // The attestation is signed under one key state and read after another.
+    let config = CreateConfig::builder(HOST)
+        .inception(inception())
+        .also_known_as(OTHER)
+        .build();
+    let created = create(config).expect("create");
+
+    let updated = update(
+        UpdateConfig {
+            did: created.did().to_string(),
+            prior: created.artifacts().clone(),
+            custody: created.custody().clone(),
+            change: Change::Rotate(RotationConfig::default()),
+        },
+        SALT,
+    )
+    .expect("rotate");
+
+    let doc = resolve(updated.did(), updated.artifacts());
+    assert!(
+        doc.also_known_as.iter().any(|a| a == OTHER),
+        "a rotation must not withdraw a designation, got {:?}",
+        doc.also_known_as,
+    );
+}
+
+#[test]
+fn designating_nothing_is_refused() {
+    let config = CreateConfig::builder(HOST).inception(inception()).build();
+    let created = create(config).expect("create");
+
+    assert!(
+        update(
+            UpdateConfig {
+                did: created.did().to_string(),
+                prior: created.artifacts().clone(),
+                custody: created.custody().clone(),
+                change: Change::AlsoKnownAs(vec![]),
+            },
+            SALT,
+        )
+        .is_err(),
+        "an attestation with no aliases designates nothing",
+    );
+}
+
+#[test]
+fn an_unanchored_attestation_is_not_carried_back() {
+    // Strip the interaction events that anchor the registry and the issuance,
+    // leaving the credential itself intact and correctly signed. Its aliases
+    // must not survive: an attestation that nothing in the key event log
+    // authorises is only a document the identifier wrote about itself.
+    //
+    // The key event log still verifies after the strip — the inception stands
+    // alone — so this exercises the anchor check rather than merely breaking
+    // the log, which would prove nothing.
+    let config = CreateConfig::builder(HOST)
+        .inception(inception())
+        .also_known_as(OTHER)
+        .build();
+    let created = create(config).expect("create");
+
+    let text = String::from_utf8(created.artifacts().keri_cesr.clone()).expect("ascii");
+    let stripped = strip_interactions(&text);
+    assert!(
+        stripped.contains(OTHER),
+        "the credential itself must still be present",
+    );
+
+    let did = DidWebs::parse(created.did()).expect("parse");
+    let doc = resolve_from_artifacts(&did, stripped.as_bytes(), None)
+        .expect("the key event log still verifies without its interactions");
+
+    assert!(
+        !doc.also_known_as.iter().any(|a| a == OTHER),
+        "an unanchored attestation must not be carried back, got {:?}",
+        doc.also_known_as,
+    );
+}
+
+/// Remove every `ixn` message from a CESR stream, leaving the rest.
+fn strip_interactions(stream: &str) -> String {
+    let mut out = String::new();
+    let mut starts: Vec<usize> = stream.match_indices("{\"v\":\"").map(|(i, _)| i).collect();
+    starts.push(stream.len());
+
+    for window in starts.windows(2) {
+        let segment = &stream[window[0]..window[1]];
+        if !segment.contains("\"t\":\"ixn\"") {
+            out.push_str(segment);
+        }
+    }
+    out
+}

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## 0.8.14
+
+### Changed
+
+- `did-webs` feature now re-exports `affinidi-did-webs` 0.7.
+
 ## 0.8.13
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.13"
+version = "0.8.14"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 # DID methods
 affinidi-did-web = { version = "0.1", path = "../../identity/did-methods/did-web", optional = true }
 did-ebsi = { version = "0.1", path = "../../identity/did-methods/did-ebsi", optional = true }
-affinidi-did-webs = { version = "0.6", path = "../../identity/did-methods/did-webs", optional = true }
+affinidi-did-webs = { version = "0.7", path = "../../identity/did-methods/did-webs", optional = true }
 did-scid = { version = "0.2.3", path = "../../identity/did-methods/did-scid", optional = true }
 
 # Trust + TSP


### PR DESCRIPTION
Closes the last gap. `alsoKnownAs` can now be designated — properly, by issuing
the credential the resolver already required, rather than by having a resolver
assert identities on people's behalf.

## An alias has to be earned

A `did:webs` document does not get to claim its own aliases. The resolver takes
`alsoKnownAs` only from a credential the identifier **issued**, anchored in its
own key event log (added in #734). Designating one therefore means building the
whole chain:

```
vcp   a credential registry, incepted by this AID
 └─ anchored by an interaction event in the key event log
iss   an issuance in that registry
 └─ anchored by a second interaction event
ACDC  the attestation, signed by the AID, listing the aliases
```

`create` takes `also_known_as`; `update` takes `Change::AlsoKnownAs`.

Every link is checked on resolution, so every link is built. The attribute and
rules blocks carry their own SAIDs, computed **before** the credential's, since
they are part of the bytes the outer SAID covers. The rules block is reproduced
verbatim from the designated-aliases schema, so what this issues is the
credential the rest of the ecosystem reads.

## The `did:scid` knob, now that it can be honest

`also_known_as_scid` designates this identifier's own `did:scid:ke:1` form. In
#740 I removed it because it could not round-trip — a hand-written entry was
silently dropped. Backed by an attestation it round-trips like any other alias,
so it is back.

It is a switch rather than an entry in `also_known_as` because the AID does not
exist until the inception event does.

⚠️ The `ke` format code is *proposed* in the did:scid registry rather than
registered, and the doc comment says so.

**Still no `also_known_as_web`.** The `did:web` twin shares this identifier's
location and document, and the resolver adds it unconditionally — so the switch
could only ever be on, and one that cannot be turned off misrepresents what the
caller controls.

## Tests

Six more, all through the existing verifier:

| test | asserts |
|---|---|
| `a_designated_alias_survives_resolution` | the alias comes back because the chain verifies |
| `the_did_scid_form_can_be_designated` | the `ke` form round-trips |
| `aliases_can_be_designated_after_creation` | via `update` |
| `an_alias_survives_a_later_rotation` | signed under one key state, read under another |
| `designating_nothing_is_refused` | an empty attestation designates nothing |
| `an_unanchored_attestation_is_not_carried_back` | the anchor check itself |

That last one is the one worth reading. It strips the two anchoring interaction
events, leaving the credential **intact and correctly signed** — and asserts the
key event log still verifies afterwards, so the test exercises the anchor check
rather than merely breaking the log and passing vacuously. An earlier draft of it
did pass vacuously; the assertion that the log still resolves is what makes it
mean something.

## Versions

`affinidi-did-webs` 0.6.0 → **0.7.0**, `did-scid` 0.2.4 → 0.2.5,
`affinidi-did-resolver-cache-sdk` 0.8.33 → 0.8.34, `affinidi-tdk` 0.8.13 →
0.8.14.

## Verification

`cargo test -p affinidi-did-webs --features create` — **76 passed** (was 70).
clippy, `cargo fmt --check`, per-package builds and all three repo guards clean.