### PR TITLE
fix(mediator): don't refuse a blind relay hop as a session mismatch

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## Unreleased (0.20.4) — blind cross-mediator relay is no longer refused as a session mismatch
+
+**Bug fix: with the default `RelayMode::Blind`, a mediator refused every
+message relayed to it by a peer mediator.**
+
+Observed in production: mediator M2 relays to M1, and M1 answers
+`HTTP 400 / errorCode 52` —
+`e.p.authorization.did.session_mismatch`, "Sender DID (…) doesn't match
+session DID", on session `ANON-INBOUND`. No cross-mediator DIDComm delivery
+completed.
+
+`inbound.rs` enforces `security.force_session_did_match` in two places, and
+only one of them was guarded. The **forward** branch (the message is addressed
+to the mediator) already skipped the check for an unauthenticated session,
+because an inter-mediator relay hop arrives anonymously and has no session DID
+to match against. The **direct-delivery** branch (the message is addressed to
+a local account) did not, so it compared the claimed sender against the
+anonymous session's empty DID and could only ever fail.
+
+Which branch a relayed message lands on is decided by the relay mode.
+`RelayMode::Blind` — the default — relays the peer's inner envelope
+byte-for-byte, and that envelope is addressed to the *recipient*, not to the
+receiving mediator: a direct delivery. So the unguarded branch is exactly the
+one every blind relay hop takes. `RelayMode::Rewrap` re-wraps the envelope as
+a forward addressed to the next mediator and therefore took the already-guarded
+branch, which is why rewrap deployments were unaffected.
+
+The direct-delivery check now carries the same `session.authenticated` guard as
+its sibling.
+
+**The security tradeoff, stated plainly.** A directly-delivered envelope cannot
+be decrypted by the mediator, so its sender is only a *claim* (the JWE `skid`),
+and that claim is what feeds `from_hash` in the recipient's access-list
+verdict. Exempting the anonymous relay session means a blind-relayed message's
+sender is not verified against anything: a relaying peer can present any sender
+DID. This is inherent to blind relay rather than introduced here — by
+construction the receiving mediator cannot see which peer relayed — and the
+alternative is the bug being fixed, refusing the hop outright.
+`RelayMode::Rewrap` together with
+`processors.forwarding.relay_trusted_mediators` exists precisely so a
+deployment can authenticate and allowlist the relaying peer; deployments that
+need the peer authenticated should run it.
+
+Unchanged: an **authenticated** session's direct delivery is still bound to its
+session DID, so a client cannot claim someone else's sender DID.
+
 ## Unreleased (0.20.3) — say which origin CORS refused, and whether CORS is on
 
 **Observability fix: a CORS refusal was invisible from both ends.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.3"
+version = "0.20.4"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -699,22 +699,28 @@ async fn handle_inbound_didcomm(
                     // claimed sender (JWE `skid` header) is unverified. When
                     // session/sender matching is enforced, bind it to the
                     // authenticated session DID before it is trusted for ACL checks.
-                    if state.config.security.force_session_did_match
-                        && envelope.from_did.as_deref() != Some(session.did.as_str())
-                    {
-                        let claimed = envelope.from_did.as_deref().unwrap_or("anonymous");
-                        return Err(MediatorError::problem_with_log(
-                            52,
-                            &session.session_id,
-                            None,
-                            ProblemReportSorter::Error,
-                            ProblemReportScope::Protocol,
-                            "authorization.did.session_mismatch",
-                            "Sender DID ({1}) doesn't match session DID",
-                            vec![claimed.to_string()],
-                            StatusCode::BAD_REQUEST,
-                            format!("Direct-delivery envelope sender ({claimed}) doesn't match session DID"),
-                        ));
+                    //
+                    // Skipped for unauthenticated sessions, exactly as the forward
+                    // branch above skips it: an inter-mediator relay hop arrives on
+                    // the anonymous `ANON-INBOUND` session, whose DID is empty, so the
+                    // comparison could only ever fail. It reaches *this* branch rather
+                    // than the forward branch because [`RelayMode::Blind`] — the
+                    // default — relays the peer's inner envelope verbatim, and that
+                    // envelope is addressed to the local recipient, not to this
+                    // mediator. Without the guard, blind relay cannot deliver at all.
+                    //
+                    // The cost is real and worth naming: on a blind relay hop the
+                    // claimed sender stays unverified, and it is that claimed sender
+                    // which `delivery_decision` above hashed into `from_hash` for the
+                    // recipient's access-list verdict. A relaying peer can therefore
+                    // present any sender DID it likes. This is inherent to blind
+                    // relay — by construction the receiving mediator cannot see who
+                    // relayed — not something this guard gives away: the alternative
+                    // is refusing the hop, which is the bug being fixed.
+                    // [`RelayMode::Rewrap`] plus `relay_trusted_mediators` is the
+                    // posture for deployments that need the peer authenticated.
+                    if state.config.security.force_session_did_match && session.authenticated {
+                        check_direct_delivery_session_match(session, envelope.from_did.as_deref())?;
                     }
 
                     // Check if the message will pass ACL Checks
@@ -935,6 +941,40 @@ fn check_session_sender_match(
     ))
 }
 
+/// Ensure a direct-delivery envelope's claimed sender matches the session DID.
+///
+/// The mediator holds no key for a directly-delivered envelope, so `from_did`
+/// here is whatever the JWE `skid` header claims — unverified. It is also the
+/// value that feeds the recipient's access-list lookup, so on an authenticated
+/// session it has to be pinned to the DID that authenticated.
+///
+/// Only the caller can decide whether the session is one that can be matched
+/// against: an anonymous inter-mediator relay hop has no session DID, and is
+/// exempted at the call site rather than here.
+#[cfg(feature = "didcomm")]
+fn check_direct_delivery_session_match(
+    session: &Session,
+    claimed_sender: Option<&str>,
+) -> Result<(), MediatorError> {
+    if claimed_sender == Some(session.did.as_str()) {
+        return Ok(());
+    }
+
+    let claimed = claimed_sender.unwrap_or("anonymous");
+    Err(MediatorError::problem_with_log(
+        52,
+        &session.session_id,
+        None,
+        ProblemReportSorter::Error,
+        ProblemReportScope::Protocol,
+        "authorization.did.session_mismatch",
+        "Sender DID ({1}) doesn't match session DID",
+        vec![claimed.to_string()],
+        StatusCode::BAD_REQUEST,
+        format!("Direct-delivery envelope sender ({claimed}) doesn't match session DID"),
+    ))
+}
+
 #[cfg(test)]
 #[cfg(feature = "didcomm")]
 mod tests {
@@ -998,6 +1038,51 @@ mod tests {
         assert!(check_session_sender_match(&session, "msg-1", &Some(&key0)).is_ok());
         assert!(check_session_sender_match(&session, "msg-1", &Some(&key1)).is_ok());
         assert!(check_session_sender_match(&session, "msg-1", &Some(&signing)).is_ok());
+    }
+
+    // --- check_direct_delivery_session_match tests ---
+    // The direct-delivery sibling of the above: it compares the whole claimed
+    // sender DID (from the JWE `skid`) against the session DID, with no key
+    // fragment involved.
+
+    #[test]
+    fn direct_delivery_sender_matching_session_ok() {
+        let session = make_session("did:example:alice");
+        assert!(check_direct_delivery_session_match(&session, Some("did:example:alice")).is_ok());
+    }
+
+    #[test]
+    fn direct_delivery_wrong_sender_rejected() {
+        let session = make_session("did:example:alice");
+        assert!(
+            check_direct_delivery_session_match(&session, Some("did:example:mallory")).is_err()
+        );
+    }
+
+    #[test]
+    fn direct_delivery_anonymous_sender_rejected() {
+        let session = make_session("did:example:alice");
+        assert!(check_direct_delivery_session_match(&session, None).is_err());
+    }
+
+    /// The bug this guard fixes: an inter-mediator relay hop arrives on the
+    /// anonymous session, whose DID is empty, so *every* claimed sender
+    /// mismatches. The call site must not run the check for such a session —
+    /// this asserts the check really does fail there, which is why the
+    /// `session.authenticated` guard is load-bearing rather than cosmetic.
+    #[test]
+    fn anonymous_relay_session_would_reject_every_sender() {
+        let relay_session = Session {
+            session_id: "ANON-INBOUND".to_string(),
+            ..Default::default()
+        };
+        assert!(!relay_session.authenticated);
+        assert!(
+            check_direct_delivery_session_match(&relay_session, Some("did:example:alice")).is_err()
+        );
+        assert!(
+            check_direct_delivery_session_match(&relay_session, Some("did:example:bob")).is_err()
+        );
     }
 
     // --- anonymous message detection tests ---

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/cross_mediator_forwarding.rs
@@ -510,3 +510,207 @@ fn unix_secs() -> u64 {
         .unwrap_or_default()
         .as_secs()
 }
+
+// ─── Blind relay into DIRECT DELIVERY ───────────────────────────────────────
+//
+// Every test above builds the routing-2.0 *double* forward, so the envelope
+// mediator B receives is itself a `forward` addressed to B — B unpacks it and
+// takes inbound.rs's `to_did == mediator_did` branch, where the session/sender
+// match has always been skipped for unauthenticated sessions. That is why they
+// pass on both sides of this fix and never caught the defect.
+//
+// A client that sends a *single* forward (`next` = the remote recipient, not
+// the remote mediator) is the shape production actually uses, and it lands on
+// the other branch: in `RelayMode::Blind` mediator A relays the inner envelope
+// verbatim, so what arrives at B is addressed to Bob, not to B — a direct
+// delivery, on the anonymous `ANON-INBOUND` relay session. Before the guard was
+// added there, B answered every such hop with HTTP 400
+// `e.p.authorization.did.session_mismatch`.
+
+/// Blind relay mediator that also accepts direct delivery.
+///
+/// A relayed inner envelope addressed to a local account *is* a direct
+/// delivery as far as the receiving mediator is concerned, so a mediator that
+/// terminates single-forward relays has to have the path enabled; the fixture
+/// ships it off. Anonymous direct delivery stays off — the relayed envelope
+/// carries an authcrypt sender, so this test must not depend on the
+/// `allow_anon` escape hatch.
+async fn spawn_direct_delivery_relay_environment() -> TestEnvironment {
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .local_direct_delivery(true, false)
+        .spawn()
+        .await
+        .expect("spawn blind relay mediator with direct delivery enabled");
+    TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment to direct-delivery relay mediator")
+}
+
+/// Drive one cross-mediator delivery using a SINGLE forward: Alice wraps the
+/// authcrypt for Bob in one `forward` addressed to her own mediator with
+/// `next = Bob`. Mediator A resolves Bob's DID document, finds it mediated by
+/// B, and relays the inner envelope there.
+async fn single_forward_and_receive(
+    sender_env: &TestEnvironment,
+    sender: &TestUser,
+    sender_mediator_did: &str,
+    recipient_env: &TestEnvironment,
+    recipient: &TestUser,
+    text: &str,
+    wait: Duration,
+) -> Option<String> {
+    let now = unix_secs();
+
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(recipient.did.clone())
+    .from(sender.did.clone())
+    .created_time(now)
+    .expires_time(now + 60)
+    .finalize();
+    let msg_id = msg.id.clone();
+
+    let (packed, _) = sender_env
+        .atm
+        .pack_encrypted(&msg, &recipient.did, Some(&sender.did), Some(&sender.did))
+        .await
+        .expect("authcrypt for recipient");
+
+    // The single forward: addressed to Alice's own mediator, `next` = Bob
+    // himself. There is no second forward layer for mediator B to unwrap, so
+    // the envelope B receives is the authcrypt addressed to Bob.
+    let (_fwd_id, forward) = sender_env
+        .atm
+        .routing()
+        .forward_message(
+            &sender.profile,
+            false,
+            &packed,
+            sender_mediator_did,
+            &recipient.did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap single forward");
+
+    sender_env
+        .atm
+        .send_message(&sender.profile, &forward, &msg_id, false, false)
+        .await
+        .expect("send forward to own mediator");
+
+    match recipient_env
+        .atm
+        .message_pickup()
+        .live_stream_get(&recipient.profile, &msg_id, wait, true)
+        .await
+    {
+        Ok(Some((received, _meta))) => received
+            .body
+            .get("content")
+            .and_then(|c| c.as_str())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// The regression for the production `session_mismatch` refusal: a blind relay
+/// whose inner envelope is addressed to a local account must be delivered, not
+/// refused for failing to match the anonymous relay session's (empty) DID.
+#[tokio::test]
+async fn blind_relay_direct_delivery_reaches_recipient() {
+    init_tracing();
+
+    let env_a = spawn_direct_delivery_relay_environment().await;
+    let env_b = spawn_direct_delivery_relay_environment().await;
+
+    let mediator_a_did = env_a.mediator.did().to_string();
+    assert_ne!(
+        mediator_a_did,
+        env_b.mediator.did(),
+        "the two mediators must have distinct DIDs for a real cross-mediator hop"
+    );
+
+    let alice = add_live_user(&env_a, "Alice").await;
+    let bob = add_live_user(&env_b, "Bob").await;
+
+    let text = "Single-forward hello, relayed blind and delivered directly.";
+    let received = single_forward_and_receive(
+        &env_a,
+        &alice,
+        &mediator_a_did,
+        &env_b,
+        &bob,
+        text,
+        Duration::from_secs(15),
+    )
+    .await;
+
+    assert_eq!(
+        received.as_deref(),
+        Some(text),
+        "Bob should receive Alice's single-forward message; a session_mismatch \
+         refusal on mediator B's direct-delivery path shows up as no delivery"
+    );
+
+    env_a.shutdown().await.expect("shutdown mediator A");
+    env_b.shutdown().await.expect("shutdown mediator B");
+}
+
+/// The guard is scoped to *unauthenticated* sessions only: an authenticated
+/// client that hands its own mediator a direct delivery claiming somebody
+/// else's sender DID is still refused. Without this, "relax the check for
+/// anonymous relay" could silently become "stop checking".
+#[tokio::test]
+async fn authenticated_direct_delivery_still_enforces_session_match() {
+    init_tracing();
+
+    let env = spawn_direct_delivery_relay_environment().await;
+    // Plain HTTP users: the refusal has to come back as the POST /inbound
+    // response, not be swallowed by a live-stream socket.
+    let alice = env.add_user("Alice").await.expect("add Alice");
+    let bob = env.add_user("Bob").await.expect("add Bob");
+    let mallory = env.add_user("Mallory").await.expect("add Mallory");
+
+    let now = unix_secs();
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": "Spoofed sender." }),
+    )
+    .to(bob.did.clone())
+    .from(alice.did.clone())
+    .created_time(now)
+    .expires_time(now + 60)
+    .finalize();
+    let msg_id = msg.id.clone();
+
+    // Authcrypted as Alice, but handed to the mediator over Mallory's
+    // authenticated session — the envelope's claimed sender and the session
+    // DID disagree.
+    let (packed, _) = env
+        .atm
+        .pack_encrypted(&msg, &bob.did, Some(&alice.did), Some(&alice.did))
+        .await
+        .expect("authcrypt as Alice");
+
+    let result = env
+        .atm
+        .send_message(&mallory.profile, &packed, &msg_id, false, false)
+        .await;
+
+    let error = result.expect_err("mediator must refuse a spoofed direct delivery");
+    assert!(
+        format!("{error:?}").contains("session_mismatch"),
+        "expected a session_mismatch problem report, got: {error:?}"
+    );
+
+    env.shutdown().await.expect("shutdown mediator");
+}


### PR DESCRIPTION
## The failure

Cross-mediator DIDComm delivery is broken in the default relay mode. Observed live: mediator M2 relays a message to mediator M1, and M1 refuses it.

```
HTTP 400 Bad Request
{"sessionId":"ANON-INBOUND","httpCode":400,"errorCode":52,
 "errorCodeStr":"DIDCommProblemReport",
 "message":"{\"code\":\"e.p.authorization.did.session_mismatch\",
             \"comment\":\"Sender DID ({1}) doesn't match session DID\",
             \"args\":[\"did:webvh:QmbTGG...:dids.eu.openvtc.net:vtc\"]}"}
```

Every hop, every time. Nothing crosses a mediator boundary.

## The forward-vs-direct asymmetry

`inbound.rs` enforces `security.force_session_did_match` in two places, and only one of them was guarded.

**Forward branch** (`to_did == mediator_did`) — guarded, and the comment says why:

```rust
// Skip for unauthenticated sessions (e.g. inter-mediator relay):
// there is no session DID to match against.
if state.config.security.force_session_did_match && session.authenticated {
```

**Direct-delivery branch** (`to_did` is a local account) — not guarded:

```rust
if state.config.security.force_session_did_match
    && envelope.from_did.as_deref() != Some(session.did.as_str())
```

A relay hop arrives on the anonymous `ANON-INBOUND` session, whose DID is empty, so on that branch the comparison could only ever fail.

Which branch a relayed message lands on is decided by the relay mode, and that is what makes this the default path rather than an edge case:

- **`RelayMode::Blind`** (the **default**) relays the peer's inner envelope byte-for-byte. That envelope is addressed to the *recipient*, not to the receiving mediator — a direct delivery, on the unguarded branch.
- **`RelayMode::Rewrap`** re-wraps it as a `forward` addressed to the next mediator, so it took the branch that was already guarded. Rewrap deployments never saw this.

The fix gives the direct-delivery check the same `&& session.authenticated` guard its sibling already has.

## The security tradeoff

Not free, and worth stating plainly.

The mediator cannot decrypt a directly-delivered envelope, so its sender is only a *claim* (the JWE `skid`) — and that claim is what feeds `from_hash` in the recipient's `delivery_decision` access-list lookup. Exempting the anonymous relay session means a blind-relayed message's sender is verified against nothing: a relaying peer can present any sender DID it likes.

That property is **inherent to blind relay** rather than introduced here — by construction the receiving mediator cannot see which peer relayed — and the alternative is the bug being fixed, refusing the hop outright. `RelayMode::Rewrap` together with `processors.forwarding.relay_trusted_mediators` exists precisely so a deployment can authenticate and allowlist the relaying peer; a deployment that needs the peer authenticated should run it.

Unchanged: an **authenticated** session's direct delivery is still bound to its session DID, so a client still cannot claim someone else's sender.

## Why the existing cross-mediator tests did not catch it

They pass on both sides of this fix, and the reason matters.

Every test in `cross_mediator_forwarding.rs` builds the routing-2.0 **double** forward — an OUTER forward to the sender's own mediator wrapping an INNER forward addressed to the *recipient's mediator*. So the envelope mediator B receives is itself a `forward` addressed to B: B unpacks it and takes the `to_did == mediator_did` branch, where the check has always been skipped for unauthenticated sessions. The tests exercise the relay *transport* thoroughly and never touch the direct-delivery branch at all.

The defect needs a **single** forward — `next` = the remote recipient, not the remote mediator — which is the shape production clients actually use. Mediator A resolves the recipient's DID document, finds it mediated by B, and relays the inner envelope there; what lands at B is addressed to Bob, not to B.

## Tests added

- **Unit** (`inbound.rs`): the check is lifted into `check_direct_delivery_session_match`, mirroring the existing `check_session_sender_match`, so the predicate is testable on its own. Four cases, including `anonymous_relay_session_would_reject_every_sender`, which pins that the anonymous session rejects *every* claimed sender — that is what makes the guard load-bearing rather than cosmetic.
- **Integration** (`cross_mediator_forwarding.rs`, real two-mediator topology, no mocks):
  - `blind_relay_direct_delivery_reaches_recipient` — Alice on A sends a single forward to Bob on B; the message must arrive. Reverting **only** the guard makes this fail with the identical `HTTP 400` / `errorCode 52` / `ANON-INBOUND` / `session_mismatch` payload quoted at the top, and no other test in either crate fails with it.
  - `authenticated_direct_delivery_still_enforces_session_match` — the control: an authenticated client handing its own mediator a direct delivery that claims someone else's sender DID is still refused. Without this, "relax the check for anonymous relay" could quietly become "stop checking".

The new relay fixture sets `local_direct_delivery(true, false)` — a relayed envelope addressed to a local account *is* a direct delivery to the receiving mediator, so the path has to be enabled; `allow_anon` stays off so the test cannot pass through the anonymous escape hatch.

## Scope

Version bumped to **0.20.4** with a changelog entry — a relaying mediator pair's delivery behaviour changes, which is exactly the kind of thing consumers pin loosely and need to read about.

Deliberately untouched: the plaintext forwarding problem report and the TSP endpoint DID indirection, both handled in parallel. Nothing in `tasks/forwarding/processor.rs` or the `affinidi-tsp` crate is modified.

## Gates run locally

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `RUSTFLAGS="-D warnings --cfg tracing_unstable" cargo clippy --workspace --all-targets` | pass, clean |
| `RUSTFLAGS="--cfg tracing_unstable" cargo test -p affinidi-messaging-mediator -p affinidi-messaging-test-mediator` | pass — 227 lib + all integration suites green, 0 failures (against a local Redis on 6379, matching CI's `useRedis: true`) |
| `scripts/check-version-bumps.sh` / `scripts/check-changelogs.sh` | pass |

Note: the ignored suites (`--include-ignored`) were not run — they need live external services.
