### PR TITLE
fix(mediator): rotate-admin works against a VTA with no REST URL

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased (0.20.2) — `rotate-admin` works against a VTA with no REST URL
+
+**Bug fix: `mediator rotate-admin` could not authenticate to a VTA that
+exposes no REST endpoint.**
+
+The command pinned `TransportPreference::PreferRest`, which vta-sdk maps to
+`TransportPlan::RestOnly` with **no DIDComm fallback**. Against a DIDComm-only
+VTA there is no REST endpoint to resolve, so rotation failed before it began.
+Newly reachable: until 0.20.1 an admin credential naming a VTA with no URL
+could not be stored at all, so the command had no way to load one.
+
+- The transport preference is now chosen from whether the credential carries a
+  usable REST URL. With a URL, `PreferRest` is kept — it is known-good, and it
+  avoids dialling DIDComm in the self-mediated topology, where the VTA's
+  DIDComm mediator is the very process the operator is running the CLI against.
+  Without one, `Auto` lets the SDK resolve the VTA's mediator from its DID
+  document and try DIDComm with a REST fallback; a VTA advertising no
+  `DIDCommMessaging` service degrades to `RestOnly`, exactly as before.
+- The original rationale for pinning REST — that `get_acl` / `create_acl`
+  needed the synchronous REST API — no longer holds. Both go through
+  `rpc_tt` -> `dispatch_trust_task`, which is identical across the REST,
+  DIDComm and TSP transports; the operation is a Trust Task on every transport
+  and REST's bespoke per-operation routes were removed upstream.
+- No behaviour change for any deployment whose admin credential has a REST URL.
+
+**Known gap: TSP-only VTAs still cannot be rotated against.** `Auto` cannot
+select TSP — `decide_transport` has no TSP arm, and `Transport::Tsp` is only
+reachable through the explicit `VtaClient::connect_tsp`. Closing that belongs
+in vta-sdk's preference matrix, not here.
+
 ## Unreleased (0.20.1) — `vta-sdk` 0.32.1
 
 - Bumps `vta-sdk` 0.25 → 0.32.1. No source changes were required across the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.1"
+version = "0.20.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/commands/rotate_admin.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/commands/rotate_admin.rs
@@ -49,6 +49,17 @@ use vta_sdk::credentials::CredentialBundle;
 use vta_sdk::integration::{TransportPreference, VtaServiceConfig, authenticate};
 
 /// Top-level entry called from the CLI dispatcher in `main.rs`.
+/// Pick the transport preference from whether the credential carries a
+/// usable REST URL. Pure so the choice is testable without a VTA — the
+/// rationale lives at the call site.
+fn transport_preference_for(vta_url: Option<&str>) -> TransportPreference {
+    if vta_url.is_some_and(|u| !u.is_empty()) {
+        TransportPreference::PreferRest
+    } else {
+        TransportPreference::Auto
+    }
+}
+
 pub async fn run(config_path: &str, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
     let raw = std::fs::read_to_string(config_path)
         .map_err(|e| format!("Failed to read config '{config_path}': {e}"))?;
@@ -120,12 +131,36 @@ pub async fn run(config_path: &str, dry_run: bool) -> Result<(), Box<dyn std::er
         vta_url: vta_url.clone(),
     };
     // vta-sdk 0.6.x split `VtaServiceConfig` into `auth` + `context`.
-    // Admin rotation is a one-shot operator command, not a hot path —
-    // REST is the right fit. Explicit `PreferRest` on the context
-    // keeps the ACL create/rotate calls off the DIDComm channel
-    // (where they'd need to negotiate an async reply envelope) and
-    // lands on the synchronous REST API that `get_acl` / `create_acl`
-    // are built for.
+    //
+    // Transport preference is chosen from whether we have a REST URL,
+    // because `PreferRest` unconditionally is a dead end for a VTA that
+    // has no REST endpoint: the SDK maps it to `TransportPlan::RestOnly`
+    // with no DIDComm fallback, so rotation against a DIDComm-only VTA
+    // could not authenticate at all.
+    //
+    // The original reason for pinning REST here — that `get_acl` /
+    // `create_acl` needed the synchronous REST API — no longer holds.
+    // Both go through `rpc_tt` -> `dispatch_trust_task`, which is
+    // identical for the REST, DIDComm and TSP transports; REST's bespoke
+    // per-operation routes were removed upstream. The operation is a
+    // Trust Task on every transport, so the wire document is the same.
+    //
+    // - `vta_url` present: keep `PreferRest`. It is known-good for
+    //   existing deployments, and it avoids dialling DIDComm in the
+    //   self-mediated topology, where the VTA's DIDComm mediator is this
+    //   very process — which may not be running when an operator invokes
+    //   `rotate-admin` from the CLI.
+    // - `vta_url` absent: `Auto`. With `mediator_did: None` the SDK
+    //   resolves the VTA's DIDComm mediator from its DID document and
+    //   tries DIDComm with a REST fallback; if the DID document
+    //   advertises no `DIDCommMessaging` service it degrades to
+    //   `RestOnly`, exactly the behaviour this branch had before.
+    //
+    // NOTE: `Auto` cannot select TSP — `decide_transport` has no TSP arm,
+    // and `Transport::Tsp` is only reachable through the explicit
+    // `VtaClient::connect_tsp`. A TSP-only VTA still cannot be rotated
+    // against; that gap has to close in vta-sdk, not here.
+    let transport_preference = transport_preference_for(vta_url.as_deref());
     let svc = VtaServiceConfig {
         auth: vta_sdk::integration::VtaAuthConfig {
             credential: bundle,
@@ -135,7 +170,7 @@ pub async fn run(config_path: &str, dry_run: bool) -> Result<(), Box<dyn std::er
         context: vta_sdk::integration::VtaContextConfig {
             id: context.clone(),
             mediator_did: None,
-            transport_preference: TransportPreference::PreferRest,
+            transport_preference,
             did_resolver: None,
         },
     };
@@ -267,4 +302,40 @@ fn mint_did_key() -> Result<(String, String), Box<dyn std::error::Error>> {
         return Err(format!("expected did:key, generator produced '{did}'").into());
     }
     Ok((did, private_key_multibase))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_credential_with_a_rest_url_prefers_rest() {
+        // Known-good for existing deployments, and it avoids dialling
+        // DIDComm in the self-mediated topology where the VTA's mediator
+        // is this very process.
+        assert!(matches!(
+            transport_preference_for(Some("https://vta.example.com")),
+            TransportPreference::PreferRest
+        ));
+    }
+
+    #[test]
+    fn a_credential_without_a_rest_url_uses_auto() {
+        // `PreferRest` here maps to `RestOnly` with no DIDComm fallback,
+        // which cannot authenticate against a DIDComm-only VTA at all.
+        assert!(matches!(
+            transport_preference_for(None),
+            TransportPreference::Auto
+        ));
+    }
+
+    #[test]
+    fn an_empty_rest_url_is_treated_as_absent() {
+        // `url_override` filters empties, so an empty string would
+        // otherwise select RestOnly with no URL to resolve against.
+        assert!(matches!(
+            transport_preference_for(Some("")),
+            TransportPreference::Auto
+        ));
+    }
 }


### PR DESCRIPTION
Follow-up to #745, which made a `vta_did`-with-no-`vta_url` admin credential storable. This makes `mediator rotate-admin` actually usable with one.

## The failure

`rotate-admin` pinned `TransportPreference::PreferRest`, which vta-sdk maps to `TransportPlan::RestOnly` with **no DIDComm fallback** (`integration/auth.rs:71`). Against a VTA that exposes no REST endpoint there is nothing to resolve, so rotation fails before it begins.

Newly *reachable* rather than newly broken: until 0.20.1 a credential naming a VTA with no URL could not be stored, so the command had no way to load one.

## Yes — it's a Trust Task on every transport

The original comment justified pinning REST on the grounds that `get_acl` / `create_acl` needed "the synchronous REST API that they are built for". That is no longer true. Both go through `rpc_tt` -> `dispatch_trust_task`, and the three arms are identical:

```rust
Transport::Rest   { .. } => self.dispatch_trust_task(tt_uri, payload, timeout).await?,
Transport::DIDComm{ .. } => self.dispatch_trust_task(tt_uri, payload, timeout).await?,
Transport::Tsp    { .. } => self.dispatch_trust_task(tt_uri, payload, timeout).await?,
```

vta-sdk's own comment records why: REST "used to fork here into a bespoke per-operation route with its own request and response bodies, which is why REST was the one transport whose wire did not match the published schemas." That fork is gone. The ACL operations are canonical Trust Tasks (`acl/show/0.1`, `acl/grant/0.1`) carried identically over REST's `POST /trust-tasks`, DIDComm and TSP — so the only thing forcing REST was our preference flag.

## Change

Preference is derived from whether the credential carries a usable REST URL:

- **With a URL — `PreferRest`, unchanged.** Known-good for existing deployments, and it avoids dialling DIDComm in the self-mediated topology, where the VTA's DIDComm mediator is the very process the operator is running the CLI against and may not be up.
- **Without one — `Auto`.** With `mediator_did: None` the SDK resolves the VTA's mediator from its DID document (`resolve_effective_mediator_did`) and tries DIDComm with a REST fallback. A VTA advertising no `DIDCommMessaging` service degrades to `RestOnly` — exactly this branch's behaviour today.

Strictly additive: **no deployment whose credential has a REST URL changes behaviour.** The only path that changes is the one that is currently guaranteed to fail.

Extracted as a pure `transport_preference_for` so the choice is testable without a VTA, mirroring the SDK's own `decide_transport`.

## Known gap — TSP

**`Auto` cannot select TSP, so a TSP-only VTA still cannot be rotated against.** `integration/auth.rs` contains zero references to TSP: `decide_transport` returns only `RestOnly` / `DidCommThenRest` / `DidCommOnly` / `DidCommUnavailable`, and `Transport::Tsp` is constructed in exactly one place — the explicit `VtaClient::connect_tsp`, behind vta-sdk's `tsp` feature, which the mediator does not enable.

Deliberately not worked around here. Hand-rolling TSP selection in the mediator would duplicate logic that belongs in the SDK's preference matrix and diverge from the runtime path in `config/mod.rs`. The fix is a TSP arm in `decide_transport` upstream; documented at the call site so the next reader does not re-derive it.

## Verification

- `cargo test -p affinidi-messaging-mediator`: **190 passed** (187 + 3 new), `cargo clippy --all-targets` clean.
- Three new tests cover REST-URL-present, absent, and the empty-string case (`url_override` filters empties, so `""` would otherwise select `RestOnly` with no URL to resolve against).
- `check-version-bumps.sh`, `check-changelogs.sh`, `cargo fmt --check` green.

Takes **0.20.2**: 0.20.1 is in flight from #745's release run, and the pipeline skips already-published versions.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

R2.1 note: the ACL-created-but-credential-write-failed window in `rotate_admin` is pre-existing and already handled — it logs the recovery path explicitly rather than leaving the operator to infer it. This change does not touch that ordering.
