### PR TITLE
chore(ci): ignore RUSTSEC-2023-0126 (im) in cargo-audit — unreachable via unbuilt did-cheqd

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -44,7 +44,17 @@ jobs:
       # Drop this entry when did-resolver-cheqd moves off ssi-dids-core 0.1
       # (see cheqd/did-resolver-rs#3), NOT when "those crates move to reqwest
       # 0.12" as this comment previously said — the crates it named are gone.
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258"
+      #
+      # RUSTSEC-2023-0126 (im, OrdSet insertion unsoundness). Same story as the h2
+      # entry above: since #719 `im` reaches the lockfile ONLY via the optional
+      # `did-cheqd` feature (did-resolver-cheqd -> ssi-dids-core 0.1 -> linked-data
+      # -> im), which no crate in this workspace enables, so it is never compiled
+      # (`cargo tree -i im --workspace` is empty; cargo-deny, which reads the build
+      # graph rather than the lockfile, does not report it). No fix exists: the crate
+      # is unmaintained and its repo was archived 2026-05-03. Clears together with
+      # RUSTSEC-2026-0258 when did-resolver-cheqd moves off ssi-dids-core 0.1
+      # (cheqd/did-resolver-rs#3).
+      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258,RUSTSEC-2023-0126"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true


### PR DESCRIPTION
## What
Adds `RUSTSEC-2023-0126` to the `cargo audit` ignore list (`auditIgnore` in `.github/workflows/checks.yaml`), with a rationale comment matching the existing entries.

## Why
The daily `audit` job (`actions-rust-lang/audit`, via the shared `pipeline-rust` CI) re-files this advisory as a **new** issue on every scheduled run — #698 was closed (via #719) and it came straight back as #732 — because the action de-dups only against *open* issues, so closing never sticks.

It's a false positive for this workspace, as verified in #719:
- `im` reaches `Cargo.lock` **only** via the optional `did-cheqd` feature (`did-resolver-cheqd` → `ssi-dids-core 0.1` → `linked-data` → `im`), which **no crate here enables** — so it is never compiled or reached (`cargo tree -i im --workspace` is empty).
- `cargo audit` reads the lockfile, not the build graph, so it flags it anyway; `cargo deny` (build-graph aware) correctly does **not**.
- No fix exists — the crate is unmaintained and its repo was archived 2026-05-03.

Same root cause and drop-condition as the existing `RUSTSEC-2026-0258` (h2) entry: both clear once `did-resolver-cheqd` moves off `ssi-dids-core 0.1` (cheqd/did-resolver-rs#3).

## Effect
Stops the recurring duplicate issues. Once this is on `main`, the next scheduled audit run also auto-closes #732 (the action closes open RUSTSEC issues no longer in findings).

Closes #732.

## Notes
- This is the correct place to fix it: `deny.toml` (cargo-deny) already doesn't flag it, and the `rust-scan`/Snyk job only logs — the noise is solely from the lockfile-based `audit` job, whose ignore list is this `auditIgnore` input.
- Filed by the security team in response to the engineering report about noisy / reopening advisory issues.
