### PR TITLE
fix(mediator): pack the forwarding-abandonment problem report

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased (0.20.5) — pack the forwarding-abandonment problem report
+
+**Bug fix (host side of mediator-common 0.15.37): the mediator now packs the
+problem report it sends when it gives up on a forward.**
+
+The report went out as bare DIDComm plaintext, which every SDK client on the
+default (authcrypt-only) receive policy discards — the mediator logged
+`FORWARD_PROBLEM_REPORT: stored problem report … for sender …` while the sender
+logged `UnexpectedEnvelope("envelope wrapping Plaintext is not in the accepted
+set …")`. Every forwarding abandonment was silent to the sender.
+
+- New `tasks::system_packer::MediatorSystemPacker` implements
+  `mediator-common`'s `SystemMessagePacker` over the same
+  `didcomm_compat::pack_encrypted` every protocol reply already goes through.
+  Only compiled with the `didcomm` feature; a TSP-only build has no DIDComm
+  packer to offer and the processor logs the abandonment instead.
+- The forwarding processor is now spawned *after* the DID resolver is built and
+  the mediator's own document preloaded — authcrypt resolves both ends, and a
+  `did:web`/`did:webvh` mediator may not reach its own document over the
+  network from inside its deployment. No other ordering depends on it.
+
 ## Unreleased (0.20.4) — blind cross-mediator relay is no longer refused as a session mismatch
 
 **Bug fix: with the default `RelayMode::Blind`, a mediator refused every

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.4"
+version = "0.20.5"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -130,7 +130,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.34", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.37", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.2.1", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.37) — every forwarding abandonment was silent to the sender
+
+**Bug fix: the forwarding-failure problem report is now authcrypted, so a
+client on the default receive policy can actually read it.**
+
+When the forwarding processor exhausts a forward's retry budget it stores a
+`report-problem/2.0` in the original sender's inbox. That report was built as
+raw JSON and handed straight to `store_message` — no `pack_encrypted`, no
+signing, DIDComm plaintext on the wire. Since the SDK's
+`BREAKING CHANGE: enforce authcrypt messages by default` (2bec127, #671) the
+default receive policy refuses exactly that, so on a live deployment the two
+halves logged past each other:
+
+```text
+INFO ...forwarding::processor: FORWARD_PROBLEM_REPORT: stored problem report
+  1a23bf7e95a854e5d8eaad598a0f9fd8af7f2a1ab8aa282e6ce697423b8eeafa
+  for sender b9b77027...
+
+ERROR affinidi_messaging_sdk::transports::websockets::websocket:
+  Error unpacking message: UnexpectedEnvelope("envelope wrapping Plaintext is
+  not in the accepted set [AuthcryptPlaintext, AuthcryptSignPlaintext,
+  AnoncryptAuthcryptPlaintext]")
+```
+
+This was not deployment-specific: **every** forwarding abandonment was silent
+to the sender, on every mediator pair, for every current SDK client.
+
+- New `tasks::forwarding::SystemMessagePacker` trait, supplied through
+  `ForwardingProcessor::with_system_packer`. This crate deliberately carries no
+  DIDComm, resolver, or secrets dependency and is itself a dependency of the
+  crate that owns `pack_encrypted`, so the packing is injected rather than
+  implemented here. `ForwardingProcessor::new` is unchanged — the standalone
+  `forwarding_processor` binary, whose config is a database plus a forwarding
+  block, compiles and runs as before.
+- The report now carries `from` (the mediator's DID). The recipient's
+  addressing-consistency check binds the authcrypt sender to that field; a
+  report without it decrypts and is *then* rejected, which is the same silent
+  outcome.
+- **A report that cannot be packed is no longer stored.** Storing an envelope
+  the recipient's policy refuses is the defect being fixed, and it re-fails on
+  every fetch until it expires; anoncrypt is no fallback either, being outside
+  the default accepted set. The abandonment instead surfaces as an
+  operator-side `FORWARD_PROBLEM_REPORT_UNSENT` error naming the sender, the
+  destination and the reason, and `start()` warns at boot when `report_errors`
+  is on with no packer configured.
+- The stored report's sender is now the mediator's DID hash. It used to be the
+  literal string `"SYSTEM"`, which is not a DID hash and gave the report an
+  outbox of its own.
+
 ## Unreleased (0.15.36) — an admin credential may name a VTA with no REST URL
 
 **Bug fix: `AdminCredential` no longer rejects a VTA-linked credential that

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.36"
+version = "0.15.37"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
@@ -10,6 +10,11 @@
 pub mod config;
 pub use config::{ForwardingConfig, RelayMode};
 
+// The mediator's own outbound packing, injected rather than implemented
+// here — see the module docs for why this crate can't pack for itself.
+pub mod packer;
+pub use packer::SystemMessagePacker;
+
 // `ForwardingProcessor` is backend-agnostic: it consumes the
 // `forward_queue_*` methods on `Arc<dyn MediatorStore>`, which every
 // backend implements (Redis via Streams consumer groups; Fjall and

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/packer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/packer.rs
@@ -1,0 +1,52 @@
+//! The packing seam for messages the **mediator itself** authors.
+//!
+//! Everything a client sends through the mediator arrives already packed and
+//! leaves the same way, so the forwarding processor never needed to encrypt
+//! anything — until it has to tell a sender that their forward was abandoned.
+//! That report has no client-supplied envelope to reuse: the mediator is the
+//! author, and it must pack it under its own DID or the recipient's default
+//! receive policy (authcrypt-only since the SDK's `enforce authcrypt messages
+//! by default` change) throws it away unread.
+//!
+//! Packing lives behind a trait rather than in this crate because
+//! `mediator-common` deliberately carries no DIDComm, DID-resolver, or
+//! secrets-resolver dependency — it is the lean layer that the SDK-flavoured
+//! consumers take with `default-features = false`, and the mediator crate that
+//! *does* own `pack_encrypted` depends on this one (so calling into it directly
+//! would be a dependency cycle). The mediator injects an implementation with
+//! [`ForwardingProcessor::with_system_packer`]; a consumer that has no mediator
+//! identity to pack with — the standalone `forwarding_processor` binary, whose
+//! config is a database plus a forwarding block and nothing else — leaves it
+//! unset and gets a loud log instead of an unreadable message.
+//!
+//! [`ForwardingProcessor::with_system_packer`]:
+//!     crate::tasks::forwarding::ForwardingProcessor::with_system_packer
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Packs a mediator-authored DIDComm plaintext for one recipient.
+///
+/// Implementations authcrypt **from the mediator's own DID**: anoncrypt is not
+/// an acceptable substitute, because bare `AnoncryptPlaintext` is not in the
+/// SDK's default accepted set either — the recipient needs an authenticated
+/// sender to bind the message's `from` to.
+#[async_trait]
+pub trait SystemMessagePacker: Send + Sync {
+    /// The mediator's own DID. Callers stamp it as the plaintext's `from`
+    /// before packing: the SDK's addressing-consistency check rejects a
+    /// message whose authcrypt `skid` does not resolve to the same DID as
+    /// `from`, so the two must agree or the report is refused after decryption
+    /// rather than before it.
+    fn mediator_did(&self) -> &str;
+
+    /// Authcrypt `plaintext` from [`mediator_did`](Self::mediator_did) to
+    /// `to_did`, returning the serialized envelope to store.
+    ///
+    /// `plaintext` is a complete DIDComm plaintext message (`id`, `type`,
+    /// `from`, `to`, `body`, …). The error is a human-readable string destined
+    /// for an operator log, so it should say *why* packing failed — an
+    /// unresolvable recipient and a recipient with no key-agreement key are
+    /// different operational problems.
+    async fn pack(&self, plaintext: &Value, to_did: &str) -> Result<String, String>;
+}

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
@@ -17,8 +17,10 @@
 
 use crate::store::{MediatorStore, types::ForwardQueueEntry};
 use crate::tasks::forwarding::config::ForwardingConfig;
+use crate::tasks::forwarding::packer::SystemMessagePacker;
 use crate::time::{unix_timestamp_millis, unix_timestamp_secs};
 use futures_util::{SinkExt, StreamExt};
+use sha256::digest;
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -188,6 +190,10 @@ pub struct ForwardingProcessor {
     http_pool: Arc<HttpClientPool>,
     /// WebSocket connection pool keyed by endpoint URL
     ws_pool: Arc<Mutex<HashMap<String, PooledWebSocket>>>,
+    /// How mediator-authored messages (the forwarding-failure problem report)
+    /// are encrypted for their recipient. `None` when the host has no mediator
+    /// identity to pack with — see [`SystemMessagePacker`].
+    packer: Option<Arc<dyn SystemMessagePacker>>,
 }
 
 impl ForwardingProcessor {
@@ -216,7 +222,19 @@ impl ForwardingProcessor {
             endpoints: Arc::new(RwLock::new(HashMap::new())),
             http_pool,
             ws_pool: Arc::new(Mutex::new(HashMap::new())),
+            packer: None,
         })
+    }
+
+    /// Supply the mediator identity that mediator-authored messages are packed
+    /// under. Without it the processor can still forward — only the
+    /// forwarding-failure problem report needs to be encrypted — so this is a
+    /// post-construction opt-in rather than a `new` argument, keeping the
+    /// standalone `forwarding_processor` binary (which has no mediator DID or
+    /// secrets in its config) compiling and running unchanged.
+    pub fn with_system_packer(mut self, packer: Arc<dyn SystemMessagePacker>) -> Self {
+        self.packer = Some(packer);
+        self
     }
 
     /// Start the forwarding processor. This runs indefinitely.
@@ -231,6 +249,17 @@ impl ForwardingProcessor {
             self.config.ws_threshold_msgs_per_10s,
             self.config.ws_idle_timeout_seconds
         );
+
+        // `report_errors` promises the sender an explanation when we give up on
+        // their forward, and we can only keep that promise if we can encrypt it
+        // as ourselves. Say so at startup rather than at the first abandonment,
+        // which may be weeks later and buried in a batch of delivery failures.
+        if self.config.report_errors && self.packer.is_none() {
+            warn!(
+                "report_errors is enabled but no system message packer is configured — \
+                 abandoned forwards will be logged here and NOT reported to their senders"
+            );
+        }
 
         // Spawn a background task to periodically reclaim stale messages
         let db_clone = self.database.clone();
@@ -603,10 +632,23 @@ impl ForwardingProcessor {
         }
     }
 
-    /// Send a problem report to the original sender when forwarding has been abandoned
-    async fn send_forwarding_failure_report(&self, msg: &ForwardQueueEntry, endpoint_url: &str) {
-        let now = unix_timestamp_secs();
+    /// How long a forwarding-failure problem report stays in the sender's
+    /// inbox before the expiry sweep reclaims it.
+    const PROBLEM_REPORT_TTL_SECS: u64 = 300;
 
+    /// Build the DIDComm **plaintext** of the abandonment problem report.
+    ///
+    /// `from` is the mediator's own DID and is not optional: the report is
+    /// packed authcrypt, and the recipient's addressing-consistency check binds
+    /// the authcrypt sender to this field. A report with no `from` decrypts and
+    /// is then rejected — which is indistinguishable, from the sender's side,
+    /// from the bug this replaces.
+    fn build_problem_report(
+        msg: &ForwardQueueEntry,
+        endpoint_url: &str,
+        from: &str,
+        now: u64,
+    ) -> serde_json::Value {
         let problem_body = serde_json::json!({
             "code": "e.p.me.res.forwarding.abandoned",
             "comment": format!(
@@ -616,25 +658,72 @@ impl ForwardingProcessor {
             "args": [msg.to_did, msg.retry_count.to_string(), endpoint_url],
         });
 
-        let report_msg = serde_json::json!({
+        serde_json::json!({
             "type": "https://didcomm.org/report-problem/2.0/problem-report",
             "id": Uuid::new_v4().to_string(),
             "body": problem_body,
+            "from": from,
             "to": [msg.from_did],
             "created_time": now,
-            "expires_time": now + 300,
-        });
+            "expires_time": now + Self::PROBLEM_REPORT_TTL_SECS,
+        })
+    }
 
-        let report_str = report_msg.to_string();
+    /// Send a problem report to the original sender when forwarding has been
+    /// abandoned.
+    ///
+    /// The report is authcrypted from the mediator to the sender, like every
+    /// other message the mediator puts in an inbox. It used to be stored as the
+    /// raw plaintext JSON, which every SDK client on the default receive policy
+    /// discards with `envelope wrapping Plaintext is not in the accepted set` —
+    /// so from the sender's point of view a forward that the mediator gave up on
+    /// simply vanished.
+    ///
+    /// When the report cannot be packed it is **not** stored. An envelope the
+    /// recipient's policy refuses is the defect being fixed, and storing one
+    /// merely moves the failure to their client (where it re-fails on every
+    /// fetch until it expires) instead of putting it where an operator can act
+    /// on it. Anoncrypt is no fallback either — bare anoncrypt is outside the
+    /// default accepted set too. So the abandonment surfaces as an operator-side
+    /// `ERROR` naming the sender, the destination and the reason.
+    async fn send_forwarding_failure_report(&self, msg: &ForwardQueueEntry, endpoint_url: &str) {
+        let now = unix_timestamp_secs();
+
+        let Some(packer) = self.packer.as_ref() else {
+            error!(
+                "FORWARD_PROBLEM_REPORT_UNSENT: no system message packer configured, so the \
+                 abandoned forward to {} (sender {}, endpoint {}) cannot be reported to its sender",
+                msg.to_did, msg.from_did_hash, endpoint_url
+            );
+            return;
+        };
+
+        let report = Self::build_problem_report(msg, endpoint_url, packer.mediator_did(), now);
+
+        let packed = match packer.pack(&report, &msg.from_did).await {
+            Ok(packed) => packed,
+            Err(e) => {
+                error!(
+                    "FORWARD_PROBLEM_REPORT_UNSENT: couldn't pack the abandonment report for \
+                     sender {} (abandoned forward to {}, endpoint {}): {}",
+                    msg.from_did_hash, msg.to_did, endpoint_url, e
+                );
+                return;
+            }
+        };
 
         match self
             .database
             .store_message(
                 "forwarding-processor",
-                &report_str,
+                &packed,
                 &msg.from_did_hash,
-                Some("SYSTEM"),
-                now + 300,
+                // The mediator authored this one, so it is the sender of
+                // record — the same `from` hash its protocol replies carry.
+                // (This slot used to hold the literal string "SYSTEM", which
+                // is not a DID hash and gave the report an outbox of its own.)
+                Some(&digest(packer.mediator_did())),
+                now + Self::PROBLEM_REPORT_TTL_SECS,
                 0, // No MAXLEN for system-generated problem reports
             )
             .await
@@ -822,6 +911,75 @@ impl ForwardingProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- build_problem_report tests ---
+
+    fn abandoned_entry() -> ForwardQueueEntry {
+        ForwardQueueEntry {
+            stream_id: "1-0".into(),
+            message: "encrypted-forward".into(),
+            to_did_hash: "to-hash".into(),
+            from_did_hash: "from-hash".into(),
+            from_did: "did:example:sender".into(),
+            to_did: "did:example:recipient".into(),
+            endpoint_url: "https://remote.example.com".into(),
+            received_at_ms: 0,
+            delay_milli: 0,
+            expires_at: 0,
+            retry_count: 5,
+            hop_count: 1,
+        }
+    }
+
+    /// The report is addressed *from* the mediator. This is the field the
+    /// recipient's addressing-consistency check binds the authcrypt sender to;
+    /// without it the report decrypts and is then thrown away, which is the
+    /// same silent outcome as never sending one.
+    #[test]
+    fn problem_report_names_the_mediator_as_sender() {
+        let report = ForwardingProcessor::build_problem_report(
+            &abandoned_entry(),
+            "https://remote.example.com",
+            "did:example:mediator",
+            1_000,
+        );
+
+        assert_eq!(report["from"], "did:example:mediator");
+        assert_eq!(report["to"], serde_json::json!(["did:example:sender"]));
+    }
+
+    /// The wire contract clients match on: the report-problem 2.0 type, the
+    /// `e.p.me.res.forwarding.abandoned` code, and the `[to_did, retries,
+    /// endpoint]` args a client needs to identify which forward was dropped.
+    #[test]
+    fn problem_report_carries_the_abandonment_code_and_args() {
+        let entry = abandoned_entry();
+        let report = ForwardingProcessor::build_problem_report(
+            &entry,
+            "https://remote.example.com",
+            "did:example:mediator",
+            1_000,
+        );
+
+        assert_eq!(
+            report["type"],
+            "https://didcomm.org/report-problem/2.0/problem-report"
+        );
+        assert_eq!(report["body"]["code"], "e.p.me.res.forwarding.abandoned");
+        assert_eq!(
+            report["body"]["args"],
+            serde_json::json!(["did:example:recipient", "5", "https://remote.example.com"])
+        );
+        assert_eq!(report["created_time"], 1_000);
+        assert_eq!(
+            report["expires_time"],
+            1_000 + ForwardingProcessor::PROBLEM_REPORT_TTL_SECS
+        );
+        assert!(
+            report["id"].as_str().is_some_and(|id| !id.is_empty()),
+            "every report needs its own message id"
+        );
+    }
 
     // --- decode_tsp_forward tests ---
 

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -396,27 +396,6 @@ pub async fn serve_internal(
         });
     }
 
-    // Forwarding processor — load-bearing (the cross-mediator delivery
-    // path). Runs against any backend via the `forward_queue_*` trait
-    // methods (Redis: Streams consumer groups; Fjall/Memory: in-process
-    // pending-claim emulation). Fjall queues survive a restart (pending
-    // claims recovered via autoclaim), Memory queues are lost with the
-    // process. Multi-process forwarding (the standalone
-    // `forwarding_processor` binary) remains Redis-only.
-    if config.processors.forwarding.enabled && config.processors.forwarding.external_forwarding {
-        let store = store.clone();
-        let fwd_config = config.processors.forwarding.clone();
-        supervisor.spawn("forwarding_processor", true, move || {
-            let store = store.clone();
-            let fwd_config = fwd_config.clone();
-            async move {
-                let processor =
-                    ForwardingProcessor::new(fwd_config, store).map_err(|e| e.to_string())?;
-                processor.start().await.map_err(|e| e.to_string())
-            }
-        });
-    }
-
     // Message expiry sweep — non-load-bearing housekeeping. Runs against
     // any backend via `MediatorStore::sweep_expired_messages`. The
     // standalone `message_expiry_cleanup` binary in mediator-processors
@@ -580,6 +559,45 @@ pub async fn serve_internal(
                  self-resolution will fall back to the network: {e}"
             ),
         }
+    }
+
+    // Forwarding processor — load-bearing (the cross-mediator delivery
+    // path). Runs against any backend via the `forward_queue_*` trait
+    // methods (Redis: Streams consumer groups; Fjall/Memory: in-process
+    // pending-claim emulation). Fjall queues survive a restart (pending
+    // claims recovered via autoclaim), Memory queues are lost with the
+    // process. Multi-process forwarding (the standalone
+    // `forwarding_processor` binary) remains Redis-only.
+    //
+    // Spawned here, after the DID resolver is built and the mediator's own
+    // document is preloaded, because the processor now packs its abandonment
+    // problem reports as the mediator — which resolves both ends.
+    if config.processors.forwarding.enabled && config.processors.forwarding.external_forwarding {
+        let store = store.clone();
+        let fwd_config = config.processors.forwarding.clone();
+        // A DIDComm-less build has no `pack_encrypted` to offer; the processor
+        // logs the abandonment instead of storing a report nobody can read.
+        #[cfg(feature = "didcomm")]
+        let packer: Arc<
+            dyn affinidi_messaging_mediator_common::tasks::forwarding::SystemMessagePacker,
+        > = Arc::new(crate::tasks::system_packer::MediatorSystemPacker::new(
+            config.mediator_did.clone(),
+            did_resolver.clone(),
+            config.security.mediator_secrets.clone(),
+        ));
+        supervisor.spawn("forwarding_processor", true, move || {
+            let store = store.clone();
+            let fwd_config = fwd_config.clone();
+            #[cfg(feature = "didcomm")]
+            let packer = packer.clone();
+            async move {
+                let processor =
+                    ForwardingProcessor::new(fwd_config, store).map_err(|e| e.to_string())?;
+                #[cfg(feature = "didcomm")]
+                let processor = processor.with_system_packer(packer);
+                processor.start().await.map_err(|e| e.to_string())
+            }
+        });
     }
 
     #[cfg(feature = "didcomm")]

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/mod.rs
@@ -7,6 +7,10 @@
 pub use affinidi_messaging_mediator_common::tasks::forwarding as forwarding_processor;
 pub mod statistics;
 pub mod supervisor;
+/// Packs messages the mediator itself authors (the forwarding-failure problem
+/// report) for the backend-agnostic `ForwardingProcessor`. Requires `didcomm`.
+#[cfg(feature = "didcomm")]
+pub mod system_packer;
 /// Periodic refresh of VTA-supplied operating secrets. Requires `vta`.
 #[cfg(feature = "vta")]
 pub mod vta_refresh;

--- a/crates/messaging/affinidi-messaging-mediator/src/tasks/system_packer.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/tasks/system_packer.rs
@@ -1,0 +1,74 @@
+//! The mediator's implementation of the forwarding processor's packing seam.
+//!
+//! [`ForwardingProcessor`] lives in `mediator-common`, which has no DIDComm,
+//! resolver, or secrets dependency of its own, so it asks its host to encrypt
+//! anything the mediator authors. This is that host side: the same
+//! [`didcomm_compat::pack_encrypted`] that every protocol reply goes through
+//! (see `messages::store`, `messages::protocols::routing::rewrap_for_relay`),
+//! reached through the [`SystemMessagePacker`] trait instead of a direct call
+//! — `mediator-common` is a dependency of this crate, so the call has to go the
+//! other way.
+//!
+//! [`ForwardingProcessor`]:
+//!     affinidi_messaging_mediator_common::tasks::forwarding::ForwardingProcessor
+//! [`didcomm_compat::pack_encrypted`]: crate::didcomm_compat::pack_encrypted
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_messaging_didcomm::message::Message;
+use affinidi_messaging_mediator_common::tasks::forwarding::SystemMessagePacker;
+use affinidi_secrets_resolver::ThreadedSecretsResolver;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+
+/// Authcrypts mediator-authored messages under the mediator's own DID.
+pub struct MediatorSystemPacker {
+    mediator_did: String,
+    did_resolver: DIDCacheClient,
+    secrets: Arc<ThreadedSecretsResolver>,
+}
+
+impl MediatorSystemPacker {
+    /// Build a packer from the mediator's identity and its operating secrets.
+    ///
+    /// `did_resolver` should be the resolver that has already preloaded the
+    /// mediator's own DID document: authcrypt resolves *both* ends, and a
+    /// `did:web`/`did:webvh` mediator may not be able to reach its own document
+    /// over the network from inside its deployment.
+    pub fn new(
+        mediator_did: String,
+        did_resolver: DIDCacheClient,
+        secrets: Arc<ThreadedSecretsResolver>,
+    ) -> Self {
+        Self {
+            mediator_did,
+            did_resolver,
+            secrets,
+        }
+    }
+}
+
+#[async_trait]
+impl SystemMessagePacker for MediatorSystemPacker {
+    fn mediator_did(&self) -> &str {
+        &self.mediator_did
+    }
+
+    async fn pack(&self, plaintext: &Value, to_did: &str) -> Result<String, String> {
+        // A DIDComm plaintext *is* a `Message`, so this is a shape check rather
+        // than a conversion: it fails only if the caller built something that
+        // isn't one, which would have produced an undecodable envelope anyway.
+        let message: Message = serde_json::from_value(plaintext.clone())
+            .map_err(|e| format!("not a DIDComm plaintext message: {e}"))?;
+
+        crate::didcomm_compat::pack_encrypted(
+            &message,
+            to_did,
+            Some(&self.mediator_did),
+            &self.did_resolver,
+            &*self.secrets,
+        )
+        .await
+        .map(|(packed, _)| packed)
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/tests/forwarding_processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/tests/forwarding_processor.rs
@@ -12,7 +12,8 @@
 use affinidi_messaging_mediator::store::MemoryStore;
 use affinidi_messaging_mediator_common::{
     store::{MediatorStore, types::ForwardQueueEntry},
-    tasks::forwarding::{ForwardingConfig, ForwardingProcessor},
+    tasks::forwarding::{ForwardingConfig, ForwardingProcessor, SystemMessagePacker},
+    types::messages::{Folder, MessageListElement},
 };
 use axum::{Router, extract::State, http::StatusCode, routing::post};
 use std::{
@@ -175,4 +176,199 @@ async fn memory_store_processor_retries_failed_delivery() {
     }
 
     assert_queue_drains(&store).await;
+}
+
+// ─── Abandonment problem reports ────────────────────────────────────────────
+//
+// When the retry budget runs out the processor tells the original sender why,
+// by storing a `report-problem/2.0` in their inbox. That report used to go in
+// as bare plaintext, which every SDK client on the default (authcrypt-only)
+// receive policy discards — so the abandonment was silent. It is now packed
+// through the injected `SystemMessagePacker`. These cover the seam; the
+// end-to-end assertion that the sender can actually *unpack* what lands in
+// their inbox is `affinidi-messaging-test-mediator`'s
+// `tests/forwarding_abandonment_report.rs`, over real mediators and real keys.
+
+/// Records what it was asked to pack and returns a recognisable envelope, so a
+/// test can tell "packed" from "stored raw" without doing crypto here.
+struct RecordingPacker {
+    mediator_did: String,
+    packed: Arc<std::sync::Mutex<Vec<(serde_json::Value, String)>>>,
+    fail: bool,
+}
+
+#[async_trait::async_trait]
+impl SystemMessagePacker for RecordingPacker {
+    fn mediator_did(&self) -> &str {
+        &self.mediator_did
+    }
+
+    async fn pack(&self, plaintext: &serde_json::Value, to_did: &str) -> Result<String, String> {
+        self.packed
+            .lock()
+            .expect("packer log")
+            .push((plaintext.clone(), to_did.to_string()));
+        if self.fail {
+            return Err("recipient has no key agreement key".into());
+        }
+        Ok(format!(
+            "PACKED({})",
+            plaintext["id"].as_str().unwrap_or("")
+        ))
+    }
+}
+
+/// Config that abandons on the first failure, with negligible backoff.
+fn abandon_immediately_config() -> ForwardingConfig {
+    ForwardingConfig {
+        max_retries: 0,
+        ..test_config()
+    }
+}
+
+/// Drain the sender's inbox, or `None` if nothing has landed yet.
+async fn sender_inbox(store: &Arc<dyn MediatorStore>) -> Option<MessageListElement> {
+    let listed = store
+        .list_messages("from-hash", Folder::Inbox, None, 10)
+        .await
+        .expect("list sender inbox");
+    let element = listed.into_iter().next()?;
+    store
+        .get_message("from-hash", &element.msg_id)
+        .await
+        .expect("get stored report")
+}
+
+/// Poll the sender's inbox until a report lands, or time out.
+async fn await_sender_report(store: &Arc<dyn MediatorStore>) -> MessageListElement {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(element) = sender_inbox(store).await {
+                return element;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("no abandonment report reached the sender's inbox")
+}
+
+/// The report the sender receives is the packer's envelope, not the plaintext
+/// JSON — the regression this guards is a stored body that starts `{"type":`,
+/// which is exactly what the SDK's default policy refuses.
+#[tokio::test]
+async fn abandoned_forward_stores_a_packed_report_for_the_sender() {
+    let mut stub = spawn_stub_mediator(u32::MAX).await;
+    let store: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+    let packed_log = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    store
+        .forward_queue_enqueue(&forward_entry(&stub.endpoint_url, "doomed-forward"), 0)
+        .await
+        .expect("enqueue");
+
+    let processor = ForwardingProcessor::new(abandon_immediately_config(), store.clone())
+        .expect("create processor")
+        .with_system_packer(Arc::new(RecordingPacker {
+            mediator_did: "did:example:mediator".into(),
+            packed: packed_log.clone(),
+            fail: false,
+        }));
+    tokio::spawn(async move {
+        let _ = processor.start().await;
+    });
+
+    // The stub has to actually reject the delivery before abandonment.
+    let _ = tokio::time::timeout(Duration::from_secs(10), stub.received.recv())
+        .await
+        .expect("timed out waiting for the failed delivery attempt");
+
+    let stored = await_sender_report(&store).await;
+    let body = stored.msg.expect("stored report carries a body");
+    assert!(
+        body.starts_with("PACKED("),
+        "the report must be stored packed, got: {body}"
+    );
+
+    // What was handed to the packer is a complete DIDComm plaintext addressed
+    // from the mediator to the abandoned forward's original sender.
+    let log = packed_log.lock().expect("packer log");
+    let (plaintext, to_did) = log.first().expect("the packer was asked to pack a report");
+    assert_eq!(to_did, "did:example:from");
+    assert_eq!(plaintext["from"], "did:example:mediator");
+    assert_eq!(plaintext["to"], serde_json::json!(["did:example:from"]));
+    assert_eq!(plaintext["body"]["code"], "e.p.me.res.forwarding.abandoned");
+
+    // The mediator authored it, so it is the sender of record.
+    assert_eq!(
+        stored.from_address.as_deref(),
+        Some(sha256::digest("did:example:mediator").as_str()),
+        "the report's sender is the mediator's DID hash, not a placeholder"
+    );
+}
+
+/// A report that cannot be packed is not stored as plaintext instead: an
+/// envelope the recipient's policy refuses is the defect, and storing one just
+/// re-fails on every fetch. The abandonment stays visible in the operator log.
+#[tokio::test]
+async fn unpackable_report_is_not_stored_as_plaintext() {
+    let mut stub = spawn_stub_mediator(u32::MAX).await;
+    let store: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+
+    store
+        .forward_queue_enqueue(&forward_entry(&stub.endpoint_url, "doomed-forward"), 0)
+        .await
+        .expect("enqueue");
+
+    let processor = ForwardingProcessor::new(abandon_immediately_config(), store.clone())
+        .expect("create processor")
+        .with_system_packer(Arc::new(RecordingPacker {
+            mediator_did: "did:example:mediator".into(),
+            packed: Arc::new(std::sync::Mutex::new(Vec::new())),
+            fail: true,
+        }));
+    tokio::spawn(async move {
+        let _ = processor.start().await;
+    });
+
+    let _ = tokio::time::timeout(Duration::from_secs(10), stub.received.recv())
+        .await
+        .expect("timed out waiting for the failed delivery attempt");
+    assert_queue_drains(&store).await;
+
+    // The queue has drained, so the abandonment has been processed; give the
+    // store a moment in case a write were still in flight, then assert nothing
+    // landed.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        sender_inbox(&store).await.is_none(),
+        "a report that could not be packed must not be stored in plaintext"
+    );
+}
+
+/// Without a packer (the standalone `forwarding_processor` binary, which has no
+/// mediator identity in its config) the same rule applies — the forward is
+/// still abandoned and dequeued, but nothing unreadable is left behind.
+#[tokio::test]
+async fn abandonment_without_a_packer_stores_nothing() {
+    let mut stub = spawn_stub_mediator(u32::MAX).await;
+    let store: Arc<dyn MediatorStore> = Arc::new(MemoryStore::new());
+
+    store
+        .forward_queue_enqueue(&forward_entry(&stub.endpoint_url, "doomed-forward"), 0)
+        .await
+        .expect("enqueue");
+
+    spawn_processor(abandon_immediately_config(), store.clone());
+
+    let _ = tokio::time::timeout(Duration::from_secs(10), stub.received.recv())
+        .await
+        .expect("timed out waiting for the failed delivery attempt");
+    assert_queue_drains(&store).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        sender_inbox(&store).await.is_none(),
+        "with no packer configured there is nothing readable to store"
+    );
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased (0.4.1) — `forwarding_retry_policy` builder knob
+
+- `TestMediatorBuilder::forwarding_retry_policy(max_retries, initial_backoff,
+  max_backoff)` overrides the forwarding processor's retry budget. The
+  production defaults (5 retries doubling from 1s) put ~31s of real
+  `tokio::time::sleep` — inside the processor task, so a paused test clock
+  cannot skip it — in front of the abandonment, which is the event an
+  abandonment test is waiting for.
+- Used by the new `tests/forwarding_abandonment_report.rs`: two real mediators,
+  the second taken down before the forward is sent, asserting that the sender
+  can `unpack` the resulting problem report under the **default** receive
+  policy. A test that only asserted a report was stored would have passed on
+  the bug.
+
 ## Unreleased (0.4.0) — `trust-tasks-rs` 0.17
 
 - Bumps `trust-tasks-rs` 0.12 → 0.17.

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.0"
+version = "0.4.1"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -94,6 +94,7 @@ pub use affinidi_messaging_mediator_common::tasks::forwarding::RelayMode;
 use std::{
     net::{SocketAddr, TcpListener},
     sync::Arc,
+    time::Duration,
 };
 
 use affinidi_messaging_mediator::{
@@ -292,6 +293,10 @@ pub struct TestMediatorBuilder {
     /// Trusted peer-mediator DID allowlist for [`RelayMode::Rewrap`]. Empty
     /// accepts any relaying peer; non-empty admits only listed DIDs.
     relay_trusted_mediators: Vec<String>,
+    /// `(max_retries, initial_backoff_ms, max_backoff_ms)` override for the
+    /// forwarding processor. `None` keeps `ForwardingConfig::default`, whose
+    /// production values take ~31s to abandon an undeliverable forward.
+    forwarding_retry_policy: Option<(u32, u64, u64)>,
     enable_message_expiry: bool,
     enable_streaming: bool,
     /// Additional DIDs to register as LOCAL accounts at startup. Tests
@@ -360,6 +365,7 @@ impl Default for TestMediatorBuilder {
             enable_external_forwarding: true,
             relay_mode: RelayMode::Blind,
             relay_trusted_mediators: Vec::new(),
+            forwarding_retry_policy: None,
             enable_message_expiry: false,
             enable_streaming: true,
             local_dids: Vec::new(),
@@ -463,6 +469,31 @@ impl TestMediatorBuilder {
     {
         self.relay_trusted_mediators
             .extend(dids.into_iter().map(Into::into));
+        self
+    }
+
+    /// Override the forwarding processor's retry budget and backoff.
+    ///
+    /// The production defaults (5 retries, 1s doubling to 60s) put ~31s of
+    /// sleeping between the first delivery failure and the abandonment, which
+    /// is the moment tests of the abandonment path are actually interested in.
+    /// Backoff is real `tokio::time::sleep` inside the processor task, so it
+    /// cannot be skipped with a paused clock from the test.
+    ///
+    /// Has no effect unless [`enable_forwarding`] is `true`.
+    ///
+    /// [`enable_forwarding`]: Self::enable_forwarding
+    pub fn forwarding_retry_policy(
+        mut self,
+        max_retries: u32,
+        initial_backoff: Duration,
+        max_backoff: Duration,
+    ) -> Self {
+        self.forwarding_retry_policy = Some((
+            max_retries,
+            initial_backoff.as_millis() as u64,
+            max_backoff.as_millis() as u64,
+        ));
         self
     }
 
@@ -819,6 +850,13 @@ impl TestMediatorBuilder {
         processors.forwarding.relay_mode = self.relay_mode;
         processors.forwarding.relay_trusted_mediators =
             self.relay_trusted_mediators.into_iter().collect();
+        if let Some((max_retries, initial_backoff_ms, max_backoff_ms)) =
+            self.forwarding_retry_policy
+        {
+            processors.forwarding.max_retries = max_retries;
+            processors.forwarding.initial_backoff_ms = initial_backoff_ms;
+            processors.forwarding.max_backoff_ms = max_backoff_ms;
+        }
         processors.message_expiry_cleanup.enabled = self.enable_message_expiry;
 
         // Default to a fresh in-memory store. Tests that want a

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/forwarding_abandonment_report.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/forwarding_abandonment_report.rs
@@ -1,0 +1,222 @@
+//! Abandoned cross-mediator forwards must be *readable* by the sender.
+//!
+//! When mediator A gives up on relaying a forward it stores a
+//! `report-problem/2.0` in the original sender's inbox saying so. That report
+//! was built as raw JSON and stored unpacked, so on a live VTC the mediator
+//! logged
+//!
+//! ```text
+//! INFO ...forwarding::processor: FORWARD_PROBLEM_REPORT: stored problem report
+//!   1a23bf7e… for sender b9b77027…
+//! ```
+//!
+//! while the sender's SDK logged
+//!
+//! ```text
+//! ERROR affinidi_messaging_sdk::transports::websockets::websocket:
+//!   Error unpacking message: UnexpectedEnvelope("envelope wrapping Plaintext is
+//!   not in the accepted set [AuthcryptPlaintext, AuthcryptSignPlaintext,
+//!   AnoncryptAuthcryptPlaintext]")
+//! ```
+//!
+//! — the mediator believed it had explained itself and the sender saw nothing.
+//! Every forwarding abandonment was silent, on every mediator pair, once the
+//! SDK's default receive policy became authcrypt-only.
+//!
+//! The assertion that matters here is therefore **not** that a report was
+//! stored (it always was) but that the sender can `unpack` it under the default
+//! policy. Two real mediators, real `did:peer` identities, real keys — the only
+//! thing arranged is that node 1 is dead before the forward is sent, so the
+//! relay hop can never succeed.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::TestTopology;
+use common::init_tracing;
+use serde_json::json;
+use uuid::Uuid;
+
+/// Wait until nothing is listening on `addr`, so the relay hop is guaranteed to
+/// fail on connect rather than racing the shutdown.
+async fn await_port_closed(addr: std::net::SocketAddr) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if tokio::net::TcpStream::connect(addr).await.is_err() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the downed mediator's port never closed");
+}
+
+#[tokio::test]
+async fn abandoned_forward_report_unpacks_under_the_default_policy() {
+    init_tracing();
+
+    // `max_retries = 0` abandons on the first delivery failure: the retry ladder
+    // is real `sleep` inside the processor task, and the production default
+    // (5 retries doubling from 1s) would put ~31s of it in front of the only
+    // event this test cares about.
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .configure_each(|b| {
+            b.forwarding_retry_policy(0, Duration::from_millis(50), Duration::from_millis(100))
+        })
+        .spawn()
+        .await
+        .expect("spawn 2-mediator topology");
+
+    // Users are added through the node directly rather than
+    // `TestTopology::add_user`, which brings up a live WebSocket. The report is
+    // written straight into the inbox by the forwarding processor (no live
+    // push), and this test wants to read it exactly as a client would on
+    // pickup.
+    let node_a = topology.node(0).expect("node 0");
+    let node_b = topology.node(1).expect("node 1");
+    let alice = node_a.add_user("Alice").await.expect("add Alice on node 0");
+    let bob = node_b.add_user("Bob").await.expect("add Bob on node 1");
+
+    let mediator_a_did = node_a.mediator.did().to_string();
+    let mediator_b_did = node_b.mediator.did().to_string();
+    let mediator_b_addr = node_b.mediator.bound_addr();
+
+    // Take mediator B down. Its `did:peer` still resolves (the DID carries its
+    // own service endpoint), so mediator A will accept the forward, queue it,
+    // and then fail every attempt to hand it over.
+    node_b.mediator.shutdown();
+    await_port_closed(mediator_b_addr).await;
+
+    // The routing-2.0 double forward: authcrypt for Bob, an INNER forward to
+    // Bob's (now dead) mediator, an OUTER forward to Alice's own mediator.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs();
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": "this one is never going to arrive" }),
+    )
+    .to(bob.did.clone())
+    .from(alice.did.clone())
+    .created_time(now)
+    .expires_time(now + 60)
+    .finalize();
+    let msg_id = msg.id.clone();
+
+    let (packed, _) = node_a
+        .atm
+        .pack_encrypted(&msg, &bob.did, Some(&alice.did), Some(&alice.did))
+        .await
+        .expect("authcrypt for Bob");
+
+    let (_inner_id, inner_fwd) = node_a
+        .atm
+        .routing()
+        .forward_message(
+            &alice.profile,
+            false,
+            &packed,
+            &mediator_b_did,
+            &bob.did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap inner forward");
+
+    let (_outer_id, outer_fwd) = node_a
+        .atm
+        .routing()
+        .forward_message(
+            &alice.profile,
+            false,
+            &inner_fwd,
+            &mediator_a_did,
+            &mediator_b_did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap outer forward");
+
+    node_a
+        .atm
+        .send_message(&alice.profile, &outer_fwd, &msg_id, false, false)
+        .await
+        .expect("send outer forward to Alice's own mediator");
+
+    // Alice picks up whatever her mediator left for her.
+    let stored = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let fetched = node_a
+                .atm
+                .fetch_messages(&alice.profile, &FetchOptions::default())
+                .await
+                .expect("Alice fetches messages");
+            if let Some(element) = fetched.success.first()
+                && let Some(body) = element.msg.clone()
+            {
+                return body;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("no abandonment report reached Alice's inbox");
+
+    // THE assertion. Before the fix this is where the test fails, with the same
+    // `UnexpectedEnvelope(...)` the live client logged — a version of this test
+    // that only checked "a report was stored" would have passed on the bug.
+    let (report, metadata) = node_a
+        .atm
+        .unpack(&stored)
+        .await
+        .expect("Alice unpacks the abandonment report under the default policy");
+
+    assert_eq!(
+        report.typ, "https://didcomm.org/report-problem/2.0/problem-report",
+        "the stored message is the forwarding-abandonment problem report"
+    );
+    assert_eq!(
+        report.body.get("code").and_then(|c| c.as_str()),
+        Some("e.p.me.res.forwarding.abandoned"),
+        "the report says the forward was abandoned"
+    );
+    assert_eq!(
+        report.from.as_deref(),
+        Some(mediator_a_did.as_str()),
+        "the report is authored by Alice's own mediator"
+    );
+    assert_eq!(
+        report.to.as_deref(),
+        Some(&[alice.did.clone()][..]),
+        "the report is addressed to the sender of the abandoned forward"
+    );
+    assert!(
+        metadata.encrypted && metadata.authenticated,
+        "the report must reach Alice authenticated, not as bare plaintext: {metadata:?}"
+    );
+    // The named destination is the *next hop* that could not be reached —
+    // Bob's mediator — not Bob. That is the layer the sender addressed in the
+    // outer forward, and the only one this mediator can speak to.
+    assert!(
+        report
+            .body
+            .get("args")
+            .and_then(|a| a.as_array())
+            .is_some_and(
+                |args| args.first().and_then(|a| a.as_str()) == Some(mediator_b_did.as_str())
+            ),
+        "the report names the next hop that could not be reached: {:?}",
+        report.body
+    );
+
+    topology.shutdown().await.expect("shutdown topology");
+}


### PR DESCRIPTION
## The failure, as observed

Every forwarding abandonment is currently **silent to the sender**.

When the mediator exhausts a forward's retry budget it stores a
`report-problem/2.0` in the original sender's inbox explaining why. That report
is built as raw JSON in `send_forwarding_failure_report` and handed straight to
`store_message` — no `pack_encrypted`, no signing, bare DIDComm plaintext.

Since `BREAKING CHANGE: enforce authcrypt messages by default` (2bec127, #671)
the SDK's default receive policy refuses exactly that envelope. On a live VTC
the two halves logged past each other:

```text
INFO ...forwarding::processor: FORWARD_PROBLEM_REPORT: stored problem report
  1a23bf7e95a854e5d8eaad598a0f9fd8af7f2a1ab8aa282e6ce697423b8eeafa
  for sender b9b77027...
```

```text
ERROR affinidi_messaging_sdk::transports::websockets::websocket:
  Error unpacking message: UnexpectedEnvelope("envelope wrapping Plaintext is
  not in the accepted set [AuthcryptPlaintext, AuthcryptSignPlaintext,
  AnoncryptAuthcryptPlaintext]")
```

The mediator believed it had explained itself; the sender saw nothing. **This
is not specific to one topology or one deployment** — it is every abandoned
forward, on every mediator pair, for every client running the default policy.
The rejection site is `affinidi-messaging-sdk/src/messages/unpack.rs`'s
`policy.accepts(wrapping)`.

## The fix

The report is now authcrypted from the mediator to the sender, through the same
`didcomm_compat::pack_encrypted` every protocol reply already goes through.

`ForwardingProcessor` lives in `mediator-common`, which carries no DIDComm,
resolver or secrets dependency and is itself a dependency of the crate that owns
`pack_encrypted` — so packing is **injected** as a `SystemMessagePacker` trait
rather than implemented there. The mediator supplies `MediatorSystemPacker`;
the standalone `forwarding_processor` binary, whose config is a database plus a
forwarding block and nothing else, supplies none and compiles unchanged
(`ForwardingProcessor::new` keeps its signature).

Two details the packing forces:

- **The report now carries `from`** (the mediator's DID). The recipient's
  addressing-consistency check binds the authcrypt sender to that field, so a
  report without it decrypts and is *then* rejected — the same silent outcome by
  a different route. Its stored sender is likewise the mediator's DID hash,
  where the slot used to hold the literal string `"SYSTEM"` — not a DID hash,
  and it gave the report an outbox of its own.
- **A report that cannot be packed is not stored.** Storing an envelope the
  recipient's policy refuses is the defect being fixed, and it would re-fail on
  every fetch until it expired; anoncrypt is no fallback either, being outside
  the default accepted set as well. The abandonment instead surfaces where an
  operator can act on it, as a `FORWARD_PROBLEM_REPORT_UNSENT` error naming the
  sender, the destination and the reason — and `start()` warns at boot when
  `report_errors` is on with no packer configured, rather than at the first
  abandonment weeks later.

The forwarding processor is now spawned after the DID resolver is built and the
mediator's own document preloaded: authcrypt resolves both ends, and a
`did:web`/`did:webvh` mediator may not reach its own document over the network
from inside its deployment. Nothing else depends on that ordering.

## Tests

`affinidi-messaging-test-mediator/tests/forwarding_abandonment_report.rs` — no
mocks: two real mediators from the `TestTopology` harness, real `did:peer`
identities and keys. Node 1 is taken down before the forward is sent, so the
relay hop can never succeed, and the assertion is that Alice can **`unpack`**
the resulting problem report under the *default* policy. A test asserting only
"a report was stored" would have passed before this fix; this one fails without
it with the same `UnexpectedEnvelope(...)` the live client logged (verified by
temporarily reverting the pack call).

Supporting coverage:

- `mediator-common` unit tests for the report's shape (`from` is the mediator,
  the abandonment code, the `[next_hop, retries, endpoint]` args).
- `affinidi-messaging-mediator/tests/forwarding_processor.rs`: the stored body
  is the packed envelope and not the plaintext; an unpackable report is not
  stored as plaintext instead; a processor with no packer stores nothing.
- New `TestMediatorBuilder::forwarding_retry_policy` knob. The production retry
  ladder is ~31s of real `tokio::time::sleep` *inside the processor task*, so a
  paused test clock cannot skip it.

## Other system-generated messages — audited, none affected

- `handlers/websocket.rs::_package_problem_report` — already packs.
- `messages/error_response.rs::generate_error_response` — already packs, via
  `WrapperType::Message` → `store_message` → `message.pack(...)`.
- The expiry sweep's `ExpiryReport` is a stats struct, not a DIDComm message;
  the `message_expiry_cleanup` binary sends nothing.

The forwarding processor was the only production `store_message` call with
hand-built JSON.

## Gates

- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS="-D warnings --cfg tracing_unstable" cargo clippy --workspace --all-targets` — pass
- `RUSTFLAGS="--cfg tracing_unstable" cargo test -p affinidi-messaging-mediator -p affinidi-messaging-mediator-common -p affinidi-messaging-test-mediator` — pass, 0 failures
- `scripts/check-version-bumps.sh` / `scripts/check-changelogs.sh` — pass

**Not verified locally:** Redis was not available, so the `REDIS_URL`-gated
Redis backend cases in `tests/store_conformance.rs` self-skipped. This change is
backend-agnostic (it goes through the `MediatorStore` trait and touches no
backend code), so CI's `useRedis: true` run is the first exercise of those.

## Out of scope

Deliberately untouched, being handled in parallel: the direct-delivery
`force_session_did_match` guard in `inbound.rs`, and TSP endpoint DID
indirection in the `affinidi-tsp` crate.
