### PR TITLE
fix(deny): allow Unicode-3.0 for the four ICU crates textwrap pulls in

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -84,6 +84,29 @@ exceptions = [
   { allow = [
     "MPL-2.0",
   ], crate = "option-ext" },
+  # `textwrap` 0.16.3 (via `affinidi-messaging-text-client`) pulls the ICU
+  # segmentation crates for line breaking, and ICU relicensed to Unicode-3.0.
+  # Not copyleft — Unicode-3.0 is the OSI-approved Unicode License v3, a
+  # permissive licence with an attribution clause covering the bundled data
+  # tables — so this is a per-crate exception rather than a global `allow`
+  # entry, for the same reason the `option-ext` note above gives: the global
+  # list is what stops a future dependency arriving under a licence nobody
+  # looked at.
+  #
+  # These four are the whole of it: the two `*_data` crates carry the data
+  # tables, the other two the code that reads them.
+  { allow = [
+    "Unicode-3.0",
+  ], crate = "icu_locale_fallback" },
+  { allow = [
+    "Unicode-3.0",
+  ], crate = "icu_locale_fallback_data" },
+  { allow = [
+    "Unicode-3.0",
+  ], crate = "icu_segmenter" },
+  { allow = [
+    "Unicode-3.0",
+  ], crate = "icu_segmenter_data" },
   { allow = [
     "MPL-2.0",
     "CDLA-Permissive-2.0",


### PR DESCRIPTION
The License check has been failing on `main`, not just on pull requests —
run 34446227300 is the same failure with nothing of ours in it.

`Cargo.lock` is gitignored here, so CI resolves fresh on every run. That
picked up `icu_*` 2.3.0, which relicensed to Unicode-3.0, and nothing in the
allowlist covered it. The path is `affinidi-messaging-text-client` ->
`textwrap` 0.16.3 -> the ICU segmentation crates, used for line breaking.

Unicode-3.0 is the OSI-approved Unicode License v3: permissive, with an
attribution clause covering the bundled data tables. Not copyleft, so nothing
here is a distribution obligation on our own source.

Scoped as four per-crate exceptions rather than a global `allow` entry, for
the reason the `option-ext` comment already gives: the global list is what
stops a future dependency arriving under a licence nobody looked at. Naming the
crates means the next ICU arrival is a decision rather than a silent pass.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>