### PR TITLE
chore(deps): move the messaging stack to trust-tasks-rs 0.12

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.4.0) — `trust-tasks-rs` 0.12
+
+- Bumps `trust-tasks-rs` 0.11 → 0.12. No source change; the crate compiles
+  unmodified against it.
+- Released as a minor bump rather than a patch because `trust-tasks-rs` types
+  reach this crate's API surface, so a consumer must move in lockstep — two
+  versions in one graph fail to compile rather than warn.
 ## [0.3.27] - 2026-08-19
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.27"
+version = "0.4.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -21,10 +21,15 @@ tsp = ["affinidi-messaging-sdk/tsp"]
 
 [dependencies]
 affinidi-tdk-common = "0.6"
-affinidi-messaging-sdk = "0.19.9"
+# Path + version, like every other crate in this family. It was a bare
+# registry requirement, so this crate compiled against the *published* SDK
+# rather than the workspace one — which is how a third `trust-tasks-rs` node
+# survived the 0.12 move and produced `expected MediatorAcl, found a different
+# MediatorAcl` from inside this workspace.
+affinidi-messaging-sdk = { version = "0.20.0", path = "../affinidi-messaging-sdk" }
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.11"
+trust-tasks-rs = "0.12"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"
@@ -44,8 +49,8 @@ affinidi-did-common = "0.4"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
-affinidi-messaging-test-mediator = { version = "0.2", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
-affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-messaging-test-mediator = { version = "0.3", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
+affinidi-tdk = { version = "0.9", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
 futures-util = "0.3"
 

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.9" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.11"
+trust-tasks-rs = "0.12"
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased (0.19.0) — `trust-tasks-rs` 0.12, and `ping` gains freshness bounds
+
+- Bumps `trust-tasks-rs` 0.11 → 0.12, and adapts the one `consume_inbound`
+  call site: 0.12 requires a `ConsumeChecks` argument and `ConsumeOutcome`
+  gains a `Duplicate` variant.
+- **Behaviour change.** `ping` now refuses two document shapes it previously
+  accepted, both as `malformedRequest`: an `issuedAt` beyond the 60s clock-skew
+  tolerance, and an `expiresAt` at or before its own `issuedAt`. Before 0.12
+  the only temporal check was `expiresAt` and `issuedAt` was parsed and never
+  looked at, so a document stamped a year ahead was accepted — and accepted
+  again for the whole of that year. A peer with a badly skewed clock will start
+  seeing refusals.
+- `ping` is declared `ConsumeChecks::not_consequential()`. Answering it grants
+  no access, moves no value, discloses nothing beyond a nonce echo and the
+  protocol list, and executing it twice leaves the mediator exactly as
+  executing it once did — so SPEC §7.2 item 11 is knowingly disapplied and no
+  duplicate-execution record is kept. On the hottest path in this module, a
+  per-document record would be pure cost.
+- The `Duplicate` arm is matched rather than `unreachable!()`, so that making
+  this call consequential later is a compile-time prompt to decide what to
+  return, not a panic on the first retried ping.
+- `PayloadPolicy::AcceptUnvalidated` is unchanged, for the reason already
+  recorded at that call site: moving it to `Validate` can start refusing
+  documents a peer sends today, and belongs in its own change with its own
+  rollout.
 ## Unreleased (0.18.22) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.18.22"
+version = "0.19.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,14 +113,14 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.9" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.11", optional = true }
+trust-tasks-rs = { version = "0.12", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -39,7 +39,7 @@ use subtle::ConstantTimeEq;
 use trust_tasks_rs::specs::messaging::{access_list, account, acl, ping};
 use trust_tasks_rs::specs::{audit, config};
 use trust_tasks_rs::{
-    ConsumeOutcome, NoValidator, Payload, PayloadPolicy, ProofPolicy, ProofVerifier,
+    ConsumeChecks, ConsumeOutcome, NoValidator, Payload, PayloadPolicy, ProofPolicy, ProofVerifier,
     TransportContext, TransportHandler, TrustTask, TypeUri, VerificationError, consume_inbound,
 };
 use uuid::Uuid;
@@ -1637,6 +1637,26 @@ async fn consume_ping(
         // can start refusing documents a peer sends today. Do it as its own
         // change, with its own rollout, never folded into a version bump.
         PayloadPolicy::<NoValidator>::AcceptUnvalidated,
+        // SPEC §7.2 items 4 and 11, required as one argument since
+        // `trust-tasks-rs` 0.12 so a deployment cannot configure a replay
+        // record and an unbounded acceptance window and believe it has a
+        // replay defence.
+        //
+        // `ping` is not a *consequential Trust Task* (§2): answering it grants
+        // no access, moves no value, discloses nothing beyond a nonce echo and
+        // the protocol list, and executing it twice leaves the mediator
+        // exactly as executing it once did. So item 11 is knowingly
+        // disapplied and no record is kept — for a liveness probe, a
+        // per-document record would be pure cost on the hottest path this
+        // module has.
+        //
+        // `not_consequential` still applies `FreshnessPolicy::default`, which
+        // is the part that matters here: a future-dated document and one whose
+        // validity interval never contained an instant are malformed whatever
+        // the task does. That is new behaviour for this call — before 0.12 the
+        // only temporal check was `expiresAt`, and `issuedAt` was parsed and
+        // never looked at.
+        ConsumeChecks::not_consequential(),
         doc,
         mediator_did,
         now,
@@ -1658,6 +1678,14 @@ async fn consume_ping(
         ConsumeOutcome::Handled(resp) => Some(serde_json::to_value(&resp).map_err(serialize_err)?),
         ConsumeOutcome::Rejected(err) => Some(serde_json::to_value(&err).map_err(serialize_err)?),
         ConsumeOutcome::Suppressed => None,
+        // Unreachable under `ReplayPolicy::NotConsequential` — no record is
+        // kept, so nothing can be recognised as a duplicate. Matched rather
+        // than `unreachable!()` so that turning this call consequential later
+        // is a compile-time prompt to decide what to return, not a panic in
+        // production on the first retried ping.
+        ConsumeOutcome::Duplicate { prior_response, .. } => prior_response
+            .map(|r| serde_json::to_value(&r).map_err(serialize_err))
+            .transpose()?,
     })
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 # ── DIDComm auth (mediator's /admin/status is gated on admin JWT) ────────
 ## Path-pinned to the workspace copy via [patch.crates-io] in the workspace
 ## root Cargo.toml; the version specs here are upper-bound contracts only.
-affinidi-messaging-sdk = "0.19"
+affinidi-messaging-sdk = { version = "0.20", path = "../../../affinidi-messaging-sdk" }
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased (0.20.0) — `trust-tasks-rs` 0.12
+
+- Bumps `trust-tasks-rs` 0.11 → 0.12.
+- **Breaking for consumers, despite no source change here.** This crate's
+  public API carries `trust-tasks-rs` types — `TrustTasks::account_update`
+  takes an `account::update::v0_1::MediatorAcl` — so a consumer must move to
+  0.12 in the same change. Two `trust-tasks-rs` versions in one graph do not
+  merely warn; they fail to compile with `expected MediatorAcl, found a
+  different MediatorAcl`.
+- No behaviour change in this crate.
 ## Unreleased (0.19.12) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.19.12"
+version = "0.20.0"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.11"
+trust-tasks-rs = "0.12"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased (0.3.0) — `trust-tasks-rs` 0.12
+
+- Bumps `trust-tasks-rs` 0.11 → 0.12, and `affinidi-messaging-sdk` to 0.20.
+- Minor rather than patch for the same reason as the rest of the family: a
+  harness a downstream workspace builds against must resolve one
+  `trust-tasks-rs`, so consumers move in lockstep.
+- Carries the mediator's new `ping` freshness bounds — a test that mints a
+  document with a badly skewed `issuedAt`, or an `expiresAt` at or before it,
+  will now see `malformedRequest`.
 ## Unreleased (0.2.53) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.53"
+version = "0.3.0"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.18", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.19", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
@@ -49,12 +49,12 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.8", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.9", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.19.9", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.20.0", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
@@ -95,7 +95,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.23"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.11"
+trust-tasks-rs = "0.12"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,11 +14,11 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.8" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.19.9" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.11"
+trust-tasks-rs = "0.12"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,21 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## 0.9.0
+
+### Changed
+
+- `messaging` feature now re-exports `affinidi-messaging-sdk` 0.20, which moves
+  to `trust-tasks-rs` 0.12.
+- **Breaking for consumers of the `messaging` feature.** The re-exported SDK
+  carries `trust-tasks-rs` types in its public API, so a consumer must move to
+  0.12 in the same change; two versions in one graph fail to compile rather
+  than warn. Minor rather than patch for that reason.
+- The dependency is now declared with a `path` alongside its version. It was a
+  bare registry requirement, so this facade re-exported the *published* SDK
+  rather than the one beside it in this workspace — which is how a stale
+  `trust-tasks-rs` node survived the 0.12 move.
+
 ## 0.8.14
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.8.14"
+version = "0.9.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tsp = ["dep:affinidi-tsp"]
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.4"
-affinidi-messaging-sdk = { version = "0.19", optional = true }
+affinidi-messaging-sdk = { version = "0.20", path = "../../messaging/affinidi-messaging-sdk", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"
 # Foundations are re-exported by the facade. Kept at major.minor (caret), NOT

--- a/scripts/workspace-duplicates-allow.txt
+++ b/scripts/workspace-duplicates-allow.txt
@@ -10,7 +10,30 @@
 #
 # ---------------------------------------------------------------------------
 #
-# (empty)
+affinidi-messaging-sdk
+affinidi-tdk
+#
+# Both entered the graph when this workspace moved to `trust-tasks-rs` 0.12 and
+# bumped `affinidi-messaging-sdk` 0.19.12 -> 0.20.0 / `affinidi-tdk` 0.8.14 ->
+# 0.9.0. Before that the workspace version and the published version were the
+# same string, so no split existed to detect.
+#
+# Both are pulled by `vta-sdk 0.25.1`, the mediator's optional `vta`
+# dev-dependency, which requires `affinidi-messaging-sdk ^0.19` and
+# `affinidi-tdk ^0.8`. A `[patch.crates-io]` entry cannot fix it: the workspace
+# copies no longer satisfy those requirements, so the patch would simply not
+# apply. Bumping the mediator's `vta-sdk = "0.25"` does not help either — every
+# published `vta-sdk`, including 0.29.0, is still built against
+# `affinidi-messaging-sdk` 0.19.
+#
+# **What clears it:** VTI publishing a `vta-sdk` built on
+# `affinidi-messaging-sdk` 0.20, which is blocked on *this* release — VTI
+# cannot move to `trust-tasks-rs` 0.12 until these crates are on crates.io.
+# The two repositories have to cross in this order; the duplicate is the cost
+# of the crossing, and it is confined to a dev-dependency subtree that no
+# type crosses (the workspace builds and tests clean).
+#
+# Remove both entries once that `vta-sdk` release lands.
 #
 # The affinidi-did-common entry that lived here was cleared on 2026-07-20:
 # vta-sdk 0.19.14 shipped on didwebvh-rs 0.6, which requires


### PR DESCRIPTION
Moves the messaging stack to `trust-tasks-rs` **0.12**.

This is the last crate holding the ecosystem on 0.11. The four sibling
trust-tasks crates have published 0.12-compatible releases; VTI cannot move
until this one does, because `affinidi-messaging-sdk` and
`affinidi-messaging-mediator` sit on VTI's `trust-tasks-rs` node and two nodes
in one graph fail to compile:

```
error[E0308]: mismatched types
   --> vta-sdk/src/acl_setup.rs:147:18
    |                  ^^^ expected `MediatorAcl`, found a different `MediatorAcl`
note: there are multiple different versions of crate `trust_tasks_rs` in the dependency graph
```

## The whole source change is one call site

Six `Cargo.toml` pins, and `consume_inbound` in
`affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs`. 0.12
requires a fourth argument, `ConsumeChecks`, and `ConsumeOutcome` gains a
`Duplicate` variant.

### `ping` is `not_consequential`, deliberately

`ConsumeChecks` is a required argument rather than a defaulted one, and the
crate is explicit about why: whether a task is *consequential* (SPEC §2) is a
decision only its consumer can make, and getting it wrong silently — "an ACL
grant applied twice by a mediator retry" — is not something to discover after
the fact.

Answering a `ping` grants no access, moves no value, discloses nothing beyond a
nonce echo and the protocol list, and executing it twice leaves the mediator
exactly as executing it once did. So item 11 is knowingly disapplied and no
record is kept — on the hottest path in this module, a per-document replay
record would be pure cost.

### It still gains freshness, and that is a behaviour change

`not_consequential()` still applies `FreshnessPolicy::default()`. **This call
will now reject two document shapes it previously accepted**: an `issuedAt`
beyond the 60s skew tolerance, and an `expiresAt` at or before its own
`issuedAt`. Both as `malformedRequest`.

That is new. Before 0.12 the only temporal check here was `expiresAt`, and
`issuedAt` was parsed and never looked at — so a document stamped a year ahead
was accepted, and accepted again for the whole of that year. Worth calling out
explicitly rather than letting it ride in as a version bump, since a peer with
a badly skewed clock will start seeing refusals.

### The `Duplicate` arm is matched, not `unreachable!()`

It cannot occur under `ReplayPolicy::NotConsequential`, since no record is kept.
Matching it anyway means that making this call consequential later is a
compile-time prompt to decide what to return, rather than a panic in production
on the first retried ping.

## What is *not* changed

`PayloadPolicy::AcceptUnvalidated` stays. The existing comment there says
turning it to `Validate` "is a behaviour change, not a tidy-up: it can start
refusing documents a peer sends today. Do it as its own change, with its own
rollout, never folded into a version bump." That reasoning applies exactly as
written, so it is left alone.

The mediator's `vta-sdk = "0.25"` pin is also untouched. It is optional behind
the default-on `vta` feature and `affinidi-messaging-test-mediator` already
takes this crate with `default-features = false`, so the
`vta-sdk → mediator → vta-sdk` cycle documented in this file is not reached and
does not need resolving here.

## Verified against VTI before publishing

VTI was built against this branch via a path `[patch.crates-io]` over the whole
TDK workspace. Its graph collapses to a **single `trust-tasks-rs` 0.12.1 node**
and the workspace compiles, with one unrelated VTI-side adaptation
(`classify_git_trust_reply` gained a required `expected_thread_id`). So the
downstream move is known to work rather than assumed.


## Version bumps are minor, not patch

| crate | bump |
|---|---|
| `affinidi-messaging-sdk` | 0.19.12 → **0.20.0** |
| `affinidi-messaging-mediator` | 0.18.22 → **0.19.0** |
| `affinidi-messaging-didcomm-service` | 0.3.27 → **0.4.0** |
| `affinidi-messaging-test-mediator` | 0.2.53 → **0.3.0** |
| `affinidi-tdk` | 0.8.14 → **0.9.0** |

`trust-tasks-rs` types reach these crates' public API —
`TrustTasks::account_update` takes an `account::update::v0_1::MediatorAcl`, and
the `affinidi-tdk` facade re-exports the SDK behind its `messaging` feature —
so a consumer must move in lockstep. Two versions in one graph do not warn, they
fail to compile. A patch bump would let a dependent resolve the old crate
against the new framework and discover it at link time.

## Three crates were building against the published SDK, not the workspace one

`affinidi-messaging-didcomm-service`, `affinidi-tdk` and `mediator-monitor`
depended on `affinidi-messaging-sdk` by **bare registry requirement**, with no
`path`. So they compiled against whatever was last released rather than the
source beside them — and that is how a third `trust-tasks-rs` node survived
this move and produced `expected MediatorAcl, found a different MediatorAcl`
*from inside this workspace*.

All three now carry `path` alongside the version, like the rest of the family.
This is the same failure VTI documents at length in its own `Cargo.toml`: a
dependent verified against the previous release's source, silently, while the
workspace's own build stayed green.

## A pre-existing test failure, for the record

`config_writer::tests::test_all_secret_storage_refs` in `mediator-setup` fails
under full-suite ordering on macOS — it compares a `TMPDIR` path against
`/private/var/...` where the OS hands back `/var/...`. **It fails identically
on unmodified `main`** (verified in a clean worktree) and passes when run
alone, so it is not caused by this change. Flagged rather than left for a
reviewer to trip over.

## Gates

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast` — 176 suites pass; the single failure is the pre-existing macOS `mediator-setup` flake described above
- `bash scripts/check-version-bumps.sh` — all four changed publishable crates bumped
- `cargo fmt --all --check`
