### PR TITLE
chore(deps)!: trust-tasks-rs 0.18 -> 0.19 across the messaging family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+### Changed
+
+- **`trust-tasks-rs` 0.18 → 0.19 across the messaging family (breaking).**
+  **`affinidi-messaging-sdk` 0.23.0**, **`affinidi-messaging-didcomm-service` 0.7.0**,
+  **`affinidi-messaging-mediator` 0.23.0**, **`affinidi-messaging-test-mediator` 0.6.0**,
+  **`affinidi-tdk` 0.13.0**.
+
+  `trust-tasks-rs` is a **public** dependency of `affinidi-messaging-sdk` — types like
+  `account::update::v0_1::MediatorAcl` appear in its signatures — so moving it changes
+  these crates' APIs even though not a line of their own source did. That is why the bump
+  is a minor rather than a patch, and why `affinidi-tdk` moves with them: it re-exports the
+  SDK, and a consumer reaching `MediatorAcl` through the facade sees the same change.
+
+  These six move together because a **mixed** graph is the failure mode. Two `Cargo.toml`
+  comments in this workspace already record the symptom — `expected MediatorAcl, found a
+  different MediatorAcl` — from the two previous times a stale node survived a move.
+
+  It moves now because that mixed graph escaped the workspace.
+  `verifiable-trust-infrastructure` needs 0.19 for two new room specs and could not take
+  it while `affinidi-messaging-sdk 0.22.0` required 0.18: pinning the consumer at 0.19 put
+  two `trust-tasks-rs` nodes in *its* graph and broke `vta-sdk` on exactly that error.
+  Nothing in the consumer's manifests was wrong and no semver check flags it, because the
+  break arrives through a public dependency — the only fix is here.
+
+  0.19 is additive for everything these crates use: it adds two room spec versions and
+  retires their predecessors, and a retired spec keeps its generated module.
+
+  One pre-existing duplicate is untouched and is a different problem: published `vta-sdk`
+  → `affinidi-tdk 0.11.0` → `affinidi-messaging-sdk 0.21.1` → `trust-tasks-rs 0.17.10`, an
+  older published copy of this workspace's own crate arriving back through a consumer. It
+  compiles because no type crosses that boundary.
+
 ### Added
 
 - **Composed test stack `docker-compose.test.yml` (TI3).** `docker compose -f

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.6.0"
+version = "0.7.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -26,10 +26,10 @@ affinidi-tdk-common = "0.6"
 # rather than the workspace one — which is how a third `trust-tasks-rs` node
 # survived the 0.12 move and produced `expected MediatorAcl, found a different
 # MediatorAcl` from inside this workspace.
-affinidi-messaging-sdk = { version = "0.22.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.23.0", path = "../affinidi-messaging-sdk" }
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.18"
+trust-tasks-rs = "0.19"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"
@@ -49,8 +49,8 @@ affinidi-did-common = "0.4"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
-affinidi-messaging-test-mediator = { version = "0.5", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
-affinidi-tdk = { version = "0.12", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-messaging-test-mediator = { version = "0.6", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
+affinidi-tdk = { version = "0.13", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
 futures-util = "0.3"
 

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.22.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.18"
+trust-tasks-rs = "0.19"
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.12" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.13" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.22.3"
+version = "0.23.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,14 +113,14 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.22.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.18", optional = true }
+trust-tasks-rs = { version = "0.19", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 # ── DIDComm auth (mediator's /admin/status is gated on admin JWT) ────────
 ## Path-pinned to the workspace copy via [patch.crates-io] in the workspace
 ## root Cargo.toml; the version specs here are upper-bound contracts only.
-affinidi-messaging-sdk = { version = "0.22", path = "../../../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.23", path = "../../../affinidi-messaging-sdk" }
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.22.0"
+version = "0.23.0"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.18"
+trust-tasks-rs = "0.19"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.5.2"
+version = "0.6.0"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.22", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.23", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15.44", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
@@ -49,12 +49,12 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.12", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.13", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.22.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.23.0", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 ring = { version = "0.17", features = ["std"] }
@@ -94,7 +94,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.23"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.18"
+trust-tasks-rs = "0.19"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,11 +14,11 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.12" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.22.0" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.13" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.18"
+trust-tasks-rs = "0.19"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.12.0"
+version = "0.13.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tsp = ["dep:affinidi-tsp"]
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.4"
-affinidi-messaging-sdk = { version = "0.22", path = "../../messaging/affinidi-messaging-sdk", optional = true }
+affinidi-messaging-sdk = { version = "0.23", path = "../../messaging/affinidi-messaging-sdk", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"
 # Foundations are re-exported by the facade. Kept at major.minor (caret), NOT


### PR DESCRIPTION
Six crates in this family pin the Trust Tasks payload types, and they have to move as a set.
A mixed graph is what produces `expected MediatorAcl, found a different MediatorAcl` — the
failure this workspace has hit twice and now documents in two `Cargo.toml` comments:

> …this crate compiled against the *published* SDK rather than the workspace one — which is
> how a third `trust-tasks-rs` node survived the 0.12 move and produced
> `expected MediatorAcl, found a different MediatorAcl` from inside this workspace.

## Why now: the mixed graph has escaped this repo

`verifiable-trust-infrastructure` needs `trust-tasks-rs 0.19` to move to
`rooms/keys/present/0.2` and `rooms/owner/issue-authority/0.2`, and **cannot take it** while
`affinidi-messaging-sdk 0.22.0` requires `0.18`:

```
affinidi-messaging-sdk 0.22.0  ->  trust-tasks-rs 0.18.9
verifiable-trust-infrastructure ->  trust-tasks-rs 0.19.0
```

Pinning the consumer at 0.19 puts two `trust-tasks-rs` nodes in *its* graph, and `vta-sdk`
breaks on precisely the documented error, at the `vta-sdk` / `affinidi-messaging-sdk`
boundary. The compiler names the cause outright: *"there are multiple different versions of
crate `trust_tasks_rs` in the dependency graph"*.

Worth noting the shape: **nothing in the consumer's manifests is wrong**, and no semver check
would flag it. The break arrives through a public dependency, which is the class of change
`cargo-semver-checks` cannot see. The only fix is here.

## Is 0.19 safe for this family?

Yes — it is additive for everything these crates touch. `0.19` adds two room spec versions
and retires their predecessors, and a retired spec keeps its generated module, so no payload
type in use here changed shape. Verified by building and testing the workspace rather than by
reading the changelog.

## One duplicate node remains, deliberately

```
vta-sdk 0.32.4 (published) -> affinidi-tdk 0.11.0 -> affinidi-messaging-sdk 0.21.1 -> trust-tasks-rs 0.17.10
```

An older published copy of this workspace's own crate arriving back through a consumer. It is
untouched because it is a different problem and it compiles: no type crosses that boundary —
the mediator's `vta-sdk` dependency is feature-gated and hands nothing across. It is the cycle
the mediator's `Cargo.toml` comment already describes, and closing it means moving that
`vta-sdk` pin, which is a separate decision with its own history in that comment.

## Verified

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace --lib` — 1074 passed, 0 failed
- Lockfile: `trust-tasks-rs 0.18.9` is gone; `0.19.0` and the pre-existing `0.17.10` remain

Downstream: OpenVTC/verifiable-trust-infrastructure#1360 carries the dtg-credentials half and
notes this as its blocker; the `0.2` cut-over lands once this publishes.