### PR TITLE
refactor(bbs): take the curve stack from bls12_381_plus's re-exports

### DIFF
--- a/crates/core/affinidi-bbs/CHANGELOG.md
+++ b/crates/core/affinidi-bbs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Affinidi BBS
 
+## Unreleased (0.3.3) — take the curve stack from `bls12_381_plus`'s re-exports
+
+No behaviour change. `elliptic-curve`, `ff` and `group` are no longer declared
+here; the types come from `bls12_381_plus::{elliptic_curve, ff, group}` instead.
+
+This is not tidying. `bls12_381_plus` deliberately links **both** RustCrypto
+generations — its `groups` feature is `["group_013", "group"]` and cannot be
+narrowed — and its public API (`G1Projective::hash`) takes the **0.13**
+`ExpandMsg`. Declaring our own copies meant pinning a generation by hand and
+hoping it matched the one that crate's functions expect; a bump on either side
+produced a trait-mismatch error naming neither crate, which is exactly what
+happened while scoping #775.
+
+Taking the types from the crate whose functions consume them makes the match
+structural rather than coincidental, and removes three declarations that
+`cargo outdated` will otherwise keep flagging as stale for as long as
+`bls12_381_plus` stays on the older generation.
+
+82 tests green, plus the 92 in `affinidi-data-integrity` that consume this.
+
 ## Changelog history
 
 ## 13th June 2026

--- a/crates/core/affinidi-bbs/Cargo.toml
+++ b/crates/core/affinidi-bbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-bbs"
 description = "BBS Signatures (IETF draft-irtf-cfrg-bbs-signatures) implementation over BLS12-381."
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -17,10 +17,19 @@ name = "bbs_selective_disclosure"
 path = "examples/bbs_selective_disclosure.rs"
 
 [dependencies]
+# The curve stack comes from `bls12_381_plus`'s own re-exports
+# (`bls12_381_plus::{elliptic_curve, ff, group}`) rather than from separate
+# declarations here.
+#
+# This is not cosmetic. `bls12_381_plus` deliberately links BOTH RustCrypto
+# generations — its `groups` feature is `["group_013", "group"]` and cannot be
+# narrowed — and its public API (`G1Projective::hash`) takes the *0.13*
+# `ExpandMsg`. Declaring our own `elliptic-curve`/`ff`/`group` meant pinning a
+# generation by hand and hoping it matched the one its API expects; a bump on
+# either side would have produced a trait-mismatch error naming neither crate.
+# Taking the types from the crate whose functions consume them makes the match
+# structural. See #775.
 bls12_381_plus = { version = "0.8", features = ["alloc"] }
-elliptic-curve = { version = "0.13", features = ["hash2curve"] }
-ff = "0.13"
-group = "0.13"
 hex = "0.4"
 rand = "0.9"
 sha2 = "0.10"

--- a/crates/core/affinidi-bbs/src/blind.rs
+++ b/crates/core/affinidi-bbs/src/blind.rs
@@ -34,8 +34,8 @@
  * blind-signatures draft test vectors.
  */
 
+use bls12_381_plus::ff::Field;
 use bls12_381_plus::{G1Projective, Scalar};
-use ff::Field;
 use rand::{Rng, SeedableRng};
 use zeroize::Zeroize;
 

--- a/crates/core/affinidi-bbs/src/generators.rs
+++ b/crates/core/affinidi-bbs/src/generators.rs
@@ -12,8 +12,8 @@
 
 use std::sync::LazyLock;
 
+use bls12_381_plus::elliptic_curve::hash2curve::ExpandMsgXmd;
 use bls12_381_plus::{G1Affine, G1Projective, Scalar};
-use elliptic_curve::hash2curve::ExpandMsgXmd;
 use sha2::Sha256;
 
 use crate::ciphersuite::Ciphersuite;
@@ -205,7 +205,7 @@ pub fn point_from_bytes(bytes: &[u8; 48]) -> Option<G1Projective> {
 
 #[cfg(test)]
 mod tests {
-    use group::Group; // for G1Projective::generator() in tests
+    use bls12_381_plus::group::Group; // for G1Projective::generator() in tests
 
     use super::*;
 

--- a/crates/core/affinidi-bbs/src/hash.rs
+++ b/crates/core/affinidi-bbs/src/hash.rs
@@ -11,7 +11,7 @@
  */
 
 use bls12_381_plus::Scalar;
-use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
+use bls12_381_plus::elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
 use sha2::Sha256;
 
 use crate::ciphersuite::Ciphersuite;

--- a/crates/core/affinidi-bbs/src/keys.rs
+++ b/crates/core/affinidi-bbs/src/keys.rs
@@ -6,7 +6,7 @@
  */
 
 use bls12_381_plus::G2Projective;
-use ff::Field;
+use bls12_381_plus::ff::Field;
 
 use crate::ciphersuite::Ciphersuite;
 use crate::error::{BbsError, Result};

--- a/crates/core/affinidi-bbs/src/proof.rs
+++ b/crates/core/affinidi-bbs/src/proof.rs
@@ -12,11 +12,11 @@
 
 use std::collections::HashSet;
 
+use bls12_381_plus::ff::Field;
+use bls12_381_plus::group::Group;
 use bls12_381_plus::{
     G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Scalar, multi_miller_loop,
 };
-use ff::Field;
-use group::Group;
 use rand::{Rng, SeedableRng};
 
 use crate::ciphersuite::Ciphersuite;

--- a/crates/core/affinidi-bbs/src/pseudonym.rs
+++ b/crates/core/affinidi-bbs/src/pseudonym.rs
@@ -31,7 +31,7 @@
  */
 
 use bls12_381_plus::G1Projective;
-use elliptic_curve::hash2curve::ExpandMsgXmd;
+use bls12_381_plus::elliptic_curve::hash2curve::ExpandMsgXmd;
 use sha2::Sha256;
 
 use crate::ciphersuite::Ciphersuite;

--- a/crates/core/affinidi-bbs/src/signature.rs
+++ b/crates/core/affinidi-bbs/src/signature.rs
@@ -16,10 +16,10 @@
  *   2. Check pairing: e(A, W + BP2*e) == e(B, BP2)
  */
 
+use bls12_381_plus::group::Group;
 use bls12_381_plus::{
     G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Scalar, multi_miller_loop,
 };
-use group::Group;
 use zeroize::Zeroize;
 
 use crate::ciphersuite::Ciphersuite;

--- a/crates/core/affinidi-bbs/src/types.rs
+++ b/crates/core/affinidi-bbs/src/types.rs
@@ -2,8 +2,8 @@
  * Core BBS types: SecretKey, PublicKey, Signature, Proof.
  */
 
+use bls12_381_plus::ff::Field;
 use bls12_381_plus::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
-use ff::Field;
 use zeroize::Zeroize;
 
 use crate::error::{BbsError, Result};


### PR DESCRIPTION
No behaviour change. `elliptic-curve`, `ff` and `group` are no longer declared in `affinidi-bbs`; the types come from `bls12_381_plus::{elliptic_curve, ff, group}` instead.

## Why this isn't tidying

`bls12_381_plus` deliberately links **both** RustCrypto generations — its `groups` feature is literally `["group_013", "group"]` and cannot be narrowed — and its public API (`G1Projective::hash`) takes the **0.13** `ExpandMsg`.

Declaring our own copies meant pinning a generation by hand and hoping it matched the one that crate's functions expect. A bump on either side then produces a trait-mismatch error naming neither crate — which is exactly what happened while scoping #775:

```
the trait `bls12_381_plus::elliptic_curve::hash2curve::ExpandMsg<'a>` is not
implemented for `ExpandMsgXmd<...>`
  --> elliptic-curve-0.13.8/src/hash2curve/...
note: there are multiple different versions of crate `digest` in the dependency graph
```

Taking the types from the crate whose functions consume them makes that match **structural rather than coincidental**. It also removes three declarations that `cargo outdated` will otherwise keep flagging for as long as `bls12_381_plus` stays on the older generation — which is upstream's transition to finish, not ours.

## What this does and doesn't achieve

It does **not** remove the 0.13 generation from the graph — `bls12_381_plus` brings it either way. What it removes is our *own* stale pins and the possibility of them drifting out of step with the API that consumes them.

When `bls12_381_plus` eventually drops the `elliptic_curve_013`/`ff_013`/`group_013` shims, `affinidi-bbs` follows automatically with no change here at all.

## Testing

82 tests in `affinidi-bbs` — the BBS+ signature, proof, blind-signature and hash-to-curve paths, including the draft test vectors — plus the 92 in `affinidi-data-integrity` that consume it. `cargo fmt --check`, clippy `-D warnings`, workspace build and both guards clean.

`affinidi-bbs` 0.3.3.
