### PR TITLE
chore(deps): bring six dependencies to their current major

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased (0.20.11) — dependency currency
+
+No behaviour change. Two major-version dependency bumps, verified against the
+full suite (242 unit tests, 30 e2e suites) rather than a compile:
+
+- **`itertools` 0.14 → 0.15.**
+- **`tikv-jemallocator` 0.6 → 0.7** — the allocator behind the `jemalloc`
+  feature. The memory work in 0.17.0 measured against jemalloc, so this is worth
+  re-measuring if RSS is ever in question again.
+
+`jsonwebtoken` 10 → 11 was attempted here and pulled back out: `SecurityConfig`
+exposes `pub jwt_encoding_key: EncodingKey` and `pub jwt_decoding_key:
+DecodingKey`, so jsonwebtoken is a **public dependency** of this crate's API and
+bumping it is semver-breaking rather than routine currency. Tracked separately.
+
 ## Unreleased (0.20.10) — TSP relay honours the peer-mediator allowlist
 
 Closes [#758], raised by the AgenticSec review on #756 (alert 67) and by the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.20.10"
+version = "0.20.11"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -268,7 +268,7 @@ ahash = { version = "0.8", features = ["serde"] }
 dashmap = "6.2"
 chrono = "0.4"
 hostname = "0.4"
-itertools = "0.14"
+itertools = "0.15"
 num-format = "0.4"
 rand = "0.10"
 regex = "1"
@@ -289,7 +289,7 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 ## Not available on MSVC; the cfg gate below falls back to the system
 ## allocator there.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.39) — dependency currency
+
+No behaviour change: `itertools` 0.14 → 0.15. 241 tests green.
+
 ## Unreleased (0.15.38) — document where the relay allowlist applies
 
 Documentation only, alongside mediator 0.20.10 (issue #758).

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.38"
+version = "0.15.39"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -203,7 +203,7 @@ redis = { version = "1.1", features = [
   "connection-manager",
   "ahash",
 ], optional = true }
-itertools = { version = "0.14", optional = true }
+itertools = { version = "0.15", optional = true }
 ## Constant-time DID-hash comparisons.
 subtle = { version = "2", optional = true }
 

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Affinidi Messaging Mediator Setup
 
+## Unreleased (0.1.30) — dependency currency
+
+No behaviour change: `serial_test` 3 → 4, a dev-dependency. 406 tests green.
+
 ## Unreleased (0.1.29) — setup completes against a DIDComm/TSP-only VTA
 
 **Bug fix: provisioning no longer aborts when the VTA advertises no REST URL.**

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-setup"
-version = "0.1.29"
+version = "0.1.30"
 description = "Interactive TUI setup wizard for Affinidi Messaging Mediator"
 edition.workspace = true
 authors.workspace = true
@@ -194,7 +194,7 @@ tempfile = "3"
 ## default and the global CWD is shared, so the double-run detector
 ## could race against an unrelated test's artefacts. `#[serial]`
 ## forces affected tests to run one at a time.
-serial_test = "3"
+serial_test = "4"
 ## Sealed-handoff tests construct `ProducerAssertion` values with
 ## `producer_did` as a did:key — uses the `affinidi-crypto` dep
 ## already declared in `[dependencies]`.

--- a/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-text-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (0.12.7) — dependency currency
+
+No behaviour change: `ratatui-image` 10 → 11.
+
 ## [0.12.6] - 2026-08-17
 
 ### Changed

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-text-client"
-version = "0.12.6"
+version = "0.12.7"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ log = "0.4"
 qrcode = "0.14"
 rand = "0.10"
 ratatui = "0.30"
-ratatui-image = { version = "10", default-features = false, features = ["crossterm"] }
+ratatui-image = { version = "11", default-features = false, features = ["crossterm"] }
 reqwest = { version = "0.13", features = ["rustls", "json"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/crates/trust/affinidi-trust-lists/CHANGELOG.md
+++ b/crates/trust/affinidi-trust-lists/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Affinidi Trust Lists Changelog
 
+## Unreleased (0.1.5) — quick-xml 0.42, x509-parser 0.18
+
+- **`quick-xml` 0.41 → 0.42**, which required a source migration. 0.42 makes
+  names and text `&str` throughout where they were byte slices, so
+  `BytesText::decode()` and `BytesRef::decode()` are gone (the content is already
+  decoded) and `QName::as_ref()` yields `&str`. `local_name_owned` now takes
+  `&str` and the intermediate `Vec<u8>` per tag is gone with it.
+
+  Entity handling is unchanged: references still arrive as their own `GeneralRef`
+  events and are still resolved and appended, so a value containing `&amp;`
+  reassembles exactly as before. `xml10_content()` exists in 0.42 but only
+  normalises EOLs, which this parser does not need — every consumer trims.
+- **`x509-parser` 0.16 → 0.18**, no source change.
+
+37 tests green, including the entity-reference cases.
+
 ## Unreleased (0.1.4) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/trust/affinidi-trust-lists/Cargo.toml
+++ b/crates/trust/affinidi-trust-lists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-trust-lists"
 description = "EU Trusted Lists (ETSI TS 119 612) for eIDAS 2.0 trust infrastructure."
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -23,13 +23,13 @@ path = "examples/browse_trust_list.rs"
 [dependencies]
 base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
-quick-xml = { version = "0.41", features = ["serialize"] }
+quick-xml = { version = "0.42", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
 tracing = "0.1"
-x509-parser = "0.16"
+x509-parser = "0.18"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/trust/affinidi-trust-lists/src/xml/mod.rs
+++ b/crates/trust/affinidi-trust-lists/src/xml/mod.rs
@@ -88,8 +88,8 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
     loop {
         match reader.read_event() {
             Ok(Event::Start(e)) => {
-                let name_bytes = e.name().as_ref().to_vec();
-                let local = local_name_owned(&name_bytes);
+                let qname = e.name();
+                let local = local_name_owned(qname.as_ref());
                 path.push(local.clone());
                 text_buf.clear();
 
@@ -99,25 +99,27 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                 }
             }
             Ok(Event::Text(e)) => {
-                // quick-xml 0.41 emits raw text between entity references; the
+                // quick-xml emits raw text between entity references; the
                 // references themselves arrive as separate `GeneralRef` events
-                // (see below), so accumulate rather than replace.
-                let text = e.decode().unwrap_or_default();
+                // (see below), so accumulate rather than replace. Since 0.42 the
+                // content is already `&str` — `decode()` is gone.
+                let text: &str = &e;
                 if in_x509_cert {
                     cert_base64.push_str(text.trim());
                 } else {
-                    text_buf.push_str(&text);
+                    text_buf.push_str(text);
                 }
             }
             Ok(Event::GeneralRef(e)) => {
                 // An entity reference inside element text (e.g. `&amp;` in an org
-                // name or URI). quick-xml 0.41 surfaces these as their own event;
-                // resolve predefined/numeric references and append so the value is
-                // reassembled exactly as 0.37's inline `unescape()` produced it.
-                let name = e.decode().unwrap_or_default();
+                // name or URI). quick-xml surfaces these as their own event since
+                // 0.41; resolve predefined/numeric references and append so the
+                // value is reassembled exactly as 0.37's inline `unescape()`
+                // produced it. `BytesRef` derefs to `str` since 0.42.
+                let name: &str = &e;
                 let resolved = quick_xml::escape::unescape(&format!("&{name};"))
                     .map(|c| c.into_owned())
-                    .unwrap_or_else(|_| name.into_owned());
+                    .unwrap_or_else(|_| name.to_string());
                 if in_x509_cert {
                     cert_base64.push_str(resolved.trim());
                 } else {
@@ -125,8 +127,8 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
                 }
             }
             Ok(Event::End(e)) => {
-                let name_bytes = e.name().as_ref().to_vec();
-                let local = local_name_owned(&name_bytes);
+                let qname = e.name();
+                let local = local_name_owned(qname.as_ref());
 
                 // Build path string for context matching
                 let path_str = path.join("/");
@@ -298,11 +300,10 @@ pub fn parse_trust_list_xml(xml: &str) -> Result<TrustServiceStatusList> {
 }
 
 /// Extract the local name from an XML element (strip namespace prefix).
-fn local_name_owned(name: &[u8]) -> String {
-    let s = std::str::from_utf8(name).unwrap_or("");
-    s.rsplit_once(':')
+fn local_name_owned(name: &str) -> String {
+    name.rsplit_once(':')
         .map(|(_, local)| local)
-        .unwrap_or(s)
+        .unwrap_or(name)
         .to_string()
 }
 


### PR DESCRIPTION
No behaviour change. Six major-version bumps, each verified against the owning crate's real suite — not a compile — because `cargo test --workspace` unifies features across the graph while CI builds per-package.

| Dependency | | Crate | Source change |
|---|---|---|---|
| `itertools` | 0.14 → 0.15 | mediator, mediator-common | none |
| `tikv-jemallocator` | 0.6 → 0.7 | mediator | none |
| `serial_test` | 3 → 4 | mediator-setup (dev) | none |
| `quick-xml` | 0.41 → 0.42 | trust-lists | **yes** |
| `x509-parser` | 0.16 → 0.18 | trust-lists | none |
| `ratatui-image` | 10 → 11 | text-client | none |

Five compiled and passed untouched; only `quick-xml` needed code changes.

## quick-xml 0.42

0.42 makes names and text `&str` throughout where they were byte slices: `BytesText::decode()` and `BytesRef::decode()` are gone (content is already decoded) and `QName::as_ref()` yields `&str`. `local_name_owned` now takes `&str`, and the intermediate `Vec<u8>` per tag disappears with it.

Entity handling is deliberately unchanged — references still arrive as their own `GeneralRef` events and are still resolved and appended, so a value containing `&amp;` reassembles exactly as before. 0.42 does offer `xml10_content()`, but it only normalises EOLs, which this parser doesn't need since every consumer trims; reaching for it would have been a silent behaviour change dressed up as an API fix.

## jsonwebtoken 11 was in here and was pulled back out

Worth reading, because `verify-publish` earned its keep. The mediator compiled and passed; `test-mediator` failed with:

```
expected `jsonwebtoken::decoding::DecodingKey`, found `DecodingKey`
note: there are multiple different versions of crate `jsonwebtoken` in the dependency graph
```

In the registry-isolated build, `test-mediator` resolves the **published** mediator 0.20.10 (jsonwebtoken 10) while itself using 11 — and the types meet because `SecurityConfig` exposes `pub jwt_encoding_key: EncodingKey` / `pub jwt_decoding_key: DecodingKey`, which `test-mediator` constructs.

So **jsonwebtoken is a public dependency of the mediator's API**, and bumping it is semver-breaking rather than routine currency. It would have gone green at release time — crates publish in dependency order — which is precisely why it was worth stopping on: it would have shipped a breaking change as a patch and left any consumer mixing versions with a type error pointing at neither crate.

Tracked in #770, with sealing the leak as the recommended fix. `test-mediator` is untouched by this PR as a result.

## Testing

mediator **242**, mediator-common **241**, mediator-setup **406**, trust-lists **37** (including the entity-reference cases), and all **30** e2e suites. `cargo fmt --check`, workspace clippy `-D warnings`, and all three repo guards clean.

## Deliberately not in this change

This is the tractable third of the 35 outdated crates. The rest wants planning, not a ride-along:

- **The RustCrypto generation** — `sha2 0.11`, `hmac 0.13`, `hkdf 0.13`, `aes-gcm 0.11`, `chacha20poly1305 0.11`, `elliptic-curve 0.14`, `group`/`ff 0.14`, `rand 0.10`, `getrandom 0.4`, `bls12_381_plus 0.9`, and the rest. ~19 crates that move as one unit and touch every crypto crate here plus VTI. **No advisory forces it**, and precedent (#672, #674) says each such move is a multi-repo effort.
- **Infra cluster** — `kube 4` + `k8s-openapi 0.28` (move together), `keyring 4`, `azure_* 1.0`.
- **`trust-tasks-rs` 0.17 → 0.18** — a public dep of the SDK's API, so source-breaking for consumers. Needs the coordinated treatment #692 got.
- **`vta-sdk` 0.32.1 → 0.32.4** needs nothing: semver-compatible, and since `Cargo.lock` is gitignored CI already resolves it fresh.
