### PR TITLE
fix(mediator): TSP direct delivery honours local_direct_delivery_allowed

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased (0.20.9) — TSP direct delivery honours `local_direct_delivery_allowed`
+
+Closes [#757], the gap deliberately left open by 0.20.7 and independently
+confirmed by the security review on that PR.
+
+`security.local_direct_delivery_allowed` exists so an operator can refuse
+unwrapped direct delivery and force everything through a routing envelope, where
+the relay layer can audit it, scrub metadata, or inspect it. The DIDComm path
+enforced it; `handle_inbound_tsp` did not, so any TSP-capable sender walked
+straight past that control and the operator got no such enforcement for TSP
+traffic.
+
+- The `receiver != mediator` branch of `handle_inbound_tsp` — the genuine
+  direct-delivery case — now returns the same `direct_delivery.denied` (code 71)
+  report the DIDComm branch does when the switch is off.
+- **No TSP analogue of `local_direct_delivery_allow_anon`, deliberately.** That
+  hatch exists because a DIDComm envelope can be anon-packed with no sender at
+  all; a TSP envelope always names its sender in the clear, so there is no
+  anonymous TSP case to admit. `docs/acls.md` now records this as the single
+  remaining asymmetry between the two protocols, in place of the deviation note
+  0.20.7 added.
+- Relay and nested submissions are unaffected: they are addressed to the
+  mediator, not to a local account, so they never reach this branch.
+
+**Behaviour change.** A deployment running with direct delivery disabled — the
+code default when the setting is absent, though the shipped `conf/mediator.toml`
+sets `"true"` — will now refuse direct TSP delivery that it previously accepted.
+That is the point of the fix, but it is a break for anyone who had (knowingly or
+not) been relying on TSP bypassing the switch (R3.6).
+
+**Test-harness change (`affinidi-messaging-test-mediator` 0.4.4).** The fixture
+defaults the flag off, and 23 TSP tests across nine files were written against a
+path that ignored it. Rather than 23 hand-rolled builders, the harness gained
+`TestEnvironment::spawn_with_direct_delivery()`, and the two TSP-specific spawns
+(`spawn_with_tsp_auth`, `spawn_with_tsp_policy`) now enable direct delivery
+themselves — every caller of those needs it, since protocol selection and pure-TSP
+auth are only observable once a message is accepted. Tests whose subject *is* the
+policy state it at the call site instead.
+
+[#757]: https://github.com/affinidi/affinidi-tdk-rs/issues/757
+
 ## Unreleased (0.20.8) — state the v2 addressing contract: DID-addressed, no keylist
 
 Answers [#755]. A downstream transport binding measured that delivery to a

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.8"
+version = "0.20.9"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/docs/acls.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/acls.md
@@ -237,9 +237,11 @@ authenticated. It is skipped for unauthenticated sessions, because an
 inter-mediator relay hop arrives anonymously and has no session DID to match
 against; on such a hop the claimed sender stays unverified.
 
-One deviation remains: **TSP does not yet honour `local_direct_delivery_allowed`**
-— a deployment that has turned direct delivery off still accepts direct TSP
-delivery. Every other step above applies to both protocols.
+Every step above applies to both protocols. The one asymmetry is
+`local_direct_delivery_allow_anon`, which has no TSP analogue: it exists because
+a DIDComm envelope can be anon-packed with no sender at all, whereas a TSP
+envelope always names its sender in the clear, so there is no anonymous TSP case
+to admit or refuse.
 
 ### Forwarding
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -176,15 +176,35 @@ pub(crate) async fn handle_inbound_tsp(
     //   * receiver == this mediator → we hold the key, so unpack to learn the kind
     //     and act as the relay hop (Routed) / metadata-privacy intermediary (Nested).
     if meta.receiver != state.config.mediator_did {
-        // Direct delivery. The sender's own SEND_MESSAGES, distinct from the
-        // session's: the WebSocket ingress gates only on LOCAL at upgrade, so
-        // without this a DID whose SEND_MESSAGES was revoked could still post
-        // TSP frames over a socket. Mirrors the DIDComm direct-delivery branch.
+        // Direct delivery, and subject to the same two gates the DIDComm
+        // direct-delivery branch applies. `docs/acls.md` §6 documents this flow
+        // as "Direct delivery (DIDComm and TSP)" and has always promised both.
         //
-        // `local_direct_delivery_allowed` is the other gate `docs/acls.md` §6
-        // promises for this flow and TSP does not honour it either — that one is
-        // a policy change with much wider blast radius than this fix, and is
-        // tracked separately rather than smuggled in here.
+        // The policy gate first: an operator who turns direct delivery off wants
+        // everything to arrive inside a routing envelope, so the relay layer can
+        // audit, scrub metadata, or inspect it. TSP ignoring this switch meant
+        // any TSP-capable sender walked straight past that control.
+        //
+        // Note there is no TSP analogue of `local_direct_delivery_allow_anon`:
+        // that hatch exists because a DIDComm envelope can be anon-packed with no
+        // sender at all, whereas a TSP envelope always names its sender in the
+        // clear. There is no anonymous TSP case to admit.
+        if !state.config.security.local_direct_delivery_allowed {
+            return Err(tsp_problem(
+                session,
+                71,
+                "direct_delivery.denied",
+                "Mediator is not accepting direct delivery of TSP messages. They must be \
+                 relayed through a routing envelope"
+                    .to_string(),
+                StatusCode::FORBIDDEN,
+            ));
+        }
+
+        // Then the sender's own SEND_MESSAGES, distinct from the session's: the
+        // WebSocket ingress gates only on LOCAL at upgrade, so without this a DID
+        // whose SEND_MESSAGES was revoked could still post TSP frames over a
+        // socket.
         let from_acls = authz::effective_acls(state, &digest(meta.sender.as_bytes())).await?;
         if authz::require_capability(&from_acls, Capability::SendMessages).is_err() {
             return Err(tsp_problem(

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased (0.4.4) — a fixture that can permit direct delivery
+
+Support for mediator 0.20.9, which makes TSP direct delivery honour
+`security.local_direct_delivery_allowed` (issue #757). The fixture defaults that
+flag **off** — matching the code default for an unset setting rather than the
+shipped `conf/mediator.toml`, which sets `"true"` — so 23 TSP tests that had been
+written against a path which ignored it now need it on.
+
+- **`TestEnvironment::spawn_with_direct_delivery()`** — the default mediator with
+  `local_direct_delivery_allowed = true`. Use it whenever the subject of a test
+  is what happens *after* a message is accepted (pickup, streaming, capability
+  discovery); without it such a test fails on the policy gate before reaching
+  what it is actually asserting.
+- **`spawn_with_tsp_auth` and `spawn_with_tsp_policy` now enable direct delivery
+  themselves.** Both exist to round-trip a TSP Direct message — pure-TSP
+  authentication and `send_to` protocol selection are only observable once a
+  message is accepted — so every caller needed it and none of them was testing
+  the policy.
+
+`TestEnvironment::spawn()` is unchanged and still defaults the flag off, which is
+what lets a test pin the refusal.
+
 ## Unreleased (0.4.3) — a test user that is mediated the way production is
 
 - Requires `affinidi-tdk` 0.11 (was 0.10), which re-exports `affinidi-mdoc`

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.3"
+version = "0.4.4"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/environment.rs
@@ -123,6 +123,25 @@ impl TestEnvironment {
         Self::new(TestMediator::spawn().await?).await
     }
 
+    /// Spawn the default mediator with `local_direct_delivery_allowed = true`.
+    ///
+    /// The fixture default is `false`, matching the code default for an unset
+    /// setting rather than the shipped `conf/mediator.toml` (which sets
+    /// `"true"`). A test whose subject is *what happens after* a message is
+    /// accepted — pickup, streaming, capability discovery — has to enable it, or
+    /// it fails on the policy gate before reaching the thing under test.
+    ///
+    /// Prefer this over building a mediator by hand for that case: it states the
+    /// requirement once, and keeps "this test needs direct delivery" visible at
+    /// the call site rather than buried in a builder chain.
+    pub async fn spawn_with_direct_delivery() -> Result<Self, TestEnvironmentError> {
+        let mediator = TestMediator::builder()
+            .local_direct_delivery(true, false)
+            .spawn()
+            .await?;
+        Self::new(mediator).await
+    }
+
     /// Spawn the default mediator (with the `tsp` feature) and wire up
     /// the SDK to authenticate every profile over **pure TSP** instead
     /// of the built-in DIDComm flow.
@@ -145,7 +164,13 @@ impl TestEnvironment {
         use affinidi_secrets_resolver::ThreadedSecretsResolver;
         use affinidi_tdk::did_authentication::CustomAuthHandlers;
 
-        let mediator = TestMediator::spawn().await?;
+        // Direct delivery on: this helper exists to round-trip a TSP Direct
+        // message, which the `local_direct_delivery_allowed` gate would
+        // otherwise refuse before the auth path under test is reached.
+        let mediator = TestMediator::builder()
+            .local_direct_delivery(true, false)
+            .spawn()
+            .await?;
 
         // Build the shared resolver exactly as `TDKSharedState::new`
         // does when the config doesn't supply one. We need a handle to
@@ -189,7 +214,12 @@ impl TestEnvironment {
     pub async fn spawn_with_tsp_policy(
         policy: affinidi_messaging_sdk::TspPolicy,
     ) -> Result<Self, TestEnvironmentError> {
-        let mediator = TestMediator::spawn().await?;
+        // Direct delivery on, for the same reason as `spawn_with_tsp_auth`:
+        // protocol selection is only observable once a message is accepted.
+        let mediator = TestMediator::builder()
+            .local_direct_delivery(true, false)
+            .spawn()
+            .await?;
         let tdk_config =
             TDKConfig::headless().map_err(|e| TestEnvironmentError::Sdk(e.to_string()))?;
         let atm_config = ATMConfig::builder()

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/receive_messages_acl.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/receive_messages_acl.rs
@@ -221,7 +221,7 @@ mod tsp {
     #[tokio::test]
     async fn tsp_delivery_is_refused_when_recipient_lacks_receive_messages() {
         init_tracing();
-        let env = TestEnvironment::spawn().await.expect("spawn environment");
+        let env = spawn_direct_delivery_env().await;
         let alice = env.add_user("alice").await.expect("add alice");
         let bob = env.add_user("bob").await.expect("add bob");
 
@@ -260,7 +260,7 @@ mod tsp {
     #[tokio::test]
     async fn tsp_delivery_succeeds_when_recipient_has_receive_messages() {
         init_tracing();
-        let env = TestEnvironment::spawn().await.expect("spawn environment");
+        let env = spawn_direct_delivery_env().await;
         let alice = env.add_user("alice").await.expect("add alice");
         let bob = env.add_user("bob").await.expect("add bob");
 

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_capability.rs
@@ -104,7 +104,7 @@ async fn observed_inbound_tsp_upgrades_send_to() {
 /// inbound TSP message writes nothing, so behaviour is unchanged.
 #[tokio::test]
 async fn observed_inbound_is_inert_under_off_policy() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn default (Off) env");
     let alice = env.add_user("alice").await.expect("add alice");

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_delivery.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn tsp_direct_message_round_trips_through_the_mediator() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -79,7 +79,7 @@ async fn tsp_direct_message_round_trips_through_the_mediator() {
 /// own TSP identity → unpack the layer sealed to it → `next_hop` → deliver.
 #[tokio::test]
 async fn tsp_routed_message_relays_through_the_mediator() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -134,7 +134,7 @@ async fn tsp_routed_message_relays_through_the_mediator() {
 /// → unpack the layer sealed to it → route the inner by its own envelope → deliver.
 #[tokio::test]
 async fn tsp_nested_message_relays_through_the_mediator() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -191,7 +191,7 @@ async fn tsp_nested_message_relays_through_the_mediator() {
 /// coverage (Direct / Routed / Nested / Control).
 #[tokio::test]
 async fn tsp_control_message_relays_through_the_mediator() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -248,7 +248,7 @@ async fn tsp_control_message_relays_through_the_mediator() {
 /// protocols by forwarding on the route, blind to the inner's protocol.
 #[tokio::test]
 async fn tsp_routed_bridges_a_didcomm_message_to_the_recipient() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -335,7 +335,7 @@ async fn tsp_routed_bridges_a_didcomm_message_to_the_recipient() {
 /// resolution + the remote-forward enqueue path.
 #[tokio::test]
 async fn tsp_routed_forwards_to_a_remote_recipients_mediator() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_discover_capability.rs
@@ -169,7 +169,7 @@ async fn disclosure_without_tsp_uri_stays_didcomm() {
 /// consuming a disclosure that lists it is inert — capability tracking stays off.
 #[tokio::test]
 async fn discovery_is_inert_under_off_policy() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn default (Off) env");
     let alice = env.add_user("alice").await.expect("add alice");

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_mediated_recipient.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_mediated_recipient.rs
@@ -59,6 +59,10 @@ async fn tsp_forward_follows_a_recipients_mediator_did() {
 
     let topology = TestTopology::builder()
         .mediators(2)
+        // The last hop is a direct delivery into Bob's mailbox, so both
+        // mediators need `local_direct_delivery_allowed`; the fixture defaults
+        // it off.
+        .configure_each(|b| b.local_direct_delivery(true, false))
         .spawn()
         .await
         .expect("spawn two-mediator topology");

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_pickup_socket.rs
@@ -25,7 +25,7 @@ use affinidi_messaging_test_mediator::TestEnvironment;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn tsp_frame_arriving_between_polls_is_not_dropped() {
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -109,7 +109,7 @@ async fn tsp_frame_arriving_between_polls_is_not_dropped() {
 async fn a_slow_consumer_does_not_lose_packed_frames() {
     const FRAMES: usize = 130;
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_session_binding.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_session_binding.rs
@@ -11,6 +11,17 @@
 //! frame sent on a socket authenticated as DID A, with envelope sender DID E,
 //! was forwarded normally.
 //!
+//! The file also covers the *policy* gate on the same branch (#757): TSP direct
+//! delivery ignored `security.local_direct_delivery_allowed`, so an operator who
+//! had turned direct delivery off — to force everything through a routing
+//! envelope the relay layer can audit — got no such enforcement for TSP.
+//!
+//! Note which fixture each test uses, because it is load-bearing.
+//! `spawn_with_direct_delivery` is for tests whose subject is the *sender*
+//! gates; plain `spawn()` leaves the policy off, which is how
+//! `direct_delivery_disabled_refuses_tsp_direct_delivery` pins the refusal and,
+//! incidentally, that the fixture default is still off.
+//!
 //! Each test asserts the recipient's mailbox as well as the send result, so
 //! "the mediator returned an error" is distinguished from "the mediator
 //! returned an error *and* stored nothing" — the DIDComm ACL tests make the
@@ -39,7 +50,9 @@ async fn inbox_len(env: &TestEnvironment, user: &TestUser) -> usize {
 /// mediator over her own authenticated session via `send_raw`.
 #[tokio::test]
 async fn spoofed_envelope_sender_is_refused() {
-    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let env = TestEnvironment::spawn_with_direct_delivery()
+        .await
+        .expect("spawn environment");
     let alice = env.add_user("alice").await.expect("add alice");
     let bob = env.add_user("bob").await.expect("add bob");
     let mallory = env.add_user("mallory").await.expect("add mallory");
@@ -77,7 +90,9 @@ async fn spoofed_envelope_sender_is_refused() {
 /// never manages to deliver anything at all.
 #[tokio::test]
 async fn envelope_sender_matching_the_session_is_accepted() {
-    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let env = TestEnvironment::spawn_with_direct_delivery()
+        .await
+        .expect("spawn environment");
     let alice = env.add_user("alice").await.expect("add alice");
     let bob = env.add_user("bob").await.expect("add bob");
 
@@ -106,7 +121,9 @@ async fn envelope_sender_matching_the_session_is_accepted() {
 /// Mallory in the envelope.
 #[tokio::test]
 async fn spoofed_sender_cannot_pass_the_recipients_access_list() {
-    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let env = TestEnvironment::spawn_with_direct_delivery()
+        .await
+        .expect("spawn environment");
     let alice = env.add_user("alice").await.expect("add alice");
     let bob = env.add_user("bob").await.expect("add bob");
     let mallory = env.add_user("mallory").await.expect("add mallory");
@@ -183,6 +200,7 @@ async fn spoofed_sender_cannot_pass_the_recipients_access_list() {
 async fn force_session_did_match_off_still_accepts_a_mismatched_sender() {
     let mediator = TestMediator::builder()
         .force_session_did_match(false)
+        .local_direct_delivery(true, false)
         .spawn()
         .await
         .expect("spawn mediator with session matching disabled");
@@ -208,6 +226,66 @@ async fn force_session_did_match_off_still_accepts_a_mismatched_sender() {
         .expect("with the check disabled the mismatched sender is still accepted");
 
     assert_eq!(inbox_len(&env, &bob).await, 1, "the message is delivered");
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// The gate closed for #757: TSP direct delivery is subject to
+/// `local_direct_delivery_allowed`, which it previously ignored entirely.
+///
+/// An operator turns direct delivery off so everything arrives inside a routing
+/// envelope, where the relay layer can audit or scrub it. Before this, any
+/// TSP-capable sender walked straight past that control while the DIDComm path
+/// honoured it.
+///
+/// This uses the fixture default (`false`) rather than configuring it, so it
+/// also pins that the default is still off — the reason every other test in this
+/// file has to opt in.
+#[tokio::test]
+async fn direct_delivery_disabled_refuses_tsp_direct_delivery() {
+    let env = TestEnvironment::spawn().await.expect("spawn environment");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    let err = env
+        .atm
+        .tsp()
+        .send(&alice.profile, &bob.did, b"direct delivery probe")
+        .await
+        .expect_err("direct TSP delivery must be refused when the policy forbids it")
+        .to_string();
+
+    assert!(
+        err.contains("direct_delivery.denied") || err.contains("not accepting direct delivery"),
+        "expected a direct-delivery policy denial, got: {err}"
+    );
+    assert_eq!(inbox_len(&env, &bob).await, 0, "nothing is stored");
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// The control: the same send, on a mediator that permits direct delivery.
+/// Without it the denial above would pass against any breakage that stops TSP
+/// delivery working at all.
+#[tokio::test]
+async fn direct_delivery_enabled_accepts_tsp_direct_delivery() {
+    let env = TestEnvironment::spawn_with_direct_delivery()
+        .await
+        .expect("spawn environment");
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+
+    env.atm
+        .tsp()
+        .send(&alice.profile, &bob.did, b"direct delivery probe")
+        .await
+        .expect("direct TSP delivery must be accepted when the policy allows it");
+
+    assert_eq!(
+        inbox_len(&env, &bob).await,
+        1,
+        "the message reaches the mailbox"
+    );
 
     env.shutdown().await.expect("shutdown");
 }

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_websocket.rs
@@ -61,7 +61,7 @@ async fn token_and_ws_uri(env: &TestEnvironment, user: &TestUser) -> (String, Ur
 async fn tsp_websocket_flushes_and_deletes_queued_message() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -162,7 +162,7 @@ async fn tsp_websocket_flushes_and_deletes_queued_message() {
 async fn tsp_websocket_sdk_consumer_flushes_and_deletes() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -236,7 +236,7 @@ async fn tsp_websocket_sdk_consumer_flushes_and_deletes() {
 async fn tsp_websocket_delivers_messages_that_arrive_after_connect() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -327,7 +327,7 @@ async fn wait_for_empty_inbox(env: &TestEnvironment, user: &TestUser) -> bool {
 async fn tsp_ack_mode_keeps_the_message_until_the_client_acks() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -398,7 +398,7 @@ async fn tsp_ack_mode_keeps_the_message_until_the_client_acks() {
 async fn an_unacked_tsp_message_is_redelivered_on_reconnect() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -472,7 +472,7 @@ async fn an_unacked_tsp_message_is_redelivered_on_reconnect() {
 async fn an_unacked_message_is_not_resent_within_the_same_connection() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
 
@@ -540,7 +540,7 @@ async fn an_unacked_message_is_not_resent_within_the_same_connection() {
 async fn tsp_ack_is_selected_even_though_the_client_lists_it_second() {
     init_tracing();
 
-    let env = TestEnvironment::spawn()
+    let env = TestEnvironment::spawn_with_direct_delivery()
         .await
         .expect("spawn test environment");
     let bob = env.add_user("bob").await.expect("add bob");


### PR DESCRIPTION
Closes #757 — the gap #756 deliberately left open, and which the AgenticSec review on that PR independently confirmed (alert 68, CWE-862/284).

## The gap

`security.local_direct_delivery_allowed` exists so an operator can refuse unwrapped direct delivery and force everything through a routing envelope, where the relay layer can audit it, scrub metadata, or inspect it. The DIDComm path enforced it. `handle_inbound_tsp` did not.

So a deployment that turned direct delivery off got that control for its DIDComm traffic and, silently, not for its TSP traffic — any TSP-capable sender walked straight past it. `docs/acls.md` §6 has documented the flow as *"Direct delivery (DIDComm and TSP)"* with this gate listed, the whole time.

## The fix

The `receiver != mediator` branch of `handle_inbound_tsp` — the genuine direct-delivery case — now returns the same `direct_delivery.denied` (code 71) report the DIDComm branch does. Relay and nested submissions are unaffected: they're addressed to the mediator, not a local account, so they never reach this branch.

**No TSP analogue of `local_direct_delivery_allow_anon`, deliberately.** That hatch exists because a DIDComm envelope can be anon-packed with no sender at all; a TSP envelope always names its sender in the clear, so there is no anonymous TSP case to admit. `docs/acls.md` now records that as the single remaining asymmetry between the two protocols, replacing the deviation note #756 added.

## The test migration, and one rejected shortcut

The fixture defaults the flag off, and 23 TSP tests across nine files were written against a path that ignored it — so adding the gate turns all 23 red at once. That is exactly why this was split out of #756 rather than ridden along with it.

Rather than 23 hand-rolled builders, the harness gained `TestEnvironment::spawn_with_direct_delivery()`, and the two TSP-specific spawns now enable direct delivery themselves. `spawn_with_tsp_auth` exists to round-trip a TSP Direct message and `spawn_with_tsp_policy` to observe `send_to` protocol selection — neither is observable until a message is accepted, so every caller needed it and none was testing the policy.

**I considered flipping the fixture default** to match the shipped `conf/mediator.toml` (which sets `"true"`), which would have touched no tests at all. Rejected: it would silently change the path DIDComm tests take too, and a test that starts passing for a *different reason* is invisible — where 23 red tests are not. `TestEnvironment::spawn()` is unchanged and still defaults the flag off, which is what lets the new test pin the refusal.

## Behaviour change (R3.6)

A deployment running with direct delivery disabled — the code default when the setting is absent, though the shipped config sets `"true"` — will now refuse direct TSP delivery it previously accepted. That is the point of the fix, but it is a break for anyone who had been relying, knowingly or not, on TSP bypassing the switch.

## Testing

- `direct_delivery_disabled_refuses_tsp_direct_delivery` uses the fixture default, so it pins both the refusal and that the default is still off. `direct_delivery_enabled_accepts_tsp_direct_delivery` is its control — without it the denial would pass against any breakage that stopped TSP delivery working at all.
- Reverting just the gate fails **exactly that one test and nothing else**.
- 242 mediator unit tests green; all 29 e2e suites green.
- `cargo fmt --check`, clippy `-D warnings` on both crates, `check-version-bumps.sh`, `check-changelogs.sh` clean.

Mediator 0.20.9, test-mediator 0.4.4.
