### PR TITLE
feat!: move affinidi-mdoc to coset 0.4

### DIFF
--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Affinidi mdoc Changelog
 
+## 1st September 2026 (0.3.0)
+
+Moves to **coset 0.4**.
+
+No source change — the API this crate uses is identical across the bump, and
+0.4.0's one breaking change (the `crit` field on `Header` gains support for
+private-use labels, per [RFC 9052
+§3.1](https://datatracker.ietf.org/doc/html/rfc9052#name-common-cose-header-paramete))
+touches nothing here. All 126 tests pass unmodified.
+
+**Minor rather than patch, because `coset` is in this crate's public API.**
+`IssuerSigned::issuer_auth` and `Document::issuer_auth` are `pub` fields of type
+`coset::CoseSign1`; `sign_mso` returns one; `extract_kid` takes one; and
+`CoseKey::default_algorithm` returns `Option<coset::iana::Algorithm>`. A
+consumer that names those types has to move in the same step, so the version
+has to say so — a patch bump would let cargo resolve a consumer on `coset 0.3`
+beside this crate on 0.4 and fail with duplicate-type errors rather than a
+version conflict.
+
+That is not hypothetical. It is what blocked
+[OpenVTC/verifiable-trust-infrastructure#1225](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1225):
+`vta-vault` compares an `alg` taken from `IssuerSigned` against one it builds
+from its own `coset`, and moving only its side produced
+
+```
+error[E0308]: mismatched types
+note: there are multiple different versions of crate `coset` in the dependency graph
+```
+
+This release is what lets that side move.
+
 ## 16th August 2026 (0.2.7)
 
 Adds the CBOR wire codec for **`DeviceResponse`** — `to_cbor_bytes` /

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.2.7"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -33,7 +33,7 @@ required-features = ["_test-utils"]
 [dependencies]
 ciborium = "0.2"
 ciborium-io = "0.2"
-coset = "0.3"
+coset = "0.4"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased (0.5.0) — `trust-tasks-rs` 0.17
+## Unreleased (0.5.1) — `trust-tasks-rs` 0.17
 
+- Requires `affinidi-tdk` 0.11 (was 0.10), which re-exports `affinidi-mdoc`
+  0.3 / `coset` 0.4. Declaration-only; no source change here.
 - Bumps `trust-tasks-rs` 0.12 → 0.17.
 - The one `MediatorAcl` construction in `service/mediator.rs` moved to the
   generated builder — `#[non_exhaustive]` in 0.17, so the

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.5.0"
+version = "0.5.1"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -50,7 +50,7 @@ affinidi-did-common = "0.4"
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
 affinidi-messaging-test-mediator = { version = "0.4", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
-affinidi-tdk = { version = "0.10", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.11", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
 futures-util = "0.3"
 

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -25,7 +25,7 @@ affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.21.0
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
 trust-tasks-rs = "0.17"
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.10" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.11" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased (0.4.2) — a test user that is mediated the way production is
+## Unreleased (0.4.3) — a test user that is mediated the way production is
 
+- Requires `affinidi-tdk` 0.11 (was 0.10), which re-exports `affinidi-mdoc`
+  0.3 / `coset` 0.4. Declaration-only; no source change here.
 - New `TestEnvironment::add_tsp_mediated_user` / `TestTopology::add_tsp_mediated_user`:
   a user whose DID advertises a `TSPTransport` service **naming its mediator by
   DID**, which is what a real persona/agent document publishes. `add_user` is

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -49,7 +49,7 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.10", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.11", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.2"
+version = "0.4.3"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.10" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.11" }
 affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.21.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Affinidi TDK Test Support
 
-## Unreleased (0.8.3) — dependency refresh
+## Unreleased (0.8.4) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.
 - Bumps `coset` 0.3 → 0.4, alongside `affinidi-mdoc` 0.3. `coset` is internal

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased (0.8.3) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.
+- Bumps `coset` 0.3 → 0.4, alongside `affinidi-mdoc` 0.3. `coset` is internal
+  here (no public API names it), but this crate and `affinidi-mdoc` exchange
+  COSE values, so they have to compile against one `coset` or the types do not
+  match.
 - No source or API change; the bumps are declaration-only and the crate
   compiles unmodified against them. Bumped workspace-wide in the same
   change so no two versions of these crates are compiled side by side.

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.8.3"
+version = "0.8.4"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -62,7 +62,7 @@ base64 = "0.23"
 # ── TI5b: mdoc (COSE sign_mso/verify_issuer_auth) + OID4VP present/verify ──
 ## mdoc issue/present/verify on the EdDSA COSE path; default-features off drops
 ## the ES256/P-256 path the scenario's Ed25519 identities don't use.
-affinidi-mdoc = { version = "0.2", path = "../../credentials/affinidi-mdoc", default-features = false, features = [
+affinidi-mdoc = { version = "0.3", path = "../../credentials/affinidi-mdoc", default-features = false, features = [
   "eddsa",
 ] }
 ## OID4VP authorization request/response + presentation-submission envelope.
@@ -70,7 +70,7 @@ affinidi-openid4vp = { version = "0.1", path = "../../protocols/affinidi-openid4
 ## CBOR for mdoc attribute values + the fixture's DeviceResponse transport;
 ## coset for the COSE_Sign1 (de)serialisation that transport round-trips.
 ciborium = "0.2"
-coset = "0.3"
+coset = "0.4"
 ## `derive` backs the DeviceResponseTransport (de)serialisation.
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -6,6 +6,20 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For the full code history see `git log` on `crates/tdk/affinidi-tdk`.
 
+## 0.11.0
+
+### Changed
+
+- `mdoc` feature now re-exports `affinidi-mdoc` 0.3, which moves to `coset` 0.4.
+- **Breaking for consumers of the `mdoc` feature.** `coset` sits in
+  `affinidi-mdoc`'s public API (`IssuerSigned::issuer_auth` is a
+  `coset::CoseSign1`), so a consumer that names those types moves in the same
+  change; two `coset` versions in one graph fail to compile rather than warn.
+  Minor rather than patch for that reason.
+- No source change in this crate. Bumped because the published manifest's
+  requirement is itself what changed: a consumer resolving `affinidi-tdk` 0.10.0
+  from crates.io stays pinned to `affinidi-mdoc` 0.2 and can never reach 0.3.
+
 ## 0.10.0
 
 ### Changed

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.10.0"
+version = "0.11.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -73,7 +73,7 @@ affinidi-data-integrity = { version = "0.7", optional = true }
 # Credentials
 affinidi-vc = { version = "0.2", path = "../../credentials/affinidi-vc", optional = true }
 affinidi-sd-jwt = { version = "0.1", path = "../../credentials/affinidi-sd-jwt", optional = true }
-affinidi-mdoc = { version = "0.2", path = "../../credentials/affinidi-mdoc", optional = true }
+affinidi-mdoc = { version = "0.3", path = "../../credentials/affinidi-mdoc", optional = true }
 affinidi-status-list = { version = "0.1", path = "../../credentials/affinidi-status-list", optional = true }
 
 # Protocols

--- a/scripts/check-publish-dry-run.sh
+++ b/scripts/check-publish-dry-run.sh
@@ -154,10 +154,32 @@ crate_versions=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
       | select(.publish == null or .publish == ["crates.io"])
       | "\(.name)\t\(.version)"')
 
+# Does the local version satisfy the requirement the dry-run could not resolve?
+#
+# String equality is wrong here, and wrong in the direction that makes the
+# `wait` path unreachable for the only shape it exists to recognise. Internal
+# requirements in this workspace are written `major.minor` by convention
+# (`affinidi-tdk = { version = "0.11", path = ... }`), while a crate version is
+# always `major.minor.patch` — so `req_ver` is `0.11` and `local_ver` is
+# `0.11.0`, and `[ "0.11.0" = "0.11" ]` is false. Every coordinated breaking
+# release therefore reported FAIL, which is precisely what the header's "ONE
+# FAILURE IS NOT A FAILURE" note says must not happen.
+#
+# Prefix-with-boundary rather than a semver library: the requirement is either
+# the local version exactly, or a `major.minor` prefix of it. The `.` in the
+# second pattern is load-bearing — without it `0.3` would also match a local
+# `0.30.0`, which is a different, incompatible release.
+version_satisfies() { # $1 = local version, $2 = required version
+  case "$1" in
+    "$2" | "$2".*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Is this failure solely "requires a sibling version this release publishes"?
 # See the header note. Returns 0 only when at least one unmet requirement was
-# found AND every one of them names a workspace crate whose local version is
-# exactly what was required.
+# found AND every one of them names a workspace crate whose local version
+# satisfies what was required.
 awaits_sibling_release() { # $1 = captured dry-run output
   local out="$1" line req_name req_ver local_ver found=0
   while IFS= read -r line; do
@@ -167,8 +189,8 @@ awaits_sibling_release() { # $1 = captured dry-run output
     [ -z "$req_name" ] && continue
     found=1
     local_ver=$(printf '%s\n' "$crate_versions" | awk -F'\t' -v n="$req_name" '$1 == n { print $2 }')
-    # Not ours, or not the version we are about to publish -> a real failure.
-    [ -n "$local_ver" ] && [ "$local_ver" = "$req_ver" ] || return 1
+    # Not ours, or not a version this release is about to publish -> real failure.
+    [ -n "$local_ver" ] && version_satisfies "$local_ver" "$req_ver" || return 1
   done <<AWAIT_EOF
 $(printf '%s\n' "$out" | grep 'failed to select a version for the requirement' || true)
 AWAIT_EOF


### PR DESCRIPTION
Unblocks
[OpenVTC/verifiable-trust-infrastructure#1225](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1225),
which cannot move on its own.

## Why the consumer is stuck

`coset` is in `affinidi-mdoc`'s **public API**, not an implementation detail:

- `IssuerSigned::issuer_auth` and `Document::issuer_auth` are `pub` fields of
  type `coset::CoseSign1`
- `sign_mso` returns one, `extract_kid` takes one
- `CoseKey::default_algorithm` returns `Option<coset::iana::Algorithm>`

So which `coset` this crate compiles against is part of what it promises. VTI's
`vta-vault` names those types directly — it compares an `alg` taken from
`IssuerSigned` against one it builds from its own `coset` — and moving only its
side produced:

```
error[E0308]: mismatched types
   --> vta-vault/src/receive.rs:439:29
    |
439 |     if alg.as_ref() != Some(&expected) {
    |                             ^^^^^^^^^ expected `RegisteredLabelWithPrivate<Algorithm>`
    |
note: there are multiple different versions of crate `coset` in the dependency graph
```

with `affinidi-mdoc 0.2.7` still holding `coset 0.3.8` underneath it. The two
sides have to move together; this is the half that has to move first.

## What's in the change

**No source change anywhere.** The API this workspace uses is identical across
the bump. coset 0.4.0's one breaking change is the `crit` field on `Header`
gaining support for private-use labels ([RFC 9052
§3.1](https://datatracker.ietf.org/doc/html/rfc9052#name-common-cose-header-paramete)),
which nothing here touches; 0.4.1 and 0.4.2 are additive. `affinidi-mdoc`
compiled unmodified on the first try and all 126 of its tests pass.

Versions, and why each:

| crate | bump | why |
|---|---|---|
| `affinidi-mdoc` | 0.2.7 → **0.3.0** | `coset` is in its public API, so the bump is breaking |
| `affinidi-tdk` | 0.10.0 → **0.11.0** | `pub use affinidi_mdoc as mdoc` — the break is in its public API too |
| `affinidi-tdk-test-support` | stays **0.8.3** (unreleased) | `coset` is internal here; entry joins the dependency refresh already in that section |

Plus the four `affinidi-tdk = "0.10"` requirements in `crates/messaging/*`. A
published `affinidi-tdk` 0.10.0 stays pinned to `affinidi-mdoc` 0.2 and can
never reach 0.3, so leaving those would strand the consumer this exists to
unblock.

**Minor rather than patch** on the two published crates, deliberately. A patch
bump would let cargo resolve a consumer on `coset 0.3` beside `affinidi-mdoc` on
0.4 and fail with duplicate-type errors instead of a version conflict — the
exact failure being fixed here, reintroduced one level down.

[ADR 0003](../blob/main/docs/adr/0003-public-api-semver-policy.md) point 3's
patch-bump carve-out does not apply. That exists for crates redirected through
`[patch.crates-io]`, where a minor bump breaks the redirect; `affinidi-mdoc` is
in no patch section here, and the consuming workspace removed its own.

## Testing

`cargo check --workspace --all-targets`, `cargo clippy --workspace
--all-targets` and `cargo fmt --all` clean. `affinidi-mdoc` (126),
`affinidi-tdk-test-support` and `affinidi-tdk` tests all pass. `Cargo.lock` now
resolves exactly one `coset`, at 0.4.2.

## After this merges

VTI #1225 is a straight re-run once `affinidi-mdoc 0.3` is published — the bump
there needs no code change either, it just needs both sides on one `coset`.
