### PR TITLE
chore(deps): kube 4, k8s-openapi 0.28, azure 1.0

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.40) — kube 4, k8s-openapi 0.28, azure 1.0
+
+No behaviour change and no source change: four major-version dependency bumps
+that needed nothing but the version numbers.
+
+- **`kube` 3.1 → 4.2** and **`k8s-openapi` 0.27 → 0.28**, which move together.
+- **`azure_core`** and **`azure_identity`** 0.35 → **1.0**, and
+  **`azure_security_keyvault_secrets`** 0.14 → **1.0**.
+
+They bump this cleanly because both backends already keep their SDK types
+private: `K8sStore` and `AzureStore` hold only `String` fields plus a lazily
+constructed client, and neither `kube` nor `azure_*` appears in a public
+signature. That is the property `jsonwebtoken` lacked in the mediator (#770) —
+worth stating, because it is the reason one of these was a patch and the other
+was a breaking change.
+
+**`keyring` 3 → 4 is deliberately not here.** It is a migration rather than a
+bump: v4 splits into `keyring-core` plus separate store crates
+(`apple-native-keyring-store`, `linux-keyutils-keyring-store`,
+`dbus-secret-service-keyring-store`, …), and the `apple-native` / `linux-native`
+features this crate selects no longer exist. Dropping those features *compiles* —
+which is the trap — but leaves no credential store registered at all, a silent
+runtime failure on the `secrets-keyring` backend. Tracked separately.
+
+Coverage note, so the green suite is not read as more than it is: the 241 tests
+here include seven touching these two backends, but they are unit-level. Neither
+backend is integration-tested against a real cluster or vault, so the strongest
+evidence for these bumps is that they required no source change at all.
+
 ## Unreleased (0.15.39) — dependency currency
 
 No behaviour change: `itertools` 0.14 → 0.15. 241 tests green.

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.39"
+version = "0.15.40"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -152,9 +152,9 @@ google-cloud-secretmanager-v1 = { version = "1.8", optional = true }
 google-cloud-gax = { version = "1.9", optional = true }
 ## Azure Key Vault Secrets (official Microsoft crate). Paired with
 ## `azure_identity` for the credential chain.
-azure_security_keyvault_secrets = { version = "0.14", optional = true }
-azure_identity = { version = "0.35", optional = true }
-azure_core = { version = "0.35", optional = true }
+azure_security_keyvault_secrets = { version = "1", optional = true }
+azure_identity = { version = "1", optional = true }
+azure_core = { version = "1", optional = true }
 ## HashiCorp Vault KV v2 (rustify-based async REST client). Token auth
 ## via VAULT_TOKEN env. Default features bring in the rustls HTTP stack.
 vaultrs = { version = "0.8", default-features = false, features = [
@@ -164,11 +164,11 @@ vaultrs = { version = "0.8", default-features = false, features = [
 ## (in-cluster ServiceAccount or local kubeconfig); rustls-tls keeps it
 ## on the workspace TLS story. `k8s-openapi` "latest" pins the generated
 ## API types to the newest supported Kubernetes version.
-kube = { version = "3.1", default-features = false, features = [
+kube = { version = "4.2", default-features = false, features = [
   "client",
   "rustls-tls",
 ], optional = true }
-k8s-openapi = { version = "0.27", features = ["latest"], optional = true }
+k8s-openapi = { version = "0.28", features = ["latest"], optional = true }
 
 # ── Async stream helpers (used by the redis-store pubsub bridge) ─────────
 tokio-stream = { version = "0.1", optional = true }


### PR DESCRIPTION
Four major-version bumps in `mediator-common`, **no source change at all**:

| | |
|---|---|
| `kube` | 3.1 → 4.2 |
| `k8s-openapi` | 0.27 → 0.28 |
| `azure_core`, `azure_identity` | 0.35 → **1.0** |
| `azure_security_keyvault_secrets` | 0.14 → **1.0** |

They bump cleanly because both backends already keep their SDK types **private**: `K8sStore` and `AzureStore` hold only `String` fields plus a lazily constructed client, and neither `kube` nor `azure_*` appears in a public signature. That's precisely the property `jsonwebtoken` lacked in the mediator (#770), and it's why one of these is a patch bump while the other was a breaking change.

## keyring 3 → 4 is deliberately not here

It's a **migration, not currency**, and the shape of it is worth recording:

v4 splits into `keyring-core` plus separate store crates — `apple-native-keyring-store`, `linux-keyutils-keyring-store`, `dbus-secret-service-keyring-store`, `windows-native-keyring-store` — and the `apple-native` / `linux-native` features this crate selects **no longer exist**.

Dropping those features *compiles clean*, which is the trap. It leaves **no credential store registered at all**, so `secrets-keyring` would fail at runtime rather than at build — on the backend that holds the mediator's operating secrets. Tracked separately.

## Coverage note

So a green suite isn't read as more than it is: the 241 tests here include seven touching these two backends, but they're unit-level. Neither is integration-tested against a real cluster or vault. **The strongest evidence for these bumps is that they required no source change at all** — not the test count.

Workspace builds with `--all-features`; clippy `-D warnings` clean; version and changelog guards pass.

mediator-common **0.15.40**.
