### PR TITLE
fix(mediator)!: make jsonwebtoken a private dependency, and move to 11

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased (0.22.0) — `jsonwebtoken` is now a private dependency, and moves to 11
+
+Closes [#770]. **Breaking:** `SecurityConfig::jwt_encoding_key` and
+`jwt_decoding_key` are no longer public fields. Set them with the new
+[`SecurityConfig::set_jwt_keys_from_pkcs8`], which takes the Ed25519 PKCS#8
+document — the same bytes the production path already reads from the
+`JWT_SECRET` well-known entry — and derives both keys from it.
+
+**Why this was worth a breaking change.** Those fields are `jsonwebtoken` types,
+so while they were public, `jsonwebtoken` was a *public dependency* of this
+crate: anyone constructing a `SecurityConfig` had to name `EncodingKey` /
+`DecodingKey` and therefore had to compile against the same `jsonwebtoken`
+major we did. Every bump of it was then source-breaking for consumers rather
+than routine currency.
+
+That is not theoretical. It was caught in #767, where bumping to 11 as ordinary
+dependency currency made `affinidi-messaging-test-mediator` fail to build
+against the published mediator with `expected jsonwebtoken::decoding::DecodingKey,
+found DecodingKey`. It would have gone green at release time, because crates
+publish in dependency order — so a breaking change would have shipped as a patch
+bump, and any consumer mixing versions would have got a type error pointing at
+neither crate.
+
+**`jsonwebtoken` 10 → 11** now lands as part of this, and from here on such
+bumps are internal.
+
+Two smaller consequences worth naming:
+
+- The key derivation lived in two places (the config loader and the test
+  fixture), each doing `Ed25519KeyPair::from_pkcs8` then `DecodingKey::from_ed_der`.
+  It now lives only in `set_jwt_keys_from_pkcs8`, so the signing and verification
+  keys cannot drift apart.
+- New `install_jwt_crypto_provider()` at the crate root. `jsonwebtoken`'s
+  `aws_lc_rs` provider is registered per *instance* of that crate, so a consumer
+  installing it against its own copy installs nothing for the copy this mediator
+  verifies with. While the key fields were public that mismatch was at least a
+  compile error; with the dependency private it would have become a silent
+  runtime failure, so the installation has to be callable from here.
+
+[#770]: https://github.com/affinidi/affinidi-tdk-rs/issues/770
+
 ## Unreleased (0.21.0) — `trust-tasks-rs` 0.18
 
 **`trust-tasks-rs` 0.17 → 0.18.** Follows `affinidi-messaging-sdk` 0.22.0. No

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.21.0"
+version = "0.22.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -222,7 +222,7 @@ aws-sdk-ssm = { version = "1", optional = true, default-features = false, featur
 aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 
 # ── Cryptography & Security ─────────────────────────────────────────────
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "11", features = ["aws_lc_rs"] }
 ring = { version = "0.17", features = ["std"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "tls12"] }
 ## Constant-time comparison for DID authorization checks

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/security.rs
@@ -273,10 +273,19 @@ pub struct SecurityConfig {
     pub ssl_certificate_file: Option<String>,
     #[serde(skip_serializing)]
     pub ssl_key_file: Option<String>,
+    // Private on purpose. These are `jsonwebtoken` types, and while they were
+    // `pub` that crate was a *public dependency* of this one: a consumer
+    // constructing a `SecurityConfig` had to name `EncodingKey`/`DecodingKey`,
+    // so it had to compile against the same `jsonwebtoken` major we did. Bumping
+    // it was then source-breaking for consumers rather than routine currency,
+    // which is how mediator 0.20.11 nearly shipped a break as a patch (#770).
+    //
+    // Build them with [`SecurityConfig::set_jwt_keys_from_pkcs8`] instead, which
+    // takes bytes and keeps the dependency private.
     #[serde(skip_serializing)]
-    pub jwt_encoding_key: EncodingKey,
+    jwt_encoding_key: EncodingKey,
     #[serde(skip_serializing)]
-    pub jwt_decoding_key: DecodingKey,
+    jwt_decoding_key: DecodingKey,
     pub jwt_access_expiry: u64,
     pub jwt_refresh_expiry: u64,
     #[serde(skip_serializing)]
@@ -335,6 +344,43 @@ impl Debug for SecurityConfig {
 }
 
 impl SecurityConfig {
+    /// Derive and install the JWT signing and verification keys from an Ed25519
+    /// **PKCS#8** document — the same bytes the production path reads from the
+    /// `JWT_SECRET` well-known entry.
+    ///
+    /// This is the only way to set them, and deliberately so: the keys are
+    /// `jsonwebtoken` types, and taking bytes here keeps that crate a *private*
+    /// dependency of this one. While the fields were public a consumer had to
+    /// name `EncodingKey`/`DecodingKey` to build a `SecurityConfig`, which made
+    /// every `jsonwebtoken` major bump source-breaking for consumers (#770).
+    ///
+    /// Both keys come from the one document: the signing key is the PKCS#8
+    /// itself, the verification key is the public half derived from it, so they
+    /// cannot drift apart.
+    pub fn set_jwt_keys_from_pkcs8(&mut self, pkcs8: &[u8]) -> Result<(), MediatorError> {
+        let pair = Ed25519KeyPair::from_pkcs8(pkcs8).map_err(|err| {
+            tracing::error!("Could not create JWT key pair. {err}");
+            MediatorError::ConfigError(
+                12,
+                "NA".into(),
+                format!("Could not create JWT key pair. {err}"),
+            )
+        })?;
+        self.jwt_encoding_key = EncodingKey::from_ed_der(pkcs8);
+        self.jwt_decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
+        Ok(())
+    }
+
+    /// The JWT signing key, for this crate's authentication handlers.
+    pub(crate) fn jwt_encoding_key(&self) -> &EncodingKey {
+        &self.jwt_encoding_key
+    }
+
+    /// The JWT verification key, for this crate's authentication handlers.
+    pub(crate) fn jwt_decoding_key(&self) -> &DecodingKey {
+        &self.jwt_decoding_key
+    }
+
     /// Construct a baseline `SecurityConfig` with conservative defaults
     /// and zero-byte JWT keys. Used by [`Config::headless`] and the
     /// `MediatorBuilder` as a starting point — embedded callers MUST
@@ -747,17 +793,7 @@ impl SecurityConfigRawExt for SecurityConfigRaw {
             }
         };
 
-        config.jwt_encoding_key = EncodingKey::from_ed_der(&jwt_bytes);
-
-        let pair = Ed25519KeyPair::from_pkcs8(&jwt_bytes).map_err(|err| {
-            tracing::error!("Could not create JWT key pair. {err}");
-            MediatorError::ConfigError(
-                12,
-                "NA".into(),
-                format!("Could not create JWT key pair. {err}"),
-            )
-        })?;
-        config.jwt_decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
+        config.set_jwt_keys_from_pkcs8(&jwt_bytes)?;
 
         Ok(config)
     }

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -137,7 +137,7 @@ pub(crate) async fn authenticate_token(
 ) -> Result<Session, AuthError> {
     let token_data: TokenData<SessionClaims> = match jsonwebtoken::decode::<SessionClaims>(
         token,
-        &state.config.security.jwt_decoding_key,
+        state.config.security.jwt_decoding_key(),
         &clock_aware_validation(),
     ) {
         Ok(token_data) => token_data,

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/refresh.rs
@@ -168,7 +168,7 @@ pub async fn authentication_refresh(
         // clock below (not by jsonwebtoken) — see `clock_aware_validation`.
         let results = match jsonwebtoken::decode::<SessionClaims>(
             refresh_token,
-            &state.config.security.jwt_decoding_key,
+            state.config.security.jwt_decoding_key(),
             &clock_aware_validation(),
         ) {
             Ok(token) => token,
@@ -327,7 +327,7 @@ pub async fn authentication_refresh(
             &session_check.session_id,
             state.config.security.jwt_access_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
 
         // Generate a new refresh token (rotation — old one is now invalid)
@@ -338,7 +338,7 @@ pub async fn authentication_refresh(
             &session_check.session_id,
             refresh_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
 
         // Store the new refresh token hash

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/response.rs
@@ -337,7 +337,7 @@ pub async fn authentication_response(
             &session.session_id,
             state.config.security.jwt_access_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
 
         let refresh_expiry =
@@ -347,7 +347,7 @@ pub async fn authentication_response(
             &session.session_id,
             refresh_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
 
         session.expires_at = access_expires_at;

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/tsp.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/authenticate/tsp.rs
@@ -177,7 +177,7 @@ pub async fn tsp_authentication_response(
             &session.session_id,
             state.config.security.jwt_access_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
         let refresh_expiry =
             state.config.security.jwt_refresh_expiry - state.config.security.jwt_access_expiry;
@@ -186,7 +186,7 @@ pub async fn tsp_authentication_response(
             &session.session_id,
             refresh_expiry,
             now,
-            &state.config.security.jwt_encoding_key,
+            state.config.security.jwt_encoding_key(),
         )?;
 
         state

--- a/crates/messaging/affinidi-messaging-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/lib.rs
@@ -36,6 +36,22 @@ pub mod tasks;
 #[cfg(feature = "tsp")]
 pub mod tsp_identity;
 
+/// Install `jsonwebtoken`'s `aws_lc_rs` crypto provider as the process-wide
+/// default, idempotently.
+///
+/// This lives here, rather than in each consumer, because the provider is
+/// registered per `jsonwebtoken` *instance*: a consumer that calls
+/// `jsonwebtoken::…::install_default()` against its own copy of the crate
+/// installs nothing for the copy this mediator verifies tokens with. While the
+/// JWT key fields were public that mismatch was at least a compile error;
+/// now that `jsonwebtoken` is a private dependency (#770) it would be a silent
+/// runtime failure instead, so the installation has to be callable from here.
+///
+/// Errors from an already-installed provider are ignored.
+pub fn install_jwt_crypto_provider() {
+    let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+}
+
 /// Shared application state available to all request handlers via Axum's state extraction.
 #[derive(Clone)]
 pub struct SharedData {

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased (0.5.1) — no longer depends on `jsonwebtoken`
+
+Support for mediator 0.22.0 (issue #770). The fixture used to build
+`EncodingKey`/`DecodingKey` itself and assign them into `SecurityConfig`; it now
+generates the Ed25519 PKCS#8 document and hands the bytes to
+`SecurityConfig::set_jwt_keys_from_pkcs8`.
+
+The `jsonwebtoken` dependency is **gone from this crate entirely**, which is the
+practical proof that it is now private to the mediator: there is no second copy
+left to mismatch. `install_default_crypto_provider` delegates to the mediator's
+`install_jwt_crypto_provider()` for the same reason — that provider is registered
+per `jsonwebtoken` instance, and it is the mediator's copy that verifies tokens.
+
 ## Unreleased (0.5.0) — `trust-tasks-rs` 0.18
 
 - Follows `affinidi-messaging-sdk` 0.22.0 and `affinidi-messaging-mediator`

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.5.0"
+version = "0.5.1"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.21", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.22", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
@@ -57,7 +57,6 @@ affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affi
 affinidi-messaging-sdk = { version = "0.22.0", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 ring = { version = "0.17", features = ["std"] }
 
 # ── rustls: needed to install a `CryptoProvider` at fixture startup so

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -111,8 +111,7 @@ use affinidi_secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, secret
 use affinidi_tdk::dids::{
     DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
 };
-use jsonwebtoken::{DecodingKey, EncodingKey};
-use ring::{rand::SystemRandom, signature::Ed25519KeyPair, signature::KeyPair};
+use ring::{rand::SystemRandom, signature::Ed25519KeyPair};
 use sha256::digest;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -791,7 +790,7 @@ impl TestMediatorBuilder {
 
         // JWT signing key — Ed25519 PKCS8, same shape as the production
         // path's `JWT_SECRET` well-known.
-        let (jwt_encoding_key, jwt_decoding_key) = generate_jwt_keys()?;
+        let jwt_pkcs8 = generate_jwt_pkcs8()?;
 
         let secrets_backend =
             MediatorSecrets::new(Arc::new(SecretsMemoryStore::new("test-mediator-memory")));
@@ -799,8 +798,9 @@ impl TestMediatorBuilder {
         let mut security = affinidi_messaging_mediator::common::config::SecurityConfig::headless(
             secrets_resolver.clone(),
         );
-        security.jwt_encoding_key = jwt_encoding_key;
-        security.jwt_decoding_key = jwt_decoding_key;
+        security
+            .set_jwt_keys_from_pkcs8(jwt_pkcs8.as_ref())
+            .map_err(|e| TestMediatorError::JwtKey(format!("install jwt keys: {e}")))?;
         security.use_ssl = false;
         // Apply Option-typed overrides — `None` keeps the headless
         // default, so behavior for callers that don't touch these
@@ -1130,13 +1130,15 @@ impl std::fmt::Debug for TestMediatorHandle {
 /// this once at process start (or letting `TestMediator::spawn` call
 /// it for you) resolves the ambiguity.
 ///
-/// Also installs jsonwebtoken's `aws_lc_rs` provider for the same
-/// reason. Errors from already-installed providers are ignored.
+/// Also installs jsonwebtoken's `aws_lc_rs` provider for the same reason —
+/// delegated to the mediator, because that provider is registered per
+/// `jsonwebtoken` instance and it is the mediator's copy that verifies tokens.
+/// Errors from already-installed providers are ignored.
 pub fn install_default_crypto_provider() {
     if rustls::crypto::CryptoProvider::get_default().is_none() {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     }
-    let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    affinidi_messaging_mediator::install_jwt_crypto_provider();
 }
 
 // ─── Internals ───────────────────────────────────────────────────────────────
@@ -1285,18 +1287,10 @@ async fn register_local_dids(
 /// production code path (`security.rs::convert`) which loads PKCS8
 /// bytes from the secrets backend and derives the public key for
 /// verification.
-fn generate_jwt_keys() -> Result<(EncodingKey, DecodingKey), TestMediatorError> {
+fn generate_jwt_pkcs8() -> Result<ring::pkcs8::Document, TestMediatorError> {
     let rng = SystemRandom::new();
-    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
-        .map_err(|e| TestMediatorError::JwtKey(format!("ring pkcs8 generate: {e}")))?;
-    let pkcs8_bytes = pkcs8.as_ref();
-
-    let encoding_key = EncodingKey::from_ed_der(pkcs8_bytes);
-    let pair = Ed25519KeyPair::from_pkcs8(pkcs8_bytes)
-        .map_err(|e| TestMediatorError::JwtKey(format!("ring pkcs8 parse: {e}")))?;
-    let decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
-
-    Ok((encoding_key, decoding_key))
+    Ed25519KeyPair::generate_pkcs8(&rng)
+        .map_err(|e| TestMediatorError::JwtKey(format!("ring pkcs8 generate: {e}")))
 }
 
 // ─── Quick sanity test ──────────────────────────────────────────────────────
@@ -1305,10 +1299,20 @@ fn generate_jwt_keys() -> Result<(EncodingKey, DecodingKey), TestMediatorError> 
 mod tests {
     use super::*;
 
-    #[test]
-    fn jwt_keys_generate() {
-        let result = generate_jwt_keys();
-        assert!(result.is_ok(), "JWT key generation should succeed");
+    #[tokio::test]
+    async fn jwt_keys_generate() {
+        let pkcs8 = generate_jwt_pkcs8().expect("JWT key generation should succeed");
+
+        // The bytes have to be installable by the mediator, which is now the
+        // only thing that turns them into keys — generating a document the
+        // mediator then rejects would be a fixture that fails at spawn.
+        let (secrets, _task) = ThreadedSecretsResolver::new(None).await;
+        let mut security = affinidi_messaging_mediator::common::config::SecurityConfig::headless(
+            std::sync::Arc::new(secrets),
+        );
+        security
+            .set_jwt_keys_from_pkcs8(pkcs8.as_ref())
+            .expect("the mediator accepts a freshly generated PKCS#8 document");
     }
 
     #[test]


### PR DESCRIPTION
Closes #770.

**Breaking:** `SecurityConfig::jwt_encoding_key` and `jwt_decoding_key` are no longer public fields. Set them with the new `SecurityConfig::set_jwt_keys_from_pkcs8`, which takes the Ed25519 PKCS#8 document — the same bytes the production path already reads from the `JWT_SECRET` well-known entry — and derives both keys from it.

## Why the break is worth taking

Those fields are `jsonwebtoken` types, so while they were public, **`jsonwebtoken` was a public dependency of this crate**: anyone constructing a `SecurityConfig` had to name `EncodingKey`/`DecodingKey`, and therefore had to compile against the same `jsonwebtoken` major we did. Every bump of it was source-breaking for consumers rather than routine currency.

That's not theoretical — it's why #770 exists. In #767 the bump to 11 went in as ordinary currency and `test-mediator` failed against the published mediator with `expected jsonwebtoken::decoding::DecodingKey, found DecodingKey`. It would have gone **green at release time**, since crates publish in dependency order — so a breaking change would have shipped as a patch bump and left any consumer mixing versions with a type error pointing at neither crate.

**`jsonwebtoken` 10 → 11 lands here**, and from now on such bumps are internal.

## The proof the seal holds

`affinidi-messaging-test-mediator` **no longer depends on `jsonwebtoken` at all** — the dependency is gone from its manifest. There is no second copy left to mismatch.

## Two consequences worth reading

**Key derivation is now in one place.** It lived in two — the config loader and the test fixture — each doing `Ed25519KeyPair::from_pkcs8` then `DecodingKey::from_ed_der`. It now lives only in `set_jwt_keys_from_pkcs8`, so signing and verification keys can't drift apart.

**New `install_jwt_crypto_provider()`, and this one is a hazard the sealing itself created.** `jsonwebtoken`'s `aws_lc_rs` provider is registered per *instance* of that crate, so a consumer installing it against its own copy installs nothing for the copy the mediator verifies with. While the key fields were public, a version mismatch was at least a compile error; with the dependency private it would instead be a **silent runtime failure**. Making the installation callable from the mediator keeps it loud. `test-mediator` now delegates to it.

## Migration

```rust
// before
security.jwt_encoding_key = EncodingKey::from_ed_der(pkcs8);
security.jwt_decoding_key = DecodingKey::from_ed_der(public);

// after
security.set_jwt_keys_from_pkcs8(pkcs8)?;
```

## Testing

mediator **242**, test-mediator lib **7**, and all **30** e2e suites — which mint and verify a JWT on every authenticated request, so they exercise jsonwebtoken 11 throughout. `cargo fmt --check`, workspace clippy `-D warnings`, and all three repo guards clean.

## Expect verify-publish to be red, benignly

This adds a new cross-crate API (`install_jwt_crypto_provider`) that the published mediator doesn't have yet, so the registry-isolated build of `test-mediator` can't resolve it. That's the #592 shape — **a resolution failure, not the `E0308` type failure** that made #767's red worth acting on. The release job publishes in dependency order.

Mediator **0.22.0** (breaking), test-mediator **0.5.1**.
