### PR TITLE
feat(mediator): apply the peer-mediator allowlist to TSP relay hops

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## Unreleased (0.20.10) — TSP relay honours the peer-mediator allowlist
+
+Closes [#758], raised by the AgenticSec review on #756 (alert 67) and by the
+correction it prompted: `relay_peer_trusted` was DIDComm-only, so a TSP
+deployment that needed its relaying peer authenticated had no lever at all.
+
+`processors.forwarding.relay_trusted_mediators` now applies to TSP relay hops,
+and TSP gets a stronger form of it than DIDComm. A routed or nested hop is
+sealed to this mediator, so `handle_inbound_tsp` unpacks it — verifying an
+Ed25519 signature over envelope‖ciphertext against the key in the sender's DID
+document, *and* opening the payload with HPKE **Auth**, which binds the sender's
+static key. Two independent proofs, so the peer identity the allowlist is
+checked against is cryptographically established rather than claimed.
+
+**No `RelayMode` distinction is needed.** DIDComm can only identify its peer in
+`RelayMode::Rewrap`, where a layer addressed to this mediator can be
+authcrypt-opened; in `Blind` the peer is invisible and the allowlist is ignored.
+TSP routed relay is re-wrap-like *by construction* — every hop is sealed to the
+next and authenticated as the previous — so there is no mode to select and no
+blind variant to except.
+
+Two scoping rules, both load-bearing:
+
+- **Anonymous sessions only.** This is the part that differs from DIDComm and is
+  easy to get wrong. Only a peer mediator ever produces a DIDComm re-wrap layer,
+  so peeling one is inter-mediator by construction; a TSP *routed* message is
+  not — an ordinary client sends one through its own mediator for metadata
+  privacy (TSP §5.5). Gating those on a list of peer *mediators* would refuse
+  every routed client the moment an operator populated it. An inter-mediator hop
+  arrives with no `Authorization` header, on the anonymous session, which is
+  exactly the traffic this list exists to admit or refuse.
+- **Relay arms only.** `Direct` and `Control` addressed to this mediator are
+  messages *to* it — Trust Tasks over TSP arrive that way — not relays through
+  it.
+
+What this does **not** cover, stated plainly: TSP opaque pass-through (a message
+addressed to a local recipient rather than to this mediator) has nothing
+addressed to us to open, so there is no peer to identify and no allowlist can
+apply. That is the true analogue of DIDComm blind relay. `security.enable_inter_mediator_relay`,
+which gates anonymous inbound at all, and `security.local_direct_delivery_allowed`
+are the levers there. The comment added in 0.20.7 saying TSP had no equivalent
+hardening has been corrected to say precisely which hops are now covered.
+
+Not a behaviour change for any deployment leaving `relay_trusted_mediators`
+empty, which is the default and means "accept any peer".
+
+[#758]: https://github.com/affinidi/affinidi-tdk-rs/issues/758
+
 ## Unreleased (0.20.9) — TSP direct delivery honours `local_direct_delivery_allowed`
 
 Closes [#757], the gap deliberately left open by 0.20.7 and independently

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.9"
+version = "0.20.10"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.38) — document where the relay allowlist applies
+
+Documentation only, alongside mediator 0.20.10 (issue #758).
+
+`ForwardingConfig::relay_trusted_mediators` said it was ignored outside
+`RelayMode::Rewrap`, which stopped being the whole story when the allowlist
+started applying to TSP relay hops. It now states which hops it governs per
+protocol and why: DIDComm only in `Rewrap` (the re-wrap layer is authcrypt-opened
+so the peer is named), TSP on every routed/nested hop (sealed to this mediator,
+so unpacking verifies both a signature and HPKE-Auth — no `RelayMode` to choose),
+and neither for TSP opaque pass-through, where nothing is addressed to us and
+there is no peer to identify.
+
 ## Unreleased (0.15.37) — every forwarding abandonment was silent to the sender
 
 **Bug fix: the forwarding-failure problem report is now authcrypted, so a

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.37"
+version = "0.15.38"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/config.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/config.rs
@@ -70,10 +70,26 @@ pub struct ForwardingConfig {
     /// How to relay a forward to a remote next-hop mediator. See [`RelayMode`].
     /// Defaults to [`RelayMode::Blind`] (historical behaviour, no regression).
     pub relay_mode: RelayMode,
-    /// In [`RelayMode::Rewrap`], the allowlist of peer-mediator DIDs whose
-    /// re-wrapped relays this mediator will accept on its inbound endpoint.
-    /// Empty = accept any peer (capability still gated by ACLs). Ignored in
-    /// [`RelayMode::Blind`], where the relaying peer's identity is not visible.
+    /// Allowlist of peer-mediator DIDs whose relays this mediator will accept on
+    /// its inbound endpoint. Empty = accept any peer (the relay capability is
+    /// still gated by ACLs).
+    ///
+    /// Applies wherever the relaying peer can actually be identified:
+    ///
+    /// * **DIDComm**, in [`RelayMode::Rewrap`] only — the re-wrap layer is
+    ///   addressed to this mediator, so authcrypt names its sender. Ignored in
+    ///   [`RelayMode::Blind`], where the peer's identity is not visible.
+    /// * **TSP**, on every routed/nested relay hop — no mode to select. Such a
+    ///   hop is sealed to this mediator, and unpacking it verifies an Ed25519
+    ///   signature over the envelope *and* opens the payload with HPKE-Auth, so
+    ///   the peer is authenticated twice over. TSP routed relay is Rewrap-like by
+    ///   construction.
+    ///
+    /// It does **not** apply to TSP opaque pass-through (a message addressed to a
+    /// local recipient rather than to this mediator): nothing there is addressed
+    /// to us, so there is no peer to identify. That case is governed by
+    /// `security.local_direct_delivery_allowed` and
+    /// `security.enable_inter_mediator_relay`.
     pub relay_trusted_mediators: HashSet<String>,
 }
 

--- a/crates/messaging/affinidi-messaging-mediator/docs/acls.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/acls.md
@@ -252,6 +252,33 @@ to admit or refuse.
 └─ access list check
 ```
 
+### Inter-mediator relay admission
+
+`processors.forwarding.relay_trusted_mediators` allowlists the peer mediators
+whose relays this mediator accepts. Empty means any peer (still ACL-gated).
+
+It applies wherever the relaying peer can actually be identified:
+
+| Protocol | Applies | Why |
+|----------|---------|-----|
+| DIDComm, `RelayMode::Rewrap` | yes | the re-wrap layer is addressed to this mediator, so authcrypt names its sender |
+| DIDComm, `RelayMode::Blind` | no | nothing is addressed to us; the peer is invisible |
+| TSP, routed/nested hop | yes | the hop is sealed to this mediator; unpacking verifies an Ed25519 signature *and* HPKE-Auth |
+| TSP, opaque pass-through | no | addressed to a local recipient, not to us — no peer to identify |
+
+TSP needs no `RelayMode` choice: a routed hop is re-wrap-like by construction.
+
+Two scoping rules matter. The check runs only on **anonymous** sessions, because
+that is how an inter-mediator hop arrives — an ordinary client's routed message
+(metadata privacy, TSP §5.5) is authenticated and must not be gated by a list of
+peer *mediators*. And it runs only on relay arms: `Direct` and `Control`
+addressed to this mediator are messages *to* it — Trust Tasks over TSP arrive
+that way — not relays through it.
+
+Where no peer can be identified, `security.enable_inter_mediator_relay` (which
+gates anonymous inbound at all) and `security.local_direct_delivery_allowed` are
+the levers.
+
 ### Access-list evaluation
 
 The single decision, applied on every delivery:

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -3,7 +3,10 @@ use crate::didcomm_compat::MetaEnvelope;
 #[cfg(feature = "didcomm")]
 use crate::messages::MessageHandler;
 #[cfg(feature = "didcomm")]
-use crate::messages::protocols::routing::{relay_peer_trusted, rewrap_inner_attachment};
+use crate::messages::protocols::routing::rewrap_inner_attachment;
+// Shared by the DIDComm re-wrap peel and the TSP routed-relay peer allowlist.
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
+use crate::messages::protocols::routing::relay_peer_trusted;
 use crate::{SharedData, common::session::Session};
 // Shared by both the DIDComm direct-delivery path and the TSP delivery path.
 #[cfg(any(feature = "didcomm", feature = "tsp"))]
@@ -156,14 +159,22 @@ pub(crate) async fn handle_inbound_tsp(
     // the one named on the DIDComm side: on an anonymous relay hop the claimed
     // sender stays unverified. That is inherent to relaying, not given away here.
     //
-    // One asymmetry worth naming rather than leaving to be inferred: on the
-    // DIDComm side a deployment that needs the relaying peer authenticated can
-    // run [`RelayMode::Rewrap`] with `processors.forwarding.relay_trusted_mediators`.
-    // TSP has no equivalent — `relay_peer_trusted` is DIDComm-only — so for TSP
-    // the anonymous hop currently has no opt-in hardening at all. Anonymous
-    // inbound is itself opt-in (`security.enable_inter_mediator_relay`, or the
-    // legacy implicit `SEND_FORWARDED` in `global_acl_default`), which bounds
-    // the exposure to relay-enabled deployments.
+    // Which anonymous hops this leaves unverified, precisely — the two TSP
+    // branches differ and it matters:
+    //
+    //   * A hop addressed to *this mediator* (`receiver == mediator_did`, the
+    //     routed/nested relay below) is not affected. It gets unpacked, which
+    //     authenticates `meta.sender` cryptographically, and the peer allowlist
+    //     is applied to it there. Session binding is redundant for that branch.
+    //   * A hop that is opaque pass-through (`receiver != mediator_did`) has
+    //     nothing addressed to us to open, so its sender stays a bare claim.
+    //     This is the true analogue of DIDComm blind relay, and no allowlist can
+    //     apply to a peer we cannot identify.
+    //
+    // For that second case the levers are `local_direct_delivery_allowed` and
+    // `security.enable_inter_mediator_relay` — anonymous inbound is opt-in (that
+    // flag, or the legacy implicit `SEND_FORWARDED` in `global_acl_default`),
+    // which bounds the exposure to relay-enabled deployments.
     if state.config.security.force_session_did_match && session.authenticated {
         check_direct_delivery_session_match(session, Some(meta.sender.as_str()))?;
     }
@@ -236,6 +247,65 @@ pub(crate) async fn handle_inbound_tsp(
             StatusCode::BAD_REQUEST,
         )
     })?;
+
+    // Peer-mediator allowlist for the branches where we act as a *relay*.
+    //
+    // `meta.sender` is safe to authorise on here, and this is the one place in
+    // the TSP path where that is true. The `unpack` above verified an Ed25519
+    // signature over envelope‖ciphertext against the signing key resolved from
+    // `meta.sender`'s DID document, and opened the payload with HPKE **Auth**,
+    // which binds the sender's static key as well. Two independent proofs, so
+    // reaching this line means the peer really is who the envelope says.
+    //
+    // That is what the DIDComm side gets only in [`RelayMode::Rewrap`], where a
+    // layer addressed to this mediator can be authcrypt-opened. TSP routed relay
+    // is Rewrap-like by construction — every hop is sealed to the next and
+    // authenticated as the previous — so there is no mode to choose and no blind
+    // variant to except. The allowlist is simply always applicable here.
+    //
+    // Scoped to *inter-mediator* relay, which needs two conditions, and getting
+    // either wrong breaks something:
+    //
+    //   * A relay arm. `Direct` and `Control` addressed to this mediator are
+    //     messages *to* us, not relays through us — Trust Tasks over TSP arrive
+    //     that way — so a list of trusted peer mediators must not gate them.
+    //   * An anonymous session. This is the part that differs from DIDComm and
+    //     is easy to get wrong: on the DIDComm side only a peer mediator ever
+    //     produces a re-wrap layer, so peeling one is inter-mediator by
+    //     construction. A TSP *routed* message is not — an ordinary client sends
+    //     one through its own mediator for metadata privacy (§5.5), and that
+    //     client is not a peer mediator. Gating those on this list would refuse
+    //     every routed client the moment an operator populated it.
+    //
+    // An inter-mediator hop is POSTed to `/inbound` with no Authorization header
+    // (see the forwarding processor), so it lands on the anonymous session —
+    // which is exactly the traffic this allowlist exists to admit or refuse. An
+    // authenticated peer is a known account and is governed by its ACLs instead,
+    // the same as an authenticated peer using DIDComm blind relay.
+    //
+    // The opaque pass-through branch above (`receiver != mediator`) is the real
+    // analogue of blind relay: nothing there is addressed to us, so there is no
+    // layer to open and no peer identity to check. No allowlist can apply to a
+    // peer we cannot identify; `local_direct_delivery_allowed` and
+    // `security.enable_inter_mediator_relay` are the levers for that case.
+    if !session.authenticated
+        && matches!(
+            unpacked.message_type,
+            TspMessageType::Routed | TspMessageType::Nested
+        )
+        && !relay_peer_trusted(
+            &state.config.processors.forwarding.relay_trusted_mediators,
+            Some(meta.sender.as_str()),
+        )
+    {
+        return Err(tsp_problem(
+            session,
+            60,
+            "authorization.relay.untrusted_peer",
+            "Relaying peer is not in the trusted relay allowlist".to_string(),
+            StatusCode::FORBIDDEN,
+        ));
+    }
 
     match unpacked.message_type {
         // We are a relay hop: unwrap our routing layer and forward the onward

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (0.4.5) — support for the TSP relay peer allowlist
+
+Support for mediator 0.20.10 (issue #758). No API change; the fixture already
+exposed `relay_trusted_mediators` on `TestMediatorBuilder` and `configure_each`
+on `TestTopologyBuilder`, which is what the new `tsp_relay_peer_trust` suite
+drives.
+
 ## Unreleased (0.4.4) — a fixture that can permit direct delivery
 
 Support for mediator 0.20.9, which makes TSP direct delivery honour

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.4"
+version = "0.4.5"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_relay_peer_trust.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/tsp_relay_peer_trust.rs
@@ -1,0 +1,195 @@
+//! `processors.forwarding.relay_trusted_mediators` applied to TSP relay hops
+//! (issue #758).
+//!
+//! Until now the allowlist was DIDComm-only, so a TSP deployment that needed its
+//! relaying peer authenticated had no lever at all. It does now, and TSP gets a
+//! stronger version than DIDComm: a routed hop addressed to this mediator is
+//! unpacked, which verifies an Ed25519 signature over the envelope *and* opens
+//! the payload with HPKE-Auth, so the peer is authenticated twice over. There is
+//! no `RelayMode` to choose — TSP routed relay is re-wrap-like by construction.
+//!
+//! # The distinction these tests exist to pin
+//!
+//! On the DIDComm side only a peer mediator ever produces a re-wrap layer, so
+//! peeling one is inter-mediator by construction. **A TSP routed message is
+//! not**: an ordinary client sends one through its own mediator for metadata
+//! privacy, and that client is not a peer mediator. Gating those on this list
+//! would refuse every routed client the moment an operator populated it.
+//!
+//! The gate is therefore scoped to *anonymous* sessions, which is how an
+//! inter-mediator hop arrives (POSTed to `/inbound` with no Authorization
+//! header). [`client_routed_message_is_unaffected_by_the_peer_allowlist`] is the
+//! test that holds that line.
+#![cfg(feature = "tsp")]
+
+use std::time::Duration;
+
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, topology::TestTopology};
+
+/// A DID that is definitely not any mediator in these fixtures.
+const STRANGER: &str = "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6PrfgtSSXhWH";
+
+/// An ordinary client's routed message must still be relayed when the operator
+/// has populated the peer allowlist. The client is not a peer mediator, and its
+/// session is authenticated, so the allowlist must not apply to it.
+///
+/// This is the regression that matters: an implementation that gates every
+/// routed hop on the allowlist passes every other test in this file and breaks
+/// metadata-private routing for real clients.
+#[tokio::test]
+async fn client_routed_message_is_unaffected_by_the_peer_allowlist() {
+    let mediator = TestMediator::builder()
+        .local_direct_delivery(true, false)
+        .relay_trusted_mediators([STRANGER])
+        .spawn()
+        .await
+        .expect("spawn mediator with a populated peer allowlist");
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire the SDK to the mediator");
+
+    let alice = env.add_user("alice").await.expect("add alice");
+    let bob = env.add_user("bob").await.expect("add bob");
+    let mediator_did = env.mediator.did().to_string();
+
+    let payload = b"routed through my own mediator, for metadata privacy";
+    env.atm
+        .tsp()
+        .send_routed(&alice.profile, &[mediator_did, bob.did.clone()], payload)
+        .await
+        .expect("a client's own routed message must not be gated by the peer allowlist");
+
+    let fetched = env
+        .atm
+        .fetch_messages(&bob.profile, &FetchOptions::default())
+        .await
+        .expect("fetch messages");
+    assert_eq!(
+        fetched.success.len(),
+        1,
+        "bob must receive the relayed message"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// An inter-mediator hop from a peer that is not on the allowlist is refused.
+///
+/// Alice on mediator A sends nested+routed to Bob on mediator B, so A relays to
+/// B over B's anonymous `/inbound`. B's allowlist names only a stranger, so B
+/// refuses the hop and nothing reaches Bob.
+///
+/// `send_nested_routed` still succeeds — it only ever reaches A, and the refusal
+/// happens a hop later — so the assertion has to be on Bob's mailbox.
+#[tokio::test]
+async fn inter_mediator_hop_from_an_untrusted_peer_is_refused() {
+    let topology = TestTopology::builder()
+        .mediators(2)
+        // Applied to both mediators, which is harmless: A only ever sees Alice
+        // on an authenticated session, where the allowlist does not apply.
+        .configure_each(|b| b.relay_trusted_mediators([STRANGER]))
+        .spawn()
+        .await
+        .expect("spawn two-mediator topology");
+
+    let mediator_a = topology.mediator_did(0).expect("mediator A").to_string();
+    let mediator_b = topology.mediator_did(1).expect("mediator B").to_string();
+    let alice = topology.add_user(0, "alice").await.expect("add alice on A");
+    let bob = topology.add_user(1, "bob").await.expect("add bob on B");
+
+    topology
+        .node(0)
+        .unwrap()
+        .atm
+        .tsp()
+        .send_nested_routed(
+            &alice.profile,
+            &[mediator_a, mediator_b],
+            &bob.did,
+            b"should not arrive",
+        )
+        .await
+        .expect("alice's send reaches her own mediator regardless");
+
+    // Give the forwarding processor time to attempt the hop and be refused. The
+    // positive case in `tsp_cross_mediator` arrives well within this window, so
+    // an empty mailbox here is a refusal rather than impatience.
+    let bob_env = topology.node(1).unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let fetched = bob_env
+            .atm
+            .fetch_messages(&bob.profile, &FetchOptions::default())
+            .await
+            .expect("fetch messages");
+        assert!(
+            fetched.success.is_empty(),
+            "a hop from an untrusted peer must not be delivered"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    topology.shutdown().await.expect("shutdown");
+}
+
+/// Control for the refusal: the same topology with an **empty** allowlist, which
+/// admits any peer. Without this, the test above would pass just as happily
+/// against a fixture where cross-mediator TSP delivery is simply broken.
+///
+/// Empty rather than naming mediator A explicitly, because A's DID does not
+/// exist until the topology spawns and `configure_each` runs before that. The
+/// pairing is still decisive: same topology, same route, same hop — only the
+/// allowlist differs, and only the empty one delivers.
+#[tokio::test]
+async fn inter_mediator_hop_with_an_empty_allowlist_is_accepted() {
+    let topology = TestTopology::builder()
+        .mediators(2)
+        .spawn()
+        .await
+        .expect("spawn two-mediator topology");
+
+    let mediator_a = topology.mediator_did(0).expect("mediator A").to_string();
+    let mediator_b = topology.mediator_did(1).expect("mediator B").to_string();
+    let alice = topology.add_user(0, "alice").await.expect("add alice on A");
+    let bob = topology.add_user(1, "bob").await.expect("add bob on B");
+
+    let payload = b"hop from a trusted peer";
+    topology
+        .node(0)
+        .unwrap()
+        .atm
+        .tsp()
+        .send_nested_routed(&alice.profile, &[mediator_a, mediator_b], &bob.did, payload)
+        .await
+        .expect("alice sends nested+routed to bob on B");
+
+    let bob_env = topology.node(1).unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let stored = loop {
+        let fetched = bob_env
+            .atm
+            .fetch_messages(&bob.profile, &FetchOptions::default())
+            .await
+            .expect("fetch messages");
+        if let Some(msg) = fetched.success.first().and_then(|e| e.msg.as_ref()) {
+            break msg.clone();
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "trusted hop was not delivered within the deadline"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+
+    let (recovered, sender) = bob_env
+        .atm
+        .tsp()
+        .unpack(&bob.profile, &stored)
+        .await
+        .expect("bob unpacks");
+    assert_eq!(recovered, payload);
+    assert_eq!(sender, alice.did);
+
+    topology.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
Closes #758 — raised by the AgenticSec review on #756 (alert 67), and by the correction it prompted: `relay_peer_trusted` was DIDComm-only, so a TSP deployment that needed its relaying peer authenticated had **no lever at all**.

## The open design question, answered

The issue asked whether TSP wants a `RelayMode` (Blind/Rewrap) distinction. **It doesn't**, and the reason is in `direct::unpack`:

A routed or nested hop is sealed to this mediator, so unpacking it verifies an **Ed25519 signature** over envelope‖ciphertext against the signing key resolved from the sender's DID document, *and* opens the payload with **HPKE-Auth**, which binds the sender's static key. Two independent proofs.

DIDComm can only identify its peer in `RelayMode::Rewrap`, where a layer addressed to this mediator can be authcrypt-opened; in `Blind` the peer is invisible and the allowlist is ignored. **TSP routed relay is re-wrap-like by construction** — every hop sealed to the next, authenticated as the previous — so there is no mode to select and no blind variant to except. TSP ends up with a stronger guarantee than DIDComm, unconditionally.

## Two scoping rules — and I got the second wrong first

- **Relay arms only.** `Direct` and `Control` addressed to this mediator are messages *to* it — Trust Tasks over TSP arrive that way — not relays through it.
- **Anonymous sessions only.** This is where TSP genuinely differs and it's easy to miss. Only a peer mediator ever produces a DIDComm re-wrap layer, so peeling one is inter-mediator *by construction*. A TSP **routed message is not**: an ordinary client sends one through its own mediator for metadata privacy (TSP §5.5), and that client is not a peer mediator.

My first implementation gated every routed hop. That would have refused every routed client the moment an operator populated the list — and the test toggle shows it's worse than that: Alice can't even *send*, because her own mediator refuses her routed message. An inter-mediator hop arrives with no `Authorization` header, on the anonymous session, which is exactly the traffic this list is meant to govern.

`client_routed_message_is_unaffected_by_the_peer_allowlist` exists to hold that line permanently.

## What this does not cover, stated plainly

TSP **opaque pass-through** — a message addressed to a local recipient rather than to this mediator — has nothing addressed to us to open, so there is no peer to identify and no allowlist can apply. That is the true analogue of DIDComm blind relay. `security.enable_inter_mediator_relay` (which gates anonymous inbound at all) and `security.local_direct_delivery_allowed` are the levers there.

The comment added in 0.20.7 claiming TSP had no equivalent hardening is corrected to say precisely which hops are now covered, and `docs/acls.md` gains a per-protocol table of where the allowlist applies and why.

## Testing

Three tests, both failure modes verified by toggle:

| Toggle | Result |
|---|---|
| Gate disabled entirely | only `inter_mediator_hop_from_an_untrusted_peer_is_refused` fails |
| `!session.authenticated` dropped | `client_routed_message_...` fails **and** the refusal test fails (Alice can't send) |

`inter_mediator_hop_with_an_empty_allowlist_is_accepted` is the control on an identical topology — same route, same hop, only the allowlist differs — so the refusal can't pass against a fixture where cross-mediator TSP is simply broken.

242 mediator unit tests and all 30 e2e suites green; `cargo fmt --check`, clippy `-D warnings`, and all three repo guards clean.

## Not a behaviour change by default

`relay_trusted_mediators` defaults to empty, which means "accept any peer". Deployments that never set it see no change.

Mediator 0.20.10, mediator-common 0.15.38 (doc only), test-mediator 0.4.5.
