### PR TITLE
chore(deps): move the messaging stack to trust-tasks-rs 0.17

### DIFF
--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased (0.5.0) — `trust-tasks-rs` 0.17
+
+- Bumps `trust-tasks-rs` 0.12 → 0.17.
+- The one `MediatorAcl` construction in `service/mediator.rs` moved to the
+  generated builder — `#[non_exhaustive]` in 0.17, so the
+  `..Default::default()` literal no longer compiles.
+- **Breaking for consumers** only in that this crate now requires
+  `trust-tasks-rs` 0.17; no API or behaviour change here.
+
 ## Unreleased (0.4.0) — `trust-tasks-rs` 0.12
 
 - Bumps `trust-tasks-rs` 0.11 → 0.12. No source change; the crate compiles

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.4.0"
+version = "0.5.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ affinidi-tdk-common = "0.6"
 # rather than the workspace one — which is how a third `trust-tasks-rs` node
 # survived the 0.12 move and produced `expected MediatorAcl, found a different
 # MediatorAcl` from inside this workspace.
-affinidi-messaging-sdk = { version = "0.20.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.21.0", path = "../affinidi-messaging-sdk" }
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
 trust-tasks-rs = "0.17"
@@ -49,8 +49,8 @@ affinidi-did-common = "0.4"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
-affinidi-messaging-test-mediator = { version = "0.3", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
-affinidi-tdk = { version = "0.9", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-messaging-test-mediator = { version = "0.4", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
+affinidi-tdk = { version = "0.10", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
 futures-util = "0.3"
 

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -29,7 +29,7 @@ affinidi-tdk-common = "0.6"
 affinidi-messaging-sdk = { version = "0.20.0", path = "../affinidi-messaging-sdk" }
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.12"
+trust-tasks-rs = "0.17"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"

--- a/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
+++ b/crates/messaging/affinidi-messaging-didcomm-service/src/service/mediator.rs
@@ -39,10 +39,10 @@ impl Listener {
                 account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny
             }
         };
-        let acl = account::update::v0_1::MediatorAcl {
-            access_list_mode: Some(mode),
-            ..Default::default()
-        };
+        let acl: account::update::v0_1::MediatorAcl = account::update::v0_1::MediatorAcl::builder()
+            .access_list_mode(Some(mode))
+            .try_into()
+            .expect("MediatorAcl has no required member");
         atm.trust_tasks()
             .account_update(
                 profile,

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/mediator_administration/main.rs"
 ## SDK for connecting to and communicating with a running mediator
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.12"
+trust-tasks-rs = "0.17"
 ## TDK for DID resolution and crypto utilities
 affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
 ## DIDComm message types — used by example binaries

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.21.0" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
 trust-tasks-rs = "0.17"
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.10" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/account_management.rs
@@ -408,10 +408,13 @@ async fn _change_account_queue_limit(
             Some(account.did.as_str().to_string()),
             None,
             None,
-            Some(account::update::v0_1::QueueLimits {
-                send_queue_limit,
-                receive_queue_limit,
-            }),
+            Some(
+                account::update::v0_1::QueueLimits::builder()
+                    .send_queue_limit(send_queue_limit)
+                    .receive_queue_limit(receive_queue_limit)
+                    .try_into()
+                    .expect("QueueLimits has no required member"),
+            ),
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
+++ b/crates/messaging/affinidi-messaging-helpers/src/mediator_administration/account_management/acl_management.rs
@@ -179,25 +179,25 @@ async fn _modify_acl_flags(
     }
 
     // Build a full ACL set from the chosen flags.
-    let new_acl = account::update::v0_1::MediatorAcl {
-        access_list_mode: Some(if flags[0] {
+    let new_acl: account::update::v0_1::MediatorAcl = account::update::v0_1::MediatorAcl::builder()
+        .access_list_mode(Some(if flags[0] {
             account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny
         } else {
             account::update::v0_1::MediatorAclAccessListMode::ExplicitAllow
-        }),
-        blocked: Some(flags[1]),
-        local: Some(flags[2]),
-        send_messages: Some(flags[3]),
-        receive_messages: Some(flags[4]),
-        send_forwarded: Some(flags[5]),
-        receive_forwarded: Some(flags[6]),
-        create_invites: Some(flags[7]),
-        anon_receive: Some(flags[8]),
-        self_manage_list: Some(flags[9]),
-        self_manage_send_queue_limit: Some(flags[10]),
-        self_manage_receive_queue_limit: Some(flags[11]),
-        ..Default::default()
-    };
+        }))
+        .blocked(Some(flags[1]))
+        .local(Some(flags[2]))
+        .send_messages(Some(flags[3]))
+        .receive_messages(Some(flags[4]))
+        .send_forwarded(Some(flags[5]))
+        .receive_forwarded(Some(flags[6]))
+        .create_invites(Some(flags[7]))
+        .anon_receive(Some(flags[8]))
+        .self_manage_list(Some(flags[9]))
+        .self_manage_send_queue_limit(Some(flags[10]))
+        .self_manage_receive_queue_limit(Some(flags[11]))
+        .try_into()
+        .expect("MediatorAcl has no required member");
 
     // Compare against the current ACL (both normalised to JSON; MediatorAcl
     // does not derive PartialEq).

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased (0.20.0) — `trust-tasks-rs` 0.17
+
+- Bumps `trust-tasks-rs` 0.12 → 0.17; sixteen response and component
+  constructions moved to the generated builders behind one `build()` helper.
+- **Behaviour change: three refusals that did not exist before.** 0.17 marks
+  the generated *enums* `#[non_exhaustive]`, so a match on one needs a wildcard
+  — and a wire enum can now carry a variant added to the registry after this
+  binary was built. What the mediator does with one is a decision per site:
+  - `account/list`'s role **filter** treats an unknown role as
+    `AccountType::Unknown`, which selects nothing. Widening it to `Standard`
+    would answer the request with a confident list of the wrong accounts.
+  - `account/update` and `account/add` **refuse** an unknown role
+    (`message.trust_task.rejected`, 400). They write it, and storing a
+    privilege level this mediator cannot reason about — while telling the
+    caller it set the role they asked for — is worse than a refusal.
+  - `merge_wire_acl` **refuses** an unknown `accessListMode`. That member
+    decides whether the access list allows or denies; guessing it inverts the
+    ACL.
+- No wire change for any known variant.
+
 ## Unreleased (0.19.0) — `trust-tasks-rs` 0.12, and `ping` gains freshness bounds
 
 - Bumps `trust-tasks-rs` 0.11 → 0.12, and adapts the one `consume_inbound`

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -120,7 +120,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.12", optional = true }
+trust-tasks-rs = { version = "0.17", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.19.0"
+version = "0.20.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,7 +113,7 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.21.0" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -309,10 +309,8 @@ async fn consume_account_get(
             )
         })?;
 
-    let response = account::get::v0_1::Response {
-        account: map_account_get(&account),
-        ext: None,
-    };
+    let response: account::get::v0_1::Response =
+        build(account::get::v0_1::Response::builder().account(map_account_get(&account)))?;
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
 }
@@ -369,11 +367,18 @@ async fn consume_account_list(
             WireType::Admin => AccountType::Admin,
             WireType::RootAdmin => AccountType::RootAdmin,
             WireType::Mediator => AccountType::Mediator,
+            // The wire enum is `#[non_exhaustive]`: a peer on a newer registry
+            // can name a role added after this binary was built. As a *filter*
+            // that selects nothing, which is the honest answer — widening it to
+            // `Standard` would return a confident list of the wrong accounts.
+            _ => AccountType::Unknown,
         }
     });
 
     let page = state.database.account_list(cursor, limit).await?;
-    let accounts = page
+    // Annotated: the element type used to be pinned by the response struct
+    // literal below, and the builder's `TryInto` setter no longer pins it.
+    let accounts: Vec<account::list::v0_1::Account> = page
         .accounts
         .iter()
         .filter(|a| type_filter.as_ref().is_none_or(|t| a._type == *t))
@@ -392,11 +397,11 @@ async fn consume_account_list(
             )
         })?;
 
-    let response = account::list::v0_1::Response {
-        accounts,
-        next_cursor,
-        ext: None,
-    };
+    let response: account::list::v0_1::Response = build(
+        account::list::v0_1::Response::builder()
+            .accounts(accounts)
+            .next_cursor(next_cursor),
+    )?;
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
 }
@@ -463,12 +468,28 @@ async fn consume_account_update(
         ));
     }
 
-    let new_type = typed.payload.account_type.as_ref().map(|t| match t {
-        WireType::Standard => AccountType::Standard,
-        WireType::Admin => AccountType::Admin,
-        WireType::RootAdmin => AccountType::RootAdmin,
-        WireType::Mediator => AccountType::Mediator,
-    });
+    // Fallible, unlike the read-side filter: this one *writes* the role, and
+    // silently storing something the caller did not ask for is worse than
+    // telling them this mediator cannot set it.
+    let new_type = typed
+        .payload
+        .account_type
+        .as_ref()
+        .map(|t| match t {
+            WireType::Standard => Ok(AccountType::Standard),
+            WireType::Admin => Ok(AccountType::Admin),
+            WireType::RootAdmin => Ok(AccountType::RootAdmin),
+            WireType::Mediator => Ok(AccountType::Mediator),
+            _ => Err(tt_problem(
+                session,
+                "message.trust_task.rejected",
+                "unrecognised accountType: this mediator cannot set a role added \
+                 to the registry after it was built"
+                    .to_string(),
+                StatusCode::BAD_REQUEST,
+            )),
+        })
+        .transpose()?;
     if let Some(new_type) = &new_type {
         // Must be an admin to change roles at all.
         if !state
@@ -629,10 +650,10 @@ async fn consume_account_update(
                 StatusCode::NOT_FOUND,
             )
         })?;
-    let response = account::update::v0_1::Response {
-        account: to_wire_account(&account),
-        ext: None,
-    };
+    let response: account::update::v0_1::Response = build(
+        account::update::v0_1::Response::builder()
+            .account(to_wire_account::<account::update::v0_1::Account>(&account)),
+    )?;
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
 }
@@ -721,11 +742,11 @@ async fn consume_account_remove(
     )
     .await;
 
-    let response = account::remove::v0_1::Response {
-        did: typed.payload.did.clone(),
-        ext: None,
-        removed,
-    };
+    let response: account::remove::v0_1::Response = build(
+        account::remove::v0_1::Response::builder()
+            .did(typed.payload.did.clone())
+            .removed(removed),
+    )?;
     let response_doc = typed.respond_with(Uuid::new_v4().to_string(), response);
     serde_json::to_value(&response_doc).map_err(serialize_err)
 }
@@ -759,6 +780,18 @@ async fn consume_account_add(
         WireType::Admin => AccountType::Admin,
         WireType::RootAdmin => AccountType::RootAdmin,
         WireType::Mediator => AccountType::Mediator,
+        // Creating an account with a role this mediator does not know would
+        // store a privilege level it cannot reason about. Refuse.
+        _ => {
+            return Err(tt_problem(
+                session,
+                "message.trust_task.rejected",
+                "unrecognised accountType: this mediator cannot create an account \
+                 with a role added to the registry after it was built"
+                    .to_string(),
+                StatusCode::BAD_REQUEST,
+            ));
+        }
     };
     let is_admin = matches!(
         session.account_type,
@@ -828,10 +861,10 @@ async fn consume_account_add(
     )
     .await;
 
-    let response = account::add::v0_1::Response {
-        account: to_wire_account(&account),
-        ext: None,
-    };
+    let response: account::add::v0_1::Response = build(
+        account::add::v0_1::Response::builder()
+            .account(to_wire_account::<account::add::v0_1::Account>(&account)),
+    )?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -877,19 +910,16 @@ async fn consume_acl_get(
     for did in &dids {
         let vid = Vid::from_str(did).expect("a requested DID is a valid Vid");
         match state.database.get_did_acl(did).await? {
-            Some(aclset) => entries.push(Entry {
-                acl: to_wire_acl(&aclset),
-                did: vid,
-            }),
+            Some(aclset) => entries.push(build(
+                Entry::builder()
+                    .acl(to_wire_acl::<acl::get::v0_1::MediatorAcl>(&aclset))
+                    .did(vid),
+            )?),
             None => unknown.push(vid),
         }
     }
 
-    let response = Response {
-        entries,
-        ext: None,
-        unknown,
-    };
+    let response: Response = build(Response::builder().entries(entries).unknown(unknown))?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -1114,13 +1144,13 @@ async fn consume_access_list_update(
             .collect();
     }
 
-    let response = Response {
-        access_list_count: access_list_count(state, &target_hash).await,
-        added,
-        did: typed.payload.did.clone(),
-        ext: None,
-        removed,
-    };
+    let response: Response = build(
+        Response::builder()
+            .access_list_count(access_list_count(state, &target_hash).await)
+            .added(added)
+            .did(typed.payload.did.clone())
+            .removed(removed),
+    )?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -1160,7 +1190,7 @@ async fn consume_access_list_list(
             .did_hashes
             .into_iter()
             .collect();
-        let entries = typed
+        let entries: Vec<Vid> = typed
             .payload
             .entries
             .iter()
@@ -1168,13 +1198,13 @@ async fn consume_access_list_list(
             .cloned()
             .collect();
 
-        let response = Response {
-            access_list_count: access_list_count(state, &target_hash).await,
-            did: typed.payload.did.clone(),
-            entries,
-            ext: None,
-            next_cursor: None,
-        };
+        // `next_cursor` stays unset: a membership check answers in one page.
+        let response: Response = build(
+            Response::builder()
+                .access_list_count(access_list_count(state, &target_hash).await)
+                .did(typed.payload.did.clone())
+                .entries(entries),
+        )?;
         return serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
             .map_err(serialize_err);
     }
@@ -1189,7 +1219,7 @@ async fn consume_access_list_list(
         .database
         .access_list_list(&target_hash, cursor)
         .await?;
-    let entries = page
+    let entries: Vec<Vid> = page
         .did_hashes
         .iter()
         .map(|h| Vid::from_str(h).expect("a stored hash is a valid Vid"))
@@ -1203,13 +1233,13 @@ async fn consume_access_list_list(
         ),
     };
 
-    let response = Response {
-        access_list_count: access_list_count(state, &target_hash).await,
-        did: typed.payload.did.clone(),
-        entries,
-        ext: None,
-        next_cursor,
-    };
+    let response: Response = build(
+        Response::builder()
+            .access_list_count(access_list_count(state, &target_hash).await)
+            .did(typed.payload.did.clone())
+            .entries(entries)
+            .next_cursor(next_cursor),
+    )?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -1273,12 +1303,12 @@ async fn consume_audit_list(
         .collect::<Result<Vec<_>, _>>()?;
     let truncated = page.cursor != 0;
 
-    let response = Response {
-        cursor: truncated.then(|| page.cursor.to_string()),
-        entries,
-        ext: None,
-        truncated,
-    };
+    let response: Response = build(
+        Response::builder()
+            .cursor(truncated.then(|| page.cursor.to_string()))
+            .entries(entries)
+            .truncated(truncated),
+    )?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -1332,23 +1362,26 @@ fn map_audit_envelope(
     let mut detail = serde_json::Map::new();
     detail.insert("detail".to_string(), Value::String(e.detail.clone()));
 
-    Ok(AuditEnvelope {
-        action: AuditEnvelopeAction::from_str(action)
-            .map_err(|err| serialize_err_msg(format!("audit action: {err}")))?,
-        actor: Some(e.actor_did_hash.clone()),
-        context_id: None,
-        detail,
-        entry_hash: None,
-        event_id: AuditEnvelopeEventId::from_str(&event_id)
-            .map_err(|err| serialize_err_msg(format!("audit event id: {err}")))?,
-        ext: None,
-        outcome: None,
-        prev_hash: None,
-        recorded_at: chrono::DateTime::from_timestamp(e.timestamp as i64, 0)
-            .unwrap_or_else(chrono::Utc::now),
-        schema_version: None,
-        target: Some(e.target_did_hash.clone()),
-    })
+    // `contextId`, `entryHash`, `outcome`, `prevHash` and `schemaVersion` are
+    // left unset: this mediator's audit rows carry no equivalent.
+    build(
+        AuditEnvelope::builder()
+            .action(
+                AuditEnvelopeAction::from_str(action)
+                    .map_err(|err| serialize_err_msg(format!("audit action: {err}")))?,
+            )
+            .actor(Some(e.actor_did_hash.clone()))
+            .detail(detail)
+            .event_id(
+                AuditEnvelopeEventId::from_str(&event_id)
+                    .map_err(|err| serialize_err_msg(format!("audit event id: {err}")))?,
+            )
+            .recorded_at(
+                chrono::DateTime::from_timestamp(e.timestamp as i64, 0)
+                    .unwrap_or_else(chrono::Utc::now),
+            )
+            .target(Some(e.target_did_hash.clone())),
+    )
 }
 
 /// The shared-schema (`messaging.schema.json#/$defs/AuditAction`) name of an
@@ -1403,14 +1436,19 @@ async fn consume_config_show(
     let mut fields = Vec::new();
     let mut push_field = |key: String, value: Value| -> Result<(), MediatorError> {
         if wanted.as_ref().is_none_or(|w| w.contains(&key)) {
-            fields.push(ConfigField {
-                key: ConfigFieldKey::from_str(&key)
-                    .map_err(|e| serialize_err_msg(format!("config key: {e}")))?,
-                requires_restart: true,
-                source: ConfigFieldSource::from_str("mediator")
-                    .map_err(|e| serialize_err_msg(format!("config source: {e}")))?,
-                value,
-            });
+            fields.push(build(
+                ConfigField::builder()
+                    .key(
+                        ConfigFieldKey::from_str(&key)
+                            .map_err(|e| serialize_err_msg(format!("config key: {e}")))?,
+                    )
+                    .requires_restart(true)
+                    .source(
+                        ConfigFieldSource::from_str("mediator")
+                            .map_err(|e| serialize_err_msg(format!("config source: {e}")))?,
+                    )
+                    .value(value),
+            )?);
         }
         Ok(())
     };
@@ -1422,7 +1460,7 @@ async fn consume_config_show(
         push_field(key, value)?;
     }
 
-    let response = Response { ext: None, fields };
+    let response: Response = build(Response::builder().fields(fields))?;
     serde_json::to_value(typed.respond_with(Uuid::new_v4().to_string(), response))
         .map_err(serialize_err)
 }
@@ -1436,26 +1474,30 @@ async fn consume_config_show(
 fn map_account_get(acc: &Account) -> account::get::v0_1::Account {
     use account::get::v0_1::{Account as WireAccount, AccountType as WireType, QueueLimits, Vid};
 
-    WireAccount {
-        did: Vid::from_str(&acc.did_hash).expect("an account hash is a non-empty Vid string"),
-        account_type: match acc._type {
+    let queue_limits: QueueLimits = QueueLimits::builder()
+        .send_queue_limit(acc.queue_send_limit.map(|v| v as i64))
+        .receive_queue_limit(acc.queue_receive_limit.map(|v| v as i64))
+        .try_into()
+        .expect("QueueLimits has no required member");
+
+    WireAccount::builder()
+        .did(Vid::from_str(&acc.did_hash).expect("an account hash is a non-empty Vid string"))
+        .account_type(match acc._type {
             AccountType::Standard => WireType::Standard,
             AccountType::Admin => WireType::Admin,
             AccountType::RootAdmin => WireType::RootAdmin,
             AccountType::Mediator => WireType::Mediator,
             AccountType::Unknown => WireType::Standard,
-        },
-        acl: decode_acl_canonical(&MediatorACLSet::from_u64(acc.acls)),
-        access_list_count: Some(acc.access_list_count as u64),
-        queue_limits: Some(QueueLimits {
-            send_queue_limit: acc.queue_send_limit.map(|v| v as i64),
-            receive_queue_limit: acc.queue_receive_limit.map(|v| v as i64),
-        }),
-        send_queue_count: Some(acc.send_queue_count as u64),
-        send_queue_bytes: Some(acc.send_queue_bytes),
-        receive_queue_count: Some(acc.receive_queue_count as u64),
-        receive_queue_bytes: Some(acc.receive_queue_bytes),
-    }
+        })
+        .acl(decode_acl_canonical(&MediatorACLSet::from_u64(acc.acls)))
+        .access_list_count(Some(acc.access_list_count as u64))
+        .queue_limits(Some(queue_limits))
+        .send_queue_count(Some(acc.send_queue_count as u64))
+        .send_queue_bytes(Some(acc.send_queue_bytes))
+        .receive_queue_count(Some(acc.receive_queue_count as u64))
+        .receive_queue_bytes(Some(acc.receive_queue_bytes))
+        .try_into()
+        .expect("every required member of the wire Account is set above")
 }
 
 /// Re-shape [`map_account_get`]'s output into another `messaging/*` module's copy of
@@ -1464,25 +1506,26 @@ fn map_account_get(acc: &Account) -> account::get::v0_1::Account {
 /// converts between them without re-implementing the bitfield decode.
 fn decode_acl_canonical(acl: &MediatorACLSet) -> account::get::v0_1::MediatorAcl {
     use account::get::v0_1::{MediatorAcl, MediatorAclAccessListMode};
-    MediatorAcl {
-        access_list_mode: Some(match acl.get_access_list_mode().0 {
+    // `didcommEnabled` / `tspEnabled` are left unset: they have no bitfield
+    // slot, so there is nothing to decode into them.
+    MediatorAcl::builder()
+        .access_list_mode(Some(match acl.get_access_list_mode().0 {
             AccessListModeType::ExplicitAllow => MediatorAclAccessListMode::ExplicitAllow,
             AccessListModeType::ExplicitDeny => MediatorAclAccessListMode::ExplicitDeny,
-        }),
-        blocked: Some(acl.get_blocked()),
-        local: Some(acl.get_local()),
-        send_messages: Some(acl.get_send_messages().0),
-        receive_messages: Some(acl.get_receive_messages().0),
-        send_forwarded: Some(acl.get_send_forwarded().0),
-        receive_forwarded: Some(acl.get_receive_forwarded().0),
-        create_invites: Some(acl.get_create_invites().0),
-        anon_receive: Some(acl.get_anon_receive().0),
-        self_manage_list: Some(acl.get_self_manage_list()),
-        self_manage_send_queue_limit: Some(acl.get_self_manage_send_queue_limit()),
-        self_manage_receive_queue_limit: Some(acl.get_self_manage_receive_queue_limit()),
-        didcomm_enabled: None,
-        tsp_enabled: None,
-    }
+        }))
+        .blocked(Some(acl.get_blocked()))
+        .local(Some(acl.get_local()))
+        .send_messages(Some(acl.get_send_messages().0))
+        .receive_messages(Some(acl.get_receive_messages().0))
+        .send_forwarded(Some(acl.get_send_forwarded().0))
+        .receive_forwarded(Some(acl.get_receive_forwarded().0))
+        .create_invites(Some(acl.get_create_invites().0))
+        .anon_receive(Some(acl.get_anon_receive().0))
+        .self_manage_list(Some(acl.get_self_manage_list()))
+        .self_manage_send_queue_limit(Some(acl.get_self_manage_send_queue_limit()))
+        .self_manage_receive_queue_limit(Some(acl.get_self_manage_receive_queue_limit()))
+        .try_into()
+        .expect("MediatorAcl has no required member")
 }
 
 /// Decode an ACL set into any `messaging/*` module's copy of `MediatorAcl`.
@@ -1512,6 +1555,18 @@ fn merge_wire_acl(
         let mode = match mode {
             MediatorAclAccessListMode::ExplicitAllow => AccessListModeType::ExplicitAllow,
             MediatorAclAccessListMode::ExplicitDeny => AccessListModeType::ExplicitDeny,
+            // The access-list mode decides whether the list is an allow-list or
+            // a deny-list. Guessing it inverts the ACL, so a mode this build
+            // does not know refuses the whole update.
+            _ => {
+                return Err(MediatorError::InternalError(
+                    14,
+                    "NA".to_string(),
+                    "unrecognised accessListMode: refusing rather than guessing \
+                     whether the access list allows or denies"
+                        .to_string(),
+                ));
+            }
         };
         let self_change = base.get_access_list_mode().1;
         base.set_access_list_mode(mode, self_change, true)
@@ -1597,6 +1652,27 @@ fn validate_tt_basic<P>(
     })
 }
 
+/// Finish a generated document builder.
+///
+/// trust-tasks-rs 0.17 made the generated payload and response structs
+/// `#[non_exhaustive]`, so this crate can no longer name every member in a
+/// struct literal. That is deliberate: the registry can add an OPTIONAL member
+/// without breaking every consumer that had spelled out the old member list.
+///
+/// The trade is that "is every required member set?" moves from compile time to
+/// this conversion — the builder starts each required member as
+/// `Err("no value supplied for …")`. Every call below therefore sets its
+/// required members explicitly and lets only optional ones default.
+fn build<T, B>(builder: B) -> Result<T, MediatorError>
+where
+    B: TryInto<T>,
+    B::Error: std::fmt::Display,
+{
+    builder
+        .try_into()
+        .map_err(|e| serialize_err_msg(format!("couldn't build Trust Task document: {e}")))
+}
+
 fn serialize_err_msg(msg: String) -> MediatorError {
     MediatorError::InternalError(14, "NA".to_string(), msg)
 }
@@ -1662,13 +1738,17 @@ async fn consume_ping(
         now,
         || Uuid::new_v4().to_string(),
         |req, _parties| async move {
-            let response = ping::v0_1::Response {
-                ext: None,
-                nonce: req.payload.nonce.clone(),
-                protocols: vec!["didcomm".to_string(), "tsp".to_string()],
-                server_time: now,
-                status: ping::v0_1::ResponseStatus::Ok,
-            };
+            // `expect`, not `?`: this closure answers with a
+            // `TrustTask<ErrorPayload>`, and there is no error to report. The
+            // builder's only failure mode is an unset required member, and all
+            // four are set on the next four lines.
+            let response: ping::v0_1::Response = ping::v0_1::Response::builder()
+                .nonce(req.payload.nonce.clone())
+                .protocols(vec!["didcomm".to_string(), "tsp".to_string()])
+                .server_time(now)
+                .status(ping::v0_1::ResponseStatus::Ok)
+                .try_into()
+                .expect("every required member of the ping response is set above");
             Ok(req.respond_with(Uuid::new_v4().to_string(), response))
         },
     )
@@ -1727,13 +1807,11 @@ mod tests {
 
     #[tokio::test]
     async fn ping_consume_returns_ok_and_echoes_nonce() {
-        let mut doc = TrustTask::for_payload(
-            "urn:uuid:ping-1",
-            ping::v0_1::Payload {
-                nonce: Some("nonce-xyz".to_string()),
-                ext: None,
-            },
-        );
+        let payload: ping::v0_1::Payload = ping::v0_1::Payload::builder()
+            .nonce(Some("nonce-xyz".to_string()))
+            .try_into()
+            .expect("the ping payload has no required member");
+        let mut doc = TrustTask::for_payload("urn:uuid:ping-1", payload);
         doc.issuer = Some("did:example:alice".to_string());
         doc.recipient = Some("did:example:mediator".to_string());
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 # ── DIDComm auth (mediator's /admin/status is gated on admin JWT) ────────
 ## Path-pinned to the workspace copy via [patch.crates-io] in the workspace
 ## root Cargo.toml; the version specs here are upper-bound contracts only.
-affinidi-messaging-sdk = { version = "0.20", path = "../../../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.21", path = "../../../affinidi-messaging-sdk" }
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased (0.21.0) — `trust-tasks-rs` 0.17
+
+- Bumps `trust-tasks-rs` 0.12 → 0.17.
+- **Breaking for consumers.** 0.17 marks the generated payload, response and
+  component types `#[non_exhaustive]`. This crate's public API carries them —
+  `TrustTasks::account_update` takes an `account::update::v0_1::MediatorAcl` —
+  so a consumer that builds one with a struct literal, with or without
+  `..Default::default()`, no longer compiles and must use the generated
+  builder. A consumer must also move to 0.17 in the same change: two
+  `trust-tasks-rs` versions in one graph do not merely warn, they fail with
+  `expected MediatorAcl, found a different MediatorAcl`.
+- The twelve payload constructions in `protocols/trust_tasks.rs` moved to
+  builders behind one `payload()` helper. No wire change and no behaviour
+  change: the same members are set, and the only new failure mode is a
+  builder left missing a required member, which every call site sets.
+
 ## Unreleased (0.20.0) — `trust-tasks-rs` 0.12
 
 - Bumps `trust-tasks-rs` 0.11 → 0.12.

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.12"
+trust-tasks-rs = "0.17"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.20.0"
+version = "0.21.0"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/trust_tasks.rs
@@ -42,6 +42,30 @@ pub struct TrustTasksOps<'a> {
     pub(crate) atm: &'a ATM,
 }
 
+/// Finish a generated payload builder.
+///
+/// trust-tasks-rs 0.17 made the generated payload structs `#[non_exhaustive]`,
+/// so a downstream crate can no longer name every member in a struct literal.
+/// That is the point of the change: the registry can add an OPTIONAL member to
+/// a payload without it being a breaking change for every consumer that had
+/// spelled out the old member list.
+///
+/// The cost is that "is every required member set?" moves from compile time to
+/// this conversion. The builder starts each required member as
+/// `Err("no value supplied for …")`, so a member this crate forgets to set
+/// becomes an `ATMError` at send time rather than a compile error — which is
+/// why every call below sets its required members explicitly and lets only the
+/// optional ones default.
+fn payload<P, B>(builder: B) -> Result<P, ATMError>
+where
+    B: TryInto<P>,
+    B::Error: std::fmt::Display,
+{
+    builder
+        .try_into()
+        .map_err(|e| ATMError::MsgSendError(format!("invalid trust-task payload: {e}")))
+}
+
 impl TrustTasksOps<'_> {
     /// Send a `messaging/ping` Trust Task to the mediator and return its response
     /// (server time, status, and the protocols the mediator supports). An optional
@@ -52,7 +76,8 @@ impl TrustTasksOps<'_> {
         nonce: Option<String>,
     ) -> Result<ping::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
-        let mut task = TrustTask::for_payload(new_id(), ping::v0_1::Payload { ext: None, nonce });
+        let p: ping::v0_1::Payload = payload(ping::v0_1::Payload::builder().nonce(nonce))?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -74,8 +99,9 @@ impl TrustTasksOps<'_> {
 
         let did = account::get::v0_1::Vid::from_str(&target)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), account::get::v0_1::Payload { did, ext: None });
+        let p: account::get::v0_1::Payload =
+            payload(account::get::v0_1::Payload::builder().did(did))?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -105,15 +131,13 @@ impl TrustTasksOps<'_> {
             .map_err(|e| ATMError::MsgSendError(format!("invalid cursor: {e}")))?;
         let limit = limit.and_then(|l| std::num::NonZeroU64::new(l as u64));
 
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            account::list::v0_1::Payload {
-                account_type,
-                cursor,
-                ext: None,
-                limit,
-            },
-        );
+        let p: account::list::v0_1::Payload = payload(
+            account::list::v0_1::Payload::builder()
+                .account_type(account_type)
+                .cursor(cursor)
+                .limit(limit),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -149,16 +173,14 @@ impl TrustTasksOps<'_> {
 
         let did = account::update::v0_1::Vid::from_str(&target)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            account::update::v0_1::Payload {
-                account_type,
-                acl,
-                did,
-                ext: None,
-                queue_limits,
-            },
-        );
+        let p: account::update::v0_1::Payload = payload(
+            account::update::v0_1::Payload::builder()
+                .account_type(account_type)
+                .acl(acl)
+                .did(did)
+                .queue_limits(queue_limits),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -180,8 +202,9 @@ impl TrustTasksOps<'_> {
 
         let did = account::remove::v0_1::Vid::from_str(&target)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), account::remove::v0_1::Payload { did, ext: None });
+        let p: account::remove::v0_1::Payload =
+            payload(account::remove::v0_1::Payload::builder().did(did))?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -204,8 +227,8 @@ impl TrustTasksOps<'_> {
             .map(|d| acl::get::v0_1::Vid::from_str(d))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), acl::get::v0_1::Payload { dids, ext: None });
+        let p: acl::get::v0_1::Payload = payload(acl::get::v0_1::Payload::builder().dids(dids))?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -229,18 +252,15 @@ impl TrustTasksOps<'_> {
 
         let did = account::add::v0_1::Vid::from_str(&did_hash)
             .map_err(|e| ATMError::MsgSendError(format!("invalid account identifier: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            account::add::v0_1::Payload {
-                account_type,
-                acl,
-                did,
-                ext: None,
-                // Initial queue limits use the mediator default; adjust with
-                // `account_update` after creation.
-                queue_limits: None,
-            },
-        );
+        // Initial queue limits are left unset so the mediator default applies;
+        // adjust with `account_update` after creation.
+        let p: account::add::v0_1::Payload = payload(
+            account::add::v0_1::Payload::builder()
+                .account_type(account_type)
+                .acl(acl)
+                .did(did),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
 
@@ -273,16 +293,14 @@ impl TrustTasksOps<'_> {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))
         };
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            access_list::update::v0_1::Payload {
-                add: to_vids(add)?,
-                clear: clear.then_some(true),
-                did,
-                ext: None,
-                remove: to_vids(remove)?,
-            },
-        );
+        let p: access_list::update::v0_1::Payload = payload(
+            access_list::update::v0_1::Payload::builder()
+                .add(to_vids(add)?)
+                .clear(clear.then_some(true))
+                .did(did)
+                .remove(to_vids(remove)?),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
         let response: TrustTask<access_list::update::v0_1::Response> =
@@ -318,16 +336,14 @@ impl TrustTasksOps<'_> {
             .map(|e| access_list::list::v0_1::Vid::from_str(e))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| ATMError::MsgSendError(format!("invalid access-list entry: {e}")))?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            access_list::list::v0_1::Payload {
-                cursor,
-                did,
-                entries,
-                ext: None,
-                limit,
-            },
-        );
+        let p: access_list::list::v0_1::Payload = payload(
+            access_list::list::v0_1::Payload::builder()
+                .cursor(cursor)
+                .did(did)
+                .entries(entries)
+                .limit(limit),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
         let response: TrustTask<access_list::list::v0_1::Response> =
@@ -344,20 +360,15 @@ impl TrustTasksOps<'_> {
         page_size: Option<u32>,
     ) -> Result<audit::list::v0_1::Response, ATMError> {
         let (profile_did, mediator_did) = profile.dids()?;
-        let mut task = TrustTask::for_payload(
-            new_id(),
-            audit::list::v0_1::Payload {
-                action: None,
-                actor: None,
-                context_id: None,
-                cursor,
-                ext: None,
-                from: None,
-                outcome: None,
-                page_size: page_size.and_then(|l| std::num::NonZeroU64::new(l as u64)),
-                to: None,
-            },
-        );
+        // Only the two members this method exposes are set; `action`, `actor`,
+        // `contextId`, `from`, `outcome` and `to` are filters the builder leaves
+        // unset, which is an unfiltered listing.
+        let p: audit::list::v0_1::Payload = payload(
+            audit::list::v0_1::Payload::builder()
+                .cursor(cursor)
+                .page_size(page_size.and_then(|l| std::num::NonZeroU64::new(l as u64))),
+        )?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
         let response: TrustTask<audit::list::v0_1::Response> =
@@ -383,8 +394,9 @@ impl TrustTasksOps<'_> {
             })
             .transpose()
             .map_err(|e| ATMError::MsgSendError(format!("invalid configuration key: {e}")))?;
-        let mut task =
-            TrustTask::for_payload(new_id(), config::show::v0_1::Payload { ext: None, keys });
+        let p: config::show::v0_1::Payload =
+            payload(config::show::v0_1::Payload::builder().keys(keys))?;
+        let mut task = TrustTask::for_payload(new_id(), p);
         task.issuer = Some(profile_did.to_string());
         task.recipient = Some(mediator_did.to_string());
         let response: TrustTask<config::show::v0_1::Response> =

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased (0.4.0) — `trust-tasks-rs` 0.17
+
+- Bumps `trust-tasks-rs` 0.12 → 0.17.
+- **Breaking for consumers** for the same reason as `affinidi-messaging-sdk`
+  0.21.0: the harness hands back generated types that are now
+  `#[non_exhaustive]`, and two `trust-tasks-rs` versions in one graph fail to
+  compile.
+- The five `QueueLimits` / `MediatorAcl` constructions in
+  `tests/trust_tasks.rs` moved to the generated builders. All 14 integration
+  tests pass unchanged against the migrated mediator.
+
 ## Unreleased (0.3.0) — `trust-tasks-rs` 0.12
 
 - Bumps `trust-tasks-rs` 0.11 → 0.12, and `affinidi-messaging-sdk` to 0.20.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -95,7 +95,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.23"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.12"
+trust-tasks-rs = "0.17"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.3.0"
+version = "0.4.0"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.19", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.20", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
@@ -49,12 +49,12 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.9", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.10", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.20.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.21.0", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/trust_tasks.rs
@@ -126,10 +126,13 @@ async fn account_update_queue_limits_self_applies_caps_and_persists() {
             None,
             None,
             None,
-            Some(QueueLimits {
-                send_queue_limit: Some(42),
-                receive_queue_limit: Some(-1),
-            }),
+            Some(
+                QueueLimits::builder()
+                    .send_queue_limit(Some(42))
+                    .receive_queue_limit(Some(-1))
+                    .try_into()
+                    .expect("QueueLimits has no required member"),
+            ),
         )
         .await
         .expect("alice changes her own queue limits");
@@ -158,10 +161,12 @@ async fn account_update_queue_limits_self_applies_caps_and_persists() {
             None,
             None,
             None,
-            Some(QueueLimits {
-                send_queue_limit: Some(5000),
-                receive_queue_limit: None,
-            }),
+            Some(
+                QueueLimits::builder()
+                    .send_queue_limit(Some(5000))
+                    .try_into()
+                    .expect("QueueLimits has no required member"),
+            ),
         )
         .await
         .expect("over-limit request is accepted but capped");
@@ -284,10 +289,10 @@ async fn account_update_acl_denies_a_non_admin() {
         .expect("enable websocket for alice");
     let bob = env.add_user("bob").await.expect("add bob");
 
-    let acl = MediatorAcl {
-        blocked: Some(true),
-        ..Default::default()
-    };
+    let acl: MediatorAcl = MediatorAcl::builder()
+        .blocked(Some(true))
+        .try_into()
+        .expect("MediatorAcl has no required member");
     let denied = env
         .atm
         .trust_tasks()
@@ -488,10 +493,10 @@ async fn account_update_acl_self_service_changes_a_self_manageable_flag() {
 
     // allow_all grants alice the self-change bits, so she may change her own
     // `anonReceive` (a self-manageable capability) from true to false.
-    let acl = MediatorAcl {
-        anon_receive: Some(false),
-        ..Default::default()
-    };
+    let acl: MediatorAcl = MediatorAcl::builder()
+        .anon_receive(Some(false))
+        .try_into()
+        .expect("MediatorAcl has no required member");
     let updated = env
         .atm
         .trust_tasks()
@@ -525,10 +530,10 @@ async fn account_update_acl_self_service_refuses_an_admin_only_flag() {
         .expect("enable websocket for alice");
 
     // `blocked` is admin-only — alice may not set it even on her own account.
-    let acl = MediatorAcl {
-        blocked: Some(true),
-        ..Default::default()
-    };
+    let acl: MediatorAcl = MediatorAcl::builder()
+        .blocked(Some(true))
+        .try_into()
+        .expect("MediatorAcl has no required member");
     let denied = env
         .atm
         .trust_tasks()

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -18,7 +18,7 @@ affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.12"
+trust-tasks-rs = "0.17"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.9" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.20.0" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.10" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.21.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
 trust-tasks-rs = "0.17"

--- a/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
+++ b/crates/messaging/affinidi-messaging-text-client/src/state_store/actions/invitation.rs
@@ -502,12 +502,13 @@ pub async fn create_invitation(
                             // Flip the access-list mode to explicit_deny. This is a
                             // self-service change; the mediator refuses it if this account
                             // may not self-manage its access-list mode.
-                            let new_acl = account::update::v0_1::MediatorAcl {
-                                access_list_mode: Some(
-                                    account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny,
-                                ),
-                                ..Default::default()
-                            };
+                            let new_acl: account::update::v0_1::MediatorAcl =
+                                account::update::v0_1::MediatorAcl::builder()
+                                    .access_list_mode(Some(
+                                        account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny,
+                                    ))
+                                    .try_into()
+                                    .expect("MediatorAcl has no required member");
                             if let Err(e) = atm
                                 .trust_tasks()
                                 .account_update(

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,23 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## 0.10.0
+
+### Changed
+
+- `messaging` feature now re-exports `affinidi-messaging-sdk` 0.21, which moves
+  to `trust-tasks-rs` 0.17.
+- **Breaking for consumers of the `messaging` feature.** 0.17 marks the
+  generated payload, response and component types `#[non_exhaustive]`, so a
+  consumer that builds one with a struct literal — with or without
+  `..Default::default()` — must move to the generated builder. As before, a
+  consumer must move to 0.17 in the same change; two `trust-tasks-rs` versions
+  in one graph fail to compile rather than warn. Minor rather than patch for
+  that reason.
+- No source change in this crate. Bumped because the published manifest's
+  requirement is itself what changed: a consumer resolving `affinidi-tdk` 0.9.0
+  from crates.io stays pinned to the SDK's 0.20 line and can never reach 0.17.
+
 ## 0.9.0
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.9.0"
+version = "0.10.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tsp = ["dep:affinidi-tsp"]
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.4"
-affinidi-messaging-sdk = { version = "0.20", path = "../../messaging/affinidi-messaging-sdk", optional = true }
+affinidi-messaging-sdk = { version = "0.21", path = "../../messaging/affinidi-messaging-sdk", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"
 # Foundations are re-exported by the facade. Kept at major.minor (caret), NOT


### PR DESCRIPTION
Six pins, and the generated types are now `#[non_exhaustive]`.

That is the whole shape of this change. trust-tasks-rs 0.17 marks every generated payload, response, component struct **and enum** `#[non_exhaustive]`, so no downstream crate can name their members in a struct literal or match their variants without a wildcard. It is what lets the registry add an OPTIONAL member, or a new enum variant, without breaking every consumer that had spelled out the old list.

## Struct literals become builders

One `build` / `payload` helper per crate finishes the builder and maps its error. The cost is real and worth stating up front: **"is every required member set?" moves from compile time to that conversion**, because the builder starts each required member as `Err("no value supplied for …")`.

Every call site here therefore sets its required members explicitly and lets only optional ones default. The two constructions that have no required members at all (`MediatorAcl`, `QueueLimits`) say so in the `expect` rather than plumbing an error nobody can trigger.

## The wildcard arms are decisions, not boilerplate

Three of them changed behaviour, and deliberately in different directions:

| site | unknown variant | why |
|---|---|---|
| `account/list` role **filter** | → `AccountType::Unknown` (selects nothing) | A peer on a newer registry can name a role added after this binary was built. Widening to `Standard` would answer with a confident list of *the wrong accounts*. |
| `account/update`, `account/add` role | **refuse** | These *write* it. Storing a privilege level this mediator cannot reason about — and telling the caller it set the role they asked for — is worse than a refusal. `account/update`'s mapping became fallible for this. |
| `merge_wire_acl` `accessListMode` | **refuse** | That member decides whether the access list *allows* or *denies*. Guessing it inverts the ACL. |

## Inference fallout

`to_wire_account` / `to_wire_acl` and two `collect()`s needed a turbofish or a type annotation. Their type parameter used to be pinned by the struct literal they fed; a builder setter takes `impl TryInto<T>`, which doesn't pin it. Same for `TrustTask::for_payload` — neither it nor `exchange` pins the payload type, so the SDK's helper takes `P` first and each call names it once.

## Files

- `affinidi-messaging-sdk` — 12 payload constructions
- `affinidi-messaging-mediator` — 16 response/component constructions, 4 match arms
- `affinidi-messaging-test-mediator` — 5 in tests
- `affinidi-messaging-helpers`, `-text-client`, `-didcomm-service` — 1 each

## Why now

VTI cannot move to 0.17 until this publishes: `affinidi-messaging-sdk` and `affinidi-messaging-mediator` sit on this workspace's `trust-tasks-rs` node, and two nodes in one graph fail to compile. This is the same ordering as #743 (0.11 → 0.12).

## Verification

- `cargo check --workspace --all-features`: exit 0
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo test --workspace --all-features`: **177 suites, 0 failed**
- including `affinidi-messaging-test-mediator`'s `tests/trust_tasks.rs` — **14/14**, round-tripping every migrated task through a live mediator over DIDComm

## Note for review

`main`'s committed `Cargo.lock` recorded `trust-tasks-rs 0.14.0` against `^0.12` manifests, which cargo silently re-resolves on every build. Not introduced here and not fixed here, but worth knowing if the lock diff looks larger than expected.
