### PR TITLE
feat: relay over WebSocket with a per-frame acknowledgement

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -41,8 +41,17 @@ than by enumeration:
   configuration — so turning relay off takes effect without a restart.
 
 `docs/multi-mediator.md` §7 is updated, and its §11 "known gaps" is now empty:
-this was the gap. Requires mediator-common 0.15.44, which carries the
-subprotocol and the sending half.
+this was the gap.
+
+The `affinidi-messaging-mediator-common` requirement moves from `0.15.37` to
+`0.15.44`, the version that introduces `relay_ack`. The old floor allowed a
+consumer resolving from the registry to pick a `0.15.x` without the module and
+fail to build this crate — normally masked by cargo picking the newest patch,
+but not under a lockfile pinning an older one. (`publish dry-run` is expected
+to be red on this PR: it resolves each crate against the registry in isolation
+and cannot see an unpublished sibling from the same PR. mediator-common 0.15.44
+verifies and publishes cleanly on its own, so the release job's dependency
+ordering resolves it.)
 
 ## Unreleased (0.22.1) — a multi-mediator guide, and the gaps writing it exposed
 

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## Unreleased (0.22.2) — admit an inter-mediator relay over WebSocket
+
+The WebSocket route now admits an anonymous inter-mediator relay hop, on the
+same terms `/inbound` has always used: only when the operator has opted in via
+`security.enable_inter_mediator_relay` (or the legacy implicit
+`SEND_FORWARDED` in `global_acl_default`), and only for a socket that
+identifies itself by offering the `relay-ack` subprotocol. The admission
+decision itself now lives in one place — `jwt_auth::anonymous_relay_session` —
+so the two routes cannot drift on *who* is let in.
+
+What such a socket may do is deliberately narrow, and structurally so rather
+than by enumeration:
+
+- **It is never registered with the streaming task.** A relay session has no
+  DID, so registering would claim the empty `did_hash`'s stream for an
+  anonymous peer. Skipping it is what makes "a relay can only send" a property
+  of the code rather than of which message types we happen to handle: the
+  socket's inbound channel can never yield.
+- **It is gated on `SEND_MESSAGES`, not `LOCAL`** — the same capability
+  `message_inbound_handler` requires of the REST relay session. `LOCAL` gates
+  access to an inbox this session does not have.
+- **It gets a `RelayAck` per frame instead of a problem report.** A problem
+  report is packed *to* `session.did`, which a relay session does not have,
+  and the peer is a mediator waiting on a transport answer rather than a client
+  reading its inbox. The ack carries the mediator error code and reason on
+  refusal, so the rejection reaches the relaying peer's logs and — once retries
+  are exhausted — the original sender.
+- **Raw-TSP mode is forced off, and a binary frame closes the socket.** Neither
+  can arise from a correct peer; both are enforced rather than assumed, because
+  the cost of being wrong is an anonymous socket registered as a live streaming
+  client.
+- **`relay-ack` is echoed if and only if the socket will actually be acked.**
+  An authenticated client that offers it is not a relay — a relay hop presents
+  no credential — so the entry is dropped from the echo rather than reflected
+  back. Same honesty requirement as `tsp-ack`, and here it is load-bearing: the
+  relaying peer relays over the socket *because* of that echo.
+- **The socket has a bounded lifetime** (one hour). There is no token expiry to
+  inherit, and re-admission re-runs the relay-enabled check against current
+  configuration — so turning relay off takes effect without a restart.
+
+`docs/multi-mediator.md` §7 is updated, and its §11 "known gaps" is now empty:
+this was the gap. Requires mediator-common 0.15.44, which carries the
+subprotocol and the sending half.
+
 ## Unreleased (0.22.1) — a multi-mediator guide, and the gaps writing it exposed
 
 `docs/multi-mediator.md` documents federating two or more independent

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.22.1"
+version = "0.22.2"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -130,7 +130,7 @@ affinidi-encoding = { version = "0.1", optional = true }
 ## Shared types: DatabaseHandler, errors, config structs, secret storage.
 ## Backend features are enabled below via the mediator's own cargo features
 ## so operators only compile the backends their deployment needs.
-affinidi-messaging-mediator-common = { version = "0.15.37", path = "affinidi-messaging-mediator-common" }
+affinidi-messaging-mediator-common = { version = "0.15.44", path = "affinidi-messaging-mediator-common" }
 ## Raw TOML config schema — the `*ConfigRaw` types are defined here and the
 ## mediator re-exports them; the runtime `Config` + conversions stay local.
 affinidi-messaging-mediator-config = { version = "0.2.1", path = "affinidi-messaging-mediator-config" }

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Affinidi Messaging Mediator Common
 
+## Unreleased (0.15.44) — the `relay-ack` subprotocol: WebSocket relay that can't lie
+
+WebSocket relay between mediators now works, and is as safe as the REST path it
+sits beside. Both halves of that mattered.
+
+**Admission.** `deliver_via_websocket` opens the socket offering the
+`relay-ack` subprotocol (new module `tasks::forwarding::relay_ack`), which is
+how an anonymous upgrade identifies itself as an inter-mediator relay rather
+than a client. The mediator side of the admission decision is in
+affinidi-messaging-mediator 0.22.2.
+
+**Acknowledgement, which is the point.** A WebSocket write says only that the
+bytes left this process. Relaying over a bare socket would therefore ACK the
+`FORWARD_Q` entry for a message the peer *refused* — untrusted relay peer, ACL
+denial, detected loop — with the rejection surviving as nothing but a log line
+on the far side, while `deliver_via_rest` has always turned a non-2xx into a
+retry and eventually a `FORWARD_ABANDONED` plus a problem report to the
+original sender.
+
+So every relayed frame is now answered by a `RelayAck` that names the frame by
+`sha256` of its exact bytes (content-addressed, so neither side keeps ordering
+state and an ack can never be read as the answer to a different frame). A frame
+is reported delivered only on a positive ack; a negative ack, a missing one
+inside 30s, or a socket error fails the message and takes the existing retry /
+abandonment path. The two transports now have the same delivery semantics.
+
+**Compatibility is the subprotocol.** A peer that does not echo `relay-ack`
+gets no frames over the socket at all — the connection is closed and delivery
+falls back to REST, which is what carried this traffic before. There is no
+version of the exchange in which a frame is relayed without an acknowledgement
+path, so an older peer is unaffected.
+
+Two smaller consequences:
+
+- `PooledWebSocket` keeps the whole `WebSocketStream` rather than just the
+  write half — this side now reads too. There is no concurrent use to split
+  for: a frame is sent, then its ack awaited.
+- A rejection keeps the pooled connection (the peer answered; the socket is
+  fine) while a transport failure drops it. Both fail the message.
+
+The 0.15.43 WebSocket suppression window stays, and still does its job: it is
+what keeps a peer that *can't* negotiate `relay-ack` from costing a connect per
+message.
+
 ## Unreleased (0.15.43) — stop re-probing a WebSocket the peer will never accept
 
 The forwarding processor prefers a pooled WebSocket over REST once an endpoint

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.43"
+version = "0.15.44"
 description = "Shared types for the Affinidi Messaging Mediator (errors, database handler, config)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/mod.rs
@@ -10,6 +10,12 @@
 pub mod config;
 pub use config::{ForwardingConfig, RelayMode};
 
+// The `relay-ack` subprotocol: the per-frame acknowledgement that gives
+// WebSocket relay the same delivery semantics as the status-checked REST
+// path. Shared with the mediator, which answers these frames.
+pub mod relay_ack;
+pub use relay_ack::{RELAY_ACK_SUBPROTOCOL, RELAY_ACK_TYPE, RelayAck, frame_id};
+
 // The mediator's own outbound packing, injected rather than implemented
 // here — see the module docs for why this crate can't pack for itself.
 pub mod packer;

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/processor.rs
@@ -28,6 +28,9 @@ use std::{
 };
 use tokio::sync::{Mutex, RwLock};
 use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+use super::relay_ack::{RELAY_ACK_SUBPROTOCOL, RelayAck, frame_id};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -194,15 +197,29 @@ impl HttpClientPool {
 
 /// A pooled WebSocket connection to a remote mediator
 struct PooledWebSocket {
-    /// Write half of the WebSocket stream
-    writer: futures_util::stream::SplitSink<
-        tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-        tungstenite::Message,
+    /// The relay socket, unsplit: every relayed frame is answered by a
+    /// [`RelayAck`] on the same connection, so this side both writes and reads
+    /// and there is no concurrent use to split for.
+    stream: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
     /// When this connection was last used
     last_used: Instant,
+}
+
+/// Why a relayed frame did not come back acknowledged.
+///
+/// The distinction decides what happens to the *connection*: a rejection is the
+/// peer answering about one message and leaves the socket usable, while a
+/// transport failure means the socket itself is no longer trustworthy. Both
+/// fail the message, which is what keeps WebSocket relay as safe as REST.
+enum AckFailure {
+    /// The peer answered with a negative [`RelayAck`] — the analogue of a
+    /// non-2xx REST response.
+    Rejected(String),
+    /// The frame, or its answer, never made it: send error, closed socket,
+    /// or no ack inside the timeout.
+    Transport(String),
 }
 
 /// The forwarding processor that reads from FORWARD_Q and delivers to remote mediators
@@ -875,36 +892,59 @@ impl ForwardingProcessor {
         }
     }
 
-    /// Deliver a message via WebSocket to the remote mediator.
+    /// How long to wait for a peer's [`RelayAck`] before giving up on the frame.
+    ///
+    /// Matches the REST client's request timeout, so a stalled peer costs the
+    /// same on either transport.
+    const RELAY_ACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Deliver a message via WebSocket to the remote mediator, and wait for the
+    /// peer's acknowledgement.
     ///
     /// Connections are pooled per endpoint URL and kept alive for the configured
     /// idle timeout. When the rate drops below the threshold, the idle cleanup
     /// task closes the connection.
     ///
-    /// If no pooled connection exists, a new one is established.
-    /// If sending on a pooled connection fails, the connection is removed from
-    /// the pool and an error is returned (caller falls back to REST).
+    /// **Delivery semantics are the REST path's.** A frame is only reported
+    /// delivered once the peer answers with a positive [`RelayAck`]; a negative
+    /// ack, a missing one, or a socket error is an `Err`, which the caller
+    /// retries and eventually abandons with a problem report to the sender —
+    /// exactly what a non-2xx does on `deliver_via_rest`. Without this a
+    /// WebSocket write would report success for a message the peer refused.
+    ///
+    /// A peer that does not negotiate the `relay-ack` subprotocol gets no
+    /// frames over the socket at all: the connection is closed and the error
+    /// sends this endpoint back to REST (and, via the suppression window, keeps
+    /// it there for a while).
     async fn deliver_via_websocket(
         &self,
         endpoint_url: &str,
         msg: &ForwardQueueEntry,
     ) -> Result<(), String> {
         let ws_url = Self::http_to_ws_url(endpoint_url);
+        let frame = msg.message.clone();
+        let id = frame_id(frame.as_bytes());
 
         let mut pool = self.ws_pool.lock().await;
 
-        // Try to send on existing connection
+        // Try the pooled connection first.
         if let Some(ws) = pool.get_mut(endpoint_url) {
-            let ws_msg = tungstenite::Message::Text(msg.message.clone().into());
-            match ws.writer.send(ws_msg).await {
+            match Self::send_and_await_ack(&mut ws.stream, &frame, &id).await {
                 Ok(()) => {
                     ws.last_used = Instant::now();
-                    debug!("Sent via pooled WebSocket to {}", endpoint_url);
+                    debug!("Relayed via pooled WebSocket to {} (acked)", endpoint_url);
                     return Ok(());
                 }
-                Err(e) => {
+                Err(AckFailure::Rejected(reason)) => {
+                    // The peer answered, and refused. The connection is fine;
+                    // the message is not. Keep the socket, fail the message —
+                    // retry/abandonment is the caller's job, as on REST.
+                    ws.last_used = Instant::now();
+                    return Err(reason);
+                }
+                Err(AckFailure::Transport(e)) => {
                     warn!(
-                        "Pooled WebSocket send failed for {}: {}. Reconnecting...",
+                        "Pooled WebSocket relay to {} failed: {}. Reconnecting...",
                         endpoint_url, e
                     );
                     pool.remove(endpoint_url);
@@ -912,38 +952,141 @@ impl ForwardingProcessor {
             }
         }
 
-        // No existing connection or it failed — establish a new one
+        // No usable connection — establish one, negotiating `relay-ack`.
         drop(pool); // Release the lock while connecting
 
-        let (ws_stream, _response) = tokio_tungstenite::connect_async(&ws_url)
+        let mut request = ws_url
+            .as_str()
+            .into_client_request()
+            .map_err(|e| format!("WebSocket request for {ws_url} is not valid: {e}"))?;
+        request.headers_mut().insert(
+            tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL,
+            tungstenite::http::HeaderValue::from_static(RELAY_ACK_SUBPROTOCOL),
+        );
+
+        let (mut stream, response) = tokio_tungstenite::connect_async(request)
             .await
             .map_err(|e| format!("WebSocket connect to {ws_url} failed: {e}"))?;
 
-        info!("WebSocket connected to {} (pool)", endpoint_url);
+        // The subprotocol IS the negotiation: a peer that doesn't echo it
+        // cannot acknowledge frames, so it must not be relayed to over this
+        // socket. (An anonymous relay upgrade is also only admitted by a peer
+        // that offers it, so in practice a non-echoing peer has refused the
+        // upgrade outright and we never reach here.)
+        let negotiated = response
+            .headers()
+            .get(tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        if negotiated != RELAY_ACK_SUBPROTOCOL {
+            let _ = stream.close(None).await;
+            return Err(format!(
+                "peer at {ws_url} did not negotiate the `{RELAY_ACK_SUBPROTOCOL}` subprotocol \
+                 (got {negotiated:?}); relaying over REST instead"
+            ));
+        }
 
-        let (mut writer, _reader) = ws_stream.split();
+        info!("WebSocket connected to {} (relay-ack, pool)", endpoint_url);
 
-        // Send the message on the fresh connection
-        let ws_msg = tungstenite::Message::Text(msg.message.clone().into());
-        writer
-            .send(ws_msg)
+        let outcome = Self::send_and_await_ack(&mut stream, &frame, &id).await;
+
+        // A transport failure means the socket is not worth keeping; a
+        // rejection is about the message and leaves the connection usable.
+        match outcome {
+            Ok(()) | Err(AckFailure::Rejected(_)) => {
+                let mut pool = self.ws_pool.lock().await;
+                pool.insert(
+                    endpoint_url.to_string(),
+                    PooledWebSocket {
+                        stream,
+                        last_used: Instant::now(),
+                    },
+                );
+            }
+            Err(AckFailure::Transport(_)) => {
+                let _ = stream.close(None).await;
+            }
+        }
+
+        match outcome {
+            Ok(()) => Ok(()),
+            Err(AckFailure::Rejected(reason)) => Err(reason),
+            Err(AckFailure::Transport(e)) => Err(e),
+        }
+    }
+
+    /// Write one relayed frame and wait for the peer's [`RelayAck`] for it.
+    ///
+    /// Frames that are not this frame's ack — a ping, a stray text frame, an
+    /// ack for something else — are skipped rather than mistaken for the
+    /// answer, until the ack arrives or [`RELAY_ACK_TIMEOUT`] elapses.
+    async fn send_and_await_ack(
+        stream: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        frame: &str,
+        id: &str,
+    ) -> Result<(), AckFailure> {
+        stream
+            .send(tungstenite::Message::Text(frame.to_string().into()))
             .await
-            .map_err(|e| format!("WebSocket send to {ws_url} failed: {e}"))?;
+            .map_err(|e| AckFailure::Transport(format!("WebSocket send failed: {e}")))?;
 
-        // Store the connection in the pool for reuse
-        // We drop the reader side — we're only using WebSocket for sending.
-        // The reader would need a background task to handle pings and detect
-        // remote close, but for simplicity we rely on send errors to detect stale connections.
-        let mut pool = self.ws_pool.lock().await;
-        pool.insert(
-            endpoint_url.to_string(),
-            PooledWebSocket {
-                writer,
-                last_used: Instant::now(),
-            },
-        );
+        let deadline = tokio::time::sleep(Self::RELAY_ACK_TIMEOUT);
+        tokio::pin!(deadline);
 
-        Ok(())
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    return Err(AckFailure::Transport(format!(
+                        "no relay-ack within {}s",
+                        Self::RELAY_ACK_TIMEOUT.as_secs()
+                    )));
+                }
+                incoming = stream.next() => {
+                    match incoming {
+                        Some(Ok(tungstenite::Message::Text(text))) => {
+                            let Ok(ack) = serde_json::from_str::<RelayAck>(&text) else {
+                                debug!("Ignoring a non-ack text frame on the relay socket");
+                                continue;
+                            };
+                            if !ack.answers(id) {
+                                debug!("Ignoring a relay-ack for another frame ({})", ack.id);
+                                continue;
+                            }
+                            return if ack.ok {
+                                Ok(())
+                            } else {
+                                Err(AckFailure::Rejected(format!(
+                                    "peer refused the relayed message: {} (code {})",
+                                    ack.reason.as_deref().unwrap_or("no reason given"),
+                                    ack.code.map(|c| c.to_string()).unwrap_or_else(|| "-".into()),
+                                )))
+                            };
+                        }
+                        Some(Ok(tungstenite::Message::Close(frame))) => {
+                            return Err(AckFailure::Transport(format!(
+                                "peer closed the relay socket before acknowledging ({frame:?})"
+                            )));
+                        }
+                        // Ping/Pong/Binary on a relay socket are not ours to
+                        // interpret; tungstenite answers pings itself.
+                        Some(Ok(_)) => continue,
+                        Some(Err(e)) => {
+                            return Err(AckFailure::Transport(format!(
+                                "WebSocket error awaiting relay-ack: {e}"
+                            )));
+                        }
+                        None => {
+                            return Err(AckFailure::Transport(
+                                "relay socket ended before acknowledging".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Convert an HTTP(S) endpoint URL to a WebSocket URL

--- a/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/relay_ack.rs
+++ b/crates/messaging/affinidi-messaging-mediator/affinidi-messaging-mediator-common/src/tasks/forwarding/relay_ack.rs
@@ -1,0 +1,199 @@
+//! The `relay-ack` WebSocket subprotocol: per-frame acknowledgement for
+//! inter-mediator relay.
+//!
+//! # Why this exists
+//!
+//! REST relay is status-checked. `deliver_via_rest` treats a non-2xx as a
+//! delivery failure, so a frame the receiving mediator *rejects* — an untrusted
+//! relay peer, an ACL denial, a detected loop — is retried, and eventually
+//! abandoned with a problem report to the original sender. That is the
+//! contract every "delivered" claim downstream is built on.
+//!
+//! A WebSocket write has no such answer. Handing a frame to the socket says
+//! only that the bytes left this process, so relaying over a bare WebSocket
+//! would ACK the queue entry for a message the peer threw away, and the
+//! rejection would exist only as a log line on the far side.
+//!
+//! So the WebSocket relay transport carries its own acknowledgement. A relaying
+//! mediator offers the `relay-ack` subprotocol at upgrade; a receiving mediator
+//! that supports it echoes it back and answers **every** relayed frame with a
+//! [`RelayAck`]. The sender treats a missing or negative ack exactly as it
+//! treats a non-2xx REST response, so the delivery semantics of the two
+//! transports are the same.
+//!
+//! # Compatibility
+//!
+//! The subprotocol is the negotiation. A peer that does not echo `relay-ack`
+//! — an older mediator, or something else entirely — gets no relayed frames
+//! over the socket at all: the connection is dropped and delivery falls back to
+//! REST, which is what carried this traffic before the WebSocket path worked.
+//! There is therefore no version of this exchange in which a frame is relayed
+//! without an acknowledgement path.
+
+use serde::{Deserialize, Serialize};
+
+/// The WebSocket subprotocol name offered by a relaying mediator and echoed by
+/// a receiving mediator that answers with [`RelayAck`] frames.
+///
+/// Offering it is also how an *anonymous* upgrade identifies itself as an
+/// inter-mediator relay rather than a client, which is what the receiving
+/// mediator's admission check keys on.
+pub const RELAY_ACK_SUBPROTOCOL: &str = "relay-ack";
+
+/// The `typ` every [`RelayAck`] carries, so a frame is self-describing and a
+/// future revision can be told apart from this one.
+pub const RELAY_ACK_TYPE: &str = "relay-ack/1.0";
+
+/// One receiving mediator's answer to one relayed frame.
+///
+/// Sent as a JSON text frame on the relay socket, in the order the frames were
+/// received.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RelayAck {
+    /// Always [`RELAY_ACK_TYPE`].
+    pub typ: String,
+    /// [`frame_id`] of the frame being answered.
+    ///
+    /// Content-addressed rather than a sequence number so neither side has to
+    /// keep ordering state, and so an ack can never be mistaken for the answer
+    /// to a different frame.
+    pub id: String,
+    /// Whether the frame was accepted for delivery.
+    ///
+    /// `true` means the receiving mediator has taken responsibility for it —
+    /// stored, live-streamed, or queued onward — exactly as a 2xx does on the
+    /// REST path.
+    pub ok: bool,
+    /// Mediator error code when `ok` is false. See the mediator's `ERRORS.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<u16>,
+    /// Human-readable rejection reason when `ok` is false. Diagnostic only —
+    /// never parsed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RelayAck {
+    /// A positive acknowledgement for the frame with this [`frame_id`].
+    pub fn accepted(id: impl Into<String>) -> Self {
+        Self {
+            typ: RELAY_ACK_TYPE.to_string(),
+            id: id.into(),
+            ok: true,
+            code: None,
+            reason: None,
+        }
+    }
+
+    /// A negative acknowledgement: the frame reached us and was refused.
+    ///
+    /// The sender treats this as it treats a non-2xx REST response — retry with
+    /// backoff, then abandon with a problem report — so the reason travels back
+    /// to whoever sent the message rather than dying in the peer's logs.
+    pub fn rejected(id: impl Into<String>, code: u16, reason: impl Into<String>) -> Self {
+        Self {
+            typ: RELAY_ACK_TYPE.to_string(),
+            id: id.into(),
+            ok: false,
+            code: Some(code),
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Whether this ack answers `frame_id` and carries the type we understand.
+    ///
+    /// Both halves matter: a differently-typed frame is not an ack of ours, and
+    /// an ack for another id must never be read as the answer to this frame —
+    /// that is precisely the confusion that would let a rejected message be
+    /// reported as delivered.
+    pub fn answers(&self, frame_id: &str) -> bool {
+        self.typ == RELAY_ACK_TYPE && self.id == frame_id
+    }
+}
+
+/// Identify a relayed frame by the SHA-256 of its exact bytes, hex-encoded.
+///
+/// Both sides compute this independently over the same wire bytes, so the
+/// relayed envelope needs no correlation field added to it and the two
+/// implementations cannot disagree about which frame an ack refers to.
+pub fn frame_id(frame: &[u8]) -> String {
+    sha256::digest(frame)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_id_is_stable_and_distinguishes_frames() {
+        assert_eq!(
+            frame_id(b"a-relayed-envelope"),
+            frame_id(b"a-relayed-envelope")
+        );
+        assert_ne!(frame_id(b"a-relayed-envelope"), frame_id(b"another-one"));
+        // Hex-encoded SHA-256.
+        assert_eq!(frame_id(b"x").len(), 64);
+    }
+
+    #[test]
+    fn accepted_answers_only_its_own_frame() {
+        let id = frame_id(b"envelope");
+        let ack = RelayAck::accepted(&id);
+
+        assert!(ack.ok);
+        assert!(ack.answers(&id));
+        assert!(!ack.answers(&frame_id(b"a different envelope")));
+    }
+
+    #[test]
+    fn rejected_carries_the_code_and_reason_back_to_the_sender() {
+        let id = frame_id(b"envelope");
+        let ack = RelayAck::rejected(
+            &id,
+            60,
+            "Relaying mediator is not in the trusted relay allowlist",
+        );
+
+        assert!(!ack.ok);
+        assert_eq!(ack.code, Some(60));
+        assert!(ack.reason.unwrap().contains("trusted relay allowlist"));
+    }
+
+    /// An ack of an unknown type must not be accepted as an answer, or a future
+    /// revision of this subprotocol would be silently misread as this one.
+    #[test]
+    fn an_ack_of_another_type_answers_nothing() {
+        let id = frame_id(b"envelope");
+        let mut ack = RelayAck::accepted(&id);
+        ack.typ = "relay-ack/2.0".to_string();
+
+        assert!(!ack.answers(&id));
+    }
+
+    #[test]
+    fn round_trips_through_json_without_the_optional_fields() {
+        let id = frame_id(b"envelope");
+        let json = serde_json::to_string(&RelayAck::accepted(&id)).unwrap();
+
+        // A positive ack is three fields — no null code/reason on the wire.
+        assert!(!json.contains("code"), "{json}");
+        assert!(!json.contains("reason"), "{json}");
+
+        let back: RelayAck = serde_json::from_str(&json).unwrap();
+        assert!(back.answers(&id));
+        assert!(back.ok);
+    }
+
+    #[test]
+    fn round_trips_a_rejection() {
+        let id = frame_id(b"envelope");
+        let json = serde_json::to_string(&RelayAck::rejected(&id, 94, "loop detected")).unwrap();
+        let back: RelayAck = serde_json::from_str(&json).unwrap();
+
+        assert!(back.answers(&id));
+        assert!(!back.ok);
+        assert_eq!(back.code, Some(94));
+        assert_eq!(back.reason.as_deref(), Some("loop detected"));
+    }
+}

--- a/crates/messaging/affinidi-messaging-mediator/docs/multi-mediator.md
+++ b/crates/messaging/affinidi-messaging-mediator/docs/multi-mediator.md
@@ -199,6 +199,7 @@ federation both roles apply to both mediators.
 | `security.global_acl_default` | must grant `RECEIVE_FORWARDED` (§6) | must grant `SEND_FORWARDED` (§6) | a relay deployment typically runs `ALLOW_ALL`; see [`acls.md` §7](./acls.md) |
 | `security.local_direct_delivery_allowed` | — | `true` for single-forward relays (§1b) | not needed for the double forward |
 | `server.local_endpoints` | required behind a hostname/LB | required behind a hostname/LB | otherwise the mediator relays to itself; `LOCAL_ENDPOINTS`, comma-separated |
+| `processors.forwarding.ws_threshold_msgs_per_10s` | rate at which the relay socket engages | — | default 1; see §7 for what the rate actually measures |
 | storage backend | any | any | Redis only if you also scale each mediator across processes |
 
 ---
@@ -252,16 +253,23 @@ Once A classifies a next hop as remote, the forward is enqueued on `FORWARD_Q`
 
 - **Transport.** Per-endpoint rate is tracked over `rate_window_seconds`; at
   or above `ws_threshold_msgs_per_10s` (default 1 msg/10s) the processor
-  prefers a pooled WebSocket, otherwise REST. **Between two mediators running
-  this implementation the WebSocket never opens, and every hop lands on
-  REST**: `deliver_via_websocket` connects with no `Authorization` header —
-  the relaying mediator holds no session on its peer — while the peer's
-  upgrade handler requires a valid bearer token *and* the `LOCAL` capability.
-  The first failed attempt suppresses WebSocket for that endpoint for five
-  minutes (`WS_SUPPRESSION_WINDOW`) so the cost is one failed connect per
-  window rather than one per message; the window then re-probes, so a peer
-  that does accept anonymous upgrades is still picked up. Watch for
-  `Falling back to REST and suppressing WebSocket` in the logs.
+  prefers a pooled WebSocket, otherwise REST. Note what that threshold means
+  in practice: the rate is `total / rate_window_seconds * 10`, so over the
+  default 300-second window a steady ~30 messages have to be in flight before
+  the socket engages at all. Below that, relay is REST.
+- **The relay socket is anonymous, so it carries its own acknowledgement.**
+  A relaying mediator holds no session on its peer, so it opens the socket
+  with no credential and identifies itself by offering the `relay-ack`
+  subprotocol; the peer admits it under `enable_inter_mediator_relay` (§4) and
+  echoes `relay-ack`. Every relayed frame is then answered by a `RelayAck`
+  naming the frame by `sha256` of its bytes. **A frame is only reported
+  delivered once that ack comes back positive** — a negative ack, a missing
+  one, or a socket error fails the message and is retried and abandoned
+  exactly as a non-2xx is on REST. This is what keeps the two transports
+  equivalent: a bare socket write would ACK the queue entry for a message the
+  peer refused. A peer that does not echo `relay-ack` is never relayed to over
+  the socket; the connection is dropped and the endpoint falls back to REST
+  (and stays there for `WS_SUPPRESSION_WINDOW`, five minutes).
 - **REST shape.** `POST {endpoint}/inbound`, `Content-Type:
   application/didcomm-encrypted+json` for DIDComm, `application/tsp` (raw qb2)
   for TSP. TSP always goes over REST regardless of rate.
@@ -386,19 +394,16 @@ mediator **DIDs**, not URLs).
 | Error 94 `loop_detected` | genuine loop, or `max_hops` too low for the topology | inspect the route before raising `max_hops` |
 | `FORWARD_ABANDONED` in A's logs | B unreachable through `max_retries` | check B's endpoint and TLS; the sender receives a problem report |
 | TSP messages never leave A | B advertises no `TSPTransport` service | add it (§8); `did:peer`/`did:webvh` need it at DID-generation time |
+| `peer … did not negotiate the \`relay-ack\` subprotocol` in A's logs | B predates the relay socket, or isn't relay-enabled | expected against an older mediator — delivery continues over REST; if B should accept it, check `enable_inter_mediator_relay` on B |
+| `peer refused the relayed message` in A's logs | B nacked the frame | the reason and mediator error code are in the log line; look it up in §6 or `ERRORS.md` — the sender gets a problem report once retries are exhausted |
 
 ---
 
 ## 11. Known gaps
 
-Accurate as of this document's commit; verify before relying on it.
-
-- **Inter-mediator WebSocket delivery cannot authenticate.** A relay hop is
-  anonymous by design, and the WebSocket route is not; the transport therefore
-  degrades to REST between two mediators running this implementation (§7).
-  Restoring it needs a relay-scoped WebSocket admission path on the receiving
-  side — the same decision `security.enable_inter_mediator_relay` already
-  makes for `/inbound` — not a change in the forwarding processor.
+None outstanding for the relay path. The one that stood here — that
+inter-mediator WebSocket delivery could not authenticate, so it degraded to
+REST — was closed by the `relay-ack` admission path described in §7.
 
 ---
 

--- a/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -306,6 +306,34 @@ fn v1_anonymous_acls() -> MediatorACLSet {
     MediatorACLSet::from_string_ruleset("DENY_ALL,SEND_MESSAGES").unwrap_or_default()
 }
 
+/// The anonymous inter-mediator relay session, if this mediator is configured
+/// to act as a relay.
+///
+/// The single place the relay-admission decision is made, so the REST
+/// `/inbound` route and the WebSocket route cannot drift apart on *who* is let
+/// in — only on what they may then do. Relay is enabled by the explicit
+/// `enable_inter_mediator_relay` flag or, for backward compatibility, by
+/// `global_acl_default` granting `SEND_FORWARDED` (the legacy implicit-relay
+/// behaviour, which boot-time validation warns about).
+///
+/// The session carries [`relay_anonymous_acls`] — `SEND_MESSAGES` +
+/// `SEND_FORWARDED`, nothing else — and no DID, which is what stops it from
+/// reaching anything that belongs to an account.
+pub(crate) fn anonymous_relay_session(
+    enable_relay_flag: bool,
+    global_acl_default: &MediatorACLSet,
+) -> Option<Session> {
+    (enable_relay_flag || anonymous_inbound_allowed(global_acl_default)).then(|| Session {
+        session_id: ANON_RELAY_SESSION_ID.to_string(),
+        acls: relay_anonymous_acls(),
+        ..Default::default()
+    })
+}
+
+/// Session id for an anonymous inter-mediator relay session, on either
+/// transport. Carries no DID — see [`anonymous_relay_session`].
+pub(crate) const ANON_RELAY_SESSION_ID: &str = "ANON-INBOUND";
+
 /// Decide whether an authentication failure should be downgraded to an anonymous
 /// relay session, and if so build that session.
 ///
@@ -333,12 +361,8 @@ fn anonymous_session_for(
 
     // Relay admission is unchanged and takes precedence: such a session keeps
     // its SEND_FORWARDED capability and is not restricted to v1 bodies.
-    if enable_relay_flag || anonymous_inbound_allowed(global_acl_default) {
-        return Some(Session {
-            session_id: "ANON-INBOUND".to_string(),
-            acls: relay_anonymous_acls(),
-            ..Default::default()
-        });
+    if let Some(session) = anonymous_relay_session(enable_relay_flag, global_acl_default) {
+        return Some(session);
     }
 
     // Otherwise a v1 forward may still be admitted, but only as a v1-scoped

--- a/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/handlers/websocket.rs
@@ -7,7 +7,7 @@ use crate::{
     SharedData,
     common::authz::{self, Capability},
     common::config::{CorsOriginPolicy, origin_matches},
-    common::jwt_auth::{AuthError, authenticate_token},
+    common::jwt_auth::{AuthError, anonymous_relay_session, authenticate_token},
     common::session::Session,
     messages::inbound::handle_inbound,
     tasks::websocket_streaming::{
@@ -21,6 +21,9 @@ use affinidi_messaging_mediator_common::errors::{AppError, MediatorError};
 #[cfg(feature = "tsp")]
 use affinidi_messaging_mediator_common::store::DeletionAuthority;
 use affinidi_messaging_mediator_common::store::StatCounter;
+use affinidi_messaging_mediator_common::tasks::forwarding::relay_ack::{
+    RELAY_ACK_SUBPROTOCOL, RelayAck, frame_id,
+};
 #[cfg(feature = "tsp")]
 use affinidi_messaging_mediator_common::types::messages::FetchOptions;
 #[cfg(feature = "didcomm")]
@@ -193,17 +196,54 @@ pub async fn websocket_handler(
         extract_bearer_subprotocol(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter())
     };
 
-    let Some(token) = token else {
-        warn!(
-            "WebSocket upgrade rejected: no bearer token in Authorization header or Sec-WebSocket-Protocol"
-        );
-        return AuthError::MissingCredentials.into_response();
-    };
+    // 1a. No token: the one case that may still be admitted is an
+    //     inter-mediator relay hop, which is anonymous by construction — the
+    //     relaying mediator holds no session here, exactly as on `/inbound`.
+    //     It has to *say* that it is one by offering the `relay-ack`
+    //     subprotocol, which is also its promise to consume the per-frame
+    //     acknowledgements that give this transport the REST path's delivery
+    //     semantics. Everything else is refused as before.
+    let offered = app_subprotocols(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter());
+    let wants_relay = offered.iter().any(|p| p == RELAY_ACK_SUBPROTOCOL);
 
-    // 2. Validate the token → Session (identical checks for both paths).
-    let session = match authenticate_token(&state, &token).await {
-        Ok(session) => session,
-        Err(e) => return e.into_response(),
+    let (session, is_relay) = match token {
+        Some(token) => {
+            // 2. Validate the token → Session (identical checks for both paths).
+            match authenticate_token(&state, &token).await {
+                Ok(session) => (session, false),
+                Err(e) => return e.into_response(),
+            }
+        }
+        None if wants_relay => {
+            let security = &state.config.security;
+            match anonymous_relay_session(
+                security.enable_inter_mediator_relay,
+                &security.global_acl_default,
+            ) {
+                Some(mut session) => {
+                    // No JWT means no expiry to inherit, and an anonymous
+                    // socket that never ends is a resource a peer can hold
+                    // open indefinitely. Give it a bounded lifetime instead;
+                    // the relaying peer's pool reconnects transparently.
+                    session.expires_at = state.clock.unix_secs() + RELAY_SOCKET_LIFETIME_SECS;
+                    (session, true)
+                }
+                None => {
+                    warn!(
+                        "WebSocket upgrade rejected: `{}` offered but this mediator is not \
+                         configured as an inter-mediator relay",
+                        RELAY_ACK_SUBPROTOCOL
+                    );
+                    return AuthError::MissingCredentials.into_response();
+                }
+            }
+        }
+        None => {
+            warn!(
+                "WebSocket upgrade rejected: no bearer token in Authorization header or Sec-WebSocket-Protocol"
+            );
+            return AuthError::MissingCredentials.into_response();
+        }
     };
 
     let _span = span!(
@@ -212,8 +252,17 @@ pub async fn websocket_handler(
         session = session.session_id
     );
 
-    // 3. ACL Check (websockets only work on local DID's).
-    if authz::require_capability(&session.acls, Capability::Local).is_err() {
+    // 3. ACL Check. A relay socket has no account here and never touches one:
+    //    it may only push frames, so it is gated on `SEND_MESSAGES` — the same
+    //    capability `message_inbound_handler` requires of the REST relay
+    //    session — instead of `LOCAL`, which exists to gate access to an
+    //    inbox this session does not have.
+    let required = if is_relay {
+        Capability::SendMessages
+    } else {
+        Capability::Local
+    };
+    if authz::require_capability(&session.acls, required).is_err() {
         let error: AppError = MediatorError::problem(
             40,
             session.session_id,
@@ -236,15 +285,23 @@ pub async fn websocket_handler(
     //    bearer entry, no subprotocol is selected and the response
     //    carries no `Sec-WebSocket-Protocol` header (RFC 6455 permits
     //    this; browsers accept it).
-    let app_protocols = app_subprotocols(headers.get_all(SEC_WEBSOCKET_PROTOCOL).iter());
+    let app_protocols = offered;
 
     // A client opts into raw-TSP WebSocket delivery by offering a `tsp`
     // subprotocol alongside `bearer.<jwt>`. The `tsp` marker is echoed back to
     // the client via the `app_protocols` path below (it's a genuine app
     // subprotocol, not the bearer entry), so the client learns the mode was
     // accepted from the 101 response's `Sec-WebSocket-Protocol` header.
+    //
+    // Never on a relay socket: raw-TSP mode is a *delivery* mode — it registers
+    // the socket as a live client and flushes an inbox — and a relay session
+    // has no DID and no inbox to flush. (It also cannot arise in practice: the
+    // relaying mediator offers `relay-ack` alone, and TSP forwards go over
+    // REST. Enforced rather than assumed, because the cost of being wrong is an
+    // anonymous socket registered as a live streaming client under the empty
+    // DID hash.)
     #[cfg(feature = "tsp")]
-    let tsp_mode = app_protocols.iter().any(|p| p == "tsp" || p == "tsp-ack");
+    let tsp_mode = !is_relay && app_protocols.iter().any(|p| p == "tsp" || p == "tsp-ack");
 
     // `tsp-ack` opts into DELETE-TO-ACK delivery. Plain `tsp` keeps the
     // original delete-on-send contract, which is at-most-once past the socket
@@ -264,7 +321,7 @@ pub async fn websocket_handler(
     // for silent duplication, since a client that never acks would be
     // redelivered its whole inbox on every reconnect.
     #[cfg(feature = "tsp")]
-    let tsp_ack_mode = app_protocols.iter().any(|p| p == "tsp-ack");
+    let tsp_ack_mode = !is_relay && app_protocols.iter().any(|p| p == "tsp-ack");
 
     // The echo has to be a HONEST capability signal, and by default it isn't:
     // the offered list is just the client's own list reflected back, so a
@@ -287,6 +344,24 @@ pub async fn websocket_handler(
         app_protocols
     };
 
+    // Same honesty requirement as `tsp-ack` above, and here it is load-bearing:
+    // the relaying peer treats the echoed `relay-ack` as proof that its frames
+    // will be acknowledged, and refuses to relay over the socket without it. A
+    // reflected-by-accident echo would be a mediator promising acks it does not
+    // send — so narrow the offer to exactly what this mediator implements.
+    let app_protocols = if is_relay {
+        vec![RELAY_ACK_SUBPROTOCOL.to_string()]
+    } else {
+        // And the converse: an authenticated client that offers `relay-ack`
+        // is not a relay (a relay hop presents no credential), so it must not
+        // be told it will get acks it is never going to receive. Drop the
+        // entry rather than reflect it.
+        app_protocols
+            .into_iter()
+            .filter(|p| p != RELAY_ACK_SUBPROTOCOL)
+            .collect()
+    };
+
     let ws = if app_protocols.is_empty() {
         ws
     } else {
@@ -303,7 +378,7 @@ pub async fn websocket_handler(
     {
         async move {
             ws.on_upgrade(move |socket| {
-                handle_socket(socket, state, session, tsp_mode, tsp_ack_mode)
+                handle_socket(socket, state, session, is_relay, tsp_mode, tsp_ack_mode)
             })
         }
         .instrument(_span)
@@ -311,7 +386,7 @@ pub async fn websocket_handler(
     }
     #[cfg(not(feature = "tsp"))]
     {
-        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session)) }
+        async move { ws.on_upgrade(move |socket| handle_socket(socket, state, session, is_relay)) }
             .instrument(_span)
             .await
     }
@@ -351,6 +426,31 @@ mod close_code {
     pub const TRY_AGAIN_LATER: u16 = 1013;
 }
 
+/// How long an anonymous inter-mediator relay socket may stay open.
+///
+/// A relay hop presents no JWT, so there is no token expiry to inherit and
+/// nothing would otherwise bound the connection. An hour keeps the peer's
+/// pooled socket useful while still forcing it to be re-admitted periodically
+/// — re-running the relay-enabled check against current configuration, which
+/// is what makes turning relay *off* take effect without a restart.
+const RELAY_SOCKET_LIFETIME_SECS: u64 = 3600;
+
+/// The error code and reason to hand back in a negative [`RelayAck`].
+///
+/// A mediator problem report already carries both, and they are what the
+/// relaying peer logs (and, once the message is abandoned, what reaches the
+/// original sender). Anything without a problem report is an internal failure
+/// the peer cannot act on beyond retrying, so it becomes a bare 500.
+fn relay_refusal(error: &MediatorError) -> (u16, String) {
+    match error {
+        MediatorError::MediatorError(code, _, _, _, _, log_message) => (*code, log_message.clone()),
+        other => (
+            StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            other.to_string(),
+        ),
+    }
+}
+
 /// Build a close message carrying an RFC 6455 code + human-readable reason.
 fn close_with(code: u16, reason: &'static str) -> Message {
     Message::Close(Some(CloseFrame {
@@ -364,6 +464,9 @@ async fn handle_socket(
     mut socket: WebSocket,
     state: SharedData,
     session: Session,
+    // An anonymous inter-mediator relay socket: it may push frames and
+    // receives nothing but the `RelayAck` answers to them.
+    is_relay: bool,
     #[cfg(feature = "tsp")] tsp_mode: bool,
     #[cfg(feature = "tsp")] tsp_ack_mode: bool,
 ) {
@@ -399,6 +502,12 @@ async fn handle_socket(
             *entry += 1;
             *entry
         };
+        // Note for relay sockets: they carry no DID, so they all share the
+        // empty-hash bucket and `max_websocket_connections_per_did` (default
+        // 100) becomes the ceiling on *concurrent relay sockets across all
+        // peers*. That is the intended bound — it is the only thing limiting
+        // anonymous sockets — and the empty string cannot collide with a real
+        // DID's bucket, which is a sha256 hash.
         let _per_did_guard = PerDidConnectionGuard {
             registry: state.ws_connections_per_did.clone(),
             did_hash: session.did_hash.clone(),
@@ -424,7 +533,17 @@ async fn handle_socket(
         // Register the transmission channel between websocket_streaming task and this websocket.
         let (tx, mut rx): (Sender<QueuedCommand>, Receiver<QueuedCommand>) =
             mpsc::channel(WS_CHANNEL_SLOTS);
-        if let Some(streaming) = &state.streaming_task {
+
+        // A relay socket is push-only and must never be registered with the
+        // streaming task. It has no DID, so it would register under the empty
+        // did_hash — claiming that stream for an anonymous peer and pointing
+        // live delivery at a socket that belongs to no account. Skipping the
+        // registration is what makes "relays can only send" structural rather
+        // than a matter of which messages we happen to handle: `rx` below can
+        // never yield.
+        if let Some(streaming) = &state.streaming_task
+            && !is_relay
+        {
 
             let start = StreamingUpdate {
                 did_hash: session.did_hash.clone(),
@@ -562,8 +681,16 @@ async fn handle_socket(
         loop {
             select! {
                 _ = &mut auth_timeout => {
-                    debug!("Auth Timeout reached");
-                    close_reason = (close_code::POLICY, "authentication token expired");
+                    debug!("Socket lifetime reached");
+                    close_reason = if is_relay {
+                        // No token was ever presented — this is the relay
+                        // socket's bounded lifetime, and the peer should
+                        // reconnect rather than go looking for a credential
+                        // problem it doesn't have.
+                        (close_code::POLICY, "relay socket lifetime reached")
+                    } else {
+                        (close_code::POLICY, "authentication token expired")
+                    };
                     break;
                 }
                 value = socket.recv() => {
@@ -577,7 +704,45 @@ async fn handle_socket(
                                     }
 
                                     // Process the message, which also takes care of any storing and live-streaming of the message
-                                    match handle_inbound(&state, &session, &msg).await {
+                                    let outcome = handle_inbound(&state, &session, &msg).await;
+
+                                    // A relay socket gets a `relay-ack` per frame instead of a
+                                    // problem report. Two reasons it cannot have the latter: a
+                                    // problem report is packed *to* `session.did`, which a relay
+                                    // session does not have; and the relaying peer is a mediator
+                                    // waiting on a transport answer, not a client reading its
+                                    // inbox. The ack is what stops a refused frame from being
+                                    // reported as delivered — see `relay_ack`.
+                                    if is_relay {
+                                        let ack = match &outcome {
+                                            Ok(_) => RelayAck::accepted(frame_id(msg.as_bytes())),
+                                            Err(e) => {
+                                                warn!("Relay frame refused: {}", e);
+                                                let (code, reason) = relay_refusal(e);
+                                                RelayAck::rejected(frame_id(msg.as_bytes()), code, reason)
+                                            }
+                                        };
+                                        match serde_json::to_string(&ack) {
+                                            Ok(body) => {
+                                                if let Err(e) = socket.send(Message::Text(body.into())).await {
+                                                    warn!("Failed to send relay-ack: {e}");
+                                                    close_reason = (close_code::GOING_AWAY, "peer disconnected");
+                                                    break;
+                                                }
+                                            }
+                                            Err(e) => {
+                                                // Unreachable for this type, and if it ever
+                                                // happened the peer must not read silence as
+                                                // success: drop the socket so it retries.
+                                                warn!("Couldn't serialise relay-ack: {e}");
+                                                close_reason = (close_code::SERVER_ERROR, "could not acknowledge");
+                                                break;
+                                            }
+                                        }
+                                        continue;
+                                    }
+
+                                    match outcome {
                                         Ok(_) => {}
                                         Err(e) => {
                                             warn!("WebSocket inbound error: {}", e);
@@ -617,6 +782,18 @@ async fn handle_socket(
                                     // Don't need to do anything
                                 }
                                 Message::Binary(msg) => {
+                                    // The relay contract is Text frames answered by acks.
+                                    // A binary frame on a relay socket is either a
+                                    // confused peer or something that is not a peer at
+                                    // all; either way it cannot be acknowledged, and
+                                    // staying open would leave the sender waiting out the
+                                    // ack timeout for every frame. Close instead, so it
+                                    // falls back to REST immediately.
+                                    if is_relay {
+                                        warn!("Binary frame on a relay socket; closing");
+                                        close_reason = (close_code::POLICY, "relay sockets carry text frames only");
+                                        break;
+                                    }
                                     if msg.len() > state.config.limits.ws_size {
                                         warn!("Error processing message, the size is too big. limit is {}, message size is {}", state.config.limits.ws_size, msg.len());
                                         continue;
@@ -735,8 +912,11 @@ async fn handle_socket(
             }
         }
 
-        // Remove this websocket and associated info from the streaming task
-        if !already_deregistered_flag { // Skip if close initiated by the streaming task
+        // Remove this websocket and associated info from the streaming task.
+        // A relay socket was never registered (see above), so there is nothing
+        // to deregister — and doing so under the empty did_hash would be a
+        // deregistration for an account that isn't this session's.
+        if !already_deregistered_flag && !is_relay { // Skip if close initiated by the streaming task
             if let Some(streaming) = &state.streaming_task  {
                 let stop = StreamingUpdate {
                     did_hash: session.did_hash.clone(),

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased (0.5.2) — `forwarding_ws_threshold` so the relay socket can be tested
+
+`TestMediatorBuilder::forwarding_ws_threshold(msgs_per_10s)` sets the rate at
+or above which the forwarding processor relays over a WebSocket instead of
+REST. Pass `0` to force the socket on the first relayed message.
+
+Without it the WebSocket relay path had no end-to-end coverage and could not
+get any. The production default reads as 1 msg/10s, but the rate is measured
+over a 300-second window — `total / window * 10` — so a single relayed message
+scores 0.03 and every short test silently relays over REST. A test could
+therefore assert cross-mediator delivery, pass, and never once exercise the
+transport it looked like it was covering.
+
+New `tests/ws_relay_admission.rs` uses it for the two-mediator case, alongside
+three raw-socket tests of the receiving side: the anonymous upgrade is admitted
+and echoes `relay-ack`, an accepted frame is acked *and* really delivered, a
+refused frame comes back nacked with the mediator's error code, and a
+non-relay mediator refuses the upgrade outright.
+
 ## Unreleased (0.5.1) — no longer depends on `jsonwebtoken`
 
 Support for mediator 0.22.0 (issue #770). The fixture used to build

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.5.1"
+version = "0.5.2"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -38,7 +38,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 affinidi-messaging-mediator = { version = "0.22", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
-affinidi-messaging-mediator-common = { version = "0.15", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
+affinidi-messaging-mediator-common = { version = "0.15.44", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
   "test-clock",
 ] }
 

--- a/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/src/lib.rs
@@ -296,6 +296,7 @@ pub struct TestMediatorBuilder {
     /// forwarding processor. `None` keeps `ForwardingConfig::default`, whose
     /// production values take ~31s to abandon an undeliverable forward.
     forwarding_retry_policy: Option<(u32, u64, u64)>,
+    forwarding_ws_threshold: Option<u64>,
     enable_message_expiry: bool,
     enable_streaming: bool,
     /// Additional DIDs to register as LOCAL accounts at startup. Tests
@@ -365,6 +366,7 @@ impl Default for TestMediatorBuilder {
             relay_mode: RelayMode::Blind,
             relay_trusted_mediators: Vec::new(),
             forwarding_retry_policy: None,
+            forwarding_ws_threshold: None,
             enable_message_expiry: false,
             enable_streaming: true,
             local_dids: Vec::new(),
@@ -493,6 +495,25 @@ impl TestMediatorBuilder {
             initial_backoff.as_millis() as u64,
             max_backoff.as_millis() as u64,
         ));
+        self
+    }
+
+    /// Messages-per-10s rate at or above which the forwarding processor
+    /// relays over a WebSocket instead of REST. `None` keeps the production
+    /// default of 1.
+    ///
+    /// Pass `0` to force the WebSocket transport on the very first relayed
+    /// message. Production's default effectively never engages it in a test:
+    /// the rate is measured over a 300-second window, so one message reads as
+    /// 0.03 msgs/10s and every short test relays over REST. Without this knob
+    /// the WebSocket relay path — subprotocol negotiation and the `relay-ack`
+    /// round trip — has no end-to-end coverage at all.
+    ///
+    /// Has no effect unless [`enable_forwarding`] is `true`.
+    ///
+    /// [`enable_forwarding`]: Self::enable_forwarding
+    pub fn forwarding_ws_threshold(mut self, msgs_per_10s: u64) -> Self {
+        self.forwarding_ws_threshold = Some(msgs_per_10s);
         self
     }
 
@@ -856,6 +877,9 @@ impl TestMediatorBuilder {
             processors.forwarding.max_retries = max_retries;
             processors.forwarding.initial_backoff_ms = initial_backoff_ms;
             processors.forwarding.max_backoff_ms = max_backoff_ms;
+        }
+        if let Some(threshold) = self.forwarding_ws_threshold {
+            processors.forwarding.ws_threshold_msgs_per_10s = threshold;
         }
         processors.message_expiry_cleanup.enabled = self.enable_message_expiry;
 

--- a/crates/messaging/affinidi-messaging-test-mediator/tests/ws_relay_admission.rs
+++ b/crates/messaging/affinidi-messaging-test-mediator/tests/ws_relay_admission.rs
@@ -1,0 +1,454 @@
+//! Anonymous inter-mediator relay over WebSocket, and the acknowledgement that
+//! makes it safe.
+//!
+//! A relay hop carries no credential — the relaying mediator holds no session
+//! on its peer — so the WebSocket route admits it the way `/inbound` does:
+//! only when the operator has turned relay on, and only for a socket that
+//! identifies itself by offering the `relay-ack` subprotocol.
+//!
+//! The subprotocol is the point. A bare WebSocket write says only that bytes
+//! left the sender, so relaying over one would let the forwarding processor ACK
+//! its queue entry for a message the peer *refused* — the rejection surviving
+//! as nothing but a log line on the far side, while every "delivered" claim
+//! downstream is built on the REST path's status check. These tests pin the
+//! three properties that keep the two transports equivalent:
+//!
+//! 1. A relay-enabled mediator admits the anonymous upgrade, echoes
+//!    `relay-ack`, and answers an accepted frame with `ok: true` — and the
+//!    message really is delivered to the recipient, so the ack means what it
+//!    says.
+//! 2. A frame the mediator refuses comes back `ok: false` with the mediator's
+//!    error code, which is what turns a rejection into a retry and eventually a
+//!    problem report to the original sender.
+//! 3. A mediator that is not a relay refuses the upgrade outright.
+//!
+//! A fourth test drives the whole thing between two real mediators, which is
+//! the only place the *sending* half — subprotocol negotiation and waiting on
+//! the ack — is exercised. It has to ask for the WebSocket transport
+//! explicitly: the processor's rate threshold is measured over a 300-second
+//! window, so a handful of messages reads as ~0.03 msgs/10s and every short
+//! test would otherwise relay over REST.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_mediator::store::MemoryStore;
+use affinidi_messaging_mediator_common::store::MediatorStore;
+use affinidi_messaging_mediator_common::tasks::forwarding::relay_ack::{
+    RELAY_ACK_SUBPROTOCOL, RelayAck, frame_id,
+};
+use affinidi_messaging_sdk::messages::fetch::FetchOptions;
+use affinidi_messaging_test_mediator::{TestEnvironment, TestMediator, TestUser, acl};
+use common::init_tracing;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{ClientRequestBuilder, Message as WsMessage, http::Uri},
+};
+use uuid::Uuid;
+
+/// Spawn a relay-enabled mediator wired to an SDK environment.
+///
+/// `enable_inter_mediator_relay` is the explicit opt-in the WebSocket route
+/// checks; the allow-all default ACL is what lets a cross-mediator forward
+/// sender auto-register, exactly as in `cross_mediator_forwarding.rs`.
+async fn spawn_relay_environment() -> TestEnvironment {
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .enable_inter_mediator_relay(true)
+        .spawn()
+        .await
+        .expect("spawn relay mediator");
+    TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment to relay mediator")
+}
+
+/// The mediator's `ws://…/ws` upgrade URI.
+fn ws_uri(env: &TestEnvironment) -> Uri {
+    env.mediator
+        .ws_endpoint()
+        .as_str()
+        .parse()
+        .expect("parse ws endpoint")
+}
+
+/// Build the frame a relaying mediator puts on the wire in blind relay mode:
+/// a `routing/2.0` forward addressed to the receiving mediator, whose
+/// attachment is an authcrypt from `sender` to `recipient`.
+async fn relayed_forward(
+    env: &TestEnvironment,
+    sender: &TestUser,
+    recipient: &TestUser,
+    text: &str,
+) -> String {
+    relayed_forward_to(env, sender, env.mediator.did(), recipient, text).await
+}
+
+/// As [`relayed_forward`], but addressed to an arbitrary next-hop mediator.
+async fn relayed_forward_to(
+    env: &TestEnvironment,
+    sender: &TestUser,
+    target_mediator: &str,
+    recipient: &TestUser,
+    text: &str,
+) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let msg = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/basicmessage/2.0/message".to_string(),
+        json!({ "content": text }),
+    )
+    .to(recipient.did.clone())
+    .from(sender.did.clone())
+    .created_time(now)
+    .expires_time(now + 60)
+    .finalize();
+
+    let (packed, _) = env
+        .atm
+        .pack_encrypted(&msg, &recipient.did, Some(&sender.did), Some(&sender.did))
+        .await
+        .expect("authcrypt for the recipient");
+
+    let (_id, forward) = env
+        .atm
+        .routing()
+        .forward_message(
+            &sender.profile,
+            false,
+            &packed,
+            target_mediator,
+            &recipient.did,
+            None,
+            None,
+        )
+        .await
+        .expect("wrap in a forward addressed to the mediator");
+
+    forward
+}
+
+/// Read frames until one parses as a [`RelayAck`], or the deadline passes.
+async fn next_ack<S>(stream: &mut S) -> RelayAck
+where
+    S: StreamExt<Item = Result<WsMessage, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let frame = tokio::time::timeout_at(deadline, stream.next())
+            .await
+            .expect("a relay-ack must arrive before the deadline")
+            .expect("the relay socket must stay open")
+            .expect("the relay socket must not error");
+
+        if let WsMessage::Text(text) = frame
+            && let Ok(ack) = serde_json::from_str::<RelayAck>(&text)
+        {
+            return ack;
+        }
+    }
+}
+
+/// A relay-enabled mediator admits the anonymous upgrade, and its ack means the
+/// message was really delivered — not merely received.
+#[tokio::test]
+async fn relay_socket_is_admitted_and_its_ack_means_delivered() {
+    init_tracing();
+
+    let env = spawn_relay_environment().await;
+    let alice = env.add_user("Alice").await.expect("add alice");
+    let bob = env.add_user("Bob").await.expect("add bob");
+    let frame = relayed_forward(&env, &alice, &bob, "relayed over a websocket").await;
+
+    // The shape a relaying mediator opens: no Authorization header, no bearer
+    // subprotocol, just `relay-ack`.
+    let request = ClientRequestBuilder::new(ws_uri(&env)).with_sub_protocol(RELAY_ACK_SUBPROTOCOL);
+    let (mut stream, response) = connect_async(request)
+        .await
+        .expect("relay upgrade must be admitted");
+
+    assert_eq!(response.status().as_u16(), 101, "expected 101");
+    assert_eq!(
+        response
+            .headers()
+            .get("sec-websocket-protocol")
+            .and_then(|v| v.to_str().ok()),
+        Some(RELAY_ACK_SUBPROTOCOL),
+        "the mediator must echo `relay-ack` — the peer relays only on that promise"
+    );
+
+    stream
+        .send(WsMessage::Text(frame.clone().into()))
+        .await
+        .expect("send the relayed frame");
+
+    let ack = next_ack(&mut stream).await;
+    assert!(
+        ack.answers(&frame_id(frame.as_bytes())),
+        "the ack must be content-addressed to the frame it answers"
+    );
+    assert!(ack.ok, "the frame was accepted: {ack:?}");
+
+    // And the ack was telling the truth.
+    let mut delivered = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        let fetched = env
+            .atm
+            .fetch_messages(&bob.profile, &FetchOptions::default())
+            .await
+            .expect("bob fetches messages");
+        if let Some(element) = fetched.success.first()
+            && element.msg.is_some()
+        {
+            delivered = element.msg.clone();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        delivered.is_some(),
+        "a positive ack must mean the mediator took responsibility for the message"
+    );
+
+    drop(stream);
+    env.shutdown().await.expect("shutdown");
+}
+
+/// A refused frame comes back as a negative ack carrying the mediator's error
+/// code. This is the property the whole subprotocol exists for: without it the
+/// relaying peer would ACK its queue entry and drop a message the peer threw
+/// away.
+#[tokio::test]
+async fn a_refused_frame_is_nacked_rather_than_silently_dropped() {
+    init_tracing();
+
+    let env = spawn_relay_environment().await;
+
+    let request = ClientRequestBuilder::new(ws_uri(&env)).with_sub_protocol(RELAY_ACK_SUBPROTOCOL);
+    let (mut stream, _response) = connect_async(request)
+        .await
+        .expect("relay upgrade must be admitted");
+
+    // Not a DIDComm envelope: the mediator cannot deliver it and must say so.
+    let frame = "this is not a DIDComm envelope";
+    stream
+        .send(WsMessage::Text(frame.into()))
+        .await
+        .expect("send the malformed frame");
+
+    let ack = next_ack(&mut stream).await;
+    assert!(
+        ack.answers(&frame_id(frame.as_bytes())),
+        "the nack must answer the frame that was refused"
+    );
+    assert!(!ack.ok, "the frame was refused, so the ack must say so");
+    assert!(
+        ack.code.is_some(),
+        "a refusal carries the mediator error code so the peer can log and \
+         report it: {ack:?}"
+    );
+
+    drop(stream);
+    env.shutdown().await.expect("shutdown");
+}
+
+/// An authenticated client is not a relay, so it must never be told it will
+/// get acks. Reflecting the offer back — the default echo behaviour — would be
+/// the mediator promising a contract it only honours for relay sockets.
+#[tokio::test]
+async fn an_authenticated_client_is_never_told_it_will_get_acks() {
+    init_tracing();
+
+    let env = spawn_relay_environment().await;
+    let alice = env.add_user("Alice").await.expect("add alice");
+
+    let mediator_did = env.mediator.did().to_string();
+    let tokens = env
+        .tdk
+        .authentication()
+        .authenticate(alice.did.clone(), mediator_did, 3, None)
+        .await
+        .expect("authenticate alice");
+
+    let request = ClientRequestBuilder::new(ws_uri(&env))
+        .with_sub_protocol(RELAY_ACK_SUBPROTOCOL)
+        .with_sub_protocol(format!("bearer.{}", tokens.access_token));
+    // tokio-tungstenite's client errors when the server selects none of the
+    // offered subprotocols — which is exactly the answer being asserted.
+    let result = connect_async(request).await;
+
+    match result {
+        Err(_) => { /* no subprotocol selected: the mediator promised nothing */ }
+        Ok((stream, response)) => {
+            assert_ne!(
+                response
+                    .headers()
+                    .get("sec-websocket-protocol")
+                    .and_then(|v| v.to_str().ok()),
+                Some(RELAY_ACK_SUBPROTOCOL),
+                "an authenticated client must not be told `relay-ack` was accepted"
+            );
+            drop(stream);
+        }
+    }
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// A mediator that is not configured as a relay refuses the anonymous upgrade,
+/// exactly as it refuses an anonymous `/inbound`.
+#[tokio::test]
+async fn a_non_relay_mediator_refuses_the_anonymous_upgrade() {
+    init_tracing();
+
+    let mediator = TestMediator::builder()
+        .enable_forwarding(true)
+        .global_acl_default(acl::deny_all())
+        .enable_inter_mediator_relay(false)
+        .spawn()
+        .await
+        .expect("spawn non-relay mediator");
+    let env = TestEnvironment::new(mediator)
+        .await
+        .expect("wire SDK environment");
+
+    let request = ClientRequestBuilder::new(ws_uri(&env)).with_sub_protocol(RELAY_ACK_SUBPROTOCOL);
+    let result = connect_async(request).await;
+
+    assert!(
+        result.is_err(),
+        "a mediator that is not a relay must refuse an anonymous upgrade"
+    );
+
+    env.shutdown().await.expect("shutdown");
+}
+
+/// Two mediators, relaying over the negotiated socket: mediator A opens a
+/// `relay-ack` WebSocket to mediator B, B admits it anonymously, and the
+/// message arrives.
+///
+/// This is the only coverage of the sending half — building the upgrade with
+/// the subprotocol, refusing to relay if the peer doesn't echo it, and holding
+/// the frame open until the ack comes back.
+#[tokio::test]
+async fn a_forward_relays_between_two_mediators_over_the_negotiated_socket() {
+    init_tracing();
+
+    // B's store is held by the test so the relay socket can be *observed*
+    // rather than assumed: nothing else in this test opens a WebSocket to B,
+    // so a non-zero `websocket_open` is the relay hop and only the relay hop.
+    let bob_store = std::sync::Arc::new(MemoryStore::new());
+
+    let mediator_a = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .enable_inter_mediator_relay(true)
+        // Force the WebSocket transport on the first relayed message.
+        .forwarding_ws_threshold(0)
+        .spawn()
+        .await
+        .expect("spawn mediator A");
+    let mediator_b = TestMediator::builder()
+        .enable_forwarding(true)
+        .enable_external_forwarding(true)
+        .global_acl_default(acl::allow_all())
+        .enable_inter_mediator_relay(true)
+        .store(bob_store.clone())
+        .spawn()
+        .await
+        .expect("spawn mediator B");
+
+    let env_a = TestEnvironment::new(mediator_a).await.expect("env A");
+    let env_b = TestEnvironment::new(mediator_b).await.expect("env B");
+
+    let alice = env_a.add_user("Alice").await.expect("add alice on A");
+    let bob = env_b.add_user("Bob").await.expect("add bob on B");
+
+    assert_eq!(
+        bob_store
+            .get_global_stats()
+            .await
+            .expect("read B's stats")
+            .websocket_open,
+        0,
+        "no WebSocket has been opened to B before the relay hop"
+    );
+
+    // The routing-2.0 double forward: an INNER forward addressed to B with
+    // next = Bob, wrapped in an OUTER forward addressed to A with next = B, so
+    // A relays the inner one over the wire.
+    let inner = relayed_forward_to(
+        &env_a,
+        &alice,
+        env_b.mediator.did(),
+        &bob,
+        "over the socket",
+    )
+    .await;
+    let (outer_id, outer) = env_a
+        .atm
+        .routing()
+        .forward_message(
+            &alice.profile,
+            false,
+            &inner,
+            env_a.mediator.did(),
+            env_b.mediator.did(),
+            None,
+            None,
+        )
+        .await
+        .expect("outer forward");
+    env_a
+        .atm
+        .send_message(&alice.profile, &outer, &outer_id, false, false)
+        .await
+        .expect("send the outer forward to A");
+
+    // Bob receives it, having crossed A → B over the relay socket.
+    let mut delivered = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        let fetched = env_b
+            .atm
+            .fetch_messages(&bob.profile, &FetchOptions::default())
+            .await
+            .expect("bob fetches messages");
+        if let Some(element) = fetched.success.first()
+            && element.msg.is_some()
+        {
+            delivered = element.msg.clone();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        delivered.is_some(),
+        "the relayed message must reach Bob on mediator B"
+    );
+
+    assert!(
+        bob_store
+            .get_global_stats()
+            .await
+            .expect("read B's stats")
+            .websocket_open
+            > 0,
+        "the hop must have gone over the relay WebSocket, not fallen back to REST"
+    );
+
+    env_a.shutdown().await.expect("shutdown A");
+    env_b.shutdown().await.expect("shutdown B");
+}


### PR DESCRIPTION
Closes the gap `docs/multi-mediator.md` §11 opened in #781: inter-mediator WebSocket delivery could not authenticate, so every relay hop fell back to REST after a failed upgrade.

Admitting the socket was only half the problem.

### Why this isn't a two-line change

`deliver_via_websocket` treated a successful socket **write** as delivery and ACKed the `FORWARD_Q` entry, while `deliver_via_rest` checks the HTTP status. So a frame the peer *refuses* — untrusted relay peer, ACL denial, detected loop — is retried on REST and eventually abandoned with a problem report to the original sender, and over a bare WebSocket would have been dropped with the rejection surviving as a log line on the far side. Every "delivered" claim downstream in the VTI stack is built on the REST path's answer (R1.1). Enabling the socket without an ack would have quietly traded that away.

So the transport carries its own acknowledgement.

### `relay-ack` subprotocol — mediator-common 0.15.44

A relaying mediator opens the socket offering `relay-ack`; a receiving mediator that supports it echoes it and answers **every** relayed frame with a `RelayAck` naming the frame by `sha256` of its exact bytes — content-addressed, so neither side keeps ordering state and an ack can never be read as the answer to a different frame. A frame is reported delivered only on a positive ack; a negative ack, a missing one inside 30s, or a socket error fails the message onto the existing retry/abandonment path. The two transports now have the same delivery semantics.

**Compatibility is the subprotocol itself.** A peer that doesn't echo `relay-ack` gets no frames over the socket at all — the connection is closed and delivery falls back to REST, which is what carried this traffic before. There is no version of the exchange in which a frame is relayed without an ack path, so an older peer is unaffected. The 0.15.43 suppression window keeps such a peer from costing a connect per message.

### Admission — mediator 0.22.2

The WebSocket route now admits an anonymous relay hop on the same terms `/inbound` always has (`enable_inter_mediator_relay`, or the legacy implicit `SEND_FORWARDED`), and only for a socket that identifies itself by offering `relay-ack`. The decision moved into `jwt_auth::anonymous_relay_session` so the two routes cannot drift on *who* is let in.

What such a socket may do is narrow, and structurally so:

- **Never registered with the streaming task** — a relay session has no DID and would claim the empty `did_hash`'s stream, so its inbound channel can never yield. "A relay can only send" is a property of the code, not of which message types happen to be handled.
- **Gated on `SEND_MESSAGES`, not `LOCAL`** — the same capability the REST relay session needs; `LOCAL` gates an inbox this session doesn't have.
- **Answered with a `RelayAck` instead of a problem report**, which is packed *to* `session.did` and would have nothing to address.
- **Raw-TSP mode forced off; a binary frame closes the socket.**
- **Bounded lifetime**, so re-admission re-runs the relay-enabled check and turning relay off takes effect without a restart.
- **`relay-ack` echoed only to a socket that will actually be acked** — an authenticated client offering it is not a relay and must not be promised acks.

### Testing — test-mediator 0.5.2

New `TestMediatorBuilder::forwarding_ws_threshold`. Without it this path could not be covered at all: the production threshold reads as 1 msg/10s, but the rate is `total / window * 10` over 300s, so one relayed message scores 0.03 and every short test relays over REST — a test could assert cross-mediator delivery, pass, and never touch the transport it appeared to cover. I verified the new two-mediator test is decisive by raising the threshold back and watching it fail on exactly the assertion that the hop used the socket.

`tests/ws_relay_admission.rs` (5 tests): the upgrade is admitted and echoes `relay-ack`; an accepted frame is acked **and** really delivered; a refused frame is nacked with the mediator's error code; an authenticated client is never promised acks; a non-relay mediator refuses the upgrade; and two real mediators relay over the negotiated socket, asserted against the receiving store's `websocket_open`.

`docs/multi-mediator.md` §7 is rewritten and its §11 known-gaps is now empty.

### Verification

- `cargo clippy --all-targets` clean on `redis-backend` (default), `--no-default-features --features didcomm,memory-backend`, and test-mediator with `tsp`
- 206 mediator-common unit tests, 226 mediator unit, `relay_rewrap`, and all 31 e2e suites green
- `cargo deny check` clean

Mediator 0.22.2, mediator-common 0.15.44, test-mediator 0.5.2.
