### PR TITLE
docs(mediator): state the v2 addressing contract — DID-addressed, no keylist

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased (0.20.8) — state the v2 addressing contract: DID-addressed, no keylist
+
+Answers [#755]. A downstream transport binding measured that delivery to a
+`did:key` client works purely on the authenticated session DID, with no keylist
+update, and asked whether that is a contract or an accident.
+
+It is structural, and now it is written down.
+
+- **New `docs/mediation-and-routing.md`.** DIDComm v2 routing is DID-addressed:
+  a `routing/2.0` forward names its next hop as a DID, which hashes straight
+  into the recipient's account lookup. There is no verkey indirection for a
+  keylist to populate, so a v2 client registers nothing. The mediator maintains
+  the account itself — `resolve_next_account` creates one on first forward, and
+  authentication registers the DID too.
+- **The keylist that exists is v1-only, and the document says why.** A DIDComm
+  v1 (Aries RFC 0019) envelope carries no DID, so the recipient is identified by
+  verkey and the mediator must hold the verkey→account mapping; the keylist is
+  how a wallet populates it. It exists to manufacture a stable identifier for a
+  client that has none — which a v2 `did:key` client already has.
+- **The advertised protocol set is now a named constant**,
+  `messages::protocols::discover_features::ADVERTISED_PROTOCOLS`, which
+  `server.rs` builds its `DiscoverFeatures` state from. The list was previously
+  inline in a long startup function and could not be asserted on.
+- **`coordinate_mediation_is_not_advertised`** pins the absence, so implementing
+  v2 mediation becomes a deliberate act — amending a contract other people have
+  built on — rather than an incidental change that silently invalidates it.
+  `did_addressed_delivery_protocols_are_advertised` is its control: without it
+  the first test would pass just as happily against an empty list.
+
+The document is also explicit that "no keylist" is not "no requirements", since
+that is the part most likely to bite a client author. `mediator_acl_mode =
+"explicit_allow"`, the `LOCAL` / `RECEIVE_MESSAGES` / `RECEIVE_FORWARDED`
+capabilities, the recipient's access list and `local_direct_delivery_allowed`
+all gate reachability without any keylist being involved — and direct delivery
+to a DID that has never authenticated is refused (`direct_delivery.recipient.unknown`)
+where a forward to the same DID would auto-create the account.
+
+No behaviour change: documentation, one extracted constant, and three tests.
+
+[#755]: https://github.com/affinidi/affinidi-tdk-rs/issues/755
+
 ## Unreleased (0.20.7) — bind a TSP envelope's sender to the authenticated session
 
 **Security fix: the TSP ingress trusted the envelope's claimed sender.**

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.7"
+version = "0.20.8"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/README.md
+++ b/crates/messaging/affinidi-messaging-mediator/README.md
@@ -311,6 +311,9 @@ See:
 - [docs/memory-tuning.md](docs/memory-tuning.md) — what the mediator holds
   in memory, which knob to raise for throughput, and how the Fjall and Redis
   backends differ (they put their memory in different places).
+- [docs/mediation-and-routing.md](docs/mediation-and-routing.md) — the
+  addressing contract: DIDComm v2 is DID-addressed and needs no keylist, v1
+  is keylist-addressed and does, and what actually gates reachability.
 
 ### Re-running the wizard / tearing down
 

--- a/crates/messaging/affinidi-messaging-mediator/docs/mediation-and-routing.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/mediation-and-routing.md
@@ -1,0 +1,103 @@
+# Mediation and routing: how a recipient becomes reachable
+
+This document states the mediator's addressing contract, so client and
+transport-binding authors can build on it rather than infer it from
+observation.
+
+The short version: **DIDComm v2 is DID-addressed and has no keylist.** A v2
+client registers nothing before it can receive. DIDComm v1 does have a keylist,
+because a v1 envelope has no DID to address.
+
+---
+
+## 1. DIDComm v2 — DID-addressed, no keylist
+
+A `routing/2.0` forward names its next hop as a DID. The mediator hashes that
+DID and looks the recipient up by the hash; delivery decisions are made against
+the account it finds. There is no verkey, no routing key and no indirection of
+any kind between the DID on the envelope and the account that receives — so
+there is nothing a keylist could populate.
+
+This is why the advertised protocol set
+(`messages::protocols::discover_features::ADVERTISED_PROTOCOLS`) contains no
+`coordinate-mediation` entry:
+
+```
+https://didcomm.org/discover-features/2.0
+https://didcomm.org/routing/2.0
+https://didcomm.org/trust-ping/2.0
+https://didcomm.org/out-of-band/2.0
+https://didcomm.org/messagepickup/3.0
+https://affinidi.com/atm/1.0/authenticate
+https://didcomm.org/mediator/1.0/admin-management
+https://didcomm.org/mediator/1.0/account-management
+https://didcomm.org/mediator/1.0/acl-management
+https://didcomm.org/report-problem/2.0
+```
+
+The mediator maintains the account itself. `resolve_next_account` creates one on
+first forward to an unknown DID, using `global_acl_default`; authenticating also
+registers the DID. A client never has to ask.
+
+`did:key` clients are the common case and are not special: a `did:key` has no
+service endpoint, so it cannot be routed to from outside and instead collects
+mail from the mediator it authenticated with, over `messagepickup/3.0` or the
+WebSocket. That works on the authenticated session DID alone.
+
+### How to depend on this
+
+Assert on discover-features. If `https://didcomm.org/coordinate-mediation/*`
+ever appears in the advertised set, the assumption has changed and your check
+should fail loudly. On our side the same assertion runs as
+`coordinate_mediation_is_not_advertised`, so adding v2 mediation cannot happen
+by accident — it means amending this document too.
+
+---
+
+## 2. DIDComm v1 — keylist-addressed, because there is no DID
+
+A v1 (Aries RFC 0019) envelope carries no DID. The recipient is identified by
+**verkey**, so the mediator has to hold the verkey→account mapping itself, and
+`coordinate-mediation/1.0` keylist-update is how a wallet populates it. The
+account is keyed by the `did:key` derived from the client's authenticated
+verkey (`messages::v1_mediation`).
+
+So the keylist exists to *manufacture* a stable identifier for a client that
+does not have one. A v2 `did:key` client already holds what the keylist would
+have produced — which is the underlying reason it needs no keylist, and why
+that is unlikely to change.
+
+v1 support is compile-gated (`--features didcomm-v1`) and additive.
+
+---
+
+## 3. What *does* gate reachability
+
+"No keylist" is not "no requirements". None of the following involves a keylist,
+and all of them can make a v2 recipient unreachable:
+
+| Gate | Effect |
+|------|--------|
+| `mediator_acl_mode = "explicit_allow"` | Unknown DIDs are refused at the authentication challenge, and v1 mediation is denied. Such a deployment registers DIDs out of band, via admin `account_add`. |
+| Account existence, on **direct delivery** | A directly-delivered message to a DID with no account is refused: `direct_delivery.recipient.unknown` (error 72). Forwarding differs — it auto-creates the account. |
+| `LOCAL` | Required to complete the WebSocket upgrade and to use inbox fetch/list/delete. |
+| `RECEIVE_MESSAGES` | Required to accept direct delivery. |
+| `RECEIVE_FORWARDED` | Required to accept a forwarded message. |
+| Recipient's access list | Evaluated against the sender; see [`acls.md`](acls.md). |
+| `local_direct_delivery_allowed` | When false, direct delivery is refused and senders must use a routing envelope. |
+
+The asymmetry in row two is the one most likely to surprise: a recipient that
+has authenticated at least once is reachable both ways, but a recipient that
+never has can be reached by a *forward* and not by *direct delivery*.
+
+---
+
+## 4. Summary for binding authors
+
+- v2: DID-addressed. No keylist, no registration call. Reachability is governed
+  by ACLs and by deployment ACL mode, not by anything the client registers.
+- v1: keylist-addressed, and the keylist is load-bearing.
+- The falsifiable check is the discover-features advertisement, not this
+  document.
+
+Related: [`acls.md`](acls.md) for the capability and access-list model.

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/discover_features.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/discover_features.rs
@@ -121,3 +121,106 @@ pub(crate) fn process(
         forward_message: false,
     })
 }
+
+/// Every DIDComm **v2** protocol this mediator serves, as advertised over
+/// `discover-features/2.0`.
+///
+/// This is the mediator's public protocol contract, and deliberately the single
+/// place it is written down: `server` builds its `DiscoverFeatures` state from
+/// this list, so what a client discovers and what this constant says cannot
+/// drift apart.
+///
+/// # What is absent, and why it will not quietly appear
+///
+/// There is no `coordinate-mediation` entry, and the absence is structural
+/// rather than an oversight — see `docs/mediation-and-routing.md`. DIDComm v2
+/// routing is DID-addressed: a `routing/2.0` forward names its next hop as a
+/// DID, which hashes straight into the recipient's account lookup. There is no
+/// verkey indirection for a keylist to populate, so a v2 client has no keylist
+/// to register and never needed one.
+///
+/// The keylist that *does* exist here is DIDComm **v1** only
+/// ([`crate::messages::v1_mediation`]), because a v1 envelope carries no DID:
+/// the recipient is identified by verkey, so the mediator must hold the
+/// verkey→account mapping itself. That is exactly the mapping a v2 DID makes
+/// unnecessary.
+///
+/// External transport bindings rely on this (issue #755).
+/// `coordinate_mediation_is_not_advertised` below exists so that adding v2
+/// mediation is a deliberate act — amending a contract others have built on —
+/// rather than an incidental change that silently invalidates it.
+pub(crate) const ADVERTISED_PROTOCOLS: &[&str] = &[
+    "https://didcomm.org/discover-features/2.0",
+    "https://didcomm.org/routing/2.0",
+    "https://didcomm.org/trust-ping/2.0",
+    "https://didcomm.org/out-of-band/2.0",
+    "https://didcomm.org/messagepickup/3.0",
+    "https://affinidi.com/atm/1.0/authenticate",
+    "https://didcomm.org/mediator/1.0/admin-management",
+    "https://didcomm.org/mediator/1.0/account-management",
+    "https://didcomm.org/mediator/1.0/acl-management",
+    "https://didcomm.org/report-problem/2.0",
+];
+
+#[cfg(test)]
+mod advertised_protocol_tests {
+    use super::ADVERTISED_PROTOCOLS;
+
+    /// The contract answered in issue #755: DIDComm v2 on this mediator is
+    /// DID-addressed and has no keylist, so a v2 client — a `did:key` client in
+    /// particular — has nothing to register before it can receive.
+    ///
+    /// If v2 coordinate-mediation is ever implemented, this is where that
+    /// decision surfaces. Do not just delete it: the absence is documented in
+    /// `docs/mediation-and-routing.md` and depended on by external transport
+    /// bindings, so adding mediation means amending both.
+    #[test]
+    fn coordinate_mediation_is_not_advertised() {
+        let offending: Vec<_> = ADVERTISED_PROTOCOLS
+            .iter()
+            .filter(|p| {
+                let p = p.to_ascii_lowercase();
+                p.contains("coordinate-mediation") || p.contains("coordinatemediation")
+            })
+            .collect();
+
+        assert!(
+            offending.is_empty(),
+            "v2 coordinate-mediation is now advertised ({offending:?}), but \
+             docs/mediation-and-routing.md tells clients v2 needs no keylist. Amend the \
+             documented contract and notify the consumers relying on it (issue #755) \
+             before letting this land."
+        );
+    }
+
+    /// The other half of the contract: the protocols that make DID-addressed
+    /// delivery work are actually offered. Without this, the test above would
+    /// pass just as happily against an empty list.
+    #[test]
+    fn did_addressed_delivery_protocols_are_advertised() {
+        for required in [
+            "https://didcomm.org/routing/2.0",
+            "https://didcomm.org/messagepickup/3.0",
+            "https://didcomm.org/discover-features/2.0",
+        ] {
+            assert!(
+                ADVERTISED_PROTOCOLS.contains(&required),
+                "{required} must be advertised: it is how a v2 client is delivered to, and \
+                 collects its mail, without a keylist"
+            );
+        }
+    }
+
+    #[test]
+    fn advertised_protocols_have_no_duplicates() {
+        let mut sorted = ADVERTISED_PROTOCOLS.to_vec();
+        sorted.sort_unstable();
+        let before = sorted.len();
+        sorted.dedup();
+        assert_eq!(
+            before,
+            sorted.len(),
+            "duplicate entry in ADVERTISED_PROTOCOLS"
+        );
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/src/server.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/server.rs
@@ -601,19 +601,15 @@ pub async fn serve_internal(
     }
 
     #[cfg(feature = "didcomm")]
+    // The advertised set is the mediator's public protocol contract and lives in
+    // one place, next to the tests that pin it. Notably it carries no
+    // coordinate-mediation entry: v2 routing is DID-addressed and needs no
+    // keylist (issue #755, `docs/mediation-and-routing.md`).
     let discover_features = Arc::new(DiscoverFeatures {
-        protocols: vec![
-            "https://didcomm.org/discover-features/2.0".to_string(),
-            "https://didcomm.org/routing/2.0".to_string(),
-            "https://didcomm.org/trust-ping/2.0".to_string(),
-            "https://didcomm.org/out-of-band/2.0".to_string(),
-            "https://didcomm.org/messagepickup/3.0".to_string(),
-            "https://affinidi.com/atm/1.0/authenticate".to_string(),
-            "https://didcomm.org/mediator/1.0/admin-management".to_string(),
-            "https://didcomm.org/mediator/1.0/account-management".to_string(),
-            "https://didcomm.org/mediator/1.0/acl-management".to_string(),
-            "https://didcomm.org/report-problem/2.0".to_string(),
-        ],
+        protocols: crate::messages::protocols::discover_features::ADVERTISED_PROTOCOLS
+            .iter()
+            .map(|p| p.to_string())
+            .collect(),
         ..Default::default()
     });
 


### PR DESCRIPTION
Closes #755.

## What was asked

A downstream transport binding measured that delivery to a `did:key` client works purely on the authenticated session DID, with no keylist update. They documented it as a no-op and asked whether that is deliberate — *"we'd like that to be a contract, not an accident."*

It is deliberate, and it is structural. This PR writes it down and pins it.

## Why it is structural

DIDComm v2 routing is **DID-addressed**. A `routing/2.0` forward names its next hop as a DID, which is hashed straight into the recipient's account lookup. No verkey, no routing key, no indirection sits between the DID on the envelope and the account that receives it — so there is nothing a keylist could populate. It isn't that the v2 keylist is a no-op; there is no v2 keylist, and `coordinate-mediation` is neither implemented nor advertised for v2.

**The keylist that does exist is v1-only, and the reason is the mirror image.** A DIDComm v1 (Aries RFC 0019) envelope carries no DID: the recipient is identified by verkey, so the mediator must hold the verkey→account mapping itself, and `coordinate-mediation/1.0` keylist-update is how a wallet populates it. The v1 account is keyed by the `did:key` *derived from* the client's authenticated verkey.

So the v1 keylist exists to manufacture a stable identifier for a client that doesn't have one — and a v2 `did:key` client already holds exactly what it would have produced. That is the underlying reason this is unlikely ever to change, and it's the part the reporter had no way to infer from outside.

## What makes it a contract rather than a comment

- **`docs/mediation-and-routing.md`** (new, linked from the README) — the v2 and v1 addressing models, and what actually gates reachability.
- **`ADVERTISED_PROTOCOLS`** — the advertised set is lifted out of the middle of a long startup function into a named constant that `server.rs` builds its `DiscoverFeatures` state from, so what a client discovers and what the contract says cannot drift apart. The list is byte-identical, just moved.
- **`coordinate_mediation_is_not_advertised`** — pins the absence, so implementing v2 mediation becomes a deliberate act of amending a contract others have built on. `did_addressed_delivery_protocols_are_advertised` is its control: without it, the first test would pass just as happily against an empty list.

The suggested check on their side is the same one: assert on discover-features. If `https://didcomm.org/coordinate-mediation/*` ever appears, the assumption has changed — a falsifiable check rather than a documented absence.

## The caveat the doc is explicit about

"No keylist" is not "no requirements", and that's the part most likely to bite a client author. `mediator_acl_mode = "explicit_allow"`, the `LOCAL` / `RECEIVE_MESSAGES` / `RECEIVE_FORWARDED` capabilities, the recipient's access list and `local_direct_delivery_allowed` all gate reachability without any keylist involved.

The sharpest edge is named explicitly: **direct delivery to a DID that has never authenticated is refused** (`direct_delivery.recipient.unknown`, error 72), where a *forward* to that same DID auto-creates the account via `resolve_next_account`. The reporter's measurement holds for their case — a client that has authenticated — but does not generalise to a recipient that has never come online, and a binding that assumed otherwise would be wrong.

## Testing

- 3 new unit tests; **242** mediator unit tests green (was 239).
- All **29** e2e suites in `affinidi-messaging-test-mediator --features tsp` green — `server.rs` startup is touched, so the full suite was run rather than a subset.
- `cargo fmt --check`, clippy `-D warnings` on `didcomm,tsp,memory-backend`, `check-version-bumps.sh`, `check-changelogs.sh` clean.

No behaviour change. Mediator bumped to 0.20.8.
