### PR TITLE
fix(tsp): follow a next hop that names its mediator by DID

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Unreleased (0.20.6) — TSP forwarding follows a next hop that names its mediator by DID
+
+**Bug fix: TSP remote forwarding could not deliver to a mediated peer.** Observed
+on a live mediator:
+
+```text
+WARN forwarding::processor: FORWARD_FAILED
+  endpoint=did:webvh:Qmb…:dids.firstperson.dev:firstperson-mediator
+  error=Connection error to did:webvh:…/inbound:
+        builder error for url (did:webvh:…/inbound)
+  retry_count=5  → FORWARD_ABANDONED
+```
+
+The `endpoint` is a DID, not a URL. Two documents are involved, and the mediator
+was only reading the first:
+
+```text
+persona     #tsp  TSPTransport  serviceEndpoint: did:webvh:…firstperson-mediator
+that mediator #tsp TSPTransport  serviceEndpoint: https://mediator.firstperson.dev/mediator/v1
+```
+
+- `forward_tsp_remote` no longer takes `endpoints.first()` as a URL. A new
+  `classify_tsp_relay` decides — without I/O — between a direct transport URL, a
+  mediator DID to follow, a hop that comes back to us, and nothing usable. A
+  mediator DID is resolved **one hop**, and that document's own `TSPTransport`
+  URL is what the forward is enqueued against.
+- **One hop only**, mirroring `protocols::routing::service_endpoint_for_remote`
+  on the DIDComm side (added in #705 for exactly this shape): a mediator's own
+  document is expected to publish a URL, and chasing further would let a chain of
+  documents steer this mediator's relay.
+- The loop guard is extended, not weakened: a transport URL on one of our own
+  authorities still fails as a loop, and so does a next hop that names *this*
+  mediator as its mediator while holding no account here.
+- Failure now names the next hop and distinguishes its causes —
+  `message.tsp.no_endpoint`, `message.tsp.mediator.unresolvable` (the named
+  mediator did not resolve) and `protocol.forwarding.loop_detected` — at the
+  point the forward is accepted, rather than five retries later inside an HTTP
+  client that has no idea whose message it is.
+- `tsp_endpoint_is_self` is gone; the TSP path now shares
+  `server::uri_points_at_self` with the DIDComm relay. That also fixes an IPv6
+  mismatch in the TSP copy, which compared `Url::host_str()` (`"[::1]"`)
+  against the bare form the authority set stores (`"::1"`) and so never matched.
+
 ## Unreleased (0.20.5) — pack the forwarding-abandonment problem report
 
 **Bug fix (host side of mediator-common 0.15.37): the mediator now packs the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.5"
+version = "0.20.6"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -404,10 +404,10 @@ async fn forward_to_next(
 
 /// Enqueue a relayed message for delivery to the next hop's **remote** TSP
 /// endpoint. The next hop's transport endpoint is read from its DID document
-/// (`TSPTransport` service); the message is queued (as base64url(qb2)) on the
-/// shared forwarding queue, and the forwarding processor POSTs the raw qb2 to the
-/// remote mediator's `/inbound`. A next hop that resolves back to this mediator is
-/// rejected as a loop.
+/// (`TSPTransport` service, via [`tsp_forward_endpoint`]); the message is queued
+/// (as base64url(qb2)) on the shared forwarding queue, and the forwarding
+/// processor POSTs the raw qb2 to the remote mediator's `/inbound`. A next hop
+/// that resolves back to this mediator is rejected as a loop.
 #[cfg(feature = "tsp")]
 async fn forward_tsp_remote(
     state: &SharedData,
@@ -419,30 +419,7 @@ async fn forward_tsp_remote(
     use affinidi_messaging_mediator_common::store::types::ForwardQueueEntry;
 
     let resolved = resolve_tsp_vid(state, next, &session.session_id).await?;
-    let endpoint_url = resolved
-        .endpoints
-        .first()
-        .map(|u| u.to_string())
-        .ok_or_else(|| {
-            tsp_problem(
-                session,
-                58,
-                "message.tsp.no_endpoint",
-                format!("next hop {next} publishes no TSP transport endpoint"),
-                StatusCode::NOT_FOUND,
-            )
-        })?;
-
-    // Loop guard: the next hop must not resolve back to this mediator.
-    if tsp_endpoint_is_self(&endpoint_url, &state.self_authorities) {
-        return Err(tsp_problem(
-            session,
-            94,
-            "protocol.forwarding.loop_detected",
-            format!("TSP next hop {next} resolves back to this mediator"),
-            StatusCode::LOOP_DETECTED,
-        ));
-    }
+    let endpoint_url = tsp_forward_endpoint(state, session, next, &resolved).await?;
 
     let entry = ForwardQueueEntry {
         stream_id: String::new(),
@@ -477,20 +454,156 @@ async fn forward_tsp_remote(
     Ok(InboundMessageResponse::Forwarded)
 }
 
-/// Whether `endpoint` resolves back to this mediator — the loop guard for remote
-/// TSP forwarding, mirroring the DIDComm forward path's self-detection.
+/// What a resolved `TSPTransport` advertisement tells this mediator to do with a
+/// message for that VID, decided without any I/O.
 #[cfg(feature = "tsp")]
-fn tsp_endpoint_is_self(
-    endpoint: &str,
+#[derive(Debug, PartialEq, Eq)]
+enum TspRelay {
+    /// Relay to this transport URL.
+    Direct(String),
+    /// The VID names its mediator by **DID**. That mediator's own document
+    /// carries the transport URL, one resolve away.
+    ViaMediator(String),
+    /// The advertisement points back at this mediator — the URL is one of our own
+    /// authorities, or the named mediator is us. Carries the offending value for
+    /// the error message.
+    Loop(String),
+    /// Nothing to go on: no `TSPTransport` service, or one this mediator has no
+    /// delivery rule for.
+    Nothing,
+}
+
+/// Classify a resolved VID's TSP transport advertisement.
+///
+/// [`affinidi_tsp::ResolvedVid`] has already split the `TSPTransport`
+/// `serviceEndpoint`s by what they name — transport URLs in `endpoints`, mediator
+/// DIDs in `mediators` — so this only has to decide *which* to act on and whether
+/// it comes back to us.
+///
+/// A direct URL wins over a mediator DID when a document publishes both: the
+/// document is telling us it can be reached without a relay. Within `endpoints`
+/// the first entry decides, in document order — the same rule the DIDComm
+/// classifier follows, where every URL it can parse is either "ours" or a remote
+/// hop and the scan stops on whichever comes first. A first entry that is ours is
+/// reported as a loop rather than skipped: the document has told us the message
+/// belongs *here*, and quietly relaying to some later entry would send it back
+/// out on a route its own document contradicts.
+#[cfg(feature = "tsp")]
+fn classify_tsp_relay(
+    resolved: &affinidi_tsp::ResolvedVid,
+    mediator_did: &str,
     self_authorities: &std::collections::HashSet<(String, u16)>,
-) -> bool {
-    let Ok(url) = url::Url::parse(endpoint) else {
-        return false;
+) -> TspRelay {
+    if let Some(url) = resolved.endpoints.first() {
+        return if crate::server::uri_points_at_self(url.as_str(), self_authorities) {
+            TspRelay::Loop(url.to_string())
+        } else {
+            TspRelay::Direct(url.to_string())
+        };
+    }
+
+    match resolved.mediators.first() {
+        // Named us as its mediator, yet reached this function — which only runs
+        // when there is no local account for it. There is nowhere onward to send
+        // it, and POSTing to our own `/inbound` would spin.
+        Some(did) if did == mediator_did => TspRelay::Loop(did.clone()),
+        Some(did) => TspRelay::ViaMediator(did.clone()),
+        None => TspRelay::Nothing,
+    }
+}
+
+/// The transport URL to relay a TSP message for `next` to.
+///
+/// A `TSPTransport` service names its transport one of two ways:
+///
+/// - **By URL** — relayed there directly, unless the authority is one of ours,
+///   which means the message came back to us.
+/// - **By DID** — the shape the VTI stack publishes: a persona's `#tsp` service
+///   carries its *mediator's DID*, and the transport URL lives in that mediator's
+///   own document. Resolved one hop, and that document's own `TSPTransport` URL
+///   used.
+///
+/// Only one hop of indirection is followed, exactly as the DIDComm forward path
+/// does in `protocols::routing::service_endpoint_for_remote`: a mediator's own
+/// document is expected to publish a URL, and chasing further would let a chain
+/// of documents steer this mediator's relay.
+///
+/// Before the indirection arm existed, a DID-valued endpoint was taken for a
+/// transport URL — `did:` parses as a URL — and the forwarding processor was
+/// handed `did:webvh:…` to POST to, which failed inside the HTTP client
+/// (`builder error for url`) and retried until the message was abandoned. The
+/// failure has to happen *here*, where the next hop can be named, or not at all.
+#[cfg(feature = "tsp")]
+async fn tsp_forward_endpoint(
+    state: &SharedData,
+    session: &Session,
+    next: &str,
+    resolved: &affinidi_tsp::ResolvedVid,
+) -> Result<String, MediatorError> {
+    let mediator = match classify_tsp_relay(
+        resolved,
+        &state.config.mediator_did,
+        &state.self_authorities,
+    ) {
+        TspRelay::Direct(url) => return Ok(url),
+        TspRelay::Loop(what) => {
+            return Err(tsp_problem(
+                session,
+                94,
+                "protocol.forwarding.loop_detected",
+                format!("TSP next hop {next} resolves back to this mediator ({what})"),
+                StatusCode::LOOP_DETECTED,
+            ));
+        }
+        TspRelay::Nothing => {
+            return Err(tsp_problem(
+                session,
+                58,
+                "message.tsp.no_endpoint",
+                format!("next hop {next} publishes no TSP transport endpoint"),
+                StatusCode::NOT_FOUND,
+            ));
+        }
+        TspRelay::ViaMediator(did) => did,
     };
-    let (Some(host), Some(port)) = (url.host_str(), url.port_or_known_default()) else {
-        return false;
-    };
-    self_authorities.contains(&(host.to_lowercase(), port))
+
+    // One hop: the peer mediator's own document carries the transport URL.
+    let peer = resolve_tsp_vid(state, &mediator, &session.session_id)
+        .await
+        .map_err(|e| {
+            tsp_problem(
+                session,
+                58,
+                "message.tsp.mediator.unresolvable",
+                format!("next hop {next} is mediated by {mediator}, which did not resolve: {e}"),
+                StatusCode::BAD_GATEWAY,
+            )
+        })?;
+
+    match classify_tsp_relay(&peer, &state.config.mediator_did, &state.self_authorities) {
+        TspRelay::Direct(url) => Ok(url),
+        TspRelay::Loop(what) => Err(tsp_problem(
+            session,
+            94,
+            "protocol.forwarding.loop_detected",
+            format!(
+                "TSP next hop {next} is mediated by {mediator}, which resolves back to this \
+                 mediator ({what})"
+            ),
+            StatusCode::LOOP_DETECTED,
+        )),
+        // A second hop of indirection is deliberately not chased.
+        TspRelay::ViaMediator(_) | TspRelay::Nothing => Err(tsp_problem(
+            session,
+            58,
+            "message.tsp.no_endpoint",
+            format!(
+                "next hop {next} is mediated by {mediator}, whose document publishes no TSP \
+                 transport URL"
+            ),
+            StatusCode::NOT_FOUND,
+        )),
+    }
 }
 
 /// Resolve a DID-based TSP VID to its keys + endpoints.
@@ -1218,5 +1331,167 @@ mod tsp_tests {
             is_tsp(&decoded),
             "decoded bytes are a recognisable TSP message"
         );
+    }
+}
+
+/// Unit coverage for the TSP relay classifier — the DID-vs-URL decision that
+/// [`forward_tsp_remote`] makes before anything is enqueued. Pure: no store, no
+/// resolver, no session.
+#[cfg(test)]
+#[cfg(feature = "tsp")]
+mod tsp_relay_tests {
+    use super::{TspRelay, classify_tsp_relay};
+    use crate::server::normalize_host;
+    use affinidi_tsp::ResolvedVid;
+    use std::collections::HashSet;
+
+    /// This mediator.
+    const US: &str = "did:web:us.example";
+    /// The mediator named in the production failure, verbatim.
+    const PEER_MEDIATOR: &str = "did:webvh:QmbHZC8JUpUD1XrdEcNiAPTxke4WpDyBPjjigPpEwYZiq5:dids.firstperson.dev:firstperson-mediator";
+    /// The transport URL that peer mediator's own document publishes.
+    const PEER_URL: &str = "https://mediator.firstperson.dev/mediator/v1";
+
+    fn authorities(entries: &[(&str, u16)]) -> HashSet<(String, u16)> {
+        entries
+            .iter()
+            .map(|(host, port)| (normalize_host(host), *port))
+            .collect()
+    }
+
+    fn no_authorities() -> HashSet<(String, u16)> {
+        HashSet::new()
+    }
+
+    /// A resolved VID advertising the given transport URLs and mediator DIDs.
+    fn vid(id: &str, endpoints: &[&str], mediators: &[&str]) -> ResolvedVid {
+        ResolvedVid {
+            id: id.to_string(),
+            signing_key: [1u8; 32],
+            encryption_key: [2u8; 32],
+            endpoints: endpoints
+                .iter()
+                .map(|u| url::Url::parse(u).expect("test endpoint parses"))
+                .collect(),
+            mediators: mediators.iter().map(|d| d.to_string()).collect(),
+        }
+    }
+
+    /// The production shape: a persona whose `#tsp` service names its mediator by
+    /// DID is an indirection to follow, never a URL to POST to.
+    #[test]
+    fn a_mediator_did_is_followed_as_indirection() {
+        let persona = vid("did:web:persona.example", &[], &[PEER_MEDIATOR]);
+        assert_eq!(
+            classify_tsp_relay(&persona, US, &no_authorities()),
+            TspRelay::ViaMediator(PEER_MEDIATOR.to_string())
+        );
+    }
+
+    /// And the second half of that shape: the mediator's own document publishes
+    /// the transport URL, which is what the forward is actually sent to.
+    #[test]
+    fn the_mediators_own_document_yields_the_transport_url() {
+        let mediator = vid(PEER_MEDIATOR, &[PEER_URL], &[]);
+        assert_eq!(
+            classify_tsp_relay(&mediator, US, &no_authorities()),
+            TspRelay::Direct(PEER_URL.to_string())
+        );
+    }
+
+    /// A VID that publishes its own URL is relayed straight there — the
+    /// unmediated case, unchanged.
+    #[test]
+    fn a_direct_url_is_relayed_as_is() {
+        let peer = vid("did:web:peer.example", &["https://peer.example/v1"], &[]);
+        assert_eq!(
+            classify_tsp_relay(&peer, US, &no_authorities()),
+            TspRelay::Direct("https://peer.example/v1".to_string())
+        );
+    }
+
+    /// Both advertised: the URL wins. A document that can be reached without a
+    /// relay is telling us so.
+    #[test]
+    fn a_direct_url_wins_over_a_mediator_did() {
+        let peer = vid(
+            "did:web:peer.example",
+            &["https://peer.example/v1"],
+            &[PEER_MEDIATOR],
+        );
+        assert_eq!(
+            classify_tsp_relay(&peer, US, &no_authorities()),
+            TspRelay::Direct("https://peer.example/v1".to_string())
+        );
+    }
+
+    /// The pre-existing loop guard, kept: a transport URL on one of our own
+    /// authorities is the message coming back to us.
+    #[test]
+    fn a_url_on_one_of_our_authorities_is_a_loop() {
+        let peer = vid("did:web:peer.example", &["http://127.0.0.1:7037/"], &[]);
+        assert_eq!(
+            classify_tsp_relay(&peer, US, &authorities(&[("127.0.0.1", 7037)])),
+            TspRelay::Loop("http://127.0.0.1:7037/".to_string())
+        );
+    }
+
+    /// The same guard extended to the indirection arm: a next hop that names
+    /// *us* as its mediator has no account here (that is the only way this code
+    /// is reached), so following it would POST to our own `/inbound`.
+    #[test]
+    fn naming_this_mediator_as_the_mediator_is_a_loop() {
+        let peer = vid("did:web:peer.example", &[], &[US]);
+        assert_eq!(
+            classify_tsp_relay(&peer, US, &no_authorities()),
+            TspRelay::Loop(US.to_string())
+        );
+    }
+
+    /// No `TSPTransport` service at all — nothing to relay to, and the caller
+    /// turns this into a "publishes no TSP transport endpoint" problem report
+    /// rather than enqueueing something undeliverable.
+    #[test]
+    fn no_advertisement_is_nothing() {
+        let peer = vid("did:web:peer.example", &[], &[]);
+        assert_eq!(
+            classify_tsp_relay(&peer, US, &no_authorities()),
+            TspRelay::Nothing
+        );
+    }
+
+    /// The regression, stated end to end over the two documents: the persona
+    /// classifies to its mediator's DID, and *that* document — not the persona's
+    /// — is where the URL comes from. Nothing anywhere hands `did:webvh:…` on as
+    /// something to connect to.
+    #[test]
+    fn the_two_document_indirection_resolves_to_the_mediators_url() {
+        let persona = vid("did:web:persona.example", &[], &[PEER_MEDIATOR]);
+        let TspRelay::ViaMediator(mediator_did) =
+            classify_tsp_relay(&persona, US, &no_authorities())
+        else {
+            panic!("a DID-valued TSPTransport endpoint must classify as indirection");
+        };
+        assert_eq!(mediator_did, PEER_MEDIATOR);
+
+        let mediator = vid(&mediator_did, &[PEER_URL], &[]);
+        assert_eq!(
+            classify_tsp_relay(&mediator, US, &no_authorities()),
+            TspRelay::Direct(PEER_URL.to_string())
+        );
+    }
+
+    /// One hop only. If the peer mediator's own document *also* only names
+    /// another mediator, the caller stops rather than chasing — a chain of
+    /// documents must not be able to steer this mediator's relay.
+    #[test]
+    fn a_second_hop_of_indirection_is_not_chased() {
+        let mediator = vid(PEER_MEDIATOR, &[], &["did:web:third.example"]);
+        assert_eq!(
+            classify_tsp_relay(&mediator, US, &no_authorities()),
+            TspRelay::ViaMediator("did:web:third.example".to_string())
+        );
+        // `tsp_forward_endpoint` maps this second-hop `ViaMediator` onto the same
+        // "no transport URL" error as `Nothing`, and does not resolve again.
     }
 }

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -1,5 +1,8 @@
 use crate::common::authz::{self, Capability};
 use crate::common::storage_timeout::with_storage_timeout;
+// Shared with the TSP relay path in `messages::inbound`, which cannot reach into
+// this module: `protocols` only exists in a `didcomm` build.
+use crate::server::uri_points_at_self;
 
 use crate::didcomm_compat::MetaEnvelope;
 use crate::{
@@ -26,7 +29,6 @@ use http::StatusCode;
 use serde::Deserialize;
 use sha256::digest;
 use tracing::{Instrument, debug, info, span, warn};
-use url::Url;
 use uuid::Uuid;
 
 // Reads the body of an incoming forward message
@@ -1165,29 +1167,6 @@ async fn service_endpoint_for_remote(
         next, peer_mediator
     );
     None
-}
-
-/// Parse `uri` and return `true` when its `(host, port)` matches any
-/// entry in `self_authorities`. Hostnames are normalized via
-/// [`crate::server::normalize_host`] (strips outer `[ ]` from IPv6
-/// literals, lowercases) so the lookup matches the form inserted by
-/// [`crate::server::compute_self_authorities`]. Port falls back to the
-/// scheme default via [`crate::server::default_port_for`].
-/// Returns `false` for unparseable URLs or schemes without a default port.
-fn uri_points_at_self(
-    uri: &str,
-    self_authorities: &std::collections::HashSet<(String, u16)>,
-) -> bool {
-    let Ok(url) = Url::parse(uri) else {
-        return false;
-    };
-    let Some(host) = url.host_str() else {
-        return false;
-    };
-    let Some(port) = crate::server::default_port_for(&url) else {
-        return false;
-    };
-    self_authorities.contains(&(crate::server::normalize_host(host), port))
 }
 
 #[cfg(test)]

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -1092,6 +1092,33 @@ pub(crate) fn compute_self_authorities_from(
     out
 }
 
+/// Parse `uri` and return `true` when its `(host, port)` matches any entry in
+/// `self_authorities` — i.e. the URI points back at this mediator instance.
+///
+/// Hostnames are normalized via [`normalize_host`] (strips outer `[ ]` from IPv6
+/// literals, lowercases) so the lookup matches the form inserted by
+/// [`compute_self_authorities`], and the port falls back to the scheme default
+/// via [`default_port_for`]. Returns `false` for unparseable URIs and for
+/// schemes without a default port — including `did:`, which parses as a URL but
+/// names an identity, not an authority.
+///
+/// Lives here, next to the authority set it consults, because both forwarding
+/// paths need it: the DIDComm relay (`protocols::routing`) and the TSP relay
+/// (`messages::inbound`), and the latter compiles in builds where the DIDComm
+/// module does not exist.
+pub(crate) fn uri_points_at_self(uri: &str, self_authorities: &HashSet<(String, u16)>) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let Some(port) = default_port_for(&url) else {
+        return false;
+    };
+    self_authorities.contains(&(normalize_host(host), port))
+}
+
 /// Normalize a host string for self-authority comparison.
 ///
 /// `Url::host_str()` returns IPv6 literals wrapped in `[ ]` (e.g. `"[::1]"`)

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased (0.21.1) — a mediated peer is TSP-capable
+
+- `TspOps::select_protocol` decided "does this peer speak TSP" with
+  `!ResolvedVid::endpoints.is_empty()`. With `affinidi-tsp` 0.1.15 that list
+  holds only direct transport URLs, and a *mediated* peer — whose `TSPTransport`
+  service names its mediator's DID — publishes none, so it would have read as
+  "no TSP" for exactly the peers TSP reaches through a mediator. Now uses
+  `ResolvedVid::advertises_tsp()`, which covers both shapes.
+- No behaviour change for an unmediated peer, and none under a fresh cached
+  capability or a completed relationship (both settle before the resolve).
+
 ## Unreleased (0.21.0) — `trust-tasks-rs` 0.17
 
 - Bumps `trust-tasks-rs` 0.12 → 0.17.

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.21.0"
+version = "0.21.1"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
+++ b/crates/messaging/affinidi-messaging-sdk/src/protocols/tsp.rs
@@ -1102,10 +1102,14 @@ impl TspOps<'_> {
             fresh_cap,
             Some(TspSupport::Supported | TspSupport::Unsupported)
         ) && !bidirectional;
+        // `advertises_tsp`, not `!endpoints.is_empty()`: a *mediated* peer
+        // publishes no transport URL of its own — its `TSPTransport` service
+        // names its mediator's DID — so testing the URL list alone reads as "no
+        // TSP" for exactly the peers TSP reaches through a mediator.
         let has_tsp_service = if needs_resolve {
             self.resolve_vid(their_did)
                 .await
-                .map(|vid| !vid.endpoints.is_empty())
+                .map(|vid| vid.advertises_tsp())
                 .unwrap_or(false)
         } else {
             false

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased (0.4.2) — a test user that is mediated the way production is
+
+- New `TestEnvironment::add_tsp_mediated_user` / `TestTopology::add_tsp_mediated_user`:
+  a user whose DID advertises a `TSPTransport` service **naming its mediator by
+  DID**, which is what a real persona/agent document publishes. `add_user` is
+  unchanged and still advertises no TSP service.
+- New `tests/tsp_mediated_recipient.rs`: a TSP message crosses two mediators
+  where the route names only the recipient, so the sending mediator has to
+  discover the transport URL through the recipient's mediator's document. This is
+  the gap `tsp_federation.rs` left — that test names the peer mediator's DID *in
+  the route*, so the mediator reads a URL straight out of the mediator's own
+  document and the indirection is never exercised. Reverting the mediator fix
+  reproduces the production `builder error for url (did:…/inbound)` verbatim.
+- The mediated user advertises **only** the TSP service: a `did:peer:2` inlines
+  each service into the identifier and the mediator's own DID is itself a
+  `did:peer:2` carrying three services, so embedding it twice pushes the user's
+  DID past the resolver's 1000-byte ceiling — an artefact of `did:peer` that a
+  real `did:webvh` persona never approaches.
+
 ## Unreleased (0.4.1) — `forwarding_retry_policy` builder knob
 
 - `TestMediatorBuilder::forwarding_retry_policy(max_retries, initial_backoff,

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.1"
+version = "0.4.2"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -33,7 +33,7 @@ use affinidi_messaging_sdk::{ATM, config::ATMConfig, profiles::ATMProfile};
 use affinidi_secrets_resolver::{SecretsResolver, secrets::Secret};
 use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
-use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole, PeerService, PeerServiceEndpoint};
 
 use crate::{AdminIdentity, TestMediator, TestMediatorHandle};
 
@@ -266,15 +266,59 @@ impl TestEnvironment {
     /// without needing a separate `local_did` declaration at builder
     /// time.
     pub async fn add_user(&self, alias: &str) -> Result<TestUser, TestEnvironmentError> {
+        self.add_user_with_services(alias, None).await
+    }
+
+    /// Add a user whose DID advertises a **`TSPTransport` service naming this
+    /// mediator by DID** — the shape a real persona/agent document publishes.
+    ///
+    /// This is what a mediated TSP identity actually looks like on the wire: the
+    /// user's own document says "my traffic goes through this mediator" and the
+    /// transport URL lives one resolve away, in the mediator's document. It is
+    /// deliberately *not* what [`add_user`](Self::add_user) produces — a plain
+    /// test user advertises no TSP service at all, and every TSP test that
+    /// federates does so by naming the peer mediator's DID explicitly in the
+    /// route, which never exercises the indirection.
+    ///
+    /// Otherwise identical to [`add_user`](Self::add_user): same `dm` service
+    /// (the mediator's DID), same LOCAL/ALLOW_ALL registration, same profile.
+    pub async fn add_tsp_mediated_user(
+        &self,
+        alias: &str,
+    ) -> Result<TestUser, TestEnvironmentError> {
         let mediator_did = self.mediator.did().to_string();
-        let (did, secrets) = DID::generate_did_peer(
-            vec![
-                (PeerKeyRole::Verification, KeyType::Ed25519),
-                (PeerKeyRole::Encryption, KeyType::X25519),
-            ],
-            Some(mediator_did.clone()),
-        )
-        .map_err(|e| TestEnvironmentError::UserDid {
+        // TSP only, no `dm` entry. A `did:peer:2` inlines each service into the
+        // identifier, and the mediator's own DID is itself a `did:peer:2`
+        // carrying three services — so embedding it twice pushes the user's DID
+        // past the resolver's 1000-byte ceiling, which a real (`did:webvh`)
+        // persona never approaches. The DIDComm side is not what is under test
+        // here, and the SDK profile is told its mediator directly.
+        let services = vec![PeerService {
+            type_: "TSPTransport".into(),
+            endpoint: PeerServiceEndpoint::Uri(mediator_did),
+            id: Some("#tsp".into()),
+        }];
+        self.add_user_with_services(alias, Some(services)).await
+    }
+
+    /// Shared body of [`add_user`](Self::add_user) and
+    /// [`add_tsp_mediated_user`](Self::add_tsp_mediated_user). `services: None`
+    /// takes the TDK default (a single `dm` service at the mediator's DID).
+    async fn add_user_with_services(
+        &self,
+        alias: &str,
+        services: Option<Vec<PeerService>>,
+    ) -> Result<TestUser, TestEnvironmentError> {
+        let mediator_did = self.mediator.did().to_string();
+        let keys = vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ];
+        let generated = match services {
+            Some(services) => DID::generate_did_peer_with_services(keys, Some(services)),
+            None => DID::generate_did_peer(keys, Some(mediator_did.clone())),
+        };
+        let (did, secrets) = generated.map_err(|e| TestEnvironmentError::UserDid {
             alias: alias.to_string(),
             source: Box::new(std::io::Error::other(e.to_string())),
         })?;

--- a/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/topology.rs
@@ -243,6 +243,29 @@ impl TestTopology {
         Ok(user)
     }
 
+    /// Add a user homed on node `index` whose DID advertises a `TSPTransport`
+    /// service **naming its mediator by DID** — see
+    /// [`TestEnvironment::add_tsp_mediated_user`]. Live stream brought up as for
+    /// [`add_user`](Self::add_user).
+    ///
+    /// Use this to drive a cross-mediator TSP forward the way production does:
+    /// the sender's mediator is handed the recipient's DID and has to discover
+    /// the transport URL through the recipient's mediator's document, rather than
+    /// being told the peer mediator's DID outright in the route.
+    pub async fn add_tsp_mediated_user(
+        &self,
+        index: usize,
+        alias: &str,
+    ) -> Result<TestUser, TestTopologyError> {
+        let env = self.node(index)?;
+        let user = env.add_tsp_mediated_user(alias).await?;
+        env.atm
+            .profile_enable_websocket(&user.profile)
+            .await
+            .map_err(|e| TestTopologyError::Sdk(e.to_string()))?;
+        Ok(user)
+    }
+
     /// Route a basic message from `sender` (on `from_node`) to `recipient` (on
     /// `to_node`) as the routing-2.0 double forward, then wait up to `wait` for
     /// the recipient's live stream to surface the decrypted body.

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_mediated_recipient.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_mediated_recipient.rs
@@ -1,0 +1,140 @@
+//! Two-mediator **TSP forward to a mediated recipient**: the recipient's DID
+//! names its mediator **by DID**, and the sending mediator has to find the
+//! transport URL in that mediator's own document.
+//!
+//! This is the shape a real persona/agent publishes, and the one that failed in
+//! production:
+//!
+//! ```text
+//! WARN forwarding::processor: FORWARD_FAILED
+//!   endpoint=did:webvh:Qmb…:dids.firstperson.dev:firstperson-mediator
+//!   error=Connection error to did:webvh:…/inbound:
+//!         builder error for url (did:webvh:…/inbound)
+//!   retry_count=5  → FORWARD_ABANDONED
+//! ```
+//!
+//! The `endpoint` was a DID, because `did:` parses as a URL and a DID-valued
+//! `TSPTransport` `serviceEndpoint` was taken for a transport URL all the way
+//! down to reqwest.
+//!
+//! The two documents involved:
+//!
+//! ```text
+//! bob        #tsp  TSPTransport  serviceEndpoint: <mediator B's DID>
+//! mediator B #tsp  TSPTransport  serviceEndpoint: http://127.0.0.1:PORT/mediator/v1
+//! ```
+//!
+//! Alice is homed on mediator A, Bob on mediator B. Alice sends Bob a TSP
+//! message routed `[mediator_A, bob]` — note that mediator B is **not** in the
+//! route. A unwraps its routing layer, sees the next hop is Bob (not a local
+//! account), resolves Bob's document, finds a `TSPTransport` service naming
+//! mediator B's DID, resolves *that* document one hop for the transport URL, and
+//! forwards there. B unwraps nothing — the message is sealed Alice → Bob — sees
+//! itself as the carrier for a local account, and stores it. Bob fetches and
+//! unpacks it.
+//!
+//! `tsp_federation.rs` is the sibling case that already worked: it names
+//! mediator B's DID *in the route*, so A resolves the mediator's own document
+//! directly and reads a URL out of it. No indirection, so the defect never
+//! showed there.
+//!
+//! All identities are `did:peer:2.*`, so every DID resolves locally; the only
+//! real socket traffic is the forwarding processor's loopback HTTP hop A → B.
+#![cfg(feature = "tsp")]
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::TestTopology;
+use common::init_tracing;
+
+/// Alice (on mediator A) sends a TSP message to Bob (on mediator B) naming only
+/// Bob in the onward route; A discovers B's transport URL through Bob's
+/// `TSPTransport` mediator DID, and Bob recovers Alice's plaintext + VID.
+#[tokio::test]
+async fn tsp_forward_follows_a_recipients_mediator_did() {
+    init_tracing();
+
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .spawn()
+        .await
+        .expect("spawn two-mediator topology");
+
+    let mediator_a_did = topology
+        .mediator_did(0)
+        .expect("mediator A did")
+        .to_string();
+
+    let alice = topology.add_user(0, "alice").await.expect("add alice on A");
+    // Bob's DID advertises `#tsp` -> mediator B's *DID*. Mediator A has never
+    // heard of him and is given no URL for him anywhere in the message.
+    let bob = topology
+        .add_tsp_mediated_user(1, "bob")
+        .await
+        .expect("add mediated bob on B");
+
+    let payload = b"hello bob, via the mediator your document names";
+
+    // Route: alice -> mediator A (the routing-layer recipient) -> bob (the final
+    // recipient, and the *only* onward hop named). Mediator B is absent by
+    // design: A has to learn about it from Bob's document.
+    let route = vec![mediator_a_did.clone(), bob.did.clone()];
+    topology
+        .node(0)
+        .expect("node A")
+        .atm
+        .tsp()
+        .send_routed(&alice.profile, &route, payload)
+        .await
+        .expect("alice sends a routed TSP message via mediator A onward to bob");
+
+    // The forwarding processor delivers A -> B's /inbound asynchronously.
+    let bob_env = topology.node(1).expect("node B");
+    let stored = {
+        let mut found = None;
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while std::time::Instant::now() < deadline {
+            let fetched = bob_env
+                .atm
+                .fetch_messages(&bob.profile, &FetchOptions::default())
+                .await
+                .expect("bob fetches messages");
+            if let Some(element) = fetched.success.first()
+                && let Some(msg) = element.msg.as_ref()
+            {
+                found = Some(msg.clone());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        found.expect(
+            "bob received the TSP message within the deadline — a DID-valued TSPTransport \
+             endpoint must be followed to the mediator's document, not POSTed to",
+        )
+    };
+
+    assert!(
+        bob_env.atm.tsp().is_tsp(&stored),
+        "the forwarded message is recognised as TSP"
+    );
+    let (recovered, sender) = bob_env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, &stored)
+        .await
+        .expect("bob unpacks the forwarded TSP message");
+
+    assert_eq!(
+        recovered, payload,
+        "payload round-trips end to end across both mediators"
+    );
+    assert_eq!(
+        sender, alice.did,
+        "the original sender VID is recovered (alice), not the relaying mediator"
+    );
+
+    topology.shutdown().await.expect("shutdown topology");
+}

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Affinidi TSP Changelog
 
+## 31st August 2026 (0.1.15)
+
+**Bug fix: a DID-valued `TSPTransport` endpoint was returned as a transport URL.**
+
+`did:` is a valid URL scheme, so `Url::parse("did:webvh:…")` succeeds. The
+`TSPTransport` service endpoints were collected with a bare `Url::parse(..).ok()`
+and no scheme test, and a `serviceEndpoint` naming a *mediator's DID* — the
+"I am mediated" shape a persona document publishes — arrived in
+`ResolvedVid::endpoints` indistinguishable from a real endpoint. On a live
+mediator it travelled all the way to the HTTP client, which could not build a
+request from it (`builder error for url (did:webvh:…/inbound)`) and abandoned
+the message after five retries.
+
+- `ResolvedVid::endpoints` now holds **only HTTP-family transport URLs**
+  (`http`/`https`/`ws`/`wss`). Anything else with no delivery rule is dropped.
+- New `ResolvedVid::mediators: Vec<String>` holds the DID-valued endpoints. The
+  advertisement is kept, not discarded: it says who carries this VID's traffic,
+  and the transport URL is one resolve away in *that* DID's document. Dropping
+  it silently would be its own bug — a mediated peer would read as "does not
+  speak TSP".
+- New `ResolvedVid::advertises_tsp()` — "advertises TSP transport at all, by URL
+  or by mediator DID". Callers testing `!endpoints.is_empty()` as a TSP-capable
+  signal want this instead.
+
+**Semver.** `ResolvedVid` is a public struct with public fields and is not
+`#[non_exhaustive]`, so adding `mediators` is technically breaking for an
+external consumer that builds one with a struct literal (in-workspace, all four
+such sites are updated). Released as a **patch** per
+[ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk`
+pins this crate through `[patch.crates-io]`, and a minor bump would break the
+redirect and pull a second copy from crates.io. Deserialization is unaffected —
+the new field is `#[serde(default)]`.
+
 ## 31st July 2026 (0.1.14)
 
 Moves to **curve25519-dalek 5** (`ed25519-dalek` 2 -> 3, `x25519-dalek` 2 -> 3),

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.14"
+version = "0.1.15"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/crates/messaging/affinidi-tsp/src/store.rs
+++ b/crates/messaging/affinidi-tsp/src/store.rs
@@ -212,6 +212,7 @@ mod tests {
             signing_key: [1u8; 32],
             encryption_key: [2u8; 32],
             endpoints: vec![],
+            mediators: vec![],
         });
 
         let resolved = store.get_remote_vid("did:example:bob").unwrap();

--- a/crates/messaging/affinidi-tsp/src/vid/did_resolver.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/did_resolver.rs
@@ -3,8 +3,14 @@
 //! [`DidVidResolver`] resolves a DID (`did:web`, `did:webvh`, `did:peer`, …) to a
 //! [`ResolvedVid`] by reading its DID document: the Ed25519 signing key from the
 //! `authentication` relationship, the X25519 encryption key from `keyAgreement`,
-//! and the TSP transport endpoint(s) from a service entry of type
+//! and the TSP transport advertisement from a service entry of type
 //! [`TSP_SERVICE_TYPE`].
+//!
+//! That last one has two shapes, and they are kept apart. A `TSPTransport`
+//! `serviceEndpoint` either names a transport URL (`endpoints`) or names the DID
+//! of the mediator that carries this VID's traffic (`mediators`), whose own
+//! document holds the URL. Both are legitimate; only the first is something a
+//! transport can connect to.
 //!
 //! DID resolution is asynchronous (it may hit the network for `did:web` /
 //! `did:webvh`), but the [`VidResolver`] trait is synchronous. The resolver
@@ -52,8 +58,8 @@ impl DidVidResolver {
     ///
     /// Returns [`TspError::DidResolution`] if the DID cannot be resolved or its
     /// document lacks an Ed25519 authentication key or an X25519 keyAgreement
-    /// key. A missing TSP service entry is not an error — `endpoints` is then
-    /// empty (the caller may deliver out of band).
+    /// key. A missing TSP service entry is not an error — `endpoints` and
+    /// `mediators` are then both empty (the caller may deliver out of band).
     pub async fn resolve_did(&self, did: &str) -> Result<ResolvedVid, TspError> {
         if let Some(cached) = self.cache.read().unwrap().get(did).cloned() {
             return Ok(cached);
@@ -96,8 +102,9 @@ impl VidResolver for DidVidResolver {
 ///
 /// Signing key = first `authentication` verification method decoding to an
 /// Ed25519 public key; encryption key = first `keyAgreement` method decoding to
-/// an X25519 public key. Endpoints = the `serviceEndpoint` URIs of every
-/// [`TSP_SERVICE_TYPE`] service. Decoding is delegated to
+/// an X25519 public key. The `serviceEndpoint` of every [`TSP_SERVICE_TYPE`]
+/// service is split by [`tsp_endpoints`] into transport URLs (`endpoints`) and
+/// mediator DIDs (`mediators`). Decoding is delegated to
 /// `VerificationMethod::decode_public_key`, which handles both
 /// `publicKeyMultibase` and `publicKeyJwk` uniformly across DID methods.
 fn extract_vid(did: &str, doc: &Document) -> Result<ResolvedVid, TspError> {
@@ -112,11 +119,13 @@ fn extract_vid(did: &str, doc: &Document) -> Result<ResolvedVid, TspError> {
             TspError::DidResolution(format!("{did}: no X25519 keyAgreement key in DID document"))
         })?;
 
+    let services = tsp_endpoints(doc);
     Ok(ResolvedVid {
         id: did.to_string(),
         signing_key,
         encryption_key,
-        endpoints: tsp_endpoints(doc),
+        endpoints: services.urls,
+        mediators: services.mediators,
     })
 }
 
@@ -144,15 +153,50 @@ fn verification_key(doc: &Document, rel: &VerificationRelationship) -> Option<(u
     vm.decode_public_key().ok()
 }
 
-/// The endpoint URLs of every `TSPTransport` service in the document.
-fn tsp_endpoints(doc: &Document) -> Vec<Url> {
-    doc.service
+/// Every `TSPTransport` `serviceEndpoint` in the document, split by what it
+/// actually names: a transport URL, or the DID of the mediator that carries this
+/// VID's traffic.
+#[derive(Debug, Default)]
+struct TspServices {
+    /// HTTP-family URLs a sender can connect to directly.
+    urls: Vec<Url>,
+    /// DIDs naming a mediator; the transport URL is in *that* document.
+    mediators: Vec<String>,
+}
+
+/// Split the `TSPTransport` service endpoints of `doc` into transport URLs and
+/// mediator DIDs.
+///
+/// The scheme test is the point of this function. `did:` is a perfectly valid
+/// URL scheme, so `Url::parse("did:webvh:…")` succeeds and a DID-valued endpoint
+/// used to arrive in `endpoints` indistinguishable from a real transport URL —
+/// and then travelled all the way to the HTTP client, which failed to build a
+/// request from it. A DID here is legitimate data (it says "I am mediated"), so
+/// it is kept, just not as something to connect to.
+///
+/// Only the HTTP family is admitted as a URL: `/inbound` is appended to these,
+/// and any other scheme is something this library has no delivery rule for.
+fn tsp_endpoints(doc: &Document) -> TspServices {
+    let mut out = TspServices::default();
+    for uri in doc
+        .service
         .iter()
         .filter(|service| service.type_.iter().any(|t| t == TSP_SERVICE_TYPE))
         .flat_map(|service| service.service_endpoint.get_uris())
+    {
         // `Endpoint::Map` yields JSON-serialized strings (quoted); strip quotes.
-        .filter_map(|uri| Url::parse(uri.trim_matches('"')).ok())
-        .collect()
+        let uri = uri.trim_matches('"');
+        if uri.starts_with("did:") {
+            out.mediators.push(uri.to_string());
+            continue;
+        }
+        if let Ok(url) = Url::parse(uri)
+            && matches!(url.scheme(), "http" | "https" | "ws" | "wss")
+        {
+            out.urls.push(url);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -164,13 +208,28 @@ mod tests {
     /// Build a DID document JSON for `did` advertising `vid`'s public keys
     /// (as Multikey verification methods) and an optional TSP endpoint.
     fn did_doc_json(did: &str, vid: &PrivateVid, tsp_endpoint: Option<&str>) -> String {
+        did_doc_json_multi(did, vid, tsp_endpoint.as_slice())
+    }
+
+    /// As [`did_doc_json`], but with any number of `TSPTransport` services — the
+    /// document order of `tsp_endpoints` is what the splitting tests assert on.
+    fn did_doc_json_multi(did: &str, vid: &PrivateVid, tsp_endpoints: &[&str]) -> String {
         let ed = encode_multikey(ED25519_PUB, &vid.verifying_key);
         let x = encode_multikey(X25519_PUB, &vid.encryption_key);
-        let service = match tsp_endpoint {
-            Some(url) => format!(
-                r#","service":[{{"id":"{did}#tsp","type":"TSPTransport","serviceEndpoint":"{url}"}}]"#
-            ),
-            None => String::new(),
+        let service = if tsp_endpoints.is_empty() {
+            String::new()
+        } else {
+            let entries = tsp_endpoints
+                .iter()
+                .enumerate()
+                .map(|(i, url)| {
+                    format!(
+                        r#"{{"id":"{did}#tsp-{i}","type":"TSPTransport","serviceEndpoint":"{url}"}}"#
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(r#","service":[{entries}]"#)
         };
         format!(
             r#"{{
@@ -213,6 +272,96 @@ mod tests {
         let resolved = extract_vid(did, &doc).expect("extracts");
         assert!(resolved.endpoints.is_empty());
         assert_eq!(resolved.signing_key, vid.verifying_key);
+    }
+
+    /// The production shape this split exists for: a persona document whose
+    /// `#tsp` service names its **mediator by DID**, not a URL. `did:` parses as
+    /// a URL (scheme `did`, cannot-be-a-base), so before the scheme test this
+    /// landed in `endpoints` and was handed to the HTTP client verbatim.
+    #[test]
+    fn a_did_valued_tsp_endpoint_is_a_mediator_not_an_endpoint() {
+        let did = "did:web:persona.example";
+        let mediator = "did:webvh:QmbHZC8JUpUD1XrdEcNiAPTxke4WpDyBPjjigPpEwYZiq5:dids.firstperson.dev:firstperson-mediator";
+        let vid = PrivateVid::generate(did);
+        let doc: Document =
+            serde_json::from_str(&did_doc_json(did, &vid, Some(mediator))).expect("doc parses");
+
+        let resolved = extract_vid(did, &doc).expect("extracts");
+
+        assert!(
+            resolved.endpoints.is_empty(),
+            "a DID is not a transport URL and must not appear as one"
+        );
+        assert_eq!(resolved.mediators, vec![mediator.to_string()]);
+        assert!(
+            resolved.advertises_tsp(),
+            "a mediated VID still advertises TSP — dropping the DID silently would read as 'no TSP'"
+        );
+    }
+
+    /// A document may publish both; each lands in its own bucket, in document
+    /// order.
+    #[test]
+    fn urls_and_mediator_dids_are_split_not_merged() {
+        let did = "did:web:both.example";
+        let vid = PrivateVid::generate(did);
+        let doc: Document = serde_json::from_str(&did_doc_json_multi(
+            did,
+            &vid,
+            &["did:web:mediator.example", "https://direct.example/v1"],
+        ))
+        .expect("doc parses");
+
+        let resolved = extract_vid(did, &doc).expect("extracts");
+
+        assert_eq!(
+            resolved
+                .endpoints
+                .iter()
+                .map(Url::as_str)
+                .collect::<Vec<_>>(),
+            vec!["https://direct.example/v1"]
+        );
+        assert_eq!(
+            resolved.mediators,
+            vec!["did:web:mediator.example".to_string()]
+        );
+    }
+
+    /// Neither a DID nor an HTTP-family URL: no delivery rule, so it is dropped
+    /// rather than passed on as an endpoint the transport would choke on.
+    #[test]
+    fn a_non_http_non_did_endpoint_is_dropped() {
+        let did = "did:web:odd.example";
+        let vid = PrivateVid::generate(did);
+        let doc: Document =
+            serde_json::from_str(&did_doc_json(did, &vid, Some("mailto:ops@odd.example")))
+                .expect("doc parses");
+
+        let resolved = extract_vid(did, &doc).expect("extracts");
+
+        assert!(resolved.endpoints.is_empty());
+        assert!(resolved.mediators.is_empty());
+        assert!(!resolved.advertises_tsp());
+    }
+
+    /// `ws://` is admitted alongside `http(s)://` — the mediator's own DID
+    /// document advertises a WebSocket transport next to its HTTP one.
+    #[test]
+    fn websocket_endpoints_are_transport_urls() {
+        let did = "did:web:ws.example";
+        let vid = PrivateVid::generate(did);
+        let doc: Document = serde_json::from_str(&did_doc_json(
+            did,
+            &vid,
+            Some("wss://ws.example/mediator/v1/ws"),
+        ))
+        .expect("doc parses");
+
+        let resolved = extract_vid(did, &doc).expect("extracts");
+
+        assert_eq!(resolved.endpoints.len(), 1);
+        assert!(resolved.mediators.is_empty());
     }
 
     #[test]

--- a/crates/messaging/affinidi-tsp/src/vid/mod.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/mod.rs
@@ -25,9 +25,38 @@ pub struct ResolvedVid {
     pub signing_key: [u8; 32],
     /// X25519 public encryption key (32 bytes).
     pub encryption_key: [u8; 32],
-    /// Service endpoints for message delivery.
+    /// Transport URLs this VID can be reached at directly — the `serviceEndpoint`
+    /// of every `TSPTransport` service that names an HTTP-family URL.
+    ///
+    /// Only URLs a sender can actually POST to land here. A `TSPTransport`
+    /// endpoint that names a DID is *not* a transport URL and is kept in
+    /// [`mediators`](Self::mediators) instead.
     #[serde(default)]
     pub endpoints: Vec<Url>,
+    /// DIDs this VID delegates its transport to — the `serviceEndpoint` of every
+    /// `TSPTransport` service that names a DID rather than a URL.
+    ///
+    /// This is the "I am mediated" advertisement: the VID publishes *who* carries
+    /// its traffic, and the transport URL lives in that DID's own document, one
+    /// resolve away. A sender resolves the named DID and uses the URL it
+    /// publishes. Kept apart from [`endpoints`](Self::endpoints) because a DID is
+    /// not something a transport can connect to — `did:` is a valid URL scheme,
+    /// so a DID that is allowed to pass as an endpoint reaches the HTTP client
+    /// intact and fails there, at the far end of the delivery path.
+    #[serde(default)]
+    pub mediators: Vec<String>,
+}
+
+impl ResolvedVid {
+    /// Whether the document advertises TSP transport at all — a direct URL or a
+    /// mediator DID.
+    ///
+    /// This is the "does this peer speak TSP" signal; a mediated VID advertises
+    /// no URL of its own, so testing [`endpoints`](Self::endpoints) alone reads
+    /// as "no TSP" for exactly the peers that are reachable over it.
+    pub fn advertises_tsp(&self) -> bool {
+        !self.endpoints.is_empty() || !self.mediators.is_empty()
+    }
 }
 
 /// A private VID with signing and decryption keys.
@@ -115,12 +144,17 @@ impl PrivateVid {
     }
 
     /// Get the public resolved VID for sharing with others.
+    ///
+    /// `mediators` is empty: a `PrivateVid` is local key material plus the
+    /// transport URLs it was handed, and whether the identity is mediated is a
+    /// property of its published document, not of the keys.
     pub fn to_resolved(&self) -> ResolvedVid {
         ResolvedVid {
             id: self.id.clone(),
             signing_key: self.verifying_key,
             encryption_key: self.encryption_key,
             endpoints: self.endpoints.clone(),
+            mediators: Vec::new(),
         }
     }
 }

--- a/crates/messaging/affinidi-tsp/src/vid/resolver.rs
+++ b/crates/messaging/affinidi-tsp/src/vid/resolver.rs
@@ -127,6 +127,7 @@ mod tests {
             signing_key: [1u8; 32],
             encryption_key: [2u8; 32],
             endpoints: vec![],
+            mediators: vec![],
         }
     }
 
@@ -173,6 +174,7 @@ mod tests {
             signing_key: [3u8; 32],
             encryption_key: [4u8; 32],
             endpoints: vec![],
+            mediators: vec![],
         });
 
         let resolved = resolver.resolve("keri:EDP12345").unwrap();
@@ -191,6 +193,7 @@ mod tests {
                         signing_key: [5u8; 32],
                         encryption_key: [6u8; 32],
                         endpoints: vec![],
+                        mediators: vec![],
                     })
                 } else {
                     Err(TspError::VidNotFound(vid.to_string()))


### PR DESCRIPTION
## The defect

TSP remote forwarding cannot deliver to a **mediated** peer. From a live mediator:

```text
WARN ...forwarding::processor: FORWARD_FAILED:
  to_did_hash=a03a2469...
  endpoint=did:webvh:QmbHZC8JUpUD1XrdEcNiAPTxke4WpDyBPjjigPpEwYZiq5:dids.firstperson.dev:firstperson-mediator
  error=Connection error to did:webvh:...firstperson-mediator/inbound:
        builder error for url (did:webvh:...firstperson-mediator/inbound)
  retry_count=5
→ FORWARD_ABANDONED
```

The `endpoint` is a **DID**, not an HTTP URL, so reqwest cannot build a request. Five retries later the message is abandoned — and the failure is reported by an HTTP client that has no idea whose message it is or which hop it belongs to.

## The shape

Two documents are involved, and the mediator was only reading the first. Verified live:

```text
persona        #tsp  TSPTransport  serviceEndpoint: "did:webvh:QmbHZ...:firstperson-mediator"
that mediator  #tsp  TSPTransport  serviceEndpoint: "https://mediator.firstperson.dev/mediator/v1"
```

This is the ordinary real-world shape, not an edge case: an agent DID advertises **who carries its traffic**, and the transport URL lives one resolve away in the mediator's own document.

Two contributing causes, one in each crate:

1. `affinidi-tsp` — `tsp_endpoints` collected `TSPTransport` service endpoints with a bare `Url::parse(..).ok()` and **no scheme test**. `did:` is a valid URL scheme, so `Url::parse("did:webvh:…")` succeeds and a DID-valued endpoint sailed through indistinguishable from a real transport URL.
2. `affinidi-messaging-mediator` — `forward_tsp_remote` took `resolved.endpoints.first()` and POSTed `[endpoint, "/inbound"].concat()`, with no equivalent of the DIDComm side's DID-indirection chasing.

## Mirrors #705 on the DIDComm side

The DIDComm relay solved exactly this in **#705**, *"forward a message whose next hop names its mediator by DID"* — `classify_endpoint` → `EndpointHop::Local` / `Remote(url)` / `Indirect(did)`, and `service_endpoint_for_remote` resolving an `Indirect` hop **one hop** and classifying that document's endpoints the same way.

This change mirrors that design hop for hop:

- `classify_tsp_relay` decides — with **no I/O** — between `Direct(url)`, `ViaMediator(did)`, `Loop(what)` and `Nothing`, the TSP analogue of `EndpointHop`.
- A mediator DID is resolved **one hop**, and that document's own `TSPTransport` URL is what the forward is enqueued against.
- **A second hop of indirection is deliberately not chased**, with the same reasoning `service_endpoint_for_remote` gives: a mediator's own document is expected to publish a URL, and chasing further would let a chain of documents steer this mediator's relay.
- A direct URL wins over a mediator DID when a document publishes both — the document is telling us it can be reached without a relay. This is the analogue of *"a later entry naming this mediator directly still wins"*.

The pre-existing loop guard is **extended, not weakened**: a transport URL on one of our own authorities still fails as a loop, and so does a next hop that names *this* mediator as its mediator while holding no account here (which, at that point in the code, means it has no account here at all).

Failure now happens where the next hop can be named, and says which kind it is: `message.tsp.no_endpoint`, `message.tsp.mediator.unresolvable` (the named mediator did not resolve), `protocol.forwarding.loop_detected`.

## Should `tsp_endpoints` reject, separate, or pass through?

**Separate.** A DID in that field is legitimate data — it means *"I am mediated"* — so dropping it silently would be its own bug, not a fix: a mediated peer whose advertisement vanished reads as *"does not speak TSP"*.

- `ResolvedVid::endpoints` now holds **only HTTP-family transport URLs** (`http`/`https`/`ws`/`wss`) — the things `/inbound` is appended to. Anything else with no delivery rule is dropped.
- New `ResolvedVid::mediators: Vec<String>` holds the DID-valued endpoints.
- New `ResolvedVid::advertises_tsp()` — "advertises TSP transport at all, by URL or by mediator DID".

That third item catches the regression the split would otherwise have caused: `TspOps::select_protocol` used `!endpoints.is_empty()` as its "does this peer speak TSP" signal, which after the split would read as *no TSP* for exactly the peers TSP reaches through a mediator. It now uses `advertises_tsp()`.

The failure to avoid is the current one — treating a DID as if it were a transport URL — and it is now impossible by type: the two live in different fields.

## Reuse across the crate boundary — and where it stops

Shared: **self-authority detection**. `tsp_endpoint_is_self` is gone; `uri_points_at_self` moved from `protocols::routing` to `server`, next to the `compute_self_authorities` / `normalize_host` / `default_port_for` set it consults, because the TSP relay lives in `messages::inbound` and `protocols` only exists in a `didcomm` build. That deduplication also **fixes a latent IPv6 bug** in the TSP copy: it compared `Url::host_str()` (`"[::1]"`, bracketed) against the bare form the authority set stores (`"::1"`), so an IPv6 self-authority never matched.

Not shared: the **URI-to-kind classifier**. `classify_endpoint` parses strings because DIDComm's endpoints arrive as strings; `affinidi-tsp` returns the split **already typed** (`Vec<Url>` + `Vec<String>`), so pushing DIDComm's string classifier across the boundary would mean re-stringifying typed data to re-derive a distinction the TSP crate has already made. The two classifiers encode the same rules and are each tested against them.

## Tests

**Unit — `affinidi-tsp`** (`did_resolver.rs`): a DID-valued `TSPTransport` endpoint lands in `mediators` and never in `endpoints`, with the production `did:webvh` verbatim; URLs and mediator DIDs in one document are split, not merged; a non-HTTP non-DID scheme is dropped; `ws`/`wss` are admitted; and a mediated VID still reports `advertises_tsp()`.

**Unit — mediator** (`inbound.rs`, new `tsp_relay_tests`): the classifier against the production DID and URL — indirection, direct URL, direct-wins-over-mediator, both loop arms, nothing-advertised, the **two-document round trip**, and the refusal to chase a second hop. Modelled on `classify_endpoint_treats_a_did_endpoint_as_indirection` / `a_did_endpoint_round_trips_through_the_document`.

**Integration — `tests/tsp_mediated_recipient.rs`**, no mocks or stubs: two real mediators via `TestTopology::builder().mediators(2)`, Alice on A, Bob on B. Bob's DID advertises `#tsp` → **mediator B's DID**, and the route names **only Bob** — mediator B is deliberately absent from it, so A must discover the transport URL through Bob's document. The forward crosses A → B over loopback HTTP and Bob unpacks Alice's plaintext and VID.

### Why the existing federation test passed throughout

`tsp_federation.rs` names the peer mediator's DID **in the route** (`[mediator_A, mediator_B, bob]`). A therefore resolves a *mediator's* document directly and reads a URL straight out of it. There is no indirection in that path, so the defect was never reachable from it — and the two-mediator federation harness looked like it already covered cross-mediator TSP. The new test is the sibling case where the recipient, not the route, carries the mediator.

**Negative control.** Reverting only the `affinidi-tsp` scheme test and re-running the new test reproduces the production failure verbatim:

```text
FORWARD_FAILED ... endpoint=did:peer:2.Vz6Mkv2... error=Connection error to did:peer:2.../inbound:
  builder error for url (did:peer:2.../inbound) retry_count=3
```

### Harness addition

`TestEnvironment::add_tsp_mediated_user` / `TestTopology::add_tsp_mediated_user` — a user whose DID advertises `TSPTransport` naming its mediator by DID. `add_user` is unchanged.

The mediated user advertises **only** the TSP service. A `did:peer:2` inlines each service into the identifier, and the mediator's own DID is itself a `did:peer:2` carrying three services, so embedding it twice pushes the user's DID past the resolver's 1000-byte ceiling — an artefact of `did:peer` that a real `did:webvh` persona never approaches. The DIDComm side is not what is under test, and the SDK profile is told its mediator directly.

## Semver

`affinidi-tsp` is published. `ResolvedVid` is a public struct with public fields and is **not** `#[non_exhaustive]`, so adding `mediators` is technically breaking for an external consumer that builds one with a struct literal (in-workspace, all four such sites are updated). Released as a **patch** (0.1.14 → 0.1.15) per [ADR 0003](docs/adr/0003-public-api-semver-policy.md) point 3: `vta-sdk` pins this crate through `[patch.crates-io]`, and a minor bump would break the redirect and pull a second copy from crates.io. Deserialization is unaffected — the new field is `#[serde(default)]`. `advertises_tsp()` is purely additive.

Also bumped: mediator 0.20.3 → 0.20.4, sdk 0.21.0 → 0.21.1, test-mediator 0.4.0 → 0.4.1, each with a CHANGELOG entry.

## Scope

Confined to the TSP forwarding path. The `force_session_did_match` guard in `inbound.rs` and the plaintext forwarding problem report in `tasks/forwarding/processor.rs` are **untouched** — they are being handled in parallel.

## Gates

Run locally on toolchain 1.95.0, with a local Redis (`redis-server`, `PING` → `PONG`):

- `cargo fmt --all -- --check` — clean.
- `RUSTFLAGS="-D warnings --cfg tracing_unstable" cargo clippy --workspace --all-targets` — clean.
- Same clippy per touched crate **with the `tsp` feature on** (`affinidi-tsp --all-features`, `affinidi-messaging-mediator --features tsp`, `affinidi-messaging-test-mediator --features tsp`, `affinidi-messaging-sdk --features tsp`) — clean. The default `--all-targets` run does not compile the TSP code, so these are the runs that mean something here.
- `RUSTFLAGS="--cfg tracing_unstable" cargo test -p affinidi-tsp -p affinidi-messaging-mediator -p affinidi-messaging-test-mediator` — all green, 0 failures.
- The same test command **with `tsp` on** (`--features affinidi-messaging-mediator/tsp,affinidi-messaging-test-mediator/tsp`) — all green, 0 failures. Mediator unit tests go 223 → 239.
- `cargo test -p affinidi-messaging-test-mediator --features tsp -- --include-ignored` — green, nothing left ignored.
- `cargo test -p affinidi-messaging-sdk --features tsp` — green.

**Pre-existing, not introduced here** (each reproduced on `origin/main` with the change stashed):

- `cargo clippy --workspace --all-targets --all-features` fails on `affinidi-did-resolver-cache-sdk/src/lib.rs:520` (`collapsible_if`) — a crate this PR does not touch, only reachable under a non-default feature.
- `RUSTDOCFLAGS="-D warnings" cargo doc` fails on unrelated pre-existing intra-doc links (`affinidi-tsp/src/vid/resolver.rs:26`, the sdk module header's bare URL, the mediator's `spawn_inbox_redelivery` link, the test-mediator's `MemoryStore` link). Not a gate in this repo's CI.
- A `tsp`-only mediator build (`--no-default-features --features tsp,memory-backend`) does not compile on `main` either (`Capability` import is `#[cfg(feature = "didcomm")]`, `inbound.rs:328`), consistent with the feature docs noting a TSP-only build has no auth path yet.
