### PR TITLE
chore(deny): drop the stale advisory ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,24 @@
 [advisories]
 version = 2
-ignore = [
-  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error (unmaintained) is a build-time-only transitive dep of the ssi-json-ld stack (ssi-dids-core -> linked-data-derive); no runtime exposure. Drops out once upstream ssi-* releases migrate off it." },
-]
+# Deliberately empty: no advisory is currently suppressed for the build graph.
+#
+# The sole entry here ignored RUSTSEC-2024-0370 (proc-macro-error) on the grounds
+# that it was a build-time-only transitive of the ssi-json-ld stack, and said it
+# would "drop out once upstream ssi-* releases migrate off it". Rather than wait
+# for upstream, cache-sdk 0.8.36 retired did:cheqd resolution and dropped
+# `did-resolver-cheqd`, which took the whole ssi-0.1 stack out of the graph — so
+# the entry stopped matching anything and cargo-deny began warning
+# `advisory-not-detected` about it.
+#
+# Keep it empty. A suppression list nobody trusts is a list nobody audits, and an
+# entry that matches nothing is indistinguishable from one that matters. If an
+# advisory genuinely has to be accepted, add it with a reason *and* the condition
+# that would clear it, and delete it the moment that condition is met.
+#
+# Note this governs the BUILD GRAPH. `cargo audit` reads Cargo.lock and has its
+# own list, `auditIgnore`, duplicated in .github/workflows/checks.yaml and
+# release.yaml — change those together.
+ignore = []
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
Part of #761 — and it turns out to be the *only* real item in it. See below.

## The change

`cargo deny check advisories` was warning:

```
warning[advisory-not-detected]: advisory was not encountered
  deny.toml:4  RUSTSEC-2024-0370
  no crate matched advisory criteria
```

The entry ignored `proc-macro-error` as a build-time-only transitive of the ssi-json-ld stack, and said it would "drop out once upstream ssi-* releases migrate off it". #763 didn't wait for upstream — it retired `did:cheqd` resolution and dropped `did-resolver-cheqd`, taking the whole ssi-0.1 stack out of the graph. Its own clearing condition was met, and then some.

The list is now empty and commented to stay that way, including a pointer that this governs the **build graph** while `cargo audit` reads `Cargo.lock` and has its own `auditIgnore` duplicated across `checks.yaml` and `release.yaml` — missing that second copy cost a follow-up PR (#764).

`cargo deny check` is clean on all four: advisories, bans, licenses, sources.

## Two things #761 claimed that turned out to be wrong

I filed #761, so these are my errors to correct.

**The two "yanked crates in the graph" are not in the graph.** A fresh resolve on current `main` takes `chacha20 0.10.2` and `wnaf 0.14.1`, neither yanked. The warnings I reported came from a **stale local `Cargo.lock`** — and since `Cargo.lock` is gitignored here, CI resolves fresh every run and never sees them. Cargo won't select a yanked version on a fresh resolve; it only keeps one already pinned in a lockfile.

That's the same class of mistake as the `paste` finding in #726: reading a lockfile artifact as if it were a property of the project. I'd flagged wanting to know *why* `chacha20` was yanked before treating it as cosmetic — the answer is that it doesn't matter, because we were never on it.

**The `auditIgnore` annotation item is already done**, by #763 and #764: both copies are trimmed to `RUSTSEC-2024-0373` alone, each with a comment saying what cleared the rest.

So after this merges, #761 can close.

## Deliberately not touched

`cargo deny` also warns `license-not-encountered` for the unused `"NCSA"` allowance. That is a different kind of staleness: an allowed license nothing currently uses hides nothing, whereas a stale advisory ignore hides a real risk. Removing it would *tighten policy* — a future dependency under NCSA would newly fail the build — rather than delete dead weight. That's a decision about license policy, not hygiene, so I left it and am flagging it instead.
