### PR TITLE
feat(net-guard): a shared egress guard for attacker-influenceable URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Per-crate version history is summarised here; for the full code history see
 
 ## [Unreleased]
 
+### Added
+
+- **`affinidi-net-guard` 0.1.0: one egress guard for URLs an attacker can
+  influence.** **`affinidi-did-web` 0.1.5**, **`affinidi-tdk-common` 0.6.11**.
+
+  A DID names the host a resolver fetches from, and a DID document names the
+  endpoints a client dials, so each is a server-side request forgery primitive
+  unless something refuses internal targets. `affinidi-did-web` 0.1.4 had the
+  strongest guard in the stack, but it was private to a DID-method crate. It is
+  now a leaf crate under `crates/core/` with no `affinidi-*` dependency, so
+  DID-method crates and external clients can take it without a cycle
+  ([ADR 0006](docs/adr/0006-egress-guard-for-attacker-influenceable-urls.md)).
+
+  The crate enforces two halves, and both are needed. `EgressPolicy::vet` checks
+  the scheme, userinfo, port, allow-list, special-use names and IP literals;
+  `reqwest` never consults a resolver for a literal, so this is the only check a
+  literal meets. `GuardedResolver` checks every address a name resolves to,
+  fails the name on any blocked answer, and pins the connection to the vetted
+  addresses. `GuardedClient` runs both, with no proxy, finite timeouts, no
+  redirects by default and a capped body read.
+
+  `conformance/egress-vectors.v1.json` is the vector file the TypeScript and
+  Swift guards will share; the crate's tests run it, including DNS rebinding and
+  redirect cases against local TLS listeners.
+
+  `affinidi-did-web` now takes its address classification and resolver from the
+  new crate, with its API and name set unchanged. The shared classifier also
+  refuses some non-routable ranges that 0.1.4 accepted; its changelog lists
+  them. `affinidi-tdk-common` adds `create_guarded_http_client(extra_roots,
+  &policy)` on the existing platform TLS setup, and re-exports the crate as
+  `net_guard`.
+
 ### Changed
 
 - **`trust-tasks-rs` 0.19 → 0.20 across the messaging family (breaking).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/core/affinidi-secrets-resolver",
   "crates/core/affinidi-bbs",
   "crates/core/affinidi-task-utils",
+  "crates/core/affinidi-net-guard",
 
   # Identity: DID resolution, authentication
   "crates/identity/affinidi-did-common",
@@ -97,6 +98,7 @@ lto = true
 affinidi-secrets-resolver = { path = "crates/core/affinidi-secrets-resolver" }
 affinidi-task-utils = { path = "crates/core/affinidi-task-utils" }
 affinidi-rate-limit = { path = "crates/core/affinidi-rate-limit" }
+affinidi-net-guard = { path = "crates/core/affinidi-net-guard" }
 affinidi-did-resolver-cache-sdk = { path = "crates/identity/affinidi-did-resolver-cache-sdk" }
 affinidi-did-common = { path = "crates/identity/affinidi-did-common" }
 affinidi-crypto = { path = "crates/core/affinidi-crypto" }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Foundational primitives with no domain dependencies.
 | [`affinidi-secrets-resolver`](./crates/core/affinidi-secrets-resolver/) | DID secret management and key resolution |
 | [`affinidi-bbs`](./crates/core/affinidi-bbs/) | BBS Signatures (IETF draft) over BLS12-381 |
 | [`affinidi-task-utils`](./crates/core/affinidi-task-utils/) | Background-task supervision with restart-on-failure and an observable health registry |
+| [`affinidi-net-guard`](./crates/core/affinidi-net-guard/) | Egress guard for attacker-influenceable URLs: IP classification, URL vetting, a DNS-pinning resolver and a hardened HTTP client |
 
 ### [Identity & DID Resolution](./crates/identity/)
 

--- a/crates/core/affinidi-net-guard/CHANGELOG.md
+++ b/crates/core/affinidi-net-guard/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to `affinidi-net-guard` are documented here. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this crate
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-09-11
+
+Initial release: one egress guard for URLs an attacker can influence, extracted
+from the SSRF guard in `affinidi-did-web` 0.1.4 and generalised. See
+[ADR 0006](../../../docs/adr/0006-egress-guard-for-attacker-influenceable-urls.md).
+
+### Added
+
+- `classify` / `is_globally_routable` / `IpClass` / `Embedding`: pure address
+  classification over the IANA special-purpose registries, including the
+  IPv4-mapped, IPv4-compatible, NAT64 (`64:ff9b::/96`, `64:ff9b:1::/48`), 6to4
+  and Teredo forms, which are classified by the IPv4 address they carry.
+- `EgressPolicy`: `public_internet()` (https/wss, globally routable addresses,
+  no special-use names, no userinfo); narrowing `with_allow_list`,
+  `with_schemes` and `with_ports`; `allow_cidrs` for explicit internal ranges
+  (never loopback, link-local, unspecified, multicast or broadcast); and
+  `with_dev_loopback`, whose `DevLoopback` token exists only with the
+  `dev-loopback` feature.
+- `VettedUrl`, built only by `EgressPolicy::vet` / `vet_url`, with a canonical
+  `host()` for operator display and `join_same_origin`.
+- `GuardedResolver` / `guarded_dns_resolver`: a `reqwest` resolver that fails a
+  name if any answer is blocked and returns only vetted addresses, closing DNS
+  rebinding.
+- `RedirectMode` / `redirect_policy`: `None` (default), `SameOrigin`, and
+  `ReVet` (hop cap, every hop re-vetted, no https-to-http downgrade).
+- `GuardedClientBuilder` / `GuardedClient`: both halves on one client, with no
+  proxy, 10 s / 5 s timeouts, no `Referer` on redirects, `https_only` unless dev
+  loopback, `execute` for externally built requests, and `read_body_capped`
+  (1 MiB default).
+- `EgressError` and `blocked_in_chain`, which recovers a refusal from a
+  `reqwest::Error`.
+- `conformance/egress-vectors.v1.json`, the vector file shared with the
+  TypeScript and Swift guards, and a runner in the test suite that executes the
+  `ip`, `url`, `names`, `scheme`, `dns`, `rebinding` and `redirect` sections
+  (the last two against local TLS listeners) and skips `webvh` and
+  `mediatorDoc` with a declared reason.
+
+### Changed relative to the `affinidi-did-web` 0.1.4 guard
+
+- Also refuses documentation, multicast, reserved, benchmarking and
+  protocol-assignment space, and 6to4, Teredo and local-use NAT64 addresses
+  that embed a non-routable IPv4 address.
+- Also refuses the special-use names `*.internal`, `*.home.arpa` and
+  single-label names.

--- a/crates/core/affinidi-net-guard/Cargo.toml
+++ b/crates/core/affinidi-net-guard/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "affinidi-net-guard"
+version = "0.1.0"
+description = "Egress guard for attacker-influenceable URLs: IP classification, URL vetting, a DNS-pinning resolver and a hardened reqwest client"
+repository.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+publish.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+
+[features]
+default = []
+# Makes `DevLoopback` constructible, so a policy can admit loopback hosts (and
+# plain http/ws to them). Enable it from dev-dependencies or development builds
+# only: a binary compiled without it cannot opt in.
+dev-loopback = []
+
+# A leaf crate on purpose: no `affinidi-*` dependency, so DID-method crates and
+# external clients (didwebvh-rs, trql-client) can depend on it without a cycle.
+[dependencies]
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+thiserror = "2"
+# The one-time warning when dev loopback is switched on.
+tracing = "0.1"
+url = "2.5"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# `net` only: the resolver looks names up itself so it can vet every answer.
+tokio = { version = "1", default-features = false, features = ["net"] }
+
+[dev-dependencies]
+rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs"] }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
+serde_json = "1"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs"] }
+
+[lints]
+workspace = true

--- a/crates/core/affinidi-net-guard/README.md
+++ b/crates/core/affinidi-net-guard/README.md
@@ -1,0 +1,57 @@
+# affinidi-net-guard
+
+An egress guard for URLs an attacker can influence, such as a `did:web` host, a
+DID document's service endpoint or a redirect `Location`. It stops such a URL
+from steering a server-side request at loopback, a private network or a
+cloud-metadata address (SSRF).
+
+It is a leaf crate (`reqwest`, `tokio`, `url`, `thiserror`, `tracing`; no
+`affinidi-*` dependency), so DID-method crates and external clients can use it
+without a dependency cycle.
+
+## Both halves are required
+
+1. **Vet the URL** (`EgressPolicy::vet`): scheme, userinfo, port, allow-list,
+   special-use names and IP literals. `reqwest` never consults a DNS resolver
+   for an IP-literal host, so this is the only check a literal ever meets.
+2. **Vet what a name resolves to** (`GuardedResolver`): every answer is
+   checked, one blocked answer fails the name, and the connection is made to
+   the checked addresses only, so there is nothing left to rebind.
+
+A proxy resolves names itself and bypasses the second half, so
+`GuardedClientBuilder` disables proxies (including `HTTP(S)_PROXY`).
+
+```rust
+use affinidi_net_guard::{EgressPolicy, GuardedClientBuilder};
+
+let policy = EgressPolicy::public_internet();
+let client = GuardedClientBuilder::new(policy.clone()).build()?;
+let url = policy.vet("https://example.com/.well-known/did.json")?;
+let response = client.get(&url)?.send().await?;
+let body = client.read_body_capped(response).await?;
+```
+
+## API
+
+| Item | Purpose |
+|---|---|
+| `classify`, `is_globally_routable`, `IpClass`, `Embedding` | Pure address classification, including IPv4-mapped/-compatible, NAT64 (`64:ff9b::/96`, `64:ff9b:1::/48`), 6to4 and Teredo |
+| `EgressPolicy` | `public_internet()`; narrowing `with_allow_list` / `with_schemes` / `with_ports`; `allow_cidrs` for explicit internal ranges; `with_dev_loopback` |
+| `DevLoopback` | Token for loopback access, constructible only with the `dev-loopback` feature |
+| `VettedUrl` | A URL that passed `vet`; `host()` for operator display, `join_same_origin` |
+| `GuardedResolver`, `guarded_dns_resolver` | `reqwest` DNS resolver that vets every answer and pins the connection |
+| `RedirectMode`, `redirect_policy` | `None` (default), `SameOrigin`, `ReVet` (hop cap, no https-to-http downgrade) |
+| `GuardedClientBuilder`, `GuardedClient` | Both halves on one client: no proxy, finite timeouts, `https_only` unless dev loopback, `read_body_capped` |
+| `EgressError`, `blocked_in_chain` | Errors, and recovering a refusal from a `reqwest::Error` |
+
+## Conformance vectors
+
+`conformance/egress-vectors.v1.json` is the vector file shared by the Rust,
+TypeScript and Swift guards. The crate's test suite runs every section it has
+the capabilities for and skips the rest with a declared reason.
+
+See [ADR 0006](../../../docs/adr/0006-egress-guard-for-attacker-influenceable-urls.md).
+
+## License
+
+Apache-2.0

--- a/crates/core/affinidi-net-guard/conformance/egress-vectors.v1.json
+++ b/crates/core/affinidi-net-guard/conformance/egress-vectors.v1.json
@@ -1,0 +1,377 @@
+{
+  "version": 1,
+  "description": "Shared egress-guard conformance vectors. Every implementation (Rust, Node, browser, Swift) loads this file and must pass each vector, or skip a section or vector whose `requires` names a capability it declares it lacks. An unknown section or capability is a failure, so new vectors cannot be silently ignored.",
+  "defaultPolicy": "public_internet",
+  "defaultPolicyDescription": "https and wss only; globally routable addresses only; no special-use names; no userinfo; any port; no redirects.",
+  "policyFields": {
+    "devLoopback": "true admits loopback hosts (the literals 127.0.0.0/8 and ::1, the names localhost and *.localhost) and plain http/ws to them. A non-localhost name resolving to loopback stays blocked.",
+    "allowList": "Array of {\"exact\": host} | {\"suffix\": domain} | {\"origin\": \"scheme://host:port\"}. Narrows; never re-admits an address class; is the only way to name a special-use host other than localhost.",
+    "allowCidrs": "Array of CIDR strings re-admitted. Never re-admits loopback, link-local, this-network, multicast or broadcast. An IPv4 range also covers that address's embedded IPv6 forms.",
+    "ports": "Array of admitted ports (narrows).",
+    "schemes": "Array of admitted schemes (narrows)."
+  },
+  "expectations": {
+    "allow": "vetted / resolved / final 2xx response",
+    "block": "refused by the guard",
+    "invalid": "the input is not a valid URL",
+    "error": "failed without a policy refusal (for example, no addresses)",
+    "not-followed": "the 3xx response is returned and not followed"
+  },
+  "reasons": {
+    "scheme": "scheme not admitted, including an https-to-http redirect downgrade",
+    "userinfo": "URL carries a username or password",
+    "address": "host is, or resolves to, a blocked address",
+    "name": "host is a special-use name",
+    "not-allowed": "host is not on the allow-list",
+    "cross-origin": "a same-origin redirect left the origin",
+    "port": "port not admitted",
+    "too-many-redirects": "redirect hop cap exceeded"
+  },
+  "capabilities": {
+    "classify": "Classify a literal IP address (pure).",
+    "vet": "Parse, canonicalise (WHATWG) and vet a URL (pure).",
+    "dns": "Vet the answers of an injected stub resolver.",
+    "dns-online": "Resolve real public names that point at loopback.",
+    "pinning": "Connect only to the addresses the guard vetted, with one lookup per connection.",
+    "redirect-inspect": "Inspect and re-vet each redirect hop.",
+    "webvh-url": "Derive the did:webvh log URL from a DID.",
+    "mediator-doc": "Extract service endpoints from a DID document and vet them."
+  },
+  "sections": {
+    "ip": {
+      "requires": ["classify"],
+      "vectors": [
+        { "input": "127.0.0.1", "expect": "block", "class": "loopback" },
+        { "input": "127.255.255.254", "expect": "block", "class": "loopback" },
+        { "input": "0.0.0.0", "expect": "block", "class": "this-network" },
+        { "input": "0.1.2.3", "expect": "block", "class": "this-network" },
+        { "input": "10.0.0.1", "expect": "block", "class": "private" },
+        { "input": "172.16.0.1", "expect": "block", "class": "private" },
+        { "input": "172.31.255.255", "expect": "block", "class": "private" },
+        { "input": "192.168.0.1", "expect": "block", "class": "private" },
+        { "input": "169.254.169.254", "expect": "block", "class": "link-local", "note": "cloud metadata" },
+        { "input": "169.254.170.2", "expect": "block", "class": "link-local", "note": "ECS task metadata" },
+        { "input": "100.64.0.1", "expect": "block", "class": "shared-cgnat" },
+        { "input": "100.100.100.200", "expect": "block", "class": "shared-cgnat", "note": "Alibaba Cloud metadata" },
+        { "input": "100.127.255.254", "expect": "block", "class": "shared-cgnat" },
+        { "input": "192.0.0.1", "expect": "block", "class": "protocol-assignment" },
+        { "input": "198.18.0.1", "expect": "block", "class": "benchmarking" },
+        { "input": "198.19.255.255", "expect": "block", "class": "benchmarking" },
+        { "input": "192.0.2.1", "expect": "block", "class": "documentation" },
+        { "input": "198.51.100.1", "expect": "block", "class": "documentation" },
+        { "input": "203.0.113.1", "expect": "block", "class": "documentation" },
+        { "input": "224.0.0.1", "expect": "block", "class": "multicast" },
+        { "input": "239.255.255.250", "expect": "block", "class": "multicast" },
+        { "input": "240.0.0.1", "expect": "block", "class": "reserved" },
+        { "input": "255.255.255.255", "expect": "block", "class": "broadcast" },
+        { "input": "::1", "expect": "block", "class": "loopback" },
+        { "input": "::", "expect": "block", "class": "this-network" },
+        { "input": "::ffff:127.0.0.1", "expect": "block", "class": "embedded", "via": "v4-mapped", "inner": "loopback" },
+        { "input": "::ffff:7f00:1", "expect": "block", "class": "embedded", "via": "v4-mapped", "inner": "loopback" },
+        { "input": "::ffff:169.254.169.254", "expect": "block", "class": "embedded", "via": "v4-mapped", "inner": "link-local" },
+        { "input": "::127.0.0.1", "expect": "block", "class": "embedded", "via": "v4-compatible", "inner": "loopback" },
+        { "input": "64:ff9b::7f00:1", "expect": "block", "class": "embedded", "via": "nat64", "inner": "loopback" },
+        { "input": "64:ff9b::a9fe:a9fe", "expect": "block", "class": "embedded", "via": "nat64", "inner": "link-local", "note": "NAT64 to metadata" },
+        { "input": "64:ff9b:1::a00:1", "expect": "block", "class": "embedded", "via": "nat64-local-use", "inner": "private" },
+        { "input": "64:ff9b:1:1::a00:1", "expect": "block", "class": "reserved", "note": "local-use NAT64 outside the /96 form has no single destination" },
+        { "input": "2002:7f00:1::1", "expect": "block", "class": "embedded", "via": "6to4", "inner": "loopback" },
+        { "input": "2001:0:4136:e378::1", "expect": "block", "class": "embedded", "via": "teredo", "inner": "reserved", "note": "client address ~0.0.0.1 = 255.255.255.254" },
+        { "input": "fc00::1", "expect": "block", "class": "unique-local" },
+        { "input": "fd00::1", "expect": "block", "class": "unique-local" },
+        { "input": "fd00:ec2::254", "expect": "block", "class": "unique-local", "note": "AWS IMDSv6" },
+        { "input": "fe80::1", "expect": "block", "class": "link-local" },
+        { "input": "febf::1", "expect": "block", "class": "link-local" },
+        { "input": "fec0::1", "expect": "block", "class": "site-local" },
+        { "input": "ff02::1", "expect": "block", "class": "multicast" },
+        { "input": "2001:db8::1", "expect": "block", "class": "documentation" },
+        { "input": "3fff::1", "expect": "block", "class": "documentation" },
+        { "input": "100::1", "expect": "block", "class": "reserved" },
+        { "input": "5f00::1", "expect": "block", "class": "reserved" },
+        { "input": "2001:2::1", "expect": "block", "class": "benchmarking" },
+        { "input": "2001:10::1", "expect": "block", "class": "protocol-assignment" },
+        { "input": "8.8.8.8", "expect": "allow", "class": "global" },
+        { "input": "1.1.1.1", "expect": "allow", "class": "global" },
+        { "input": "11.0.0.1", "expect": "allow", "class": "global" },
+        { "input": "100.63.255.255", "expect": "allow", "class": "global" },
+        { "input": "100.128.0.0", "expect": "allow", "class": "global" },
+        { "input": "172.15.255.255", "expect": "allow", "class": "global" },
+        { "input": "172.32.0.1", "expect": "allow", "class": "global" },
+        { "input": "169.253.255.255", "expect": "allow", "class": "global" },
+        { "input": "192.169.0.1", "expect": "allow", "class": "global" },
+        { "input": "198.20.0.1", "expect": "allow", "class": "global" },
+        { "input": "2606:4700:4700::1111", "expect": "allow", "class": "global" },
+        { "input": "2001:4860:4860::8888", "expect": "allow", "class": "global" },
+        { "input": "2001:1::1", "expect": "allow", "class": "global" },
+        { "input": "2001:4:112::1", "expect": "allow", "class": "global" },
+        { "input": "64:ff9b::808:808", "expect": "allow", "class": "embedded", "via": "nat64", "inner": "global", "note": "NAT64 to a public address" },
+        { "input": "64:ff9b:1::808:808", "expect": "allow", "class": "embedded", "via": "nat64-local-use", "inner": "global" },
+        { "input": "::ffff:8.8.8.8", "expect": "allow", "class": "embedded", "via": "v4-mapped", "inner": "global" },
+        { "input": "2002:808:808::1", "expect": "allow", "class": "embedded", "via": "6to4", "inner": "global" },
+        { "input": "2001:0:4136:e378:8000:63bf:f7f7:f7f7", "expect": "allow", "class": "embedded", "via": "teredo", "inner": "global", "note": "client address ~f7f7f7f7 = 8.8.8.8" }
+      ]
+    },
+    "url": {
+      "requires": ["vet"],
+      "note": "`host` is the WHATWG canonical host of the input, independent of the verdict.",
+      "vectors": [
+        { "input": "https://2130706433/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://0x7f000001/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://017700000001/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://0177.0.0.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://0x7f.0.0.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://127.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://127.0.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://0/", "expect": "block", "reason": "address", "host": "0.0.0.0" },
+        { "input": "https://169.254.169.254./", "expect": "block", "reason": "address", "host": "169.254.169.254" },
+        { "input": "https://%31%32%37.0.0.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://①②⑦.0.0.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://127。0。0。1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://[::ffff:127.0.0.1]/", "expect": "block", "reason": "address", "host": "[::ffff:7f00:1]" },
+        { "input": "https://[0:0:0:0:0:ffff:7f00:1]/", "expect": "block", "reason": "address", "host": "[::ffff:7f00:1]" },
+        { "input": "https://[::1]:8443/", "expect": "block", "reason": "address", "host": "[::1]" },
+        { "input": "wss://0x7f.1/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://example.com@127.0.0.1/", "expect": "block", "host": "127.0.0.1", "note": "userinfo and a loopback host; either reason is correct" },
+        { "input": "https://127.0.0.1\\@example.com/", "expect": "block", "reason": "address", "host": "127.0.0.1" },
+        { "input": "https://user:pass@example.com/", "expect": "block", "reason": "userinfo", "host": "example.com" },
+        { "input": "https://0x100000000/", "expect": "invalid" },
+        { "input": "https://1.2.3.4.5/", "expect": "invalid" },
+        { "input": "https://[fe80::1%25en0]/", "expect": "invalid" },
+        { "input": "https://example.com/", "expect": "allow", "host": "example.com" },
+        { "input": "https://example.com:8443/", "expect": "allow", "host": "example.com" },
+        { "input": "https://93.184.216.34/", "expect": "allow", "host": "93.184.216.34" },
+        { "input": "https://10.20.0.5/", "policy": { "allowCidrs": ["10.20.0.0/16"] }, "expect": "allow" },
+        { "input": "https://[::ffff:10.20.0.5]/", "policy": { "allowCidrs": ["10.20.0.0/16"] }, "expect": "allow" },
+        { "input": "https://10.21.0.5/", "policy": { "allowCidrs": ["10.20.0.0/16"] }, "expect": "block", "reason": "address" },
+        { "input": "https://127.0.0.1/", "policy": { "allowCidrs": ["127.0.0.0/8"] }, "expect": "block", "reason": "address" },
+        { "input": "https://169.254.169.254/", "policy": { "allowCidrs": ["169.254.0.0/16"] }, "expect": "block", "reason": "address" },
+        { "input": "https://example.com:8443/", "policy": { "ports": [443] }, "expect": "block", "reason": "port" },
+        { "input": "https://example.com/", "policy": { "ports": [443] }, "expect": "allow" },
+        { "input": "https://example.com/", "policy": { "allowList": [{ "exact": "example.com" }] }, "expect": "allow" },
+        { "input": "https://other.example/", "policy": { "allowList": [{ "exact": "example.com" }] }, "expect": "block", "reason": "not-allowed" },
+        { "input": "https://api.push.apple.com/", "policy": { "allowList": [{ "suffix": ".push.apple.com" }] }, "expect": "allow" },
+        { "input": "https://push.apple.com/", "policy": { "allowList": [{ "suffix": ".push.apple.com" }] }, "expect": "block", "reason": "not-allowed" },
+        { "input": "https://evilpush.apple.com/", "policy": { "allowList": [{ "suffix": ".push.apple.com" }] }, "expect": "block", "reason": "not-allowed" },
+        { "input": "https://example.com:8443/", "policy": { "allowList": [{ "origin": "https://example.com:8443" }] }, "expect": "allow" },
+        { "input": "https://example.com/", "policy": { "allowList": [{ "origin": "https://example.com:8443" }] }, "expect": "block", "reason": "not-allowed" },
+        { "input": "https://127.0.0.1/", "policy": { "allowList": [{ "exact": "127.0.0.1" }] }, "expect": "block", "reason": "address", "note": "an allow-list never re-admits an address class" }
+      ]
+    },
+    "names": {
+      "requires": ["vet"],
+      "vectors": [
+        { "input": "https://localhost/", "expect": "block", "reason": "name" },
+        { "input": "https://LOCALHOST./", "expect": "block", "reason": "name" },
+        { "input": "https://svc.localhost/", "expect": "block", "reason": "name" },
+        { "input": "https://printer.local/", "expect": "block", "reason": "name" },
+        { "input": "https://printer.local./", "expect": "block", "reason": "name" },
+        { "input": "https://kube-dns.kube-system.svc.cluster.local/", "expect": "block", "reason": "name" },
+        { "input": "https://metadata.google.internal/", "expect": "block", "reason": "name" },
+        { "input": "https://router.home.arpa/", "expect": "block", "reason": "name" },
+        { "input": "https://metadata/", "expect": "block", "reason": "name" },
+        { "input": "https://metadata./", "expect": "block", "reason": "name" },
+        { "input": "https://example.com/", "expect": "allow" },
+        { "input": "https://example.com./", "expect": "allow" },
+        { "input": "https://localhost.example.com/", "expect": "allow" },
+        { "input": "https://local.example.com/", "expect": "allow" },
+        { "input": "https://metadata/", "policy": { "allowList": [{ "exact": "metadata" }] }, "expect": "allow", "note": "an explicit allow-list entry names an internal host; its addresses are still vetted" },
+        { "input": "https://kube-dns.kube-system.svc.cluster.local/", "policy": { "allowList": [{ "suffix": ".svc.cluster.local" }] }, "expect": "allow" },
+        { "input": "https://localhost/", "policy": { "allowList": [{ "exact": "localhost" }] }, "expect": "block", "reason": "name", "note": "localhost needs devLoopback" },
+        { "input": "https://localhost/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "https://svc.localhost/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "https://printer.local/", "policy": { "devLoopback": true }, "expect": "block", "reason": "name" }
+      ]
+    },
+    "scheme": {
+      "requires": ["vet"],
+      "vectors": [
+        { "input": "http://example.com/", "expect": "block", "reason": "scheme" },
+        { "input": "ws://example.com/", "expect": "block", "reason": "scheme" },
+        { "input": "ftp://example.com/", "expect": "block", "reason": "scheme" },
+        { "input": "file:///etc/passwd", "expect": "block", "reason": "scheme" },
+        { "input": "gopher://example.com/", "expect": "block", "reason": "scheme" },
+        { "input": "data:text/plain,x", "expect": "block", "reason": "scheme" },
+        { "input": "javascript:alert(1)", "expect": "block", "reason": "scheme" },
+        { "input": "blob:https://x/y", "expect": "block", "reason": "scheme" },
+        { "input": "https://example.com/", "expect": "allow" },
+        { "input": "wss://example.com/", "expect": "allow" },
+        { "input": "wss://example.com/", "policy": { "schemes": ["https"] }, "expect": "block", "reason": "scheme" },
+        { "input": "http://localhost:8000/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "http://127.0.0.1:9099/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "http://[::1]:7037/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "ws://localhost:8080/", "policy": { "devLoopback": true }, "expect": "allow" },
+        { "input": "http://10.0.0.5/", "policy": { "devLoopback": true }, "expect": "block", "reason": "address" },
+        { "input": "http://169.254.169.254/", "policy": { "devLoopback": true }, "expect": "block", "reason": "address" },
+        { "input": "http://[::ffff:127.0.0.1]/", "policy": { "devLoopback": true }, "expect": "block", "reason": "address" },
+        { "input": "http://example.com/", "policy": { "devLoopback": true }, "expect": "block", "reason": "scheme" }
+      ]
+    },
+    "webvh": {
+      "requires": ["webvh-url"],
+      "vectors": [
+        { "did": "did:webvh:QmS:example.com", "expect": "allow", "url": "https://example.com/.well-known/did.jsonl" },
+        { "did": "did:webvh:QmS:example.com:users:alice", "expect": "allow", "url": "https://example.com/users/alice/did.jsonl" },
+        { "did": "did:webvh:QmS:example.com:localhost", "expect": "allow", "url": "https://example.com/localhost/did.jsonl", "note": "regression: a path segment named localhost must not downgrade to http" },
+        { "did": "did:webvh:QmS:localhost%3A8000", "expect": "block" },
+        { "did": "did:webvh:QmS:localhost%3A8000", "policy": { "devLoopback": true }, "expect": "allow", "url": "http://localhost:8000/.well-known/did.jsonl" },
+        { "did": "did:webvh:QmS:127.0.0.1", "expect": "block" },
+        { "did": "did:webvh:QmS:2130706433", "expect": "block" },
+        { "did": "did:webvh:QmS:169.254.169.254%3A80", "expect": "block" },
+        { "did": "did:web:127.0.0.1%3A9099", "expect": "block" },
+        { "did": "did:web:localhost", "expect": "block" }
+      ]
+    },
+    "mediatorDoc": {
+      "requires": ["mediator-doc"],
+      "vectors": [
+        { "serviceEndpoint": [{ "uri": "https://mediator.example.com" }], "expect": "accept" },
+        { "serviceEndpoint": [{ "uri": "https://127.0.0.1:7037" }], "expect": "reject" },
+        { "serviceEndpoint": [{ "uri": "wss://10.0.0.5/ws" }], "expect": "reject" },
+        { "serviceEndpoint": "https://169.254.169.254/", "expect": "reject" },
+        { "authentication": "https://[fd00:ec2::254]/", "expect": "reject" },
+        { "serviceEndpoint": [{ "uri": "https://mediator.example.com" }, { "uri": "wss://10.0.0.5/ws" }], "expect": "reject", "note": "fail closed on a mixed document" },
+        { "serviceEndpoint": "http://mediator.example.com", "expect": "reject" },
+        { "serviceEndpoint": "http://10.0.0.5", "allowInsecure": true, "expect": "reject", "note": "allowInsecure is a scheme opt-out only" }
+      ]
+    },
+    "dns": {
+      "requires": ["dns"],
+      "vectors": [
+        { "name": "a.test", "answers": ["93.184.216.34"], "expect": "allow" },
+        { "name": "b.test", "answers": ["127.0.0.1"], "expect": "block" },
+        { "name": "c.test", "answers": ["93.184.216.34", "10.0.0.1"], "expect": "block", "note": "one bad answer fails the whole name" },
+        { "name": "d.test", "answers": ["::ffff:169.254.169.254"], "expect": "block" },
+        { "name": "e.test", "answers": ["64:ff9b::7f00:1"], "expect": "block" },
+        { "name": "f.test", "answers": [], "expect": "error" },
+        { "name": "g.test", "answers": ["2606:4700:4700::1111", "93.184.216.34"], "expect": "allow" },
+        { "name": "localhost", "answers": ["127.0.0.1", "::1"], "expect": "block" },
+        { "name": "localhost", "answers": ["127.0.0.1", "::1"], "policy": { "devLoopback": true }, "expect": "allow" },
+        { "name": "rebind.test", "answers": ["127.0.0.1"], "policy": { "devLoopback": true }, "expect": "block", "note": "dev loopback admits localhost names, not any name that resolves to loopback" },
+        { "name": "internal.test", "answers": ["10.20.0.5"], "policy": { "allowCidrs": ["10.20.0.0/16"] }, "expect": "allow" },
+        { "name": "internal.test", "answers": ["10.20.0.5", "10.30.0.5"], "policy": { "allowCidrs": ["10.20.0.0/16"] }, "expect": "block" },
+        { "name": "localtest.me", "requires": ["dns-online"], "expect": "block" },
+        { "name": "127.0.0.1.nip.io", "requires": ["dns-online"], "expect": "block" }
+      ]
+    },
+    "rebinding": {
+      "requires": ["dns", "pinning"],
+      "note": "The stub returns `lookups[n]` on the nth lookup. A runner maps each public answer to a local listener; a blocked answer must reach no listener at all.",
+      "vectors": [
+        {
+          "id": "rebind-after-pool-expiry",
+          "name": "rebind.test",
+          "lookups": [["93.184.216.34"], ["127.0.0.1"]],
+          "requests": [{ "expect": "allow" }, { "expect": "block" }],
+          "assert": { "lookupsPerConnection": 1, "blockedTargetConnections": 0, "connectTargetIsVetted": true }
+        }
+      ]
+    },
+    "redirect": {
+      "requires": ["redirect-inspect", "pinning"],
+      "note": "Names in `zone` resolve through a stub, and a runner maps each public answer to a local listener that serves `routes`. `{sink}` is the port of a listener standing in for an internal service. `zeroConnections` names listeners that must see no connection. `mode` defaults to none.",
+      "zone": {
+        "origin.test": ["93.184.216.34"],
+        "public.test": ["93.184.216.35"],
+        "private.test": ["127.0.0.1"]
+      },
+      "vectors": [
+        {
+          "id": "default-mode-returns-the-3xx",
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "https://public.test/" } },
+          "expect": "not-followed",
+          "zeroConnections": ["public.test"]
+        },
+        {
+          "id": "push-gateway-poc-replay",
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "http://127.0.0.1:{sink}/listener" } },
+          "expect": "not-followed",
+          "zeroConnections": ["sink"]
+        },
+        {
+          "id": "revet-http-loopback-literal",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "http://127.0.0.1:{sink}/" } },
+          "expect": "block",
+          "zeroConnections": ["sink"]
+        },
+        {
+          "id": "revet-ipv6-loopback-literal",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "https://[::1]:{sink}/" } },
+          "expect": "block",
+          "reason": "address",
+          "zeroConnections": ["sink"]
+        },
+        {
+          "id": "revet-name-resolving-to-loopback",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "https://private.test/" } },
+          "expect": "block",
+          "reason": "address",
+          "zeroConnections": ["sink"]
+        },
+        {
+          "id": "revet-https-to-http-downgrade",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 307, "location": "http://public.test/" } },
+          "expect": "block",
+          "reason": "scheme",
+          "zeroConnections": ["public.test"]
+        },
+        {
+          "id": "revet-relative-location",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "/x" }, "/x": { "status": 200 } },
+          "expect": "allow"
+        },
+        {
+          "id": "revet-allow-list-escape",
+          "mode": { "type": "revet", "max": 10 },
+          "policy": { "allowList": [{ "exact": "origin.test" }] },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "https://public.test/" } },
+          "expect": "block",
+          "reason": "not-allowed",
+          "zeroConnections": ["public.test"]
+        },
+        {
+          "id": "revet-10-hops",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/hop/0",
+          "chain": 10,
+          "expect": "allow"
+        },
+        {
+          "id": "revet-11-hops",
+          "mode": { "type": "revet", "max": 10 },
+          "start": "https://origin.test/hop/0",
+          "chain": 11,
+          "expect": "block",
+          "reason": "too-many-redirects"
+        },
+        {
+          "id": "same-origin-refuses-another-host",
+          "mode": { "type": "same-origin", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "https://public.test/" } },
+          "expect": "block",
+          "reason": "cross-origin",
+          "zeroConnections": ["public.test"]
+        },
+        {
+          "id": "same-origin-follows-a-relative-location",
+          "mode": { "type": "same-origin", "max": 10 },
+          "start": "https://origin.test/",
+          "routes": { "/": { "status": 302, "location": "/x" }, "/x": { "status": 200 } },
+          "expect": "allow"
+        }
+      ]
+    }
+  }
+}

--- a/crates/core/affinidi-net-guard/src/cidr.rs
+++ b/crates/core/affinidi-net-guard/src/cidr.rs
@@ -1,0 +1,98 @@
+//! Explicit address ranges for [`EgressPolicy::allow_cidrs`](crate::EgressPolicy::allow_cidrs).
+
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use crate::EgressError;
+
+/// An IP network in CIDR notation, such as `10.20.0.0/16` or `fd12:3456::/48`.
+///
+/// Host bits are cleared on construction, so `10.20.1.2/16` is `10.20.0.0/16`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Cidr {
+    network: IpAddr,
+    prefix_len: u8,
+}
+
+impl Cidr {
+    /// Build a range from an address and a prefix length.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::InvalidConfig`] if `prefix_len` is longer than the
+    /// address (32 bits for IPv4, 128 for IPv6).
+    pub fn new(addr: IpAddr, prefix_len: u8) -> Result<Self, EgressError> {
+        let network = match addr {
+            IpAddr::V4(v4) if prefix_len <= 32 => {
+                IpAddr::V4(Ipv4Addr::from(u32::from(v4) & mask_v4(prefix_len)))
+            }
+            IpAddr::V6(v6) if prefix_len <= 128 => {
+                IpAddr::V6(Ipv6Addr::from(u128::from(v6) & mask_v6(prefix_len)))
+            }
+            _ => {
+                return Err(EgressError::InvalidConfig(format!(
+                    "prefix length /{prefix_len} is too long for {addr}"
+                )));
+            }
+        };
+        Ok(Self {
+            network,
+            prefix_len,
+        })
+    }
+
+    /// The network address (host bits cleared).
+    pub fn network(&self) -> IpAddr {
+        self.network
+    }
+
+    /// The prefix length.
+    pub fn prefix_len(&self) -> u8 {
+        self.prefix_len
+    }
+
+    /// Whether `addr` falls inside this range. An IPv4 range never contains an
+    /// IPv6 address, nor the reverse.
+    pub fn contains(&self, addr: IpAddr) -> bool {
+        match (self.network, addr) {
+            (IpAddr::V4(network), IpAddr::V4(addr)) => {
+                u32::from(addr) & mask_v4(self.prefix_len) == u32::from(network)
+            }
+            (IpAddr::V6(network), IpAddr::V6(addr)) => {
+                u128::from(addr) & mask_v6(self.prefix_len) == u128::from(network)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn mask_v4(prefix_len: u8) -> u32 {
+    u32::MAX
+        .checked_shl(32 - u32::from(prefix_len))
+        .unwrap_or(0)
+}
+
+fn mask_v6(prefix_len: u8) -> u128 {
+    u128::MAX
+        .checked_shl(128 - u32::from(prefix_len))
+        .unwrap_or(0)
+}
+
+impl FromStr for Cidr {
+    type Err = EgressError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let invalid = || EgressError::InvalidConfig(format!("{s:?} is not CIDR notation"));
+        let (addr, prefix_len) = s.split_once('/').ok_or_else(invalid)?;
+        let addr = addr.parse::<IpAddr>().map_err(|_| invalid())?;
+        let prefix_len = prefix_len.parse::<u8>().map_err(|_| invalid())?;
+        Self::new(addr, prefix_len)
+    }
+}
+
+impl fmt::Display for Cidr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.network, self.prefix_len)
+    }
+}

--- a/crates/core/affinidi-net-guard/src/classify.rs
+++ b/crates/core/affinidi-net-guard/src/classify.rs
@@ -1,0 +1,245 @@
+//! Address classification: the canonical table that the guards in other
+//! languages port, and that `conformance/egress-vectors.v1.json` pins.
+
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// What kind of address an [`IpAddr`] is, for egress purposes.
+///
+/// Only [`IpClass::Global`], and an [`IpClass::Embedded`] address whose
+/// embedded IPv4 destination is `Global`, are globally routable. See
+/// [`IpClass::is_globally_routable`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IpClass {
+    /// Globally routable unicast.
+    Global,
+    /// `127.0.0.0/8`, `::1`.
+    Loopback,
+    /// RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`.
+    Private,
+    /// `169.254.0.0/16` (which holds the cloud-metadata address
+    /// `169.254.169.254`) and `fe80::/10`.
+    LinkLocal,
+    /// Carrier-grade NAT `100.64.0.0/10`, which holds `100.100.100.200` (the
+    /// Alibaba Cloud metadata address) and many Kubernetes node ranges.
+    SharedCgnat,
+    /// `0.0.0.0/8` ("this network", including the unspecified address) and
+    /// `::`.
+    ThisNetwork,
+    /// `255.255.255.255`.
+    Broadcast,
+    /// `224.0.0.0/4`, `ff00::/8`.
+    Multicast,
+    /// `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32`,
+    /// `3fff::/20`.
+    Documentation,
+    /// `198.18.0.0/15`, `2001:2::/48`.
+    Benchmarking,
+    /// IETF protocol assignments: `192.0.0.0/24`, and `2001::/23` apart from
+    /// the assignments in it that are globally reachable.
+    ProtocolAssignment,
+    /// `240.0.0.0/4` (apart from broadcast), discard-only `100::/64`, SRv6
+    /// SIDs `5f00::/16`, and local-use NAT64 addresses that are not in the
+    /// `/96` form.
+    Reserved,
+    /// `fc00::/7`, which holds the AWS IMDSv6 address `fd00:ec2::254`.
+    UniqueLocal,
+    /// Deprecated site-local `fec0::/10`.
+    SiteLocal,
+    /// An IPv6 address that carries an IPv4 destination.
+    Embedded {
+        /// How the IPv4 address is carried.
+        via: Embedding,
+        /// The class of the embedded IPv4 address.
+        inner: Box<IpClass>,
+    },
+}
+
+/// How an [`IpClass::Embedded`] IPv6 address carries its IPv4 destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Embedding {
+    /// IPv4-mapped `::ffff:0:0/96`.
+    V4Mapped,
+    /// Deprecated IPv4-compatible `::/96` (apart from `::` and `::1`).
+    V4Compatible,
+    /// NAT64 well-known prefix `64:ff9b::/96` (RFC 6052).
+    Nat64,
+    /// Local-use NAT64 `64:ff9b:1::/48` (RFC 8215), with the IPv4 address in
+    /// the low 32 bits and bits 48 to 95 zero.
+    Nat64LocalUse,
+    /// 6to4 `2002::/16`, with the IPv4 address in bits 16 to 47.
+    SixToFour,
+    /// Teredo `2001::/32`. The IPv4 address is the client's, stored inverted
+    /// in the low 32 bits.
+    Teredo,
+}
+
+impl IpClass {
+    /// `true` for [`IpClass::Global`], and for an embedded address whose IPv4
+    /// destination is `Global`: a DNS64 network hands out `64:ff9b::808:808`
+    /// for a public host, and refusing it would break every lookup there.
+    pub fn is_globally_routable(&self) -> bool {
+        match self {
+            Self::Global => true,
+            Self::Embedded { inner, .. } => inner.is_globally_routable(),
+            _ => false,
+        }
+    }
+
+    /// A stable kebab-case name, as used in the conformance vectors.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Loopback => "loopback",
+            Self::Private => "private",
+            Self::LinkLocal => "link-local",
+            Self::SharedCgnat => "shared-cgnat",
+            Self::ThisNetwork => "this-network",
+            Self::Broadcast => "broadcast",
+            Self::Multicast => "multicast",
+            Self::Documentation => "documentation",
+            Self::Benchmarking => "benchmarking",
+            Self::ProtocolAssignment => "protocol-assignment",
+            Self::Reserved => "reserved",
+            Self::UniqueLocal => "unique-local",
+            Self::SiteLocal => "site-local",
+            Self::Embedded { .. } => "embedded",
+        }
+    }
+}
+
+impl fmt::Display for IpClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Embedded { via, inner } => write!(f, "{inner} via {}", via.name()),
+            other => f.write_str(other.name()),
+        }
+    }
+}
+
+impl Embedding {
+    /// A stable kebab-case name, as used in the conformance vectors.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::V4Mapped => "v4-mapped",
+            Self::V4Compatible => "v4-compatible",
+            Self::Nat64 => "nat64",
+            Self::Nat64LocalUse => "nat64-local-use",
+            Self::SixToFour => "6to4",
+            Self::Teredo => "teredo",
+        }
+    }
+}
+
+/// Classify an address. Pure; no I/O.
+pub fn classify(ip: IpAddr) -> IpClass {
+    match ip {
+        IpAddr::V4(addr) => classify_v4(addr),
+        IpAddr::V6(addr) => classify_v6(addr),
+    }
+}
+
+/// Whether an egress may connect to `ip` under a policy with no exceptions.
+/// Equivalent to `classify(ip).is_globally_routable()`.
+pub fn is_globally_routable(ip: IpAddr) -> bool {
+    classify(ip).is_globally_routable()
+}
+
+fn classify_v4(addr: Ipv4Addr) -> IpClass {
+    match addr.octets() {
+        [0, ..] => IpClass::ThisNetwork,
+        [10, ..] => IpClass::Private,
+        [100, second, ..] if (64..128).contains(&second) => IpClass::SharedCgnat,
+        [127, ..] => IpClass::Loopback,
+        [169, 254, ..] => IpClass::LinkLocal,
+        [172, second, ..] if (16..32).contains(&second) => IpClass::Private,
+        [192, 0, 0, _] => IpClass::ProtocolAssignment,
+        [192, 0, 2, _] => IpClass::Documentation,
+        [192, 168, ..] => IpClass::Private,
+        [198, 18 | 19, ..] => IpClass::Benchmarking,
+        [198, 51, 100, _] => IpClass::Documentation,
+        [203, 0, 113, _] => IpClass::Documentation,
+        [224..=239, ..] => IpClass::Multicast,
+        [255, 255, 255, 255] => IpClass::Broadcast,
+        [240..=255, ..] => IpClass::Reserved,
+        _ => IpClass::Global,
+    }
+}
+
+fn classify_v6(addr: Ipv6Addr) -> IpClass {
+    if addr.is_unspecified() {
+        return IpClass::ThisNetwork;
+    }
+    if addr.is_loopback() {
+        return IpClass::Loopback;
+    }
+    if let Some((via, v4)) = embedded_v4(addr) {
+        return IpClass::Embedded {
+            via,
+            inner: Box::new(classify_v4(v4)),
+        };
+    }
+    let s = addr.segments();
+    match s {
+        // Local-use NAT64 outside the /96 form. Its gateway may embed the
+        // IPv4 address at another RFC 6052 offset, so there is no single
+        // destination to classify.
+        [0x64, 0xff9b, 1, ..] => IpClass::Reserved,
+        [0x100, 0, 0, 0, ..] => IpClass::Reserved,
+        [0x2001, second, ..] if second < 0x200 => classify_2001_23(s),
+        [0x2001, 0xdb8, ..] => IpClass::Documentation,
+        [0x3fff, second, ..] if second < 0x1000 => IpClass::Documentation,
+        [0x5f00, ..] => IpClass::Reserved,
+        [first, ..] if first & 0xfe00 == 0xfc00 => IpClass::UniqueLocal,
+        [first, ..] if first & 0xffc0 == 0xfe80 => IpClass::LinkLocal,
+        [first, ..] if first & 0xffc0 == 0xfec0 => IpClass::SiteLocal,
+        [first, ..] if first & 0xff00 == 0xff00 => IpClass::Multicast,
+        _ => IpClass::Global,
+    }
+}
+
+/// `2001::/23` (IANA IPv6 special-purpose registry). Teredo is handled by
+/// [`embedded_v4`] before this is reached.
+fn classify_2001_23(s: [u16; 8]) -> IpClass {
+    let globally_reachable = match s[1] {
+        // 2001:1::1, ::2 and ::3 (PCP, TURN and DNS-SD SRP anycast)
+        1 => s[2..7] == [0; 5] && (1..=3).contains(&s[7]),
+        // 2001:3::/32 AMT
+        3 => true,
+        // 2001:4:112::/48 AS112-v6
+        4 => s[2] == 0x112,
+        // 2001:20::/28 ORCHIDv2, 2001:30::/28 DRIP DETs
+        second => matches!(second & 0xfff0, 0x20 | 0x30),
+    };
+    if globally_reachable {
+        IpClass::Global
+    } else if s[1] == 2 && s[2] == 0 {
+        IpClass::Benchmarking
+    } else {
+        IpClass::ProtocolAssignment
+    }
+}
+
+/// The IPv4 destination an IPv6 address carries, if it is one of the
+/// [`Embedding`] forms.
+pub(crate) fn embedded_v4(addr: Ipv6Addr) -> Option<(Embedding, Ipv4Addr)> {
+    let s = addr.segments();
+    let o = addr.octets();
+    let low32 = Ipv4Addr::new(o[12], o[13], o[14], o[15]);
+    match s {
+        [0, 0, 0, 0, 0, 0xffff, ..] => Some((Embedding::V4Mapped, low32)),
+        [0, 0, 0, 0, 0, 0, ..] if !addr.is_unspecified() && !addr.is_loopback() => {
+            Some((Embedding::V4Compatible, low32))
+        }
+        [0x64, 0xff9b, 0, 0, 0, 0, ..] => Some((Embedding::Nat64, low32)),
+        [0x64, 0xff9b, 1, 0, 0, 0, ..] => Some((Embedding::Nat64LocalUse, low32)),
+        [0x2002, high, low, ..] => Some((
+            Embedding::SixToFour,
+            Ipv4Addr::from((u32::from(high) << 16) | u32::from(low)),
+        )),
+        [0x2001, 0, ..] => Some((Embedding::Teredo, Ipv4Addr::from(!u32::from(low32)))),
+        _ => None,
+    }
+}

--- a/crates/core/affinidi-net-guard/src/client.rs
+++ b/crates/core/affinidi-net-guard/src/client.rs
@@ -1,0 +1,267 @@
+//! [`GuardedClientBuilder`] and [`GuardedClient`]: both halves of the guard
+//! on one `reqwest` client.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::dns::Resolve;
+use reqwest::{Method, Request, RequestBuilder, Response};
+
+use crate::redirect::{RedirectMode, redirect_policy};
+use crate::resolver::GuardedResolver;
+use crate::{EgressError, EgressPolicy, VettedUrl};
+
+/// Default whole-request timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default connect timeout.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default cap for [`GuardedClient::read_body_capped`]: 1 MiB.
+pub const DEFAULT_MAX_BODY: usize = 1 << 20;
+
+#[cfg(test)]
+pub(crate) type ResolverWrap = Box<dyn FnOnce(Arc<dyn Resolve>) -> Arc<dyn Resolve> + Send>;
+
+/// Builds a [`GuardedClient`].
+///
+/// The guard settings are applied last in [`build`](Self::build), so nothing
+/// set here can undo them: the [`GuardedResolver`], the redirect policy,
+/// finite timeouts, no proxy (neither the environment's nor any other), no
+/// `Referer` on redirects, and `https_only` unless the policy has dev
+/// loopback.
+pub struct GuardedClientBuilder {
+    policy: EgressPolicy,
+    builder: reqwest::ClientBuilder,
+    timeout: Duration,
+    connect_timeout: Duration,
+    redirects: RedirectMode,
+    max_body: usize,
+    inner_resolver: Option<Arc<dyn Resolve>>,
+    #[cfg(test)]
+    wrap_resolver: Option<ResolverWrap>,
+}
+
+impl fmt::Debug for GuardedClientBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GuardedClientBuilder")
+            .field("policy", &self.policy)
+            .field("timeout", &self.timeout)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("redirects", &self.redirects)
+            .field("max_body", &self.max_body)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GuardedClientBuilder {
+    /// Start a client for `policy`, with [`DEFAULT_TIMEOUT`],
+    /// [`DEFAULT_CONNECT_TIMEOUT`], [`RedirectMode::None`] and
+    /// [`DEFAULT_MAX_BODY`].
+    pub fn new(policy: EgressPolicy) -> Self {
+        Self {
+            policy,
+            builder: reqwest::Client::builder(),
+            timeout: DEFAULT_TIMEOUT,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            redirects: RedirectMode::None,
+            max_body: DEFAULT_MAX_BODY,
+            inner_resolver: None,
+            #[cfg(test)]
+            wrap_resolver: None,
+        }
+    }
+
+    /// Whole-request timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Connect timeout.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// How redirects are treated.
+    pub fn redirects(mut self, mode: RedirectMode) -> Self {
+        self.redirects = mode;
+        self
+    }
+
+    /// Cap for [`GuardedClient::read_body_capped`].
+    pub fn max_body(mut self, bytes: usize) -> Self {
+        self.max_body = bytes;
+        self
+    }
+
+    /// `User-Agent` header. An invalid value fails [`build`](Self::build).
+    pub fn user_agent(mut self, value: impl Into<String>) -> Self {
+        self.builder = self.builder.user_agent(value.into());
+        self
+    }
+
+    /// How long an idle pooled connection may be reused.
+    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.builder = self.builder.pool_idle_timeout(timeout);
+        self
+    }
+
+    /// A preconfigured TLS configuration, passed to
+    /// `reqwest::ClientBuilder::tls_backend_preconfigured` (for example a
+    /// `rustls::ClientConfig` with the platform verifier). TLS settings
+    /// cannot change where a connection goes.
+    pub fn tls_preconfigured(mut self, tls: impl Any) -> Self {
+        self.builder = self.builder.tls_backend_preconfigured(tls);
+        self
+    }
+
+    /// Look names up with `resolver` instead of the system resolver. Its
+    /// answers are still vetted.
+    pub fn inner_resolver(mut self, resolver: Arc<dyn Resolve>) -> Self {
+        self.inner_resolver = Some(resolver);
+        self
+    }
+
+    /// Wraps the guarded resolver: lets this crate's tests map a vetted
+    /// public address onto a local listener.
+    #[cfg(test)]
+    pub(crate) fn wrap_resolver(mut self, wrap: ResolverWrap) -> Self {
+        self.wrap_resolver = Some(wrap);
+        self
+    }
+
+    /// Build the client.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::Transport`] if `reqwest` cannot build it.
+    pub fn build(self) -> Result<GuardedClient, EgressError> {
+        let mut resolver = GuardedResolver::new(self.policy.clone());
+        if let Some(inner) = self.inner_resolver {
+            resolver = resolver.with_inner(inner);
+        }
+        let resolver: Arc<dyn Resolve> = Arc::new(resolver);
+        #[cfg(test)]
+        let resolver = match self.wrap_resolver {
+            Some(wrap) => wrap(resolver),
+            None => resolver,
+        };
+        let inner = self
+            .builder
+            .dns_resolver(resolver)
+            .redirect(redirect_policy(self.policy.clone(), self.redirects))
+            .timeout(self.timeout)
+            .connect_timeout(self.connect_timeout)
+            .https_only(!self.policy.is_dev_loopback())
+            .referer(false)
+            .no_proxy()
+            .build()?;
+        Ok(GuardedClient {
+            inner,
+            policy: self.policy,
+            max_body: self.max_body,
+        })
+    }
+}
+
+/// A `reqwest` client that runs both halves of the guard.
+///
+/// Requests take a [`VettedUrl`] and re-vet it under this client's policy,
+/// so a URL vetted under a looser policy cannot slip through. Cloning is
+/// cheap.
+#[derive(Debug, Clone)]
+pub struct GuardedClient {
+    inner: reqwest::Client,
+    policy: EgressPolicy,
+    max_body: usize,
+}
+
+impl GuardedClient {
+    /// The policy this client enforces.
+    pub fn policy(&self) -> &EgressPolicy {
+        &self.policy
+    }
+
+    /// The cap [`read_body_capped`](Self::read_body_capped) applies.
+    pub fn max_body(&self) -> usize {
+        self.max_body
+    }
+
+    /// Start a `GET`.
+    ///
+    /// # Errors
+    ///
+    /// A refusal if `url` does not pass this client's policy.
+    pub fn get(&self, url: &VettedUrl) -> Result<RequestBuilder, EgressError> {
+        self.request(Method::GET, url)
+    }
+
+    /// Start a `POST`.
+    ///
+    /// # Errors
+    ///
+    /// A refusal if `url` does not pass this client's policy.
+    pub fn post(&self, url: &VettedUrl) -> Result<RequestBuilder, EgressError> {
+        self.request(Method::POST, url)
+    }
+
+    /// Start a request with any method.
+    ///
+    /// # Errors
+    ///
+    /// A refusal if `url` does not pass this client's policy.
+    pub fn request(&self, method: Method, url: &VettedUrl) -> Result<RequestBuilder, EgressError> {
+        let vetted = self.policy.vet_url(url.as_url())?;
+        Ok(self.inner.request(method, vetted.into_url()))
+    }
+
+    /// Send a request built elsewhere (for libraries that produce their own
+    /// request, such as a Web Push encoder). The request's URL is vetted
+    /// under this client's policy and must be on `url`'s origin.
+    ///
+    /// # Errors
+    ///
+    /// A refusal, [`EgressError::CrossOrigin`], or
+    /// [`EgressError::Transport`].
+    pub async fn execute(
+        &self,
+        url: &VettedUrl,
+        request: Request,
+    ) -> Result<Response, EgressError> {
+        let target = self.policy.vet_url(request.url())?;
+        if target.as_url().origin() != url.as_url().origin() {
+            return Err(EgressError::CrossOrigin(
+                target.as_url().origin().ascii_serialization(),
+            ));
+        }
+        Ok(self.inner.execute(request).await?)
+    }
+
+    /// Read a response body, refusing more than [`max_body`](Self::max_body)
+    /// bytes whether or not the server declared a `Content-Length`.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::BodyTooLarge`] or [`EgressError::Transport`].
+    pub async fn read_body_capped(&self, mut response: Response) -> Result<Vec<u8>, EgressError> {
+        let max = self.max_body;
+        if response
+            .content_length()
+            .is_some_and(|declared| declared > max as u64)
+        {
+            return Err(EgressError::BodyTooLarge { max });
+        }
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await? {
+            if body.len() + chunk.len() > max {
+                return Err(EgressError::BodyTooLarge { max });
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(body)
+    }
+}

--- a/crates/core/affinidi-net-guard/src/error.rs
+++ b/crates/core/affinidi-net-guard/src/error.rs
@@ -1,0 +1,140 @@
+//! [`EgressError`] and [`blocked_in_chain`].
+
+use std::net::IpAddr;
+
+use crate::IpClass;
+
+/// Why an egress was refused, or failed.
+///
+/// [`EgressError::is_refusal`] separates a policy refusal from a malformed URL
+/// or a transport failure. A refusal raised inside `reqwest` (by the resolver
+/// or the redirect policy) arrives wrapped in a `reqwest::Error`; recover it
+/// with [`blocked_in_chain`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EgressError {
+    /// The input is not a valid URL, or has no host.
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+
+    /// A policy was configured with a value it cannot use (a malformed CIDR
+    /// or allow-list rule).
+    #[error("invalid egress policy configuration: {0}")]
+    InvalidConfig(String),
+
+    /// The scheme is not admitted. Also raised for an https-to-http redirect
+    /// downgrade.
+    #[error("scheme not allowed: {0}")]
+    SchemeNotAllowed(String),
+
+    /// The URL carries a username or password.
+    #[error("URLs carrying userinfo are not allowed")]
+    UserinfoNotAllowed,
+
+    /// The port is not admitted.
+    #[error("port not allowed: {0}")]
+    PortNotAllowed(u16),
+
+    /// The host is not on the operator allow-list.
+    #[error("host is not on the allow-list: {0}")]
+    HostNotAllowed(String),
+
+    /// A URL left the origin it was required to stay on.
+    #[error("cross-origin URL not allowed: {0}")]
+    CrossOrigin(String),
+
+    /// The host is a special-use name (`localhost`, `*.local`, a single
+    /// label, ...).
+    #[error("special-use host name not allowed: {0}")]
+    BlockedName(String),
+
+    /// The host is, or resolves to, an address the policy refuses.
+    #[error("blocked address {addr} ({class}) for host {host}")]
+    BlockedAddress {
+        /// The host as written, or the name that was resolved.
+        host: String,
+        /// The refused address.
+        addr: IpAddr,
+        /// Its classification.
+        class: IpClass,
+    },
+
+    /// A name resolved to no addresses at all.
+    #[error("{0} resolved to no addresses")]
+    NoAddresses(String),
+
+    /// A redirect hop was refused.
+    #[error("redirect to {to} refused: {reason}")]
+    RedirectBlocked {
+        /// The `Location` the server redirected to.
+        to: String,
+        /// Why the hop was refused.
+        #[source]
+        reason: Box<EgressError>,
+    },
+
+    /// The redirect chain exceeded its hop cap.
+    #[error("more than {max} redirects")]
+    TooManyRedirects {
+        /// The cap that was exceeded.
+        max: u8,
+    },
+
+    /// The response body exceeded the client's cap.
+    #[error("response body exceeded the {max}-byte cap")]
+    BodyTooLarge {
+        /// The cap that was exceeded.
+        max: usize,
+    },
+
+    /// The HTTP client failed to build or the request failed in transport.
+    /// A refusal may still be inside; see [`blocked_in_chain`].
+    #[error("HTTP transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+}
+
+impl EgressError {
+    /// `true` when the policy refused the egress, as opposed to the URL being
+    /// malformed, a name not resolving, or the transport failing.
+    pub fn is_refusal(&self) -> bool {
+        matches!(
+            self,
+            Self::SchemeNotAllowed(_)
+                | Self::UserinfoNotAllowed
+                | Self::PortNotAllowed(_)
+                | Self::HostNotAllowed(_)
+                | Self::CrossOrigin(_)
+                | Self::BlockedName(_)
+                | Self::BlockedAddress { .. }
+                | Self::RedirectBlocked { .. }
+                | Self::TooManyRedirects { .. }
+        )
+    }
+}
+
+/// Find the outermost policy refusal anywhere in an error's source chain.
+///
+/// Use it on a `reqwest::Error` from a guarded client to tell "refused by the
+/// guard" apart from "unreachable":
+///
+/// ```no_run
+/// # async fn run(client: affinidi_net_guard::GuardedClient, url: affinidi_net_guard::VettedUrl) {
+/// match client.get(&url).unwrap().send().await {
+///     Err(e) if affinidi_net_guard::blocked_in_chain(&e).is_some() => { /* refused */ }
+///     Err(_) => { /* transport failure */ }
+///     Ok(_) => {}
+/// }
+/// # }
+/// ```
+pub fn blocked_in_chain<'a>(err: &'a (dyn std::error::Error + 'static)) -> Option<&'a EgressError> {
+    let mut next = Some(err);
+    while let Some(current) = next {
+        if let Some(egress) = current.downcast_ref::<EgressError>()
+            && egress.is_refusal()
+        {
+            return Some(egress);
+        }
+        next = current.source();
+    }
+    None
+}

--- a/crates/core/affinidi-net-guard/src/lib.rs
+++ b/crates/core/affinidi-net-guard/src/lib.rs
@@ -1,0 +1,122 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+/*!
+# affinidi-net-guard
+
+An egress guard for URLs an attacker can influence: a `did:web` host, a DID
+document's service endpoint, a push-subscription endpoint, a redirect
+`Location`. Any of them can aim a server-side request at loopback, a private
+network or a cloud-metadata address (SSRF).
+
+This crate is deliberately a leaf: it depends on `reqwest`, `tokio`, `url`,
+`thiserror` and `tracing`, and on no `affinidi-*` crate, so DID-method crates
+and other clients can use it without creating a dependency cycle.
+
+# Both halves are required
+
+A URL is only safe to fetch when **both** checks run.
+
+1. **Vet the URL** with [`EgressPolicy::vet`]. It checks the scheme, userinfo,
+   port, operator allow-list, special-use names (`localhost`, `*.local`,
+   single-label names, ...) and **IP literals**. Nothing else ever sees a
+   literal: `reqwest` (through `hyper-util`) skips any custom DNS resolver when
+   the host is already an IP address, so `https://169.254.169.254/` never
+   reaches the resolver.
+2. **Vet what a name resolves to** with [`GuardedResolver`]. It catches
+   `evil.example` with an A record of `169.254.169.254`, fails the whole name
+   if *any* answer is blocked, and hands the connector only the addresses it
+   checked, so there is no second lookup to rebind.
+
+[`GuardedClient`] runs both. Its request methods take a [`VettedUrl`] and
+re-vet it under the client's own policy, and its resolver is a
+[`GuardedResolver`].
+
+# Proxies bypass the DNS half
+
+Through an HTTP(S) proxy, the *proxy* resolves the target name, so the
+resolver never sees it and only the literal half still applies. `reqwest`
+honours `HTTP_PROXY`/`HTTPS_PROXY` by default. [`GuardedClientBuilder`] turns
+that off and offers no way to set a proxy. A deployment that must egress
+through a proxy needs the proxy itself to enforce the policy.
+
+# Quick start
+
+```no_run
+use affinidi_net_guard::{EgressPolicy, GuardedClientBuilder};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let policy = EgressPolicy::public_internet();
+let client = GuardedClientBuilder::new(policy.clone()).build()?;
+
+let url = policy.vet("https://example.com/.well-known/did.json")?;
+let response = client.get(&url)?.send().await?;
+let body = client.read_body_capped(response).await?;
+# let _ = body;
+# Ok(()) }
+```
+
+# What `public_internet()` refuses
+
+* Every address that [`classify`] does not report as globally routable:
+  loopback, RFC 1918, link-local (cloud metadata), CGNAT, `0.0.0.0/8`,
+  broadcast, multicast, documentation, benchmarking, protocol assignments,
+  reserved, unique-local and site-local; and the IPv4-mapped,
+  IPv4-compatible, NAT64, 6to4 and Teredo spellings of any of those.
+* Special-use names: `localhost`, `*.localhost`, `*.local`, `*.internal`,
+  `*.home.arpa` and single-label names, with or without a trailing dot.
+* Schemes other than `https` and `wss`, and URLs with userinfo.
+* Redirects: a [`GuardedClient`] defaults to [`RedirectMode::None`].
+
+# Narrowing, and the two ways to widen
+
+[`EgressPolicy::with_allow_list`], [`EgressPolicy::with_schemes`] and
+[`EgressPolicy::with_ports`] only narrow. Two things widen a policy:
+
+* [`EgressPolicy::allow_cidrs`] re-admits explicit private ranges for internal
+  deployments. It never re-admits loopback, link-local, unspecified,
+  multicast or broadcast addresses.
+* [`EgressPolicy::with_dev_loopback`] admits loopback hosts, and plain
+  `http`/`ws` to them. It takes a [`DevLoopback`] token that can only be
+  constructed with the `dev-loopback` feature, so a release build without the
+  feature cannot opt in.
+
+# Platforms
+
+On `wasm32` only classification and URL vetting are available; the resolver,
+redirect policy and client need a native `reqwest`.
+
+# Conformance
+
+`conformance/egress-vectors.v1.json` in this crate is the shared vector file
+the Rust, TypeScript and Swift guards all run. This crate's own runner executes
+every section it has the capabilities for.
+*/
+
+mod cidr;
+mod classify;
+mod error;
+mod policy;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod client;
+#[cfg(not(target_arch = "wasm32"))]
+mod redirect;
+#[cfg(not(target_arch = "wasm32"))]
+mod resolver;
+
+#[cfg(test)]
+mod tests;
+
+pub use cidr::Cidr;
+pub use classify::{Embedding, IpClass, classify, is_globally_routable};
+pub use error::{EgressError, blocked_in_chain};
+pub use policy::{AllowList, DevLoopback, EgressPolicy, HostRule, PortPolicy, Scheme, VettedUrl};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use client::{
+    DEFAULT_CONNECT_TIMEOUT, DEFAULT_MAX_BODY, DEFAULT_TIMEOUT, GuardedClient, GuardedClientBuilder,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use redirect::{RedirectMode, redirect_policy};
+#[cfg(not(target_arch = "wasm32"))]
+pub use resolver::{GuardedResolver, guarded_dns_resolver};

--- a/crates/core/affinidi-net-guard/src/policy.rs
+++ b/crates/core/affinidi-net-guard/src/policy.rs
@@ -1,0 +1,558 @@
+//! [`EgressPolicy`]: what an egress may reach, and the URL-vetting half of
+//! the guard.
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Once};
+
+use url::{Host, Url};
+
+use crate::classify::{IpClass, classify, embedded_v4};
+use crate::{Cidr, EgressError};
+
+/// A URL scheme an [`EgressPolicy`] can admit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Scheme {
+    /// `https`.
+    Https,
+    /// `wss`.
+    Wss,
+    /// `http`. Only ever admitted for a loopback host under [`DevLoopback`].
+    Http,
+    /// `ws`. Only ever admitted for a loopback host under [`DevLoopback`].
+    Ws,
+}
+
+impl Scheme {
+    /// The scheme as it appears in a URL.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Https => "https",
+            Self::Wss => "wss",
+            Self::Http => "http",
+            Self::Ws => "ws",
+        }
+    }
+
+    /// `true` for `https` and `wss`.
+    pub fn is_secure(self) -> bool {
+        matches!(self, Self::Https | Self::Wss)
+    }
+
+    fn from_url_scheme(scheme: &str) -> Option<Self> {
+        match scheme {
+            "https" => Some(Self::Https),
+            "wss" => Some(Self::Wss),
+            "http" => Some(Self::Http),
+            "ws" => Some(Self::Ws),
+            _ => None,
+        }
+    }
+
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Https => 1,
+            Self::Wss => 2,
+            Self::Http => 4,
+            Self::Ws => 8,
+        }
+    }
+}
+
+const ALL_SCHEMES: u8 = 0b1111;
+
+/// Which ports an [`EgressPolicy`] admits, checked against the URL's port or
+/// the scheme's default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PortPolicy {
+    /// Any port. The default, because a `did:web` host may name its port.
+    Any,
+    /// Only these ports.
+    Only(Vec<u16>),
+}
+
+/// One entry of an operator [`AllowList`].
+///
+/// Hosts are compared in canonical form: lowercase, IDNA (punycode), no
+/// trailing root dot, IPv6 in brackets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HostRule {
+    /// Exactly this host.
+    Exact(String),
+    /// Any host strictly below this domain: `.push.apple.com` (or
+    /// `push.apple.com`) matches `api.push.apple.com` but not `push.apple.com`.
+    Suffix(String),
+    /// Exactly this scheme, host and port.
+    Origin {
+        /// Scheme.
+        scheme: Scheme,
+        /// Host.
+        host: String,
+        /// Port.
+        port: u16,
+    },
+}
+
+/// An operator allow-list. See [`EgressPolicy::with_allow_list`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllowList {
+    rules: Vec<Rule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Rule {
+    Exact(String),
+    Suffix(String),
+    Origin(Scheme, String, u16),
+}
+
+impl AllowList {
+    /// Normalise `rules` into an allow-list.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::InvalidConfig`] if the list is empty or a rule's host
+    /// is not a valid host name or IP literal.
+    pub fn new(rules: impl IntoIterator<Item = HostRule>) -> Result<Self, EgressError> {
+        let rules = rules
+            .into_iter()
+            .map(|rule| match rule {
+                HostRule::Exact(host) => canonical_rule_host(&host).map(Rule::Exact),
+                HostRule::Suffix(domain) => canonical_rule_host(domain.trim_start_matches('.'))
+                    .map(|domain| Rule::Suffix(format!(".{domain}"))),
+                HostRule::Origin { scheme, host, port } => {
+                    canonical_rule_host(&host).map(|host| Rule::Origin(scheme, host, port))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if rules.is_empty() {
+            return Err(EgressError::InvalidConfig(
+                "an allow-list needs at least one rule".into(),
+            ));
+        }
+        Ok(Self { rules })
+    }
+
+    fn matches(&self, scheme: Scheme, host: &str, port: u16) -> bool {
+        self.rules.iter().any(|rule| match rule {
+            Rule::Exact(exact) => exact == host,
+            Rule::Suffix(suffix) => host.len() > suffix.len() && host.ends_with(suffix.as_str()),
+            Rule::Origin(rule_scheme, rule_host, rule_port) => {
+                *rule_scheme == scheme && rule_host == host && *rule_port == port
+            }
+        })
+    }
+}
+
+fn canonical_rule_host(raw: &str) -> Result<String, EgressError> {
+    let invalid =
+        || EgressError::InvalidConfig(format!("allow-list host {raw:?} is not a valid host"));
+    let trimmed = raw.trim().trim_end_matches('.');
+    if trimmed.is_empty() {
+        return Err(invalid());
+    }
+    Host::parse(trimmed)
+        .map(|host| host.to_string())
+        .map_err(|_| invalid())
+}
+
+/// The acknowledgement that turns on loopback access; see
+/// [`EgressPolicy::with_dev_loopback`].
+///
+/// It can only be constructed when the crate is compiled with the
+/// `dev-loopback` feature (or for this crate's own tests), so a release binary
+/// built without that feature cannot opt in, whatever its configuration says.
+///
+#[cfg_attr(not(feature = "dev-loopback"), doc = "```compile_fail")]
+#[cfg_attr(feature = "dev-loopback", doc = "```")]
+/// // Only compiles with `--features dev-loopback`.
+/// let token = affinidi_net_guard::DevLoopback::acknowledge_ssrf_protection_disabled_for_loopback();
+/// let policy = affinidi_net_guard::EgressPolicy::public_internet().with_dev_loopback(token);
+/// ```
+#[derive(Debug)]
+pub struct DevLoopback(());
+
+#[cfg(any(test, feature = "dev-loopback"))]
+impl DevLoopback {
+    /// Acknowledge that the policy this is passed to will reach loopback
+    /// hosts. For development and test builds only.
+    pub fn acknowledge_ssrf_protection_disabled_for_loopback() -> Self {
+        Self(())
+    }
+}
+
+/// What an egress may reach.
+///
+/// Start from [`EgressPolicy::public_internet`]. [`with_allow_list`],
+/// [`with_schemes`] and [`with_ports`] only ever narrow it. Two things widen
+/// it, each deliberately: [`allow_cidrs`] re-admits named private ranges, and
+/// [`with_dev_loopback`] admits loopback hosts in development builds.
+///
+/// Cloning is cheap.
+///
+/// [`with_allow_list`]: EgressPolicy::with_allow_list
+/// [`with_schemes`]: EgressPolicy::with_schemes
+/// [`with_ports`]: EgressPolicy::with_ports
+/// [`allow_cidrs`]: EgressPolicy::allow_cidrs
+/// [`with_dev_loopback`]: EgressPolicy::with_dev_loopback
+#[derive(Debug, Clone)]
+pub struct EgressPolicy {
+    inner: Arc<PolicyInner>,
+}
+
+#[derive(Debug, Clone)]
+struct PolicyInner {
+    schemes: u8,
+    ports: Option<Vec<u16>>,
+    allow_lists: Vec<AllowList>,
+    allow_cidrs: Vec<Cidr>,
+    dev_loopback: bool,
+}
+
+impl EgressPolicy {
+    /// `https` and `wss` only; globally routable addresses only; no
+    /// special-use names (`localhost`, `*.localhost`, `*.local`,
+    /// `*.internal`, `*.home.arpa`, single-label names, each with or without
+    /// a trailing dot); no userinfo; any port.
+    pub fn public_internet() -> Self {
+        Self {
+            inner: Arc::new(PolicyInner {
+                schemes: ALL_SCHEMES,
+                ports: None,
+                allow_lists: Vec::new(),
+                allow_cidrs: Vec::new(),
+                dev_loopback: false,
+            }),
+        }
+    }
+
+    /// Admit only hosts that match `list`. Applying a second list requires a
+    /// host to match both.
+    ///
+    /// An allow-list never re-admits a blocked address class. It is, however,
+    /// the way to name an internal host that the special-use name rule would
+    /// refuse (`metadata`, `*.svc.cluster.local`); that host's resolved
+    /// addresses are still checked. `localhost` needs [`DevLoopback`].
+    pub fn with_allow_list(mut self, list: AllowList) -> Self {
+        Arc::make_mut(&mut self.inner).allow_lists.push(list);
+        self
+    }
+
+    /// Keep only the schemes in `schemes`.
+    pub fn with_schemes(mut self, schemes: &[Scheme]) -> Self {
+        let mask = schemes.iter().fold(0, |mask, scheme| mask | scheme.bit());
+        Arc::make_mut(&mut self.inner).schemes &= mask;
+        self
+    }
+
+    /// Keep only the ports `ports` admits.
+    pub fn with_ports(mut self, ports: PortPolicy) -> Self {
+        if let PortPolicy::Only(only) = ports {
+            let inner = Arc::make_mut(&mut self.inner);
+            inner.ports = Some(match inner.ports.take() {
+                None => only,
+                Some(current) => current
+                    .into_iter()
+                    .filter(|port| only.contains(port))
+                    .collect(),
+            });
+        }
+        self
+    }
+
+    /// Admit addresses in these ranges, for internal deployments
+    /// (`10.20.0.0/16`), one explicit range at a time.
+    ///
+    /// A range never re-admits loopback, link-local (cloud metadata),
+    /// unspecified, multicast or broadcast addresses, even if it covers them:
+    /// `0.0.0.0/0` admits private space but not `169.254.169.254`. An IPv4
+    /// range also covers that address's embedded IPv6 forms.
+    pub fn allow_cidrs(mut self, cidrs: impl IntoIterator<Item = Cidr>) -> Self {
+        Arc::make_mut(&mut self.inner).allow_cidrs.extend(cidrs);
+        self
+    }
+
+    /// Admit loopback hosts, and plain `http`/`ws` to them: the literals
+    /// `127.0.0.0/8` and `::1`, and the names `localhost` and `*.localhost`.
+    ///
+    /// Only those hosts. A name that is not a localhost name still may not
+    /// resolve to loopback, so DNS rebinding stays closed in development too,
+    /// and embedded forms such as `::ffff:127.0.0.1` stay blocked. Logs a
+    /// warning once per process.
+    pub fn with_dev_loopback(mut self, acknowledged: DevLoopback) -> Self {
+        let DevLoopback(()) = acknowledged;
+        static WARNED: Once = Once::new();
+        WARNED.call_once(|| {
+            tracing::warn!(
+                "egress guard: dev loopback is enabled, so loopback hosts (and plain http/ws to \
+                 them) are reachable from this process; never build a release with the \
+                 `dev-loopback` feature"
+            );
+        });
+        Arc::make_mut(&mut self.inner).dev_loopback = true;
+        self
+    }
+
+    /// Whether [`EgressPolicy::with_dev_loopback`] was applied.
+    pub fn is_dev_loopback(&self) -> bool {
+        self.inner.dev_loopback
+    }
+
+    /// Parse and vet a URL.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::InvalidUrl`] if `raw` does not parse, otherwise as
+    /// [`EgressPolicy::vet_url`].
+    pub fn vet(&self, raw: &str) -> Result<VettedUrl, EgressError> {
+        let url = Url::parse(raw).map_err(|e| EgressError::InvalidUrl(e.to_string()))?;
+        self.vet_url(&url)
+    }
+
+    /// Vet a parsed URL: scheme, userinfo, literal address class, special-use
+    /// names, allow-list and port.
+    ///
+    /// This is the half of the guard that sees IP literals. The other half,
+    /// what a name resolves to, runs at connect time in
+    /// [`GuardedResolver`](crate::GuardedResolver).
+    ///
+    /// # Errors
+    ///
+    /// A refusal ([`EgressError::is_refusal`]), or
+    /// [`EgressError::InvalidUrl`] for a URL with no host.
+    pub fn vet_url(&self, url: &Url) -> Result<VettedUrl, EgressError> {
+        let policy = &*self.inner;
+        let scheme = Scheme::from_url_scheme(url.scheme())
+            .filter(|scheme| policy.schemes & scheme.bit() != 0)
+            .filter(|scheme| scheme.is_secure() || policy.dev_loopback)
+            .ok_or_else(|| EgressError::SchemeNotAllowed(url.scheme().to_owned()))?;
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(EgressError::UserinfoNotAllowed);
+        }
+        let host = url
+            .host_str()
+            .map(|host| host.trim_end_matches('.'))
+            .filter(|host| !host.is_empty())
+            .ok_or_else(|| EgressError::InvalidUrl("URL has no host".into()))?
+            .to_owned();
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| EgressError::InvalidUrl("URL has no port".into()))?;
+        let loopback_host = match url.host() {
+            Some(Host::Ipv4(addr)) => {
+                self.admit_address(&host, IpAddr::V4(addr), true)?;
+                addr.is_loopback()
+            }
+            Some(Host::Ipv6(addr)) => {
+                self.admit_address(&host, IpAddr::V6(addr), true)?;
+                addr.is_loopback()
+            }
+            Some(Host::Domain(_)) => {
+                self.admit_name(scheme, &host, port)?;
+                is_localhost_name(&host)
+            }
+            None => return Err(EgressError::InvalidUrl("URL has no host".into())),
+        };
+        if !scheme.is_secure() && !loopback_host {
+            return Err(EgressError::SchemeNotAllowed(url.scheme().to_owned()));
+        }
+        if !policy
+            .allow_lists
+            .iter()
+            .all(|list| list.matches(scheme, &host, port))
+        {
+            return Err(EgressError::HostNotAllowed(host));
+        }
+        if let Some(ports) = &policy.ports
+            && !ports.contains(&port)
+        {
+            return Err(EgressError::PortNotAllowed(port));
+        }
+        Ok(VettedUrl {
+            url: url.clone(),
+            host,
+            policy: self.clone(),
+        })
+    }
+
+    /// The connect-time check: every address `host` resolved to must be
+    /// admitted, and there must be at least one.
+    pub(crate) fn check_resolved(
+        &self,
+        host: &str,
+        addrs: &[SocketAddr],
+    ) -> Result<(), EgressError> {
+        let host = host.trim_end_matches('.').to_ascii_lowercase();
+        if addrs.is_empty() {
+            return Err(EgressError::NoAddresses(host));
+        }
+        let localhost = is_localhost_name(&host);
+        addrs
+            .iter()
+            .try_for_each(|addr| self.admit_address(&host, addr.ip(), localhost))
+    }
+
+    /// `loopback_host`: the host names loopback itself (a literal, or a
+    /// localhost name), which is the only case dev loopback admits.
+    fn admit_address(
+        &self,
+        host: &str,
+        addr: IpAddr,
+        loopback_host: bool,
+    ) -> Result<(), EgressError> {
+        let class = classify(addr);
+        if class.is_globally_routable() {
+            return Ok(());
+        }
+        let policy = &*self.inner;
+        if policy.dev_loopback && loopback_host && class == IpClass::Loopback {
+            return Ok(());
+        }
+        if readmittable(&class)
+            && policy
+                .allow_cidrs
+                .iter()
+                .any(|cidr| cidr_covers(cidr, addr))
+        {
+            return Ok(());
+        }
+        Err(EgressError::BlockedAddress {
+            host: host.to_owned(),
+            addr,
+            class,
+        })
+    }
+
+    fn admit_name(&self, scheme: Scheme, host: &str, port: u16) -> Result<(), EgressError> {
+        let policy = &*self.inner;
+        let admitted = match special_use(host) {
+            None => true,
+            Some(SpecialUse::Localhost) => policy.dev_loopback,
+            Some(SpecialUse::Other) => {
+                !policy.allow_lists.is_empty()
+                    && policy
+                        .allow_lists
+                        .iter()
+                        .all(|list| list.matches(scheme, host, port))
+            }
+        };
+        if admitted {
+            Ok(())
+        } else {
+            Err(EgressError::BlockedName(host.to_owned()))
+        }
+    }
+}
+
+fn readmittable(class: &IpClass) -> bool {
+    match class {
+        IpClass::Loopback
+        | IpClass::ThisNetwork
+        | IpClass::LinkLocal
+        | IpClass::Broadcast
+        | IpClass::Multicast => false,
+        IpClass::Embedded { inner, .. } => readmittable(inner),
+        _ => true,
+    }
+}
+
+fn cidr_covers(cidr: &Cidr, addr: IpAddr) -> bool {
+    if cidr.contains(addr) {
+        return true;
+    }
+    match addr {
+        IpAddr::V6(v6) => embedded_v4(v6).is_some_and(|(_, v4)| cidr.contains(IpAddr::V4(v4))),
+        IpAddr::V4(_) => false,
+    }
+}
+
+enum SpecialUse {
+    Localhost,
+    Other,
+}
+
+fn special_use(host: &str) -> Option<SpecialUse> {
+    if is_localhost_name(host) {
+        return Some(SpecialUse::Localhost);
+    }
+    let single_label = !host.contains('.');
+    let reserved = ["local", "internal", "home.arpa"]
+        .iter()
+        .any(|domain| is_at_or_below(host, domain));
+    (single_label || reserved).then_some(SpecialUse::Other)
+}
+
+fn is_localhost_name(host: &str) -> bool {
+    is_at_or_below(host, "localhost")
+}
+
+fn is_at_or_below(host: &str, domain: &str) -> bool {
+    host.strip_suffix(domain)
+        .is_some_and(|rest| rest.is_empty() || rest.ends_with('.'))
+}
+
+/// A URL that passed [`EgressPolicy::vet`]: scheme, userinfo, literal address
+/// class, special-use names, allow-list and port.
+///
+/// It can only be built by vetting, and it keeps the policy that vetted it.
+/// What a name resolves to is checked later, at connect time.
+#[derive(Debug, Clone)]
+pub struct VettedUrl {
+    url: Url,
+    host: String,
+    policy: EgressPolicy,
+}
+
+impl VettedUrl {
+    /// The vetted URL.
+    pub fn as_url(&self) -> &Url {
+        &self.url
+    }
+
+    /// The vetted URL, by value.
+    pub fn into_url(self) -> Url {
+        self.url
+    }
+
+    /// The canonical host: lowercase, IDNA, no trailing root dot, IPv6 in
+    /// brackets. Show this to an operator rather than the raw input:
+    /// `https://2130706433/` shows as `127.0.0.1`.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// The policy that vetted this URL.
+    pub fn policy(&self) -> &EgressPolicy {
+        &self.policy
+    }
+
+    /// Resolve `reference` against this URL and vet the result under the same
+    /// policy, refusing anything that leaves this URL's origin.
+    ///
+    /// # Errors
+    ///
+    /// [`EgressError::CrossOrigin`] if the result has a different scheme,
+    /// host or port (including a `//host` reference), otherwise as
+    /// [`EgressPolicy::vet_url`].
+    pub fn join_same_origin(&self, reference: &str) -> Result<VettedUrl, EgressError> {
+        let joined = self
+            .url
+            .join(reference)
+            .map_err(|e| EgressError::InvalidUrl(e.to_string()))?;
+        if joined.origin() != self.url.origin() {
+            return Err(EgressError::CrossOrigin(
+                joined.origin().ascii_serialization(),
+            ));
+        }
+        self.policy.vet_url(&joined)
+    }
+}
+
+impl fmt::Display for VettedUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.url.fmt(f)
+    }
+}

--- a/crates/core/affinidi-net-guard/src/redirect.rs
+++ b/crates/core/affinidi-net-guard/src/redirect.rs
@@ -1,0 +1,92 @@
+//! Redirect handling: refuse by default, or re-vet every hop.
+
+use reqwest::redirect::{Attempt, Policy};
+use url::Url;
+
+use crate::{EgressError, EgressPolicy};
+
+/// How a guarded client treats an HTTP redirect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum RedirectMode {
+    /// Do not follow. The 3xx response is returned to the caller. The default.
+    #[default]
+    None,
+    /// Follow up to `max` redirects that keep the original request's scheme,
+    /// host and port. Each hop is also re-vetted.
+    SameOrigin {
+        /// Most redirects followed.
+        max: u8,
+    },
+    /// Follow up to `max` redirects, re-vetting every hop against the policy
+    /// and refusing any `https`/`wss` to `http`/`ws` downgrade.
+    ReVet {
+        /// Most redirects followed.
+        max: u8,
+    },
+}
+
+/// A `reqwest` redirect policy that enforces `mode` under `policy`.
+///
+/// Only the URL half re-runs here. The DNS half re-applies by itself, because
+/// the next hop's host goes through the same client's [`GuardedResolver`](crate::GuardedResolver);
+/// install this on a client that has one.
+pub fn redirect_policy(policy: EgressPolicy, mode: RedirectMode) -> Policy {
+    match mode {
+        RedirectMode::None => Policy::none(),
+        RedirectMode::SameOrigin { .. } | RedirectMode::ReVet { .. } => {
+            Policy::custom(move |attempt: Attempt| {
+                match check_redirect(&policy, mode, attempt.url(), attempt.previous()) {
+                    Ok(()) => attempt.follow(),
+                    Err(refusal) => attempt.error(refusal),
+                }
+            })
+        }
+    }
+}
+
+/// `previous` is every URL already requested in the chain, starting with the
+/// original request, as `reqwest` reports it.
+pub(crate) fn check_redirect(
+    policy: &EgressPolicy,
+    mode: RedirectMode,
+    next: &Url,
+    previous: &[Url],
+) -> Result<(), EgressError> {
+    let (max, same_origin) = match mode {
+        RedirectMode::None => return Err(EgressError::TooManyRedirects { max: 0 }),
+        RedirectMode::SameOrigin { max } => (max, true),
+        RedirectMode::ReVet { max } => (max, false),
+    };
+    // The first entry is the original request, not a redirect.
+    if previous.len() > usize::from(max) {
+        return Err(EgressError::TooManyRedirects { max });
+    }
+    let refuse = |reason: EgressError| EgressError::RedirectBlocked {
+        to: next.to_string(),
+        reason: Box::new(reason),
+    };
+    if let Some(last) = previous.last()
+        && is_secure(last)
+        && !is_secure(next)
+    {
+        return Err(refuse(EgressError::SchemeNotAllowed(format!(
+            "{} to {} downgrade",
+            last.scheme(),
+            next.scheme()
+        ))));
+    }
+    if same_origin
+        && let Some(first) = previous.first()
+        && first.origin() != next.origin()
+    {
+        return Err(refuse(EgressError::CrossOrigin(
+            next.origin().ascii_serialization(),
+        )));
+    }
+    policy.vet_url(next).map(drop).map_err(refuse)
+}
+
+fn is_secure(url: &Url) -> bool {
+    matches!(url.scheme(), "https" | "wss")
+}

--- a/crates/core/affinidi-net-guard/src/resolver.rs
+++ b/crates/core/affinidi-net-guard/src/resolver.rs
@@ -1,0 +1,80 @@
+//! The connect-time half of the guard: a DNS resolver that vets every answer.
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+use crate::EgressPolicy;
+
+/// A [`reqwest::dns::Resolve`] that refuses to hand back an address its policy
+/// blocks.
+///
+/// It resolves with the system resolver (or an `inner` resolver), fails the
+/// whole name if **any** answer is blocked, and returns only the addresses it
+/// checked. The connection is therefore made to exactly what was vetted: there
+/// is no second lookup, and no window for DNS rebinding.
+///
+/// This is only half the guard. `reqwest` never consults a resolver when the
+/// URL's host is an IP literal, and a proxy resolves names itself; vet URLs
+/// with [`EgressPolicy::vet`] and build clients with
+/// [`GuardedClientBuilder`](crate::GuardedClientBuilder), which does both.
+#[derive(Clone)]
+pub struct GuardedResolver {
+    policy: EgressPolicy,
+    inner: Option<Arc<dyn Resolve>>,
+}
+
+impl fmt::Debug for GuardedResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GuardedResolver")
+            .field("policy", &self.policy)
+            .field("inner", &self.inner.as_ref().map(|_| "custom"))
+            .finish()
+    }
+}
+
+impl GuardedResolver {
+    /// A resolver that looks names up with the system resolver.
+    pub fn new(policy: EgressPolicy) -> Self {
+        Self {
+            policy,
+            inner: None,
+        }
+    }
+
+    /// Look names up with `inner` instead (hickory, DNS-over-HTTPS, a test
+    /// stub). Its answers are vetted exactly like the system resolver's.
+    pub fn with_inner(mut self, inner: Arc<dyn Resolve>) -> Self {
+        self.inner = Some(inner);
+        self
+    }
+}
+
+impl Resolve for GuardedResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let policy = self.policy.clone();
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let host = name.as_str().to_owned();
+            let addrs: Vec<SocketAddr> = match inner {
+                Some(inner) => inner.resolve(name).await?.collect(),
+                // Port 0: reqwest substitutes the URL's port, or the scheme's
+                // default, for it.
+                None => tokio::net::lookup_host((host.as_str(), 0)).await?.collect(),
+            };
+            policy.check_resolved(&host, &addrs)?;
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// A [`GuardedResolver`] over the system resolver, ready for
+/// `reqwest::ClientBuilder::dns_resolver`.
+///
+/// Installing it on your own client is not enough on its own; see
+/// [`GuardedResolver`].
+pub fn guarded_dns_resolver(policy: EgressPolicy) -> Arc<dyn Resolve> {
+    Arc::new(GuardedResolver::new(policy))
+}

--- a/crates/core/affinidi-net-guard/src/tests/conformance.rs
+++ b/crates/core/affinidi-net-guard/src/tests/conformance.rs
@@ -1,0 +1,677 @@
+//! Runs `conformance/egress-vectors.v1.json` against this crate.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::dns::{Name, Resolve};
+use serde_json::{Map, Value};
+use url::Url;
+
+use super::harness::{self, Counter, Network, Route, StubResolver};
+use crate::{
+    AllowList, Cidr, DevLoopback, EgressError, EgressPolicy, GuardedClient, GuardedClientBuilder,
+    GuardedResolver, HostRule, IpClass, PortPolicy, RedirectMode, Scheme, blocked_in_chain,
+    classify, is_globally_routable,
+};
+
+const VECTORS: &str = include_str!("../../conformance/egress-vectors.v1.json");
+
+const SECTIONS: &[&str] = &[
+    "ip",
+    "url",
+    "names",
+    "scheme",
+    "webvh",
+    "mediatorDoc",
+    "dns",
+    "rebinding",
+    "redirect",
+];
+
+/// Capabilities this runner implements.
+const SUPPORTED: &[&str] = &["classify", "vet", "dns", "pinning", "redirect-inspect"];
+
+/// Capabilities this runner does not implement, and why. A capability in
+/// neither list fails the run.
+const NOT_SUPPORTED: &[(&str, &str)] = &[
+    (
+        "webvh-url",
+        "did:webvh URL derivation belongs to didwebvh-rs, whose runner executes this section",
+    ),
+    (
+        "mediator-doc",
+        "DID-document endpoint extraction belongs to the consuming SDK, not the guard",
+    ),
+    (
+        "dns-online",
+        "this runner is hermetic; the online DNS job is optional",
+    ),
+];
+
+const POLICY_FIELDS: &[&str] = &["devLoopback", "allowList", "allowCidrs", "ports", "schemes"];
+
+#[derive(Default)]
+struct Tally {
+    passed: usize,
+    skipped: Vec<(String, usize, &'static str)>,
+}
+
+impl Tally {
+    fn skip(&mut self, what: String, count: usize, reason: &'static str) {
+        self.skipped.push((what, count, reason));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn egress_vectors_v1() {
+    let document: Value = serde_json::from_str(VECTORS).expect("vector file is JSON");
+    assert_eq!(document["version"], 1, "this runner implements version 1");
+    let declared = document["capabilities"]
+        .as_object()
+        .expect("a capabilities object");
+    let sections = document["sections"].as_object().expect("a sections object");
+    for expected in SECTIONS {
+        assert!(
+            sections.contains_key(*expected),
+            "section `{expected}` is missing from the vector file"
+        );
+    }
+
+    let mut tally = Tally::default();
+    for (name, section) in sections {
+        assert!(
+            SECTIONS.contains(&name.as_str()),
+            "unknown section `{name}`: a runner must fail rather than ignore it"
+        );
+        let vectors = section["vectors"]
+            .as_array()
+            .unwrap_or_else(|| panic!("section `{name}` has no vectors"));
+        let context = format!("section `{name}`");
+        if let Some(reason) = missing_capability(declared, section.get("requires"), &context) {
+            tally.skip(name.clone(), vectors.len(), reason);
+            continue;
+        }
+        match name.as_str() {
+            "ip" => run_ip(vectors, &mut tally),
+            "url" | "names" | "scheme" => run_vet(name, vectors, declared, &mut tally),
+            "dns" => run_dns(vectors, declared, &mut tally).await,
+            "rebinding" => run_rebinding(vectors, &mut tally).await,
+            "redirect" => run_redirect(section, vectors, &mut tally).await,
+            other => panic!("section `{other}` is runnable but this runner has no arm for it"),
+        }
+    }
+
+    let skipped: usize = tally.skipped.iter().map(|(_, count, _)| count).sum();
+    println!(
+        "egress-vectors.v1: {} passed, {skipped} skipped",
+        tally.passed
+    );
+    for (what, count, reason) in &tally.skipped {
+        println!("  skipped {count} in {what}: {reason}");
+    }
+    assert!(tally.passed > 0, "no vectors ran");
+}
+
+fn missing_capability(
+    declared: &Map<String, Value>,
+    requires: Option<&Value>,
+    context: &str,
+) -> Option<&'static str> {
+    for capability in requires.and_then(Value::as_array).into_iter().flatten() {
+        let capability = capability.as_str().expect("capability names are strings");
+        assert!(
+            declared.contains_key(capability),
+            "{context} requires `{capability}`, which the file does not declare"
+        );
+        if SUPPORTED.contains(&capability) {
+            continue;
+        }
+        let reason = NOT_SUPPORTED
+            .iter()
+            .find(|(name, _)| *name == capability)
+            .map(|(_, reason)| *reason)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{context} requires `{capability}`, which this runner neither supports nor \
+                     declares a reason to skip"
+                )
+            });
+        return Some(reason);
+    }
+    None
+}
+
+fn text<'a>(value: &'a Value, key: &str) -> &'a str {
+    value[key]
+        .as_str()
+        .unwrap_or_else(|| panic!("vector {value} needs a string `{key}`"))
+}
+
+fn ips(value: &Value) -> Vec<IpAddr> {
+    value
+        .as_array()
+        .unwrap_or_else(|| panic!("{value} is not an array of addresses"))
+        .iter()
+        .map(|ip| {
+            ip.as_str()
+                .and_then(|ip| ip.parse().ok())
+                .unwrap_or_else(|| panic!("{ip} is not an IP address"))
+        })
+        .collect()
+}
+
+fn scheme_named(name: &str) -> Scheme {
+    match name {
+        "https" => Scheme::Https,
+        "wss" => Scheme::Wss,
+        "http" => Scheme::Http,
+        "ws" => Scheme::Ws,
+        other => panic!("unknown scheme {other}"),
+    }
+}
+
+fn policy_from(spec: Option<&Value>) -> EgressPolicy {
+    let mut policy = EgressPolicy::public_internet();
+    let Some(spec) = spec else {
+        return policy;
+    };
+    for key in spec.as_object().expect("a policy object").keys() {
+        assert!(
+            POLICY_FIELDS.contains(&key.as_str()),
+            "unknown policy field `{key}`: a runner must fail rather than ignore it"
+        );
+    }
+    if spec["devLoopback"].as_bool() == Some(true) {
+        policy = policy
+            .with_dev_loopback(DevLoopback::acknowledge_ssrf_protection_disabled_for_loopback());
+    }
+    if let Some(rules) = spec["allowList"].as_array() {
+        let rules = rules.iter().map(|rule| {
+            if let Some(host) = rule["exact"].as_str() {
+                HostRule::Exact(host.to_owned())
+            } else if let Some(domain) = rule["suffix"].as_str() {
+                HostRule::Suffix(domain.to_owned())
+            } else if let Some(origin) = rule["origin"].as_str() {
+                let origin = Url::parse(origin).expect("origin rule is a URL");
+                HostRule::Origin {
+                    scheme: scheme_named(origin.scheme()),
+                    host: origin.host_str().expect("origin host").to_owned(),
+                    port: origin.port_or_known_default().expect("origin port"),
+                }
+            } else {
+                panic!("unknown allow-list rule {rule}")
+            }
+        });
+        policy = policy.with_allow_list(AllowList::new(rules).expect("valid allow-list"));
+    }
+    if let Some(cidrs) = spec["allowCidrs"].as_array() {
+        policy =
+            policy.allow_cidrs(cidrs.iter().map(|cidr| {
+                Cidr::from_str(cidr.as_str().expect("CIDR string")).expect("valid CIDR")
+            }));
+    }
+    if let Some(ports) = spec["ports"].as_array() {
+        policy = policy.with_ports(PortPolicy::Only(
+            ports
+                .iter()
+                .map(|port| {
+                    port.as_u64()
+                        .and_then(|port| u16::try_from(port).ok())
+                        .expect("port number")
+                })
+                .collect(),
+        ));
+    }
+    if let Some(schemes) = spec["schemes"].as_array() {
+        let schemes: Vec<Scheme> = schemes
+            .iter()
+            .map(|scheme| scheme_named(scheme.as_str().expect("scheme string")))
+            .collect();
+        policy = policy.with_schemes(&schemes);
+    }
+    policy
+}
+
+fn mode_from(spec: Option<&Value>) -> RedirectMode {
+    let Some(spec) = spec else {
+        return RedirectMode::None;
+    };
+    let max = || {
+        spec["max"]
+            .as_u64()
+            .and_then(|max| u8::try_from(max).ok())
+            .expect("redirect max")
+    };
+    match text(spec, "type") {
+        "none" => RedirectMode::None,
+        "revet" => RedirectMode::ReVet { max: max() },
+        "same-origin" => RedirectMode::SameOrigin { max: max() },
+        other => panic!("unknown redirect mode {other}"),
+    }
+}
+
+fn reason_of(error: &EgressError) -> &'static str {
+    match error {
+        EgressError::RedirectBlocked { reason, .. } => reason_of(reason),
+        EgressError::SchemeNotAllowed(_) => "scheme",
+        EgressError::UserinfoNotAllowed => "userinfo",
+        EgressError::BlockedAddress { .. } => "address",
+        EgressError::BlockedName(_) => "name",
+        EgressError::HostNotAllowed(_) => "not-allowed",
+        EgressError::CrossOrigin(_) => "cross-origin",
+        EgressError::PortNotAllowed(_) => "port",
+        EgressError::TooManyRedirects { .. } => "too-many-redirects",
+        _ => "other",
+    }
+}
+
+fn run_ip(vectors: &[Value], tally: &mut Tally) {
+    for vector in vectors {
+        let input = text(vector, "input");
+        let ip: IpAddr = input
+            .parse()
+            .unwrap_or_else(|e| panic!("ip vector {input}: {e}"));
+        let class = classify(ip);
+        let allow = match text(vector, "expect") {
+            "allow" => true,
+            "block" => false,
+            other => panic!("ip {input}: unknown expectation {other}"),
+        };
+        assert_eq!(
+            is_globally_routable(ip),
+            allow,
+            "ip {input} classified {class}"
+        );
+        assert_eq!(class.name(), text(vector, "class"), "ip {input}");
+        if let IpClass::Embedded { via, inner } = &class {
+            assert_eq!(via.name(), text(vector, "via"), "ip {input}");
+            assert_eq!(inner.name(), text(vector, "inner"), "ip {input}");
+        }
+        tally.passed += 1;
+    }
+}
+
+fn run_vet(section: &str, vectors: &[Value], declared: &Map<String, Value>, tally: &mut Tally) {
+    for vector in vectors {
+        let input = text(vector, "input");
+        let context = format!(
+            "{section} {input} (policy {})",
+            vector
+                .get("policy")
+                .map_or_else(|| "default".to_owned(), Value::to_string)
+        );
+        if let Some(reason) = missing_capability(declared, vector.get("requires"), &context) {
+            tally.skip(context, 1, reason);
+            continue;
+        }
+        let result = policy_from(vector.get("policy")).vet(input);
+        match text(vector, "expect") {
+            "allow" => {
+                let vetted =
+                    result.unwrap_or_else(|e| panic!("{context}: expected allow, got {e}"));
+                if let Some(host) = vector["host"].as_str() {
+                    assert_eq!(vetted.as_url().host_str(), Some(host), "{context}");
+                }
+            }
+            "block" => {
+                let error = match result {
+                    Ok(vetted) => panic!("{context}: expected block, vetted {vetted}"),
+                    Err(error) => error,
+                };
+                assert!(
+                    error.is_refusal(),
+                    "{context}: expected a refusal, got {error}"
+                );
+                if let Some(reason) = vector["reason"].as_str() {
+                    assert_eq!(reason_of(&error), reason, "{context}: {error}");
+                }
+                if let Some(host) = vector["host"].as_str() {
+                    let parsed = Url::parse(input).expect("a blocked vector parses");
+                    assert_eq!(parsed.host_str(), Some(host), "{context}: canonical host");
+                }
+            }
+            "invalid" => assert!(
+                matches!(result, Err(EgressError::InvalidUrl(_))),
+                "{context}: expected invalid, got {result:?}"
+            ),
+            other => panic!("{context}: unknown expectation {other}"),
+        }
+        tally.passed += 1;
+    }
+}
+
+async fn run_dns(vectors: &[Value], declared: &Map<String, Value>, tally: &mut Tally) {
+    for vector in vectors {
+        let name = text(vector, "name");
+        let context = format!("dns {name} (policy {:?})", vector.get("policy"));
+        if let Some(reason) = missing_capability(declared, vector.get("requires"), &context) {
+            tally.skip(context, 1, reason);
+            continue;
+        }
+        let answers = ips(&vector["answers"]);
+        let stub = StubResolver::new(HashMap::from([(name.to_owned(), vec![answers.clone()])]), 0);
+        let resolver = GuardedResolver::new(policy_from(vector.get("policy"))).with_inner(stub);
+        let lookup = Name::from_str(name).unwrap_or_else(|_| panic!("{context}: invalid name"));
+        let result = resolver.resolve(lookup).await;
+        match text(vector, "expect") {
+            "allow" => {
+                let resolved: Vec<IpAddr> = result
+                    .unwrap_or_else(|e| panic!("{context}: expected allow, got {e}"))
+                    .map(|addr| addr.ip())
+                    .collect();
+                assert_eq!(
+                    resolved, answers,
+                    "{context}: must return exactly the vetted answers"
+                );
+            }
+            "block" => {
+                let Err(error) = result else {
+                    panic!("{context}: expected block, resolved");
+                };
+                assert!(
+                    matches!(
+                        blocked_in_chain(error.as_ref()),
+                        Some(EgressError::BlockedAddress { .. })
+                    ),
+                    "{context}: expected BlockedAddress, got {error}"
+                );
+            }
+            "error" => {
+                let Err(error) = result else {
+                    panic!("{context}: expected an error, resolved");
+                };
+                assert!(
+                    blocked_in_chain(error.as_ref()).is_none(),
+                    "{context}: {error}"
+                );
+                assert!(
+                    matches!(
+                        error.downcast_ref::<EgressError>(),
+                        Some(EgressError::NoAddresses(_))
+                    ),
+                    "{context}: expected NoAddresses, got {error}"
+                );
+            }
+            other => panic!("{context}: unknown expectation {other}"),
+        }
+        tally.passed += 1;
+    }
+}
+
+#[derive(Debug)]
+enum Outcome {
+    Allow,
+    NotFollowed,
+    Block(&'static str),
+    Failed(String),
+}
+
+impl std::fmt::Display for Outcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Block(reason) => write!(f, "block ({reason})"),
+            Self::Failed(detail) => write!(f, "failed: {detail}"),
+            other => f.write_str(other.label()),
+        }
+    }
+}
+
+impl Outcome {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::NotFollowed => "not-followed",
+            Self::Block(_) => "block",
+            Self::Failed(_) => "failed",
+        }
+    }
+}
+
+async fn outcome_of(result: Result<reqwest::Response, reqwest::Error>) -> Outcome {
+    match result {
+        Ok(response) if response.status().is_success() => {
+            let _ = response.bytes().await;
+            Outcome::Allow
+        }
+        Ok(response) if response.status().is_redirection() => Outcome::NotFollowed,
+        Ok(response) => Outcome::Failed(format!("status {}", response.status())),
+        Err(error) => match blocked_in_chain(&error) {
+            Some(refusal) => Outcome::Block(reason_of(refusal)),
+            None => Outcome::Failed(format!("{error:?}")),
+        },
+    }
+}
+
+fn live_client(
+    policy: EgressPolicy,
+    mode: RedirectMode,
+    stub: Arc<StubResolver>,
+    network: Network,
+    tls: rustls::ClientConfig,
+) -> GuardedClient {
+    GuardedClientBuilder::new(policy)
+        .redirects(mode)
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
+        .inner_resolver(stub)
+        .tls_preconfigured(tls)
+        .wrap_resolver(Box::new(move |guarded| network.around(guarded)))
+        .build()
+        .expect("guarded client builds")
+}
+
+/// Lets a connection that should not have happened reach its listener's
+/// accept loop before the counters are read.
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+async fn run_rebinding(vectors: &[Value], tally: &mut Tally) {
+    for vector in vectors {
+        let id = text(vector, "id");
+        let name = text(vector, "name");
+        let lookups: Vec<Vec<IpAddr>> = vector["lookups"]
+            .as_array()
+            .expect("lookups")
+            .iter()
+            .map(ips)
+            .collect();
+        let tls = harness::tls_for(&[name.to_owned()]);
+        let routes = Arc::new(HashMap::from([(
+            "/".to_owned(),
+            Route {
+                status: 200,
+                location: None,
+            },
+        )]));
+        let (sink_port, sink) = harness::spawn_sink().await;
+        let mut listeners = HashMap::new();
+        let mut public = Vec::new();
+        for ip in lookups
+            .iter()
+            .flatten()
+            .copied()
+            .filter(|ip| is_globally_routable(*ip))
+        {
+            if let std::collections::hash_map::Entry::Vacant(slot) = listeners.entry(ip) {
+                let (port, counter) =
+                    harness::spawn_tls_listener(tls.server.clone(), routes.clone()).await;
+                slot.insert(port);
+                public.push(counter);
+            }
+        }
+        let stub = StubResolver::new(HashMap::from([(name.to_owned(), lookups)]), sink_port);
+        let network = Network::new(listeners);
+        let policy = policy_from(vector.get("policy"));
+        let client = live_client(
+            policy.clone(),
+            RedirectMode::None,
+            stub.clone(),
+            network.clone(),
+            tls.client.clone(),
+        );
+        let url = policy
+            .vet(&format!("https://{name}/"))
+            .unwrap_or_else(|e| panic!("{id}: {e}"));
+
+        let requests = vector["requests"].as_array().expect("requests");
+        let mut allowed = 0;
+        for (index, request) in requests.iter().enumerate() {
+            let outcome = outcome_of(client.get(&url).expect("re-vets").send().await).await;
+            assert_eq!(
+                outcome.label(),
+                text(request, "expect"),
+                "{id} request {index}: {outcome}"
+            );
+            if matches!(outcome, Outcome::Allow) {
+                allowed += 1;
+            }
+        }
+        settle().await;
+
+        let assertions = &vector["assert"];
+        if assertions["lookupsPerConnection"].as_u64() == Some(1) {
+            assert_eq!(
+                stub.lookups(name),
+                requests.len(),
+                "{id}: every new connection resolves exactly once, and never twice"
+            );
+        }
+        if let Some(expected) = assertions["blockedTargetConnections"].as_u64() {
+            assert_eq!(
+                sink.get() as u64,
+                expected,
+                "{id}: the rebound target was reached"
+            );
+        }
+        if assertions["connectTargetIsVetted"].as_bool() == Some(true) {
+            let connections: usize = public.iter().map(Counter::get).sum();
+            assert_eq!(
+                connections, allowed,
+                "{id}: connections to the vetted address"
+            );
+            let vetted = network.vetted();
+            assert_eq!(
+                vetted.len(),
+                allowed,
+                "{id}: only vetted answers reach the connector"
+            );
+            assert!(
+                vetted.iter().all(|ip| is_globally_routable(*ip)),
+                "{id}: the connector was handed {vetted:?}"
+            );
+        }
+        tally.passed += 1;
+    }
+}
+
+fn routes_from(vector: &Value, sink_port: u16) -> HashMap<String, Route> {
+    if let Some(hops) = vector["chain"].as_u64() {
+        let mut routes: HashMap<String, Route> = (0..hops)
+            .map(|hop| {
+                let next = hop + 1;
+                (
+                    format!("/hop/{hop}"),
+                    Route {
+                        status: 302,
+                        location: Some(format!("/hop/{next}")),
+                    },
+                )
+            })
+            .collect();
+        routes.insert(
+            format!("/hop/{hops}"),
+            Route {
+                status: 200,
+                location: None,
+            },
+        );
+        return routes;
+    }
+    vector["routes"]
+        .as_object()
+        .expect("routes or chain")
+        .iter()
+        .map(|(path, route)| {
+            let status = route["status"]
+                .as_u64()
+                .and_then(|status| u16::try_from(status).ok())
+                .expect("status");
+            let location = route["location"]
+                .as_str()
+                .map(|location| location.replace("{sink}", &sink_port.to_string()));
+            (path.clone(), Route { status, location })
+        })
+        .collect()
+}
+
+async fn run_redirect(section: &Value, vectors: &[Value], tally: &mut Tally) {
+    let zone: HashMap<String, Vec<Vec<IpAddr>>> = section["zone"]
+        .as_object()
+        .expect("a zone")
+        .iter()
+        .map(|(name, answers)| (name.clone(), vec![ips(answers)]))
+        .collect();
+    let names: Vec<String> = zone.keys().cloned().collect();
+    let tls = harness::tls_for(&names);
+
+    for vector in vectors {
+        let id = text(vector, "id");
+        let (sink_port, sink) = harness::spawn_sink().await;
+        let routes = Arc::new(routes_from(vector, sink_port));
+        let mut listeners = HashMap::new();
+        let mut counters: HashMap<&str, Counter> = HashMap::new();
+        for (name, lookups) in &zone {
+            for ip in lookups
+                .iter()
+                .flatten()
+                .copied()
+                .filter(|ip| is_globally_routable(*ip))
+            {
+                let (port, counter) =
+                    harness::spawn_tls_listener(tls.server.clone(), routes.clone()).await;
+                listeners.insert(ip, port);
+                counters.insert(name.as_str(), counter);
+            }
+        }
+        let stub = StubResolver::new(zone.clone(), sink_port);
+        let policy = policy_from(vector.get("policy"));
+        let client = live_client(
+            policy.clone(),
+            mode_from(vector.get("mode")),
+            stub,
+            Network::new(listeners),
+            tls.client.clone(),
+        );
+        let start = policy
+            .vet(text(vector, "start"))
+            .unwrap_or_else(|e| panic!("{id}: start URL refused: {e}"));
+
+        let outcome = outcome_of(client.get(&start).expect("re-vets").send().await).await;
+        settle().await;
+
+        assert_eq!(outcome.label(), text(vector, "expect"), "{id}: {outcome}");
+        if let Some(reason) = vector["reason"].as_str() {
+            assert!(
+                matches!(outcome, Outcome::Block(actual) if actual == reason),
+                "{id}: expected reason {reason}, got {outcome}"
+            );
+        }
+        for target in vector["zeroConnections"].as_array().into_iter().flatten() {
+            let target = target.as_str().expect("listener name");
+            let count = if target == "sink" {
+                sink.get()
+            } else {
+                counters
+                    .get(target)
+                    .unwrap_or_else(|| panic!("{id}: {target} is not a public zone name"))
+                    .get()
+            };
+            assert_eq!(count, 0, "{id}: {target} received {count} connection(s)");
+        }
+        tally.passed += 1;
+    }
+}

--- a/crates/core/affinidi-net-guard/src/tests/harness.rs
+++ b/crates/core/affinidi-net-guard/src/tests/harness.rs
@@ -1,0 +1,270 @@
+//! A hermetic network for the live conformance sections: TLS listeners that
+//! play public addresses, a sink that plays an internal service, a stub DNS
+//! zone, and a post-vetting map from public addresses to those listeners.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use crate::is_globally_routable;
+
+pub(crate) struct Tls {
+    pub(crate) server: Arc<rustls::ServerConfig>,
+    pub(crate) client: rustls::ClientConfig,
+}
+
+/// A self-signed certificate for `names`, with a server config presenting it
+/// and a client config trusting only it.
+pub(crate) fn tls_for(names: &[String]) -> Tls {
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let certified = rcgen::generate_simple_self_signed(names.to_vec()).expect("self-signed cert");
+    let cert = certified.cert.der().clone();
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+        certified.signing_key.serialize_der(),
+    ));
+    let server = rustls::ServerConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .expect("protocol versions")
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.clone()], key)
+        .expect("server cert");
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(cert).expect("root");
+    let client = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .expect("protocol versions")
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Tls {
+        server: Arc::new(server),
+        client,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Route {
+    pub(crate) status: u16,
+    pub(crate) location: Option<String>,
+}
+
+/// Counts accepted TCP connections.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Counter(Arc<AtomicUsize>);
+
+impl Counter {
+    fn hit(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn get(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// An HTTPS listener on `127.0.0.1` that serves `routes`, one request per
+/// connection, and counts connections.
+pub(crate) async fn spawn_tls_listener(
+    tls: Arc<rustls::ServerConfig>,
+    routes: Arc<HashMap<String, Route>>,
+) -> (u16, Counter) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("local addr").port();
+    let counter = Counter::default();
+    let accepted = counter.clone();
+    let acceptor = tokio_rustls::TlsAcceptor::from(tls);
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            accepted.hit();
+            let acceptor = acceptor.clone();
+            let routes = routes.clone();
+            tokio::spawn(async move {
+                let Ok(mut stream) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let Some(path) = read_request_path(&mut stream).await else {
+                    return;
+                };
+                let route = routes.get(&path).cloned().unwrap_or(Route {
+                    status: 404,
+                    location: None,
+                });
+                let location = route
+                    .location
+                    .map(|location| format!("Location: {location}\r\n"))
+                    .unwrap_or_default();
+                let response = format!(
+                    "HTTP/1.1 {} Test\r\n{location}Content-Length: 2\r\nConnection: close\r\n\r\nok",
+                    route.status
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+    (port, counter)
+}
+
+async fn read_request_path<S: AsyncRead + Unpin>(stream: &mut S) -> Option<String> {
+    let mut head = Vec::new();
+    let mut chunk = [0u8; 1024];
+    while !head.windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = stream.read(&mut chunk).await.ok()?;
+        if read == 0 || head.len() > 16 * 1024 {
+            return None;
+        }
+        head.extend_from_slice(&chunk[..read]);
+    }
+    let head = String::from_utf8_lossy(&head);
+    head.lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)
+        .map(str::to_owned)
+}
+
+/// A plain TCP listener standing in for an internal service. It listens on
+/// `127.0.0.1` and, where the host has it, on `::1` at the same port.
+pub(crate) async fn spawn_sink() -> (u16, Counter) {
+    let v4 = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind");
+    let port = v4.local_addr().expect("local addr").port();
+    let counter = Counter::default();
+    spawn_counting(v4, counter.clone());
+    if let Ok(v6) = TcpListener::bind((Ipv6Addr::LOCALHOST, port)).await {
+        spawn_counting(v6, counter.clone());
+    }
+    (port, counter)
+}
+
+fn spawn_counting(listener: TcpListener, counter: Counter) {
+    tokio::spawn(async move {
+        while let Ok((_stream, _)) = listener.accept().await {
+            counter.hit();
+        }
+    });
+}
+
+/// A fixed DNS zone. The nth lookup of a name returns its nth answer set (the
+/// last one repeats). A non-routable answer carries the sink's port, so a
+/// guard that let it through would be caught connecting there.
+#[derive(Debug)]
+pub(crate) struct StubResolver {
+    zone: HashMap<String, Vec<Vec<IpAddr>>>,
+    sink_port: u16,
+    lookups: Mutex<HashMap<String, usize>>,
+}
+
+impl StubResolver {
+    pub(crate) fn new(zone: HashMap<String, Vec<Vec<IpAddr>>>, sink_port: u16) -> Arc<Self> {
+        Arc::new(Self {
+            zone,
+            sink_port,
+            lookups: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub(crate) fn lookups(&self, name: &str) -> usize {
+        self.lookups
+            .lock()
+            .expect("lookups lock")
+            .get(name)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+impl Resolve for StubResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_owned();
+        let answers = {
+            let mut lookups = self.lookups.lock().expect("lookups lock");
+            let count = lookups.entry(host.clone()).or_default();
+            let answers = self
+                .zone
+                .get(&host)
+                .and_then(|sets| sets.get(*count).or_else(|| sets.last()))
+                .cloned();
+            *count += 1;
+            answers
+        };
+        let sink_port = self.sink_port;
+        Box::pin(async move {
+            let answers = answers.ok_or_else(|| format!("stub zone has no entry for {host}"))?;
+            let addrs: Vec<SocketAddr> = answers
+                .into_iter()
+                .map(|ip| {
+                    let port = if is_globally_routable(ip) {
+                        0
+                    } else {
+                        sink_port
+                    };
+                    SocketAddr::new(ip, port)
+                })
+                .collect();
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// Stands in for the internet: sends each public address the guard vetted to
+/// the local listener playing that address, and records what it was handed.
+#[derive(Debug, Clone)]
+pub(crate) struct Network {
+    listeners: Arc<HashMap<IpAddr, u16>>,
+    vetted: Arc<Mutex<Vec<IpAddr>>>,
+}
+
+impl Network {
+    pub(crate) fn new(listeners: HashMap<IpAddr, u16>) -> Self {
+        Self {
+            listeners: Arc::new(listeners),
+            vetted: Arc::default(),
+        }
+    }
+
+    /// Every address the guarded resolver returned, in order.
+    pub(crate) fn vetted(&self) -> Vec<IpAddr> {
+        self.vetted.lock().expect("vetted lock").clone()
+    }
+
+    pub(crate) fn around(self, guarded: Arc<dyn Resolve>) -> Arc<dyn Resolve> {
+        Arc::new(Routed {
+            guarded,
+            network: self,
+        })
+    }
+}
+
+struct Routed {
+    guarded: Arc<dyn Resolve>,
+    network: Network,
+}
+
+impl Resolve for Routed {
+    fn resolve(&self, name: Name) -> Resolving {
+        let resolving = self.guarded.resolve(name);
+        let network = self.network.clone();
+        Box::pin(async move {
+            let addrs: Vec<SocketAddr> = resolving
+                .await?
+                .map(|addr| {
+                    network.vetted.lock().expect("vetted lock").push(addr.ip());
+                    match network.listeners.get(&addr.ip()) {
+                        Some(port) => SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), *port),
+                        None => addr,
+                    }
+                })
+                .collect();
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}

--- a/crates/core/affinidi-net-guard/src/tests/mod.rs
+++ b/crates/core/affinidi-net-guard/src/tests/mod.rs
@@ -1,0 +1,3 @@
+mod conformance;
+mod harness;
+mod unit;

--- a/crates/core/affinidi-net-guard/src/tests/unit.rs
+++ b/crates/core/affinidi-net-guard/src/tests/unit.rs
@@ -1,0 +1,278 @@
+//! Behaviour the shared vectors do not pin: composition of narrowing, client
+//! wiring, and the body cap.
+
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use url::Url;
+
+use crate::redirect::check_redirect;
+use crate::{
+    AllowList, Cidr, DevLoopback, EgressError, EgressPolicy, GuardedClientBuilder, HostRule,
+    PortPolicy, RedirectMode, Scheme, blocked_in_chain,
+};
+
+fn public() -> EgressPolicy {
+    EgressPolicy::public_internet()
+}
+
+fn dev() -> EgressPolicy {
+    public().with_dev_loopback(DevLoopback::acknowledge_ssrf_protection_disabled_for_loopback())
+}
+
+#[test]
+fn narrowing_composes_and_never_widens() {
+    let ports = public()
+        .with_ports(PortPolicy::Only(vec![443, 8443]))
+        .with_ports(PortPolicy::Only(vec![8443, 9443]))
+        .with_ports(PortPolicy::Any);
+    assert!(matches!(
+        ports.vet("https://example.com/"),
+        Err(EgressError::PortNotAllowed(443))
+    ));
+    assert!(ports.vet("https://example.com:8443/").is_ok());
+    assert!(matches!(
+        ports.vet("https://example.com:9443/"),
+        Err(EgressError::PortNotAllowed(9443))
+    ));
+
+    let schemes = public()
+        .with_schemes(&[Scheme::Https, Scheme::Wss])
+        .with_schemes(&[Scheme::Https, Scheme::Http]);
+    assert!(matches!(
+        schemes.vet("wss://example.com/"),
+        Err(EgressError::SchemeNotAllowed(_))
+    ));
+    assert!(matches!(
+        schemes.vet("http://example.com/"),
+        Err(EgressError::SchemeNotAllowed(_))
+    ));
+
+    let lists = public()
+        .with_allow_list(AllowList::new([HostRule::Suffix(".example.com".into())]).unwrap())
+        .with_allow_list(AllowList::new([HostRule::Exact("a.example.com".into())]).unwrap());
+    assert!(lists.vet("https://a.example.com/").is_ok());
+    assert!(matches!(
+        lists.vet("https://b.example.com/"),
+        Err(EgressError::HostNotAllowed(_))
+    ));
+}
+
+#[test]
+fn allow_cidrs_never_readmit_loopback_link_local_unspecified_multicast_or_broadcast() {
+    let policy =
+        public().allow_cidrs(["0.0.0.0/0", "::/0"].map(|cidr| Cidr::from_str(cidr).unwrap()));
+    for raw in [
+        "https://127.0.0.1/",
+        "https://169.254.169.254/",
+        "https://0.0.0.0/",
+        "https://224.0.0.1/",
+        "https://255.255.255.255/",
+        "https://[::1]/",
+        "https://[fe80::1]/",
+        "https://[::ffff:169.254.169.254]/",
+    ] {
+        assert!(
+            matches!(policy.vet(raw), Err(EgressError::BlockedAddress { .. })),
+            "{raw}"
+        );
+    }
+    assert!(policy.vet("https://10.1.2.3/").is_ok());
+    assert!(policy.vet("https://[fd00:ec2::254]/").is_ok());
+}
+
+#[test]
+fn allow_list_rules_are_canonicalised_and_validated() {
+    let policy =
+        public().with_allow_list(AllowList::new([HostRule::Exact("BÜCHER.de.".into())]).unwrap());
+    assert!(policy.vet("https://xn--bcher-kva.de/").is_ok());
+    assert!(matches!(
+        AllowList::new([HostRule::Exact("exa mple.com".into())]),
+        Err(EgressError::InvalidConfig(_))
+    ));
+    assert!(matches!(
+        AllowList::new(Vec::<HostRule>::new()),
+        Err(EgressError::InvalidConfig(_))
+    ));
+}
+
+#[test]
+fn cidr_parsing_masks_host_bits_and_rejects_nonsense() {
+    let cidr = Cidr::from_str("10.20.1.2/16").unwrap();
+    assert_eq!(cidr.to_string(), "10.20.0.0/16");
+    assert!(cidr.contains("10.20.255.1".parse().unwrap()));
+    assert!(!cidr.contains("10.21.0.1".parse().unwrap()));
+    assert!(!cidr.contains("::ffff:10.20.0.1".parse().unwrap()));
+    assert!(
+        Cidr::from_str("0.0.0.0/0")
+            .unwrap()
+            .contains("8.8.8.8".parse().unwrap())
+    );
+    for bad in [
+        "10.0.0.0/33",
+        "::/129",
+        "10.0.0.0",
+        "nonsense/8",
+        "10.0.0.0/-1",
+    ] {
+        assert!(Cidr::from_str(bad).is_err(), "{bad}");
+    }
+}
+
+#[test]
+fn vetted_host_is_canonical_for_display() {
+    assert_eq!(
+        public().vet("https://EXAMPLE.com./x").unwrap().host(),
+        "example.com"
+    );
+    assert_eq!(
+        dev().vet("http://2130706433:8080/").unwrap().host(),
+        "127.0.0.1"
+    );
+    assert_eq!(dev().vet("http://[0:0::1]/").unwrap().host(), "[::1]");
+}
+
+#[test]
+fn join_same_origin_refuses_to_leave_the_origin() {
+    let base = public().vet("https://example.com/users/alice/").unwrap();
+    assert_eq!(
+        base.join_same_origin("did.json").unwrap().as_url().as_str(),
+        "https://example.com/users/alice/did.json"
+    );
+    for escape in [
+        "//169.254.169.254/latest/meta-data",
+        "https://evil.example/",
+        "http://example.com/",
+        "https://example.com:8443/",
+    ] {
+        assert!(
+            matches!(
+                base.join_same_origin(escape),
+                Err(EgressError::CrossOrigin(_))
+            ),
+            "{escape}"
+        );
+    }
+}
+
+#[test]
+fn a_redirect_downgrade_is_refused_even_under_dev_loopback() {
+    let next = Url::parse("http://localhost:8080/").unwrap();
+    let from_https = [Url::parse("https://localhost:8443/").unwrap()];
+    let refusal =
+        check_redirect(&dev(), RedirectMode::ReVet { max: 10 }, &next, &from_https).unwrap_err();
+    assert!(
+        matches!(&refusal, EgressError::RedirectBlocked { reason, .. } if matches!(**reason, EgressError::SchemeNotAllowed(_))),
+        "{refusal}"
+    );
+    let from_http = [Url::parse("http://localhost:8443/").unwrap()];
+    assert!(check_redirect(&dev(), RedirectMode::ReVet { max: 10 }, &next, &from_http).is_ok());
+}
+
+#[test]
+fn the_hop_cap_counts_redirects_not_requests() {
+    let next = Url::parse("https://example.com/next").unwrap();
+    let chain = |requests: usize| -> Vec<Url> {
+        (0..requests)
+            .map(|index| Url::parse(&format!("https://example.com/{index}")).unwrap())
+            .collect()
+    };
+    let mode = RedirectMode::ReVet { max: 2 };
+    assert!(check_redirect(&public(), mode, &next, &chain(2)).is_ok());
+    assert!(matches!(
+        check_redirect(&public(), mode, &next, &chain(3)),
+        Err(EgressError::TooManyRedirects { max: 2 })
+    ));
+}
+
+#[test]
+fn blocked_in_chain_finds_refusals_and_ignores_other_errors() {
+    assert!(blocked_in_chain(&EgressError::NoAddresses("x.test".into())).is_none());
+    let nested = EgressError::RedirectBlocked {
+        to: "https://[::1]/".into(),
+        reason: Box::new(EgressError::BlockedName("localhost".into())),
+    };
+    assert!(matches!(
+        blocked_in_chain(&nested),
+        Some(EgressError::RedirectBlocked { .. })
+    ));
+}
+
+#[tokio::test]
+async fn a_client_re_vets_urls_under_its_own_policy() {
+    let vetted_elsewhere = dev().vet("https://127.0.0.1:8443/").unwrap();
+    let client = GuardedClientBuilder::new(public()).build().unwrap();
+    assert!(matches!(
+        client.get(&vetted_elsewhere),
+        Err(EgressError::BlockedAddress { .. })
+    ));
+}
+
+#[tokio::test]
+async fn execute_refuses_a_request_for_another_origin_or_a_blocked_host() {
+    let client = GuardedClientBuilder::new(public()).build().unwrap();
+    let vetted = public().vet("https://example.com/").unwrap();
+    let other = reqwest::Request::new(
+        reqwest::Method::POST,
+        Url::parse("https://example.org/").unwrap(),
+    );
+    assert!(matches!(
+        client.execute(&vetted, other).await,
+        Err(EgressError::CrossOrigin(_))
+    ));
+    let internal = reqwest::Request::new(
+        reqwest::Method::POST,
+        Url::parse("https://127.0.0.1/").unwrap(),
+    );
+    assert!(matches!(
+        client.execute(&vetted, internal).await,
+        Err(EgressError::BlockedAddress { .. })
+    ));
+}
+
+async fn serve_once(response: Vec<u8>) -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let response = response.clone();
+            tokio::spawn(async move {
+                let mut head = [0u8; 4096];
+                let _ = stream.read(&mut head).await;
+                let _ = stream.write_all(&response).await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+    port
+}
+
+#[tokio::test]
+async fn the_body_cap_holds_with_and_without_content_length() {
+    let body = vec![b'x'; 64];
+    let mut declared =
+        b"HTTP/1.1 200 OK\r\nContent-Length: 64\r\nConnection: close\r\n\r\n".to_vec();
+    declared.extend_from_slice(&body);
+    let mut chunked =
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n40\r\n"
+            .to_vec();
+    chunked.extend_from_slice(&body);
+    chunked.extend_from_slice(b"\r\n0\r\n\r\n");
+
+    let policy = dev();
+    let client = GuardedClientBuilder::new(policy.clone())
+        .max_body(16)
+        .build()
+        .unwrap();
+    for response in [declared, chunked] {
+        let port = serve_once(response).await;
+        let url = policy.vet(&format!("http://127.0.0.1:{port}/")).unwrap();
+        let response = client.get(&url).unwrap().send().await.unwrap();
+        assert!(matches!(
+            client.read_body_capped(response).await,
+            Err(EgressError::BodyTooLarge { max: 16 })
+        ));
+    }
+}

--- a/crates/core/affinidi-net-guard/tests/dev_loopback.rs
+++ b/crates/core/affinidi-net-guard/tests/dev_loopback.rs
@@ -1,0 +1,83 @@
+//! The `dev-loopback` feature, used from outside the crate the way a
+//! consumer's development build would use it. Compiles to nothing without the
+//! feature.
+#![cfg(feature = "dev-loopback")]
+
+use std::net::Ipv4Addr;
+
+use affinidi_net_guard::{DevLoopback, EgressError, EgressPolicy, GuardedClientBuilder};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn dev_policy() -> EgressPolicy {
+    EgressPolicy::public_internet()
+        .with_dev_loopback(DevLoopback::acknowledge_ssrf_protection_disabled_for_loopback())
+}
+
+async fn serve_ok() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut head = [0u8; 4096];
+                let _ = stream.read(&mut head).await;
+                let _ = stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                    )
+                    .await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+    port
+}
+
+#[tokio::test]
+async fn fetches_plain_http_from_a_loopback_literal_and_localhost() {
+    let port = serve_ok().await;
+    let policy = dev_policy();
+    assert!(policy.is_dev_loopback());
+    let client = GuardedClientBuilder::new(policy.clone()).build().unwrap();
+    for raw in [
+        format!("http://127.0.0.1:{port}/"),
+        format!("http://localhost:{port}/"),
+    ] {
+        let url = policy.vet(&raw).unwrap();
+        let response = client.get(&url).unwrap().send().await.unwrap();
+        assert!(response.status().is_success(), "{raw}");
+        assert_eq!(client.read_body_capped(response).await.unwrap(), b"ok");
+    }
+}
+
+#[test]
+fn still_refuses_private_metadata_embedded_loopback_and_plaintext_to_public_hosts() {
+    let policy = dev_policy();
+    for raw in [
+        "http://10.0.0.5/",
+        "http://169.254.169.254/",
+        "http://[::ffff:127.0.0.1]/",
+    ] {
+        assert!(
+            matches!(policy.vet(raw), Err(EgressError::BlockedAddress { .. })),
+            "{raw}"
+        );
+    }
+    assert!(matches!(
+        policy.vet("http://example.com/"),
+        Err(EgressError::SchemeNotAllowed(_))
+    ));
+}
+
+#[tokio::test]
+async fn a_public_client_refuses_a_url_vetted_under_dev_loopback() {
+    let port = serve_ok().await;
+    let vetted = dev_policy()
+        .vet(&format!("http://127.0.0.1:{port}/"))
+        .unwrap();
+    let client = GuardedClientBuilder::new(EgressPolicy::public_internet())
+        .build()
+        .unwrap();
+    assert!(client.get(&vetted).is_err());
+}

--- a/crates/identity/did-methods/did-web/CHANGELOG.md
+++ b/crates/identity/did-methods/did-web/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Changelog history
 
+## 11th September 2026
+
+### 0.1.5 — the SSRF guard moves to `affinidi-net-guard`
+
+- Address classification and the connect-time DNS resolver now come from the
+  new shared `affinidi-net-guard` 0.1.0 crate instead of private code here.
+  The public API is unchanged: `HostPolicy`, `DIDWeb::with_policy`,
+  `DIDWeb::with_client_and_policy` and `guarded_dns_resolver()` behave as in
+  0.1.4, and `BlockedHost` messages keep their wording.
+- **Names are unchanged.** did-web still refuses only `localhost`,
+  `*.localhost` and `*.local`. `affinidi-net-guard`'s default also refuses
+  `*.internal`, `*.home.arpa` and single-label names; since those can resolve
+  to real internal hosts, adopting that set is a behaviour change and is left
+  for a minor release.
+- **Addresses the shared classifier also refuses.** These were accepted by
+  0.1.4 and are now `BlockedHost`. None can host a working public HTTPS
+  endpoint, so no working deployment is affected, but a test that expected a
+  connect error for one of them now sees `BlockedHost` instead:
+  - IPv4 documentation (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`),
+    multicast (`224.0.0.0/4`) and reserved (`240.0.0.0/4`) space;
+  - IPv6 multicast (`ff00::/8`), documentation (`2001:db8::/32`, `3fff::/20`),
+    discard-only `100::/64`, SRv6 `5f00::/16`, and the non-global parts of
+    `2001::/23`;
+  - the IPv4-mapped, IPv4-compatible and NAT64 forms of those IPv4 ranges;
+  - 6to4 (`2002::/16`) and Teredo (`2001::/32`) addresses whose embedded IPv4
+    address is not globally routable, and local-use NAT64 (`64:ff9b:1::/48`)
+    addresses that embed a non-routable IPv4 address (such as
+    `64:ff9b:1::a9fe:a9fe`, which a local NAT64 gateway would translate to the
+    metadata address) or are not in the `/96` form.
+- The direct `tokio` dependency is dropped; the lookup happens in
+  `affinidi-net-guard`.
+
 ## 3rd September 2026
 
 ### 0.1.4 — SSRF hardening

--- a/crates/identity/did-methods/did-web/Cargo.toml
+++ b/crates/identity/did-methods/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-web"
-version = "0.1.4"
+version = "0.1.5"
 description = "Minimal did:web DID method resolver for the Affinidi TDK"
 repository.workspace = true
 edition.workspace = true
@@ -17,6 +17,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 affinidi-did-common = "0.4"
+# Address classification and the connect-time DNS resolver of the SSRF guard.
+# Named at the exact sibling version so the publish dry-run guard reports
+# `wait` until it is on crates.io, rather than registry drift.
+affinidi-net-guard = "0.1.0"
 percent-encoding = "2"
 reqwest = { version = "0.13", default-features = false, features = [
   "rustls",
@@ -26,9 +30,6 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 serde_json = "1"
 thiserror = "2"
-# `net` only: the SSRF guard resolves hostnames itself so it can refuse a name
-# that points at a non-routable address. reqwest already pulls tokio.
-tokio = { version = "1", default-features = false, features = ["net"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/identity/did-methods/did-web/src/lib.rs
+++ b/crates/identity/did-methods/did-web/src/lib.rs
@@ -62,12 +62,12 @@
  * ```
  */
 
-use std::fmt;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::sync::Arc;
+use std::net::IpAddr;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use affinidi_did_common::{DID, DIDMethod, Document};
+use affinidi_net_guard::{EgressError, EgressPolicy};
 use percent_encoding::percent_decode_str;
 use thiserror::Error;
 use tracing::debug;
@@ -250,7 +250,9 @@ impl DIDWeb {
             .map_err(|e| {
                 blocked_address_in_chain(&e).map_or_else(
                     || DidWebError::Http(format!("GET {url}: {e}")),
-                    |blocked| DidWebError::BlockedHost(blocked.to_string()),
+                    |(host, addr)| {
+                        DidWebError::BlockedHost(format!("{host} resolves to non-routable {addr}"))
+                    },
                 )
             })?;
 
@@ -306,6 +308,11 @@ pub async fn resolve(did: &str) -> Result<Document, DidWebError> {
 /// This classifies the host *as written in the DID*. A hostname that resolves
 /// to one of these addresses is caught separately, at connect time, by
 /// [`guarded_dns_resolver`].
+///
+/// Addresses are classified by `affinidi_net_guard`. The name set is this
+/// crate's own and deliberately narrower than `affinidi-net-guard`'s default
+/// (which also refuses `*.internal`, `*.home.arpa` and single-label names):
+/// adopting that is a behaviour change, left for a minor release.
 fn host_is_blocked(host: &str) -> bool {
     // A trailing root dot is part of a legal hostname and survives URL
     // normalisation, so `localhost.` must normalise to `localhost` before the
@@ -324,81 +331,23 @@ fn host_is_blocked(host: &str) -> bool {
     }
 }
 
-/// Reject a resolved address that must never be connected to.
+/// Reject a resolved address that must never be connected to: anything
+/// `affinidi_net_guard` does not classify as globally routable.
 fn ip_is_blocked(addr: IpAddr) -> bool {
-    match addr {
-        IpAddr::V4(a) => ipv4_is_blocked(a),
-        IpAddr::V6(a) => ipv6_is_blocked(a),
-    }
+    !affinidi_net_guard::is_globally_routable(addr)
 }
 
-fn ipv4_is_blocked(a: Ipv4Addr) -> bool {
-    let o = a.octets();
-    a.is_loopback()
-        || a.is_private()
-        || a.is_link_local() // 169.254.0.0/16 — covers cloud metadata 169.254.169.254
-        || a.is_broadcast()
-        || o[0] == 0 // 0.0.0.0/8 "this network" — includes the unspecified address
-        // 100.64.0.0/10 carrier-grade NAT: the Alibaba/Oracle metadata address
-        // 100.100.100.200 lives here, as do the node/pod CIDRs of many
-        // Kubernetes deployments. `Ipv4Addr::is_shared` is still unstable.
-        || (o[0] == 100 && (64..128).contains(&o[1]))
-        || (o[0] == 192 && o[1] == 0 && o[2] == 0) // 192.0.0.0/24 IETF protocol assignments
-        || (o[0] == 198 && (o[1] & 0xfe) == 18) // 198.18.0.0/15 benchmarking
-}
-
-fn ipv6_is_blocked(a: Ipv6Addr) -> bool {
-    if a.is_loopback() || a.is_unspecified() {
-        return true;
-    }
-    // Both IPv4-mapped (::ffff:a.b.c.d) and the deprecated IPv4-compatible
-    // (::a.b.c.d) forms reach the same v4 target on stacks that still route
-    // them, and `to_ipv4` — unlike `to_ipv4_mapped` — covers both.
-    if let Some(v4) = a.to_ipv4() {
-        return ipv4_is_blocked(v4);
-    }
-    let s = a.segments();
-    // NAT64 well-known prefix 64:ff9b::/96 embeds a v4 destination in the low
-    // 32 bits, so classify that destination.
-    if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6] == [0, 0, 0, 0] {
-        let v4 = Ipv4Addr::from(((u32::from(s[6])) << 16) | u32::from(s[7]));
-        return ipv4_is_blocked(v4);
-    }
-    (s[0] & 0xfe00) == 0xfc00 // unique-local fc00::/7
-        || (s[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
-        || (s[0] & 0xffc0) == 0xfec0 // deprecated site-local fec0::/10
-}
-
-/// Refusal raised by [`guarded_dns_resolver`] when a hostname resolves to a
-/// non-routable address. Travels out through `reqwest`'s error chain, where
-/// [`blocked_address_in_chain`] recovers it and reports
-/// [`DidWebError::BlockedHost`] rather than a generic transport failure.
-#[derive(Debug)]
-struct BlockedAddress {
-    host: String,
-    addr: IpAddr,
-}
-
-impl fmt::Display for BlockedAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} resolves to non-routable {}", self.host, self.addr)
-    }
-}
-
-impl std::error::Error for BlockedAddress {}
-
-/// Recover a [`BlockedAddress`] from anywhere in an error's source chain.
+/// Recover the refusal raised by [`guarded_dns_resolver`] (a hostname that
+/// resolved to a non-routable address) from anywhere in an error's source
+/// chain, so it is reported as [`DidWebError::BlockedHost`] rather than as a
+/// generic transport failure.
 fn blocked_address_in_chain<'a>(
     err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a BlockedAddress> {
-    let mut next = Some(err);
-    while let Some(e) = next {
-        if let Some(blocked) = e.downcast_ref::<BlockedAddress>() {
-            return Some(blocked);
-        }
-        next = e.source();
+) -> Option<(&'a str, IpAddr)> {
+    match affinidi_net_guard::blocked_in_chain(err) {
+        Some(EgressError::BlockedAddress { host, addr, .. }) => Some((host.as_str(), *addr)),
+        _ => None,
     }
-    None
 }
 
 /// A DNS resolver that refuses to hand back a non-routable address.
@@ -424,32 +373,22 @@ pub fn guarded_dns_resolver() -> Arc<dyn reqwest::dns::Resolve> {
     Arc::new(GuardedResolver)
 }
 
+/// Delegates to `affinidi_net_guard::GuardedResolver` under
+/// `EgressPolicy::public_internet()`: it resolves the name, fails closed if
+/// *any* answer is non-routable, and returns only the vetted addresses. The
+/// resolver checks addresses only, never names, so this crate's name set is
+/// unaffected.
 #[derive(Debug, Clone, Copy)]
 struct GuardedResolver;
 
 impl reqwest::dns::Resolve for GuardedResolver {
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
-        Box::pin(async move {
-            let host = name.as_str().to_owned();
-            // Port 0: reqwest substitutes the URL's port (or the scheme's
-            // default) over whatever we return.
-            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
-                .await
-                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
-                .collect();
-
-            // Fail closed on the whole name, not per-address: a name with even
-            // one internal answer is not a name we are willing to fetch from.
-            if let Some(bad) = addrs.iter().find(|a| ip_is_blocked(a.ip())) {
-                return Err(Box::new(BlockedAddress {
-                    host,
-                    addr: bad.ip(),
-                })
-                    as Box<dyn std::error::Error + Send + Sync>);
-            }
-
-            Ok(Box::new(addrs.into_iter()) as reqwest::dns::Addrs)
-        })
+        static PUBLIC_ONLY: OnceLock<affinidi_net_guard::GuardedResolver> = OnceLock::new();
+        PUBLIC_ONLY
+            .get_or_init(|| {
+                affinidi_net_guard::GuardedResolver::new(EgressPolicy::public_internet())
+            })
+            .resolve(name)
     }
 }
 

--- a/crates/tdk/affinidi-tdk-common/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `affinidi-tdk-common`
 
+## Unreleased (0.6.11) — guarded HTTP client
+
+- Adds `create_guarded_http_client(extra_roots, &EgressPolicy)` next to
+  `create_http_client`. It returns an `affinidi_net_guard::GuardedClient` built
+  on the same platform TLS verifier, extra roots, pool idle timeout and user
+  agent, and enforces the egress policy for URLs an attacker can influence.
+- Re-exports `affinidi-net-guard` as `affinidi_tdk_common::net_guard`, so a
+  consumer can build an `EgressPolicy` without a direct dependency.
+- `create_http_client` is unchanged; its TLS setup moved into a private helper
+  that both constructors share. Additive, hence a patch.
+
 ## Unreleased (0.6.10) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/tdk/affinidi-tdk-common/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinidi-tdk-common"
 description = "Common utilities for Affinidi Trust Development Kit."
-version = "0.6.10"
+version = "0.6.11"
 edition.workspace = true
 authors.workspace = true
 readme = "README.md"
@@ -21,6 +21,10 @@ affinidi-did-resolver-cache-sdk = "0.8"
 # registry-drift failure — see scripts/check-publish-dry-run.sh.
 affinidi-did-authentication = "0.3.11"
 affinidi-did-common = "0.4"
+# A public dependency: re-exported as `net_guard`, and
+# `create_guarded_http_client` takes and returns its types. Exact sibling
+# version for the same publish dry-run reason as above.
+affinidi-net-guard = "0.1.0"
 affinidi-secrets-resolver = "0.5"
 affinidi-data-integrity = "0.7"
 

--- a/crates/tdk/affinidi-tdk-common/src/lib.rs
+++ b/crates/tdk/affinidi-tdk-common/src/lib.rs
@@ -88,6 +88,7 @@ pub mod profiles;
 pub mod secrets;
 pub mod tasks;
 
+pub use affinidi_net_guard as net_guard;
 pub use affinidi_secrets_resolver as secrets_resolver;
 use tasks::authentication::AuthenticationCache;
 
@@ -158,6 +159,54 @@ const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15
 /// [`reqwest::Client`] cannot be constructed, or if non-empty `extra_roots`
 /// are supplied on Android (see *Platform support*).
 pub fn create_http_client(extra_roots: &[CertificateDer<'static>]) -> Result<Client, TDKError> {
+    let tls_config = platform_tls_config(extra_roots)?;
+    reqwest::ClientBuilder::new()
+        .use_rustls_tls()
+        .use_preconfigured_tls(tls_config)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .user_agent(user_agent())
+        .build()
+        .map_err(|e| TDKError::Config(format!("HTTP client build failed: {e}")))
+}
+
+/// Build a [`GuardedClient`](affinidi_net_guard::GuardedClient) for URLs an
+/// attacker can influence (DID-document endpoints, redirect targets, anything
+/// derived from a DID), with the same TLS setup, pool idle timeout and user
+/// agent as [`create_http_client`].
+///
+/// On top of that client it enforces `policy` in both halves: the URL is
+/// vetted before a request is built (the only check an IP literal meets), and
+/// every address a name resolves to is vetted at connect time. It also uses
+/// no proxy, finite timeouts, no redirects, a capped body read and
+/// `https_only` unless the policy has dev loopback. See
+/// [`affinidi_net_guard`] (re-exported as [`net_guard`]).
+///
+/// # Errors
+///
+/// As [`create_http_client`].
+pub fn create_guarded_http_client(
+    extra_roots: &[CertificateDer<'static>],
+    policy: &affinidi_net_guard::EgressPolicy,
+) -> Result<affinidi_net_guard::GuardedClient, TDKError> {
+    let tls_config = platform_tls_config(extra_roots)?;
+    affinidi_net_guard::GuardedClientBuilder::new(policy.clone())
+        .tls_preconfigured(tls_config)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .user_agent(user_agent())
+        .build()
+        .map_err(|e| TDKError::Config(format!("guarded HTTP client build failed: {e}")))
+}
+
+fn user_agent() -> String {
+    format!(
+        "Affinidi Trust Development Kit {}",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// The rustls configuration both client constructors share: the platform
+/// verifier, plus `extra_roots` where the platform allows it.
+fn platform_tls_config(extra_roots: &[CertificateDer<'static>]) -> Result<ClientConfig, TDKError> {
     static CRYPTO_INIT: OnceLock<()> = OnceLock::new();
     CRYPTO_INIT.get_or_init(|| {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -206,16 +255,7 @@ pub fn create_http_client(extra_roots: &[CertificateDer<'static>]) -> Result<Cli
                 .with_no_client_auth()
         }
     };
-    reqwest::ClientBuilder::new()
-        .use_rustls_tls()
-        .use_preconfigured_tls(tls_config)
-        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
-        .user_agent(format!(
-            "Affinidi Trust Development Kit {}",
-            env!("CARGO_PKG_VERSION")
-        ))
-        .build()
-        .map_err(|e| TDKError::Config(format!("HTTP client build failed: {e}")))
+    Ok(tls_config)
 }
 
 impl TDKSharedState {

--- a/crates/tdk/affinidi-tdk-common/tests/end_to_end.rs
+++ b/crates/tdk/affinidi-tdk-common/tests/end_to_end.rs
@@ -87,3 +87,30 @@ fn create_http_client_default_succeeds() {
     // would require sending a request, which we avoid in unit-style tests.
     drop(client);
 }
+
+/// `create_guarded_http_client` builds on the same TLS setup and carries the
+/// policy it was given, which refuses internal targets before any I/O.
+#[test]
+fn create_guarded_http_client_default_succeeds() {
+    use affinidi_tdk_common::net_guard::{EgressError, EgressPolicy};
+
+    let policy = EgressPolicy::public_internet();
+    let client = affinidi_tdk_common::create_guarded_http_client(&[], &policy)
+        .expect("guarded client builds with empty extras");
+    assert!(!client.policy().is_dev_loopback());
+    assert!(matches!(
+        client
+            .policy()
+            .vet("https://169.254.169.254/latest/meta-data/"),
+        Err(EgressError::BlockedAddress { .. })
+    ));
+    assert!(matches!(
+        client.policy().vet("https://localhost/"),
+        Err(EgressError::BlockedName(_))
+    ));
+    assert!(
+        client
+            .get(&policy.vet("https://example.com/").unwrap())
+            .is_ok()
+    );
+}

--- a/docs/adr/0006-egress-guard-for-attacker-influenceable-urls.md
+++ b/docs/adr/0006-egress-guard-for-attacker-influenceable-urls.md
@@ -1,0 +1,111 @@
+# ADR 0006 — Egress guard for attacker-influenceable URLs
+
+- **Status:** Proposed
+- **Date:** 2026-09-11
+- **Relates to:** the SSRF guard in `affinidi-did-web` 0.1.4 (`HostPolicy`,
+  `guarded_dns_resolver`); [ADR 0003](0003-public-api-semver-policy.md) (semver
+  and the external `[patch.crates-io]` coupling); SEC-4045.
+
+## Context
+
+Much of what this workspace fetches is named by data someone else controls. A
+`did:web` or `did:webvh` value names the host its document is fetched from; a
+DID document names its service endpoints; an HTTP server names its redirect
+target. If nothing refuses internal targets, each of these lets whoever controls
+the data aim our process at loopback services, a private network, or a
+cloud-metadata endpoint (`169.254.169.254`, `fd00:ec2::254`,
+`100.100.100.200`): server-side request forgery.
+
+`affinidi-did-web` 0.1.4 closed this for `did:web`, and its guard is the most
+complete one in the stack. It checks the host as written, and it also installs a
+DNS resolver that refuses any name with a non-routable answer and pins the
+connection to the addresses it checked, which closes DNS rebinding. But its
+classifier is private to a DID-method crate. Other resolvers and clients, in
+this workspace and outside it, either re-implement a weaker check (IP literals
+only, IPv4-mapped IPv6 not unwrapped, carrier-grade NAT missing, no name check)
+or have none.
+
+Three facts about the HTTP stack shape any fix:
+
+1. **`reqwest` never calls a custom resolver for an IP-literal host.**
+   `hyper-util`'s connector parses the host and connects directly if it is an
+   address. A resolver-only guard therefore misses `https://169.254.169.254/`.
+2. **A proxy resolves the target itself.** With `HTTP(S)_PROXY` set (which
+   `reqwest` honours by default), the resolver never sees the name, and only
+   the literal check still applies.
+3. **Redirects re-open everything** unless each hop is checked again.
+
+The guard also has to be consumable by crates this workspace depends on, such as
+`didwebvh-rs`, so it cannot depend on any `affinidi-*` crate.
+
+## Decision
+
+1. **A new leaf crate, `affinidi-net-guard`, in `crates/core/`.** Its
+   dependencies are `reqwest` (rustls, no default features), `tokio` (`net`),
+   `url`, `thiserror` and `tracing`. No `affinidi-*` dependency.
+
+2. **Two halves, both mandatory, one client that runs both.**
+   `EgressPolicy::vet` checks scheme, userinfo, port, allow-list, special-use
+   names and literal addresses, and is the only thing that produces a
+   `VettedUrl`. `GuardedResolver` checks every resolved address, fails the whole
+   name on any blocked answer, and returns only the vetted addresses.
+   `GuardedClient` request methods take a `VettedUrl` and re-vet it under the
+   client's own policy; the client uses `GuardedResolver`, disables proxies,
+   has finite timeouts, does not follow redirects by default, and caps body
+   reads.
+
+3. **Deny by default, narrow freely, widen only explicitly.**
+   `EgressPolicy::public_internet()` admits `https`/`wss` to globally routable
+   addresses only and refuses the special-use names `localhost`, `*.localhost`,
+   `*.local`, `*.internal`, `*.home.arpa` and single-label names. The
+   allow-list, scheme and port settings only narrow. Internal deployments name
+   explicit CIDRs with `allow_cidrs`, which never re-admits loopback,
+   link-local, unspecified, multicast or broadcast addresses, and name internal
+   hosts with an allow-list entry, whose resolved addresses are still checked.
+
+4. **Loopback for development is compile-gated.** It needs a `DevLoopback`
+   token that can only be constructed with the `dev-loopback` Cargo feature. It
+   admits only loopback hosts (the literals `127.0.0.0/8` and `::1`, the names
+   `localhost` and `*.localhost`) and plain `http`/`ws` to them; a different
+   name resolving to loopback stays blocked. It logs a warning once per
+   process. No environment variable enables it.
+
+5. **Redirects** are `None` by default. `ReVet { max }` re-vets every hop and
+   refuses a secure-to-plaintext downgrade; `SameOrigin { max }` also requires
+   the original origin. The DNS half re-applies to each hop automatically,
+   because the next host goes through the same resolver.
+
+6. **One conformance vector file**,
+   `crates/core/affinidi-net-guard/conformance/egress-vectors.v1.json`, is the
+   contract for every implementation of the guard (Rust, TypeScript, Swift).
+   Each runner must pass every vector or skip it for a declared missing
+   capability; an unknown section or capability fails the run.
+
+7. **Existing guards delegate without changing behaviour in a patch.**
+   `affinidi-did-web` keeps its API and its narrower name set, and takes its
+   address classification and resolver from the new crate. The classifier
+   refuses some additional non-routable ranges; these cannot host a working
+   endpoint, and the did-web changelog lists them. Adopting the full special-use
+   name set in did-web is a behaviour change, left for its next minor release
+   per ADR 0003.
+
+## Consequences
+
+- One classifier and one resolver to review and test, instead of one per
+  resolver or client. New egress points should use `GuardedClient`, or
+  `affinidi_tdk_common::create_guarded_http_client` to keep the platform TLS
+  verifier. Consumer repositories can enforce this with a clippy
+  `disallowed-methods` entry for `reqwest::Client::new` and `reqwest::get`.
+- A deployment that must egress through a proxy loses the DNS half, and the
+  proxy must enforce the policy itself. The crate does not offer a proxy
+  setting in 0.1.
+- `wasm32` targets get classification and URL vetting only; a browser has no
+  resolver hook.
+- Not yet provided, and additive when needed: a pinned `connect_tcp` for
+  non-`reqwest` transports (WebSocket, TSP), and an explicit proxy mode.
+- Follow-ups outside this change: `didwebvh-rs` resolution (client injection
+  and the default client's resolver), `WebvhResolver::with_policy` in the
+  resolver cache SDK, migrating the agent-names redirect resolver, auditing the
+  messaging SDK's DID-document endpoint dials, and the did-web minor release
+  that adopts the full name set and replaces `HostPolicy::AllowPrivate` with
+  `allow_cidrs`.


### PR DESCRIPTION

## Summary

Adds **`affinidi-net-guard` 0.1.0**, a small leaf crate that stops a URL someone
else controls (a `did:web` host, a DID document's service endpoint, a redirect
`Location`) from steering a server-side request at loopback, a private network
or a cloud-metadata address. `affinidi-did-web` 0.1.4 already had the strongest
such guard in the stack, but it was private to a DID-method crate. This change
extracts it into a primitive that every egress point can share, generalises it,
and records the decision as ADR 0006.

- **`affinidi-net-guard` 0.1.0** (new, `crates/core/`)
- **`affinidi-did-web` 0.1.5**: delegates classification and its resolver to the new crate; API and name set unchanged
- **`affinidi-tdk-common` 0.6.11**: adds `create_guarded_http_client(extra_roots, &EgressPolicy)` on the existing platform TLS setup, and re-exports the crate as `net_guard`
- **ADR 0006**: egress guard for attacker-influenceable URLs

## Design

The crate depends only on `reqwest` (rustls, no default features), `tokio`
(`net`), `url`, `thiserror` and `tracing`, and on **no `affinidi-*` crate**.
DID-method crates and external clients such as `didwebvh-rs` can therefore
depend on it without a cycle.

It enforces two halves, and both are required:

1. **`EgressPolicy::vet`** checks the scheme, userinfo, port, allow-list,
   special-use names and IP literals. `hyper-util` skips any custom resolver when
   the host is already an IP address, so this is the only check a literal meets.
2. **`GuardedResolver`** checks every address a name resolves to, fails the
   name if any answer is blocked, and returns only the vetted addresses. The
   connection goes to exactly what was checked, which closes DNS rebinding.

`GuardedClient` runs both. Requests take a `VettedUrl` and are re-vetted under
the client's own policy, and the client sets no proxy (a proxy resolves names
itself and would bypass the DNS half), 10 s / 5 s timeouts, no redirects by
default, no `Referer`, `https_only` unless dev loopback, and a capped body read.

### Public API

| Item | Notes |
|---|---|
| `classify`, `is_globally_routable`, `IpClass`, `Embedding` | IANA special-purpose table; IPv4-mapped, IPv4-compatible, NAT64 `64:ff9b::/96` and `64:ff9b:1::/48`, 6to4 and Teredo are classified by the IPv4 address they carry |
| `EgressPolicy` | `public_internet()`; narrowing `with_allow_list` / `with_schemes` / `with_ports`; `allow_cidrs` (never re-admits loopback, link-local, unspecified, multicast, broadcast); `with_dev_loopback` |
| `DevLoopback` | Constructible only with the `dev-loopback` feature (or the crate's own tests); admits `127/8`, `::1`, `localhost`, `*.localhost` and plain http/ws to them, but never a different name that resolves to loopback |
| `AllowList`, `HostRule`, `PortPolicy`, `Scheme`, `Cidr` | Policy inputs |
| `VettedUrl` | Only from `vet` / `vet_url`; `host()` for operator display; `join_same_origin` |
| `GuardedResolver`, `guarded_dns_resolver` | Fail closed on any blocked answer; optional inner resolver |
| `RedirectMode`, `redirect_policy` | `None` (default), `SameOrigin { max }`, `ReVet { max }` (every hop re-vetted, no https-to-http downgrade) |
| `GuardedClientBuilder`, `GuardedClient` | `get` / `post` / `request` / `execute` / `read_body_capped` |
| `EgressError`, `blocked_in_chain` | Recover a refusal from a `reqwest::Error` |

Special-use names refused by default: `localhost`, `*.localhost`, `*.local`,
`*.internal`, `*.home.arpa`, and single-label names, with or without a trailing
dot. Internal deployments name hosts with an allow-list entry (their addresses
are still checked) and ranges with `allow_cidrs`.

### Kept out of 0.1, and additive later

- `connect_tcp` for non-`reqwest` transports (WebSocket, TSP): no consumer in this change.
- An explicit proxy mode: it silently disables the DNS half and deserves its own review.

## Conformance vectors

`crates/core/affinidi-net-guard/conformance/egress-vectors.v1.json` is the
vector file to be shared with the TypeScript and Swift guards. It has sections
`ip`, `url`, `names`, `scheme`, `webvh`, `mediatorDoc`, `dns`, `rebinding` and
`redirect`, each declaring the capabilities it requires. A runner must pass
every vector or skip it for a declared missing capability, and an unknown
section, capability or policy field fails the run.

The Rust runner (`src/tests/conformance.rs`) executes `ip`, `url`, `names`,
`scheme` and `dns` directly, and `rebinding` and `redirect` against local TLS
listeners. Public stub answers are mapped onto listeners after vetting, and
internal answers point at a counting sink, so "zero connections to the blocked
target" is actually observed. It skips `webvh` and `mediatorDoc` (owned by
didwebvh-rs and the consuming SDKs) and the optional online DNS vectors, each
with a stated reason.

## `affinidi-did-web` compatibility

- `HostPolicy`, `guarded_dns_resolver()`, `DIDWeb::with_*` and all 16 existing tests are unchanged, and `BlockedHost` messages keep their wording.
- The **name set is unchanged** (`localhost`, `*.localhost`, `*.local`). Adopting the fuller default is a behaviour change, left for a minor release together with replacing `AllowPrivate` by `allow_cidrs`.
- The shared classifier also refuses some ranges 0.1.4 accepted: IPv4/IPv6 documentation, multicast, reserved, discard-only, SRv6 and non-global `2001::/23` space, plus 6to4, Teredo and local-use NAT64 addresses that embed a non-routable IPv4 address. None can host a working public endpoint, so the only visible difference is `BlockedHost` instead of a connect error. The did-web changelog lists them.

## Test plan

- [x] `cargo fmt --check` for the three crates
- [x] `cargo clippy --all-targets -- -D warnings` for the three crates, and for net-guard with `--features dev-loopback` (`RUSTFLAGS="-D warnings --cfg tracing_unstable"`, as CI)
- [x] `cargo test -p affinidi-net-guard -p affinidi-did-web -p affinidi-tdk-common`
- [x] `cargo test -p affinidi-net-guard --features dev-loopback` (adds the integration test against a real loopback server)
- [x] `cargo build --release -p affinidi-net-guard` without `dev-loopback`; a `compile_fail` doctest proves `DevLoopback` cannot be constructed there
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p affinidi-net-guard --no-deps`
- [x] `scripts/check-version-bumps.sh`, `check-changelogs.sh`, `check-workspace-duplicates.sh`
- [ ] Publish order: `affinidi-net-guard` must reach crates.io before `affinidi-did-web` 0.1.5 and `affinidi-tdk-common` 0.6.11 (their dry-runs report `wait` until then)

## Follow-ups (not in this PR)

- `didwebvh-rs`: give the native client a `GuardedResolver`, add client injection to `ResolveOptions`, allow `localhost`/http only through `DevLoopback`, and set `Policy::none()` on the wasm client.
- `WebvhResolver::with_policy` in the resolver cache SDK, once didwebvh-rs can take a policy.
- Move the agent-names redirect resolver onto `GuardedResolver` + `RedirectMode::ReVet`.
- Audit the messaging SDK's DID-document endpoint dials.
- A did-web minor release that adopts the full special-use name set.
