### PR TITLE
fix(resolver): did:webvh host policy via didwebvh-rs 0.7

### DIFF
--- a/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Affinidi DID Resolver Cache SDK
 
+## Unreleased (0.8.37) — did:webvh host policy, one setting for did:web and did:webvh
+
+### Changed
+
+- **SECURITY / BEHAVIOUR (SSRF):** `did:webvh` resolution now refuses
+  non-public hosts by default, as `did:web` resolution has since 0.8.35. This
+  moves to `didwebvh-rs` 0.7, which:
+  - rejects `localhost`, `*.localhost`, `*.local`, `*.internal`, `home.arpa`
+    and single-label names before making any request;
+  - refuses, at connect time, a name that resolves to a loopback,
+    private-network, carrier-grade NAT, link-local or other non-public address;
+  - ignores system proxy settings in its default client.
+
+  Before, `did:webvh:{SCID}:localhost%3A<port>` was fetched over `http://`, and
+  any other name was fetched from whatever address it resolved to. A refused
+  DID now fails with `DIDCacheError::DIDError` naming `BlockedHost`.
+
+  This is breaking in effect for local stacks and for deployments whose
+  did:webvh hosts are on a private network. One setting opts both did:web and
+  did:webvh back in:
+
+  ```rust
+  use affinidi_did_resolver_cache_sdk::{
+      config::DIDCacheConfigBuilder, network_resolvers::HostPolicy,
+  };
+
+  let config = DIDCacheConfigBuilder::default()
+      .with_host_policy(HostPolicy::AllowPrivate)
+      .build();
+  ```
+
+- `DIDCacheClient::new` builds both its did:web and did:webvh resolvers from
+  the configured policy. The default is still `PublicOnly`, so did:web
+  behaviour does not change unless the setting is used.
+- `WebvhResolver` passes no HTTP client to `didwebvh-rs`, so the client that
+  crate builds is used. It refuses redirects, ignores proxies and vets resolved
+  addresses.
+- `WebvhResolver` is now a struct with a private field instead of a unit
+  struct. Code that used the value directly (`Box::new(WebvhResolver)`) must
+  call `WebvhResolver::new()` instead. No caller in this workspace did.
+- The `did-scid` feature now requires `did-scid` 0.2.7, which is built on
+  `didwebvh-rs` 0.7. `did:scid:vh` resolution therefore also contacts public
+  hosts only, and `with_host_policy` does not change that.
+
+### Added
+
+- `DIDCacheConfigBuilder::with_host_policy`.
+- `WebvhResolver::new`, `WebvhResolver::with_policy` and `Default`, mirroring
+  `WebResolver`.
+
+This is a patch bump per [ADR 0003](../../../docs/adr/0003-public-api-semver-policy.md)
+point 3: `vta-sdk` pins `^0.8` through `[patch.crates-io]`.
+
 ## Unreleased (0.8.36) — retire did:cheqd resolution, clearing eight advisories
 
 Closes [#760]. `did:cheqd` still **parses**; this SDK no longer **resolves** it.

--- a/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.36"
+version = "0.8.37"
 description = "Affinidi DID Resolver SDK"
 edition.workspace = true
 authors.workspace = true
@@ -59,7 +59,7 @@ affinidi-did-resolver-traits = { version = "0.1", path = "../affinidi-did-resolv
 affinidi-task-utils = { version = "0.1", optional = true }
 did-example = { version = "0.5", optional = true }
 # `default-features = false` selects only the did:webvh backend of did-scid.
-did-scid = { version = "0.2.6", optional = true, default-features = false, features = [
+did-scid = { version = "0.2.7", optional = true, default-features = false, features = [
   "did-webvh",
 ] }
 did-ebsi = { version = "0.1", path = "../did-methods/did-ebsi", optional = true }
@@ -68,7 +68,7 @@ affinidi-did-webs = { version = "0.7", path = "../did-methods/did-webs", optiona
 # External Crates
 ahash = "0.8"
 base64 = { version = "0.23", optional = true }
-didwebvh-rs = { version = "0.6", optional = true }
+didwebvh-rs = { version = "0.7", optional = true }
 # Community-name support (`example.com/@`) needs agent-names >= 0.1.3. The
 # requirement stays at `0.1` rather than pinning that floor: both crates
 # release from the same commit, so a `0.1.3` floor cannot resolve against the

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/config.rs
@@ -21,6 +21,7 @@
 //! ```
 //!
 
+use affinidi_did_web::HostPolicy;
 #[cfg(feature = "network")]
 use std::time::Duration;
 use wasm_bindgen::prelude::*;
@@ -49,6 +50,7 @@ pub struct DIDCacheConfig {
     pub(crate) agent_names_over_websocket: bool,
     #[cfg(feature = "agent-names")]
     pub(crate) resolve_shortcuts: bool,
+    pub(crate) host_policy: HostPolicy,
 }
 
 /// DID Cache Config Builder to construct options required for the client.
@@ -59,6 +61,7 @@ pub struct DIDCacheConfig {
 /// - cache_ttl: The time-to-live in seconds for each item in the local cache (default: 300 (5 Minutes)).
 /// - network_timeout: The timeout for network requests in milliseconds (default: 5000 (5 seconds)).
 /// - network_cache_limit_count: The maximum number of items to store in the network cache (default: 100).
+/// - host_policy: Which hosts did:web and did:webvh resolution may contact (default: `PublicOnly`).
 pub struct DIDCacheConfigBuilder {
     #[cfg(feature = "network")]
     service_address: Option<String>,
@@ -78,6 +81,7 @@ pub struct DIDCacheConfigBuilder {
     agent_names_over_websocket: bool,
     #[cfg(feature = "agent-names")]
     resolve_shortcuts: bool,
+    host_policy: HostPolicy,
 }
 
 impl Default for DIDCacheConfigBuilder {
@@ -101,6 +105,7 @@ impl Default for DIDCacheConfigBuilder {
             agent_names_over_websocket: false,
             #[cfg(feature = "agent-names")]
             resolve_shortcuts: false,
+            host_policy: HostPolicy::PublicOnly,
         }
     }
 }
@@ -218,6 +223,25 @@ impl DIDCacheConfigBuilder {
         self
     }
 
+    /// Set which hosts `did:web` and `did:webvh` resolution may contact.
+    ///
+    /// Both methods name the host their document is fetched from, so whoever
+    /// supplies the DID chooses where this client sends HTTP requests.
+    /// [`HostPolicy::PublicOnly`] refuses loopback, private-network,
+    /// link-local and other non-public hosts, whether the DID names them
+    /// directly or a hostname resolves to one. [`HostPolicy::AllowPrivate`]
+    /// lifts that, for local development (`did:webvh:{SCID}:localhost%3A8000`)
+    /// and for deployments whose DID hosts are trusted and on a private network.
+    ///
+    /// Applies to the built-in did:web and did:webvh resolvers. A resolver
+    /// installed with [`set_resolver`](crate::DIDCacheClient::set_resolver)
+    /// carries its own policy.
+    /// Default: `PublicOnly`
+    pub fn with_host_policy(mut self, host_policy: HostPolicy) -> Self {
+        self.host_policy = host_policy;
+        self
+    }
+
     /// Build the [ClientConfig].
     pub fn build(self) -> DIDCacheConfig {
         DIDCacheConfig {
@@ -239,6 +263,7 @@ impl DIDCacheConfigBuilder {
             agent_names_over_websocket: self.agent_names_over_websocket,
             #[cfg(feature = "agent-names")]
             resolve_shortcuts: self.resolve_shortcuts,
+            host_policy: self.host_policy,
         }
     }
 }
@@ -254,6 +279,15 @@ mod tests {
         assert_eq!(config.cache_ttl, 300);
         assert_eq!(config.max_did_parts, 12);
         assert_eq!(config.max_did_size_in_bytes, 1_000);
+        assert_eq!(config.host_policy, HostPolicy::PublicOnly);
+    }
+
+    #[test]
+    fn builder_overrides_host_policy() {
+        let config = DIDCacheConfigBuilder::default()
+            .with_host_policy(HostPolicy::AllowPrivate)
+            .build();
+        assert_eq!(config.host_policy, HostPolicy::AllowPrivate);
     }
 
     #[test]

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/lib.rs
@@ -833,7 +833,9 @@ impl DIDCacheClient {
         resolvers
             .entry(MethodName::Web)
             .or_default()
-            .push_back(Box::new(network_resolvers::WebResolver::new()));
+            .push_back(Box::new(network_resolvers::WebResolver::with_policy(
+                config.host_policy,
+            )));
         #[cfg(feature = "did-jwk")]
         resolvers
             .entry(MethodName::Jwk)
@@ -843,7 +845,9 @@ impl DIDCacheClient {
         resolvers
             .entry(MethodName::Webvh)
             .or_default()
-            .push_back(Box::new(network_resolvers::WebvhResolver));
+            .push_back(Box::new(network_resolvers::WebvhResolver::with_policy(
+                config.host_policy,
+            )));
         #[cfg(feature = "did-cheqd")]
         resolvers
             .entry(MethodName::Cheqd)

--- a/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/src/resolver/network_resolvers.rs
@@ -194,8 +194,52 @@ impl AsyncResolver for JwkResolver {
 // ---------------------------------------------------------------------------
 
 /// Resolver for `did:webvh` — Web Verifiable History DID method.
+///
+/// Like `did:web`, a `did:webvh` value names the host its log is fetched from,
+/// so by default this refuses non-public hosts — see [`HostPolicy`]. Special-use
+/// names such as `localhost` are refused before any request is made, and a
+/// name that resolves to a non-public address is refused at connect time. A
+/// local stack using `did:webvh:{SCID}:localhost%3A8000` opts out with
+/// [`WebvhResolver::with_policy`], or with
+/// [`DIDCacheConfigBuilder::with_host_policy`](crate::config::DIDCacheConfigBuilder::with_host_policy),
+/// which sets did:web and did:webvh together.
+///
+/// No HTTP client is handed to `didwebvh-rs`, so resolution uses the client it
+/// builds itself: redirects refused, system proxy settings ignored and, under
+/// [`HostPolicy::PublicOnly`], every resolved address vetted before connecting.
 #[cfg(feature = "did-webvh")]
-pub struct WebvhResolver;
+#[derive(Debug, Clone, Copy)]
+pub struct WebvhResolver {
+    policy: HostPolicy,
+}
+
+#[cfg(feature = "did-webvh")]
+impl WebvhResolver {
+    /// Create a resolver refusing non-public hosts.
+    pub fn new() -> Self {
+        Self::with_policy(HostPolicy::PublicOnly)
+    }
+
+    /// Create a resolver under an explicit [`HostPolicy`].
+    pub fn with_policy(policy: HostPolicy) -> Self {
+        Self { policy }
+    }
+
+    fn resolve_options(&self) -> didwebvh_rs::resolve::ResolveOptions {
+        let policy = match self.policy {
+            HostPolicy::AllowPrivate => didwebvh_rs::resolve::HostPolicy::AllowPrivate,
+            _ => didwebvh_rs::resolve::HostPolicy::PublicOnly,
+        };
+        didwebvh_rs::resolve::ResolveOptions::default().with_host_policy(policy)
+    }
+}
+
+#[cfg(feature = "did-webvh")]
+impl Default for WebvhResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(feature = "did-webvh")]
 impl AsyncResolver for WebvhResolver {
@@ -217,7 +261,8 @@ impl AsyncResolver for WebvhResolver {
             let mut method = didwebvh_rs::DIDWebVHState::default();
             let did_str = did.to_string();
 
-            Some(match method.resolve(&did_str, Default::default()).await {
+            let resolution = method.resolve(&did_str, self.resolve_options()).await;
+            Some(match resolution {
                 Ok((log_entry, _)) => {
                     let doc_value = log_entry.get_did_document().map_err(|e| {
                         ResolverError::InvalidDocument(format!(
@@ -230,6 +275,10 @@ impl AsyncResolver for WebvhResolver {
                         }),
                         Err(e) => Err(e),
                     }
+                }
+                Err(e @ didwebvh_rs::DIDWebVHError::BlockedHost(_)) => {
+                    tracing::warn!("did:webvh resolution refused by host policy: {e}");
+                    Err(ResolverError::ResolutionFailed(e.to_string()))
                 }
                 Err(e) => {
                     error!("did:webvh resolution error: {e:?}");

--- a/crates/identity/affinidi-did-resolver-cache-sdk/tests/host_policy.rs
+++ b/crates/identity/affinidi-did-resolver-cache-sdk/tests/host_policy.rs
@@ -1,0 +1,165 @@
+//! Host policy through the resolver cache: one `DIDCacheConfigBuilder` setting
+//! decides whether did:web and did:webvh resolution may contact a private host.
+//!
+//! Each test points a DID at a loopback TCP listener and counts the connections
+//! it accepts. Nothing serves a valid document: under the default policy the
+//! listener must see no connection at all, and under `AllowPrivate` reaching it
+//! is the assertion.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use affinidi_did_resolver_cache_sdk::{
+    DIDCacheClient, config::DIDCacheConfigBuilder, errors::DIDCacheError,
+    network_resolvers::HostPolicy,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    task::JoinHandle,
+};
+
+#[cfg(feature = "did-webvh")]
+const SCID: &str = "Qmd1FCL9Vj2vJ433UDfC9MBstK6W6QWSQvYyeNn8va2fai";
+
+const RESOLVE_DEADLINE: Duration = Duration::from_secs(20);
+
+/// Long enough for a connection the resolver did open to be accepted and
+/// counted before the test reads the counter.
+const ACCEPT_GRACE: Duration = Duration::from_millis(200);
+
+/// A loopback listener that answers every connection with a 404 and counts
+/// the connections it accepts.
+struct CountingListener {
+    port: u16,
+    connections: Arc<AtomicUsize>,
+    accept_task: JoinHandle<()>,
+}
+
+impl CountingListener {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let counter = connections.clone();
+        let accept_task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                counter.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let mut request = [0u8; 4096];
+                    let _ = stream.read(&mut request).await;
+                    let _ = stream
+                        .write_all(
+                            b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                        )
+                        .await;
+                });
+            }
+        });
+        Self {
+            port,
+            connections,
+            accept_task,
+        }
+    }
+
+    async fn connections_after_grace(&self) -> usize {
+        tokio::time::sleep(ACCEPT_GRACE).await;
+        self.connections.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for CountingListener {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
+async fn cache_client(policy: Option<HostPolicy>) -> DIDCacheClient {
+    let mut builder = DIDCacheConfigBuilder::default();
+    if let Some(policy) = policy {
+        builder = builder.with_host_policy(policy);
+    }
+    DIDCacheClient::new(builder.build())
+        .await
+        .expect("build cache client")
+}
+
+async fn resolve(client: &DIDCacheClient, did: &str) -> Result<(), DIDCacheError> {
+    tokio::time::timeout(RESOLVE_DEADLINE, client.resolve(did))
+        .await
+        .expect("resolution finishes within the deadline")
+        .map(|_| ())
+}
+
+#[cfg(feature = "did-webvh")]
+#[tokio::test]
+async fn webvh_localhost_is_refused_by_default_without_connecting() {
+    let listener = CountingListener::start().await;
+    let did = format!("did:webvh:{SCID}:localhost%3A{}", listener.port);
+
+    let error = resolve(&cache_client(None).await, &did)
+        .await
+        .expect_err("a localhost did:webvh must not resolve under the default policy");
+
+    match error {
+        DIDCacheError::DIDError(message) => {
+            assert!(message.contains("BlockedHost"), "{message}");
+        }
+        other => panic!("expected a blocked-host DIDError, got {other:?}"),
+    }
+    assert_eq!(listener.connections_after_grace().await, 0);
+}
+
+#[cfg(feature = "did-webvh")]
+#[tokio::test]
+async fn webvh_localhost_is_contacted_under_allow_private() {
+    let listener = CountingListener::start().await;
+    let did = format!("did:webvh:{SCID}:localhost%3A{}", listener.port);
+
+    let error = resolve(&cache_client(Some(HostPolicy::AllowPrivate)).await, &did)
+        .await
+        .expect_err("the listener serves no log");
+
+    if let DIDCacheError::DIDError(message) = &error {
+        assert!(!message.contains("BlockedHost"), "{message}");
+    }
+    assert!(
+        listener.connections_after_grace().await > 0,
+        "AllowPrivate must let resolution reach the local host ({error:?})"
+    );
+}
+
+#[tokio::test]
+async fn web_localhost_is_refused_by_default_without_connecting() {
+    let listener = CountingListener::start().await;
+    let did = format!("did:web:localhost%3A{}", listener.port);
+
+    resolve(&cache_client(None).await, &did)
+        .await
+        .expect_err("a localhost did:web must not resolve under the default policy");
+
+    assert_eq!(listener.connections_after_grace().await, 0);
+}
+
+#[tokio::test]
+async fn web_localhost_is_contacted_under_allow_private() {
+    let listener = CountingListener::start().await;
+    let did = format!("did:web:localhost%3A{}", listener.port);
+
+    let error = resolve(&cache_client(Some(HostPolicy::AllowPrivate)).await, &did)
+        .await
+        .expect_err("the listener serves no document");
+
+    assert!(
+        listener.connections_after_grace().await > 0,
+        "the same setting must let did:web reach the local host ({error:?})"
+    );
+}

--- a/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
+++ b/crates/identity/affinidi-did-resolver-cache-server/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Affinidi DID Resolver Cache Server
 
+## Unreleased (0.9.13) — did:webvh host policy
+
+- Bumps `didwebvh-rs` 0.6 → 0.7 and requires `affinidi-did-resolver-cache-sdk`
+  0.8.37. did:webvh resolution through this server now refuses non-public
+  hosts, as did:web resolution already did (see the SDK's 0.8.37 entry).
+- The client that fetches `did.jsonl` and `did-witness.json` for `_did_log` /
+  `_did_witness_log` now matches the one `didwebvh-rs` builds:
+  - it ignores system proxy settings;
+  - it resolves names through `didwebvh_rs::resolve::guarded_dns_resolver()`,
+    which refuses a name when any resolved address is non-public;
+  - it still refuses redirects.
+
+  The fetch URLs come from `WebVHURL::get_fetch_url` under
+  `HostPolicy::PublicOnly`, instead of from `get_http_url`.
+- **Behaviour:** a deployment that can reach did:webvh hosts only through
+  `HTTP(S)_PROXY` can no longer resolve did:webvh DIDs or attach their logs.
+
 ## Unreleased (0.9.12) — dependency refresh
 
 - Bumps `tower-http` 0.6 → 0.7.

--- a/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/crates/identity/affinidi-did-resolver-cache-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-did-resolver-cache-server"
-version = "0.9.12"
+version = "0.9.13"
 description = "Affinidi DID Network Cache + Resolver Service"
 edition.workspace = true
 authors.workspace = true
@@ -28,13 +28,13 @@ network = ["affinidi-did-resolver-cache-sdk/network"]
 # it keeps full method coverage. `did-jwk` was advertised in the README but not
 # actually enabled here between 0.8.22 and now — the SDK gating in #674 moved
 # it behind a feature and only `did-ethr` / `did-pkh` were opted back in.
-affinidi-did-resolver-cache-sdk = { version = "0.8.23", default-features = true, features = ["did-ethr", "did-pkh", "did-jwk"], path = "../affinidi-did-resolver-cache-sdk/" }
+affinidi-did-resolver-cache-sdk = { version = "0.8.37", default-features = true, features = ["did-ethr", "did-pkh", "did-jwk"], path = "../affinidi-did-resolver-cache-sdk/" }
 affinidi-did-common = "0.4"
 # Shared background-task supervision (restart-on-failure + health registry)
 affinidi-task-utils = "0.1"
 affinidi-rate-limit = "0.1"
 
-didwebvh-rs = "0.6"
+didwebvh-rs = "0.7"
 agent-names = "0.1.2"
 
 # External Crates

--- a/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/handlers/mod.rs
@@ -84,13 +84,16 @@ async fn read_text_limited(mut resp: reqwest::Response, limit: usize) -> Option<
 /// For did:webvh DIDs, fetch the raw DID log + witness file from the source
 /// HTTP endpoint so clients can independently verify the cryptographic chain.
 ///
-/// The target host is derived from the caller-supplied DID, so this client
-/// refuses redirects and caps the response body to avoid being used as an SSRF
-/// pivot / reflection oracle or memory-exhaustion vector.
+/// The target host is derived from the caller-supplied DID, so the URLs are
+/// built under `HostPolicy::PublicOnly` (the policy this server's resolver
+/// uses), the client refuses redirects and non-public DNS answers, and the
+/// response body is capped, to avoid being used as an SSRF pivot / reflection
+/// oracle or memory-exhaustion vector.
 pub(crate) async fn fetch_webvh_log(
     client: &reqwest::Client,
     did: &str,
 ) -> (Option<String>, Option<String>) {
+    let policy = didwebvh_rs::resolve::HostPolicy::PublicOnly;
     let parsed_url = match didwebvh_rs::url::WebVHURL::parse_did_url(did) {
         Ok(url) => url,
         Err(e) => {
@@ -99,7 +102,7 @@ pub(crate) async fn fetch_webvh_log(
         }
     };
 
-    let log_url = match parsed_url.get_http_url(Some("did.jsonl")) {
+    let log_url = match parsed_url.get_fetch_url("did.jsonl", policy) {
         Ok(url) => url,
         Err(e) => {
             warn!("Failed to construct log URL for WebVH DID: {e}");
@@ -122,7 +125,7 @@ pub(crate) async fn fetch_webvh_log(
     };
 
     let did_witness_log = if did_log.is_some() {
-        let witness_url = match parsed_url.get_http_url(Some("did-witness.json")) {
+        let witness_url = match parsed_url.get_fetch_url("did-witness.json", policy) {
             Ok(url) => url,
             Err(_) => return (did_log, None),
         };

--- a/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
+++ b/crates/identity/affinidi-did-resolver-cache-server/src/server.rs
@@ -92,11 +92,16 @@ pub async fn start_with_config(config_path: &str) -> Result<(), DIDCacheError> {
     let resolver = DIDCacheClient::new(cache_config).await?;
 
     // One shared HTTP client for did:webvh log fetches, built once so
-    // connections are pooled (was previously rebuilt per request). Refuses
-    // redirects to avoid SSRF pivots, matching the previous per-call config.
+    // connections are pooled. The DID names the host, so this client keeps the
+    // protections of didwebvh-rs's own client: redirects refused, system proxy
+    // settings ignored (a proxy resolves the name where the DNS guard cannot
+    // see it), and a DNS resolver that refuses a name resolving to any
+    // non-public address.
     let webvh_client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .dns_resolver(didwebvh_rs::resolve::guarded_dns_resolver())
         .build()
         .map_err(|e| {
             DIDCacheError::ConfigError(format!("Failed to build WebVH HTTP client: {e}"))

--- a/crates/identity/did-methods/did-scid/CHANGELOG.md
+++ b/crates/identity/did-methods/did-scid/CHANGELOG.md
@@ -1,5 +1,18 @@
 # did:scid
 
+## Unreleased (0.2.7) — `didwebvh-rs` 0.7
+
+- Bumps `didwebvh-rs` 0.6 → 0.7. Only the manifest changes.
+- **Behaviour:** `resolve` for a `did:scid:vh` DID now contacts public hosts
+  only. `didwebvh-rs` 0.7 refuses `localhost`, other special-use names, and
+  names that resolve to non-public addresses. A `src` such as `localhost:3000`
+  now fails with `DIDSCIDError::WebVHError` wrapping
+  `DIDWebVHError::BlockedHost`, and no request is made. `resolve` takes no host
+  policy argument, so this crate offers no opt-out.
+- `DIDSCIDError::WebVHError` wraps `didwebvh_rs::DIDWebVHError`, so that variant
+  now carries the 0.7 type. This is a patch bump per ADR 0003 point 3, as for
+  the `didwebvh-rs` 0.5 → 0.6 move.
+
 ## Unreleased (0.2.6) — retire did:cheqd resolution
 
 Part of [#760]. A `did:scid` whose `?src=` names a `did:cheqd` still parses, and

--- a/crates/identity/did-methods/did-scid/Cargo.toml
+++ b/crates/identity/did-methods/did-scid/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "did-scid"
-version = "0.2.6"
+version = "0.2.7"
 description = "Implementation of did:scid in Rust"
 repository.workspace = true
 edition.workspace = true
@@ -31,7 +31,7 @@ crate-type = ["cdylib", "rlib"]
 affinidi-did-common = "0.4"
 
 affinidi-did-webs = { version = "0.7", optional = true }
-didwebvh-rs = { version = "0.6", optional = true }
+didwebvh-rs = { version = "0.7", optional = true }
 regex = "1"
 serde_json = "1"
 thiserror = "2"

--- a/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
+++ b/crates/messaging/affinidi-messaging-mediator/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased (0.24.1) — `didwebvh-rs` 0.7
+
+- Bumps `didwebvh-rs` 0.6 → 0.7. There is no source change: this crate reads
+  its own did:webvh log through `LogEntry`, which 0.7 leaves unchanged.
+- **Behaviour, through `affinidi-did-resolver-cache-sdk` 0.8.37:** the resolver
+  this mediator builds from `[did_resolver]` now refuses did:webvh DIDs on
+  non-public hosts, as it already did for did:web. `[did_resolver]` has no
+  setting for this. Two consequences:
+  - A mediator whose own DID is `did:webvh:…:localhost%3A<port>`, and which
+    does not self-host that DID, logs the existing "Could not resolve our own
+    published DID document at boot" warning and skips the operating-secret
+    coverage check.
+  - Peers whose DIDs are on such hosts no longer resolve.
+
+  An embedder can pass a `DIDCacheConfig` built with
+  `with_host_policy(HostPolicy::AllowPrivate)` to `MediatorBuilder::did_resolver`.
+
 ## Unreleased (0.24.0) — `trust-tasks-rs` 0.20
 
 - Bumps `trust-tasks-rs` 0.19 → 0.20. **No source change** — only manifests.

--- a/crates/messaging/affinidi-messaging-mediator/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-messaging-mediator"
-version = "0.24.0"
+version = "0.24.1"
 description = "Messaging Mediator service for Affinidi Messaging (DIDComm and TSP)"
 edition.workspace = true
 authors.workspace = true
@@ -188,7 +188,7 @@ redis = { version = "1.2", features = [
 fjall = { version = "3.1", optional = true }
 
 # ── DID Infrastructure ───────────────────────────────────────────────────
-didwebvh-rs = "0.6"
+didwebvh-rs = "0.7"
 
 # ── AWS Integration (optional, behind `aws` feature) ────────────────────
 ## Used for Secrets Manager (aws_secrets://), Parameter Store (aws_parameter_store://)

--- a/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
+++ b/crates/messaging/affinidi-messaging-mediator/tools/mediator-setup/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-messaging-mediator-common = { path = "../../affinidi-messaging-mediator
 ] }
 
 # ── DID:webvh ────────────────────────────────────────────────────────────
-didwebvh-rs = "0.6"
+didwebvh-rs = "0.7"
 
 # ── VTA Integration ──────────────────────────────────────────────────────
 ## provision-client: orchestration layer that drives setup-key minting,

--- a/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
+++ b/crates/tdk/affinidi-tdk-test-support/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Affinidi TDK Test Support
 
+## Unreleased (0.8.5) — document the did:webvh host policy
+
+- Documentation only. A DID minted with `MockDidWebServer::webvh_authority`
+  (`did:webvh:…:localhost%3A<port>`) resolves only through a resolver that
+  allows private hosts, because `didwebvh-rs` 0.7 refuses `localhost` by
+  default. The module docs now show the `HostPolicy::AllowPrivate` opt-in.
+
 ## Unreleased (0.8.4) — dependency refresh
 
 - Bumps `base64` 0.22 → 0.23.

--- a/crates/tdk/affinidi-tdk-test-support/Cargo.toml
+++ b/crates/tdk/affinidi-tdk-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affinidi-tdk-test-support"
-version = "0.8.4"
+version = "0.8.5"
 description = "Shared in-process test fixtures and harnesses for the Affinidi TDK workspace"
 edition.workspace = true
 authors.workspace = true

--- a/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
+++ b/crates/tdk/affinidi-tdk-test-support/src/did_web.rs
@@ -17,7 +17,11 @@
 //! host `localhost`, so [`MockDidWebServer::webvh_authority`] returns
 //! `localhost%3A<port>` for minting `did:webvh:…:localhost%3A<port>:…` DIDs.
 //! That path relies on `localhost` resolving to the loopback the server is
-//! bound on (the standard configuration).
+//! bound on (the standard configuration), and on the resolver allowing private
+//! hosts: `didwebvh-rs` 0.7 refuses `localhost` by default. Opt in with
+//! `ResolveOptions::default().with_host_policy(HostPolicy::AllowPrivate)`, or
+//! through the resolver cache with
+//! `DIDCacheConfigBuilder::default().with_host_policy(HostPolicy::AllowPrivate)`.
 //!
 //! ```
 //! use affinidi_tdk_test_support::did_web::{Fault, MockDidWebServer};
@@ -152,7 +156,8 @@ impl MockDidWebServer {
     }
 
     /// `localhost%3A<port>` — the authority to embed in a `did:webvh` DID so
-    /// its resolver fetches the log over `http://localhost:<port>/…`.
+    /// its resolver fetches the log over `http://localhost:<port>/…`. The
+    /// resolver must allow private hosts (see the module docs).
     pub fn webvh_authority(&self) -> String {
         format!("localhost%3A{}", self.addr.port())
     }


### PR DESCRIPTION

## Summary

`didwebvh-rs` 0.7 adds a resolution host policy and makes public-only the default. This PR moves the workspace to 0.7. It also gives the resolver cache one setting that decides which hosts both did:web and did:webvh resolution may contact.

Under `didwebvh-rs` 0.7's default `HostPolicy::PublicOnly`:
- a DID naming `localhost`, `*.localhost`, `*.local`, `*.internal`, `home.arpa` or a single-label host is refused before any request is made;
- the default client refuses a name if any address it resolves to is non-public;
- the default client refuses redirects and ignores system proxy settings.

## Changes

### `affinidi-did-resolver-cache-sdk` 0.8.37
- `didwebvh-rs` 0.6 → 0.7, and `did-scid` requirement raised to 0.2.7.
- `WebvhResolver` changes, mirroring `WebResolver`:
  - adds `new()`, `with_policy(HostPolicy)` and `Default`;
  - the cache SDK's `HostPolicy` (re-exported from `affinidi-did-web`) maps onto `ResolveOptions::default().with_host_policy(..)`;
  - no HTTP client is passed, so resolution uses the guarded client that `didwebvh-rs` builds itself.
- `DIDCacheConfigBuilder::with_host_policy(HostPolicy)` is new, with default `PublicOnly`. `DIDCacheClient::new` builds both the built-in did:web and did:webvh resolvers from it.
- `DIDWebVHError::BlockedHost` is logged as a policy refusal and returned as `ResolverError::ResolutionFailed`.

### `affinidi-did-resolver-cache-server` 0.9.13
- `didwebvh-rs` 0.6 → 0.7, and cache SDK requirement raised to 0.8.37.
- The shared client that fetches `did.jsonl` / `did-witness.json` for `_did_log`:
  - adds `no_proxy()` and `dns_resolver(didwebvh_rs::resolve::guarded_dns_resolver())`;
  - still refuses redirects.
- The fetch URLs come from `WebVHURL::get_fetch_url(.., HostPolicy::PublicOnly)` instead of `get_http_url`.

### `did-scid` 0.2.7, `affinidi-messaging-mediator` 0.24.1, `mediator-setup`
- `didwebvh-rs` 0.6 → 0.7. No source change is needed: `ResolveOptions` is already built with `..Default::default()`, and no code matches exhaustively on `DIDWebVHError`.

### `affinidi-tdk-test-support` 0.8.5
- Documentation only. `MockDidWebServer::webvh_authority` DIDs need a resolver set to `HostPolicy::AllowPrivate`.

## Behaviour changes for consumers

- **did:webvh on non-public hosts no longer resolves by default.** This covers `did:webvh:{SCID}:localhost%3A<port>` and hostnames that resolve to private addresses, and applies through the cache SDK, the cache server and the mediator. The error is `DIDCacheError::DIDError` containing `BlockedHost`.
  - To opt back in for both methods: `DIDCacheConfigBuilder::default().with_host_policy(HostPolicy::AllowPrivate)`.
  - For did:webvh alone: `set_resolver(MethodName::Webvh, Box::new(WebvhResolver::with_policy(HostPolicy::AllowPrivate)))`.
- **did:web behaviour is unchanged** unless `with_host_policy` is used. It has been `PublicOnly` since 0.8.35.
- **`WebvhResolver` is no longer a unit struct.** `Box::new(WebvhResolver)` becomes `Box::new(WebvhResolver::new())`. No caller in this workspace used the unit form.
- **`did:scid:vh` resolution is public-only**, following `didwebvh-rs`'s default. `did_scid::resolve` takes no policy argument, so `with_host_policy` does not affect it.
- **Proxy-only egress:** did:webvh resolution and the cache server's log fetch ignore `HTTP(S)_PROXY`.
- **Mediator:** `[did_resolver]` has no host-policy setting. A mediator whose own did:webvh DID is on `localhost` and is not self-hosted now logs the existing boot warning and skips the operating-secret coverage check. Embedders can pass a config built with `with_host_policy` to `MediatorBuilder::did_resolver`.

Versions are patch bumps per ADR 0003 point 3: `vta-sdk` pins these crates through `[patch.crates-io]`.

No test, example or dev config in this workspace resolves a `localhost` did:webvh DID over the network, so there were no call sites to opt into `AllowPrivate`.

## Tests

- `affinidi-did-resolver-cache-sdk/tests/host_policy.rs`: each case runs through `DIDCacheClient` against a loopback TCP listener that counts accepted connections.
  - `did:webvh:{SCID}:localhost%3A<port>` with the default config fails with `BlockedHost`, and the listener accepts zero connections.
  - The same DID with `AllowPrivate` reaches the listener.
  - The same pair for `did:web:localhost%3A<port>`, showing the one setting governs both methods.
- `config.rs` unit tests cover the default and the override of `host_policy`.
