### PR TITLE
fix: a service endpoint's URI, and `tsp` reaching the messaging SDK

### DIFF
--- a/crates/identity/affinidi-did-common/src/service.rs
+++ b/crates/identity/affinidi-did-common/src/service.rs
@@ -105,14 +105,8 @@ impl Endpoint {
         match self {
             Endpoint::Url(uri) => Some(uri.to_string()),
             Endpoint::Map(map) => match map {
-                Value::Array(array) => {
-                    if let Some(first) = array.first() {
-                        first.get("uri").map(|u| u.to_string())
-                    } else {
-                        None
-                    }
-                }
-                Value::Object(obj) => obj.get("uri").map(|u| u.to_string()),
+                Value::Array(array) => array.first().and_then(uri_of),
+                Value::Object(_) => uri_of(map),
                 _ => None,
             },
         }
@@ -122,27 +116,28 @@ impl Endpoint {
     pub fn get_uris(&self) -> Vec<String> {
         match self {
             Endpoint::Url(uri) => vec![uri.to_string()],
-            Endpoint::Map(map) => {
-                let mut uris = Vec::new();
-                match map {
-                    Value::Array(array) => {
-                        for sep in array {
-                            if let Some(uri) = sep.get("uri") {
-                                uris.push(uri.to_string());
-                            }
-                        }
-                    }
-                    Value::Object(obj) => {
-                        if let Some(uri) = obj.get("uri") {
-                            uris.push(uri.to_string());
-                        }
-                    }
-                    _ => {}
-                }
-                uris
-            }
+            Endpoint::Map(map) => match map {
+                Value::Array(array) => array.iter().filter_map(uri_of).collect(),
+                Value::Object(_) => uri_of(map).into_iter().collect(),
+                _ => Vec::new(),
+            },
         }
     }
+}
+/// The `uri` member of one service-endpoint object, as a **string**.
+///
+/// `Value::to_string()` is JSON serialisation, so on a `Value::String` it keeps the quotes —
+/// which is how `get_uri` came to return `https://example.com/` for the plain-URL form and
+/// `"\"https://example.com\""` for the map form of the same endpoint. A caller cannot tell
+/// which it got without knowing the shape it did not have to care about, and two callers in
+/// this workspace carried a `trim_matches('"')` to compensate while two others did not and
+/// returned a quoted URI.
+///
+/// `as_str` instead, which yields the value rather than its JSON encoding. A non-string
+/// `uri` is `None`: the specification says the member is a URI, and a number or an object
+/// there is not one — returning its JSON text would be inventing an endpoint.
+fn uri_of(entry: &Value) -> Option<String> {
+    entry.get("uri")?.as_str().map(str::to_string)
 }
 
 #[cfg(test)]
@@ -174,10 +169,15 @@ mod tests {
         assert_eq!(ep.get_uri().unwrap(), "https://example.com/");
     }
 
+    /// The map form yields the same string the plain-URL form does.
+    ///
+    /// It used to yield `"\"https://example.com\""` — `Value::to_string()` on a JSON string
+    /// keeps the quotes — so which of the two shapes a document happened to use decided
+    /// whether a caller got a usable URI. That was asserted here rather than fixed.
     #[test]
     fn get_uri_from_map_object() {
         let ep = Endpoint::Map(json!({"uri": "https://example.com"}));
-        assert_eq!(ep.get_uri().unwrap(), "\"https://example.com\"");
+        assert_eq!(ep.get_uri().unwrap(), "https://example.com");
     }
 
     #[test]
@@ -186,7 +186,34 @@ mod tests {
             {"uri": "https://first.example.com"},
             {"uri": "https://second.example.com"}
         ]));
-        assert_eq!(ep.get_uri().unwrap(), "\"https://first.example.com\"");
+        assert_eq!(ep.get_uri().unwrap(), "https://first.example.com");
+    }
+
+    /// A DIDComm service endpoint names its mediator by **DID**, not by URL, so this is the
+    /// shape that actually travels — and the one the quoting broke: `did:webvh:…` came back
+    /// as `"did:webvh:…"`, which resolves as nothing and reads like a malformed document.
+    #[test]
+    fn get_uri_from_a_didcomm_service_endpoint() {
+        let ep = Endpoint::Map(json!({
+            "uri": "did:webvh:QmTS3a:webvh.example:mediator",
+            "accept": ["didcomm/v2"],
+        }));
+        assert_eq!(
+            ep.get_uri().unwrap(),
+            "did:webvh:QmTS3a:webvh.example:mediator"
+        );
+    }
+
+    /// A `uri` that is not a string is not a URI. Returning its JSON text would hand the
+    /// caller an endpoint nobody wrote.
+    #[test]
+    fn get_uri_from_map_object_with_non_string_uri() {
+        assert!(Endpoint::Map(json!({"uri": 42})).get_uri().is_none());
+        assert!(
+            Endpoint::Map(json!({"uri": {"nested": "x"}}))
+                .get_uri()
+                .is_none()
+        );
     }
 
     #[test]
@@ -218,7 +245,7 @@ mod tests {
     #[test]
     fn get_uris_from_map_object() {
         let ep = Endpoint::Map(json!({"uri": "https://example.com"}));
-        assert_eq!(ep.get_uris(), vec!["\"https://example.com\""]);
+        assert_eq!(ep.get_uris(), vec!["https://example.com"]);
     }
 
     #[test]
@@ -227,10 +254,10 @@ mod tests {
             {"uri": "https://first.example.com"},
             {"uri": "https://second.example.com"}
         ]));
-        let uris = ep.get_uris();
-        assert_eq!(uris.len(), 2);
-        assert!(uris[0].contains("first.example.com"));
-        assert!(uris[1].contains("second.example.com"));
+        assert_eq!(
+            ep.get_uris(),
+            vec!["https://first.example.com", "https://second.example.com"]
+        );
     }
 
     #[test]

--- a/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/common/config/mod.rs
@@ -1098,7 +1098,7 @@ fn augment_did_web_doc_with_tsp_service(doc: &mut Document, did: &str) -> Option
         .iter()
         .find(|s| s.type_.iter().any(|t| t == "DIDCommMessaging"))
         .and_then(|s| s.service_endpoint.get_uri())?;
-    let endpoint = url::Url::parse(uri.trim_matches('"')).ok()?;
+    let endpoint = url::Url::parse(&uri).ok()?;
 
     let service = ServiceBuilder::new(tsp_type, Endpoint::Url(endpoint))
         .id(&format!("{did}#tsp"))

--- a/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
+++ b/crates/messaging/affinidi-messaging-mediator/src/messages/v1_mediation.rs
@@ -474,7 +474,6 @@ fn mediator_endpoint(state: &SharedData) -> String {
                 .find(|s| s.type_.iter().any(|t| t == "DIDCommMessaging"))
                 .and_then(|s| s.service_endpoint.get_uri())
         })
-        .map(|uri| uri.trim_matches('"').to_string())
         .unwrap_or_else(|| state.config.listen_address.clone())
 }
 

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -51,7 +51,21 @@ did-scid = ["dep:did-scid"]
 
 # ── Trust + TSP ──────────────────────────────────────────────────────────
 trust = ["dep:affinidi-trust-lists"]
-tsp = ["dep:affinidi-tsp"]
+# `tsp` has to reach the messaging SDK, not only pull in the TSP crate.
+#
+# Without the second entry a consumer who enables `tsp` on this facade gets
+# `affinidi_tdk::tsp` and a `DidCommTransport` whose inbound stream **drops every
+# TSP frame** — the `#[cfg(not(feature = "tsp"))]` arm of `tsp_to_inbound` logs
+# and returns `None`. Nothing fails to compile and nothing errors at runtime;
+# TSP simply never arrives, which is the hardest shape of bug to find from the
+# outside. The only way to turn it on was to name `affinidi-messaging-sdk`
+# directly alongside the facade and rely on cargo unifying the features, which
+# is exactly the "use the facade OR direct sub-crate deps, not both" the
+# dependency comment below warns against.
+#
+# `?/` so this stays additive: enabling `tsp` without `messaging` does not drag
+# the messaging SDK in, it just says what `tsp` means once something else has.
+tsp = ["dep:affinidi-tsp", "affinidi-messaging-sdk?/tsp"]
 
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"


### PR DESCRIPTION
Two defects found while building a DIDComm + TSP client against a live mediator.

## `Endpoint::get_uri` returned JSON, not a URI

The map and array arms used `Value::to_string()` on the `uri` member. On a JSON string that keeps the quotes, so the same endpoint came back two different ways depending on which shape the document used:

| form | before | after |
|---|---|---|
| `Endpoint::Url` | `https://example.com/` | unchanged |
| `{"uri": "https://example.com"}` | `"\"https://example.com\""` | `https://example.com` |

A caller cannot tell which it got without knowing the shape it should not have to care about. Two callers in this workspace carry a `trim_matches('"')` to compensate — `config/mod.rs` and `v1_mediation.rs` — and **two do not**: `affinidi-did-authentication`'s `find_service_endpoint` and the SDK's `find_auth_endpoint` both return a quoted URI today. The unit tests asserted the quoted form, so this had been noticed and written down rather than fixed.

It bites hardest on the shape that actually travels. A DIDComm service endpoint names its mediator by **DID**, not URL, so `did:webvh:…` came back as `"did:webvh:…"` — which resolves as nothing, and reads like a malformed DID document rather than like a stringify.

`as_str` instead, the two workarounds removed, and a test for the DIDComm shape. A non-string `uri` is now `None`: the member is specified as a URI, and returning the JSON text of a number or an object would invent an endpoint.

## The facade's `tsp` feature did not reach the messaging SDK

`tsp = ["dep:affinidi-tsp"]` enabled the TSP crate and stopped there. A consumer who turned it on got `affinidi_tdk::tsp` **and** a `DidCommTransport` whose inbound stream drops every TSP frame — the `cfg(not(feature = "tsp"))` arm of `tsp_to_inbound` logs and returns `None`. Nothing fails to compile, nothing errors at runtime; TSP just never arrives, which is the hardest shape of bug to find from outside.

The only way to turn it on was to name `affinidi-messaging-sdk` directly alongside the facade and rely on cargo unifying the features — exactly the "use the facade OR direct sub-crate deps, not both" the manifest's own comment warns against.

Now `affinidi-messaging-sdk?/tsp`. The `?/` keeps it additive: `tsp` without `messaging` still pulls nothing extra.

Confirmed by the feature graph rather than by inspection:

```
# before — affinidi-tsp reaches only the facade
$ cargo tree -p affinidi-tdk --features tsp,messaging -e features -i affinidi-tsp
affinidi-tsp v0.1.16
├── affinidi-tsp feature "default"
│   └── affinidi-tdk v0.13.0

# after — it reaches the SDK, which is what compiles the real unpack arm
affinidi-tsp v0.1.16
├── affinidi-tsp feature "default"
│   ├── affinidi-messaging-sdk v0.23.0
```

## Testing

`affinidi-did-common` 204 tests and `affinidi-messaging-mediator` 201 tests pass. The `get_uri` tests that asserted the quoted form are updated, with two added: the DIDComm mediator-DID shape, and a non-string `uri`.