### PR TITLE
feat: answer management Trust Tasks over TSP, not just DIDComm

### DIFF
--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## Unreleased (0.22.3) — answer management Trust Tasks over TSP
+
+A TSP-only deployment could not manage its own accounts. The dispatcher that
+turns a `TrustTaskEnvelope` into `account/update`, `acl/get`,
+`access-list/update` and the rest — `MessageType::process` — is wholly
+`#[cfg(feature = "didcomm")]` and takes a DIDComm `Message`, so a TSP
+`Direct`/`Control` message addressed to the mediator never reached it. It went
+to `deliver_tsp_local` → `deliver_opaque`, which files it for pickup. There was
+no packet a TSP-only client could send to set its own account ACL.
+
+That bites where it is least visible. An account is created at authentication
+with `global_acl_default`, so a permissive default hides the gap entirely; a
+restrictive one leaves the client unable to fix its own ACL over any transport.
+TSP delivery is not exempt from ACLs — `deliver_opaque` applies existence,
+`RECEIVE_MESSAGES` and the access-list verdict through `delivery_decision`.
+
+The handlers were already transport-agnostic: each takes the document, the
+authenticated sender, `state` and `session`, and nothing about them is DIDComm.
+So the dispatch splits into a core plus a wrapper per transport.
+
+- `consume` runs the dispatch and returns the response document. It requires the
+  caller to have established the sender cryptographically — the handlers
+  authorise against that sender, so a caller passing an unverified claim would
+  hand over the admin surface.
+- The DIDComm wrapper is unchanged in behaviour: sender from `UnpackMetadata`,
+  document from the message body, reply packed as a DIDComm message.
+- The TSP wrapper unpacks a `Direct`/`Control` message addressed to this
+  mediator, dispatches, then seals the reply to the sender and delivers it
+  through the ordinary local path — so it arrives on the client's existing
+  pickup socket. No second socket, and no new delivery mechanism.
+
+The TSP sender carries the same standing as the DIDComm one: `direct::unpack`
+verifies Ed25519 over envelope‖ciphertext against the key resolved from the
+VID's DID document *and* opens with HPKE-Auth, binding the sender's static key.
+Two independent proofs, which is what lets the handlers authorise on it
+unchanged.
+
+Requests are recognised by payload rather than a binding type URI, because the
+client packs the bare task document and there is no envelope tag to switch on. A
+document that parses *and* names a served type is claimed; everything else falls
+through to delivery unchanged, so ordinary traffic addressed to the mediator is
+unaffected.
+
+**Behavioural note for operators.** A message that previously landed in the
+mediator's own inbox is now answered if it is a served management task. Nothing
+else changes, and no client is required to move — the DIDComm path is
+untouched.
+
 ## Unreleased (0.22.2) — admit an inter-mediator relay over WebSocket
 
 The WebSocket route now admits an anonymous inter-mediator relay hop, on the

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.22.2"
+version = "0.22.3"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/inbound.rs
@@ -11,6 +11,8 @@ use crate::{SharedData, common::session::Session};
 // Shared by both the DIDComm direct-delivery path and the TSP delivery path.
 #[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::common::authz::Capability;
+#[cfg(feature = "tsp")]
+use crate::messages::protocols::trust_tasks;
 #[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::{common::authz, messages::store::store_message};
 use affinidi_messaging_mediator_common::errors::MediatorError;
@@ -397,14 +399,103 @@ pub(crate) async fn handle_inbound_tsp(
             .await
         }
 
-        // Direct or Control addressed to the mediator itself: store it for the
-        // mediator's own pickup (the mediator is the addressed recipient). Direct
-        // and Control messages destined for *local accounts* never reach here —
-        // they took the `receiver != mediator` opaque pass-through above.
+        // Direct or Control addressed to the mediator itself.
+        //
+        // Two kinds of traffic arrive here and they are not interchangeable. A
+        // **management Trust Task** is a request the mediator must *answer* —
+        // `account/update`, `acl/get`, `access-list/update` and friends. Anything
+        // else addressed to us is mail for the mediator's own account, which is
+        // stored for its pickup.
+        //
+        // Telling them apart on the payload rather than a binding type URI is
+        // deliberate: the client sends the bare Trust Task document (that is what
+        // `VtaClient`'s TSP arm packs — the task document, not a `{type,
+        // document}` wrapper), so there is no envelope tag to switch on. A
+        // document that parses as a Trust Task *and* names a type the mediator
+        // serves is unambiguous; everything else falls through unchanged.
         TspMessageType::Direct | TspMessageType::Control => {
+            if let Some(doc) = trust_tasks::parse_if_served(&unpacked.payload) {
+                return dispatch_tsp_trust_task(state, session, &meta.sender, doc).await;
+            }
             deliver_tsp_local(state, session, raw).await
         }
     }
+}
+
+/// Answer a management Trust Task that arrived over TSP.
+///
+/// The mediator's management surface is one core
+/// ([`trust_tasks::consume`]) with a wrapper per transport; this is the TSP
+/// wrapper. It exists so a **TSP-only deployment is not a second-class one**:
+/// without it a client cannot set its own account ACL over any transport, since
+/// the DIDComm dispatcher (`MessageType::process`) is the only other way in and
+/// takes a DIDComm `Message`.
+///
+/// `sender_vid` is the envelope sender, which the caller has already proven:
+/// `direct::unpack` verified an Ed25519 signature over envelope‖ciphertext
+/// against the key resolved from that VID's DID document, and opened the payload
+/// with HPKE-Auth, which binds the sender's static key too. Two independent
+/// proofs — the same standing the DIDComm path gets from authcrypt, which is
+/// what lets the handlers authorise against it unchanged.
+///
+/// The reply is sealed back to the sender and delivered through the ordinary
+/// local-delivery path, so it reaches a connected client on its existing pickup
+/// socket. No second socket, and no new delivery mechanism.
+#[cfg(feature = "tsp")]
+async fn dispatch_tsp_trust_task(
+    state: &SharedData,
+    session: &Session,
+    sender_vid: &str,
+    doc: trust_tasks_rs::TrustTask<serde_json::Value>,
+) -> Result<InboundMessageResponse, MediatorError> {
+    let now_secs = state.clock.unix_secs();
+
+    // The sender VID is the framework identity; TSP VIDs carry no key fragment,
+    // so it is already the shape `consume` wants.
+    let Some(response) = trust_tasks::consume(doc, state, session, sender_vid, now_secs).await?
+    else {
+        // A ping identity mismatch emits nothing — same as the DIDComm path.
+        return Ok(InboundMessageResponse::Stored(
+            affinidi_messaging_sdk::messages::sending::InboundMessageList::default(),
+        ));
+    };
+
+    let identity = state.tsp_identity().await?;
+    let recipient = resolve_tsp_vid(state, sender_vid, &session.session_id).await?;
+
+    let payload = serde_json::to_vec(&response).map_err(|e| {
+        tsp_problem(
+            session,
+            37,
+            "message.tsp.trust_task.serialize",
+            format!("could not serialise the Trust Task response: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
+
+    let packed = affinidi_tsp::message::direct::pack(
+        &payload,
+        affinidi_tsp::MessageType::Direct,
+        &identity.vid,
+        sender_vid,
+        &identity.signing_key,
+        &identity.decryption_key,
+        &recipient.encryption_key,
+    )
+    .map_err(|e| {
+        tsp_problem(
+            session,
+            37,
+            "message.tsp.trust_task.seal",
+            format!("could not seal the Trust Task response: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
+
+    // Delivered as any other local message: `deliver_opaque` applies the
+    // recipient's own access-list against the mediator as sender, then stores +
+    // live-streams. A client that can reach us to ask can receive the answer.
+    deliver_opaque(state, session, sender_vid, &identity.vid, &packed.bytes).await
 }
 
 /// Deliver a TSP message to the local recipient named in *its own envelope*:

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -274,10 +274,15 @@ pub(crate) async fn consume(
     Ok(Some(response_value))
 }
 
-/// Every Trust Task type this mediator serves. The dispatch in [`consume`]
+/// Every Trust Task type this mediator serves.
+///
+/// `tsp`-gated with [`parse_if_served`]: the DIDComm binding carries an envelope
+/// type URI, so it never needs to recognise a request by its payload. Only the
+/// TSP arm does. The dispatch in [`consume`]
 /// must stay in step with it — [`parse_if_served`] uses it to decide whether an
 /// untagged payload is a management request, and a type missing here would be
 /// filed into the mediator's inbox instead of answered.
+#[cfg(feature = "tsp")]
 fn served_type_uris() -> [TypeUri; 11] {
     [
         type_uri_of::<ping::v0_1::Payload>(),
@@ -304,6 +309,7 @@ fn served_type_uris() -> [TypeUri; 11] {
 /// being wrong runs one way only: a served type mis-parsed as mail would be
 /// silently filed, so the type check is the thing that must not drift, which is
 /// why [`served_type_uris`] is a single list next to the dispatch that uses it.
+#[cfg(feature = "tsp")]
 pub(crate) fn parse_if_served(payload: &[u8]) -> Option<TrustTask<Value>> {
     let doc: TrustTask<Value> = serde_json::from_slice(payload).ok()?;
     served_type_uris().contains(&doc.type_uri).then_some(doc)
@@ -1908,7 +1914,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tsp"))]
 mod tsp_dispatch_tests {
     use super::*;
 

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/protocols/trust_tasks.rs
@@ -114,11 +114,6 @@ pub(crate) async fn process(
                 StatusCode::BAD_REQUEST,
             )
         })?;
-    let sender_did = sender_kid
-        .split('#')
-        .next()
-        .unwrap_or(&sender_kid)
-        .to_string();
 
     // The body is the full TrustTask document.
     let doc: TrustTask<Value> = serde_json::from_value(message.body.clone()).map_err(|e| {
@@ -131,6 +126,64 @@ pub(crate) async fn process(
     })?;
 
     let now_secs = state.clock.unix_secs();
+    let Some(response_value) = consume(doc, state, session, &sender_kid, now_secs).await? else {
+        // identity_mismatch with no transport sender → emit nothing.
+        return Ok(ProcessMessageResponse::default());
+    };
+    let sender_did = vid_of(&sender_kid);
+
+    // Pack the response back through the mediator's existing outbound path.
+    // `thid` threads it to the request so the caller's live-stream correlates it.
+    let response_msg = Message::build(
+        Uuid::new_v4().to_string(),
+        ENVELOPE_TYPE.to_string(),
+        response_value,
+    )
+    .thid(message.id.clone())
+    .to(sender_did)
+    .from(mediator_did)
+    .created_time(now_secs)
+    .expires_time(now_secs + 300)
+    .finalize();
+
+    Ok(ProcessMessageResponse {
+        store_message: true,
+        force_live_delivery: false,
+        data: WrapperType::Message(Box::new(response_msg)),
+        forward_message: false,
+    })
+}
+
+/// Strip a key fragment from a `did#key` to get the framework VID.
+pub(crate) fn vid_of(kid: &str) -> String {
+    kid.split('#').next().unwrap_or(kid).to_string()
+}
+
+/// Consume one Trust Task document from an authenticated sender and produce the
+/// response document. `None` means "emit nothing" (a ping identity mismatch).
+///
+/// **Transport-agnostic on purpose.** Every `consume_*` handler below takes the
+/// document, the authenticated sender and `state`/`session` — nothing about a
+/// DIDComm envelope — so the only transport-specific work is establishing
+/// `sender_kid` and packing the reply, which the callers do. That is what lets
+/// the same management surface answer over TSP: see the TSP arm in
+/// [`crate::messages::inbound`], which unpacks a `Direct`/`Control` message
+/// addressed to this mediator and calls straight into here.
+///
+/// `sender_kid` MUST have been established cryptographically by the caller — a
+/// DIDComm authcrypt/JWS unpack, or a TSP unpack (Ed25519 over
+/// envelope‖ciphertext plus HPKE-Auth). Handlers authorise against it, so a
+/// caller that passes an unverified claim hands an attacker the admin surface.
+pub(crate) async fn consume(
+    doc: TrustTask<Value>,
+    state: &SharedData,
+    session: &Session,
+    sender_kid: &str,
+    now_secs: u64,
+) -> Result<Option<Value>, MediatorError> {
+    let mediator_did = state.config.mediator_did.clone();
+    let sender_kid = sender_kid.to_string();
+    let sender_did = vid_of(&sender_kid);
     let now = chrono::DateTime::from_timestamp(now_secs as i64, 0).unwrap_or_else(chrono::Utc::now);
 
     // Route by task type across the ping / account / acl / access-list families.
@@ -139,7 +192,7 @@ pub(crate) async fn process(
         match consume_ping(downcast(&doc, session)?, &mediator_did, &sender_did, now).await? {
             Some(value) => value,
             // identity_mismatch with no transport sender → emit nothing.
-            None => return Ok(ProcessMessageResponse::default()),
+            None => return Ok(None),
         }
     } else if doc.type_uri == type_uri_of::<account::get::v0_1::Payload>() {
         consume_account_get(
@@ -218,26 +271,42 @@ pub(crate) async fn process(
         ));
     };
 
-    // Pack the response back through the mediator's existing outbound path.
-    // `thid` threads it to the request so the caller's live-stream correlates it.
-    let response_msg = Message::build(
-        Uuid::new_v4().to_string(),
-        ENVELOPE_TYPE.to_string(),
-        response_value,
-    )
-    .thid(message.id.clone())
-    .to(sender_did)
-    .from(mediator_did)
-    .created_time(now_secs)
-    .expires_time(now_secs + 300)
-    .finalize();
+    Ok(Some(response_value))
+}
 
-    Ok(ProcessMessageResponse {
-        store_message: true,
-        force_live_delivery: false,
-        data: WrapperType::Message(Box::new(response_msg)),
-        forward_message: false,
-    })
+/// Every Trust Task type this mediator serves. The dispatch in [`consume`]
+/// must stay in step with it — [`parse_if_served`] uses it to decide whether an
+/// untagged payload is a management request, and a type missing here would be
+/// filed into the mediator's inbox instead of answered.
+fn served_type_uris() -> [TypeUri; 11] {
+    [
+        type_uri_of::<ping::v0_1::Payload>(),
+        type_uri_of::<account::get::v0_1::Payload>(),
+        type_uri_of::<account::list::v0_1::Payload>(),
+        type_uri_of::<account::update::v0_1::Payload>(),
+        type_uri_of::<account::remove::v0_1::Payload>(),
+        type_uri_of::<account::add::v0_1::Payload>(),
+        type_uri_of::<acl::get::v0_1::Payload>(),
+        type_uri_of::<access_list::update::v0_1::Payload>(),
+        type_uri_of::<access_list::list::v0_1::Payload>(),
+        type_uri_of::<audit::list::v0_1::Payload>(),
+        type_uri_of::<config::show::v0_1::Payload>(),
+    ]
+}
+
+/// Parse `payload` as a Trust Task document, but only claim it when this
+/// mediator actually serves the type.
+///
+/// Used by the TSP arm, which has no envelope tag to switch on: the client packs
+/// the bare task document. Being strict about the type is what keeps that safe —
+/// an ordinary message that merely happens to deserialise into the document
+/// shape is *not* claimed, so it still reaches the mediator's inbox. The cost of
+/// being wrong runs one way only: a served type mis-parsed as mail would be
+/// silently filed, so the type check is the thing that must not drift, which is
+/// why [`served_type_uris`] is a single list next to the dispatch that uses it.
+pub(crate) fn parse_if_served(payload: &[u8]) -> Option<TrustTask<Value>> {
+    let doc: TrustTask<Value> = serde_json::from_slice(payload).ok()?;
+    served_type_uris().contains(&doc.type_uri).then_some(doc)
 }
 
 /// The canonical request type URI of a generated payload `P`.
@@ -1836,5 +1905,139 @@ mod tests {
         // respond_with swaps the parties: the mediator answers alice.
         assert_eq!(resp.issuer.as_deref(), Some("did:example:mediator"));
         assert_eq!(resp.recipient.as_deref(), Some("did:example:alice"));
+    }
+}
+
+#[cfg(test)]
+mod tsp_dispatch_tests {
+    use super::*;
+
+    /// A minimal but structurally valid Trust Task document of `type_uri`.
+    fn doc_json(type_uri: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "id": "urn:uuid:2b1e0a1e-0000-4000-8000-000000000001",
+            "type": type_uri,
+            "issuer": "did:key:zSender",
+            "recipient": "did:key:zMediator",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "payload": {},
+        }))
+        .expect("test document serialises")
+    }
+
+    #[test]
+    fn a_served_management_task_is_claimed() {
+        // The whole point of the TSP arm: `account/update` addressed to the
+        // mediator must be *answered*, not filed into its inbox.
+        let uri = type_uri_of::<account::update::v0_1::Payload>();
+        let claimed = parse_if_served(&doc_json(&uri.to_string()))
+            .expect("a served type must be claimed for dispatch");
+        assert_eq!(claimed.type_uri, uri);
+    }
+
+    #[test]
+    fn the_served_list_matches_what_consume_dispatches() {
+        // `served_type_uris` decides what the TSP arm *claims*; the if/else
+        // chain in `consume` decides what it *answers*. Drift either way is
+        // silent and expensive:
+        //
+        //   * dispatched but not served → over TSP the request is filed into
+        //     the mediator's inbox instead of answered, and the caller waits out
+        //     its timeout with no error logged anywhere;
+        //   * served but not dispatched → the arm claims the message, then
+        //     `consume` refuses it as unsupported, so a message that would have
+        //     been delivered is now an error.
+        //
+        // Neither is reachable from a runtime assertion: the dispatch is an
+        // if/else chain, not a table, so nothing enumerates it. Read the source
+        // instead — the same technique the chain itself would need to be
+        // rewritten to avoid.
+        const SRC: &str = include_str!("trust_tasks.rs");
+
+        let consume_body = {
+            let start = SRC
+                .find("pub(crate) async fn consume(")
+                .expect("`consume` must exist");
+            let rest = &SRC[start..];
+            &rest[..rest.find("\n}\n").expect("`consume` must terminate")]
+        };
+        let served_body = {
+            let start = SRC
+                .find("fn served_type_uris()")
+                .expect("`served_type_uris` must exist");
+            let rest = &SRC[start..];
+            &rest[..rest
+                .find("\n}\n")
+                .expect("`served_type_uris` must terminate")]
+        };
+
+        // Every `type_uri_of::<X>()` mentioned, by its turbofish payload path.
+        fn payload_paths(body: &str) -> std::collections::BTreeSet<&str> {
+            body.match_indices("type_uri_of::<")
+                .filter_map(|(i, m)| {
+                    let rest = &body[i + m.len()..];
+                    rest.find(">()").map(|end| rest[..end].trim())
+                })
+                .collect()
+        }
+
+        let dispatched = payload_paths(consume_body);
+        let served = payload_paths(served_body);
+
+        assert!(
+            !dispatched.is_empty(),
+            "failed to read the dispatch chain — did `consume` change shape?"
+        );
+        let missing: Vec<_> = dispatched.difference(&served).collect();
+        assert!(
+            missing.is_empty(),
+            "dispatched by `consume` but absent from `served_type_uris`, so the TSP arm \
+             will file these as mail and the caller will time out: {missing:?}"
+        );
+        let extra: Vec<_> = served.difference(&dispatched).collect();
+        assert!(
+            extra.is_empty(),
+            "listed in `served_type_uris` but not dispatched by `consume`, so the TSP arm \
+             will claim these and then refuse them as unsupported: {extra:?}"
+        );
+    }
+
+    #[test]
+    fn an_unserved_trust_task_is_left_alone() {
+        // Shape alone must not be enough. A Trust Task the mediator does not
+        // serve is someone else's traffic that happens to be addressed here —
+        // it belongs in the inbox, not in the management dispatch.
+        assert!(
+            parse_if_served(&doc_json(
+                "https://trusttasks.org/spec/vta/contexts/list/1.0"
+            ))
+            .is_none(),
+            "a type this mediator does not serve must fall through to delivery"
+        );
+    }
+
+    #[test]
+    fn ordinary_traffic_is_left_alone() {
+        // The TSP arm sees every Direct/Control message addressed to the
+        // mediator, most of which is not a Trust Task at all.
+        for payload in [
+            &b"not json at all"[..],
+            &b"{}"[..],
+            &br#"{"hello":"world"}"#[..],
+            &b""[..],
+        ] {
+            assert!(
+                parse_if_served(payload).is_none(),
+                "non-Trust-Task payload must fall through to delivery"
+            );
+        }
+    }
+
+    #[test]
+    fn the_vid_helper_strips_a_key_fragment() {
+        // DIDComm gives a `did#key`; TSP gives a bare VID. Handlers authorise on
+        // the VID, so both must land on the same string.
+        assert_eq!(vid_of("did:key:zAlice#z6Mk"), "did:key:zAlice");
+        assert_eq!(vid_of("did:key:zAlice"), "did:key:zAlice");
     }
 }


### PR DESCRIPTION
A TSP-only deployment could not manage its own accounts.

The dispatcher that turns a `TrustTaskEnvelope` into `account/update`, `acl/get`, `access-list/update` and the rest — `MessageType::process` in `messages/mod.rs` — is wholly `#[cfg(feature = "didcomm")]` and takes a DIDComm `Message`. A TSP `Direct`/`Control` message addressed to the mediator never reached it: it went to `deliver_tsp_local` → `deliver_opaque`, which files it for pickup. **There was no packet a TSP-only client could send to set its own account ACL.**

That bites where it is least visible. A client's account is created at authentication with `global_acl_default`, so a permissive default hides the gap entirely. A restrictive one leaves the client unable to fix its own ACL over any transport — and TSP delivery is not exempt from ACLs: `deliver_opaque` applies existence, `RECEIVE_MESSAGES` and the access-list verdict through `delivery_decision`. It only gets worse as TSP displaces DIDComm.

Found from the other side: [OpenVTC/verifiable-trust-infrastructure#1309](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1309) makes VTA key rotation work over TSP, and had to leave its mediator-ACL pass DIDComm-only because of this.

## The handlers were already transport-agnostic

Nothing in them is DIDComm — each takes the document, the authenticated sender, `state` and `session`. So `process` splits into a core plus a wrapper per transport:

- **`consume`** runs the dispatch and returns the response document. It requires the caller to have established the sender cryptographically, which is stated on it: the handlers authorise against that sender, so a caller passing an unverified claim would hand over the admin surface.
- **The DIDComm wrapper** is what it was — sender from `UnpackMetadata`, document from `message.body`, reply packed as a DIDComm message.
- **The TSP wrapper** unpacks a `Direct`/`Control` message addressed to this mediator, dispatches, then seals the reply to the sender and delivers it through the ordinary local path, so it arrives on the client's existing pickup socket. No second socket, no new delivery mechanism.

The TSP sender has the same standing the DIDComm one does: `direct::unpack` verifies Ed25519 over envelope‖ciphertext against the key resolved from the VID's DID document *and* opens with HPKE-Auth, binding the sender's static key. Two independent proofs.

Worth noting `inbound.rs` already anticipated this. The comment excluding `Direct`/`Control` from the peer-mediator allowlist says so outright:

> `Direct` and `Control` addressed to this mediator are messages *to* us, not relays through us — **Trust Tasks over TSP arrive that way** — so a list of trusted peer mediators must not gate them.

The design was intended; only the handler was missing.

## Recognising a request without a binding tag

Requests are matched on payload rather than a binding type URI, because the client packs the bare task document — there is no envelope tag to switch on. A document that parses **and** names a type this mediator serves is claimed; everything else falls through to delivery unchanged, so ordinary traffic addressed to the mediator is unaffected.

That makes `served_type_uris` load-bearing, and drift from the dispatch silent in **both** directions:

- dispatched but not served → over TSP the request is filed into the mediator's inbox instead of answered, and the caller waits out its timeout with nothing logged anywhere;
- served but not dispatched → the arm claims the message, then `consume` refuses it as unsupported, so a message that would have been delivered becomes an error.

The dispatch is an if/else chain, so nothing enumerates it at runtime. `the_served_list_matches_what_consume_dispatches` reads both from source and compares as sets. Both directions were mutation-checked:

| Mutation | Result |
|---|---|
| Drop `acl::get` from `served_type_uris` | fails — *"dispatched by `consume` but absent from `served_type_uris`… caller will time out: [acl::get::v0_1::Payload]"* |
| Repoint `consume`'s `acl::get` arm at another type | fails — *"listed in `served_type_uris` but not dispatched… will claim these and then refuse them: [acl::get::v0_1::Payload]"* |

The other four tests cover the claim decision itself: a served task is claimed, an unserved Trust Task is left alone (shape alone is not enough), non-JSON/empty/ordinary payloads are left alone, and the VID helper strips a DIDComm key fragment so both transports land on the same identity string.

## Verification

`cargo test -p affinidi-messaging-mediator --all-features` green, `cargo clippy --all-features --all-targets` clean, `cargo fmt` applied. No public API change: `consume`, `vid_of`, `parse_if_served` and `served_type_uris` are all `pub(crate)` or private, and `process` keeps its signature.

## Not in scope

The `{type, document}` binding wrapper. This accepts the bare document because that is what clients emit today; if the published TSP binding is adopted later, accepting both is a small additive change at `parse_if_served`.
