### PR TITLE
chore(deps)!: trust-tasks-rs 0.19 -> 0.20 across the messaging family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ Per-crate version history is summarised here; for the full code history see
 
 ### Changed
 
+- **`trust-tasks-rs` 0.19 → 0.20 across the messaging family (breaking).**
+  **`affinidi-messaging-sdk` 0.24.0**, **`affinidi-messaging-didcomm-service` 0.8.0**,
+  **`affinidi-messaging-mediator` 0.24.0**, **`affinidi-messaging-test-mediator` 0.7.0**,
+  **`affinidi-tdk` 0.14.0**.
+
+  The same move as 0.18 → 0.19 below, for the same reason and with the same shape:
+  `trust-tasks-rs` is a **public** dependency of `affinidi-messaging-sdk`, so its version
+  is part of these crates' APIs though not a line of their own source changed. Not one
+  source file is touched by this commit — only manifests.
+
+  **It moves now because the mixed graph escaped the workspace again.**
+  `verifiable-trust-infrastructure` needs 0.20.1 for `vta/contexts/secrets/1.0`, the task
+  by which a service fetches the keys of the DID it operates. It could not take it while
+  `affinidi-messaging-sdk 0.23.0` required 0.19: pinning the consumer at 0.20 put two
+  `trust-tasks-rs` nodes in its graph and broke `vta-sdk` on exactly the
+  `expected MediatorAcl, found a different MediatorAcl` error the two `Cargo.toml`
+  comments in this workspace already record. Nothing in the consumer's manifests is
+  wrong and no semver check flags it, because the break arrives through a public
+  dependency. The only fix is here.
+
+  0.20 is additive for everything these crates use. Its one breaking change is a
+  `process-attestation` schema tightening — a digest floor raised from 16 to 43 base64url
+  characters, a category correction, and a dropped duplicate member — and no crate in this
+  workspace references that spec.
+
+  One pre-existing duplicate is untouched, being a different problem: published
+  `vta-sdk` → `affinidi-tdk 0.11.0` → `affinidi-messaging-sdk 0.21.1` →
+  `trust-tasks-rs 0.17.10`, an older published copy arriving back through a consumer. It
+  compiles because no type crosses that boundary, and it is the cycle the mediator's
+  `Cargo.toml` comment describes.
+
+  Refs: trustoverip/dtgwg-trust-tasks-tf#440
+
+### Changed
+
 - **`trust-tasks-rs` 0.18 → 0.19 across the messaging family (breaking).**
   **`affinidi-messaging-sdk` 0.23.0**, **`affinidi-messaging-didcomm-service` 0.7.0**,
   **`affinidi-messaging-mediator` 0.23.0**, **`affinidi-messaging-test-mediator` 0.6.0**,

--- a/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-didcomm-service/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased (0.8.0) — `trust-tasks-rs` 0.20
+
+- Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.
+  0.20 is additive for everything this crate uses: its one breaking change is a
+  `process-attestation` schema tightening (digest floor 16 → 43 base64url
+  characters, a category correction, a dropped duplicate member), and no crate
+  in this workspace references that spec.
+- **Moves because it is the path, not because its own code changed.** This crate
+  re-exports `affinidi-messaging-sdk`, so a consumer reaching a generated type
+  through the facade sees the same API change. Leaving it unbumped would publish
+  a move that never arrives — and the version guard cannot see it, because only
+  its manifest changed.
+
 ## Unreleased (0.6.0) — `trust-tasks-rs` 0.18
 
 - Follows `affinidi-messaging-sdk` 0.22.0 to `trust-tasks-rs` 0.18. No source

--- a/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-didcomm-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-didcomm-service"
-version = "0.7.0"
+version = "0.8.0"
 description = "Shared DIDComm service framework for always-online DIDComm client. Manages mediator connection, message lifecycle, and handler dispatch."
 edition.workspace = true
 authors.workspace = true
@@ -26,10 +26,10 @@ affinidi-tdk-common = "0.6"
 # rather than the workspace one — which is how a third `trust-tasks-rs` node
 # survived the 0.12 move and produced `expected MediatorAcl, found a different
 # MediatorAcl` from inside this workspace.
-affinidi-messaging-sdk = { version = "0.23.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.24.0", path = "../affinidi-messaging-sdk" }
 affinidi-messaging-didcomm = "0.15"
 ## Trust Tasks payload types (the atm.trust_tasks() surface accepts these).
-trust-tasks-rs = "0.19"
+trust-tasks-rs = "0.20"
 affinidi-secrets-resolver = "0.5"
 
 async-trait = "0.1"
@@ -49,8 +49,8 @@ affinidi-did-common = "0.4"
 # Embedded mediator fixture + DID generation for the soft-restart websocket
 # regression test. Sister-crate path deps carry an explicit `version =` so the
 # package stays publishable while using the in-tree path for dev-builds.
-affinidi-messaging-test-mediator = { version = "0.6", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
-affinidi-tdk = { version = "0.13", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-messaging-test-mediator = { version = "0.7", path = "../affinidi-messaging-test-mediator", features = ["tsp"] }
+affinidi-tdk = { version = "0.14", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-messaging-core = { version = "0.1", path = "../affinidi-messaging-core" }
 futures-util = "0.3"
 

--- a/crates/messaging/affinidi-messaging-helpers/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-helpers/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/mediator_administration/main.rs"
 [dependencies]
 # ── Affinidi Crates ──────────────────────────────────────────────────────
 ## SDK for connecting to and communicating with a running mediator
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.24.0" }
 ## Trust Tasks payload types (the atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.19"
+trust-tasks-rs = "0.20"
 ## TDK for DID resolution and crypto utilities
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.13" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.14" }
 ## DIDComm message types — used by example binaries
 affinidi-crypto = { version = "0.2", features = ["jose"] }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", features = ["messaging-core"] }

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased (0.24.0) — `trust-tasks-rs` 0.20
+
+- Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.
+  0.20 is additive for everything this crate uses: its one breaking change is a
+  `process-attestation` schema tightening (digest floor 16 → 43 base64url
+  characters, a category correction, a dropped duplicate member), and no crate
+  in this workspace references that spec.
+- **Moves because it is the path, not because its own code changed.** This crate
+  re-exports `affinidi-messaging-sdk`, so a consumer reaching a generated type
+  through the facade sees the same API change. Leaving it unbumped would publish
+  a move that never arrives — and the version guard cannot see it, because only
+  its manifest changed.
+
 ## Unreleased (0.22.3) — answer management Trust Tasks over TSP
 
 A TSP-only deployment could not manage its own accounts. The dispatcher that

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.23.0"
+version = "0.24.0"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -113,14 +113,14 @@ aws = ["dep:aws-config", "dep:aws-sdk-ssm", "dep:aws-sdk-s3"]
 # 0.18.61+: reconnect backoff no longer resets on a socket that is immediately
 # closed. Pinned tighter than the usual "0.18" because a mediator built against
 # an older SDK still amplifies duplicate-socket duels client-side.
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.24.0" }
 ## Optional: DIDComm v2.1 protocol implementation (activated by `didcomm` feature)
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15", optional = true }
 ## Optional: DIDComm v1 (Aries RFC 0019) implementation (activated by `didcomm-v1`)
 affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", version = "0.2", optional = true }
 ## Trust Tasks framework core — consumes Trust Task documents (the messaging
 ## ping / account / acl / access-list tasks) carried over the binding envelope.
-trust-tasks-rs = { version = "0.19", optional = true }
+trust-tasks-rs = { version = "0.20", optional = true }
 ## Optional: JOSE key-agreement types for the didcomm compat layer (#327)
 affinidi-crypto = { version = "0.2", features = ["jose"], optional = true }
 ## Optional: Trust Spanning Protocol (activated by `tsp` feature)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-monitor/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 # ── DIDComm auth (mediator's /admin/status is gated on admin JWT) ────────
 ## Path-pinned to the workspace copy via [patch.crates-io] in the workspace
 ## root Cargo.toml; the version specs here are upper-bound contracts only.
-affinidi-messaging-sdk = { version = "0.23", path = "../../../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.24", path = "../../../affinidi-messaging-sdk" }
 affinidi-tdk-common = "0.6"
 affinidi-secrets-resolver = "0.5"
 

--- a/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-sdk/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased (0.24.0) — `trust-tasks-rs` 0.20
+
+- Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.
+  0.20 is additive for everything this crate uses: its one breaking change is a
+  `process-attestation` schema tightening (digest floor 16 → 43 base64url
+  characters, a category correction, a dropped duplicate member), and no crate
+  in this workspace references that spec.
+- **Breaking for consumers, for the same reason as every previous
+  `trust-tasks-rs` move here.** This crate's public API carries generated types —
+  `TrustTasks::account_update` takes an `account::update::v0_1::MediatorAcl` and
+  returns an `account::update::v0_1::Account` — so the dependency is a *public*
+  one. A consumer must move to 0.20 in the same change: two `trust-tasks-rs`
+  versions in one graph do not warn, they fail with `expected MediatorAcl, found
+  a different MediatorAcl`.
+- That failure is why this bump exists. `verifiable-trust-infrastructure` needs
+  0.20.1 for `vta/contexts/secrets/1.0` and could not reach it while this crate
+  required ^0.19.
+
 ## Unreleased (0.22.0) — `trust-tasks-rs` 0.18
 
 - Bumps `trust-tasks-rs` 0.17 → 0.18. No source change: 0.18.0 carries exactly

--- a/crates/messaging/affinidi-messaging-sdk/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-sdk"
-version = "0.23.0"
+version = "0.24.0"
 description = "Affinidi Messaging SDK"
 edition.workspace = true
 authors.workspace = true
@@ -34,7 +34,7 @@ affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version =
 affinidi-messaging-core = { path = "../affinidi-messaging-core", version = "0.1.6" }
 ## Trust Tasks framework — typed request/response documents for the messaging
 ## tasks (ping / account / acl / access-list), carried over the binding envelope.
-trust-tasks-rs = "0.19"
+trust-tasks-rs = "0.20"
 ## Optional: Trust Spanning Protocol (activated by the `tsp` feature)
 affinidi-tsp = { path = "../affinidi-tsp", version = "0.1", optional = true }
 ## Async trait support for the pluggable TSP `RelationshipStore` (tsp feature only).

--- a/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-test-mediator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased (0.7.0) — `trust-tasks-rs` 0.20
+
+- Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.
+  0.20 is additive for everything this crate uses: its one breaking change is a
+  `process-attestation` schema tightening (digest floor 16 → 43 base64url
+  characters, a category correction, a dropped duplicate member), and no crate
+  in this workspace references that spec.
+- **Moves because it is the path, not because its own code changed.** This crate
+  re-exports `affinidi-messaging-sdk`, so a consumer reaching a generated type
+  through the facade sees the same API change. Leaving it unbumped would publish
+  a move that never arrives — and the version guard cannot see it, because only
+  its manifest changed.
+
 ## Unreleased (0.5.2) — `forwarding_ws_threshold` so the relay socket can be tested
 
 `TestMediatorBuilder::forwarding_ws_threshold(msgs_per_10s)` sets the rate at

--- a/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-test-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-test-mediator"
-version = "0.6.0"
+version = "0.7.0"
 description = "Embedded mediator fixture for integration tests against affinidi-messaging-mediator"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ affinidi-messaging-didcomm-v1 = { path = "../affinidi-messaging-didcomm-v1", ver
 ## is publishable to crates.io while still using the in-tree path for
 ## workspace dev-builds. Pins follow the workspace's caret-pin policy
 ## (major.minor only) so transitive patch fixes resolve automatically.
-affinidi-messaging-mediator = { version = "0.23", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
+affinidi-messaging-mediator = { version = "0.24", path = "../affinidi-messaging-mediator", default-features = false, features = ["didcomm", "memory-backend"] }
 # `test-clock` compiles the advanceable `TestClock` this fixture injects via
 # `TestMediatorBuilder::clock` for fast expiry/TTL tests.
 affinidi-messaging-mediator-common = { version = "0.15.44", path = "../affinidi-messaging-mediator/affinidi-messaging-mediator-common", features = [
@@ -49,12 +49,12 @@ tempfile = { version = "3", optional = true }
 
 # ── DID + key generation ────────────────────────────────────────────────
 ## Used for `DID::generate_did_peer` (Ed25519 + X25519, with service URI).
-affinidi-tdk = { version = "0.13", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
+affinidi-tdk = { version = "0.14", path = "../../tdk/affinidi-tdk", default-features = false, features = ["did-peer"] }
 affinidi-secrets-resolver = { version = "0.5", path = "../../core/affinidi-secrets-resolver" }
 affinidi-did-resolver-cache-sdk = { version = "0.8", path = "../../identity/affinidi-did-resolver-cache-sdk" }
 
 # ── SDK client (for the e2e test environment) ───────────────────────────
-affinidi-messaging-sdk = { version = "0.23.0", path = "../affinidi-messaging-sdk" }
+affinidi-messaging-sdk = { version = "0.24.0", path = "../affinidi-messaging-sdk" }
 
 # ── JWT signing key generation for the test mediator's session tokens ───
 ring = { version = "0.17", features = ["std"] }
@@ -94,7 +94,7 @@ affinidi-tsp = { version = "0.1", path = "../affinidi-tsp" }
 ## the stored base64url form so the SDK can unpack it (tsp_websocket test).
 base64 = "0.23"
 ## Trust Tasks payload types named by the Trust Tasks integration tests.
-trust-tasks-rs = "0.19"
+trust-tasks-rs = "0.20"
 ## Tracing subscriber for test diagnostics.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ## WebSocket handshake test.

--- a/crates/messaging/affinidi-messaging-text-client/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-text-client/Cargo.toml
@@ -14,11 +14,11 @@ repository.workspace = true
 
 [dependencies]
 # Affinidi Crates
-affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.13" }
-affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.23.0" }
+affinidi-tdk = { path = "../../tdk/affinidi-tdk", version = "0.14" }
+affinidi-messaging-sdk = { path = "../affinidi-messaging-sdk", version = "0.24.0" }
 affinidi-messaging-didcomm = { path = "../affinidi-messaging-didcomm", version = "0.15" }
 ## Trust Tasks payload types (the new atm.trust_tasks() surface returns/accepts these).
-trust-tasks-rs = "0.19"
+trust-tasks-rs = "0.20"
 affinidi-did-resolver-cache-sdk = "0.8"
 
 # External Crates

--- a/crates/tdk/affinidi-tdk/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — `affinidi-tdk`
 
+## Unreleased (0.14.0) — `trust-tasks-rs` 0.20
+
+- Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.
+  0.20 is additive for everything this crate uses: its one breaking change is a
+  `process-attestation` schema tightening (digest floor 16 → 43 base64url
+  characters, a category correction, a dropped duplicate member), and no crate
+  in this workspace references that spec.
+- **Moves because it is the path, not because its own code changed.** This crate
+  re-exports `affinidi-messaging-sdk`, so a consumer reaching a generated type
+  through the facade sees the same API change. Leaving it unbumped would publish
+  a move that never arrives — and the version guard cannot see it, because only
+  its manifest changed.
+
 All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/tdk/affinidi-tdk/Cargo.toml
+++ b/crates/tdk/affinidi-tdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk"
-version = "0.13.0"
+version = "0.14.0"
 description.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -70,7 +70,7 @@ tsp = ["dep:affinidi-tsp", "affinidi-messaging-sdk?/tsp"]
 [dependencies]
 affinidi-did-resolver-cache-sdk = "0.8"
 affinidi-did-common = "0.4"
-affinidi-messaging-sdk = { version = "0.23", path = "../../messaging/affinidi-messaging-sdk", optional = true }
+affinidi-messaging-sdk = { version = "0.24", path = "../../messaging/affinidi-messaging-sdk", optional = true }
 affinidi-messaging-didcomm = { path = "../../messaging/affinidi-messaging-didcomm", version = "0.15" }
 affinidi-did-authentication = "0.3"
 # Foundations are re-exported by the facade. Kept at major.minor (caret), NOT


### PR DESCRIPTION
`trust-tasks-rs` is a PUBLIC dependency of `affinidi-messaging-sdk` — types like
`account::update::v0_1::MediatorAcl` appear in its signatures — so moving it
changes these crates' APIs though not a line of their own source did. Hence minor
bumps rather than patches: sdk 0.24.0, didcomm-service 0.8.0, mediator 0.24.0,
test-mediator 0.7.0, and `affinidi-tdk` 0.14.0, which re-exports the SDK and would
otherwise keep every consumer on the old node.

Five crates move together because a MIXED graph is the failure mode, not an old
one. Only manifests change; no source file is touched.

It moves now because that mixed graph escaped the workspace again.
`verifiable-trust-infrastructure` needs 0.20.1 for `vta/contexts/secrets/1.0` —
the task by which a service fetches the private keys of the DID it operates,
instead of holding global Admin and making one call per key. It could not take it
while `affinidi-messaging-sdk 0.23.0` required 0.19: pinning the consumer at 0.20
put two `trust-tasks-rs` nodes in ITS graph and broke `vta-sdk` on exactly the
`expected MediatorAcl, found a different MediatorAcl` error the two Cargo.toml
comments in this workspace already record. Nothing in the consumer's manifests is
wrong and no semver check flags it, because the break arrives through a public
dependency. The only fix is here.

`affinidi-tdk` is the crate the guard cannot see: only its manifest changed, so
`check-version-bumps.sh` does not flag it — but it is the sole path by which the
consumer reaches the SDK at all, and leaving it unbumped would publish a move that
never arrives.

0.20 is additive for everything these crates use. Its one breaking change is a
`process-attestation` schema tightening (digest floor 16 -> 43 base64url
characters, a category correction, a dropped duplicate member) and no crate here
references that spec.

One pre-existing duplicate is untouched, being a different problem: published
`vta-sdk` -> `affinidi-tdk 0.11.0` -> `affinidi-messaging-sdk 0.21.1` ->
`trust-tasks-rs 0.17.10`, an older published copy of this workspace's own crate
arriving back through a consumer. It compiles because no type crosses that
boundary, and it is the cycle the mediator's Cargo.toml comment describes.

Refs: trustoverip/dtgwg-trust-tasks-tf#440
Signed-off-by: Glenn Gore <glenn.g@affinidi.com>