### PR TITLE
fix(mediator): bind a TSP envelope's sender to the authenticated session

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## Unreleased (0.20.7) — bind a TSP envelope's sender to the authenticated session
+
+**Security fix: the TSP ingress trusted the envelope's claimed sender.**
+Reported as [#754], measured against a public deployment: a TSP frame sent on a
+socket authenticated as DID A, carrying envelope sender DID E (never
+authenticated), was forwarded normally.
+
+A TSP envelope names its sender in the clear and the mediator does not decrypt
+it, so `meta.sender` is a claim. `handle_inbound_tsp` never consulted the
+session at all — it passed that claim straight to `deliver_opaque`, which hashes
+it into the recipient's `delivery_decision` access-list lookup. An authenticated
+client could therefore borrow any allow-listed VID and be admitted to an inbox
+that does not admit it.
+
+This is the TSP twin of the DIDComm direct-delivery bypass fixed in 0.15.5. The
+TSP path was written after that fix and did not carry it. `docs/acls.md` §6 has
+documented the flow as "Direct delivery (DIDComm and TSP)" — including the
+session-DID match — the whole time, so the contract was already stated; only the
+implementation was missing.
+
+- The cleartext envelope sender is now bound to the session DID under the same
+  `security.force_session_did_match` switch the DIDComm paths use, reusing the
+  same `check_direct_delivery_session_match` predicate and returning the same
+  `authorization.did.session_mismatch` problem report.
+- Checked on the **outer** envelope, before the receiver branch, so it covers
+  relayed and nested submissions too: a client must have authored the layer it
+  hands over. Inner layers are exempt by construction — they are sealed to
+  someone else.
+- **Anonymous sessions are exempt**, exactly as on the DIDComm side since 0.20.4:
+  an inter-mediator relay hop is POSTed to `/inbound` with no `Authorization`
+  header and lands on the anonymous `ANON-INBOUND` session, whose DID is empty.
+  Without the exemption cross-mediator TSP delivery would stop entirely. The
+  residual cost is the one already named for blind relay: on an anonymous hop the
+  claimed sender stays unverified, which is inherent to relaying.
+- Direct TSP delivery now also checks the sender's own `SEND_MESSAGES`, mirroring
+  the DIDComm direct-delivery branch. This is load-bearing on the **WebSocket**
+  ingress in particular, which gates only on `LOCAL` at upgrade: a DID whose
+  `SEND_MESSAGES` had been revoked could still post TSP frames over a socket.
+
+**Behaviour change.** A client that deliberately sends under a VID other than the
+one it authenticated as will now be refused with
+`e.p.authorization.did.session_mismatch` unless the deployment sets
+`security.force_session_did_match = "false"`. Deployments relying on the split
+between connection identity and egress identity should move to TSP **routed**
+mode, where the outer sender is the connection identity and the egress identity
+travels inside the sealed layer — that shape satisfies the binding by
+construction (R3.6: coordinate with consuming repos).
+
+**Still outstanding, tracked separately:** TSP direct delivery does not honour
+`security.local_direct_delivery_allowed`, so a deployment that has turned direct
+delivery off to force everything through a routing envelope still accepts direct
+TSP. That is a policy change with far wider blast radius than this fix — it
+changes the default fixture's behaviour for ~20 existing tests — and is being
+handled on its own rather than folded in here.
+
+[#754]: https://github.com/affinidi/affinidi-tdk-rs/issues/754
+
 ## Unreleased (0.20.6) — TSP forwarding follows a next hop that names its mediator by DID
 
 **Bug fix: TSP remote forwarding could not deliver to a mediated peer.** Observed

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -33,7 +33,13 @@ implementation was missing.
   header and lands on the anonymous `ANON-INBOUND` session, whose DID is empty.
   Without the exemption cross-mediator TSP delivery would stop entirely. The
   residual cost is the one already named for blind relay: on an anonymous hop the
-  claimed sender stays unverified, which is inherent to relaying.
+  claimed sender stays unverified, which is inherent to relaying. Note the
+  asymmetry: DIDComm deployments that need the relaying peer authenticated can run
+  `RelayMode::Rewrap` with `processors.forwarding.relay_trusted_mediators`, and
+  **TSP has no equivalent yet** — `relay_peer_trusted` is DIDComm-only. Anonymous
+  inbound is itself opt-in (`security.enable_inter_mediator_relay`, or the legacy
+  implicit `SEND_FORWARDED` in `global_acl_default`), which bounds the exposure to
+  relay-enabled deployments.
 - Direct TSP delivery now also checks the sender's own `SEND_MESSAGES`, mirroring
   the DIDComm direct-delivery branch. This is load-bearing on the **WebSocket**
   ingress in particular, which gates only on `LOCAL` at upgrade: a DID whose

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.6"
+version = "0.20.7"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/docs/acls.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/acls.md
@@ -229,6 +229,18 @@ deliberately identical (§2).
 └─ recipient's access list admits the sender?   else 403 authorization.access_list.denied
 ```
 
+The claimed sender is unverified in both protocols — the mediator holds no key
+for an envelope it is only carrying, so it reads the JWE `skid` (DIDComm) or the
+cleartext CESR sender field (TSP). `force_session_did_match` is what makes it
+trustworthy enough to feed the access-list lookup, by pinning it to the DID that
+authenticated. It is skipped for unauthenticated sessions, because an
+inter-mediator relay hop arrives anonymously and has no session DID to match
+against; on such a hop the claimed sender stays unverified.
+
+One deviation remains: **TSP does not yet honour `local_direct_delivery_allowed`**
+— a deployment that has turned direct delivery off still accepts direct TSP
+delivery. Every other step above applies to both protocols.
+
 ### Forwarding
 
 ```

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -155,6 +155,15 @@ pub(crate) async fn handle_inbound_tsp(
     // DID is empty, and could only ever fail the comparison. The residual cost is
     // the one named on the DIDComm side: on an anonymous relay hop the claimed
     // sender stays unverified. That is inherent to relaying, not given away here.
+    //
+    // One asymmetry worth naming rather than leaving to be inferred: on the
+    // DIDComm side a deployment that needs the relaying peer authenticated can
+    // run [`RelayMode::Rewrap`] with `processors.forwarding.relay_trusted_mediators`.
+    // TSP has no equivalent — `relay_peer_trusted` is DIDComm-only — so for TSP
+    // the anonymous hop currently has no opt-in hardening at all. Anonymous
+    // inbound is itself opt-in (`security.enable_inter_mediator_relay`, or the
+    // legacy implicit `SEND_FORWARDED` in `global_acl_default`), which bounds
+    // the exposure to relay-enabled deployments.
     if state.config.security.force_session_did_match && session.authenticated {
         check_direct_delivery_session_match(session, Some(meta.sender.as_str()))?;
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -6,7 +6,7 @@ use crate::messages::MessageHandler;
 use crate::messages::protocols::routing::{relay_peer_trusted, rewrap_inner_attachment};
 use crate::{SharedData, common::session::Session};
 // Shared by both the DIDComm direct-delivery path and the TSP delivery path.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::common::authz::Capability;
 #[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::{common::authz, messages::store::store_message};
@@ -134,6 +134,31 @@ pub(crate) async fn handle_inbound_tsp(
 
     use affinidi_tsp::message::routed::{RouteStep, next_hop, pack_routed};
 
+    // Bind the cleartext envelope sender to the identity that authenticated,
+    // exactly as the DIDComm paths do. A TSP envelope names its sender in the
+    // clear and the mediator does not decrypt it here, so `meta.sender` is a
+    // claim; it is also what feeds the recipient's access-list lookup in
+    // `deliver_opaque`, so on an authenticated session it has to be pinned to
+    // the session DID or the access list is evaluated against an attacker-chosen
+    // VID. This is the TSP twin of the DIDComm direct-delivery bypass fixed in
+    // mediator 0.15.5.
+    //
+    // Checked on the OUTER envelope, before the receiver branch, so it covers
+    // relay and nested submissions too: whatever a client hands its mediator, it
+    // has to have authored the layer it handed over. Inner layers are exempt by
+    // construction — they are sealed to someone else and the client did not
+    // write their envelopes.
+    //
+    // Skipped for unauthenticated sessions, exactly as the DIDComm branches skip
+    // it: an inter-mediator relay hop is POSTed to `/inbound` with no
+    // Authorization header, lands on the anonymous `ANON-INBOUND` session whose
+    // DID is empty, and could only ever fail the comparison. The residual cost is
+    // the one named on the DIDComm side: on an anonymous relay hop the claimed
+    // sender stays unverified. That is inherent to relaying, not given away here.
+    if state.config.security.force_session_did_match && session.authenticated {
+        check_direct_delivery_session_match(session, Some(meta.sender.as_str()))?;
+    }
+
     // The message kind (Direct/Routed/Nested/Control) now lives in the ENCRYPTED
     // payload, not the cleartext envelope, so a keys-free relay can no longer
     // dispatch on it. Route on the cleartext *receiver* instead:
@@ -142,6 +167,26 @@ pub(crate) async fn handle_inbound_tsp(
     //   * receiver == this mediator → we hold the key, so unpack to learn the kind
     //     and act as the relay hop (Routed) / metadata-privacy intermediary (Nested).
     if meta.receiver != state.config.mediator_did {
+        // Direct delivery. The sender's own SEND_MESSAGES, distinct from the
+        // session's: the WebSocket ingress gates only on LOCAL at upgrade, so
+        // without this a DID whose SEND_MESSAGES was revoked could still post
+        // TSP frames over a socket. Mirrors the DIDComm direct-delivery branch.
+        //
+        // `local_direct_delivery_allowed` is the other gate `docs/acls.md` §6
+        // promises for this flow and TSP does not honour it either — that one is
+        // a policy change with much wider blast radius than this fix, and is
+        // tracked separately rather than smuggled in here.
+        let from_acls = authz::effective_acls(state, &digest(meta.sender.as_bytes())).await?;
+        if authz::require_capability(&from_acls, Capability::SendMessages).is_err() {
+            return Err(tsp_problem(
+                session,
+                44,
+                "authorization.send",
+                "Sender DID is not authorized to send messages through this mediator".to_string(),
+                StatusCode::FORBIDDEN,
+            ));
+        }
+
         return deliver_tsp_local(state, session, raw).await;
     }
 
@@ -1054,17 +1099,18 @@ fn check_session_sender_match(
     ))
 }
 
-/// Ensure a direct-delivery envelope's claimed sender matches the session DID.
+/// Ensure an opaque envelope's claimed sender matches the session DID.
 ///
-/// The mediator holds no key for a directly-delivered envelope, so `from_did`
-/// here is whatever the JWE `skid` header claims — unverified. It is also the
-/// value that feeds the recipient's access-list lookup, so on an authenticated
-/// session it has to be pinned to the DID that authenticated.
+/// The mediator holds no key for the envelope it is being handed, so the sender
+/// here is only a claim — the JWE `skid` header for DIDComm direct delivery, the
+/// cleartext CESR sender field for TSP. In both cases it is also the value that
+/// feeds the recipient's access-list lookup, so on an authenticated session it
+/// has to be pinned to the DID that authenticated.
 ///
 /// Only the caller can decide whether the session is one that can be matched
 /// against: an anonymous inter-mediator relay hop has no session DID, and is
 /// exempted at the call site rather than here.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 fn check_direct_delivery_session_match(
     session: &Session,
     claimed_sender: Option<&str>,

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_session_binding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_session_binding.rs
@@ -1,0 +1,213 @@
+//! End-to-end coverage for the sender-side gates on the TSP ingress path.
+//!
+//! A TSP envelope names its sender in the clear and the mediator does not
+//! decrypt it, so `meta.sender` is a *claim* — the exact position the DIDComm
+//! direct-delivery path was in before mediator 0.15.5, where an authenticated
+//! session could set the JWE `skid` to any DID and have the recipient's access
+//! list evaluated against it. `handle_inbound_tsp` was written after that fix
+//! and did not carry it: it never consulted the session at all.
+//!
+//! Reported as affinidi-tdk-rs#754, measured against a public deployment: a TSP
+//! frame sent on a socket authenticated as DID A, with envelope sender DID E,
+//! was forwarded normally.
+//!
+//! Each test asserts the recipient's mailbox as well as the send result, so
+//! "the mediator returned an error" is distinguished from "the mediator
+//! returned an error *and* stored nothing" — the DIDComm ACL tests make the
+//! same distinction for the same reason.
+#![cfg(feature = "tsp")]
+
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::{
+    AccessListModeType, TestEnvironment, TestMediator, TestUser, acl,
+};
+
+async fn inbox_len(env: &TestEnvironment, user: &TestUser) -> usize {
+    env.atm
+        .fetch_messages(&user.profile, &FetchOptions::default())
+        .await
+        .expect("fetch messages")
+        .success
+        .len()
+}
+
+/// The regression for #754: a frame whose envelope sender is not the session
+/// DID is refused.
+///
+/// Mallory packs the message — so it is a genuinely well-formed TSP envelope
+/// naming her as sender, not a hand-mangled one — and Alice hands it to the
+/// mediator over her own authenticated session via `send_raw`.
+#[tokio::test]
+async fn spoofed_envelope_sender_is_refused() {
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mallory = env.add_user("mallory").await.expect("add mallory");
+
+    let spoofed = env
+        .atm
+        .tsp()
+        .pack(&mallory.profile, &bob.did, b"sent as mallory")
+        .await
+        .expect("mallory packs a TSP message to bob");
+
+    let err = env
+        .atm
+        .tsp()
+        .send_raw(&alice.profile, &spoofed)
+        .await
+        .expect_err("a TSP envelope claiming another DID as sender must be refused")
+        .to_string();
+
+    assert!(
+        err.contains("session_mismatch"),
+        "expected a session-mismatch denial, got: {err}"
+    );
+    assert_eq!(
+        inbox_len(&env, &bob).await,
+        0,
+        "a refused TSP message must not be stored for the recipient"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// Control for the denial above: the same path, same fixture, sender matching
+/// the session. Without this the denial test would pass against a fixture that
+/// never manages to deliver anything at all.
+#[tokio::test]
+async fn envelope_sender_matching_the_session_is_accepted() {
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, b"sent as alice")
+        .await
+        .expect("a TSP message whose sender is the session DID must be accepted");
+
+    assert_eq!(
+        inbox_len(&env, &bob).await,
+        1,
+        "an accepted TSP message must reach the recipient's mailbox"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// What the gap actually cost: the claimed sender feeds the recipient's
+/// access-list lookup, so before the fix Alice could borrow an allow-listed
+/// VID to get past an allowlist that does not admit her.
+///
+/// Bob runs `ExplicitAllow` (allowlist) with Mallory on it and Alice not. The
+/// first assertion pins that the allowlist is load-bearing — Alice as herself
+/// is refused — and the second that she cannot buy her way past it by naming
+/// Mallory in the envelope.
+#[tokio::test]
+async fn spoofed_sender_cannot_pass_the_recipients_access_list() {
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mallory = env.add_user("mallory").await.expect("add mallory");
+
+    // Bob admits Mallory, then switches his inbox to allowlist mode. In that
+    // order: the trust-task reply is itself a delivery to Bob, so populating the
+    // list while he is still in denylist mode keeps the setup from tripping the
+    // gate it is setting up. The access list is stored separately from the ACL
+    // bitset, so the later `set_acl` leaves it intact.
+    env.atm
+        .profile_add(&bob.profile, true)
+        .await
+        .expect("enable websocket for bob so the trust-task reply arrives");
+    env.atm
+        .trust_tasks()
+        .access_list_update(&bob.profile, None, false, vec![mallory.did_hash()], vec![])
+        .await
+        .expect("bob allows mallory");
+
+    let mut bob_acls = acl::allow_all();
+    bob_acls
+        .set_access_list_mode(AccessListModeType::ExplicitAllow, true, true)
+        .expect("put bob's inbox in allowlist mode");
+    env.mediator
+        .set_acl(&bob.did, bob_acls)
+        .await
+        .expect("set bob's ACLs");
+
+    // The allowlist is real: Alice, sending honestly as herself, is refused.
+    let honest = env
+        .atm
+        .tsp()
+        .send(&alice.profile, &bob.did, b"alice, honestly")
+        .await
+        .expect_err("alice is not on bob's allowlist")
+        .to_string();
+    assert!(
+        honest.contains("access_list") || honest.contains("ACLs"),
+        "expected an access-list denial for the honest send, got: {honest}"
+    );
+
+    // And she cannot borrow Mallory's place on it.
+    let spoofed = env
+        .atm
+        .tsp()
+        .pack(&mallory.profile, &bob.did, b"alice, as mallory")
+        .await
+        .expect("pack a message naming mallory as sender");
+    let err = env
+        .atm
+        .tsp()
+        .send_raw(&alice.profile, &spoofed)
+        .await
+        .expect_err("borrowing an allow-listed sender VID must not pass the access list")
+        .to_string();
+    assert!(
+        err.contains("session_mismatch"),
+        "expected a session-mismatch denial, got: {err}"
+    );
+
+    assert_eq!(
+        inbox_len(&env, &bob).await,
+        0,
+        "neither send may reach bob's mailbox"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// The binding is governed by the same switch as the DIDComm one, so a
+/// deployment that has deliberately turned `force_session_did_match` off keeps
+/// the old behaviour rather than finding TSP newly restricted.
+#[tokio::test]
+async fn force_session_did_match_off_still_accepts_a_mismatched_sender() {
+    let mediator = TestMediator::builder()
+        .force_session_did_match(false)
+        .spawn()
+        .await
+        .expect("spawn mediator with session matching disabled");
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire the SDK to the mediator");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mallory = env.add_user("mallory").await.expect("add mallory");
+
+    let spoofed = env
+        .atm
+        .tsp()
+        .pack(&mallory.profile, &bob.did, b"sent as mallory")
+        .await
+        .expect("mallory packs a TSP message to bob");
+
+    env.atm
+        .tsp()
+        .send_raw(&alice.profile, &spoofed)
+        .await
+        .expect("with the check disabled the mismatched sender is still accepted");
+
+    assert_eq!(inbox_len(&env, &bob).await, 1, "the message is delivered");
+
+    env.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
Closes #754.

## What was reported

Measured against a public deployment: a TSP frame sent on a socket authenticated as DID **A**, carrying envelope sender DID **E** which never authenticated, is forwarded normally. The reporter asked whether that is a stable property or a future anti-spoofing target.

It is neither intended nor stable — it is a gap.

## Why it is a gap, not a posture

A TSP envelope names its sender in the clear and the mediator does not decrypt it, so `meta.sender` is a *claim*. `handle_inbound_tsp` never consulted the session at all: it passed that claim straight to `deliver_opaque`, which hashes it into the recipient's `delivery_decision` access-list lookup.

Three things say this was missed rather than decided:

1. **`docs/acls.md` §6 already promised the check.** The flow is headed *"Direct delivery (DIDComm and TSP)"* and lists `force_session_did_match` as a step. The contract was stated; only the implementation was missing.
2. **It is the same bug we already fixed once.** Mediator 0.15.5 (May 2026) fixed exactly this on the DIDComm path — *"an authenticated session could set `skid` to any allow-listed DID and bypass both checks"*. The TSP path was written after that fix and did not carry it.
3. **The function's own comment asserts the invariant it did not hold** — `"The mediator routes on the authenticated sender"`, where the value is unauthenticated.

No test pinned the old behaviour, so closing it breaks no pinned expectation.

## What it cost

The claimed sender feeds the recipient's access list, so a client could borrow an allow-listed VID and be admitted to an inbox that does not admit it. The recipient still fails to unpack end-to-end, so this is an access-list / flooding bypass rather than identity forgery — which is precisely what the 0.15.5 fix was about.

`spoofed_sender_cannot_pass_the_recipients_access_list` demonstrates it rather than asserting it: revert just the guard and that test fails **at the spoofed send succeeding**.

## The fix

- Bind the cleartext envelope sender to the session DID under the same `security.force_session_did_match` switch, reusing the existing `check_direct_delivery_session_match` predicate so both protocols return the same `authorization.did.session_mismatch` report.
- Checked on the **outer** envelope, before the receiver branch, so it covers relayed and nested submissions: a client must have authored the layer it hands over. Inner layers are exempt by construction — sealed to someone else.
- **Anonymous sessions exempt**, exactly as on the DIDComm side since 0.20.4 (#748). An inter-mediator relay hop is POSTed to `/inbound` with no `Authorization` header and lands on `ANON-INBOUND`, whose DID is empty. Without the exemption, cross-mediator TSP delivery stops entirely. Residual cost is the one already named for blind relay: on an anonymous hop the claimed sender stays unverified — inherent to relaying.
- Direct TSP delivery also now checks the sender's own `SEND_MESSAGES`. That is load-bearing on the **WebSocket** ingress in particular, which gates only on `LOCAL` at upgrade: a DID whose `SEND_MESSAGES` had been revoked could still post TSP frames over a socket.

## Deliberately not fixed here

TSP direct delivery still ignores `security.local_direct_delivery_allowed`, so a deployment that turned direct delivery off to force everything through a routing envelope still accepts direct TSP.

I implemented that gate, measured it, and backed it out: it fails **~20 existing tests across nine files**, all because the fixture defaults the flag off and the TSP tests were written against a path that ignored it. That is blast radius deserving its own change and changelog entry, not something to fold into a security fix where a reviewer cannot tell which test edits are incidental. `docs/acls.md` now names the deviation instead of implying it does not exist. Follow-up issue to come.

## Behaviour change (R3.6)

A client that deliberately sends under a VID other than the one it authenticated as is now refused with `e.p.authorization.did.session_mismatch`, unless the deployment sets `security.force_session_did_match = "false"`.

Deployments relying on the split between connection identity and egress identity — which is what #754 describes — should move to TSP **routed** mode, where the outer sender is the connection identity and the egress identity travels inside the sealed layer. That shape satisfies the binding by construction and is what survives this class of fix.

Mediator bumped to 0.20.7 with a changelog entry.

## Testing

- New `tsp_session_binding.rs` (4 tests): the regression, a matching-sender control, the access-list bypass demonstration, and one pinning that `force_session_did_match = false` still accepts a mismatched sender.
- Reverting only the guard fails exactly the two session-binding tests and nothing else.
- Full `affinidi-messaging-test-mediator --features tsp` suite green, cross-mediator forwarding included; `affinidi-messaging-mediator` unit tests green (239 + integration).
- `cargo fmt --check`, clippy `-D warnings` on `didcomm,tsp,memory-backend`, `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` all clean.

## Pre-merge checklist (vti-stack-development-guide)

- **R1.1** — unaffected; this path returns a problem report on refusal, never a silent `Ok`.
- **R3.6** — behavioural change to send semantics, called out above and in CHANGELOG; consuming repos need to know before upgrading.
- **R6.2 / R1.7** — untouched.
