### PR TITLE
fix(deps): retire did:cheqd resolution, clearing eight advisories

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -54,7 +54,13 @@ jobs:
       # is unmaintained and its repo was archived 2026-05-03. Clears together with
       # RUSTSEC-2026-0258 when did-resolver-cheqd moves off ssi-dids-core 0.1
       # (cheqd/did-resolver-rs#3).
-      auditIgnore: "RUSTSEC-2022-0040,RUSTSEC-2023-0071,RUSTSEC-2024-0373,RUSTSEC-2026-0258,RUSTSEC-2023-0126"
+      # Only quinn-proto remains. The other four entries were retired with
+      # did:cheqd in cache-sdk 0.8.36: RUSTSEC-2026-0258 (h2 DoS) and
+      # RUSTSEC-2023-0126 (im) came through `did-resolver-cheqd`, and
+      # owning_ref / rsa left the graph with it. h2 now resolves at 0.4.19,
+      # above the >=0.4.16 fix, so that DoS is fixed rather than suppressed.
+      # Anything re-entering the graph should fail the build, not be inherited.
+      auditIgnore: "RUSTSEC-2024-0373"
       ubuntu-rust-deps: "libdbus-1-dev libssl-dev libchafa-dev"
       coverage: 0
       useRedis: true

--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Affinidi DID Resolver Cache SDK
 
+## Unreleased (0.8.36) — retire did:cheqd resolution, clearing eight advisories
+
+Closes [#760]. `did:cheqd` still **parses**; this SDK no longer **resolves** it.
+
+`did-resolver-cheqd` was an optional dependency behind the opt-in `did-cheqd`
+feature — off by default, enabled by nothing in this workspace, and compiled by
+no build. It still put eight advisories into `Cargo.lock`, because `cargo audit`
+reads the lockfile rather than the build graph:
+
+| Advisory | Crate | Reached via |
+|----------|-------|-------------|
+| RUSTSEC-2026-0258 (**vulnerability**, h2 DoS) | `h2 0.3.27` | `ssi-dids-core 0.1.3` → `reqwest 0.11` → `hyper 0.14` |
+| RUSTSEC-2025-0134 | `rustls-pemfile 1.0.4` / `2.2.0` | `reqwest 0.11`, and `tonic 0.12.3` |
+| RUSTSEC-2026-0248, RUSTSEC-2023-0126 | `im 15.1.0` | `linked-data 0.1.2` → `json-ld 0.21` |
+| RUSTSEC-2026-0251, RUSTSEC-2026-0255 | `sized-chunks 0.6.5` | `im` |
+| RUSTSEC-2026-0247 | `bitmaps 2.1.0` | `im` |
+| RUSTSEC-2026-0215 | `smallstr 0.3.1` | `json-syntax` |
+| RUSTSEC-2024-0370 | `proc-macro-error 1.0.4` | `linked-data-derive` |
+
+The upstream crate publishes **no source repository**, has a single release from
+2025, and pins `ssi-dids-core ^0.1` — so there was no version to move to and no
+repository to fork. It used ssi only as a type vocabulary; both call sites here
+serialised its document straight back out to JSON.
+
+**Result:** every one of the eight is gone. `h2` now resolves at 0.4.19, above
+the `>=0.4.16` fix, so the DoS is *fixed* rather than suppressed — its
+`auditIgnore` entry has been removed from CI along with three others that went
+with it. `cargo audit` drops from 1 vulnerability + 12 warnings to 0 + 1, and the
+resolved graph from 1064 crates to 942. The `tonic 0.12` / rustls `ring` conflict
+that made `did-cheqd` awkward to enable is gone with it.
+
+**Nothing was removed from the public API.** The `did-cheqd` feature remains
+(now empty), `CheqdResolver` remains and declines with an explanatory
+`ResolutionFailed`, and `DIDMethod::Cheqd` in `affinidi-did-common` is untouched.
+Code that named any of them still compiles, which is why this ships as a patch:
+under ADR 0003 a true minor would break the external `[patch.crates-io]`
+redirects (`vta-sdk 0.32.3` pins `^0.8`) and require sequencing releases in
+another repository first. Verified with `check-workspace-duplicates.sh`.
+
+To resolve `did:cheqd`, append your own resolver — the chain is a public
+extension point for exactly this:
+
+```rust,ignore
+client.append_resolver(MethodName::Cheqd, Box::new(MyCheqdResolver));
+```
+
+[#760]: https://github.com/affinidi/affinidi-tdk-rs/issues/760
+
 ## 0.8.35
 
 ### Changed

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.35"
+version = "0.8.36"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -30,22 +30,19 @@ network = [
   "tokio/net",
   "tokio/io-util",
 ]
-# `did-cheqd` is intentionally NOT part of `did-methods` (and so not in
-# `default`): it pulls `did-resolver-cheqd`, whose `tonic 0.12` dependency
-# hardcodes the rustls `ring` backend on `tokio-rustls`/`rustls 0.23`. With
-# `network` (which uses `aws_lc_rs`) or any downstream that selects `aws_lc_rs`
-# (kube/reqwest/jsonwebtoken), compiling both backends makes rustls unable to
-# auto-select one, panicking with "no process-level CryptoProvider available"
-# at the first TLS call. Enable `did-cheqd` explicitly only when you accept the
-# `ring` backend and install a CryptoProvider in your binary's `main`.
 did-methods = ["did-webvh", "did-scid"]
 did_example = ["dep:did-example"]
 did-jwk = ["dep:affinidi-did-jwk"]
-# Legacy blockchain DID methods, resolved by in-tree crates. These were the
-# last consumers of the ssi-* stack outside `did-cheqd`.
+# Legacy blockchain DID methods, resolved by in-tree crates. With did:cheqd
+# resolution retired in 0.8.36, nothing in this crate reaches the ssi-* stack.
 did-ethr = ["dep:affinidi-did-ethr"]
 did-pkh = ["dep:affinidi-did-pkh"]
-did-cheqd = ["dep:did-resolver-cheqd", "dep:ssi-dids-core"]
+# Retired in 0.8.36 and now inert: `did:cheqd` resolution was removed (see the
+# CHANGELOG). The feature is kept, and empty, so that a consumer enabling it
+# still builds — `cargo` errors on an unknown feature name, so deleting it would
+# be a hard break for a purely additive-to-nothing capability. It will be removed
+# at the next major.
+did-cheqd = []
 did-webvh = ["dep:didwebvh-rs"]
 # Agent names: human-memorable "/@" shortcuts resolvable via `resolve_any()`.
 agent-names = ["dep:agent-names"]
@@ -61,10 +58,8 @@ affinidi-did-resolver-traits = { version = "0.1", path = "../affinidi-did-resolv
 # Shared background-task supervision (network mode only)
 affinidi-task-utils = { version = "0.1", optional = true }
 did-example = { version = "0.5", optional = true }
-# `default-features = false` keeps did-scid's own optional `did-cheqd` backend
-# (and its `tonic`/`ring` TLS stack) out of this SDK's default build; pulling
-# `did-cheqd` here re-enables it deliberately.
-did-scid = { version = "0.2.3", optional = true, default-features = false, features = [
+# `default-features = false` selects only the did:webvh backend of did-scid.
+did-scid = { version = "0.2.6", optional = true, default-features = false, features = [
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
@@ -95,22 +90,6 @@ affinidi-did-web = { version = "0.1", path = "../did-methods/did-web" }
 affinidi-did-ethr = { version = "0.1", optional = true, path = "../did-methods/did-ethr" }
 affinidi-did-jwk = { version = "0.1", optional = true, path = "../did-methods/did-jwk" }
 affinidi-did-pkh = { version = "0.1", optional = true, path = "../did-methods/did-pkh" }
-did-resolver-cheqd = { version = "1", optional = true }
-# `did-cheqd` is the ONLY remaining consumer of the ssi stack — did:ethr,
-# did:pkh and did:jwk moved to in-tree crates that do not depend on it. Because
-# `did-resolver-cheqd 1.0.1` pins `ssi-dids-core ^0.1`, this optional dep is
-# what still resolves `reqwest 0.11` (and with it the vulnerable `h2 0.3.x`),
-# `rustls-pemfile 1.0.4`, `im`, `sized-chunks`, `bitmaps`, `smallstr` and
-# `proc-macro-error` into Cargo.lock — even though none of them compile,
-# because `did-cheqd` is not enabled by any crate in this workspace.
-#
-# A patched fork of `did-resolver-cheqd` is in progress. Note that moving it to
-# `ssi-dids-core 0.3` clears `h2` and `rustls-pemfile 1.0.4` (that line uses
-# reqwest 0.13) but NOT the archived `im`/`sized-chunks`/`bitmaps`/`smallstr`/
-# `proc-macro-error` cluster: ssi 0.3 still reaches `json-ld 0.21` and
-# `linked-data 0.1.2`, which are themselves unmaintained. Clearing those needs
-# the fork to drop `ssi-dids-core` outright, as the in-tree method crates did.
-ssi-dids-core = { version = "0.1", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 tokio-rustls = { version = "0.26", optional = true }

--- a/crates/identity/affinidi-did-resolver-cache-sdk/README.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/README.md
@@ -28,7 +28,7 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | `did:pkh` | No | `did-pkh` (opt-in — pulls the `ssi-*` stack, see below) |
 | `did:webvh` | Yes | `did-methods` |
 | `did:scid` | Yes | `did-methods` |
-| `did:cheqd` | No | `did-cheqd` (opt-in — pulls a `ring` TLS backend, see below) |
+| `did:cheqd` | **Retired** | parses, but is no longer resolved — see below |
 | `did:ebsi` | No | `did-ebsi` (EBSI DID Registry API) |
 | `did:webs` | No | `affinidi-did-webs` (KERI-verified key state) |
 | `did:example` | No | `did_example` (must be manually loaded) |
@@ -45,7 +45,7 @@ affinidi-did-resolver-cache-sdk = "0.8"
 | `did-webs` | No | did:webs — did:web discovery with a KERI-verified key event log |
 | `network` | No | Enable network mode for remote cache server |
 | `did-webvh` | — | WebVH DID method support |
-| `did-cheqd` | No | Cheqd blockchain DID method support (opt-in, see TLS note) |
+| `did-cheqd` | No | Inert since 0.8.36 — retained so enabling it still builds |
 | `did-scid` | — | Self-Certifying Identifier DID method |
 | `did_example` | — | Example DID method for testing |
 
@@ -56,28 +56,32 @@ and `affinidi-did-jwk` in this workspace, not by the spruceid crates of the
 same names. Enabling them costs three small dependencies rather than the whole
 `ssi-*` stack. See each crate's README for scope and conformance.
 
-### `did-cheqd` and the rustls `ring` backend
+### `did:cheqd` resolution was retired in 0.8.36
 
-`did-cheqd` is **not** enabled by default. It pulls `did-resolver-cheqd`, whose
-gRPC client (`tonic 0.12`) hardcodes the `ring` backend on
-`tokio-rustls`/`rustls 0.23`. This SDK's `network` feature — and most downstream
-binaries (via `kube`, `reqwest`, `jsonwebtoken`, …) — select the `aws_lc_rs`
-backend instead. When both backends are compiled, `rustls` cannot auto-select
-one and panics at the first TLS call with:
+`did:cheqd` still **parses** — `DIDMethod::Cheqd` is unchanged in
+`affinidi-did-common` — but this SDK no longer **resolves** it. `CheqdResolver`
+still exists under the `did-cheqd` feature and now declines with an explanatory
+`ResolutionFailed`.
 
-```text
-no process-level CryptoProvider available
-```
+The implementation came from `did-resolver-cheqd`: a crate with no published
+source repository, a single release from 2025, pinning `ssi-dids-core 0.1`. It
+was off by default and enabled by nothing in this workspace, yet its presence as
+an optional dependency put eight advisories into `Cargo.lock` — seven
+unmaintained crates plus a live `h2` denial-of-service that had to be suppressed
+in CI to keep the build green. Removing it cleared all eight and dropped 122
+crates from the resolved graph. It also removed the `tonic 0.12` / rustls `ring`
+conflict that made this feature awkward to enable in the first place.
 
-If you enable `did-cheqd`, you accept the `ring` backend. Because installing a
-process-global `CryptoProvider` is the application's decision, your binary's
-`main` must do it before any TLS is used, e.g.:
+Nothing was removed from the public API: the feature, the resolver type and
+`ScidMethod::Cheqd` all remain, so code that named them still compiles.
+
+To resolve `did:cheqd`, append your own resolver — the chain is a public
+extension point for exactly this:
 
 ```rust,ignore
-rustls::crypto::aws_lc_rs::default_provider()
-    .install_default()
-    .expect("install default rustls CryptoProvider");
+client.append_resolver(MethodName::Cheqd, Box::new(MyCheqdResolver));
 ```
+
 
 ## Usage
 

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
@@ -8,25 +8,13 @@ use std::future::Future;
 use std::pin::Pin;
 
 use affinidi_did_common::{DID, DIDMethod};
-pub use affinidi_did_web::HostPolicy;
-// `Document` is only named by the ssi-backed helper below, which is gated.
-#[cfg(feature = "did-cheqd")]
-use affinidi_did_common::Document;
 use affinidi_did_resolver_traits::{AsyncResolver, Resolution, ResolverError};
+pub use affinidi_did_web::HostPolicy;
 use tracing::error;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Convert an ssi `DIDResolver` result (typed output) into a `Document`.
-#[cfg(feature = "did-cheqd")]
-fn document_from_ssi_output(output: impl serde::Serialize) -> Result<Document, ResolverError> {
-    let value = serde_json::to_value(output)
-        .map_err(|e| ResolverError::InvalidDocument(format!("Serialization failed: {e}")))?;
-    serde_json::from_value(value)
-        .map_err(|e| ResolverError::InvalidDocument(format!("Invalid document shape: {e}")))
-}
 
 // ---------------------------------------------------------------------------
 // did:ethr
@@ -256,7 +244,18 @@ impl AsyncResolver for WebvhResolver {
 // did:cheqd (feature-gated)
 // ---------------------------------------------------------------------------
 
-/// Resolver for `did:cheqd` — Cheqd network DID method.
+/// Resolver for `did:cheqd` — retired in 0.8.36, kept so the type still exists.
+///
+/// It now declines every DID with a `ResolutionFailed` explaining why, rather
+/// than resolving. The implementation came from `did-resolver-cheqd`, a crate
+/// with no published source repository and a single 2025 release, which pinned
+/// `ssi-dids-core 0.1` and pulled eight advisories — including a live h2 DoS —
+/// into the lockfile even though the feature is off by default and nothing in
+/// this workspace enabled it.
+///
+/// `did:cheqd` still *parses* (see `affinidi-did-common`). To resolve it, append
+/// your own [`AsyncResolver`] for the method; the chain is a public extension
+/// point precisely so a method can live outside this crate.
 #[cfg(feature = "did-cheqd")]
 pub struct CheqdResolver;
 
@@ -275,29 +274,16 @@ impl AsyncResolver for CheqdResolver {
                 return None;
             }
 
-            let did_str = did.to_string();
-            use ssi_dids_core::DIDResolver;
-            let ssi_did = match ssi_dids_core::DID::new(&did_str) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Some(Err(ResolverError::InvalidDocument(format!(
-                        "Invalid DID: {e}"
-                    ))));
-                }
-            };
-
-            Some(
-                match did_resolver_cheqd::DIDCheqd::default()
-                    .resolve(ssi_did)
-                    .await
-                {
-                    Ok(res) => document_from_ssi_output(res.document.into_document()),
-                    Err(e) => {
-                        error!("did:cheqd resolution error: {e:?}");
-                        Err(ResolverError::ResolutionFailed(e.to_string()))
-                    }
-                },
-            )
+            // Deliberately `Some(Err(..))`, not `None`: declining would fall
+            // through to "no resolver registered for DID method 'cheqd'", which
+            // reads like a configuration mistake. This says what actually
+            // happened and what to do about it.
+            error!("did:cheqd resolution is retired; refusing {did}");
+            Some(Err(ResolverError::ResolutionFailed(
+                "did:cheqd resolution was retired in affinidi-did-resolver-cache-sdk 0.8.36; \
+                 append your own AsyncResolver for the method if you need it"
+                    .to_string(),
+            )))
         })
     }
 }

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,23 @@
 # did:scid
 
+## Unreleased (0.2.6) — retire did:cheqd resolution
+
+Part of [#760]. A `did:scid` whose `?src=` names a `did:cheqd` still parses, and
+`ScidMethod::Cheqd` is unchanged; `resolve` now returns an explanatory
+`CheqdError` instead of resolving.
+
+The implementation came from `did-resolver-cheqd`, which pinned `ssi-dids-core
+0.1` and — even unbuilt, behind an off-by-default feature — pulled eight
+advisories into `Cargo.lock`, including a live `h2` denial-of-service. The crate
+publishes no source repository and has a single 2025 release, so there was
+nothing to upgrade to and nothing to fork. See
+`affinidi-did-resolver-cache-sdk` 0.8.36 for the full accounting.
+
+Nothing was removed from the public API: the `did-cheqd` feature remains (now
+empty) and so does the enum variant, so code naming either still compiles.
+
+[#760]: https://github.com/affinidi/affinidi-tdk-rs/issues/760
+
 ## 0.2.5
 
 ### Changed

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.5"
+version = "0.2.6"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -14,16 +14,11 @@ readme = "README.md"
 rust-version.workspace = true
 
 [features]
-# `did-cheqd` is intentionally NOT in `default`: it pulls `did-resolver-cheqd`,
-# whose `tonic 0.12` dependency hardcodes the rustls `ring` backend on
-# `tokio-rustls`/`rustls 0.23`. Forcing `ring` clashes with downstream binaries
-# that select `aws_lc_rs` (the ecosystem default via kube/reqwest/jsonwebtoken),
-# producing a "no process-level CryptoProvider available" panic. Opt in to
-# `did-cheqd` only when you accept the `ring` backend (and install a
-# CryptoProvider in your binary's `main`).
+# Retired in 0.2.6 and now inert: `did:cheqd` resolution was removed (see the
+# CHANGELOG). Kept, and empty, so a consumer enabling it still builds.
+did-cheqd = []
 default = ["did-webvh"]
 
-did-cheqd = ["dep:did-resolver-cheqd", "dep:ssi-dids-core"]
 did-webvh = ["dep:didwebvh-rs"]
 # did:scid:ke — a KERI AID via did:webs. Optional so did-scid does not pull the
 # KERI stack into builds that never resolve it.
@@ -37,10 +32,8 @@ affinidi-did-common = "0.4"
 
 affinidi-did-webs = { version = "0.7", optional = true }
 didwebvh-rs = { version = "0.6", optional = true }
-did-resolver-cheqd = { version = "1", optional = true }
 regex = "1"
 serde_json = "1"
-ssi-dids-core = { version = "0.1", optional = true }
 thiserror = "2"
 tracing = "0.1"
 

--- a/crates/identity/did-methods/did-scid/src/lib.rs
+++ b/crates/identity/did-methods/did-scid/src/lib.rs
@@ -105,36 +105,30 @@ pub async fn resolve(
             }
         }
         ScidMethod::Webs(webs_did) => resolve_webs(&webs_did).await,
+        // Retired in 0.2.6. The `did:cheqd` shape still parses and this arm still
+        // exists, so nothing a consumer named has gone away — only the
+        // implementation. It came from `did-resolver-cheqd`, a crate with no
+        // published source repository and a single 2025 release, which pinned
+        // `ssi-dids-core 0.1` and pulled eight advisories (including an h2 DoS)
+        // into the lockfile. Register your own resolver for the method if you
+        // need it; see the CHANGELOG.
         #[cfg(feature = "did-cheqd")]
         ScidMethod::Cheqd(cheqd_did) => {
-            use did_resolver_cheqd::DIDCheqd;
-            use ssi_dids_core::{DID, DIDResolver};
-
-            debug!("Resolving Cheqd DID: {cheqd_did}");
-            let parsed = DID::new::<str>(&cheqd_did).map_err(|e| {
-                DIDSCIDError::DidUrlError(format!(
-                    "derived cheqd DID is not a valid DID ({cheqd_did}): {e}"
-                ))
-            })?;
-            match DIDCheqd::default().resolve(parsed).await {
-                Ok(res) => {
-                    let doc_value = serde_json::to_value(res.document.into_document())?;
-                    Ok(serde_json::from_value(doc_value)?)
-                }
-                Err(e) => {
-                    error!("Error: {e:?}");
-                    Err(DIDSCIDError::CheqdError(e.to_string()))
-                }
-            }
+            debug!("did:cheqd resolution is retired; refusing {cheqd_did}");
+            Err(DIDSCIDError::CheqdError(format!(
+                "did:cheqd resolution was retired in did-scid 0.2.6 and this crate no longer \
+                 resolves {cheqd_did}; register your own resolver for the method"
+            )))
         }
     }
 }
 
 /// Derive a `did:cheqd` method DID from a URL-mode `?src=did:cheqd:...` source.
 ///
-/// `did-cheqd` is optional because `did-resolver-cheqd` forces the rustls `ring`
-/// TLS backend (via `tonic 0.12`); see the crate's feature docs. When the
-/// feature is disabled this returns a clear error instead of failing to compile.
+/// `did-cheqd` is now an inert feature: it gates the `did:cheqd` *shape* only.
+/// Resolution was retired in 0.2.6 (see `resolve`), so enabling it changes what
+/// parses, not what resolves. When the feature is disabled this returns a clear
+/// error instead of failing to compile.
 #[cfg(feature = "did-cheqd")]
 fn derive_cheqd_url(src: &str, scid: &str) -> Result<ScidMethod, DIDSCIDError> {
     let cheqd = format!("{src}:{scid}");
@@ -747,27 +741,6 @@ mod tests {
                 assert_eq!(doc.id.as_str(), "did:webvh:Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai:identity.foundation:didwebvh-implementations:implementations:affinidi-didwebvh-rs");
             }
             Err(_) => panic!("Couldn't resolve SCID WebVH DID")
-        }
-    }
-
-    #[cfg(feature = "did-cheqd")]
-    #[tokio::test]
-    #[ignore = "requires external network (cheqd.net)"]
-    async fn test_scid_cheqd_resolution() {
-        match resolve(
-            "did:scid:vh:1:cad53e1d-71e0-48d2-9352-39cc3d0fac99?src=did:cheqd:testnet",
-            None,
-            None,
-        )
-        .await
-        {
-            Ok(doc) => {
-                assert_eq!(
-                    doc.id.as_str(),
-                    "did:cheqd:testnet:cad53e1d-71e0-48d2-9352-39cc3d0fac99"
-                );
-            }
-            Err(_) => panic!("Couldn't resolve SCID Cheqd DID"),
         }
     }
 }


### PR DESCRIPTION
Closes #760.

`did:cheqd` still **parses**. The TDK no longer **resolves** it.

## What one dependency was costing

`did-resolver-cheqd` sat behind the opt-in `did-cheqd` feature — off by default, enabled by nothing in this workspace, compiled by no build. It still put eight advisories into `Cargo.lock`, because `cargo audit` reads the lockfile while `cargo deny` reads the build graph:

| Advisory | Crate | |
|---|---|---|
| RUSTSEC-2026-0258 | `h2 0.3.27` | **vulnerability** — DoS |
| RUSTSEC-2025-0134 | `rustls-pemfile` 1.0.4 + 2.2.0 | |
| RUSTSEC-2026-0248 / 2023-0126 | `im 15.1.0` | one unsound |
| RUSTSEC-2026-0251 / 2026-0255 | `sized-chunks` | one unsound |
| RUSTSEC-2026-0247 | `bitmaps` | |
| RUSTSEC-2026-0215 | `smallstr` | |
| RUSTSEC-2024-0370 | `proc-macro-error` | |

All through one edge: `did-cheqd → did-resolver-cheqd 1.0.1 → ssi-dids-core 0.1.3` (plus `tonic 0.12.3` for the second `rustls-pemfile`).

## Why removal, not an upgrade or a fork

`did-resolver-cheqd` **publishes no source repository**, has a single release from 2025-10-21, and pins `ssi-dids-core ^0.1`. There is no newer version to move to and no repository to fork — the "patched fork in progress" noted in our Cargo.toml would have had to start from the `.crate` tarball.

Moving to `ssi 0.3` would have cleared only `h2` and `rustls-pemfile 1.0.4` anyway, not the `json-ld`/`linked-data` cluster, which is simultaneously the newest release *and* unmaintained.

And the coupling was thin: the crate used ssi purely as a type vocabulary, and both of our call sites serialised its document straight back out to JSON to parse into our own type.

## Result

- **All eight gone.** `h2` now resolves at 0.4.19, above the `>=0.4.16` fix — the DoS is *fixed*, not suppressed.
- **Four of five `auditIgnore` entries removed** (`h2` and `im` directly; `owning_ref` and `rsa` left the graph alongside), leaving only `quinn-proto`. That was the concern raised in #761: a live vulnerability suppressed with the same syntax and same silence as four unmaintained notices.
- `cargo audit`: **1 vulnerability + 12 warnings → 0 + 1**. The remaining warning is `paste`, already closed as not-applicable in #726 (lockfile-only, compiled by nothing).
- Resolved graph: **1064 → 942 crates.**
- The `tonic 0.12` / rustls `ring` conflict that made `did-cheqd` awkward to enable in the first place is gone with it.

## Nothing was removed from the public API — and that took a second attempt

The `did-cheqd` feature remains (now empty), `CheqdResolver` remains and declines with an explanatory `ResolutionFailed`, `ScidMethod::Cheqd` remains, and `DIDMethod::Cheqd` in `affinidi-did-common` is untouched. Code that named any of them still compiles.

**I first did the obvious thing** — deleted the API and took the honest minor (0.9.0 / 0.3.0). `check-workspace-duplicates.sh` failed: external `vta-sdk 0.32.3` pins `affinidi-did-resolver-cache-sdk ^0.8` and reaches us *through our own mediator*, so the `[patch.crates-io]` redirect stopped applying and the registry copy of 0.8.35 came back alongside the local 0.9.0 — two copies of the same types, which is precisely the failure ADR 0003 exists to prevent.

ADR 0003's patch-within-minor carve-out covers changes that are *technically* breaking but safe in practice; a removal is neither, and it says a true minor "requires first coordinating new releases of the external consumers". Retaining the surface makes the change genuinely non-breaking, so the patch bump is honest rather than a semver dodge — and no cross-repo sequencing is needed. The duplicate guard passes.

To resolve `did:cheqd`, append your own resolver — the chain is a public extension point for exactly this:

```rust
client.append_resolver(MethodName::Cheqd, Box::new(MyCheqdResolver));
```

## Testing

- 149 tests green across both crates (`--all-features`).
- `cargo check --workspace --all-features` clean; `cargo clippy --workspace --all-targets -D warnings` clean.
- `check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh` all pass.

cache-sdk 0.8.36, did-scid 0.2.6.

## Note

There is a pre-existing `clippy::collapsible_if` in `cache-sdk/src/lib.rs:520` (the `agent-names` shortcut path) that only fires under `--all-features`, which CI does not use for this crate. Byte-identical on `main`; left alone rather than widening this diff.
