### PR TITLE
fix(mediator): accept a VTA-linked admin credential with no REST URL

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased (0.20.1) — `vta-sdk` 0.32.1
+
+- Bumps `vta-sdk` 0.25 → 0.32.1. No source changes were required across the
+  seven intervening minor releases, and `ContextProvisionBundle` is unchanged.
+- Realigns this crate with the VTI workspace copy. Per the `vta` feature's
+  comment, VTI's `[patch.crates-io] vta-sdk = { path = "vta-sdk" }` only
+  deletes the registry node while our requirement admits their workspace
+  version; holding at 0.25 while they shipped 0.32 is what re-opens the
+  cross-repo dependency cycle.
+- **`vta-sdk` is a public dependency of this crate's API** — `tasks::VtaRefresher`
+  exposes a `VtaServiceConfig` field — so this is source-breaking for a consumer
+  that builds with `--features vta` against `vta-sdk` 0.25. Shipped as a patch
+  deliberately: `affinidi-messaging-test-mediator` pins `"0.20"`, and a minor
+  would drop out of that range and duplicate this crate in the graph. Consumers
+  that do not enable `vta` (including `test-mediator`, which builds
+  `default-features = false`) never compile `vta-sdk` and are unaffected.
+
 ## Unreleased (0.20.0) — `trust-tasks-rs` 0.17
 
 - Bumps `trust-tasks-rs` 0.12 → 0.17; sixteen response and component

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.0"
+version = "0.20.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -157,7 +157,7 @@ affinidi-task-utils = "0.1"
 ## a second `trust-tasks-rs` (0.2.57, from vta-sdk 0.21.6) in this workspace's
 ## lockfile long after everything else had moved to 0.9. A bounded range is a
 ## tax that comes due silently; prefer a caret and move it deliberately.
-vta-sdk = { version = "0.25", features = [
+vta-sdk = { version = "0.32.1", features = [
   "integration",
 ], optional = true }
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.36) — an admin credential may name a VTA with no REST URL
+
+**Bug fix: `AdminCredential` no longer rejects a VTA-linked credential that
+carries no `vta_url`.**
+
+The shape validation required `vta_did` and `vta_url` to be set together or not
+at all. That is wrong for a VTA reached only over DIDComm/TSP, which advertises
+no REST endpoint: `mediator-setup` produced `vta_did` with no URL and the write
+failed with `admin credential must set vta_did and vta_url together, or neither
+(self-hosted)` — aborting setup at its last step, after the JWT and operating
+secrets had already been written to the backend.
+
+Nothing downstream ever needed the URL. Both consumers pass it straight into
+`VtaAuthConfig::url_override`, which is itself an `Option`, and `config::load`
+logs `"(from DID doc)"` when it is absent — the endpoint is discovered from the
+VTA's DID document.
+
+- `validate` now rejects only the unusable direction, `vta_url` **without**
+  `vta_did`: a bare URL names no VTA DID to authenticate against, and storing
+  it leaves the runtime treating the credential as self-hosted while the
+  operator believes it is VTA-linked.
+- **Behaviour change (R3.6): `is_vta_linked()` now tests `vta_did` alone.**
+  Previously it required both fields, so a credential with a DID and no URL
+  read as self-hosted and the mediator silently skipped VTA startup. Any
+  consumer using it to mean "has a REST URL" should test `vta_url` directly.
+- No signature change; the struct and its serialised form are untouched.
+
 ## Unreleased (0.15.35) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.35"
+version = "0.15.36"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/well_known.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/well_known.rs
@@ -88,10 +88,13 @@ const KIND_ADMIN_CREDENTIAL: &str = "admin-credential";
 /// (and tooling like `mediator rotate-admin`) always load from one
 /// well-known key:
 ///
-/// - **VTA-linked** (`vta_did.is_some() && vta_url.is_some()`): the
-///   mediator uses the credential to authenticate to its VTA at
-///   startup. Produced by the online-VTA or sealed-handoff flows.
-/// - **Self-hosted** (`vta_did.is_none() && vta_url.is_none()`): the
+/// - **VTA-linked** (`vta_did.is_some()`): the mediator uses the
+///   credential to authenticate to its VTA at startup. Produced by
+///   the online-VTA or sealed-handoff flows. `vta_url` is optional —
+///   a DIDComm-only VTA, or a sealed context export from a VTA with
+///   no public REST URL, ships a DID and no URL, and the runtime
+///   discovers the endpoint from the VTA's DID document.
+/// - **Self-hosted** (`vta_did.is_none()`): the
 ///   mediator does not talk to a VTA; the credential is just a
 ///   persistent record of the admin DID + private key so a later
 ///   wizard run can reuse it without prompting the operator. The
@@ -110,6 +113,12 @@ pub struct AdminCredential {
     /// deserialize; new self-hosted records omit it entirely.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vta_did: Option<String>,
+    /// REST URL override for the VTA. Optional even when `vta_did` is
+    /// set: both `config::load` and `rotate-admin` pass this straight
+    /// into `VtaAuthConfig::url_override`, which is itself an
+    /// `Option` — `None` means "resolve the endpoint from the VTA DID
+    /// document". Meaningless without `vta_did` (there is nothing to
+    /// authenticate against), which `validate` rejects.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vta_url: Option<String>,
     #[serde(default = "default_context")]
@@ -142,16 +151,22 @@ impl AdminCredential {
                 reason: format!("admin credential VTA DID '{vta}' is not a DID URI"),
             });
         }
-        // Soft invariant: a VTA-linked credential should have both
-        // fields populated. Reject the half-set case where only one
-        // of vta_did / vta_url is present — that's almost certainly
-        // a caller bug, and the mediator runtime would later fail in
-        // an unhelpful way.
-        if self.vta_did.is_some() != self.vta_url.is_some() {
+        // `vta_url` without `vta_did` is unusable: the DID is what the
+        // credential authenticates against, and a bare URL leaves the
+        // runtime treating the credential as self-hosted while the
+        // operator believes it is VTA-linked. Reject at write time
+        // rather than fail silently at boot.
+        //
+        // The converse — `vta_did` with no `vta_url` — is legitimate:
+        // a DIDComm-only VTA, or a sealed context export from a VTA
+        // that advertises no public REST URL. The runtime passes the
+        // URL through as `url_override: Option<_>` and falls back to
+        // the VTA's DID document when it is absent.
+        if self.vta_did.is_none() && self.vta_url.is_some() {
             return Err(SecretStoreError::InvalidShape {
                 key: key.to_string(),
-                reason: "admin credential must set vta_did and vta_url together, or neither \
-                         (self-hosted)"
+                reason: "admin credential sets vta_url without vta_did — a VTA-linked \
+                         credential must name the VTA DID it authenticates against"
                     .into(),
             });
         }
@@ -160,10 +175,12 @@ impl AdminCredential {
 
     /// True when this credential represents a VTA-linked admin
     /// identity — the mediator's runtime VTA-startup branch is
-    /// gated on this. A `None` means "self-hosted admin, no VTA
-    /// integration".
+    /// gated on this. A `None` `vta_did` means "self-hosted admin,
+    /// no VTA integration". `vta_url` is deliberately *not* part of
+    /// the test: it is only a URL override, and its absence means
+    /// "discover the endpoint from the VTA DID document".
     pub fn is_vta_linked(&self) -> bool {
-        self.vta_did.is_some() && self.vta_url.is_some()
+        self.vta_did.is_some()
     }
 
     /// Derive the 32-byte HMAC key used to sign the VTA cache. Derivation
@@ -725,12 +742,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_credential_rejects_half_set_vta_fields() {
+    async fn admin_credential_rejects_vta_url_without_vta_did() {
         let secrets = helper();
-        // Populating vta_url alone without vta_did (or vice versa) is
-        // almost certainly a caller bug — the mediator runtime would
-        // later fail the VTA startup in an unhelpful way. Reject at
-        // write time instead.
+        // A bare URL with no VTA DID is unusable — there is nothing to
+        // authenticate against, and the runtime would silently treat
+        // the credential as self-hosted. Reject at write time instead.
         let half_set = AdminCredential {
             did: "did:key:z6MkSAMPLE".into(),
             private_key_multibase: "z3u2SAMPLE".into(),
@@ -742,6 +758,34 @@ mod tests {
             secrets.store_admin_credential(&half_set).await,
             Err(SecretStoreError::InvalidShape { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn admin_credential_accepts_vta_did_without_vta_url() {
+        let secrets = helper();
+        // A DIDComm-only VTA, and a sealed context export from a VTA
+        // with no public REST URL, both produce this shape. The URL is
+        // only an override; the runtime resolves the endpoint from the
+        // VTA DID document when it is absent.
+        let no_url = AdminCredential {
+            did: "did:key:z6MkSAMPLE".into(),
+            private_key_multibase: "z3u2SAMPLE".into(),
+            vta_did: Some("did:webvh:vta.example.com".into()),
+            vta_url: None,
+            context: "mediator".into(),
+        };
+        secrets.store_admin_credential(&no_url).await.unwrap();
+        let got = secrets
+            .load_admin_credential()
+            .await
+            .unwrap()
+            .expect("credential must be present");
+        assert_eq!(got.vta_did.as_deref(), Some("did:webvh:vta.example.com"));
+        assert!(got.vta_url.is_none());
+        assert!(
+            got.is_vta_linked(),
+            "a credential naming a VTA DID is VTA-linked even without a URL override"
+        );
     }
 
     #[tokio::test]

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Affinidi Messaging Mediator Setup
 
+## Unreleased (0.1.29) — setup completes against a DIDComm/TSP-only VTA
+
+**Bug fix: provisioning no longer aborts when the VTA advertises no REST URL.**
+
+`provision_secret_backend` stored `vta_did: Some(...)` unconditionally alongside
+`vta_url: session.rest_url.clone()`. `VtaSession::rest_url` is documented as
+`None` for a DIDComm-only VTA or a sealed-handoff session, so both of those
+produced a half-set admin credential that `AdminCredential::validate` rejected —
+failing setup at its final step, after the JWT and operating secrets had already
+been written to the secret backend.
+
+- Both VTA fields are now normalised before the write. `vta_url: None` alongside
+  a `vta_did` is a supported shape (see mediator-common 0.15.36); the mediator
+  resolves the VTA endpoint from its DID document.
+- Also closes a second failure on the same path: `VtaSession::context_export`
+  uses `unwrap_or_default()`, so a sealed bundle that omits `vta_did` arrived as
+  an empty string and failed the *DID-URI* check instead — the same fatal-at-the
+  -last-step abort with a different message. An empty `vta_did` now stores a
+  self-hosted credential, and the summary line says so.
+- A `vta_url` with no `vta_did` is dropped rather than stored: it is not a VTA
+  linkage, since there is nothing to authenticate against.
+- Bumps `vta-sdk` 0.25 → 0.32.1 (no source changes required).
+
 ## 1st August 2026 (0.1.27)
 
 Drops the **legacy rustls 0.21 stack** from the AWS SDK dependency path,

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.28"
+version = "0.1.29"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -95,7 +95,7 @@ didwebvh-rs = "0.6"
 ##                   `sealed-transfer`), so this single feature covers the
 ##                   wizard's online VTA flow plus the sealed-handoff bundle
 ##                   handling in `sealed_handoff.rs`.
-vta-sdk = { version = "0.25", features = ["provision-client"] }
+vta-sdk = { version = "0.32.1", features = ["provision-client"] }
 
 # ── DID Resolution ───────────────────────────────────────────────────────
 ## Used to resolve the VTA's DID document and extract VTARest /
@@ -186,7 +186,7 @@ aws-sdk-s3 = { version = "1", optional = true, default-features = false, feature
 ## Additive — `cargo test` unions [dependencies] + [dev-dependencies]
 ## features, so this lands the `test-support` flag without affecting
 ## release builds.
-vta-sdk = { version = "0.25", features = ["test-support"] }
+vta-sdk = { version = "0.32.1", features = ["test-support"] }
 ## Used by setup_key persistence tests to create scoped temporary paths.
 tempfile = "3"
 ## Required by `bootstrap_headless` tests that mutate CWD via

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/src/main.rs
@@ -1509,12 +1509,30 @@ async fn provision_secret_backend(
 
     // Admin credential — VTA-linked path. The session captures the
     // rotated admin did:key + the VTA DID/URL that minted it.
+    //
+    // Both VTA fields are normalised through `non_empty`. A sealed
+    // context export whose bundle omitted `vta_did` reaches us as an
+    // empty string (`VtaSession::context_export` uses
+    // `unwrap_or_default`), and an empty `vta_url` is equally
+    // meaningless — storing either verbatim fails the credential's
+    // shape validation at the last step of setup, after the JWT and
+    // operating secrets have already been written to the backend.
+    // `vta_url: None` is a supported shape: the mediator resolves the
+    // VTA endpoint from its DID document.
     if let Some(session) = vta_session {
+        let non_empty = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
+        let vta_did = non_empty(Some(session.vta_did.clone()));
+        // A URL with no DID is not a VTA linkage — there is nothing to
+        // authenticate against — so it is dropped rather than stored.
+        let vta_url = vta_did
+            .as_ref()
+            .and_then(|_| non_empty(session.rest_url.clone()));
+        let vta_linked = vta_did.is_some();
         let cred = affinidi_messaging_mediator_common::AdminCredential {
             did: session.admin_did().to_string(),
             private_key_multibase: session.admin_private_key_mb().to_string(),
-            vta_did: Some(session.vta_did.clone()),
-            vta_url: session.rest_url.clone(),
+            vta_did,
+            vta_url,
             context: session.context_id.clone(),
         };
         mediator_secrets_store
@@ -1522,8 +1540,13 @@ async fn provision_secret_backend(
             .await
             .map_err(|e| anyhow::anyhow!("Failed to store admin credential: {e}"))?;
         println!(
-            "    \x1b[32m\u{2714}\x1b[0m {}",
-            affinidi_messaging_mediator_common::ADMIN_CREDENTIAL
+            "    \x1b[32m\u{2714}\x1b[0m {}{}",
+            affinidi_messaging_mediator_common::ADMIN_CREDENTIAL,
+            if vta_linked {
+                ""
+            } else {
+                " (self-hosted — session carried no VTA DID)"
+            }
         );
 
         // Seed the VTA fallback cache with the bundle we just

--- a/deny.toml
+++ b/deny.toml
@@ -59,6 +59,15 @@ exceptions = [
   { allow = [
     "MPL-2.0",
   ], crate = "im" },
+  # Reached only via `vta-sdk`'s `session` feature (new in 0.32.0):
+  # vta-sdk -> dirs 6 -> dirs-sys 0.5 -> option-ext. MPL-2.0 is file-level
+  # copyleft — the obligation attaches to the MPL'd files themselves, not to
+  # the combined work — and we consume it unmodified, so a per-crate exception
+  # is the right scope. Deliberately not added to the global `allow` list:
+  # that would silently admit any future copyleft dependency.
+  { allow = [
+    "MPL-2.0",
+  ], crate = "option-ext" },
   { allow = [
     "MPL-2.0",
     "CDLA-Permissive-2.0",


### PR DESCRIPTION
## The failure

`mediator-setup` aborted at its final step against a VTA reached only over DIDComm/TSP:

```
Provisioning unified secret backend: aws_secrets://eu-west-1/gdc/mediator
  ✔ mediator_jwt_secret
  ✔ mediator_operating_secrets (3 keys)

Error: Failed to store admin credential: stored secret 'mediator_admin_credential'
failed shape validation: admin credential must set vta_did and vta_url together,
or neither (self-hosted)
```

## Why

`AdminCredential::validate` required `vta_did` and `vta_url` to be set together or not at all. A VTA with no REST endpoint advertises no URL — `VtaSession::rest_url` is documented as `None` for exactly this case (`vta/session.rs:27`, "a DIDComm-only VTA or a sealed-handoff session") — so the wizard produced `vta_did` alone and the write was refused.

**Nothing downstream ever needed the URL.** Both consumers pass it straight into `VtaAuthConfig::url_override`, which is itself an `Option`, and `config::load` logs `"(from DID doc)"` when it is absent (`config/mod.rs:566,615`) — the endpoint is discovered from the VTA's DID document. Only `is_vta_linked()` demanded both fields, and had the write succeeded, *that* would have classified the mediator as self-hosted and skipped VTA startup entirely at boot. The loud failure was the better of the two outcomes.

## Changes

**`affinidi-messaging-mediator-common` 0.15.35 → 0.15.36**
- `validate` now rejects only the unusable direction, `vta_url` **without** `vta_did` — a bare URL names no VTA DID to authenticate against.
- `is_vta_linked()` tests `vta_did` alone. **R3.6 behaviour change**, called out in the changelog: a credential with a DID and no URL previously read as self-hosted. A consumer using it to mean "has a REST URL" should test `vta_url` directly.
- No signature change; the struct and its serialised form are untouched.

**`affinidi-messaging-mediator-setup` 0.1.28 → 0.1.29**
- `provision_secret_backend` normalises both VTA fields before the write.
- Closes a second abort on the same path: `VtaSession::context_export` uses `unwrap_or_default()`, so a sealed bundle omitting `vta_did` arrived as an empty string and failed the *DID-URI* check instead — same fatal-at-the-last-step abort, different message.
- A `vta_url` with no `vta_did` is dropped rather than stored, and the summary line now says when a credential was stored self-hosted, so the outcome is visible rather than inferred.

**`affinidi-messaging-mediator` 0.20.0 → 0.20.1**
- Bumps `vta-sdk` 0.25 → 0.32.1. No source changes were required across the seven intervening minor releases; `ContextProvisionBundle` is byte-identical between 0.25.1 and 0.32.1, so the fix above is correct against both.
- Realigns with the VTI workspace copy. Per the `vta` feature's comment, VTI's `[patch.crates-io] vta-sdk = { path = "vta-sdk" }` only deletes the registry node while our requirement admits their workspace version — holding at 0.25 while they ship 0.32 re-opens the cross-repo cycle that already bit at 0.20, 0.21 and 0.22.

### Why these version numbers

`vta-sdk` is a **public dependency** of the mediator's API — `tasks::VtaRefresher` exposes a `VtaServiceConfig` field — so the bump is source-breaking for a consumer building with `--features vta` against 0.25. Shipped as a **patch** deliberately: `affinidi-messaging-test-mediator` pins `"0.20"` (`test-mediator/Cargo.toml:38`), and a minor would fall out of that range and duplicate this crate in our own graph (ADR 0003). Consumers that do not enable `vta` — including `test-mediator`, which builds `default-features = false` — never compile `vta-sdk` and are unaffected.

## Verification

- `cargo test`: mediator-common **195 passed**, mediator **187 passed**, mediator-setup **406 passed**.
- `cargo clippy --all-targets` clean on all three crates, run **per-package** rather than workspace-wide, since a workspace build unifies features and CI does not.
- Two new tests: the accepted direction (`vta_did` with no URL round-trips and reads as VTA-linked) and the rejected one (renamed to `admin_credential_rejects_vta_url_without_vta_did`).
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh`, `cargo fmt --check` — all green.

## Coordination (R3.6)

This needs a release before VTI can consume it, and VTI should be on `vta-sdk` 0.32.x for the `[patch.crates-io]` alignment to hold.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [!] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

**R2.1 flagged, not ticked.** `provision_secret_backend` writes the JWT and operating secrets to the backend *before* the admin credential, with no rollback — which is why the original failure left a half-provisioned AWS backend. This PR removes the trigger but not the ordering hazard; any later failure in that function leaves the same partial state. Re-running setup overwrites all three keys, so it is recoverable rather than wedging, but making the sequence transactional (or explicitly resumable) is a separate change and I did not widen scope to it here.
