### PR TITLE
chore(deps): move to the RustCrypto digest 0.11 generation

### DIFF
--- a/crates/core/affinidi-crypto/CHANGELOG.md
+++ b/crates/core/affinidi-crypto/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Affinidi Crypto Changelog
 
+## Unreleased (0.2.9) — RustCrypto digest 0.11 generation
+
+`sha2` 0.11, `hmac` 0.13, `aes` 0.9, `cbc` 0.2.
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+The API changes were renames, all in JOSE:
+
+- `cipher` 0.5 renamed the block traits: `BlockEncrypt`/`BlockDecrypt` →
+  `BlockCipherEncrypt`/`BlockCipherDecrypt` (AES-KW), and
+  `BlockEncryptMut`/`BlockDecryptMut` → `BlockModeEncrypt`/`BlockModeDecrypt`
+  (CBC content encryption). The `encrypt_block`/`decrypt_block` methods
+  themselves are unchanged.
+- The padded-vec helpers lost their `_mut` suffix: `encrypt_padded_vec_mut` →
+  `encrypt_padded_vec`.
+- `new_from_slice` moved from the `Mac` trait to `KeyInit`.
+- hybrid-array deprecated `Array::from_mut_slice` in favour of `TryFrom`. AES-KW
+  operates on a fixed `[u8; 16]`, so this now uses the infallible array
+  conversion and the length is checked at compile time rather than panicking at
+  runtime on a mismatch.
+
+76 tests green, including the AES-KW and CBC-HMAC round-trips that exercise
+every one of the above.
+
 ## Unreleased (0.2.8) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/core/affinidi-crypto/Cargo.toml
+++ b/crates/core/affinidi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-crypto"
-version = "0.2.8"
+version = "0.2.9"
 description = "Cryptographic primitives and JWK types for Affinidi TDK"
 edition.workspace = true
 authors.workspace = true
@@ -45,9 +45,9 @@ p256 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional 
 p384 = { version = "0.14", features = ["ecdsa", "arithmetic", "ecdh"], optional = true }
 p521 = { version = "0.14", features = ["arithmetic", "ecdh"], optional = true }
 # JOSE content-encryption / key-wrap primitives (`jose` feature).
-aes = { version = "0.8", optional = true }
-cbc = { version = "0.1", features = ["alloc"], optional = true }
-hmac = { version = "0.12", optional = true }
+aes = { version = "0.9", optional = true }
+cbc = { version = "0.2", features = ["alloc"], optional = true }
+hmac = { version = "0.13", optional = true }
 subtle = { version = "2", optional = true }
 ml-dsa = { version = "0.1.0", features = ["rand_core", "zeroize"], optional = true }
 slh-dsa = { version = "=0.2.0-rc.5", features = ["zeroize"], optional = true }
@@ -58,7 +58,7 @@ rand_10 = { package = "rand", version = "0.10", default-features = false, featur
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = "2"
 x25519-dalek = { version = "3", features = ["static_secrets"] }
 zeroize = "1"

--- a/crates/core/affinidi-crypto/src/jose/aes_kw.rs
+++ b/crates/core/affinidi-crypto/src/jose/aes_kw.rs
@@ -6,7 +6,10 @@
 //! by the known-answer tests in [`super::kat`].
 
 use aes::Aes256;
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+// cipher 0.5 renamed the block traits: BlockEncrypt/BlockDecrypt became
+// BlockCipherEncrypt/BlockCipherDecrypt. The `encrypt_block`/`decrypt_block`
+// methods themselves are unchanged.
+use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 
 use crate::error::CryptoError;
 
@@ -42,7 +45,10 @@ pub fn wrap(kek: &[u8; 32], plaintext_key: &[u8]) -> Result<Vec<u8>, CryptoError
             block[..8].copy_from_slice(&a.to_be_bytes());
             block[8..].copy_from_slice(&ri.to_be_bytes());
 
-            let b = aes::Block::from_mut_slice(&mut block);
+            // hybrid-array deprecated `from_mut_slice` (it panics on a length
+            // mismatch); `block` is a fixed `[u8; 16]`, so the infallible
+            // array conversion applies and the length is checked at compile time.
+            let b: &mut aes::Block = (&mut block).into();
             cipher.encrypt_block(b);
 
             // A = MSB(64, B) XOR t where t = (n*j)+i+1
@@ -93,7 +99,10 @@ pub fn unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError>
             block[..8].copy_from_slice(&(a ^ t).to_be_bytes());
             block[8..].copy_from_slice(&r[i].to_be_bytes());
 
-            let b = aes::Block::from_mut_slice(&mut block);
+            // hybrid-array deprecated `from_mut_slice` (it panics on a length
+            // mismatch); `block` is a fixed `[u8; 16]`, so the infallible
+            // array conversion applies and the length is checked at compile time.
+            let b: &mut aes::Block = (&mut block).into();
             cipher.decrypt_block(b);
 
             a = u64::from_be_bytes(block[..8].try_into().unwrap());

--- a/crates/core/affinidi-crypto/src/jose/content_encryption.rs
+++ b/crates/core/affinidi-crypto/src/jose/content_encryption.rs
@@ -6,8 +6,12 @@
 //! centralization; byte-level behaviour is locked by [`super::kat`].
 
 use aes::Aes256;
-use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
-use hmac::{Hmac, Mac};
+// cipher 0.5 renamed the block-mode traits: BlockEncryptMut/BlockDecryptMut
+// became BlockModeEncrypt/BlockModeDecrypt, and the padded-vec helpers lost
+// their `_mut` suffix.
+use cbc::cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit};
+// `new_from_slice` moved from `Mac` to `KeyInit` in the digest 0.11 generation.
+use hmac::{Hmac, KeyInit, Mac};
 use rand_10::Rng;
 use sha2::Sha512;
 use subtle::ConstantTimeEq;
@@ -59,8 +63,7 @@ pub fn encrypt(
     // AES-256-CBC encrypt
     let enc_key_arr: [u8; 32] = enc_key.try_into().unwrap();
     let encryptor = Aes256CbcEnc::new(&enc_key_arr.into(), iv.into());
-    let ciphertext =
-        encryptor.encrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&padded);
+    let ciphertext = encryptor.encrypt_padded_vec::<cbc::cipher::block_padding::NoPadding>(&padded);
 
     // HMAC-SHA-512 over: AAD || IV || ciphertext || AAD_len_bits (big-endian u64)
     let aad_len_bits = (aad.len() as u64) * 8;
@@ -113,7 +116,7 @@ pub fn decrypt(
     let decryptor = Aes256CbcDec::new(&enc_key_arr.into(), iv.into());
     let buf = ciphertext.to_vec();
     let decrypted = decryptor
-        .decrypt_padded_vec_mut::<cbc::cipher::block_padding::NoPadding>(&buf)
+        .decrypt_padded_vec::<cbc::cipher::block_padding::NoPadding>(&buf)
         .map_err(|e| CryptoError::ContentEncryption(format!("AES-CBC decrypt failed: {e}")))?;
 
     // Remove PKCS7 padding

--- a/crates/core/affinidi-secrets-resolver/CHANGELOG.md
+++ b/crates/core/affinidi-secrets-resolver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi Secrets Manager
 
+## Unreleased (0.5.11) — `sha2` 0.11
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+Version bump only; no source change. 23 tests green.
+
 ## Unreleased (0.5.10) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/core/affinidi-secrets-resolver/Cargo.toml
+++ b/crates/core/affinidi-secrets-resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-secrets-resolver"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.5.10"
+version = "0.5.11"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -34,7 +34,7 @@ multibase = "0.9"
 rand = "0.10"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 thiserror = "2"

--- a/crates/credentials/affinidi-data-integrity/CHANGELOG.md
+++ b/crates/credentials/affinidi-data-integrity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi Data Integrity Changelog
 
+## Unreleased (0.7.11) — `sha2` 0.11, `hmac` 0.13
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+One-line change: `new_from_slice` moved from the `Mac` trait to `KeyInit`.
+92 tests green.
+
 ## 16th August 2026 (0.7.10)
 
 Adds the **`ecdsa-jcs-2019`** cryptosuite — ES256 (P-256) signatures over

--- a/crates/credentials/affinidi-data-integrity/Cargo.toml
+++ b/crates/credentials/affinidi-data-integrity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-data-integrity"
 description = "W3C Data Integrity Implementation"
-version = "0.7.10"
+version = "0.7.11"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -27,7 +27,7 @@ affinidi-rdf-encoding = { version = "0.1", path = "../affinidi-rdf-encoding" }
 affinidi-secrets-resolver = "0.5"
 affinidi-did-common = "0.4"
 affinidi-bbs = { version = "0.3", path = "../../core/affinidi-bbs", optional = true }
-hmac = { version = "0.12", optional = true }
+hmac = { version = "0.13", optional = true }
 ciborium = { version = "0.2", optional = true }
 
 async-trait = "0.1"
@@ -37,7 +37,7 @@ multibase = "0.9"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_json_canonicalizer = "0.3"
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = "2"
 tracing = "0.1"
 zeroize = "1.8"

--- a/crates/credentials/affinidi-data-integrity/src/bbs_2023_transform.rs
+++ b/crates/credentials/affinidi-data-integrity/src/bbs_2023_transform.rs
@@ -30,7 +30,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use affinidi_bbs as bbs;
 use affinidi_rdf_encoding::jsonld::context::Context as JsonLdContext;
 use affinidi_rdf_encoding::{jsonld, nquads, rdfc1};
-use hmac::{Hmac, Mac};
+// `new_from_slice` moved from `Mac` to `KeyInit` in the digest 0.11 generation.
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 

--- a/crates/credentials/affinidi-mdoc/CHANGELOG.md
+++ b/crates/credentials/affinidi-mdoc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi mdoc Changelog
 
+## Unreleased (0.3.1) — `sha2` 0.11, `hmac` 0.13, `hkdf` 0.13, `aes-gcm` 0.11
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+One-line change: `new_from_slice` moved from the `Mac` trait to `KeyInit`.
+144 tests green, including the device-MAC round-trips.
+
 ## 1st September 2026 (0.3.0)
 
 Moves to **coset 0.4**.

--- a/crates/credentials/affinidi-mdoc/Cargo.toml
+++ b/crates/credentials/affinidi-mdoc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-mdoc"
 description = "ISO/IEC 18013-5 mdoc (Mobile Document) implementation for mobile driving licences and eIDAS attestations."
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -41,10 +41,10 @@ serde_json = "1"
 p256 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
 p384 = { version = "0.14", features = ["ecdsa", "arithmetic"], optional = true }
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
-sha2 = "0.10"
-hmac = "0.12"
-hkdf = "0.12"
-aes-gcm = "0.10"
+sha2 = "0.11"
+hmac = "0.13"
+hkdf = "0.13"
+aes-gcm = "0.11"
 thiserror = "2"
 time = { version = "0.3", features = ["parsing"] }
 tracing = "0.1"

--- a/crates/credentials/affinidi-mdoc/src/device_auth.rs
+++ b/crates/credentials/affinidi-mdoc/src/device_auth.rs
@@ -32,7 +32,8 @@
 use std::collections::BTreeMap;
 
 use coset::{CoseSign1, CoseSign1Builder, HeaderBuilder};
-use hmac::{Hmac, Mac};
+// `new_from_slice` moved from `Mac` to `KeyInit` in the digest 0.11 generation.
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::cose::{CoseSigner, CoseVerifier};

--- a/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
+++ b/crates/credentials/affinidi-rdf-encoding/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Affinidi RDF Encoding Changelog
 
+## Unreleased (0.1.7) — `sha2` 0.11
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+Version bump only; no source change. 63 tests green.
+
 ## 14th June 2026 Release 0.1.6
 
 - `RdfError` is now `#[non_exhaustive]` (ADR-0003) so new variants land

--- a/crates/credentials/affinidi-rdf-encoding/Cargo.toml
+++ b/crates/credentials/affinidi-rdf-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-rdf-encoding"
 description = "RDF Dataset Canonicalization (RDFC-1.0) and JSON-LD expansion for W3C Verifiable Credentials"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -13,7 +13,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-sha2 = "0.10"
+sha2 = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/identity/did-methods/did-ethr/CHANGELOG.md
+++ b/crates/identity/did-methods/did-ethr/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased (0.1.2) — `sha3` 0.12
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+Version bump only; no source change. 11 tests green.
+
 ## Unreleased (0.1.1) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/identity/did-methods/did-ethr/Cargo.toml
+++ b/crates/identity/did-methods/did-ethr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-ethr"
-version = "0.1.1"
+version = "0.1.2"
 description = "Minimal did:ethr DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -21,7 +21,7 @@ base64 = "0.23"
 hex = "0.4"
 k256 = { version = "0.14", default-features = false, features = ["arithmetic"] }
 serde_json = "1"
-sha3 = "0.11"
+sha3 = "0.12"
 thiserror = "2"
 tracing = "0.1"
 

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.42) — `sha2` 0.11, `hmac` 0.13, `hkdf` 0.13, `aes-gcm` 0.11, `argon2` 0.6
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+One-line change: `new_from_slice` moved from the `Mac` trait to `KeyInit`.
+241 tests green.
+
 ## Unreleased (0.15.41) — keyring 4: depend on keyring-core and pick the store explicitly
 
 `keyring` 3 → 4 is a restructure rather than a new major. v4 splits into

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.41"
+version = "0.15.42"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true
@@ -116,17 +116,17 @@ uuid = { version = "1", features = ["v4"], optional = true }
 
 # ── Secrets module: cache integrity (HMAC-SHA256 keyed via HKDF from the
 ## admin credential's private key) + freshness ──────────────────────────
-hkdf = { version = "0.12", optional = true }
-hmac = { version = "0.12", optional = true }
-sha2 = { version = "0.10", optional = true }
+hkdf = { version = "0.13", optional = true }
+hmac = { version = "0.13", optional = true }
+sha2 = { version = "0.11", optional = true }
 hex = { version = "0.4", optional = true }
 humantime = { version = "2", optional = true }
 
 # ── Secrets module: file:// envelope encryption (`?encrypt=1`) ──────────
 ## AES-256-GCM with 12-byte nonces per write; passphrase-derived key via
 ## Argon2id.
-aes-gcm = { version = "0.10", optional = true }
-argon2 = { version = "0.5", optional = true }
+aes-gcm = { version = "0.11", optional = true }
+argon2 = { version = "0.6", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"], optional = true }
 
 # ── Secrets module: optional cloud backends ─────────────────────────

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/well_known.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/secrets/well_known.rs
@@ -10,7 +10,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
-use hmac::{Hmac, Mac};
+// `new_from_slice` moved from `Mac` to `KeyInit` in the digest 0.11 generation.
+use hmac::{Hmac, KeyInit, Mac};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -232,8 +233,8 @@ impl VtaCachedBundle {
     }
 
     fn compute_hmac(&self, key: &[u8; 32]) -> String {
-        let mut mac =
-            <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC-SHA256 accepts any 32-byte key");
+        let mut mac = <HmacSha256 as KeyInit>::new_from_slice(key)
+            .expect("HMAC-SHA256 accepts any 32-byte key");
         mac.update(&Self::hmac_input(
             self.fetched_at,
             self.ttl_secs,

--- a/crates/messaging/affinidi-tsp/CHANGELOG.md
+++ b/crates/messaging/affinidi-tsp/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Affinidi TSP Changelog
 
+## Unreleased (0.1.16) — `sha2` 0.11, `hkdf` 0.13, `blake2` 0.11, `chacha20poly1305` 0.11
+
+No behaviour change and no public API change: these are private dependencies
+here, which is what lets each crate move on its own schedule. Verified by
+`cargo tree`/grep that no RustCrypto type appears in a public signature anywhere
+in the workspace.
+
+One import changed, in the HPKE path: `aead` 0.6 renamed `AeadInPlace` to
+`AeadInOut` (the in-place helpers remain provided methods on it) and replaced
+generic-array with hybrid-array, so `aead::generic_array::GenericArray` became
+`aead::array::Array`.
+
+99 tests green, including the HPKE seal/open round-trips.
+
 ## 31st August 2026 (0.1.15)
 
 **Bug fix: a DID-valued `TSPTransport` endpoint was returned as a transport URL.**

--- a/crates/messaging/affinidi-tsp/Cargo.toml
+++ b/crates/messaging/affinidi-tsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tsp"
 description = "Trust Spanning Protocol (TSP) implementation for the Affinidi TDK"
-version = "0.1.15"
+version = "0.1.16"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -35,14 +35,14 @@ affinidi-encoding = { path = "../../core/affinidi-encoding", version = "0.1", op
 # Crypto
 ed25519-dalek = { version = "3", features = ["rand_core"] }
 x25519-dalek = { version = "3", features = ["static_secrets"] }
-hkdf = "0.12"
-sha2 = "0.10"
+hkdf = "0.13"
+sha2 = "0.11"
 ## TSP mandates ChaCha20Poly1305 as the HPKE AEAD (spec Rev 2); see docs/tsp/interop.md.
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 rand_core = { version = "0.6", features = ["getrandom"] }
 rand_10 = { package = "rand", version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 zeroize = { version = "1", features = ["derive"] }
-blake2 = "0.10"
+blake2 = "0.11"
 
 # Encoding / serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
+++ b/crates/messaging/affinidi-tsp/src/crypto/hpke.rs
@@ -6,7 +6,9 @@
 //! This implements only the specific HPKE suite required by TSP, built from
 //! standard cryptographic primitives rather than a generic HPKE library.
 
-use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, KeyInit, aead::generic_array::GenericArray};
+// aead 0.6: `AeadInPlace` became `AeadInOut` (the in-place helpers are still
+// provided methods on it), and generic-array became hybrid-array `Array`.
+use chacha20poly1305::{AeadInOut, ChaCha20Poly1305, KeyInit, aead::array::Array as GenericArray};
 use hkdf::Hkdf;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};


### PR DESCRIPTION
Eight crates to the current RustCrypto generation. **No behaviour change, no public API change, all patch bumps.**

| crate | | |
|---|---|---|
| `affinidi-crypto` | 0.2.9 | `sha2` 0.11, `hmac` 0.13, `aes` 0.9, `cbc` 0.2 |
| `affinidi-secrets-resolver` | 0.5.11 | `sha2` 0.11 |
| `affinidi-rdf-encoding` | 0.1.7 | `sha2` 0.11 |
| `affinidi-data-integrity` | 0.7.11 | `sha2` 0.11, `hmac` 0.13 |
| `affinidi-mdoc` | 0.3.1 | `sha2` 0.11, `hmac` 0.13, `hkdf` 0.13, `aes-gcm` 0.11 |
| `affinidi-tsp` | 0.1.16 | `sha2` 0.11, `hkdf` 0.13, `blake2` 0.11, `chacha20poly1305` 0.11 |
| `mediator-common` | 0.15.42 | `sha2` 0.11, `hmac` 0.13, `hkdf` 0.13, `aes-gcm` 0.11, `argon2` 0.6 |
| `did-ethr` | 0.1.2 | `sha3` 0.12 |

## Why eight small changes, not one coordinated one

The gating question — the lesson from #770 — was whether these types cross a **public** boundary between our crates. They don't: no `pub use` re-export, no RustCrypto type in a public signature, no generic bound leaking `Digest` or `Mac`. So each crate moves on its own schedule, and a crate blocked upstream doesn't block the rest.

The rule that *does* bind is per-crate: every RustCrypto dependency inside one crate must be the same generation, since they share the `digest`/`crypto-common` traits. Getting that wrong is what made my first measurement look alarming — I'd bumped `hkdf` in TSP while leaving its own `sha2` behind. Aligned properly, the error count fell from ~41 to 23, and every one turned out to be a rename.

## The source changes, all renames

- **`new_from_slice` moved from `Mac` to `KeyInit`** — four crates, one import line each.
- **cipher 0.5 renamed the block traits**: `BlockEncrypt`/`BlockDecrypt` → `BlockCipherEncrypt`/`BlockCipherDecrypt` (AES-KW), `BlockEncryptMut`/`BlockDecryptMut` → `BlockModeEncrypt`/`BlockModeDecrypt` (CBC), and the padded-vec helpers lost their `_mut` suffix.
- **aead 0.6 renamed `AeadInPlace` → `AeadInOut`** (the in-place helpers are still provided methods on it) and replaced generic-array with hybrid-array, so `aead::generic_array::GenericArray` is now `aead::array::Array`.
- **hybrid-array deprecated `Array::from_mut_slice`** in favour of `TryFrom`. AES-KW works on a fixed `[u8; 16]`, so it now uses the infallible array conversion — length checked at compile time instead of panicking at runtime on a mismatch. A small improvement that fell out of the move.

## Deliberately not moved — both blocked upstream

- **`affinidi-bbs`** — `bls12_381_plus 0.9` depends on *both* generations at once (`elliptic-curve ^0.14.1` **and** `elliptic_curve_013 ^0.13.8`) and its `G1Projective::hash` still takes 0.13's `ExpandMsg`. Detail in #775.
- **`affinidi-messaging-didcomm-v1`** — `crypto_secretbox` has no stable release past 0.1.1, pinning it to generic-array while `salsa20 0.11` uses hybrid-array. Found by chasing an `hsalsa` signature error to its actual cause rather than the apparent one; the error looked like a salsa20 API change and wasn't.

Both stay on the old generation, which is fine *precisely because* nothing crosses crate boundaries. The workspace now carries both, as it already did for `rand`/`getrandom`.

## Testing

**508 tests** across the eight migrated crates, plus mediator-common's **241** and all **30** e2e suites — which drive this crypto through real message flows. The round-trips that matter are covered: AES-KW and CBC-HMAC in `affinidi-crypto`, HPKE seal/open in TSP, device MAC in mdoc. A rename that compiles can still be wrong, so those were the check rather than the build.

`cargo fmt --check`, workspace clippy `-D warnings`, and all three repo guards clean.
