### PR TITLE
feat(mediator-common)!: migrate to keyring 4 via keyring-core

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.41) — keyring 4: depend on keyring-core and pick the store explicitly
+
+`keyring` 3 → 4 is a restructure rather than a new major. v4 splits into
+`keyring-core` plus one crate per credential store, and its own docs say an
+application that wants to choose its stores should link to those directly rather
+than to the `keyring` facade. This crate is exactly that application, so it now
+depends on `keyring-core` plus `apple-native-keyring-store` (macOS) and
+`linux-keyutils-keyring-store` (Linux), and installs the store itself.
+
+**Behaviour is deliberately unchanged on both platforms**, which took some care:
+
+| | keyring 3 | now |
+|---|---|---|
+| macOS | `apple-native` → Keychain | `apple-native-keyring-store/keychain` |
+| Linux | `linux-native` → kernel keyutils | `linux-keyutils-keyring-store` |
+
+The trap avoided was the facade's `v1` compatibility shim, which looks like a
+drop-in — the API is identical — but selects **Secret Service** on Linux rather
+than keyutils. Secret Service needs a D-Bus session with an unlocked collection,
+which a headless mediator host does not have, so taking it would have moved the
+`secrets-keyring` backend onto a daemon that isn't running, failing at first
+secret access rather than at boot.
+
+- The store is installed once per process, latched in a `OnceLock` so a repeated
+  `open()` (config reload, tests) gets the same outcome including a failure.
+- Platforms other than macOS and Linux now fail at `open()` with an explicit
+  message instead of erroring later from `Entry` with nothing to say about why.
+- The call surface is otherwise unchanged: `Entry::new`, `get_password`,
+  `set_password`, `delete_credential`, `Error::NoEntry` all exist on
+  `keyring-core` with the same shapes.
+
+**Operational caveat, now documented in the module rather than left implicit:**
+keyutils keeps credentials in kernel memory, so on Linux secrets stored via
+`keyring://` **do not survive a reboot**. This is not a regression — `keyring 3`
+selected the same backend — but it makes `keyring://` a poor choice for a Linux
+mediator's operating secrets unless something re-seeds them at start. Use
+`vault://`, `k8s://` or a cloud secret manager for durable storage.
+
+Verification note: the macOS path is compiled and tested here (197 tests). The
+Linux path is **not** compiled locally — no Linux target is installed — so it
+rests on the store crate exposing the same `Store::new() -> Result<Arc<Self>>`
+shape as the macOS one, which was confirmed against its published source. CI
+builds Linux.
 ## Unreleased (0.15.40) — kube 4, k8s-openapi 0.28, azure 1.0
 
 No behaviour change and no source change: four major-version dependency bumps

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.40"
+version = "0.15.41"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -71,7 +71,12 @@ redis-backend = [
 # ── Secret backends ─────────────────────────────────────────────────
 ## Each backend implies `server` (so the secrets module is compiled in)
 ## and pulls the matching cloud SDK.
-secrets-keyring = ["server", "dep:keyring"]
+secrets-keyring = [
+  "server",
+  "dep:keyring-core",
+  "dep:apple-native-keyring-store",
+  "dep:linux-keyutils-keyring-store",
+]
 secrets-aws = ["server", "dep:aws-config", "dep:aws-sdk-secretsmanager"]
 secrets-gcp = [
   "server",
@@ -125,10 +130,13 @@ argon2 = { version = "0.5", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"], optional = true }
 
 # ── Secrets module: optional cloud backends ─────────────────────────
-keyring = { version = "3", features = [
-  "apple-native",
-  "linux-native",
-], optional = true }
+# keyring 4 split into `keyring-core` plus one crate per credential store, and
+# upstream's guidance is that an application which wants to choose its stores
+# should depend on those directly rather than on the `keyring` facade. We do:
+# the facade's `v1` shim selects Secret Service on Linux, which needs a D-Bus
+# session with an unlocked collection — something a headless mediator host does
+# not have. The per-target store crates are below.
+keyring-core = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }
 # `default-features = false` + the default set MINUS `rustls`.
 # The aws-sdk crates ship BOTH TLS stacks in their defaults:
@@ -232,6 +240,25 @@ tempfile = "3"
 ## `test-util` enables `start_paused`, used by the secrets/retry tests
 ## to skip the exponential-backoff delays without sleeping for real.
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+
+# ── OS keyring stores (secrets-keyring) ─────────────────────────────
+# One per platform, chosen to preserve what `keyring 3` selected:
+#   macOS  `apple-native`  -> Keychain
+#   Linux  `linux-native`  -> kernel keyutils (NOT Secret Service; no daemon,
+#                             which is what a headless mediator host needs)
+# Windows is not a supported mediator host, so no store is declared for it;
+# `secrets-keyring` there fails at open() with a clear message rather than
+# silently using a different store.
+[target.'cfg(target_os = "macos")'.dependencies]
+# `keychain` (the classic file-based Keychain) rather than `protected` (the Data
+# Protection Keychain, which needs an app group / entitlements a server binary
+# does not have). `keychain` is what `keyring 3`'s `apple-native` used.
+apple-native-keyring-store = { version = "1", features = [
+  "keychain",
+], optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-keyutils-keyring-store = { version = "1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/keyring.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/backends/keyring.rs
@@ -5,12 +5,27 @@
 //! `user` is the secret key itself (forward-slashes allowed — the `keyring`
 //! crate passes them through verbatim on all platforms we target).
 //!
-//! Value encoding: base64url of the raw bytes, because `keyring::Entry`
+//! Value encoding: base64url of the raw bytes, because `keyring_core::Entry`
 //! stores UTF-8 strings and our stored bytes are binary envelopes.
 //!
 //! Feature-gated behind `secrets-keyring`; when the feature is off
 //! [`open`] returns `BackendUnavailable` with a pointer at the required
 //! cargo feature.
+//!
+//! # Which store, and one operational caveat
+//!
+//! Since keyring 4 there is no built-in store — see [`install_default_store`].
+//! macOS uses the Keychain; Linux uses the **kernel keyutils** keyring.
+//!
+//! Keyutils keeps credentials in kernel memory, so on Linux **secrets stored
+//! here do not survive a reboot**. That is not new — `keyring 3`'s
+//! `linux-native` selected the same backend — but it is worth stating plainly,
+//! because it makes `keyring://` a poor choice for a Linux mediator's operating
+//! secrets unless something re-seeds them on start. The persistent alternatives
+//! (Secret Service via D-Bus) need a session bus and an unlocked collection that
+//! a headless host does not have, which is exactly why they are not the default
+//! here. Operators wanting durable storage on Linux should use one of the other
+//! backends (`vault://`, `k8s://`, cloud secret managers).
 
 use crate::secrets::error::{Result, SecretStoreError};
 use crate::secrets::store::DynSecretStore;
@@ -27,6 +42,67 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
 
 const BACKEND_LABEL: &str = "keyring";
 
+/// Register the platform credential store with `keyring-core`, once per process.
+///
+/// keyring 4 ships no built-in store: `keyring_core::Entry` talks to whatever
+/// was installed via `set_default_store`, and errors if nothing was. That is the
+/// whole reason this was a migration rather than a version bump — the choice
+/// below is ours to make, and is deliberately the one `keyring 3` made for us.
+///
+/// macOS gets the Keychain, matching `keyring 3`'s `apple-native`. Linux gets
+/// **kernel keyutils**, matching `linux-native` — *not* Secret Service, which is
+/// what the `keyring` facade's `v1` shim picks. Secret Service needs a D-Bus
+/// session with an unlocked collection; a headless mediator host has neither, so
+/// that substitution would fail at first secret access rather than at boot.
+///
+/// `set_default_store` is process-wide, so this is latched: `open()` can be
+/// called more than once (config reload, tests) and the outcome — including a
+/// failure — has to be the same every time.
+#[cfg(feature = "secrets-keyring")]
+fn install_default_store() -> Result<()> {
+    static INSTALLED: std::sync::OnceLock<std::result::Result<(), String>> =
+        std::sync::OnceLock::new();
+
+    match INSTALLED.get_or_init(install_platform_store) {
+        Ok(()) => Ok(()),
+        Err(reason) => Err(SecretStoreError::BackendUnavailable {
+            backend: BACKEND_LABEL,
+            reason: reason.clone(),
+        }),
+    }
+}
+
+#[cfg(all(feature = "secrets-keyring", target_os = "macos"))]
+fn install_platform_store() -> std::result::Result<(), String> {
+    let store = apple_native_keyring_store::keychain::Store::new()
+        .map_err(|e| format!("could not open the macOS Keychain store: {e}"))?;
+    keyring_core::set_default_store(store);
+    Ok(())
+}
+
+#[cfg(all(feature = "secrets-keyring", target_os = "linux"))]
+fn install_platform_store() -> std::result::Result<(), String> {
+    let store = linux_keyutils_keyring_store::Store::new()
+        .map_err(|e| format!("could not open the Linux keyutils store: {e}"))?;
+    keyring_core::set_default_store(store);
+    Ok(())
+}
+
+/// Every other target. Failing here is the point: with no store installed,
+/// `keyring_core::Entry` would error on first use with nothing useful to say,
+/// and a secrets backend is the wrong place to discover that.
+#[cfg(all(
+    feature = "secrets-keyring",
+    not(any(target_os = "macos", target_os = "linux"))
+))]
+fn install_platform_store() -> std::result::Result<(), String> {
+    Err(
+        "no OS keyring store is compiled in for this platform; the mediator \
+         supports the macOS Keychain and Linux kernel keyutils"
+            .to_string(),
+    )
+}
+
 #[cfg(feature = "secrets-keyring")]
 pub(crate) fn open(url: BackendUrl) -> Result<DynSecretStore> {
     let BackendUrl::Keyring { service } = url else {
@@ -34,6 +110,7 @@ pub(crate) fn open(url: BackendUrl) -> Result<DynSecretStore> {
             "internal error: keyring backend received non-keyring URL".into(),
         ));
     };
+    install_default_store()?;
     Ok(std::sync::Arc::new(KeyringStore { service }))
 }
 
@@ -54,8 +131,8 @@ pub struct KeyringStore {
 
 #[cfg(feature = "secrets-keyring")]
 impl KeyringStore {
-    fn entry(&self, key: &str) -> Result<keyring::Entry> {
-        keyring::Entry::new(&self.service, key).map_err(|e| SecretStoreError::Unreachable {
+    fn entry(&self, key: &str) -> Result<keyring_core::Entry> {
+        keyring_core::Entry::new(&self.service, key).map_err(|e| SecretStoreError::Unreachable {
             backend: BACKEND_LABEL,
             reason: format!("could not open keyring entry '{}/{key}': {e}", self.service),
         })
@@ -73,7 +150,7 @@ impl SecretStore for KeyringStore {
         let entry = self.entry(key)?;
         let raw = match entry.get_password() {
             Ok(s) => s,
-            Err(keyring::Error::NoEntry) => return Ok(None),
+            Err(keyring_core::Error::NoEntry) => return Ok(None),
             Err(e) => {
                 return Err(SecretStoreError::Unreachable {
                     backend: BACKEND_LABEL,
@@ -106,7 +183,7 @@ impl SecretStore for KeyringStore {
         let entry = self.entry(key)?;
         match entry.delete_credential() {
             Ok(()) => Ok(()),
-            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(keyring_core::Error::NoEntry) => Ok(()),
             Err(e) => Err(SecretStoreError::Unreachable {
                 backend: BACKEND_LABEL,
                 reason: format!("keyring delete failed: {e}"),
@@ -144,7 +221,7 @@ impl SecretStore for KeyringStore {
         // macOS. Name lives in the shared `mediator_probe_*` namespace.
         let entry = self.entry("mediator_probe_keyring_sentinel")?;
         match entry.get_password() {
-            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+            Ok(_) | Err(keyring_core::Error::NoEntry) => Ok(()),
             Err(e) => Err(SecretStoreError::ProbeFailed {
                 backend: BACKEND_LABEL,
                 reason: format!("keyring read-probe failed: {e}"),


### PR DESCRIPTION
Closes #774.

keyring 3 → 4 is a **restructure, not a new major**. v4 splits into `keyring-core` plus one crate per credential store, and its own docs are explicit about which side we belong on:

> Such applications should not be linking to this library at all; they should instead be linking to the `keyring-core` library and any specific credential stores they want to use.

So `mediator-common` now depends on `keyring-core` plus `apple-native-keyring-store` (macOS, `keychain`) and `linux-keyutils-keyring-store` (Linux), and installs the store itself.

## Behaviour is deliberately unchanged

| | keyring 3 | now |
|---|---|---|
| macOS | `apple-native` → Keychain | `apple-native-keyring-store/keychain` |
| Linux | `linux-native` → kernel keyutils | `linux-keyutils-keyring-store` |

**The trap avoided was the facade's `v1` shim.** It looks like a perfect drop-in — its API is byte-for-byte what this backend already calls — but on Linux it installs **Secret Service** rather than keyutils. Secret Service needs a D-Bus session with an unlocked collection, which a headless mediator host doesn't have. Taking it would have moved the `secrets-keyring` backend onto a daemon that isn't running, failing at *first secret access* rather than at boot, on the backend holding the mediator's operating secrets.

I should also flag that **my first reading of this in #774 was wrong.** I thought v4 with no features left no store registered at all. It doesn't — `default = ["v1"]` installs one. The real hazard is narrower and worse-behaved: a store *is* installed, just not the one we had. Corrected on the issue.

## Details

- Store installed once per process, latched in a `OnceLock` so a repeated `open()` (config reload, tests) yields the same outcome, failures included.
- Targets other than macOS and Linux now fail at `open()` with an explicit message, rather than erroring later from `Entry` with nothing to say about why.
- Call surface otherwise untouched — `Entry::new`, `get_password`, `set_password`, `delete_credential`, `Error::NoEntry` all exist on `keyring-core` with the same shapes.

## Operational caveat, now documented

Keyutils keeps credentials **in kernel memory**, so on Linux secrets stored via `keyring://` **do not survive a reboot**. Not a regression — keyring 3 chose the same backend — but it makes `keyring://` a poor choice for a Linux mediator's operating secrets unless something re-seeds them at start. `vault://`, `k8s://` and the cloud managers are the durable options. This was implicit before; it's now in the module docs.

If we'd rather offer Secret Service as an *option* on Linux for operators who do have a session bus, that's a follow-up — the store crates make it a dependency + match arm.

## Verification — and its limit

macOS is compiled and tested here: **197 tests**, plus workspace build and clippy `-D warnings`.

**The Linux path is not compiled locally** — no Linux target is installed on this machine. It rests on `linux-keyutils-keyring-store` exposing the same `Store::new() -> Result<Arc<Self>>` shape as the macOS store, which I confirmed against its published source rather than assuming. CI builds Linux, so that's where it gets proven.

## Note on merge order

This touches the same manifest as #773 (`kube`/`azure`), which also takes `mediator-common` to 0.15.40. Whichever merges second needs a trivial rebase — two adjacent dependency lines and a version renumber.

Marked breaking for the crate: `secrets-keyring` pulls a different dependency set and refuses to build a store on unsupported targets, though no public Rust API changed.
