### PR TITLE
fix(mediator): say which origin CORS refused, and whether CORS is on

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased (0.20.3) — say which origin CORS refused, and whether CORS is on
+
+**Observability fix: a CORS refusal was invisible from both ends.**
+
+The browser gets an opaque `TypeError: Failed to fetch` with the reason
+confined to its devtools console, and the mediator logs a clean `200` — the
+`CorsLayer` does not reject anything, it simply omits the header. Operator and
+user are left with no shared evidence. `curl` cannot reproduce the fault
+either, because a terminal sends no `Origin` header, so the endpoint answers
+perfectly and the refusal looks like it never happened.
+
+- The `List` predicate now logs a refused origin at `warn`, naming it and
+  pointing at `security.cors_allow_origin`. Logged **once per distinct
+  origin** and capped at 32: the origin is attacker-controlled, so an
+  unbounded record of it is a log-flooding and memory-growth primitive for
+  anyone who can reach the port. A misconfigured deployment has one or two
+  distinct origins to report, so the cap loses nothing real.
+- The effective policy is now stated at boot. This is the half that matters
+  most: `CorsOriginPolicy::None` (the default) installs **no predicate** — it
+  never emits the header at all — so there is no per-request hook to log from,
+  and a mediator refusing every browser client otherwise says so nowhere.
+- The WebSocket path already logged its equivalent refusal and returns a
+  readable `403`; only the REST path was silent, which is the one a browser
+  client reaches first.
+
+No behaviour change: the layer, the matchers and the policy are untouched, and
+refusals are still refusals.
+
 ## Unreleased (0.20.2) — `rotate-admin` works against a VTA with no REST URL
 
 **Bug fix: `mediator rotate-admin` could not authenticate to a VTA that

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.2"
+version = "0.20.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -15,8 +15,9 @@ use jsonwebtoken::{DecodingKey, EncodingKey};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::Serialize;
 use std::{
+    collections::HashSet,
     fmt::{self, Debug},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
@@ -189,6 +190,41 @@ pub fn origin_matches(matchers: &[OriginMatcher], origin: &HeaderValue) -> bool 
     matchers.iter().any(|m| m.matches(origin))
 }
 
+/// How many distinct refused origins to name in the log before going quiet.
+///
+/// Refusals are logged so an operator can see *which* origin they are missing
+/// from the allowlist, but the origin is attacker-controlled: an unbounded
+/// record of it is a log-flooding and memory-growth primitive for anyone who
+/// can reach the port. A misconfigured deployment has one or two distinct
+/// origins to report, so a small cap loses nothing real.
+const MAX_LOGGED_REFUSED_ORIGINS: usize = 32;
+
+/// Log a refused origin once, then never again for that origin.
+///
+/// Why this exists: a CORS refusal is invisible from both ends. The browser
+/// gets an opaque `TypeError` with the reason confined to its devtools
+/// console, and the mediator's own logs show a clean `200` — the `CorsLayer`
+/// simply omits a header. Operator and user are left staring at each other,
+/// which is exactly how one deployment spent a day on this. The WebSocket path
+/// has always logged its equivalent refusal; the REST path did not.
+fn note_refused_origin(seen: &Mutex<HashSet<String>>, origin: &HeaderValue) {
+    let Ok(origin) = origin.to_str() else { return };
+    let Ok(mut seen) = seen.lock() else { return };
+    if seen.contains(origin) {
+        return;
+    }
+    if seen.len() >= MAX_LOGGED_REFUSED_ORIGINS {
+        return;
+    }
+    seen.insert(origin.to_string());
+    tracing::warn!(
+        "CORS: refused origin '{origin}' — it is not in security.cors_allow_origin. \
+         Browser clients from this origin (including browser extensions) cannot use \
+         the REST API or open a WebSocket. Add it to the allowlist and restart if \
+         this origin is expected."
+    );
+}
+
 /// Build the mediator's [`CorsLayer`] for the given origin policy. The
 /// allowed methods/headers are fixed; only the origin matching varies.
 fn build_cors_layer(policy: &CorsOriginPolicy) -> CorsLayer {
@@ -212,8 +248,14 @@ fn build_cors_layer(policy: &CorsOriginPolicy) -> CorsLayer {
         // exact request origin on a match and sets `Vary: Origin`.
         CorsOriginPolicy::List(matchers) => {
             let matchers = matchers.clone();
+            // Bounded, de-duplicated: see `note_refused_origin`.
+            let refused: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
             base.allow_origin(AllowOrigin::predicate(move |origin, _parts| {
-                origin_matches(&matchers, origin)
+                let allowed = origin_matches(&matchers, origin);
+                if !allowed {
+                    note_refused_origin(&refused, origin);
+                }
+                allowed
             }))
         }
     }
@@ -601,6 +643,26 @@ impl SecurityConfigRawExt for SecurityConfigRaw {
             config.cors_allow_origin = build_cors_layer(&policy);
             config.cors_origins = policy;
         }
+        // State the effective policy at boot. The default-closed case has no
+        // per-request hook to log from — `CorsOriginPolicy::None` installs no
+        // predicate, it simply never emits the header — so without this line a
+        // mediator that refuses every browser client says so nowhere at all,
+        // and the operator's first sight of it is a user reporting an error
+        // the server logs as a clean 200.
+        match &config.cors_origins {
+            CorsOriginPolicy::None => tracing::info!(
+                "CORS: disabled (security.cors_allow_origin unset). Browser clients \
+                 carrying an Origin header are refused on both the REST API and the \
+                 WebSocket upgrade; native clients are unaffected."
+            ),
+            CorsOriginPolicy::Any => {
+                tracing::info!("CORS: any origin allowed (security.cors_allow_origin = \"*\")")
+            }
+            CorsOriginPolicy::List(matchers) => tracing::info!(
+                "CORS: {} allowed origin(s) configured; all others refused",
+                matchers.len()
+            ),
+        }
 
         // ── Populate the DIDComm secrets resolver ────────────────────────
         if let Some(bundle) = vta_bundle {
@@ -704,9 +766,12 @@ impl SecurityConfigRawExt for SecurityConfigRaw {
 #[cfg(test)]
 mod tests {
     use super::{
-        CorsOriginPolicy, OriginMatcher, SecurityConfigRaw, SecurityConfigRawExt, origin_matches,
+        CorsOriginPolicy, MAX_LOGGED_REFUSED_ORIGINS, OriginMatcher, SecurityConfigRaw,
+        SecurityConfigRawExt, note_refused_origin, origin_matches,
     };
     use http::HeaderValue;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
 
     /// Parse `spec` into a `List` policy and return its matchers, or panic
     /// with the actual variant for a clearer failure than `unwrap`.
@@ -874,5 +939,53 @@ mod tests {
         assert!(SecurityConfigRaw::parse_cors_origins("https://*.affinidi.com:notaport").is_err());
         // Empty suffix.
         assert!(SecurityConfigRaw::parse_cors_origins("https://*.").is_err());
+    }
+
+    // ─── Refused-origin logging ───
+    //
+    // The record is bounded because the origin is attacker-controlled: an
+    // unbounded set of it is a memory-growth and log-flooding primitive for
+    // anyone who can reach the port.
+
+    #[test]
+    fn refused_origin_is_recorded_once() {
+        let seen = Mutex::new(HashSet::new());
+        let origin = HeaderValue::from_static("https://app.example.com");
+        note_refused_origin(&seen, &origin);
+        note_refused_origin(&seen, &origin);
+        note_refused_origin(&seen, &origin);
+        assert_eq!(seen.lock().unwrap().len(), 1, "a repeated origin logs once");
+    }
+
+    #[test]
+    fn distinct_refused_origins_are_each_recorded() {
+        let seen = Mutex::new(HashSet::new());
+        note_refused_origin(&seen, &HeaderValue::from_static("https://a.example"));
+        note_refused_origin(&seen, &HeaderValue::from_static("https://b.example"));
+        assert_eq!(seen.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn refused_origin_record_is_bounded() {
+        let seen = Mutex::new(HashSet::new());
+        for i in 0..(MAX_LOGGED_REFUSED_ORIGINS * 4) {
+            let origin = HeaderValue::from_str(&format!("https://host{i}.example")).unwrap();
+            note_refused_origin(&seen, &origin);
+        }
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            MAX_LOGGED_REFUSED_ORIGINS,
+            "an unbounded caller must not be able to grow the record without limit"
+        );
+    }
+
+    #[test]
+    fn a_non_utf8_origin_is_ignored_rather_than_panicking() {
+        // `HeaderValue` admits bytes that are not valid UTF-8; the logger must
+        // decline them, not unwrap.
+        let seen = Mutex::new(HashSet::new());
+        let origin = HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap();
+        note_refused_origin(&seen, &origin);
+        assert!(seen.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## The problem

A CORS refusal is invisible from **both** ends.

The browser gets an opaque `TypeError: Failed to fetch`; the actual reason (`No 'Access-Control-Allow-Origin' header is present`) is confined to its devtools console, unreadable by the calling code. The mediator, meanwhile, logs a clean `200` — `CorsLayer` doesn't reject anything, it just omits a header. Operator and user are left staring at each other with no shared evidence.

One deployment spent a day on exactly this. A browser extension could not authenticate; the operator had allowlisted it on a *different* service and reasonably believed CORS was configured. And the obvious check makes it worse — `curl` cannot reproduce the fault, because a terminal sends no `Origin` header:

```console
$ curl -sS -X POST https://mediator.example/mediator/v1/authenticate/challenge \
    -H 'content-type: application/json' -d '{"did":"did:example:probe"}'
{"sessionId":"…","httpCode":200,"data":{"challenge":"…"}}   # perfectly healthy
```

The endpoint is fine. The origin is what's refused, and nothing on this side said so.

## The change

Two log lines. No behaviour change — the layer, the matchers and the policy are untouched, and refusals are still refusals.

**Per-request, on the `List` predicate.** Names the refused origin at `warn`, once per distinct origin, capped at 32. The origin is attacker-controlled, so an unbounded record of it is a log-flooding and memory-growth primitive for anyone who can reach the port. A misconfigured deployment has one or two distinct origins to report, so the cap loses nothing real.

```
WARN CORS: refused origin 'chrome-extension://dbjgfkjl…' — it is not in
     security.cors_allow_origin. Browser clients from this origin (including
     browser extensions) cannot use the REST API or open a WebSocket. Add it
     to the allowlist and restart if this origin is expected.
```

**At boot, the effective policy.** This is the half that matters most, and the case the incident actually hit: `CorsOriginPolicy::None` installs **no predicate** — it simply never emits the header — so there is no per-request hook to log from. Without a boot line, a mediator refusing every browser client says so nowhere at all.

```
INFO CORS: disabled (security.cors_allow_origin unset). Browser clients carrying
     an Origin header are refused on both the REST API and the WebSocket upgrade;
     native clients are unaffected.
```

## Why only the REST path needed this

The WebSocket path has always logged its equivalent refusal (`WebSocket upgrade rejected: Origin not permitted by CORS policy`, `handlers/websocket.rs`) and returns a readable `403 origin not allowed`. Only the REST path was silent, which is unfortunate ordering — the REST handshake is what runs *first*, so it is the one a browser client fails on.

## Tests

Four, covering the parts that are easy to get wrong rather than the logging itself:

- a repeated origin is recorded once
- distinct origins are each recorded
- the record is bounded — 4× the cap of distinct origins still yields exactly `MAX_LOGGED_REFUSED_ORIGINS`
- a non-UTF-8 `HeaderValue` is declined rather than unwrapped

## Checks

- [x] `cargo check -p affinidi-messaging-mediator`
- [x] `cargo test -p affinidi-messaging-mediator --lib security::` — 16 passed
- [x] `cargo clippy -p affinidi-messaging-mediator --all-targets` — clean (including test targets, which CI's clippy invocation skips)
- [x] `cargo fmt --check` clean